### PR TITLE
Allow to retrieve the implicitCapacityLimit of a Buffer

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/Buffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/Buffer.java
@@ -262,6 +262,14 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
     Buffer implicitCapacityLimit(int limit);
 
     /**
+     * Returns the implicit capacity limit of the buffer. If none was set before via {@link #implicitCapacityLimit(int)}
+     * this method will return the default value.
+     *
+     * @return the limit.
+     */
+    int implicitCapacityLimit();
+
+    /**
      * Copies the given length of data from this buffer into the given destination array, beginning at the given source
      * position in this buffer, and the given destination position in the destination array.
      * <p>

--- a/buffer/src/main/java/io/netty5/buffer/api/BufferStub.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/BufferStub.java
@@ -121,6 +121,11 @@ public class BufferStub implements Buffer {
     }
 
     @Override
+    public int implicitCapacityLimit() {
+        return delegate.implicitCapacityLimit();
+    }
+
+    @Override
     public void copyInto(int srcPos, byte[] dest, int destPos, int length) {
         delegate.copyInto(srcPos, dest, destPos, length);
     }

--- a/buffer/src/main/java/io/netty5/buffer/api/DefaultCompositeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/DefaultCompositeBuffer.java
@@ -385,6 +385,11 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
     }
 
     @Override
+    public int implicitCapacityLimit() {
+        return implicitCapacityLimit;
+    }
+
+    @Override
     public CompositeBuffer copy(int offset, int length, boolean readOnly) {
         checkLength(length);
         checkGetBounds(offset, length);

--- a/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
@@ -228,6 +228,11 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
     }
 
     @Override
+    public int implicitCapacityLimit() {
+        return implicitCapacityLimit;
+    }
+
+    @Override
     public void copyInto(int srcPos, byte[] dest, int destPos, int length) {
         if (!isAccessible()) {
             throw attachTrace(bufferIsClosed(this));

--- a/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
@@ -209,6 +209,11 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
     }
 
     @Override
+    public int implicitCapacityLimit() {
+        return implicitCapacityLimit;
+    }
+
+    @Override
     public Buffer copy(int offset, int length, boolean readOnly) {
         checkLength(length);
         checkGet(offset, length);

--- a/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
@@ -205,6 +205,11 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
     }
 
     @Override
+    public int implicitCapacityLimit() {
+        return implicitCapacityLimit;
+    }
+
+    @Override
     public Buffer copy(int offset, int length, boolean readOnly) {
         checkLength(length);
         checkGet(offset, length);

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferImplicitCapacityTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferImplicitCapacityTest.java
@@ -17,6 +17,7 @@ package io.netty5.buffer.api.tests;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
+import io.netty5.buffer.api.internal.Statics;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -24,6 +25,17 @@ import static io.netty5.buffer.api.internal.Statics.MAX_BUFFER_SIZE;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class BufferImplicitCapacityTest extends BufferTestSupport {
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void implicitLimit(Fixture fixture) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buffer = allocator.allocate(8)) {
+            assertEquals(MAX_BUFFER_SIZE, buffer.implicitCapacityLimit());
+            buffer.implicitCapacityLimit(buffer.capacity());
+            assertEquals(buffer.capacity(), buffer.implicitCapacityLimit());
+        }
+    }
+
     @ParameterizedTest
     @MethodSource("allocators")
     public void implicitLimitMustBeWithinBounds(Fixture fixture) {


### PR DESCRIPTION
Motivation:

We should allow to retrieve the implicitCapacityLimit of a Buffer to know if a write method will throw or not.

Modifications:

- Add implicitCapacityLimit() method
- Add unit test

Result:

Be able to retrieve the limit
