### PR TITLE
We should only include maxAge when its not negative

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ServerCookieEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ServerCookieEncoder.java
@@ -101,7 +101,8 @@ public final class ServerCookieEncoder extends CookieEncoder {
             add(buf, name, value);
         }
 
-        if (cookie.maxAge() != Long.MIN_VALUE) {
+        // Only include maxAge if its positive as otherwise it has not meaning
+        if (cookie.maxAge() >= 0) {
             add(buf, CookieHeaderNames.MAX_AGE, cookie.maxAge());
             Date expires = new Date(cookie.maxAge() * 1000 + System.currentTimeMillis());
             buf.append(CookieHeaderNames.EXPIRES);


### PR DESCRIPTION
Motivation:

At the moment we try to encode the maxAge value of the cookie even if its negative. We should just not include it in this case

Modifications:

- Only include the maxAge value if its nnot negative.
- Add unit test

Result:

More correct handling of maxAge cookie value
