### PR TITLE
Rename skipReadable(...) and skipWritable(...) to be more consistent …

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/BufferInputStream.java
+++ b/buffer/src/main/java/io/netty5/buffer/BufferInputStream.java
@@ -203,7 +203,7 @@ public final class BufferInputStream extends InputStream implements DataInput {
 
                 case '\r':
                     if (available > 0 && (char) buffer.getUnsignedByte(buffer.readerOffset()) == '\n') {
-                        buffer.skipReadable(1);
+                        buffer.skipReadableBytes(1);
                     }
                     break loop;
 
@@ -248,7 +248,7 @@ public final class BufferInputStream extends InputStream implements DataInput {
     @Override
     public int skipBytes(int n) throws IOException {
         int nBytes = Math.min(available(), n);
-        buffer.skipReadable(nBytes);
+        buffer.skipReadableBytes(nBytes);
         return nBytes;
     }
 

--- a/buffer/src/main/java/io/netty5/buffer/api/Buffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/Buffer.java
@@ -141,7 +141,7 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
      * @throws IllegalArgumentException if the given delta is negative.
      * @throws BufferClosedException if this buffer is closed.
      */
-    default Buffer skipReadable(int delta) {
+    default Buffer skipReadableBytes(int delta) {
         checkPositiveOrZero(delta, "delta");
         readerOffset(readerOffset() + delta);
         return this;
@@ -175,7 +175,7 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
      * @throws BufferClosedException if this buffer is closed.
      * @throws BufferReadOnlyException if this buffer is {@linkplain #readOnly() read-only}.
      */
-    default Buffer skipWritable(int delta) {
+    default Buffer skipWritableBytes(int delta) {
         checkPositiveOrZero(delta, "delta");
         writerOffset(writerOffset() + delta);
         return this;
@@ -435,8 +435,8 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
         }
         int woff = writerOffset();
         source.copyInto(source.readerOffset(), this, woff, size);
-        source.skipReadable(size);
-        skipWritable(size);
+        source.skipReadableBytes(size);
+        skipWritableBytes(size);
         return this;
     }
 
@@ -469,7 +469,7 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
         for (int i = 0; i < length; i++) {
             setByte(woff + i, source[srcPos + i]);
         }
-        skipWritable(length);
+        skipWritableBytes(length);
         return this;
     }
 
@@ -519,7 +519,7 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
     default Buffer readBytes(ByteBuffer destination) {
         int byteCount = destination.remaining();
         copyInto(readerOffset(), destination, destination.position(), byteCount);
-        skipReadable(byteCount);
+        skipReadableBytes(byteCount);
         destination.position(destination.limit());
         return this;
     }

--- a/buffer/src/main/java/io/netty5/buffer/api/BufferAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/BufferAllocator.java
@@ -263,7 +263,7 @@ public interface BufferAllocator extends SafeCloseable {
             duplicate.position(length + duplicate.position());
             return true;
         });
-        copy.skipWritable(bytesToCopy);
+        copy.skipWritableBytes(bytesToCopy);
         return copy;
     }
 

--- a/buffer/src/main/java/io/netty5/buffer/api/BufferStub.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/BufferStub.java
@@ -55,8 +55,8 @@ public class BufferStub implements Buffer {
     }
 
     @Override
-    public Buffer skipReadable(int delta) {
-        delegate.skipReadable(delta);
+    public Buffer skipReadableBytes(int delta) {
+        delegate.skipReadableBytes(delta);
         return this;
     }
 
@@ -72,8 +72,8 @@ public class BufferStub implements Buffer {
     }
 
     @Override
-    public Buffer skipWritable(int delta) {
-        delegate.skipWritable(delta);
+    public Buffer skipWritableBytes(int delta) {
+        delegate.skipWritableBytes(delta);
         return this;
     }
 

--- a/buffer/src/main/java/io/netty5/buffer/api/CompositeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/CompositeBuffer.java
@@ -180,13 +180,13 @@ public interface CompositeBuffer extends Buffer {
     CompositeBuffer writerOffset(int offset);
 
     @Override
-    default CompositeBuffer skipReadable(int delta) {
-        return (CompositeBuffer) Buffer.super.skipReadable(delta);
+    default CompositeBuffer skipReadableBytes(int delta) {
+        return (CompositeBuffer) Buffer.super.skipReadableBytes(delta);
     }
 
     @Override
-    default CompositeBuffer skipWritable(int delta) {
-        return (CompositeBuffer) Buffer.super.skipWritable(delta);
+    default CompositeBuffer skipWritableBytes(int delta) {
+        return (CompositeBuffer) Buffer.super.skipWritableBytes(delta);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty5/buffer/api/DefaultCompositeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/DefaultCompositeBuffer.java
@@ -553,7 +553,7 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
                 }
             }
         } finally {
-            skipReadable(totalBytesWritten);
+            skipReadableBytes(totalBytesWritten);
         }
         return totalBytesWritten;
     }
@@ -591,7 +591,7 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
             }
         } finally {
             if (totalBytesRead > 0) { // Don't skipWritable if total is 0 or -1
-                skipWritable(totalBytesRead);
+                skipWritableBytes(totalBytesRead);
             }
         }
         return totalBytesRead;
@@ -633,7 +633,7 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
             }
         } finally {
             if (totalBytesRead > 0) { // Don't skipWritable if total is 0 or -1
-                skipWritable(totalBytesRead);
+                skipWritableBytes(totalBytesRead);
             }
         }
         return totalBytesRead;
@@ -1044,7 +1044,7 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
                 int roffAfter = buf.readerOffset();
                 if (roffAfter != roffBefore) { // Check if ReadableComponent.skipReadable was called.
                     buf.readerOffset(roffBefore); // Reset component offset.
-                    skipReadable(roffAfter - roffBefore); // Then move *composite* buffer offset.
+                    skipReadableBytes(roffAfter - roffBefore); // Then move *composite* buffer offset.
                 }
                 if (count > 0) {
                     visited += count;
@@ -1081,7 +1081,7 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
                 int woffAfter = buf.writerOffset();
                 if (woffAfter != woffBefore) { // Check if WritableComponent.skipWritable was called.
                     buf.writerOffset(woffBefore);
-                    skipWritable(woffAfter - woffBefore);
+                    skipWritableBytes(woffAfter - woffBefore);
                 }
                 if (count > 0) {
                     visited += count;
@@ -2147,8 +2147,8 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
         }
 
         @Override
-        public ReadableComponent skipReadable(int byteCount) {
-            ((ReadableComponent) currentComponent).skipReadable(byteCount);
+        public ReadableComponent skipReadableBytes(int byteCount) {
+            ((ReadableComponent) currentComponent).skipReadableBytes(byteCount);
             compositeBuffer.readerOffset(pastOffset + currentReadSkip + byteCount);
             currentReadSkip += byteCount; // This needs to be after the bounds-checks.
             return this;
@@ -2190,8 +2190,8 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
         }
 
         @Override
-        public WritableComponent skipWritable(int byteCount) {
-            ((WritableComponent) currentComponent).skipWritable(byteCount);
+        public WritableComponent skipWritableBytes(int byteCount) {
+            ((WritableComponent) currentComponent).skipWritableBytes(byteCount);
             compositeBuffer.writerOffset(pastOffset + currentWriteSkip + byteCount);
             currentWriteSkip += byteCount; // This needs to be after the bounds-checks.
             return this;

--- a/buffer/src/main/java/io/netty5/buffer/api/MemoryManager.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/MemoryManager.java
@@ -144,7 +144,7 @@ public interface MemoryManager {
         ManagedBufferAllocator allocator = new ManagedBufferAllocator(manager, false);
         WrappingAllocation allocationType = new WrappingAllocation(array);
         Buffer buffer = manager.allocateShared(allocator, array.length, ArcDrop::wrap, allocationType);
-        buffer.skipWritable(array.length);
+        buffer.skipWritableBytes(array.length);
         return buffer.makeReadOnly();
     }
 

--- a/buffer/src/main/java/io/netty5/buffer/api/ReadableComponent.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/ReadableComponent.java
@@ -109,7 +109,7 @@ public interface ReadableComponent {
      *
      * @param byteCount The number of bytes read from this component.
      * @return itself.
-     * @see Buffer#skipReadable(int)
+     * @see Buffer#skipReadableBytes(int)
      */
-    ReadableComponent skipReadable(int byteCount);
+    ReadableComponent skipReadableBytes(int byteCount);
 }

--- a/buffer/src/main/java/io/netty5/buffer/api/WritableComponent.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/WritableComponent.java
@@ -84,7 +84,7 @@ public interface WritableComponent {
      *
      * @param byteCount The number of bytes written to this component.
      * @return itself.
-     * @see Buffer#skipWritable(int)
+     * @see Buffer#skipWritableBytes(int)
      */
-    WritableComponent skipWritable(int byteCount);
+    WritableComponent skipWritableBytes(int byteCount);
 }

--- a/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
@@ -283,7 +283,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
             GatheringByteChannel gatheringByteChannel = (GatheringByteChannel) channel;
             int bytesWritten = delegate.getBytes(readerOffset(), gatheringByteChannel, length);
             if (bytesWritten > 0) {
-                skipReadable(bytesWritten);
+                skipReadableBytes(bytesWritten);
             }
             return bytesWritten;
         }
@@ -291,7 +291,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
         copyInto(readerOffset(), buf, 0, buf.remaining());
         int bytesWritten = channel.write(buf);
         if (bytesWritten > 0) {
-            skipReadable(bytesWritten);
+            skipReadableBytes(bytesWritten);
         }
         return bytesWritten;
     }
@@ -315,7 +315,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
         }
         int bytesRead = delegate.setBytes(writerOffset(), channel, position, length);
         if (bytesRead > 0) { // Don't skipWritable if bytesRead is 0 or -1
-            skipWritable(bytesRead);
+            skipWritableBytes(bytesRead);
         }
         return bytesRead;
     }
