### PR TITLE
correct comment of date from cate

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspHeaderNames.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspHeaderNames.java
@@ -95,7 +95,7 @@ public final class RtspHeaderNames {
      */
     public static final AsciiString CSEQ = AsciiString.cached("cseq");
     /**
-     * {@code "cate"}
+     * {@code "date"}
      */
     public static final AsciiString DATE = HttpHeaderNames.DATE;
     /**


### PR DESCRIPTION
Motivation:

found a misspelling, the comment of RTSP header DATE should be "date" not "cate"

Modification:

cate -> date

Result:

correct comment
