### PR TITLE
Use new implicitCapacity() method to limit size of buffer

### DIFF
--- a/codec/src/main/java/io/netty5/handler/codec/compression/ZlibDecompressor.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/ZlibDecompressor.java
@@ -47,7 +47,7 @@ public final class ZlibDecompressor implements Decompressor {
     /**
      * Maximum allowed size of the decompression buffer.
      */
-    protected final int maxAllocation;
+    private final int maxAllocation;
 
     private enum GzipState {
         HEADER_START,
@@ -551,14 +551,13 @@ public final class ZlibDecompressor implements Decompressor {
             return buf;
         }
 
-        // TODO:
-        buffer.ensureWritable(preferredSize);
-        if (buffer.writableBytes() < preferredSize) {
+        if (buffer.implicitCapacityLimit() < preferredSize) {
             decompressionBufferExhausted(buffer);
             buffer.skipReadable(buffer.readableBytes());
             throw new DecompressionException(
-                    "Decompression buffer has reached maximum size: " + buffer.capacity());
+                    "Decompression buffer has reached maximum size: " + buffer.implicitCapacityLimit());
         }
+        buffer.ensureWritable(preferredSize);
         return buffer;
     }
 


### PR DESCRIPTION
Motivation:

We added a new method that we can use to limit the size of the buffer we can allocate

Modifications:

Use new method

Result:

Cleanup
