### PR TITLE
Make buffer composition requirements more lenient

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/BufferAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/BufferAllocator.java
@@ -132,8 +132,8 @@ public interface BufferAllocator extends SafeCloseable {
      * <p>
      * When a composite buffer is closed, all of its constituent component buffers are closed as well.
      * <p>
-     * See the class documentation for more information on what is required of the given buffers for composition to be
-     * allowed.
+     * See the class documentation for more information on how buffers compose, and what is required of the given
+     * buffers for composition to be allowed.
      *
      * @param send The sent buffer to compose into a single buffer view.
      * @return A buffer composed of, and backed by, the given buffers.
@@ -149,8 +149,8 @@ public interface BufferAllocator extends SafeCloseable {
      * <p>
      * When a composite buffer is closed, all of its constituent component buffers are closed as well.
      * <p>
-     * See the class documentation for more information on what is required of the given buffers for composition to be
-     * allowed.
+     * See the class documentation for more information on how buffers compose, and what is required of the given
+     * buffers for composition to be allowed.
      *
      * @param sends The sent buffers to compose into a single buffer view.
      * @return A buffer composed of, and backed by, the given buffers.


### PR DESCRIPTION
Motivation:
Our composite buffers required that their components could be concatenated in a gapless fashion,
where there were no already-read or writable regions in between regions of readable memory.
This requirement turned out to be quite restrictive in practice.

Modification:
The buffer composition process now tolerates such gaps, and trim the incoming buffers to its liking in the composition process.

Result:
We can now compose arbitrary buffers without worrying about gaps, which makes it much easier to use this API.