### PR TITLE
Make SensitiveBufferAllocator respect memory manager override

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/MemoryManager.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/MemoryManager.java
@@ -213,6 +213,15 @@ public interface MemoryManager {
     Object sliceMemory(Object memory, int offset, int length);
 
     /**
+     * Overwrite the given recoverable memory object with zeroes, erasing all data that it contains.
+     * <p>
+     * This is used by the {@link SensitiveBufferAllocator} to erase data on deallocation.
+     *
+     * @param memory The memory that should be overwritten.
+     */
+    void clearMemory(Object memory);
+
+    /**
      * Get the name for this implementation, which can be used for finding this particular implementation via the
      * {@link #lookupImplementation(String)} method.
      *

--- a/buffer/src/main/java/io/netty5/buffer/api/SensitiveBufferAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/SensitiveBufferAllocator.java
@@ -17,6 +17,7 @@ package io.netty5.buffer.api;
 
 import io.netty5.buffer.api.internal.ArcDrop;
 import io.netty5.buffer.api.internal.CleanerDrop;
+import io.netty5.buffer.api.internal.MemoryManagerOverride;
 
 import java.nio.ByteBuffer;
 import java.util.function.Function;
@@ -40,9 +41,10 @@ import java.util.function.Supplier;
  * This allocator is stateless, and the {@link #close()} method has no effect.
  */
 public final class SensitiveBufferAllocator implements BufferAllocator {
-    private static final BufferAllocator INSTANCE = new SensitiveBufferAllocator();
-    private static final AllocatorControl CONTROL = () -> INSTANCE;
-    private static final Function<Drop<Buffer>, Drop<Buffer>> DECORATOR = SensitiveBufferAllocator::decorate;
+    private static final BufferAllocator INSTANCE = new SensitiveBufferAllocator(null);
+    private final AllocatorControl control = () -> this;
+    private final Function<Drop<Buffer>, Drop<Buffer>> decorator = this::decorate;
+    private final MemoryManager manager;
 
     /**
      * Get the sensitive off-heap buffer allocator instance.
@@ -50,10 +52,15 @@ public final class SensitiveBufferAllocator implements BufferAllocator {
      * @return The allocator.
      */
     public static BufferAllocator sensitiveOffHeapAllocator() {
+        MemoryManager memoryManagerOverride = MemoryManagerOverride.configuredOrDefaultManager(null);
+        if (memoryManagerOverride != null) {
+            return new SensitiveBufferAllocator(memoryManagerOverride);
+        }
         return INSTANCE;
     }
 
-    private SensitiveBufferAllocator() {
+    private SensitiveBufferAllocator(MemoryManager manager) {
+        this.manager = manager;
     }
 
     @Override
@@ -68,13 +75,20 @@ public final class SensitiveBufferAllocator implements BufferAllocator {
 
     @Override
     public Buffer allocate(int size) {
-        MemoryManager manager = MemoryManager.instance();
-        return manager.allocateShared(CONTROL, size, DECORATOR, getAllocationType());
+        MemoryManager manager = getManager();
+        return manager.allocateShared(control, size, decorator, getAllocationType());
     }
 
-    private static Drop<Buffer> decorate(Drop<Buffer> base) {
-        MemoryManager manager = MemoryManager.instance();
-        return CleanerDrop.wrap(ArcDrop.wrap(new ZeroingDrop(manager, base)), manager);
+    private Drop<Buffer> decorate(Drop<Buffer> base) {
+        MemoryManager manager = getManager();
+        return CleanerDrop.wrap(ArcDrop.wrap(new ZeroingDrop(manager, control, base)), manager);
+    }
+
+    private MemoryManager getManager() {
+        if (manager != null) {
+            return MemoryManagerOverride.configuredOrDefaultManager(manager);
+        }
+        return MemoryManager.instance();
     }
 
     @Override
@@ -90,9 +104,11 @@ public final class SensitiveBufferAllocator implements BufferAllocator {
     private static final class ZeroingDrop implements Drop<Buffer> {
         private final MemoryManager manager;
         private final Drop<Buffer> base;
+        private final AllocatorControl control;
 
-        ZeroingDrop(MemoryManager manager, Drop<Buffer> base) {
+        ZeroingDrop(MemoryManager manager, AllocatorControl control, Drop<Buffer> base) {
             this.manager = manager;
+            this.control = control;
             this.base = base;
         }
 
@@ -101,7 +117,7 @@ public final class SensitiveBufferAllocator implements BufferAllocator {
             // The given buffer object might only be a small piece of the original buffer, due to split() calls.
             // We go through the memory recovery process in order to get back the full memory allocation.
             Object memory = manager.unwrapRecoverableMemory(obj);
-            try (Buffer buffer = manager.recoverMemory(CONTROL, memory, base)) {
+            try (Buffer buffer = manager.recoverMemory(control, memory, base)) {
                 buffer.fill((byte) 0);
             }
         }

--- a/buffer/src/main/java/io/netty5/buffer/api/SensitiveBufferAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/SensitiveBufferAllocator.java
@@ -117,9 +117,8 @@ public final class SensitiveBufferAllocator implements BufferAllocator {
             // The given buffer object might only be a small piece of the original buffer, due to split() calls.
             // We go through the memory recovery process in order to get back the full memory allocation.
             Object memory = manager.unwrapRecoverableMemory(obj);
-            try (Buffer buffer = manager.recoverMemory(control, memory, base)) {
-                buffer.fill((byte) 0);
-            }
+            manager.clearMemory(memory);
+            base.drop(obj);
         }
 
         @Override

--- a/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
@@ -1236,7 +1236,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
     }
 
     ByteBuf unwrapRecoverableMemory() {
-        return delegate;
+        return delegate.isReadOnly() ? delegate.unwrap() : delegate;
     }
 
     private RuntimeException accessException(RuntimeException e, boolean isWrite) {

--- a/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufMemoryManager.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufMemoryManager.java
@@ -103,6 +103,12 @@ public final class ByteBufMemoryManager implements MemoryManager {
     }
 
     @Override
+    public void clearMemory(Object memory) {
+        ByteBuf byteBuf = (ByteBuf) memory;
+        byteBuf.setZero(0, byteBuf.capacity());
+    }
+
+    @Override
     public String implementationName() {
         return "Netty ByteBuf";
     }

--- a/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/ByteBufferMemoryManager.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/ByteBufferMemoryManager.java
@@ -92,6 +92,12 @@ public final class ByteBufferMemoryManager implements MemoryManager {
     }
 
     @Override
+    public void clearMemory(Object memory) {
+        ByteBuffer buffer = (ByteBuffer) memory;
+        Statics.setMemory(buffer, buffer.capacity(), (byte) 0);
+    }
+
+    @Override
     public String implementationName() {
         return "ByteBuffer";
     }

--- a/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
@@ -52,6 +52,7 @@ import static io.netty5.buffer.api.internal.Statics.bufferIsReadOnly;
 import static io.netty5.buffer.api.internal.Statics.checkImplicitCapacity;
 import static io.netty5.buffer.api.internal.Statics.checkLength;
 import static io.netty5.buffer.api.internal.Statics.nativeAddressWithOffset;
+import static io.netty5.buffer.api.internal.Statics.setMemory;
 import static io.netty5.util.internal.ObjectUtil.checkPositiveOrZero;
 import static io.netty5.util.internal.PlatformDependent.roundToPowerOfTwo;
 
@@ -158,27 +159,8 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
             throw bufferIsClosed(this);
         }
         final ByteBuffer wmem = this.wmem;
-        if (!wmem.hasArray()) {
-            fill(wmem, capacity, value);
-        } else {
-            final int start = wmem.arrayOffset();
-            final int end = wmem.arrayOffset() + capacity;
-            Arrays.fill(wmem.array(), start, end, value);
-        }
+        setMemory(wmem, capacity, value);
         return this;
-    }
-
-    private static void fill(final ByteBuffer wmem, final int capacity, final byte value) {
-        final int intFillValue = (value & 0xFF) * 0x01010101;
-        final int intCount = capacity >>> 2;
-        for (int i = 0; i < intCount; i++) {
-            wmem.putInt(i << 2, intFillValue);
-        }
-        final int byteCount = capacity & 3;
-        final int bytesOffset = intCount << 2;
-        for (int i = 0; i < byteCount; i++) {
-            wmem.put(bytesOffset + i, value);
-        }
     }
 
     private long nativeAddress() {

--- a/buffer/src/main/java/io/netty5/buffer/api/internal/MemoryManagerOverride.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/internal/MemoryManagerOverride.java
@@ -66,10 +66,14 @@ public final class MemoryManagerOverride {
     }
 
     public static MemoryManager configuredOrDefaultManager() {
+        return configuredOrDefaultManager(DEFAULT);
+    }
+
+    public static MemoryManager configuredOrDefaultManager(MemoryManager desiredDefault) {
         if (OVERRIDES_AVAILABLE.get() > 0) {
-            return OVERRIDES.getOrDefault(Thread.currentThread(), DEFAULT);
+            return OVERRIDES.getOrDefault(Thread.currentThread(), desiredDefault);
         }
-        return DEFAULT;
+        return desiredDefault;
     }
 
     public static <T> T using(MemoryManager managers, Supplier<T> supplier) {

--- a/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeMemory.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeMemory.java
@@ -15,6 +15,8 @@
  */
 package io.netty5.buffer.api.unsafe;
 
+import io.netty5.util.internal.PlatformDependent;
+
 class UnsafeMemory {
     final Object base;
     final long address;
@@ -28,5 +30,9 @@ class UnsafeMemory {
 
     public UnsafeMemory slice(int offset, int length) {
         return new UnsafeMemory(base, address + offset, length);
+    }
+
+    public void clearMemory() {
+        PlatformDependent.setMemory(base, address, size, (byte) 0);
     }
 }

--- a/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeMemoryManager.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeMemoryManager.java
@@ -123,6 +123,11 @@ public final class UnsafeMemoryManager implements MemoryManager {
     }
 
     @Override
+    public void clearMemory(Object memory) {
+        ((UnsafeMemory) memory).clearMemory();
+    }
+
+    @Override
     public String implementationName() {
         return "Unsafe";
     }

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/CleanerDropTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/CleanerDropTest.java
@@ -151,6 +151,11 @@ public class CleanerDropTest {
         }
 
         @Override
+        public void clearMemory(Object memory) {
+            manager.clearMemory(memory);
+        }
+
+        @Override
         public String implementationName() {
             return "Leak Tracking " + manager.implementationName();
         }


### PR DESCRIPTION
Motivation:
We need to override the memory manager used by the SensitiveBufferAllocator, so we can make sure we cover all implementations.
The SensitiveBufferAllocator was capturing the memory manager on allocation, but our tests only override when the allocator is obtained.

Modification:
If a MemoryManager override is set when the SensitiveBufferAllocator is obtained, then we now capture it and use it when allocating, unless the allocation site has a another override.
To correctly zero out the memory, a clearMemory method has been added to MemoryManager.
This avoids allocating a Buffer instance when one isn't needed.
Some implementation specific optimisations to the memory zeroing have also been done.
The ByteBuf based implementation also got a bug fix so it can now zero out sensitive buffers that were made read-only.

Result:
We now cover all possible buffer implementations in our tests, with the SensitiveBufferAllocator.
And we thus ensure that all implementations work correctly.