### PR TITLE
Bulk write and copyInto fixes

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/DefaultCompositeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/DefaultCompositeBuffer.java
@@ -290,7 +290,7 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
 
         @Override
         public Iterator<T> iterator() {
-            return new ConcatIterator(first.iterator(), second.iterator());
+            return new ConcatIterator<>(first.iterator(), second.iterator());
         }
     }
 
@@ -769,11 +769,11 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
     @Override
     public ByteCursor openCursor(int fromOffset, int length) {
         if (fromOffset < 0) {
-            throw new IllegalArgumentException("The fromOffset cannot be negative: " + fromOffset + '.');
+            throw new IndexOutOfBoundsException("The fromOffset cannot be negative: " + fromOffset + '.');
         }
         checkLength(length);
         if (capacity < addExact(fromOffset, length)) {
-            throw new IllegalArgumentException("The fromOffset+length is beyond the end of the buffer: " +
+            throw new IndexOutOfBoundsException("The fromOffset+length is beyond the end of the buffer: " +
                                                "fromOffset=" + fromOffset + ", length=" + length + '.');
         }
         if (closed) {
@@ -789,11 +789,11 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
     @Override
     public ByteCursor openReverseCursor(int fromOffset, int length) {
         if (fromOffset < 0) {
-            throw new IllegalArgumentException("The fromOffset cannot be negative: " + fromOffset + '.');
+            throw new IndexOutOfBoundsException("The fromOffset cannot be negative: " + fromOffset + '.');
         }
         checkLength(length);
         if (fromOffset - length < -1) {
-            throw new IllegalArgumentException("The fromOffset-length would underflow the buffer: " +
+            throw new IndexOutOfBoundsException("The fromOffset-length would underflow the buffer: " +
                                                "fromOffset=" + fromOffset + ", length=" + length + '.');
         }
         if (closed) {

--- a/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
@@ -248,6 +248,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
         if (dest.isReadOnly()) {
             throw new ReadOnlyBufferException();
         }
+        checkLength(length);
         dest = dest.duplicate().clear();
         for (int i = 0; i < length; i++) {
             dest.put(destPos + i, getByte(srcPos + i));
@@ -262,6 +263,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
         if (dest.readOnly()) {
             throw bufferIsReadOnly(dest);
         }
+        checkLength(length);
         while (--length >= 0) {
             dest.setByte(destPos + length, getByte(srcPos + length));
         }
@@ -379,11 +381,11 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
             throw attachTrace(bufferIsClosed(this));
         }
         if (fromOffset < 0) {
-            throw new IllegalArgumentException("The fromOffset cannot be negative: " + fromOffset + '.');
+            throw new IndexOutOfBoundsException("The fromOffset cannot be negative: " + fromOffset + '.');
         }
         checkLength(length);
         if (capacity() < fromOffset + length) {
-            throw new IllegalArgumentException("The fromOffset + length is beyond the end of the buffer: " +
+            throw new IndexOutOfBoundsException("The fromOffset + length is beyond the end of the buffer: " +
                                                "fromOffset = " + fromOffset + ", length = " + length + '.');
         }
         return new ForwardCursor(delegate, fromOffset, length);
@@ -395,14 +397,14 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
             throw attachTrace(bufferIsClosed(this));
         }
         if (fromOffset < 0) {
-            throw new IllegalArgumentException("The fromOffset cannot be negative: " + fromOffset + '.');
+            throw new IndexOutOfBoundsException("The fromOffset cannot be negative: " + fromOffset + '.');
         }
         checkLength(length);
         if (capacity() <= fromOffset) {
-            throw new IllegalArgumentException("The fromOffset is beyond the end of the buffer: " + fromOffset + '.');
+            throw new IndexOutOfBoundsException("The fromOffset is beyond the end of the buffer: " + fromOffset + '.');
         }
         if (fromOffset - length < -1) {
-            throw new IllegalArgumentException("The fromOffset - length would underflow the buffer: " +
+            throw new IndexOutOfBoundsException("The fromOffset - length would underflow the buffer: " +
                                                "fromOffset = " + fromOffset + ", length = " + length + '.');
         }
         return new ReverseCursor(delegate, fromOffset, length);
@@ -455,6 +457,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
 
     @Override
     public Buffer copy(int offset, int length, boolean readOnly) {
+        checkLength(length);
         if (readOnly && readOnly()) {
             ByteBufBuffer copy = newConstChild();
             if (offset > 0 || length < capacity()) {

--- a/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
@@ -234,12 +234,19 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
             throw bufferIsClosed(this);
         }
         if (srcPos < 0) {
-            throw new IllegalArgumentException("The srcPos cannot be negative: " + srcPos + '.');
+            throw new IndexOutOfBoundsException("The srcPos cannot be negative: " + srcPos + '.');
+        }
+        if (destPos < 0) {
+            throw new IndexOutOfBoundsException("The destination position cannot be negative: " + destPos);
         }
         checkLength(length);
         if (capacity() < srcPos + length) {
-            throw new IllegalArgumentException("The srcPos + length is beyond the end of the buffer: " +
-                    "srcPos = " + srcPos + ", length = " + length + '.');
+            throw new IndexOutOfBoundsException("The srcPos + length is beyond the end of the buffer: " +
+                                               "srcPos = " + srcPos + ", length = " + length + '.');
+        }
+        if (dest.capacity() < destPos + length) {
+            throw new IndexOutOfBoundsException("The destPos + length is beyond the end of the buffer: " +
+                                                "destPos = " + destPos + ", length = " + length + '.');
         }
         if (dest.hasArray() && hasReadableArray()) {
             final byte[] srcArray = rmem.array();
@@ -391,11 +398,11 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
             throw bufferIsClosed(this);
         }
         if (fromOffset < 0) {
-            throw new IllegalArgumentException("The fromOffset cannot be negative: " + fromOffset + '.');
+            throw new IndexOutOfBoundsException("The fromOffset cannot be negative: " + fromOffset + '.');
         }
         checkLength(length);
         if (capacity() < fromOffset + length) {
-            throw new IllegalArgumentException("The fromOffset + length is beyond the end of the buffer: " +
+            throw new IndexOutOfBoundsException("The fromOffset + length is beyond the end of the buffer: " +
                     "fromOffset = " + fromOffset + ", length = " + length + '.');
         }
         return new ForwardNioByteCursor(rmem, fromOffset, length);
@@ -407,14 +414,14 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
             throw bufferIsClosed(this);
         }
         if (fromOffset < 0) {
-            throw new IllegalArgumentException("The fromOffset cannot be negative: " + fromOffset + '.');
+            throw new IndexOutOfBoundsException("The fromOffset cannot be negative: " + fromOffset + '.');
         }
         checkLength(length);
         if (capacity() <= fromOffset) {
-            throw new IllegalArgumentException("The fromOffset is beyond the end of the buffer: " + fromOffset + '.');
+            throw new IndexOutOfBoundsException("The fromOffset is beyond the end of the buffer: " + fromOffset + '.');
         }
         if (fromOffset - length < -1) {
-            throw new IllegalArgumentException("The fromOffset - length would underflow the buffer: " +
+            throw new IndexOutOfBoundsException("The fromOffset - length would underflow the buffer: " +
                     "fromOffset = " + fromOffset + ", length = " + length + '.');
         }
         return new ReverseNioByteCursor(rmem, fromOffset, length);

--- a/buffer/src/main/java/io/netty5/buffer/api/internal/Statics.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/internal/Statics.java
@@ -141,11 +141,12 @@ public interface Statics {
 
     static void checkLength(int length) {
         if (length < 0) {
-            throw new IllegalArgumentException("The length cannot be negative: " + length + '.');
+            throw new IndexOutOfBoundsException("The length cannot be negative: " + length + '.');
         }
     }
 
     static void copyToViaReverseLoop(Buffer src, int srcPos, Buffer dest, int destPos, int length) {
+        checkLength(length);
         if (length == 0) {
             return;
         }

--- a/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
@@ -278,18 +278,18 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
             throw bufferIsClosed(this);
         }
         if (srcPos < 0) {
-            throw new IllegalArgumentException("The srcPos cannot be negative: " + srcPos + '.');
+            throw new IndexOutOfBoundsException("The srcPos cannot be negative: " + srcPos + '.');
         }
         checkLength(length);
         if (rsize < srcPos + length) {
-            throw new IllegalArgumentException("The srcPos + length is beyond the end of the buffer: " +
+            throw new IndexOutOfBoundsException("The srcPos + length is beyond the end of the buffer: " +
                     "srcPos = " + srcPos + ", length = " + length + '.');
         }
         if (destPos < 0) {
-            throw new IllegalArgumentException("The destPos cannot be negative: " + destPos + '.');
+            throw new IndexOutOfBoundsException("The destPos cannot be negative: " + destPos + '.');
         }
         if (destLength < destPos + length) {
-            throw new IllegalArgumentException("The destPos + length is beyond the end of the destination: " +
+            throw new IndexOutOfBoundsException("The destPos + length is beyond the end of the destination: " +
                     "destPos = " + destPos + ", length = " + length + '.');
         }
     }
@@ -462,11 +462,11 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
             throw bufferIsClosed(this);
         }
         if (fromOffset < 0) {
-            throw new IllegalArgumentException("The fromOffset cannot be negative: " + fromOffset + '.');
+            throw new IndexOutOfBoundsException("The fromOffset cannot be negative: " + fromOffset + '.');
         }
         checkLength(length);
         if (capacity() < fromOffset + length) {
-            throw new IllegalArgumentException("The fromOffset + length is beyond the end of the buffer: " +
+            throw new IndexOutOfBoundsException("The fromOffset + length is beyond the end of the buffer: " +
                     "fromOffset = " + fromOffset + ", length = " + length + '.');
         }
         return new ForwardUnsafeByteCursor(memory, base, address, fromOffset, length);
@@ -478,14 +478,14 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
             throw bufferIsClosed(this);
         }
         if (fromOffset < 0) {
-            throw new IllegalArgumentException("The fromOffset cannot be negative: " + fromOffset + '.');
+            throw new IndexOutOfBoundsException("The fromOffset cannot be negative: " + fromOffset + '.');
         }
         checkLength(length);
         if (capacity() <= fromOffset) {
-            throw new IllegalArgumentException("The fromOffset is beyond the end of the buffer: " + fromOffset + '.');
+            throw new IndexOutOfBoundsException("The fromOffset is beyond the end of the buffer: " + fromOffset + '.');
         }
         if (fromOffset - length < -1) {
-            throw new IllegalArgumentException("The fromOffset - length would underflow the buffer: " +
+            throw new IndexOutOfBoundsException("The fromOffset - length would underflow the buffer: " +
                     "fromOffset = " + fromOffset + ", length = " + length + '.');
         }
         return new ReverseUnsafeByteCursor(memory, base, address, fromOffset, length);

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferLifeCycleTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferLifeCycleTest.java
@@ -500,10 +500,10 @@ public class BufferLifeCycleTest extends BufferTestSupport {
     void copyWithNegativeSizeMustThrow(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
-            assertThrows(IllegalArgumentException.class, () -> buf.copy(0, -1));
-            assertThrows(IllegalArgumentException.class, () -> buf.copy(2, -1));
-            assertThrows(IllegalArgumentException.class, () -> buf.copy(0, -1, true));
-            assertThrows(IllegalArgumentException.class, () -> buf.copy(2, -1, true));
+            assertThrows(IndexOutOfBoundsException.class, () -> buf.copy(0, -1));
+            assertThrows(IndexOutOfBoundsException.class, () -> buf.copy(2, -1));
+            assertThrows(IndexOutOfBoundsException.class, () -> buf.copy(0, -1, true));
+            assertThrows(IndexOutOfBoundsException.class, () -> buf.copy(2, -1, true));
             // Verify that the copy is closed properly afterwards.
             assertTrue(isOwned((ResourceSupport<?, ?>) buf));
         }


### PR DESCRIPTION
Motivation:
The different buffer implementations should behave the same as much as possible.
Some bulk-write methods and copyInto methods did not behave the same with regards to error handling and what exceptions were thrown.
Additionally, it also needs to be possible to perform writes to a buffer that is shared, such as when components are being iterated.

Modification:
Increase test coverage of writeBytes and copyInto methods.
Align all of their thrown exceptions.
The writeBytes method now only call ensureWritable if expansion is needed, and now respects the implicit capacity limit as it should.

Result:
More consistent behaviours from bulk methods on Buffer.