@@ -342,7 +342,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
             ScatteringByteChannel scatteringByteChannel = (ScatteringByteChannel) channel;
             int bytesRead = delegate.setBytes(writerOffset(), scatteringByteChannel, length);
             if (bytesRead > 0) {
-                skipWritable(bytesRead);
+                skipWritableBytes(bytesRead);
             }
             return bytesRead;
         }
@@ -467,7 +467,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
         Buffer copy = control.getAllocator().allocate(length);
         try {
             copyInto(offset, copy, 0, length);
-            copy.skipWritable(length);
+            copy.skipWritableBytes(length);
             if (readOnly) {
                 copy.makeReadOnly();
             }
@@ -1329,8 +1329,8 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
         }
 
         @Override
-        public ReadableComponent skipReadable(int byteCount) {
-            buffer.skipReadable(byteCount);
+        public ReadableComponent skipReadableBytes(int byteCount) {
+            buffer.skipReadableBytes(byteCount);
             int delta = buffer.readerOffset() - startBufferReaderOffset;
             byteBuffer.position(startByteBufferPosition + delta);
             return this;
@@ -1398,8 +1398,8 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
         }
 
         @Override
-        public WritableComponent skipWritable(int byteCount) {
-            buffer.skipWritable(byteCount);
+        public WritableComponent skipWritableBytes(int byteCount) {
+            buffer.skipWritableBytes(byteCount);
             int delta = buffer.writerOffset() - startBufferWriterOffset;
             byteBuffer.position(startByteBufferPosition + delta);
             return this;

--- a/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
@@ -141,13 +141,13 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
     }
 
     @Override
-    public NioBuffer skipReadable(int delta) {
-        return (NioBuffer) super.skipReadable(delta);
+    public NioBuffer skipReadableBytes(int delta) {
+        return (NioBuffer) super.skipReadableBytes(delta);
     }
 
     @Override
-    public NioBuffer skipWritable(int delta) {
-        return (NioBuffer) super.skipWritable(delta);
+    public NioBuffer skipWritableBytes(int delta) {
+        return (NioBuffer) super.skipWritableBytes(delta);
     }
 
     @Override
@@ -300,7 +300,7 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
         }
         checkGet(readerOffset(), length);
         int bytesWritten = channel.write(readableBuffer().limit(length));
-        skipReadable(bytesWritten);
+        skipReadableBytes(bytesWritten);
         return bytesWritten;
     }
 
@@ -321,7 +321,7 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
         checkSet(writerOffset(), length);
         int bytesRead = channel.read(writableBuffer().limit(length), position);
         if (bytesRead > 0) { // Don't skipWritable if bytesRead is 0 or -1
-            skipWritable(bytesRead);
+            skipWritableBytes(bytesRead);
         }
         return bytesRead;
     }
@@ -341,7 +341,7 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
         checkSet(writerOffset(), length);
         int bytesRead = channel.read(writableBuffer().limit(length));
         if (bytesRead != -1) {
-            skipWritable(bytesRead);
+            skipWritableBytes(bytesRead);
         }
         return bytesRead;
     }

--- a/buffer/src/main/java/io/netty5/buffer/api/internal/Statics.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/internal/Statics.java
@@ -261,7 +261,7 @@ public interface Statics {
 
     static CharSequence readCharSequence(Buffer source, int length, Charset charset) {
         final CharSequence charSequence = copyToCharSequence(source, source.readerOffset(), length, charset);
-        source.skipReadable(length);
+        source.skipReadableBytes(length);
         return charSequence;
     }
 

--- a/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
@@ -153,13 +153,13 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
     }
 
     @Override
-    public UnsafeBuffer skipReadable(int delta) {
-        return (UnsafeBuffer) super.skipReadable(delta);
+    public UnsafeBuffer skipReadableBytes(int delta) {
+        return (UnsafeBuffer) super.skipReadableBytes(delta);
     }
 
     @Override
-    public UnsafeBuffer skipWritable(int delta) {
-        return (UnsafeBuffer) super.skipWritable(delta);
+    public UnsafeBuffer skipWritableBytes(int delta) {
+        return (UnsafeBuffer) super.skipWritableBytes(delta);
     }
 
     @Override
@@ -333,7 +333,7 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
         }
         checkGet(readerOffset(), length);
         int bytesWritten = channel.write(readableBuffer().limit(length));
-        skipReadable(bytesWritten);
+        skipReadableBytes(bytesWritten);
         return bytesWritten;
     }
 
@@ -354,7 +354,7 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
         checkSet(writerOffset(), length);
         int bytesRead = channel.read(writableBuffer().limit(length), position);
         if (bytesRead > 0) { // Don't skipWritable if bytesRead is 0 or -1
-            skipWritable(bytesRead);
+            skipWritableBytes(bytesRead);
         }
         return bytesRead;
     }
@@ -374,7 +374,7 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
         checkSet(writerOffset(), length);
         int bytesRead = channel.read(writableBuffer().limit(length));
         if (bytesRead != -1) {
-            skipWritable(bytesRead);
+            skipWritableBytes(bytesRead);
         }
         return bytesRead;
     }

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferBulkAccessTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferBulkAccessTest.java
@@ -312,7 +312,7 @@ public class BufferBulkAccessTest extends BufferTestSupport {
                 long addr = component.writableNativeAddress();
                 assertThat(addr).isNotZero();
                 component.writableBuffer().putInt(0x01020304);
-                component.skipWritable(4);
+                component.skipWritableBytes(4);
                 assertThat(component.writableBytes()).isEqualTo(4);
                 assertThat(component.writableNativeAddress()).isEqualTo(addr + 4);
                 return true;
@@ -326,11 +326,11 @@ public class BufferBulkAccessTest extends BufferTestSupport {
                 long addr = component.readableNativeAddress();
                 assertThat(addr).isNotZero();
                 assertThat(component.readableBuffer().get()).isEqualTo((byte) 0x01);
-                component.skipReadable(1);
+                component.skipReadableBytes(1);
                 assertThat(component.readableBytes()).isEqualTo(3);
                 assertThat(component.readableNativeAddress()).isEqualTo(addr + 1);
                 assertThat(component.readableBuffer().get()).isEqualTo((byte) 0x02);
-                component.skipReadable(1);
+                component.skipReadableBytes(1);
                 return true;
             });
 

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferComponentIterationTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferComponentIterationTest.java
@@ -719,9 +719,9 @@ public class BufferComponentIterationTest extends BufferTestSupport {
                     byte value = byteBuffer.get();
                     byteBuffer.clear();
                     target.writeByte(value);
-                    assertThrows(IndexOutOfBoundsException.class, () -> component.skipReadable(9));
-                    component.skipReadable(0);
-                    component.skipReadable(1);
+                    assertThrows(IndexOutOfBoundsException.class, () -> component.skipReadableBytes(9));
+                    component.skipReadableBytes(0);
+                    component.skipReadableBytes(1);
                 }
                 return target.writableBytes() > 0;
             });
@@ -749,9 +749,9 @@ public class BufferComponentIterationTest extends BufferTestSupport {
                         byteBuffer.clear();
                         target.writeByte(value);
                         var cmp = component; // Capture for lambda.
-                        assertThrows(IndexOutOfBoundsException.class, () -> cmp.skipReadable(9));
-                        component.skipReadable(0);
-                        component.skipReadable(1);
+                        assertThrows(IndexOutOfBoundsException.class, () -> cmp.skipReadableBytes(9));
+                        component.skipReadableBytes(0);
+                        component.skipReadableBytes(1);
                     }
                 }
             }
@@ -776,9 +776,9 @@ public class BufferComponentIterationTest extends BufferTestSupport {
                     byte value = byteBuffer.get();
                     byteBuffer.clear();
                     assertThat(value).isEqualTo(target.readByte());
-                    assertThrows(IndexOutOfBoundsException.class, () -> component.skipWritable(9));
-                    component.skipWritable(0);
-                    component.skipWritable(1);
+                    assertThrows(IndexOutOfBoundsException.class, () -> component.skipWritableBytes(9));
+                    component.skipWritableBytes(0);
+                    component.skipWritableBytes(1);
                 }
                 return true;
             });
