### PR TITLE
Simplify lifecycle traces

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/internal/LifecycleTracer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/internal/LifecycleTracer.java
@@ -290,7 +290,7 @@ public abstract class LifecycleTracer {
 
         @Override
         public Trace apply(Stream<StackWalker.StackFrame> frames) {
-            this.frames = frames.limit(TRACE_LIFECYCLE_DEPTH + 1).toArray(StackWalker.StackFrame[]::new);
+            this.frames = frames.skip(2).limit(TRACE_LIFECYCLE_DEPTH + 1).toArray(StackWalker.StackFrame[]::new);
             return this;
         }
 


### PR DESCRIPTION
Motivation:
Lifecycle errors reproduce the object lifecycle as suppressed stack traces.
Since these can be very long, it makes sense to remove as much internal scaffolding from them as possible.

Modification:
Remove the top two stack frames from the lifecycle traces, because those two frames are inside the LifecycleTracer itself and only add noise.

Result:
Cleaner lifecycle traces.