### PR TITLE
DefaultChannelId, current ProcessId: use ProcessHandle instead of jmx in java9+ env

### DIFF
--- a/transport/src/main/java/io/netty/channel/DefaultChannelId.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelId.java
@@ -128,13 +128,7 @@ public final class DefaultChannelId implements ChannelId {
         return nilValue;
     }
 
-    private static int defaultProcessId() {
-        ClassLoader loader = PlatformDependent.getClassLoader(DefaultChannelId.class);
-        int processId = processHandlePid(loader);
-        if (processId != -1) {
-            return processId;
-        }
-
+    static int jmxPid(ClassLoader loader) {
         String value;
         try {
             // Invoke java.lang.management.ManagementFactory.getRuntimeMXBean().getName()
@@ -177,6 +171,15 @@ public final class DefaultChannelId implements ChannelId {
         }
 
         return pid;
+    }
+
+    static int defaultProcessId() {
+        ClassLoader loader = PlatformDependent.getClassLoader(DefaultChannelId.class);
+        int processId = processHandlePid(loader);
+        if (processId != -1) {
+            return processId;
+        }
+        return jmxPid(loader);
     }
 
     private final byte[] data;

--- a/transport/src/main/java/io/netty/channel/DefaultChannelId.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelId.java
@@ -20,7 +20,6 @@ import io.netty.buffer.ByteBufUtil;
 import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.MacAddressUtil;
 import io.netty.util.internal.PlatformDependent;
-import io.netty.util.internal.SuppressJava6Requirement;
 import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -107,17 +106,15 @@ public final class DefaultChannelId implements ChannelId {
     }
 
     static int processHandlePid(ClassLoader loader) {
-        /*pid is positive on unix, non{-1,0} on windows*/
+        // pid is positive on unix, non{-1,0} on windows
         int nilValue = -1;
         if (PlatformDependent.javaVersion() >= 9) {
             Long pid;
             try {
-                Class<?> processHandleImplType = Class.forName("java.lang.ProcessHandleImpl", true, loader);
+                Class<?> processHandleImplType = Class.forName("java.lang.ProcessHandle", true, loader);
                 Method processHandleCurrent = processHandleImplType.getMethod("current");
-                processHandleCurrent.setAccessible(true);
                 Object processHandleInstance = processHandleCurrent.invoke(null);
                 Method processHandlePid = processHandleImplType.getMethod("pid");
-                processHandlePid.setAccessible(true);
                 pid = (Long) processHandlePid.invoke(processHandleInstance);
             } catch (Exception e) {
                 return nilValue;

--- a/transport/src/main/java/io/netty/channel/DefaultChannelId.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelId.java
@@ -117,6 +117,7 @@ public final class DefaultChannelId implements ChannelId {
                 Method processHandlePid = processHandleImplType.getMethod("pid");
                 pid = (Long) processHandlePid.invoke(processHandleInstance);
             } catch (Exception e) {
+                logger.debug("Could not invoke ProcessHandle.current().pid();", e);
                 return nilValue;
             }
             if (pid > Integer.MAX_VALUE || pid < Integer.MIN_VALUE) {

--- a/transport/src/test/java/io/netty/channel/AbstractChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/AbstractChannelTest.java
@@ -22,8 +22,9 @@ import java.nio.channels.ClosedChannelException;
 
 import io.netty.util.NetUtil;
 import io.netty.util.internal.PlatformDependent;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -91,8 +92,8 @@ public class AbstractChannelTest {
     }
 
     @Test
+    @EnabledForJreRange(min = JRE.JAVA_9)
     void processIdWithProcessHandleJava9() {
-        Assumptions.assumeTrue(PlatformDependent.javaVersion() >= 9);
         ClassLoader loader = PlatformDependent.getClassLoader(DefaultChannelId.class);
         int processHandlePid = DefaultChannelId.processHandlePid(loader);
         assertTrue(processHandlePid != -1);
@@ -101,8 +102,8 @@ public class AbstractChannelTest {
     }
 
     @Test
+    @EnabledForJreRange(max = JRE.JAVA_8)
     void processIdWithJmxPrejava9() {
-        Assumptions.assumeTrue(PlatformDependent.javaVersion() < 9);
         ClassLoader loader = PlatformDependent.getClassLoader(DefaultChannelId.class);
         int processHandlePid = DefaultChannelId.processHandlePid(loader);
         assertEquals(-1, processHandlePid);

--- a/transport/src/test/java/io/netty/channel/AbstractChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/AbstractChannelTest.java
@@ -21,12 +21,13 @@ import java.net.SocketAddress;
 import java.nio.channels.ClosedChannelException;
 
 import io.netty.util.NetUtil;
+import io.netty.util.internal.PlatformDependent;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 public class AbstractChannelTest {
@@ -85,6 +86,25 @@ public class AbstractChannelTest {
         TestChannel channel = new TestChannel();
         final ChannelId channelId = channel.id();
         assertTrue(channelId instanceof DefaultChannelId);
+    }
+
+    @Test
+    void processIdWithProcessHandleJava9() {
+        Assumptions.assumeTrue(PlatformDependent.javaVersion() >= 9);
+        ClassLoader loader = PlatformDependent.getClassLoader(DefaultChannelId.class);
+        int processHandlePid = DefaultChannelId.processHandlePid(loader);
+        assertTrue(processHandlePid != -1);
+        assertEquals(DefaultChannelId.jmxPid(loader), processHandlePid);
+        assertEquals(DefaultChannelId.defaultProcessId(), processHandlePid);
+    }
+
+    @Test
+    void processIdWithJmxPrejava9() {
+        Assumptions.assumeTrue(PlatformDependent.javaVersion() < 9);
+        ClassLoader loader = PlatformDependent.getClassLoader(DefaultChannelId.class);
+        int processHandlePid = DefaultChannelId.processHandlePid(loader);
+        assertEquals(-1, processHandlePid);
+        assertEquals(DefaultChannelId.defaultProcessId(), DefaultChannelId.jmxPid(loader));
     }
 
     @Test

--- a/transport/src/test/java/io/netty/channel/AbstractChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/AbstractChannelTest.java
@@ -27,7 +27,9 @@ import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 public class AbstractChannelTest {


### PR DESCRIPTION
Motivation:

Netty relies on jmx to get current process id used by DefaultChannelId. This brings in java.management JPMS module which takes additional 1.8mb in application runtime image of total size ~60 mb. It would be useful to remove this dependency for java9+ by using ProcessHandle API instead of jmx. 

Modification:

Current process id: use ProcessHandle API instead of jmx in java9+ env.

Result:

Less dependencies, smaller application runtime image with java9+ env.