@@ -805,9 +805,9 @@ public class BufferComponentIterationTest extends BufferTestSupport {
                         byteBuffer.clear();
                         assertThat(value).isEqualTo(target.readByte());
                         var cmp = component; // Capture for lambda.
-                        assertThrows(IndexOutOfBoundsException.class, () -> cmp.skipWritable(9));
-                        component.skipWritable(0);
-                        component.skipWritable(1);
+                        assertThrows(IndexOutOfBoundsException.class, () -> cmp.skipWritableBytes(9));
+                        component.skipWritableBytes(0);
+                        component.skipWritableBytes(1);
                     }
                 }
             }
@@ -826,14 +826,14 @@ public class BufferComponentIterationTest extends BufferTestSupport {
             buf.writeLong(0x0102030405060708L);
             assertThat(buf.readInt()).isEqualTo(0x01020304);
             buf.forEachReadable(0, (index, component) -> {
-                assertThrows(IllegalArgumentException.class, () -> component.skipReadable(-1));
+                assertThrows(IllegalArgumentException.class, () -> component.skipReadableBytes(-1));
                 return true;
             });
 
             try (var iterator = buf.forEachReadable()) {
                 for (var component = iterator.first(); component != null; component = component.next()) {
                     var cmp = component; // Capture for lambda.
-                    assertThrows(IllegalArgumentException.class, () -> cmp.skipReadable(-1));
+                    assertThrows(IllegalArgumentException.class, () -> cmp.skipReadableBytes(-1));
                 }
             }
         }
@@ -845,14 +845,14 @@ public class BufferComponentIterationTest extends BufferTestSupport {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             buf.forEachWritable(0, (index, component) -> {
-                assertThrows(IllegalArgumentException.class, () -> component.skipWritable(-1));
+                assertThrows(IllegalArgumentException.class, () -> component.skipWritableBytes(-1));
                 return true;
             });
 
             try (var iterator = buf.forEachWritable()) {
                 for (var component = iterator.first(); component != null; component = component.next()) {
                     var cmp = component; // Capture for lambda.
-                    assertThrows(IllegalArgumentException.class, () -> cmp.skipWritable(-1));
+                    assertThrows(IllegalArgumentException.class, () -> cmp.skipWritableBytes(-1));
                 }
             }
         }

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferEqualsTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferEqualsTest.java
@@ -62,7 +62,7 @@ public class BufferEqualsTest extends BufferTestSupport {
              Buffer buf2 = allocator.allocate(data2.length)) {
             buf1.writeBytes(data1);
             buf2.writeBytes(data2);
-            buf2.skipReadable(3);
+            buf2.skipReadableBytes(3);
             buf2.writerOffset(buf2.writerOffset() - 5);
 
             Assertions.assertEquals(buf1, buf2);

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferOffsetsTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferOffsetsTest.java
@@ -190,7 +190,7 @@ public class BufferOffsetsTest extends BufferTestSupport {
                 buf.readByte();
             }
 
-            buf.skipReadable(8);
+            buf.skipReadableBytes(8);
             assertEquals(8 + 8, buf.readerOffset());
         }
     }
@@ -202,7 +202,7 @@ public class BufferOffsetsTest extends BufferTestSupport {
              Buffer buf = allocator.allocate(8)) {
             buf.writeLong(1);
             buf.readInt();
-            assertThrows(IllegalArgumentException.class, () -> buf.skipReadable(-1));
+            assertThrows(IllegalArgumentException.class, () -> buf.skipReadableBytes(-1));
         }
     }
 
@@ -213,7 +213,7 @@ public class BufferOffsetsTest extends BufferTestSupport {
              Buffer buf = allocator.allocate(32)) {
             writeRandomBytes(buf, 16);
 
-            buf.skipWritable(8);
+            buf.skipWritableBytes(8);
             assertEquals(16 + 8, buf.writerOffset());
         }
     }
@@ -224,7 +224,7 @@ public class BufferOffsetsTest extends BufferTestSupport {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             buf.writeInt(1);
-            assertThrows(IllegalArgumentException.class, () -> buf.skipWritable(-1));
+            assertThrows(IllegalArgumentException.class, () -> buf.skipWritableBytes(-1));
         }
     }
 }

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferSearchTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferSearchTest.java
@@ -68,7 +68,7 @@ public class BufferSearchTest extends BufferTestSupport {
             fillBuffer(buf);
             byte needle = (byte) 0xA5;
             buf.setByte(3, needle);
-            buf.skipReadable(3);
+            buf.skipReadableBytes(3);
             assertThat(buf.bytesBefore(needle))
                     .as("bytesBefore(%X) should be 0", needle)
                     .isEqualTo(0);
@@ -83,7 +83,7 @@ public class BufferSearchTest extends BufferTestSupport {
              Buffer needle = allocator.allocate(3).writeMedium(0xA5A5A5)) {
             fillBuffer(buf);
             buf.setMedium(3, needle.getMedium(0));
-            buf.skipReadable(3);
+            buf.skipReadableBytes(3);
             assertThat(buf.bytesBefore(needle))
                     .as("bytesBefore(Buffer(%X)) should be 0", needle.getMedium(0))
                     .isEqualTo(0);
@@ -98,7 +98,7 @@ public class BufferSearchTest extends BufferTestSupport {
             fillBuffer(buf);
             byte needle = (byte) 0xA5;
             buf.setByte(3, needle);
-            buf.skipReadable(2);
+            buf.skipReadableBytes(2);
             assertThat(buf.bytesBefore(needle))
                     .as("bytesBefore(%X) should be 0", needle)
                     .isEqualTo(1);
@@ -113,7 +113,7 @@ public class BufferSearchTest extends BufferTestSupport {
              Buffer needle = allocator.allocate(3).writeMedium(0xA5A5A5)) {
             fillBuffer(buf);
             buf.setMedium(3, needle.getMedium(0));
-            buf.skipReadable(2);
+            buf.skipReadableBytes(2);
             assertThat(buf.bytesBefore(needle))
                     .as("bytesBefore(Buffer(%X)) should be 0", needle.getMedium(0))
                     .isEqualTo(1);
@@ -134,7 +134,7 @@ public class BufferSearchTest extends BufferTestSupport {
                         .as("bytesBefore(%X)", needle)
                         .isEqualTo(offset);
                 offset--;
-                buf.skipReadable(1);
+                buf.skipReadableBytes(1);
             }
         }
     }
@@ -153,7 +153,7 @@ public class BufferSearchTest extends BufferTestSupport {
                         .as("bytesBefore(Buffer(%X))", needle.getMedium(0))
                         .isEqualTo(offset);
                 offset--;
-                buf.skipReadable(1);
+                buf.skipReadableBytes(1);
             }
         }
     }
@@ -172,7 +172,7 @@ public class BufferSearchTest extends BufferTestSupport {
                         .as("bytesBefore(%X)", needle)
                         .isEqualTo(offset);
                 offset--;
-                buf.skipReadable(1);
+                buf.skipReadableBytes(1);
             }
         }
     }
@@ -191,7 +191,7 @@ public class BufferSearchTest extends BufferTestSupport {
                         .as("bytesBefore(Buffer(%X))", needle.getMedium(0))
                         .isEqualTo(offset);
                 offset--;
-                buf.skipReadable(1);
+                buf.skipReadableBytes(1);
             }
         }
     }
@@ -211,7 +211,7 @@ public class BufferSearchTest extends BufferTestSupport {
                 assertThat(buf.bytesBefore(needle))
                         .as("bytesBefore(%X)", needle)
                         .isEqualTo(-1);
-                buf.skipReadable(1);
+                buf.skipReadableBytes(1);
             }
         }
     }
