### PR TITLE
Avoid exponential back-off in PemReader

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/PemReader.java
+++ b/handler/src/main/java/io/netty/handler/ssl/PemReader.java
@@ -47,12 +47,12 @@ final class PemReader {
 
     private static final Pattern CERT_PATTERN = Pattern.compile(
             "-+BEGIN\\s+.*CERTIFICATE[^-]*-+(?:\\s|\\r|\\n)+" + // Header
-                    "([a-z0-9+/=\\r\\n]+)" +                    // Base64 text
+                    "([a-z0-9+/=][a-z0-9+/=\\r\\n]*)" +         // Base64 text
                     "-+END\\s+.*CERTIFICATE[^-]*-+",            // Footer
             Pattern.CASE_INSENSITIVE);
     private static final Pattern KEY_PATTERN = Pattern.compile(
             "-+BEGIN\\s+.*PRIVATE\\s+KEY[^-]*-+(?:\\s|\\r|\\n)+" + // Header
-                    "([a-z0-9+/=\\r\\n]+)" +                       // Base64 text
+                    "([a-z0-9+/=][a-z0-9+/=\\r\\n]*)" +            // Base64 text
                     "-+END\\s+.*PRIVATE\\s+KEY[^-]*-+",            // Footer
             Pattern.CASE_INSENSITIVE);
 

--- a/handler/src/main/java/io/netty/handler/ssl/PemReader.java
+++ b/handler/src/main/java/io/netty/handler/ssl/PemReader.java
@@ -46,14 +46,14 @@ final class PemReader {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(PemReader.class);
 
     private static final Pattern CERT_PATTERN = Pattern.compile(
-            "-+BEGIN\\s+.*CERTIFICATE[^-]*-+(?:\\s|\\r|\\n)+" + // Header
-                    "([a-z0-9+/=][a-z0-9+/=\\r\\n]*)" +         // Base64 text
-                    "-+END\\s+.*CERTIFICATE[^-]*-+",            // Footer
+            "-+BEGIN\\s[^-\\r\\n]*CERTIFICATE[^-\\r\\n]*-+(?:\\s|\\r|\\n)+" + // Header
+                    "([a-z0-9+/=][a-z0-9+/=\\r\\n]*)" +                       // Base64 text
+                    "-+END\\s[^-\\r\\n]*CERTIFICATE[^-\\r\\n]*-+",            // Footer
             Pattern.CASE_INSENSITIVE);
     private static final Pattern KEY_PATTERN = Pattern.compile(
-            "-+BEGIN\\s+.*PRIVATE\\s+KEY[^-]*-+(?:\\s|\\r|\\n)+" + // Header
-                    "([a-z0-9+/=][a-z0-9+/=\\r\\n]*)" +            // Base64 text
-                    "-+END\\s+.*PRIVATE\\s+KEY[^-]*-+",            // Footer
+            "-+BEGIN\\s[^-\\r\\n]*PRIVATE\\s+KEY[^-\\r\\n]*-+(?:\\s|\\r|\\n)+" + // Header
+                    "([a-z0-9+/=][a-z0-9+/=\\r\\n]*)" +                          // Base64 text
+                    "-+END\\s[^-\\r\\n]*PRIVATE\\s+KEY[^-\\r\\n]*-+",            // Footer
             Pattern.CASE_INSENSITIVE);
 
     static ByteBuf[] readCertificates(File file) throws CertificateException {

--- a/handler/src/main/java/io/netty/handler/ssl/PemReader.java
+++ b/handler/src/main/java/io/netty/handler/ssl/PemReader.java
@@ -45,16 +45,15 @@ final class PemReader {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(PemReader.class);
 
-    private static final Pattern CERT_PATTERN = Pattern.compile(
-            "-+BEGIN\\s[^-\\r\\n]*CERTIFICATE[^-\\r\\n]*-+(?:\\s|\\r|\\n)+" + // Header
-                    "([a-z0-9+/=][a-z0-9+/=\\r\\n]*)" +                       // Base64 text
-                    "-+END\\s[^-\\r\\n]*CERTIFICATE[^-\\r\\n]*-+",            // Footer
-            Pattern.CASE_INSENSITIVE);
-    private static final Pattern KEY_PATTERN = Pattern.compile(
-            "-+BEGIN\\s[^-\\r\\n]*PRIVATE\\s+KEY[^-\\r\\n]*-+(?:\\s|\\r|\\n)+" + // Header
-                    "([a-z0-9+/=][a-z0-9+/=\\r\\n]*)" +                          // Base64 text
-                    "-+END\\s[^-\\r\\n]*PRIVATE\\s+KEY[^-\\r\\n]*-+",            // Footer
-            Pattern.CASE_INSENSITIVE);
+    private static final Pattern CERT_HEADER = Pattern.compile(
+            "-+BEGIN\\s[^-\\r\\n]*CERTIFICATE[^-\\r\\n]*-+(?:\\s|\\r|\\n)+");
+    private static final Pattern CERT_FOOTER = Pattern.compile(
+            "-+END\\s[^-\\r\\n]*CERTIFICATE[^-\\r\\n]*-+(?:\\s|\\r|\\n)*");
+    private static final Pattern KEY_HEADER = Pattern.compile(
+            "-+BEGIN\\s[^-\\r\\n]*PRIVATE\\s+KEY[^-\\r\\n]*-+(?:\\s|\\r|\\n)+");
+    private static final Pattern KEY_FOOTER = Pattern.compile(
+            "-+END\\s[^-\\r\\n]*PRIVATE\\s+KEY[^-\\r\\n]*-+(?:\\s|\\r|\\n)*");
+    private static final Pattern BODY = Pattern.compile("[a-z0-9+/=][a-z0-9+/=\\r\\n]*", Pattern.CASE_INSENSITIVE);
 
     static ByteBuf[] readCertificates(File file) throws CertificateException {
         try {
@@ -79,19 +78,29 @@ final class PemReader {
         }
 
         List<ByteBuf> certs = new ArrayList<ByteBuf>();
-        Matcher m = CERT_PATTERN.matcher(content);
+        Matcher m = CERT_HEADER.matcher(content);
         int start = 0;
         for (;;) {
             if (!m.find(start)) {
                 break;
             }
+            m.usePattern(BODY);
+            if (!m.find()) {
+                break;
+            }
 
-            ByteBuf base64 = Unpooled.copiedBuffer(m.group(1), CharsetUtil.US_ASCII);
+            ByteBuf base64 = Unpooled.copiedBuffer(m.group(0), CharsetUtil.US_ASCII);
+            m.usePattern(CERT_FOOTER);
+            if (!m.find()) {
+                // Certificate is incomplete.
+                break;
+            }
             ByteBuf der = Base64.decode(base64);
             base64.release();
             certs.add(der);
 
             start = m.end();
+            m.usePattern(CERT_HEADER);
         }
 
         if (certs.isEmpty()) {
@@ -123,16 +132,29 @@ final class PemReader {
             throw new KeyException("failed to read key input stream", e);
         }
 
-        Matcher m = KEY_PATTERN.matcher(content);
+        Matcher m = KEY_HEADER.matcher(content);
         if (!m.find()) {
-            throw new KeyException("could not find a PKCS #8 private key in input stream" +
-                    " (see https://netty.io/wiki/sslcontextbuilder-and-private-key.html for more information)");
+            throw keyNotFoundException();
+        }
+        m.usePattern(BODY);
+        if (!m.find()) {
+            throw keyNotFoundException();
         }
 
-        ByteBuf base64 = Unpooled.copiedBuffer(m.group(1), CharsetUtil.US_ASCII);
+        ByteBuf base64 = Unpooled.copiedBuffer(m.group(0), CharsetUtil.US_ASCII);
+        m.usePattern(KEY_FOOTER);
+        if (!m.find()) {
+            // Key is incomplete.
+            throw keyNotFoundException();
+        }
         ByteBuf der = Base64.decode(base64);
         base64.release();
         return der;
+    }
+
+    private static KeyException keyNotFoundException() {
+        return new KeyException("could not find a PKCS #8 private key in input stream" +
+                " (see https://netty.io/wiki/sslcontextbuilder-and-private-key.html for more information)");
     }
 
     private static String readContent(InputStream in) throws IOException {

--- a/handler/src/test/java/io/netty/handler/ssl/PemReaderTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/PemReaderTest.java
@@ -60,6 +60,9 @@ class PemReaderTest {
         ByteBuf[] bufs = PemReader.readCertificates(in);
         in.close();
         assertThat(bufs.length).isEqualTo(2);
+        for (ByteBuf buf : bufs) {
+            buf.release();
+        }
     }
 
     @Test
@@ -83,5 +86,6 @@ class PemReaderTest {
         ByteBuf buf = PemReader.readPrivateKey(in);
         in.close();
         assertThat(buf.readableBytes()).isEqualTo(686);
+        buf.release();
     }
 }

--- a/handler/src/test/java/io/netty/handler/ssl/PemReaderTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/PemReaderTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.util.CharsetUtil;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PemReaderTest {
+    @Test
+    public void mustBeAbleToReadMultipleCertificates() throws Exception {
+        byte[] certs = ("-----BEGIN CERTIFICATE-----\n" +
+                "MIICqjCCAZKgAwIBAgIIEaz8uuDHTcIwDQYJKoZIhvcNAQELBQAwFDESMBAGA1UEAwwJbG9jYWxo\n" +
+                "b3N0MCAXDTIxMDYxNjE3MjYyOFoYDzk5OTkxMjMxMjM1OTU5WjAUMRIwEAYDVQQDDAlsb2NhbGhv\n" +
+                "c3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCVjENomtpMqHkg1yJ/uYZgSWmf/0Gb\n" +
+                "U4yMDf30muPvMYb3gO6peEnoXa2b0WDOjLbLrcltp1YdjTlLhRRTYgDo9TAvHoUdoMGlTnfQtQne\n" +
+                "2o+/92bnlZTroRIjUT0lqSxQ6UNXcOi9tNqVD4tML3vk20fudwBur8Plx+3hOhM/v64GbV46k06+\n" +
+                "AblrFwBt9u6V0uIVtvgraOd+NgL4yNf594uND30mbB7Q7xe/Y6DiPhI6cVI/CbLlXVwKLvC5OziS\n" +
+                "JKZ7svP0K3DBRxk+dOD9pg4SdaAEQVtR734ZlDh1XJ+mZssuDDda3NGZAjpCU4rkeV/J3Tr5KKMD\n" +
+                "g3NEOmifAgMBAAEwDQYJKoZIhvcNAQELBQADggEBABejZGeRNCyPdIqac6cyAf99JPp5OySEMWHU\n" +
+                "QXVCHEbQ8Eh6hsmrXSEaZS2zy/5dixPb5Rin0xaX5fqZdfLIUc0Mw/zXV/RiOIjrtUKez15Ko/4K\n" +
+                "ONyxELjUq+SaJx2C1UcKEMfQBeq7O6XO60CLQ2AtVozmvJU9pt4KYQv0Kr+br3iNFpRuR43IYHyx\n" +
+                "HP7QsD3L3LEqIqW/QtYEnAAngZofUiq0XELh4GB0L8DbcSJIxfZmYagFl7c2go9OZPD14mlaTnMV\n" +
+                "Pjd+OkwMif5T7v+r+KVSmDSMQwa+NfW+V6Xngg5/bN3kWHdw9qFQGANojl9wsRVN/B3pu3Cc2XFD\n" +
+                "MmQ=\n" +
+                "-----END CERTIFICATE-----\n" +
+                "-----BEGIN CERTIFICATE-----\n" +
+                "MIICqjCCAZKgAwIBAgIIIsUS6UkDau4wDQYJKoZIhvcNAQELBQAwFDESMBAGA1UEAwwJbG9jYWxo\n" +
+                "b3N0MCAXDTIxMDYxNjE3MjYyOFoYDzk5OTkxMjMxMjM1OTU5WjAUMRIwEAYDVQQDDAlsb2NhbGhv\n" +
+                "c3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCTZmahFZXB0Dv3N8t6gfXTeqhTxRng\n" +
+                "mIBBPmrbZBODrZm06vrR5KNhxB2FhWIq1Yu8xXXv8sO+PaO2Sw/h6TeslRJ4EkrNd9zmYhT2cJvP\n" +
+                "d1CtkX5EHyMZRUKj7Eg4eUO1k/+JnhMmaY+nUAG7fCtvs8pS9SEXbEqYW7S4AQ1oopbCAMqQekly\n" +
+                "KCdnjGlVhXwL2Lj2rr/uw1Fc2+WvY/leQGo0rbIqoc7OSAktsP+MXI6iQ1RWJOec15V6iFRzcdE3\n" +
+                "Q4ODSMZ/R8wm9DH+4hkeQNPMbcc1wlvVZpDZ/FZegr1XimcYcJr2AoAQf3Xe1yFKAtBMXCjCIGm8\n" +
+                "veCQ+xeHAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAGyV+dib2MdpenbntKk7PdZEx+/vNl9cEpwL\n" +
+                "BfWmQN/j2RmHUxrUM+PVkLTgyCq8okdCKqCvraKwBkF6vlzp4u5CL4L323z+/uxAi6pzbcWnG1EH\n" +
+                "JpSkf1OhTUFu6UhLfpg3XqeiIujYdVZTpHr7KHVLRYUSQPprt4HjLZeCIg4P2pZ0yQ3SEBhVed89\n" +
+                "GMj/+O4jjvuZv5NQc57NpMIrE9fNINczLG1CPTgnhvqMP42W6ahBuexQUe4gP+jmB/BZmBYKoauU\n" +
+                "mPBKruq3mNuoXtbHufv5I7CFVXNgJ0/aT+lvEkQ4IlCIcJyvTgyUTOQVbqDp+SswymAIRowaRdxa\n" +
+                "7Ss=\n" +
+                "-----END CERTIFICATE-----\n").getBytes(CharsetUtil.US_ASCII);
+        ByteArrayInputStream in = new ByteArrayInputStream(certs);
+        ByteBuf[] bufs = PemReader.readCertificates(in);
+        in.close();
+        assertThat(bufs.length).isEqualTo(2);
+    }
+
+    @Test
+    public void mustBeAbleToReadPrivateKey() throws Exception {
+        byte[] key = ("-----BEGIN PRIVATE KEY-----\n" +
+                "MIICqjCCAZKgAwIBAgIIEaz8uuDHTcIwDQYJKoZIhvcNAQELBQAwFDESMBAGA1UEAwwJbG9jYWxo\n" +
+                "b3N0MCAXDTIxMDYxNjE3MjYyOFoYDzk5OTkxMjMxMjM1OTU5WjAUMRIwEAYDVQQDDAlsb2NhbGhv\n" +
+                "c3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCVjENomtpMqHkg1yJ/uYZgSWmf/0Gb\n" +
+                "U4yMDf30muPvMYb3gO6peEnoXa2b0WDOjLbLrcltp1YdjTlLhRRTYgDo9TAvHoUdoMGlTnfQtQne\n" +
+                "2o+/92bnlZTroRIjUT0lqSxQ6UNXcOi9tNqVD4tML3vk20fudwBur8Plx+3hOhM/v64GbV46k06+\n" +
+                "AblrFwBt9u6V0uIVtvgraOd+NgL4yNf594uND30mbB7Q7xe/Y6DiPhI6cVI/CbLlXVwKLvC5OziS\n" +
+                "JKZ7svP0K3DBRxk+dOD9pg4SdaAEQVtR734ZlDh1XJ+mZssuDDda3NGZAjpCU4rkeV/J3Tr5KKMD\n" +
+                "g3NEOmifAgMBAAEwDQYJKoZIhvcNAQELBQADggEBABejZGeRNCyPdIqac6cyAf99JPp5OySEMWHU\n" +
+                "QXVCHEbQ8Eh6hsmrXSEaZS2zy/5dixPb5Rin0xaX5fqZdfLIUc0Mw/zXV/RiOIjrtUKez15Ko/4K\n" +
+                "ONyxELjUq+SaJx2C1UcKEMfQBeq7O6XO60CLQ2AtVozmvJU9pt4KYQv0Kr+br3iNFpRuR43IYHyx\n" +
+                "HP7QsD3L3LEqIqW/QtYEnAAngZofUiq0XELh4GB0L8DbcSJIxfZmYagFl7c2go9OZPD14mlaTnMV\n" +
+                "Pjd+OkwMif5T7v+r+KVSmDSMQwa+NfW+V6Xngg5/bN3kWHdw9qFQGANojl9wsRVN/B3pu3Cc2XFD\n" +
+                "MmQ=\n" +
+                "-----END PRIVATE KEY-----\n").getBytes(CharsetUtil.US_ASCII);
+        ByteArrayInputStream in = new ByteArrayInputStream(key);
+        ByteBuf buf = PemReader.readPrivateKey(in);
+        in.close();
+        assertThat(buf.readableBytes()).isEqualTo(686);
+    }
+}


### PR DESCRIPTION
Motivation:
The key and certificate patterns used in PemReader were susceptible to exponential back-off.
The reason is that they had two adjacent matching groups that overlapped in their matching characters.
For instance, it is not clear to the matcher if a long string of newlines after the header actually belong to the header or to the base64 text body.

Modification:
Now, the patterns have been broken into separate header, body, and footer patterns.
This makes any backtracking across the pattern boundaries impossible by construction.
Thus, we guarantee linear time progression through the input.

Result:
More robust PEM parsing.