### PR TITLE
Remove the last references to JUnit 4

### DIFF
--- a/codec/src/test/resources/io/netty/handler/codec/xml/sample-04.xml
+++ b/codec/src/test/resources/io/netty/handler/codec/xml/sample-04.xml
@@ -211,12 +211,6 @@
   <dependencies>
     <!-- Testing frameworks and related dependencies -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
       <version>3.4</version>

--- a/microbench/pom.xml
+++ b/microbench/pom.xml
@@ -186,16 +186,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.openjdk.jmh</groupId>
       <artifactId>jmh-core</artifactId>
       <version>${jmh.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -887,18 +887,6 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>org.junit.vintage</groupId>
-        <artifactId>junit-vintage-engine</artifactId>
-        <version>${junit.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>4.13.1</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>netty-build-common</artifactId>
         <version>${netty.build.version}</version>
@@ -1031,16 +1019,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-build-common</artifactId>
       <scope>test</scope>
@@ -1147,6 +1125,12 @@
                   <code>java.field.removed</code>
                   <classQualifiedName>io.netty.util.internal.InternalThreadLocalMap</classQualifiedName>
                   <justification>Ignore cache padding.</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.removed</code>
+                  <old>method java.lang.String io.netty.testsuite.util.TestUtils::testMethodName(org.junit.rules.TestName)</old>
+                  <justification>This should be test-only, and we're removing support for JUnit 4.</justification>
                 </item>
               </differences>
             </revapi.differences>

--- a/testsuite-native/pom.xml
+++ b/testsuite-native/pom.xml
@@ -45,14 +45,6 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-    </dependency>
   </dependencies>
   <profiles>
     <profile>

--- a/testsuite-shading/pom.xml
+++ b/testsuite-shading/pom.xml
@@ -200,14 +200,6 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-    </dependency>
   </dependencies>
   <profiles>
     <profile>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -95,16 +95,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
       <scope>compile</scope>

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastIPv6Test.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastIPv6Test.java
@@ -18,8 +18,8 @@ package io.netty.testsuite.transport.socket;
 import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SuppressJava6Requirement;
-import org.junit.AssumptionViolatedException;
 import org.junit.jupiter.api.BeforeAll;
+import org.opentest4j.TestAbortedException;
 
 import java.io.IOException;
 import java.net.StandardProtocolFamily;
@@ -38,7 +38,7 @@ public class DatagramUnicastIPv6Test extends DatagramUnicastInetTest {
             Channel channel = SelectorProvider.provider().openDatagramChannel(StandardProtocolFamily.INET6);
             channel.close();
         } catch (UnsupportedOperationException e) {
-           throw new AssumptionViolatedException("IPv6 not supported", e);
+           throw new TestAbortedException("IPv6 not supported", e);
         } catch (IOException ignore) {
             // Ignore
         }

--- a/testsuite/src/main/java/io/netty/testsuite/util/TestUtils.java
+++ b/testsuite/src/main/java/io/netty/testsuite/util/TestUtils.java
@@ -21,7 +21,6 @@ import io.netty.util.internal.SuppressJava6Requirement;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import org.junit.jupiter.api.TestInfo;
-import org.junit.rules.TestName;
 import org.tukaani.xz.LZMA2Options;
 import org.tukaani.xz.XZOutputStream;
 
@@ -114,17 +113,6 @@ public final class TestUtils {
                 return method.getName();
             }
         }).orElse("[unknown method]");
-        if (testMethodName.contains("[")) {
-            testMethodName = testMethodName.substring(0, testMethodName.indexOf('['));
-        }
-        return testMethodName;
-    }
-
-    /**
-     * Returns the method name of the current test.
-     */
-    public static String testMethodName(TestName testName) {
-        String testMethodName = testName.getMethodName();
         if (testMethodName.contains("[")) {
             testMethodName = testMethodName.substring(0, testMethodName.indexOf('['));
         }

--- a/transport-native-unix-common-tests/pom.xml
+++ b/transport-native-unix-common-tests/pom.xml
@@ -54,15 +54,5 @@
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>compile</scope>
     </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>compile</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/transport-native-unix-common-tests/src/main/java/io/netty/channel/unix/tests/SocketTest.java
+++ b/transport-native-unix-common-tests/src/main/java/io/netty/channel/unix/tests/SocketTest.java
@@ -17,10 +17,10 @@ package io.netty.channel.unix.tests;
 
 import io.netty.channel.unix.Buffer;
 import io.netty.channel.unix.Socket;
-import org.junit.AssumptionViolatedException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.opentest4j.TestAbortedException;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -127,10 +127,10 @@ public abstract class SocketTest<T extends Socket> {
     }
 
     protected int level() {
-        throw new AssumptionViolatedException("Not supported");
+        throw new TestAbortedException("Not supported");
     }
 
     protected int optname() {
-        throw new AssumptionViolatedException("Not supported");
+        throw new TestAbortedException("Not supported");
     }
 }


### PR DESCRIPTION
Motivation:
This completes our migration to JUnit 5.

Modification:
Remove all JUnit 4 dependencies.
Replace or remove the last references to JUnit 4 types in the code.
Add a revapi exception because a public TestUtils method was exposing JUnit 4 types and had to be removed.

Result:
No more JUnit 4 in our project.

Fixes #10757