### PR TITLE
Update SslHandler to set bio fd member to facilitate openssl tracing (Pixie integration)

### DIFF
--- a/handler/pom.xml
+++ b/handler/pom.xml
@@ -57,6 +57,11 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>netty-transport-native-unix-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>netty-codec</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -614,8 +614,10 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
         return sslWrote;
     }
 
-    public void bioSetFd(int fd) {
-        SSL.bioSetFd(this.ssl, fd);
+   synchronized void bioSetFd(int fd) {
+        if (!isDestroyed()) {
+            SSL.bioSetFd(this.ssl, fd);
+        }
     }
 
     /**

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -614,6 +614,10 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
         return sslWrote;
     }
 
+    public void bioSetFd(int fd) {
+        SSL.bioSetFd(this.ssl, fd);
+    }
+
     /**
      * Write encrypted data to the OpenSSL network BIO.
      */

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -914,7 +914,6 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
     private boolean wrapNonAppData(final ChannelHandlerContext ctx, boolean inUnwrap) throws SSLException {
         ByteBuf out = null;
         ByteBufAllocator alloc = ctx.alloc();
-
         try {
             // Only continue to loop if the handler was not removed in the meantime.
             // See https://github.com/netty/netty/issues/5860
@@ -2143,14 +2142,9 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
      */
     @Override
     public void channelActive(final ChannelHandlerContext ctx) throws Exception {
-        Channel c = this.ctx.channel();
-        if (c instanceof UnixChannel) {
-          UnixChannel uc = (UnixChannel) c;
-          int fd = uc.fd().intValue();
-          if (this.engine instanceof ReferenceCountedOpenSslEngine) {
-            ReferenceCountedOpenSslEngine rcEngine = (ReferenceCountedOpenSslEngine) this.engine;
-            rcEngine.bioSetFd(fd);
-          }
+        Channel c = ctx.channel();
+        if (c instanceof UnixChannel && engine instanceof ReferenceCountedOpenSslEngine) {
+            ((ReferenceCountedOpenSslEngine) engine).bioSetFd(((UnixChannel) c).fd().intValue());
         }
         if (!startTls) {
             startHandshakeProcessing(true);


### PR DESCRIPTION
Motivation:

I've been working on extending the pixie platform to support out of the box instrumentation for [twitter/finagle](https://github.com/twitter/finagle) and eventually the netty project (https://github.com/pixie-io/pixie/issues/407).

For those that aren't familiar, [Pixie](https://github.com/pixie-io/pixie) is an open source, Kubernetes Observability tool that provides auto instrumentation by leveraging eBPF. It has support for tracing network traffic for a variety of protocols (http/2, kafka, mysql, mux, etc) even if encrypted with openssl. Its openssl tracing support works by instrumenting the `SSL_read` and `SSL_write` functions through a uprobe. This uprobe captures the data just before encryption or just after decryption, in addition to navigating [openssl's rbio struct](https://github.com/pixie-io/pixie/blob/294d3f36214dece583dd499ebd578cecb7cc7425/src/stirling/source_connectors/socket_tracer/bcc_bpf/openssl_trace.c#L59-L78) to access the socket file descriptor (necessary for associating network traffic with a particular container).

Modification:

Due to how netty uses openssl today, the openssl SSL struct passed to `SSL_read` and `SSL_write` does not have the socket fd set. This is because netty's Java code handles the network transport and leverages openssl only for encryption and decryption. The functionality added in this PR allows netty to populate the SSL struct's rbio field with the socket file descriptor when a channel becomes active (first created). This change is dependent on the netty-tcnative changes made in https://github.com/netty/netty-tcnative/pull/731

My understanding is that each netty channel will be given its own ssl engine, so setting this socket file descriptor on a per connection basis shouldn't be a problem. It's also worth mentioning that getting this to work with Pixie requires setting `-Dio.netty.native.deleteLibAfterLoading=false`. So while the goal is to instrument netty TLS connections with no configuration, that option would be necessary.

Result:

Fixes the majority of the remaining work in https://github.com/pixie-io/pixie/issues/407. The remaining changes would be in the pixie project
- [x] Verified that pixie's netty TLS tracing works for a twitter/finagle service on https://github.com/pixie-io/pixie/pull/446

I wanted to open up this PR to facilitate discussion on how to accomplish this integration between pixie and netty and look forward to your feedback :)

# Todo
- [ ] Deploy a Twitter production service with this change to stress test there aren't any regressions
- [ ] Other items from code review