@@ -231,7 +231,7 @@ public class BufferSearchTest extends BufferTestSupport {
                 assertThat(buf.bytesBefore(needle))
                         .as("bytesBefore(Buffer(%X))", needle.getMedium(0))
                         .isEqualTo(-1);
-                buf.skipReadable(1);
+                buf.skipReadableBytes(1);
             }
         }
     }

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/DefaultDnsRecordEncoder.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/DefaultDnsRecordEncoder.java
@@ -140,7 +140,7 @@ public class DefaultDnsRecordEncoder implements DnsRecordEncoder {
         out.ensureWritable(2 + contentLen);
         out.writeShort((short) contentLen);
         content.copyInto(content.readerOffset(), out, out.writerOffset(), contentLen);
-        out.skipWritable(contentLen);
+        out.skipWritableBytes(contentLen);
     }
 
     protected void encodeName(String name, Buffer buf) throws Exception {

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/TcpDnsQueryEncoder.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/TcpDnsQueryEncoder.java
@@ -46,7 +46,7 @@ public final class TcpDnsQueryEncoder extends MessageToByteEncoderForBuffer<DnsQ
         // Length is two octets as defined by RFC-7766
         // See https://tools.ietf.org/html/rfc7766#section-8
         int initialOffset = out.writerOffset();
-        out.skipWritable(2);
+        out.skipWritableBytes(2);
         encoder.encode(msg, out);
 
         // Now fill in the correct length based on the amount of data that we wrote the ByteBuf.

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/TcpDnsResponseEncoder.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/TcpDnsResponseEncoder.java
@@ -48,7 +48,7 @@ public final class TcpDnsResponseEncoder extends MessageToMessageEncoder<DnsResp
     protected void encode(ChannelHandlerContext ctx, DnsResponse response, List<Object> out) throws Exception {
         Buffer buf = ctx.bufferAllocator().allocate(1024);
 
-        buf.skipWritable(2);
+        buf.skipWritableBytes(2);
         DnsMessageUtil.encodeDnsResponse(encoder, response, buf);
         buf.setShort(0, (short) (buf.readableBytes() - 2));
 

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/HttpObjectDecoder.java
@@ -371,9 +371,9 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoderForBuffer {
             int bytesToSkip = buffer.bytesBefore(HttpConstants.LF) + 1;
             if (bytesToSkip > 0) {
                 currentState = State.READ_CHUNK_SIZE;
-                buffer.skipReadable(bytesToSkip);
+                buffer.skipReadableBytes(bytesToSkip);
             } else {
-                buffer.skipReadable(buffer.readableBytes());
+                buffer.skipReadableBytes(buffer.readableBytes());
             }
             return;
         }
@@ -391,7 +391,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoderForBuffer {
         }
         case BAD_MESSAGE: {
             // Keep discarding until disconnection.
-            buffer.skipReadable(buffer.readableBytes());
+            buffer.skipReadableBytes(buffer.readableBytes());
             break;
         }
         case UPGRADED: {
@@ -539,7 +539,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoderForBuffer {
 
         // Advance the readerIndex so that ByteToMessageDecoder does not complain
         // when we produced an invalid message without consuming anything.
-        in.skipReadable(in.readableBytes());
+        in.skipReadableBytes(in.readableBytes());
 
         if (message == null) {
             message = createInvalidMessage(ctx);
@@ -556,7 +556,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoderForBuffer {
 
         // Advance the readerIndex so that ByteToMessageDecoder does not complain
         // when we produced an invalid message without consuming anything.
-        in.skipReadable(in.readableBytes());
+        in.skipReadableBytes(in.readableBytes());
 
         HttpContent<?> chunk = new DefaultLastHttpContent(allocator.allocate(0));
         chunk.setDecoderResult(DecoderResult.failure(cause));
@@ -889,7 +889,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoderForBuffer {
                 size = oldSize;
                 return null;
             }
-            buffer.skipReadable(i + 1);
+            buffer.skipReadableBytes(i + 1);
             return seq;
         }
 

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/CloseWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/CloseWebSocketFrame.java
@@ -147,7 +147,7 @@ public class CloseWebSocketFrame extends WebSocketFrame {
 
         int base = binaryData.readerOffset();
         try {
-            binaryData.skipReadable(2);
+            binaryData.skipReadableBytes(2);
             return binaryData.toString(CharsetUtil.UTF_8);
         } finally {
             binaryData.readerOffset(base);

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocket13FrameDecoder.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocket13FrameDecoder.java
@@ -151,7 +151,7 @@ public class WebSocket13FrameDecoder extends ByteToMessageDecoderForBuffer imple
     protected void decode(ChannelHandlerContext ctx, Buffer in) throws Exception {
         // Discard all data received if closing handshake was received before.
         if (receivedClosingHandshake) {
-            in.skipReadable(actualReadableBytes());
+            in.skipReadableBytes(actualReadableBytes());
             return;
         }
 
@@ -424,7 +424,7 @@ public class WebSocket13FrameDecoder extends ByteToMessageDecoderForBuffer imple
         if (readableBytes > 0) {
             // Fix for memory leak, caused by ByteToMessageDecoder#channelRead:
             // buffer 'cumulation' is released ONLY when no more readable bytes available.
-            in.skipReadable(readableBytes);
+            in.skipReadableBytes(readableBytes);
         }
         if (ctx.channel().isActive() && config.closeOnProtocolViolation()) {
             Object closeMessage;

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpContentDecoderTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpContentDecoderTest.java
@@ -811,7 +811,7 @@ public class HttpContentDecoderTest {
                 Buffer b = ((HttpContent<?>) o).payload();
                 int readableBytes = b.readableBytes();
                 b.copyInto(b.readerOffset(), receivedContent, readCount, readableBytes);
-                b.skipReadable(readableBytes);
+                b.skipReadableBytes(readableBytes);
                 readCount += readableBytes;
             }
             if (o instanceof HttpMessage) {
@@ -853,7 +853,7 @@ public class HttpContentDecoderTest {
         for (Buffer b : outbound) {
             int readableBytes = b.readableBytes();
             b.copyInto(b.readerOffset(), output, readCount, readableBytes);
-            b.skipReadable(readableBytes);
+            b.skipReadableBytes(readableBytes);
             b.close();
             readCount += readableBytes;
         }

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpContentEncoderTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpContentEncoderTest.java
@@ -58,7 +58,7 @@ public class HttpContentEncoderTest {
                 @Override
                 public Buffer compress(Buffer input, BufferAllocator allocator) throws CompressionException {
                     Buffer out = allocator.copyOf(String.valueOf(input.readableBytes()), CharsetUtil.US_ASCII);
-                    input.skipReadable(input.readableBytes());
+                    input.skipReadableBytes(input.readableBytes());
                     return out;
                 }
 

--- a/codec/src/main/java/io/netty5/handler/codec/DelimiterBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty5/handler/codec/DelimiterBasedFrameDecoder.java
@@ -222,7 +222,7 @@ public class DelimiterBasedFrameDecoder extends ByteToMessageDecoderForBuffer {
                 // We've just finished discarding a very large frame.
                 // Go back to the initial state.
                 discardingTooLongFrame = false;
-                buffer.skipReadable(minFrameLength + minDelimLength);
+                buffer.skipReadableBytes(minFrameLength + minDelimLength);
 
                 int tooLongFrameLength = this.tooLongFrameLength;
                 this.tooLongFrameLength = 0;
@@ -234,14 +234,14 @@ public class DelimiterBasedFrameDecoder extends ByteToMessageDecoderForBuffer {
 
             if (minFrameLength > maxFrameLength) {
                 // Discard read frame.
-                buffer.skipReadable(minFrameLength + minDelimLength);
+                buffer.skipReadableBytes(minFrameLength + minDelimLength);
                 fail(minFrameLength);
                 return null;
             }
 
             if (stripDelimiter) {
                 frame = buffer.readSplit(minFrameLength);
-                buffer.skipReadable(minDelimLength);
+                buffer.skipReadableBytes(minDelimLength);
             } else {
                 frame = buffer.readSplit(minFrameLength + minDelimLength);
             }
@@ -252,7 +252,7 @@ public class DelimiterBasedFrameDecoder extends ByteToMessageDecoderForBuffer {
                 if (buffer.readableBytes() > maxFrameLength) {
                     // Discard the content of the buffer until a delimiter is found.
                     tooLongFrameLength = buffer.readableBytes();
-                    buffer.skipReadable(buffer.readableBytes());
+                    buffer.skipReadableBytes(buffer.readableBytes());
                     discardingTooLongFrame = true;
                     if (failFast) {
                         fail(tooLongFrameLength);
@@ -261,7 +261,7 @@ public class DelimiterBasedFrameDecoder extends ByteToMessageDecoderForBuffer {
             } else {
                 // Still discarding the buffer since a delimiter is not found.
                 tooLongFrameLength += buffer.readableBytes();
-                buffer.skipReadable(buffer.readableBytes());
+                buffer.skipReadableBytes(buffer.readableBytes());
             }
             return null;
         }

--- a/codec/src/main/java/io/netty5/handler/codec/LengthFieldBasedFrameDecoderForBuffer.java
+++ b/codec/src/main/java/io/netty5/handler/codec/LengthFieldBasedFrameDecoderForBuffer.java
@@ -310,7 +310,7 @@ public class LengthFieldBasedFrameDecoderForBuffer extends ByteToMessageDecoderF
 
     private void discardTooLongFrame(Buffer in) {
         final int bytesToDiscardNow = (int) Math.min(bytesToDiscard, in.readableBytes());
-        in.skipReadable(bytesToDiscardNow);
+        in.skipReadableBytes(bytesToDiscardNow);
 
         bytesToDiscard -= bytesToDiscardNow;
 
@@ -318,13 +318,13 @@ public class LengthFieldBasedFrameDecoderForBuffer extends ByteToMessageDecoderF
     }
 
     private static void failOnNegativeLengthField(Buffer buffer, long frameLength, int lengthFieldEndOffset) {
-        buffer.skipReadable(lengthFieldEndOffset);
+        buffer.skipReadableBytes(lengthFieldEndOffset);
         throw new CorruptedFrameException("negative pre-adjustment length field: " + frameLength);
     }
 
     private static void failOnFrameLengthLessThanLengthFieldEndOffset(
             Buffer buffer, long frameLength, int lengthFieldEndOffset) {
-        buffer.skipReadable(lengthFieldEndOffset);
+        buffer.skipReadableBytes(lengthFieldEndOffset);
         throw new CorruptedFrameException(
                 "Adjusted frame length (" + frameLength + ") is less " +
                 "than lengthFieldEndOffset: " + lengthFieldEndOffset);
@@ -336,18 +336,18 @@ public class LengthFieldBasedFrameDecoderForBuffer extends ByteToMessageDecoderF
 
         if (discard < 0) {
             // buffer contains more bytes then the frameLength so we can discard all now
-            buffer.skipReadable((int) frameLength);
+            buffer.skipReadableBytes((int) frameLength);
         } else {
             // Enter the discard mode and discard everything received so far.
             bytesToDiscard = discard;
-            buffer.skipReadable(buffer.readableBytes());
+            buffer.skipReadableBytes(buffer.readableBytes());
         }
         failOnLengthExceededIfNecessary(true);
     }
 
     private static void failOnFrameLengthLessThanInitialBytesToStrip(
             Buffer buffer, int frameLength, int initialBytesToStrip) {
-        buffer.skipReadable(frameLength);
+        buffer.skipReadableBytes(frameLength);
         throw new CorruptedFrameException(
                 "Adjusted frame length (" + frameLength + ") is less " +
                 "than initialBytesToStrip: " + initialBytesToStrip);
@@ -400,7 +400,7 @@ public class LengthFieldBasedFrameDecoderForBuffer extends ByteToMessageDecoderF
             failOnFrameLengthLessThanInitialBytesToStrip(buffer, currentFrameLength, initialBytesToStrip);
         }
 
-        buffer.skipReadable(initialBytesToStrip);
+        buffer.skipReadableBytes(initialBytesToStrip);
 
         // extract frame
         final Buffer frame = extractFrame(ctx, buffer, currentFrameLength - initialBytesToStrip);

--- a/codec/src/main/java/io/netty5/handler/codec/LineBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty5/handler/codec/LineBasedFrameDecoder.java
@@ -109,7 +109,7 @@ public class LineBasedFrameDecoder extends ByteToMessageDecoderForBuffer {
 
                 if (stripDelimiter) {
                     frame = buffer.readSplit(length);
-                    buffer.skipReadable(delimLength);
+                    buffer.skipReadableBytes(delimLength);
                 } else {
                     frame = buffer.readSplit(length + delimLength);
                 }

--- a/codec/src/main/java/io/netty5/handler/codec/compression/Bzip2Compressor.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/Bzip2Compressor.java
@@ -146,7 +146,7 @@ public final class Bzip2Compressor implements Compressor {
                     Bzip2BlockCompressor blockCompressor = this.blockCompressor;
                     final int length = Math.min(in.readableBytes(), blockCompressor.availableSize());
                     final int bytesWritten = blockCompressor.write(in, in.readerOffset(), length);
-                    in.skipReadable(bytesWritten);
+                    in.skipReadableBytes(bytesWritten);
                     if (!blockCompressor.isFull()) {
                         if (in.readableBytes() > 0) {
                             break;

--- a/codec/src/main/java/io/netty5/handler/codec/compression/DecompressionHandler.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/DecompressionHandler.java
@@ -78,7 +78,7 @@ public final class DecompressionHandler extends ByteToMessageDecoderForBuffer {
         }
         assert decompressor.isFinished();
         if (discardBytesAfterFinished) {
-            in.skipReadable(in.readableBytes());
+            in.skipReadableBytes(in.readableBytes());
         } else {
             ctx.fireChannelRead(in.split());
         }

--- a/codec/src/main/java/io/netty5/handler/codec/compression/FastLzCompressor.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/FastLzCompressor.java
@@ -211,7 +211,7 @@ public final class FastLzCompressor implements Compressor {
             out.setByte(outputIdx + OPTIONS_OFFSET,
                     (byte) (blockType | (checksum != null ? BLOCK_WITH_CHECKSUM : BLOCK_WITHOUT_CHECKSUM)));
             out.writerOffset(outputOffset + 2 + chunkLength);
-            in.skipReadable(length);
+            in.skipReadableBytes(length);
         }
     }
 

--- a/codec/src/main/java/io/netty5/handler/codec/compression/FastLzDecompressor.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/FastLzDecompressor.java
@@ -172,8 +172,8 @@ public final class FastLzDecompressor implements Decompressor {
                                     "stream corrupted: originalLength(%d) and actual length(%d) mismatch",
                                     originalLength, decompressedBytes));
                         }
-                        output.skipWritable(decompressedBytes);
-                        in.skipReadable(chunkLength);
+                        output.skipWritableBytes(decompressedBytes);
+                        in.skipReadableBytes(chunkLength);
                     } else {
                         output = in.readSplit(chunkLength);
                     }

--- a/codec/src/main/java/io/netty5/handler/codec/compression/Lz4Compressor.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/Lz4Compressor.java
@@ -254,7 +254,7 @@ public final class Lz4Compressor implements Compressor {
                 footer.setInt(idx + DECOMPRESSED_LENGTH_OFFSET, 0);
                 footer.setInt(idx + CHECKSUM_OFFSET, 0);
 
-                footer.skipWritable(HEADER_LENGTH);
+                footer.skipWritableBytes(HEADER_LENGTH);
                 return footer;
             default:
                 throw new IllegalStateException();
@@ -293,7 +293,7 @@ public final class Lz4Compressor implements Compressor {
         final int idx = out.writerOffset();
         int compressedLength = 0;
         try {
-            out.skipWritable(HEADER_LENGTH);
+            out.skipWritableBytes(HEADER_LENGTH);
             assert out.countWritableComponents() == 1;
             int readable = flushableBytes;
 

--- a/codec/src/main/java/io/netty5/handler/codec/compression/Lz4Decompressor.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/Lz4Decompressor.java
@@ -271,15 +271,15 @@ public final class Lz4Decompressor implements Decompressor {
                                     try (Buffer inBuffer = allocator.allocate(compressedLength)) {
                                         in.copyInto(in.readerOffset(), inBuffer,
                                                 inBuffer.writerOffset(), compressedLength);
-                                        inBuffer.skipWritable(compressedLength);
+                                        inBuffer.skipWritableBytes(compressedLength);
                                         decompress(inBuffer, uncompressed);
                                     }
                                 } else {
                                     decompress(in, uncompressed);
                                 }
-                                in.skipReadable(compressedLength);
+                                in.skipReadableBytes(compressedLength);
                                 // Update the writerIndex now to reflect what we decompressed.
-                                uncompressed.skipWritable(decompressedLength);
+                                uncompressed.skipWritableBytes(decompressedLength);
                                 break;
                             default:
                                 streamCorrupted(String.format(

--- a/codec/src/main/java/io/netty5/handler/codec/compression/LzfCompressor.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/LzfCompressor.java
@@ -213,7 +213,7 @@ public final class LzfCompressor implements Compressor {
                             outputLength = encodeNonCompress(input, inputPtr, length, output, 0);
                         }
 
-                        readableComponent.skipReadable(length);
+                        readableComponent.skipReadableBytes(length);
 
                         if (!readableComponent.hasReadableArray()) {
                             recycler.releaseInputBuffer(input);

--- a/codec/src/main/java/io/netty5/handler/codec/compression/LzfDecompressor.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/LzfDecompressor.java
@@ -208,7 +208,7 @@ public final class LzfDecompressor implements Decompressor {
                                     int inPos = readableComponent.readableArrayOffset();
                                     try {
                                         Buffer out = decompress(allocator, inputArray, inPos, originalLength);
-                                        in.skipReadable(chunkLength);
+                                        in.skipReadableBytes(chunkLength);
                                         currentState = State.INIT_BLOCK;
                                         return out;
                                     } finally {
@@ -224,7 +224,7 @@ public final class LzfDecompressor implements Decompressor {
                         in.copyInto(idx, inputArray, 0, chunkLength);
                         try {
                             Buffer out = decompress(allocator, inputArray, 0, originalLength);
-                            in.skipReadable(chunkLength);
+                            in.skipReadableBytes(chunkLength);
                             currentState = State.INIT_BLOCK;
                             return out;
                         } finally {

--- a/codec/src/main/java/io/netty5/handler/codec/compression/Snappy.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/Snappy.java
@@ -235,8 +235,8 @@ public final class Snappy {
 
         out.ensureWritable(length);
         in.copyInto(in.readerOffset(), out, out.writerOffset(), length);
-        in.skipReadable(length);
-        out.skipWritable(length);
+        in.skipReadableBytes(length);
+        out.skipWritableBytes(length);
     }
 
     private static void encodeCopyWithOffset(Buffer out, int offset, int length) {
@@ -450,8 +450,8 @@ public final class Snappy {
 
         out.ensureWritable(length);
         in.copyInto(in.readerOffset(), out, out.writerOffset(), length);
-        in.skipReadable(length);
-        out.skipWritable(length);
+        in.skipReadableBytes(length);
+        out.skipWritableBytes(length);
         return length;
     }
 
@@ -499,7 +499,7 @@ public final class Snappy {
     private static void copyRegion(Buffer out, int initialIndex, int offset, int length) {
         out.readerOffset(initialIndex - offset);
         out.copyInto(out.readerOffset(), out, out.writerOffset(), length);
-        out.skipWritable(length).skipReadable(length);
+        out.skipWritableBytes(length).skipReadableBytes(length);
     }
 
     /**

--- a/codec/src/main/java/io/netty5/handler/codec/compression/SnappyCompressor.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/SnappyCompressor.java
@@ -163,8 +163,8 @@ public final class SnappyCompressor implements Compressor {
         writeChunkLength(out, dataLength + 4);
         calculateAndWriteChecksum(in, out);
         in.copyInto(in.readerOffset(), out, out.writerOffset(), dataLength);
-        in.skipReadable(dataLength);
-        out.skipWritable(dataLength);
+        in.skipReadableBytes(dataLength);
+        out.skipWritableBytes(dataLength);
     }
 
     private static void setChunkLength(Buffer out, int lengthIdx) {

--- a/codec/src/main/java/io/netty5/handler/codec/compression/SnappyDecompressor.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/SnappyDecompressor.java
@@ -118,7 +118,7 @@ public final class SnappyDecompressor implements Decompressor {
                 if (numBytesToSkip != 0) {
                     // The last chunkType we detected was RESERVED_SKIPPABLE and we still have some bytes to skip.
                     int skipBytes = Math.min(numBytesToSkip, in.readableBytes());
-                    in.skipReadable(skipBytes);
+                    in.skipReadableBytes(skipBytes);
                     numBytesToSkip -= skipBytes;
 
                     // Let's return and try again.
@@ -147,9 +147,9 @@ public final class SnappyDecompressor implements Decompressor {
                             return null;
                         }
 
-                        in.skipReadable(4);
+                        in.skipReadableBytes(4);
                         int offset = in.readerOffset();
-                        in.skipReadable(SNAPPY_IDENTIFIER_LEN);
+                        in.skipReadableBytes(SNAPPY_IDENTIFIER_LEN);
 
                         checkByte(in.getByte(offset++), (byte) 's');
                         checkByte(in.getByte(offset++), (byte) 'N');
@@ -165,10 +165,10 @@ public final class SnappyDecompressor implements Decompressor {
                             streamCorrupted("Received RESERVED_SKIPPABLE tag before STREAM_IDENTIFIER");
                         }
 
-                        in.skipReadable(4);
+                        in.skipReadableBytes(4);
 
                         int skipBytes = Math.min(chunkLength, in.readableBytes());
-                        in.skipReadable(skipBytes);
+                        in.skipReadableBytes(skipBytes);
                         if (skipBytes != chunkLength) {
                             // We could skip all bytes, let's store the remaining so we can do so once we receive more
                             // data.
@@ -194,7 +194,7 @@ public final class SnappyDecompressor implements Decompressor {
                             return null;
                         }
 
-                        in.skipReadable(4);
+                        in.skipReadableBytes(4);
                         if (validateChecksums) {
                             int checksum = Integer.reverseBytes(in.readInt());
                             try {
@@ -204,7 +204,7 @@ public final class SnappyDecompressor implements Decompressor {
                                 throw e;
                             }
                         } else {
-                            in.skipReadable(4);
+                            in.skipReadableBytes(4);
                         }
                         return in.readSplit(chunkLength - 4);
                     case COMPRESSED_DATA:
@@ -221,7 +221,7 @@ public final class SnappyDecompressor implements Decompressor {
                             return null;
                         }
 
-                        in.skipReadable(4);
+                        in.skipReadableBytes(4);
                         int checksum = Integer.reverseBytes(in.readInt());
 
                         int uncompressedSize = snappy.getPreamble(in);

--- a/codec/src/main/java/io/netty5/handler/codec/compression/ZlibCompressor.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/ZlibCompressor.java
@@ -16,8 +16,6 @@
 package io.netty5.handler.codec.compression;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.Unpooled;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 
@@ -313,7 +311,7 @@ public final class ZlibCompressor implements Compressor {
                         if (numBytes <= 0) {
                             break;
                         }
-                        writableComponent.skipWritable(numBytes);
+                        writableComponent.skipWritableBytes(numBytes);
                     }
                 } else {
                     for (;;) {
@@ -321,7 +319,7 @@ public final class ZlibCompressor implements Compressor {
                         if (numBytes <= 0) {
                             break;
                         }
-                        writableComponent.skipWritable(numBytes);
+                        writableComponent.skipWritableBytes(numBytes);
                     }
                 }
             }

--- a/codec/src/main/java/io/netty5/handler/codec/compression/ZlibDecompressor.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/ZlibDecompressor.java
@@ -276,7 +276,7 @@ public final class ZlibDecompressor implements Decompressor {
                         outputLength = inflater.inflate(buffer);
                     }
                     if (outputLength > 0) {
-                        writableComponent.skipWritable(outputLength);
+                        writableComponent.skipWritableBytes(outputLength);
                         if (crc != null) {
                             crc.update(decompressed, writerIndex, outputLength);
                         }
@@ -301,7 +301,7 @@ public final class ZlibDecompressor implements Decompressor {
             }
 
             int remaining = inflater.getRemaining();
-            in.skipReadable(readableBytes - remaining);
+            in.skipReadableBytes(readableBytes - remaining);
 
             if (readFooter) {
                 gzipState = GzipState.FOOTER_START;
@@ -370,7 +370,7 @@ public final class ZlibDecompressor implements Decompressor {
 
                 // mtime (int)
                 crc.update(in, in.readerOffset(), 4);
-                in.skipReadable(4);
+                in.skipReadableBytes(4);
 
                 crc.update(in.readUnsignedByte()); // extra flags
                 crc.update(in.readUnsignedByte()); // operating system
@@ -397,7 +397,7 @@ public final class ZlibDecompressor implements Decompressor {
                         return false;
                     }
                     crc.update(in, in.readerOffset(), xlen);
-                    in.skipReadable(xlen);
+                    in.skipReadableBytes(xlen);
                 }
                 gzipState = GzipState.SKIP_FNAME;
                 // fall through
@@ -553,7 +553,7 @@ public final class ZlibDecompressor implements Decompressor {
 
         if (buffer.implicitCapacityLimit() < preferredSize) {
             decompressionBufferExhausted(buffer);
-            buffer.skipReadable(buffer.readableBytes());
+            buffer.skipReadableBytes(buffer.readableBytes());
             throw new DecompressionException(
                     "Decompression buffer has reached maximum size: " + buffer.implicitCapacityLimit());
         }

--- a/codec/src/main/java/io/netty5/handler/codec/compression/ZstdCompressor.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/ZstdCompressor.java
@@ -237,8 +237,8 @@ public final class ZstdCompressor implements Compressor {
                                 writableComponent.writableBuffer().put(outArray);
                             }
                         }
-                        writableComponent.skipWritable(compressedLength);
-                        readableComponent.skipReadable(readableComponent.readableBytes());
+                        writableComponent.skipWritableBytes(compressedLength);
+                        readableComponent.skipReadableBytes(readableComponent.readableBytes());
                     }
                 }
             }

--- a/codec/src/test/java/io/netty5/handler/codec/ByteToMessageDecoderForBufferTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/ByteToMessageDecoderForBufferTest.java
@@ -616,8 +616,8 @@ public class ByteToMessageDecoderForBufferTest {
             int valuesSkipped = rng.nextInt(0, valueCapacity / 4);
             int valuesWritten = rng.nextInt(0, valueCapacity - valuesSkipped);
             Buffer buf = allocator.allocate(valueCapacity * Integer.BYTES);
-            buf.skipWritable(valuesSkipped * Integer.BYTES);
-            buf.skipReadable(valuesSkipped * Integer.BYTES);
+            buf.skipWritableBytes(valuesSkipped * Integer.BYTES);
+            buf.skipReadableBytes(valuesSkipped * Integer.BYTES);
             for (int i = 0; i < valuesWritten; i++) {
                 buf.writeInt(++sendCounter);
             }

--- a/handler/src/main/java/io/netty5/handler/ssl/EngineWrapper.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/EngineWrapper.java
@@ -185,7 +185,7 @@ class EngineWrapper implements ReadableComponentProcessor<RuntimeException>,
     private void finish(Buffer in, Buffer out) {
         if (result != null) { // Result can be null if the operation failed.
             if (in != null) {
-                in.skipReadable(result.bytesConsumed());
+                in.skipReadableBytes(result.bytesConsumed());
             }
             if (out != null) {
                 if (writeBack) {
@@ -204,7 +204,7 @@ class EngineWrapper implements ReadableComponentProcessor<RuntimeException>,
                         out.writeByte(buf.get());
                     }
                 } else {
-                    out.skipWritable(result.bytesProduced());
+                    out.skipWritableBytes(result.bytesProduced());
                 }
             }
             result = null;

--- a/handler/src/main/java/io/netty5/handler/ssl/PemX509Certificate.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/PemX509Certificate.java
@@ -115,7 +115,7 @@ public final class PemX509Certificate extends X509Certificate implements PemEnco
         }
 
         int length = content.readableBytes();
-        pem.skipWritable(length);
+        pem.skipWritableBytes(length);
         content.copyInto(content.readerOffset(), pem, pem.writerOffset(), length);
         return pem;
     }

--- a/handler/src/main/java/io/netty5/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -925,7 +925,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
         int readableBytes = content.readableBytes();
         try (Buffer buffer = allocator.allocate(readableBytes)) {
             content.copyInto(content.readerOffset(), buffer, 0, readableBytes);
-            buffer.skipWritable(readableBytes);
+            buffer.skipWritableBytes(readableBytes);
             return newBIO(buffer);
         }
     }

--- a/handler/src/main/java/io/netty5/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -951,7 +951,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine
                     dst.position(dst.position() + bytesProduced);
                 } else {
                     try (bioReadCopyBuf) {
-                        bioReadCopyBuf.skipWritable(bytesProduced);
+                        bioReadCopyBuf.skipWritableBytes(bytesProduced);
                         assert bioReadCopyBuf.readableBytes() <= dst.remaining() :
                                 "The destination buffer " + dst + " didn't have enough remaining space to hold the " +
                                 "encrypted content in " + bioReadCopyBuf;

--- a/handler/src/main/java/io/netty5/handler/ssl/SslClientHelloHandler.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslClientHelloHandler.java
@@ -64,7 +64,7 @@ public abstract class SslClientHelloHandler<T> extends ByteToMessageDecoderForBu
                                 handshakeFailed = true;
                                 NotSslRecordException e = new NotSslRecordException(
                                         "not an SSL/TLS record: " + BufferUtil.hexDump(in));
-                                in.skipReadable(in.readableBytes());
+                                in.skipReadableBytes(in.readableBytes());
                                 ctx.fireUserEventTriggered(new SniCompletionEvent(e));
                                 ctx.fireUserEventTriggered(new SslHandshakeCompletionEvent(e));
                                 throw e;
@@ -141,7 +141,7 @@ public abstract class SslClientHelloHandler<T> extends ByteToMessageDecoderForBu
                                 int hsLen = packetLength - SslUtils.SSL_RECORD_HEADER_LENGTH;
                                 in.copyInto(readerIndex + SslUtils.SSL_RECORD_HEADER_LENGTH,
                                             handshakeBuffer, handshakeBuffer.writerOffset(), hsLen);
-                                handshakeBuffer.skipWritable(hsLen);
+                                handshakeBuffer.skipWritableBytes(hsLen);
                                 readerIndex += packetLength;
                                 readableBytes -= packetLength;
                                 if (handshakeLength <= handshakeBuffer.readableBytes()) {

--- a/handler/src/main/java/io/netty5/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslHandler.java
@@ -1048,7 +1048,7 @@ public class SslHandler extends ByteToMessageDecoderForBuffer {
                 // Not an SSL/TLS packet
                 NotSslRecordException e = new NotSslRecordException(
                         "not an SSL/TLS record: " + BufferUtil.hexDump(in));
-                in.skipReadable(in.readableBytes());
+                in.skipReadableBytes(in.readableBytes());
 
                 // First fail the handshake promise as we may need to have access to the SSLEngine which may
                 // be released because the user will remove the SslHandler in an exceptionCaught(...) implementation.

--- a/handler/src/test/java/io/netty5/handler/ssl/ParameterizedSslHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/ParameterizedSslHandlerTest.java
@@ -177,7 +177,7 @@ public class ParameterizedSslHandlerTest {
                                             List<Send<Buffer>> components = new ArrayList<>(numComponents);
                                             for (int i = 0; i < numComponents; ++i) {
                                                 Buffer buf = ctx.bufferAllocator().allocate(singleComponentSize);
-                                                buf.skipWritable(singleComponentSize);
+                                                buf.skipWritableBytes(singleComponentSize);
                                                 components.add(buf.send());
                                             }
                                             CompositeBuffer content = ctx.bufferAllocator().compose(components);

--- a/handler/src/test/java/io/netty5/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SslHandlerTest.java
@@ -617,7 +617,7 @@ public class SslHandlerTest {
                               logger.debug("[testHandshakeFailBeforeWritePromise] server channel active");
                               Buffer buf = ctx.bufferAllocator().allocate(10);
                               buf.fill((byte) 0);
-                              buf.skipWritable(buf.capacity());
+                              buf.skipWritableBytes(buf.capacity());
                               ctx.writeAndFlush(buf).addListener(future -> {
                                   logger.debug("[testHandshakeFailBeforeWritePromise] " +
                                                "server write and flush completed: " + future);
@@ -651,7 +651,7 @@ public class SslHandlerTest {
                               logger.debug("[testHandshakeFailBeforeWritePromise] client channel active");
                               Buffer buf = ctx.bufferAllocator().allocate(1000);
                               buf.fill((byte) 0);
-                              buf.skipWritable(buf.capacity());
+                              buf.skipWritableBytes(buf.capacity());
                               ctx.writeAndFlush(buf).addListener(future -> {
                                   logger.debug("[testHandshakeFailBeforeWritePromise] " +
                                                "client write and flush completed");
@@ -752,7 +752,7 @@ public class SslHandlerTest {
             firstBuffer.writeByte((byte) 0);
             firstBuffer = firstBuffer.makeReadOnly();
             Buffer secondBuffer = offHeapAllocator().allocate(10);
-            secondBuffer.skipWritable(secondBuffer.capacity());
+            secondBuffer.skipWritableBytes(secondBuffer.capacity());
             cc.write(firstBuffer);
             cc.writeAndFlush(secondBuffer).syncUninterruptibly();
             serverReceiveLatch.countDown();

--- a/microbench/src/main/java/io/netty5/microbench/buffer/BufferBytesBeforeBenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/buffer/BufferBytesBeforeBenchmark.java
@@ -99,7 +99,7 @@ public class BufferBytesBeforeBenchmark extends AbstractMicrobenchmark {
         }
         for (int i = 0; i < permutations; ++i) {
             data[i] = allocator.allocate(size);
-            data[i].skipWritable(size);
+            data[i].skipWritableBytes(size);
             for (int j = 0; j < size; j++) {
                 int value = random.nextInt(Byte.MIN_VALUE, Byte.MAX_VALUE + 1);
                 // turn any found value into something different

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConditionalWritabilityTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConditionalWritabilityTest.java
@@ -81,7 +81,7 @@ public class SocketConditionalWritabilityTest extends AbstractSocketTest {
                                 int chunkSize = Math.min(expectedBytes - bytesWritten, maxWriteChunkSize);
                                 bytesWritten += chunkSize;
                                 Buffer buffer = ctx.bufferAllocator().allocate(chunkSize);
-                                buffer.skipWritable(chunkSize);
+                                buffer.skipWritableBytes(chunkSize);
                                 ctx.write(buffer);
                             }
                             ctx.flush();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -390,7 +390,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
             if (bytesRead >= expectedBytes) {
                 // We write a reply and immediately close our end of the socket.
                 Buffer buf = ctx.bufferAllocator().allocate(expectedBytes);
-                buf.skipWritable(expectedBytes);
+                buf.skipWritableBytes(expectedBytes);
                 ctx.writeAndFlush(buf).addListener(ctx.channel(), (c, f) ->
                         c.close().addListener(c, (channel, future) -> {
                             // This is a bit racy but there is no better way how to handle this in Java11.
@@ -430,7 +430,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
         @Override
         public void channelActive(ChannelHandlerContext ctx) throws Exception {
             Buffer buf = ctx.bufferAllocator().allocate(expectedBytes);
-            buf.skipWritable(expectedBytes);
+            buf.skipWritableBytes(expectedBytes);
             Buffer msg = buf.copy();
             ctx.writeAndFlush(buf);
 

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
@@ -325,7 +325,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
             int localReadAmount = socket.readAddress(address, 0, component.writableBytes());
             unsafe().recvBufAllocHandle().lastBytesRead(localReadAmount);
             if (localReadAmount > 0) {
-                component.skipWritable(localReadAmount);
+                component.skipWritableBytes(localReadAmount);
             }
             return false;
         });
@@ -338,7 +338,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
             assert address != 0;
             int written = socket.writeAddress(address, 0, component.readableBytes());
             if (written > 0) {
-                component.skipReadable(written);
+                component.skipReadableBytes(written);
             }
             return false;
         });

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDatagramChannel.java
@@ -546,7 +546,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
                 if (bytesRead <= 0) {
                     return false;
                 }
-                component.skipWritable(bytesRead);
+                component.skipWritableBytes(bytesRead);
                 return true;
             });
             final int totalBytesRead = initialWritableBytes - buf.writableBytes();

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDomainDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDomainDatagramChannel.java
@@ -198,7 +198,7 @@ public final class EpollDomainDatagramChannel extends AbstractEpollChannel imple
         if (remoteAddress == null) {
             data.forEachReadable(0, (index, component) -> {
                 int written = socket.writeAddress(component.readableNativeAddress(), 0, component.readableBytes());
-                component.skipReadable(written);
+                component.skipReadableBytes(written);
                 return false;
             });
         } else {
@@ -206,7 +206,7 @@ public final class EpollDomainDatagramChannel extends AbstractEpollChannel imple
                 int written = socket.sendToAddressDomainSocket(
                         component.readableNativeAddress(), 0, component.readableBytes(),
                         remoteAddress.path().getBytes(UTF_8));
-                component.skipReadable(written);
+                component.skipReadableBytes(written);
                 return false;
             });
         }
@@ -367,7 +367,7 @@ public final class EpollDomainDatagramChannel extends AbstractEpollChannel imple
                             localAddress = (DomainSocketAddress) localAddress();
                         }
                         allocHandle.lastBytesRead(remoteAddress.receivedAmount());
-                        buf.skipWritable(allocHandle.lastBytesRead());
+                        buf.skipWritableBytes(allocHandle.lastBytesRead());
 
                         packet = new DomainDatagramPacket(buf, localAddress, remoteAddress);
                     }

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/NativeDatagramPacketArray.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/NativeDatagramPacketArray.java
@@ -76,7 +76,7 @@ final class NativeDatagramPacketArray {
                 NativeDatagramPacket p = packets[count];
                 p.init(iovArray.memoryAddress(iovArrayStart), iovArray.count() - iovArrayStart, segmentLen, recipient);
                 count++;
-                component.skipWritable(byteCount);
+                component.skipWritableBytes(byteCount);
                 return true;
             }
             return false;
@@ -104,7 +104,7 @@ final class NativeDatagramPacketArray {
                 long packetAddr = iovArray.memoryAddress(iovArrayStart);
                 p.init(packetAddr, iovArray.count() - iovArrayStart, segmentLen, recipient);
                 count++;
-                component.skipReadable(byteCount);
+                component.skipReadableBytes(byteCount);
                 return true;
             }
             return false;

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueChannel.java
@@ -252,7 +252,7 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
             int localReadAmount = socket.readAddress(address, 0, component.writableBytes());
             unsafe().recvBufAllocHandle().lastBytesRead(localReadAmount);
             if (localReadAmount > 0) {
-                component.skipWritable(localReadAmount);
+                component.skipWritableBytes(localReadAmount);
             }
             return localReadAmount;
         }
@@ -265,7 +265,7 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
             assert address != 0;
             int written = socket.writeAddress(address, 0, component.readableBytes());
             if (written > 0) {
-                component.skipReadable(written);
+                component.skipReadableBytes(written);
             }
             return false;
         });

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDatagramChannel.java
@@ -279,14 +279,14 @@ public final class KQueueDatagramChannel extends AbstractKQueueDatagramChannel i
             if (remoteAddress == null) {
                 data.forEachReadable(0, (index, component) -> {
                     int written = socket.writeAddress(component.readableNativeAddress(), 0, component.readableBytes());
-                    component.skipReadable(written);
+                    component.skipReadableBytes(written);
                     return false;
                 });
             } else {
                 data.forEachReadable(0, (index, component) -> {
                     int written = socket.sendToAddress(component.readableNativeAddress(), 0, component.readableBytes(),
                                                             remoteAddress.getAddress(), remoteAddress.getPort());
-                    component.skipReadable(written);
+                    component.skipReadableBytes(written);
                     return false;
                 });
             }
@@ -429,7 +429,7 @@ public final class KQueueDatagramChannel extends AbstractKQueueDatagramChannel i
                                 localAddress = (InetSocketAddress) localAddress();
                             }
                             allocHandle.lastBytesRead(remoteAddress.receivedAmount());
-                            buffer.skipWritable(allocHandle.lastBytesRead());
+                            buffer.skipWritableBytes(allocHandle.lastBytesRead());
 
                             packet = new DatagramPacket(buffer, localAddress, remoteAddress);
                         }

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDomainDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDomainDatagramChannel.java
@@ -152,7 +152,7 @@ public final class KQueueDomainDatagramChannel extends AbstractKQueueDatagramCha
             if (remoteAddress == null) {
                 data.forEachReadable(0, (index, component) -> {
                     int written = socket.writeAddress(component.readableNativeAddress(), 0, component.readableBytes());
-                    component.skipReadable(written);
+                    component.skipReadableBytes(written);
                     return false;
                 });
             } else {
@@ -160,7 +160,7 @@ public final class KQueueDomainDatagramChannel extends AbstractKQueueDatagramCha
                     int written = socket.sendToAddressDomainSocket(
                             component.readableNativeAddress(), 0, component.readableBytes(),
                             remoteAddress.path().getBytes(UTF_8));
-                    component.skipReadable(written);
+                    component.skipReadableBytes(written);
                     return false;
                 });
             }
@@ -316,7 +316,7 @@ public final class KQueueDomainDatagramChannel extends AbstractKQueueDatagramCha
                             localAddress = (DomainSocketAddress) localAddress();
                         }
                         allocHandle.lastBytesRead(remoteAddress.receivedAmount());
-                        buf.skipWritable(allocHandle.lastBytesRead());
+                        buf.skipWritableBytes(allocHandle.lastBytesRead());
 
                         packet = new DomainDatagramPacket(buf, localAddress, remoteAddress);
                     }

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDatagramUnicastTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDatagramUnicastTest.java
@@ -165,13 +165,13 @@ public class EpollDatagramUnicastTest extends DatagramUnicastInetTest {
                 for (int i = 0; i < numBuffers; i++) {
                     components[i] = offHeapAllocator().allocate(segmentSize);
                     components[i].fill((byte) 0);
-                    components[i].skipWritable(segmentSize);
+                    components[i].skipWritableBytes(segmentSize);
                 }
                 buffer = offHeapAllocator().compose(stream(components).map(Buffer::send).collect(Collectors.toList()));
             } else {
                 buffer = offHeapAllocator().allocate(bufferCapacity);
                 buffer.fill((byte) 0);
-                buffer.skipWritable(bufferCapacity);
+                buffer.skipWritableBytes(bufferCapacity);
             }
             cc.writeAndFlush(new SegmentedDatagramPacket(buffer, segmentSize, addr)).sync();
 

--- a/transport-native-unix-common-tests/src/main/java/io/netty5/channel/unix/tests/DetectPeerCloseWithoutReadTest.java
+++ b/transport-native-unix-common-tests/src/main/java/io/netty5/channel/unix/tests/DetectPeerCloseWithoutReadTest.java
@@ -88,7 +88,7 @@ public abstract class DetectPeerCloseWithoutReadTest {
             cb.handler(new ChannelHandler() { });
             Channel clientChannel = cb.connect(serverChannel.localAddress()).get();
             Buffer buf = clientChannel.bufferAllocator().allocate(expectedBytes);
-            buf.skipWritable(expectedBytes);
+            buf.skipWritableBytes(expectedBytes);
             clientChannel.writeAndFlush(buf).addListener(clientChannel, ChannelFutureListeners.CLOSE);
 
             latch.await();
@@ -139,7 +139,7 @@ public abstract class DetectPeerCloseWithoutReadTest {
                         @Override
                         public void channelActive(ChannelHandlerContext ctx) {
                             Buffer buf = ctx.bufferAllocator().allocate(expectedBytes);
-                            buf.skipWritable(expectedBytes);
+                            buf.skipWritableBytes(expectedBytes);
                             ctx.writeAndFlush(buf).addListener(ctx.channel(), ChannelFutureListeners.CLOSE);
                             ctx.fireChannelActive();
                         }

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioDatagramChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioDatagramChannel.java
@@ -253,7 +253,7 @@ public final class NioDatagramChannel
             }
 
             allocHandle.lastBytesRead(receiveDatagram.bytesReceived);
-            data.skipWritable(allocHandle.lastBytesRead());
+            data.skipWritableBytes(allocHandle.lastBytesRead());
             buf.add(new DatagramPacket(data, localAddress(), remoteAddress));
             free = false;
             return 1;
@@ -293,7 +293,7 @@ public final class NioDatagramChannel
                 } else {
                     writtenBytes = javaChannel().write(component.readableBuffer());
                 }
-                component.skipReadable(writtenBytes);
+                component.skipReadableBytes(writtenBytes);
                 return true;
             });
             return buf.readableBytes() < initialReadable;


### PR DESCRIPTION
…with the rest of the API

Motivation:

We use readableBytes(...) and writableBytes(...) etc so we should also name the methods skipReadableBytes(...) and skipWritableBytes(...) to make the API more consistent in terms of naming

Modifications:

Rename methods

Result:

More consistent naming of methods in the API