### PR TITLE
Remove uninterruptible future methods

### DIFF
--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpClientCodecTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpClientCodecTest.java
@@ -192,7 +192,7 @@ public class HttpClientCodecTest {
             int port = ((InetSocketAddress) serverChannel.localAddress()).getPort();
 
             Future<Channel> ccf = cb.connect(new InetSocketAddress(NetUtil.LOCALHOST, port));
-            assertTrue(ccf.awaitUninterruptibly().isSuccess());
+            assertTrue(ccf.await().isSuccess());
             Channel clientChannel = ccf.get();
             assertTrue(serverChannelLatch.await(5, SECONDS));
             clientChannel.writeAndFlush(new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/"));

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketClientHandshakerTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketClientHandshakerTest.java
@@ -156,17 +156,17 @@ public abstract class WebSocketClientHandshakerTest {
 
     @Test
     @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
-    void testHttpResponseAndFrameInSameBuffer() {
+    void testHttpResponseAndFrameInSameBuffer() throws Exception {
         testHttpResponseAndFrameInSameBuffer(false);
     }
 
     @Test
     @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
-    void testHttpResponseAndFrameInSameBufferCodec() {
+    void testHttpResponseAndFrameInSameBufferCodec() throws Exception {
         testHttpResponseAndFrameInSameBuffer(true);
     }
 
-    private void testHttpResponseAndFrameInSameBuffer(boolean codec) {
+    private void testHttpResponseAndFrameInSameBuffer(boolean codec) throws Exception {
         String url = "ws://localhost:9999/ws";
         final WebSocketClientHandshaker shaker = newHandshaker(URI.create(url));
         final WebSocketClientHandshaker handshaker = new WebSocketClientHandshaker(
@@ -235,7 +235,7 @@ public abstract class WebSocketClientHandshakerTest {
         }
         // We need to first write the request as HttpClientCodec will fail if we receive a response before a request
         // was written.
-        shaker.handshake(ch).syncUninterruptibly();
+        shaker.handshake(ch).sync();
         for (;;) {
             // Just consume the bytes, we are not interested in these.
             try (Buffer buf = ch.readOutbound()) {

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketHandshakeHandOverTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketHandshakeHandOverTest.java
@@ -181,7 +181,7 @@ public class WebSocketHandshakeHandOverTest {
         // Should throw WebSocketHandshakeException
         try {
             assertTrue(assertThrows(CompletionException.class,
-                () -> handshakeHandler.getHandshakeFuture().syncUninterruptibly())
+                () -> handshakeHandler.getHandshakeFuture().sync())
                     .getCause() instanceof WebSocketHandshakeException);
         } finally {
             serverChannel.finishAndReleaseAll();

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -128,20 +128,20 @@ public class Http2ConnectionRoundtripTest {
             clientChannel = null;
         }
         if (serverChannel != null) {
-            serverChannel.close().syncUninterruptibly();
+            serverChannel.close().sync();
             serverChannel = null;
         }
         final Channel serverConnectedChannel = this.serverConnectedChannel;
         if (serverConnectedChannel != null) {
-            serverConnectedChannel.close().syncUninterruptibly();
+            serverConnectedChannel.close().sync();
             this.serverConnectedChannel = null;
         }
         Future<?> serverGroup = sb.config().group().shutdownGracefully(0, 5, SECONDS);
         Future<?> serverChildGroup = sb.config().childGroup().shutdownGracefully(0, 5, SECONDS);
         Future<?> clientGroup = cb.config().group().shutdownGracefully(0, 5, SECONDS);
-        serverGroup.syncUninterruptibly();
-        serverChildGroup.syncUninterruptibly();
-        clientGroup.syncUninterruptibly();
+        serverGroup.sync();
+        serverChildGroup.sync();
+        clientGroup.sync();
     }
 
     @Test

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameCodecTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameCodecTest.java
@@ -156,7 +156,7 @@ public class Http2FrameCodecTest {
     }
 
     @Test
-    public void stateChanges() {
+    public void stateChanges() throws Exception {
         frameInboundWriter.writeInboundHeaders(1, request, 31, true);
 
         Http2Stream stream = frameCodec.connection().stream(1);
@@ -188,7 +188,7 @@ public class Http2FrameCodecTest {
     }
 
     @Test
-    public void headerRequestHeaderResponse() {
+    public void headerRequestHeaderResponse() throws Exception {
         frameInboundWriter.writeInboundHeaders(1, request, 31, true);
 
         Http2Stream stream = frameCodec.connection().stream(1);
@@ -283,7 +283,7 @@ public class Http2FrameCodecTest {
     }
 
     @Test
-    public void sendRstStream() {
+    public void sendRstStream() throws Exception {
         frameInboundWriter.writeInboundHeaders(3, request, 31, true);
 
         Http2Stream stream = frameCodec.connection().stream(3);
@@ -305,7 +305,7 @@ public class Http2FrameCodecTest {
     }
 
     @Test
-    public void receiveRstStream() {
+    public void receiveRstStream() throws Exception {
         frameInboundWriter.writeInboundHeaders(3, request, 31, false);
 
         Http2Stream stream = frameCodec.connection().stream(3);
@@ -326,7 +326,7 @@ public class Http2FrameCodecTest {
     }
 
     @Test
-    public void sendGoAway() {
+    public void sendGoAway() throws Exception {
         frameInboundWriter.writeInboundHeaders(3, request, 31, false);
         Http2Stream stream = frameCodec.connection().stream(3);
         assertNotNull(stream);
@@ -349,7 +349,7 @@ public class Http2FrameCodecTest {
     }
 
     @Test
-    public void receiveGoaway() {
+    public void receiveGoaway() throws Exception {
         ByteBuf debugData = bb("foo");
         frameInboundWriter.writeInboundGoAway(2, NO_ERROR.code(), debugData);
         Http2GoAwayFrame expectedFrame = new DefaultHttp2GoAwayFrame(2, NO_ERROR.code(), bb("foo"));
@@ -390,7 +390,7 @@ public class Http2FrameCodecTest {
     }
 
     @Test
-    public void unknownFrameTypeOnConnectionStream() {
+    public void unknownFrameTypeOnConnectionStream() throws Exception {
         // handle the case where unknown frames are sent before a stream is created,
         // for example: HTTP/2 GREASE testing
         ByteBuf debugData = bb("debug");
@@ -402,7 +402,7 @@ public class Http2FrameCodecTest {
     }
 
     @Test
-    public void goAwayLastStreamIdOverflowed() {
+    public void goAwayLastStreamIdOverflowed() throws Exception {
         frameInboundWriter.writeInboundHeaders(5, request, 31, false);
 
         Http2Stream stream = frameCodec.connection().stream(5);
@@ -424,7 +424,7 @@ public class Http2FrameCodecTest {
     }
 
     @Test
-    public void streamErrorShouldFireExceptionForInbound() {
+    public void streamErrorShouldFireExceptionForInbound() throws Exception {
         frameInboundWriter.writeInboundHeaders(3, request, 31, false);
 
         Http2Stream stream = frameCodec.connection().stream(3);
@@ -469,7 +469,7 @@ public class Http2FrameCodecTest {
     }
 
     @Test
-    public void windowUpdateFrameDecrementsConsumedBytes() {
+    public void windowUpdateFrameDecrementsConsumedBytes() throws Exception {
         frameInboundWriter.writeInboundHeaders(3, request, 31, false);
 
         Http2Connection connection = frameCodec.connection();
@@ -493,7 +493,7 @@ public class Http2FrameCodecTest {
     }
 
     @Test
-    public void windowUpdateMayFail() {
+    public void windowUpdateMayFail() throws Exception {
         frameInboundWriter.writeInboundHeaders(3, request, 31, false);
         Http2Connection connection = frameCodec.connection();
         Http2Stream stream = connection.stream(3);
@@ -512,7 +512,7 @@ public class Http2FrameCodecTest {
     }
 
     @Test
-    public void inboundWindowUpdateShouldBeForwarded() {
+    public void inboundWindowUpdateShouldBeForwarded() throws Exception {
         frameInboundWriter.writeInboundHeaders(3, request, 31, false);
         frameInboundWriter.writeInboundWindowUpdate(3, 100);
         // Connection-level window update
@@ -603,7 +603,7 @@ public class Http2FrameCodecTest {
 
     @Test
     @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
-    public void newOutboundStream() {
+    public void newOutboundStream() throws Exception {
         final Http2FrameStream stream = frameCodec.newStream();
 
         assertNotNull(stream);
@@ -622,7 +622,7 @@ public class Http2FrameCodecTest {
         Future<Void> f = channel.writeAndFlush(new DefaultHttp2DataFrame(data).stream(stream));
         assertTrue(f.isSuccess());
 
-        listenerExecuted.asFuture().syncUninterruptibly();
+        listenerExecuted.asFuture().sync();
         assertTrue(listenerExecuted.isSuccess());
     }
 
@@ -643,7 +643,7 @@ public class Http2FrameCodecTest {
         channel.runPendingTasks();
         assertTrue(isStreamIdValid(stream2.id()));
 
-        assertTrue(future1.syncUninterruptibly().isSuccess());
+        assertTrue(future1.sync().isSuccess());
         assertFalse(future2.isDone());
 
         // Increase concurrent streams limit to 2
@@ -651,7 +651,7 @@ public class Http2FrameCodecTest {
 
         channel.flush();
 
-        assertTrue(future2.syncUninterruptibly().isSuccess());
+        assertTrue(future2.sync().isSuccess());
     }
 
     @Test
@@ -675,7 +675,7 @@ public class Http2FrameCodecTest {
         channel.runPendingTasks();
         assertTrue(isStreamIdValid(stream2.id()));
 
-        assertTrue(future1.syncUninterruptibly().isSuccess());
+        assertTrue(future1.sync().isSuccess());
         assertFalse(future2.isDone());
         assertFalse(future3.isDone());
 
@@ -684,14 +684,14 @@ public class Http2FrameCodecTest {
         channel.flush();
 
         // As we increased the limit to 2 we should have also succeed the second frame.
-        assertTrue(future2.syncUninterruptibly().isSuccess());
+        assertTrue(future2.sync().isSuccess());
         assertFalse(future3.isDone());
 
         frameInboundWriter.writeInboundSettings(new Http2Settings().maxConcurrentStreams(3));
         channel.flush();
 
         // With the max streams of 3 all streams should be succeed now.
-        assertTrue(future3.syncUninterruptibly().isSuccess());
+        assertTrue(future3.sync().isSuccess());
 
         assertFalse(channel.finishAndReleaseAll());
     }
@@ -711,7 +711,7 @@ public class Http2FrameCodecTest {
                 new DefaultHttp2HeadersFrame(new DefaultHttp2Headers()).stream(stream2));
         channel.runPendingTasks();
 
-        assertTrue(stream1HeaderFuture.syncUninterruptibly().isSuccess());
+        assertTrue(stream1HeaderFuture.sync().isSuccess());
         assertTrue(stream2HeaderFuture.isDone());
 
         assertEquals(0, frameCodec.numInitializingStreams());
@@ -742,7 +742,7 @@ public class Http2FrameCodecTest {
     }
 
     @Test
-    public void receivePing() {
+    public void receivePing() throws Exception {
         frameInboundWriter.writeInboundPing(false, 12345L);
 
         Http2PingFrame pingFrame = inboundHandler.readInbound();
@@ -761,7 +761,7 @@ public class Http2FrameCodecTest {
     }
 
     @Test
-    public void receiveSettings() {
+    public void receiveSettings() throws Exception {
         Http2Settings settings = new Http2Settings().maxConcurrentStreams(1);
         frameInboundWriter.writeInboundSettings(settings);
 
@@ -922,14 +922,14 @@ public class Http2FrameCodecTest {
     }
 
     @Test
-    public void priorityForNonExistingStream() {
+    public void priorityForNonExistingStream() throws Exception {
         writeHeaderAndAssert(1);
 
         frameInboundWriter.writeInboundPriority(3, 1, (short) 31, true);
     }
 
     @Test
-    public void priorityForExistingStream() {
+    public void priorityForExistingStream() throws Exception {
         writeHeaderAndAssert(1);
         writeHeaderAndAssert(3);
         frameInboundWriter.writeInboundPriority(3, 1, (short) 31, true);
@@ -937,7 +937,7 @@ public class Http2FrameCodecTest {
         assertInboundStreamFrame(3, new DefaultHttp2PriorityFrame(1, (short) 31, true));
     }
 
-    private void writeHeaderAndAssert(int streamId) {
+    private void writeHeaderAndAssert(int streamId) throws Exception {
         frameInboundWriter.writeInboundHeaders(streamId, request, 31, false);
 
         Http2Stream stream = frameCodec.connection().stream(streamId);

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameInboundWriter.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameInboundWriter.java
@@ -48,60 +48,61 @@ final class Http2FrameInboundWriter {
         this.writer = writer;
     }
 
-    void writeInboundData(int streamId, ByteBuf data, int padding, boolean endStream) {
-        writer.writeData(ctx, streamId, data, padding, endStream).syncUninterruptibly();
+    void writeInboundData(int streamId, ByteBuf data, int padding, boolean endStream) throws Exception {
+        writer.writeData(ctx, streamId, data, padding, endStream).sync();
     }
 
     void writeInboundHeaders(int streamId, Http2Headers headers,
-                         int padding, boolean endStream) {
-        writer.writeHeaders(ctx, streamId, headers, padding, endStream).syncUninterruptibly();
+                         int padding, boolean endStream) throws Exception {
+        writer.writeHeaders(ctx, streamId, headers, padding, endStream).sync();
     }
 
-    void writeInboundHeaders(int streamId, Http2Headers headers,
-                               int streamDependency, short weight, boolean exclusive, int padding, boolean endStream) {
+    void writeInboundHeaders(
+            int streamId, Http2Headers headers, int streamDependency, short weight, boolean exclusive,
+            int padding, boolean endStream) throws Exception {
         writer.writeHeaders(ctx, streamId, headers, streamDependency,
-                weight, exclusive, padding, endStream).syncUninterruptibly();
+                weight, exclusive, padding, endStream).sync();
     }
 
     void writeInboundPriority(int streamId, int streamDependency,
-                                short weight, boolean exclusive) {
+                                short weight, boolean exclusive) throws Exception {
         writer.writePriority(ctx, streamId, streamDependency, weight,
-                exclusive).syncUninterruptibly();
+                exclusive).sync();
     }
 
-    void writeInboundRstStream(int streamId, long errorCode) {
-        writer.writeRstStream(ctx, streamId, errorCode).syncUninterruptibly();
+    void writeInboundRstStream(int streamId, long errorCode) throws Exception {
+        writer.writeRstStream(ctx, streamId, errorCode).sync();
     }
 
-    void writeInboundSettings(Http2Settings settings) {
-        writer.writeSettings(ctx, settings).syncUninterruptibly();
+    void writeInboundSettings(Http2Settings settings) throws Exception {
+        writer.writeSettings(ctx, settings).sync();
     }
 
-    void writeInboundSettingsAck() {
-        writer.writeSettingsAck(ctx).syncUninterruptibly();
+    void writeInboundSettingsAck() throws Exception {
+        writer.writeSettingsAck(ctx).sync();
     }
 
-    void writeInboundPing(boolean ack, long data) {
-        writer.writePing(ctx, ack, data).syncUninterruptibly();
+    void writeInboundPing(boolean ack, long data) throws Exception {
+        writer.writePing(ctx, ack, data).sync();
     }
 
     void writePushPromise(int streamId, int promisedStreamId,
-                                   Http2Headers headers, int padding) {
+                                   Http2Headers headers, int padding) throws Exception {
            writer.writePushPromise(ctx, streamId, promisedStreamId,
-                   headers, padding).syncUninterruptibly();
+                   headers, padding).sync();
     }
 
-    void writeInboundGoAway(int lastStreamId, long errorCode, ByteBuf debugData) {
-        writer.writeGoAway(ctx, lastStreamId, errorCode, debugData).syncUninterruptibly();
+    void writeInboundGoAway(int lastStreamId, long errorCode, ByteBuf debugData) throws Exception {
+        writer.writeGoAway(ctx, lastStreamId, errorCode, debugData).sync();
     }
 
-    void writeInboundWindowUpdate(int streamId, int windowSizeIncrement) {
-        writer.writeWindowUpdate(ctx, streamId, windowSizeIncrement).syncUninterruptibly();
+    void writeInboundWindowUpdate(int streamId, int windowSizeIncrement) throws Exception {
+        writer.writeWindowUpdate(ctx, streamId, windowSizeIncrement).sync();
     }
 
-    void writeInboundFrame(byte frameType, int streamId,
-                             Http2Flags flags, ByteBuf payload) {
-        writer.writeFrame(ctx, frameType, streamId, flags, payload).syncUninterruptibly();
+    void writeInboundFrame(
+            byte frameType, int streamId, Http2Flags flags, ByteBuf payload) throws Exception {
+        writer.writeFrame(ctx, frameType, streamId, flags, payload).sync();
     }
 
     private static final class WriteInboundChannelHandlerContext

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexTest.java
@@ -89,7 +89,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
     protected abstract ChannelHandler newMultiplexer(TestChannelInitializer childChannelInitializer);
 
     @BeforeEach
-    public void setUp() {
+    public void setUp() throws Exception {
         childChannelInitializer = new TestChannelInitializer();
         parentChannel = new EmbeddedChannel();
         frameInboundWriter = new Http2FrameInboundWriter(parentChannel);
@@ -138,7 +138,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
     // TODO(buchgr): Test ChannelConfig.setMaxMessagesPerRead
 
     @Test
-    public void writeUnknownFrame() {
+    public void writeUnknownFrame() throws Exception {
         Http2StreamChannel childChannel = newOutboundStream(new ChannelHandler() {
             @Override
             public void channelActive(ChannelHandlerContext ctx) {
@@ -153,12 +153,14 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
                 any(Http2Flags.class), any(ByteBuf.class));
     }
 
-    private Http2StreamChannel newInboundStream(int streamId, boolean endStream, final ChannelHandler childHandler) {
+    private Http2StreamChannel newInboundStream(int streamId, boolean endStream, final ChannelHandler childHandler)
+            throws Exception {
         return newInboundStream(streamId, endStream, null, childHandler);
     }
 
-    private Http2StreamChannel newInboundStream(int streamId, boolean endStream,
-                                                AtomicInteger maxReads, final ChannelHandler childHandler) {
+    private Http2StreamChannel newInboundStream(
+            int streamId, boolean endStream, AtomicInteger maxReads, final ChannelHandler childHandler)
+            throws Exception {
         final AtomicReference<Http2StreamChannel> streamChannelRef = new AtomicReference<Http2StreamChannel>();
         childChannelInitializer.maxReads = maxReads;
         childChannelInitializer.handler = new ChannelHandler() {
@@ -178,7 +180,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
     }
 
     @Test
-    public void readUnkownFrame() {
+    public void readUnkownFrame() throws Exception {
         LastInboundHandler handler = new LastInboundHandler();
 
         Http2StreamChannel channel = newInboundStream(3, true, handler);
@@ -192,7 +194,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
     }
 
     @Test
-    public void headerAndDataFramesShouldBeDelivered() {
+    public void headerAndDataFramesShouldBeDelivered() throws Exception {
         LastInboundHandler inboundHandler = new LastInboundHandler();
 
         Http2StreamChannel channel = newInboundStream(3, false, inboundHandler);
@@ -213,16 +215,16 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
     }
 
     @Test
-    public void headerMultipleContentLengthValidationShouldPropagate() {
+    public void headerMultipleContentLengthValidationShouldPropagate() throws Exception {
         headerMultipleContentLengthValidationShouldPropagate(false);
     }
 
     @Test
-    public void headerMultipleContentLengthValidationShouldPropagateWithEndStream() {
+    public void headerMultipleContentLengthValidationShouldPropagateWithEndStream() throws Exception {
         headerMultipleContentLengthValidationShouldPropagate(true);
     }
 
-    private void headerMultipleContentLengthValidationShouldPropagate(boolean endStream) {
+    private void headerMultipleContentLengthValidationShouldPropagate(boolean endStream) throws Exception {
         final LastInboundHandler inboundHandler = new LastInboundHandler();
         request.addLong(HttpHeaderNames.CONTENT_LENGTH, 0);
         request.addLong(HttpHeaderNames.CONTENT_LENGTH, 1);
@@ -239,26 +241,27 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
     }
 
     @Test
-    public void headerPlusSignContentLengthValidationShouldPropagate() {
+    public void headerPlusSignContentLengthValidationShouldPropagate() throws Exception {
         headerSignContentLengthValidationShouldPropagateWithEndStream(false, false);
     }
 
     @Test
-    public void headerPlusSignContentLengthValidationShouldPropagateWithEndStream() {
+    public void headerPlusSignContentLengthValidationShouldPropagateWithEndStream() throws Exception {
         headerSignContentLengthValidationShouldPropagateWithEndStream(false, true);
     }
 
     @Test
-    public void headerMinusSignContentLengthValidationShouldPropagate() {
+    public void headerMinusSignContentLengthValidationShouldPropagate() throws Exception {
         headerSignContentLengthValidationShouldPropagateWithEndStream(true, false);
     }
 
     @Test
-    public void headerMinusSignContentLengthValidationShouldPropagateWithEndStream() {
+    public void headerMinusSignContentLengthValidationShouldPropagateWithEndStream() throws Exception {
         headerSignContentLengthValidationShouldPropagateWithEndStream(true, true);
     }
 
-    private void headerSignContentLengthValidationShouldPropagateWithEndStream(boolean minus, boolean endStream) {
+    private void headerSignContentLengthValidationShouldPropagateWithEndStream(boolean minus, boolean endStream)
+            throws Exception {
         final LastInboundHandler inboundHandler = new LastInboundHandler();
         request.add(HttpHeaderNames.CONTENT_LENGTH, (minus ? "-" : "+") + 1);
         Http2StreamChannel channel = newInboundStream(3, endStream, inboundHandler);
@@ -274,55 +277,54 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
     }
 
     @Test
-    public void headerContentLengthNotMatchValidationShouldPropagate() {
+    public void headerContentLengthNotMatchValidationShouldPropagate() throws Exception {
         headerContentLengthNotMatchValidationShouldPropagate(false, false, false);
     }
 
     @Test
-    public void headerContentLengthNotMatchValidationShouldPropagateWithEndStream() {
+    public void headerContentLengthNotMatchValidationShouldPropagateWithEndStream() throws Exception {
         headerContentLengthNotMatchValidationShouldPropagate(false, true, false);
     }
 
     @Test
-    public void headerContentLengthNotMatchValidationShouldPropagateCloseLocal() {
+    public void headerContentLengthNotMatchValidationShouldPropagateCloseLocal() throws Exception {
         headerContentLengthNotMatchValidationShouldPropagate(true, false, false);
     }
 
     @Test
-    public void headerContentLengthNotMatchValidationShouldPropagateWithEndStreamCloseLocal() {
+    public void headerContentLengthNotMatchValidationShouldPropagateWithEndStreamCloseLocal() throws Exception {
         headerContentLengthNotMatchValidationShouldPropagate(true, true, false);
     }
 
     @Test
-    public void headerContentLengthNotMatchValidationShouldPropagateTrailers() {
+    public void headerContentLengthNotMatchValidationShouldPropagateTrailers() throws Exception {
         headerContentLengthNotMatchValidationShouldPropagate(false, false, true);
     }
 
     @Test
-    public void headerContentLengthNotMatchValidationShouldPropagateWithEndStreamTrailers() {
+    public void headerContentLengthNotMatchValidationShouldPropagateWithEndStreamTrailers() throws Exception {
         headerContentLengthNotMatchValidationShouldPropagate(false, true, true);
     }
 
     @Test
-    public void headerContentLengthNotMatchValidationShouldPropagateCloseLocalTrailers() {
+    public void headerContentLengthNotMatchValidationShouldPropagateCloseLocalTrailers() throws Exception {
         headerContentLengthNotMatchValidationShouldPropagate(true, false, true);
     }
 
     @Test
-    public void headerContentLengthNotMatchValidationShouldPropagateWithEndStreamCloseLocalTrailers() {
+    public void headerContentLengthNotMatchValidationShouldPropagateWithEndStreamCloseLocalTrailers() throws Exception {
         headerContentLengthNotMatchValidationShouldPropagate(true, true, true);
     }
 
     private void headerContentLengthNotMatchValidationShouldPropagate(
-            boolean closeLocal, boolean endStream, boolean trailer) {
+            boolean closeLocal, boolean endStream, boolean trailer) throws Exception {
         final LastInboundHandler inboundHandler = new LastInboundHandler();
         request.addLong(HttpHeaderNames.CONTENT_LENGTH, 1);
         Http2StreamChannel channel = newInboundStream(3, false, inboundHandler);
         assertTrue(channel.isActive());
 
         if (closeLocal) {
-            channel.writeAndFlush(new DefaultHttp2HeadersFrame(new DefaultHttp2Headers(), true))
-                    .syncUninterruptibly();
+            channel.writeAndFlush(new DefaultHttp2HeadersFrame(new DefaultHttp2Headers(), true)).sync();
             assertEquals(Http2Stream.State.HALF_CLOSED_LOCAL, channel.stream().state());
         } else {
             assertEquals(Http2Stream.State.OPEN, channel.stream().state());
@@ -348,7 +350,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
     }
 
     @Test
-    public void framesShouldBeMultiplexed() {
+    public void framesShouldBeMultiplexed() throws Exception {
         LastInboundHandler handler1 = new LastInboundHandler();
         Http2StreamChannel channel1 = newInboundStream(3, false, handler1);
         LastInboundHandler handler2 = new LastInboundHandler();
@@ -371,7 +373,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
     }
 
     @Test
-    public void inboundDataFrameShouldUpdateLocalFlowController() throws Http2Exception {
+    public void inboundDataFrameShouldUpdateLocalFlowController() throws Exception {
         Http2LocalFlowController flowController = Mockito.mock(Http2LocalFlowController.class);
         codec.connection().local().flowController(flowController);
 
@@ -390,7 +392,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
     }
 
     @Test
-    public void unhandledHttp2FramesShouldBePropagated() {
+    public void unhandledHttp2FramesShouldBePropagated() throws Exception {
         Http2PingFrame pingFrame = new DefaultHttp2PingFrame(0);
         frameInboundWriter.writeInboundPing(false, 0);
         assertEquals(parentChannel.readInbound(), pingFrame);
@@ -404,7 +406,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
     }
 
     @Test
-    public void channelReadShouldRespectAutoRead() {
+    public void channelReadShouldRespectAutoRead() throws Exception {
         LastInboundHandler inboundHandler = new LastInboundHandler();
         Http2StreamChannel childChannel = newInboundStream(3, false, inboundHandler);
         assertTrue(childChannel.config().isAutoRead());
@@ -464,16 +466,16 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
     }
 
     @Test
-    public void readInChannelReadWithoutAutoRead() {
+    public void readInChannelReadWithoutAutoRead() throws Exception {
         useReadWithoutAutoRead(false);
     }
 
     @Test
-    public void readInChannelReadCompleteWithoutAutoRead() {
+    public void readInChannelReadCompleteWithoutAutoRead() throws Exception {
         useReadWithoutAutoRead(true);
     }
 
-    private void useReadWithoutAutoRead(final boolean readComplete) {
+    private void useReadWithoutAutoRead(final boolean readComplete) throws Exception {
         LastInboundHandler inboundHandler = new LastInboundHandler();
         Http2StreamChannel childChannel = newInboundStream(3, false, inboundHandler);
         assertTrue(childChannel.config().isAutoRead());
@@ -512,10 +514,10 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
         verifyFramesMultiplexedToCorrectChannel(childChannel, inboundHandler, 6);
     }
 
-    private Http2StreamChannel newOutboundStream(ChannelHandler handler) {
+    private Http2StreamChannel newOutboundStream(ChannelHandler handler) throws Exception {
         Future<Http2StreamChannel> future = new Http2StreamChannelBootstrap(parentChannel).handler(handler)
                 .open();
-        return future.syncUninterruptibly().getNow();
+        return future.sync().getNow();
     }
 
     /**
@@ -523,7 +525,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
      * should not emit a RST_STREAM frame on close, as this is a connection error of type protocol error.
      */
     @Test
-    public void idleOutboundStreamShouldNotWriteResetFrameOnClose() {
+    public void idleOutboundStreamShouldNotWriteResetFrameOnClose() throws Exception {
         LastInboundHandler handler = new LastInboundHandler();
 
         Channel childChannel = newOutboundStream(handler);
@@ -537,7 +539,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
     }
 
     @Test
-    public void outboundStreamShouldWriteResetFrameOnClose_headersSent() {
+    public void outboundStreamShouldWriteResetFrameOnClose_headersSent() throws Exception {
         ChannelHandler handler = new ChannelHandler() {
             @Override
             public void channelActive(ChannelHandlerContext ctx) {
@@ -555,7 +557,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
     }
 
     @Test
-    public void outboundStreamShouldNotWriteResetFrameOnClose_IfStreamDidntExist() {
+    public void outboundStreamShouldNotWriteResetFrameOnClose_IfStreamDidntExist() throws Exception {
         when(frameWriter.writeHeaders(any(ChannelHandlerContext.class), anyInt(),
                 any(Http2Headers.class), anyInt(), anyBoolean())).thenAnswer(new Answer<Future<Void>>() {
 
@@ -591,7 +593,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
     }
 
     @Test
-    public void inboundRstStreamFireChannelInactive() {
+    public void inboundRstStreamFireChannelInactive() throws Exception {
         LastInboundHandler inboundHandler = new LastInboundHandler();
         Http2StreamChannel channel = newInboundStream(3, false, inboundHandler);
         assertTrue(inboundHandler.isChannelActive());
@@ -646,15 +648,15 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
 
         CompletionException e = assertThrows(CompletionException.class, new Executable() {
             @Override
-            public void execute() {
-                future.syncUninterruptibly();
+            public void execute() throws Exception {
+                future.sync();
             }
         });
         assertThat(e.getCause(), CoreMatchers.instanceOf(ClosedChannelException.class));
     }
 
     @Test
-    public void creatingWritingReadingAndClosingOutboundStreamShouldWork() {
+    public void creatingWritingReadingAndClosingOutboundStreamShouldWork() throws Exception {
         LastInboundHandler inboundHandler = new LastInboundHandler();
         Http2StreamChannel childChannel = newOutboundStream(inboundHandler);
         assertTrue(childChannel.isActive());
@@ -707,15 +709,15 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
 
         CompletionException e = assertThrows(CompletionException.class, new Executable() {
             @Override
-            public void execute() {
-                future.syncUninterruptibly();
+            public void execute() throws Exception {
+                future.sync();
             }
         });
         assertThat(e.getCause(), CoreMatchers.instanceOf(Http2NoMoreStreamIdsException.class));
     }
 
     @Test
-    public void channelClosedWhenCloseListenerCompletes() {
+    public void channelClosedWhenCloseListenerCompletes() throws Exception {
         LastInboundHandler inboundHandler = new LastInboundHandler();
         Http2StreamChannel childChannel = newInboundStream(3, false, inboundHandler);
 
@@ -732,7 +734,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
             channelOpen.set(channel.isOpen());
             channelActive.set(channel.isActive());
         });
-        childChannel.close().cascadeTo(p).syncUninterruptibly();
+        childChannel.close().cascadeTo(p).sync();
 
         assertFalse(channelOpen.get());
         assertFalse(channelActive.get());
@@ -740,7 +742,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
     }
 
     @Test
-    public void channelClosedWhenChannelClosePromiseCompletes() {
+    public void channelClosedWhenChannelClosePromiseCompletes() throws Exception {
          LastInboundHandler inboundHandler = new LastInboundHandler();
          Http2StreamChannel childChannel = newInboundStream(3, false, inboundHandler);
 
@@ -754,7 +756,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
              channelOpen.set(channel.isOpen());
              channelActive.set(channel.isActive());
          });
-         childChannel.close().syncUninterruptibly();
+         childChannel.close().sync();
 
          assertFalse(channelOpen.get());
          assertFalse(channelActive.get());
@@ -762,7 +764,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
     }
 
     @Test
-    public void channelClosedWhenWriteFutureFails() {
+    public void channelClosedWhenWriteFutureFails() throws Exception {
         final Queue<Promise<Void>> writePromises = new ArrayDeque<>();
 
         LastInboundHandler inboundHandler = new LastInboundHandler();
@@ -791,7 +793,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
 
         Promise<Void> first = writePromises.poll();
         first.setFailure(new ClosedChannelException());
-        f.awaitUninterruptibly();
+        f.await();
 
         assertFalse(channelOpen.get());
         assertFalse(channelActive.get());
@@ -799,21 +801,21 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
     }
 
     @Test
-    public void channelClosedTwiceMarksPromiseAsSuccessful() {
+    public void channelClosedTwiceMarksPromiseAsSuccessful() throws Exception {
         LastInboundHandler inboundHandler = new LastInboundHandler();
         Http2StreamChannel childChannel = newInboundStream(3, false, inboundHandler);
 
         assertTrue(childChannel.isOpen());
         assertTrue(childChannel.isActive());
-        childChannel.close().syncUninterruptibly();
-        childChannel.close().syncUninterruptibly();
+        childChannel.close().sync();
+        childChannel.close().sync();
 
         assertFalse(childChannel.isOpen());
         assertFalse(childChannel.isActive());
     }
 
     @Test
-    public void settingChannelOptsAndAttrs() {
+    public void settingChannelOptsAndAttrs() throws Exception {
         AttributeKey<String> key = AttributeKey.newInstance(UUID.randomUUID().toString());
 
         Channel childChannel = newOutboundStream(new ChannelHandler() { });
@@ -825,7 +827,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
     }
 
     @Test
-    public void outboundFlowControlWritability() {
+    public void outboundFlowControlWritability() throws Exception {
         Http2StreamChannel childChannel = newOutboundStream(new ChannelHandler() { });
         assertTrue(childChannel.isActive());
 
@@ -843,7 +845,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
     }
 
     @Test
-    public void writabilityOfParentIsRespected() {
+    public void writabilityOfParentIsRespected() throws Exception {
         Http2StreamChannel childChannel = newOutboundStream(new ChannelHandler() { });
         childChannel.config().setWriteBufferWaterMark(new WriteBufferWaterMark(2048, 4096));
         parentChannel.config().setWriteBufferWaterMark(new WriteBufferWaterMark(256, 512));
@@ -894,7 +896,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
     }
 
     @Test
-    public void channelClosedWhenInactiveFired() {
+    public void channelClosedWhenInactiveFired() throws Exception {
         LastInboundHandler inboundHandler = new LastInboundHandler();
         Http2StreamChannel childChannel = newInboundStream(3, false, inboundHandler);
 
@@ -913,13 +915,13 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
             }
         });
 
-        childChannel.close().syncUninterruptibly();
+        childChannel.close().sync();
         assertFalse(channelOpen.get());
         assertFalse(channelActive.get());
     }
 
     @Test
-    public void channelInactiveHappensAfterExceptionCaughtEvents() {
+    public void channelInactiveHappensAfterExceptionCaughtEvents() throws Exception {
         final AtomicInteger count = new AtomicInteger(0);
         final AtomicInteger exceptionCaught = new AtomicInteger(-1);
         final AtomicInteger channelInactive = new AtomicInteger(-1);
@@ -964,19 +966,19 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
     }
 
     @Test
-    public void callUnsafeCloseMultipleTimes() {
+    public void callUnsafeCloseMultipleTimes() throws Exception {
         LastInboundHandler inboundHandler = new LastInboundHandler();
         Http2StreamChannel childChannel = newInboundStream(3, false, inboundHandler);
         childChannel.unsafe().close(childChannel.newPromise());
 
         Promise<Void> promise = childChannel.newPromise();
         childChannel.unsafe().close(promise);
-        promise.asFuture().syncUninterruptibly();
-        childChannel.closeFuture().syncUninterruptibly();
+        promise.asFuture().sync();
+        childChannel.closeFuture().sync();
     }
 
     @Test
-    public void endOfStreamDoesNotDiscardData() {
+    public void endOfStreamDoesNotDiscardData() throws Exception {
         AtomicInteger numReads = new AtomicInteger(1);
         final AtomicBoolean shouldDisableAutoRead = new AtomicBoolean();
         Consumer<ChannelHandlerContext> ctxConsumer = obj -> {
@@ -1040,7 +1042,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
         parentChannel.pipeline().remove(readCompleteSupressHandler);
         parentChannel.flushInbound();
 
-        childChannel.closeFuture().syncUninterruptibly();
+        childChannel.closeFuture().sync();
     }
 
     protected abstract boolean useUserEventForResetFrame();
@@ -1048,7 +1050,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
     protected abstract boolean ignoreWindowUpdateFrames();
 
     @Test
-    public void windowUpdateFrames() {
+    public void windowUpdateFrames() throws Exception {
         AtomicInteger numReads = new AtomicInteger(1);
         LastInboundHandler inboundHandler = new LastInboundHandler();
         Http2StreamChannel childChannel = newInboundStream(3, false, numReads, inboundHandler);
@@ -1067,11 +1069,11 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
         frameInboundWriter.writeInboundWindowUpdate(Http2CodecUtil.CONNECTION_STREAM_ID, 6);
 
         assertNull(parentChannel.readInbound());
-        childChannel.close().syncUninterruptibly();
+        childChannel.close().sync();
     }
 
     @Test
-    public void childQueueIsDrainedAndNewDataIsDispatchedInParentReadLoopAutoRead() {
+    public void childQueueIsDrainedAndNewDataIsDispatchedInParentReadLoopAutoRead() throws Exception {
         AtomicInteger numReads = new AtomicInteger(1);
         final AtomicInteger channelReadCompleteCount = new AtomicInteger(0);
         final AtomicBoolean shouldDisableAutoRead = new AtomicBoolean();
@@ -1131,7 +1133,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
     }
 
     @Test
-    public void childQueueIsDrainedAndNewDataIsDispatchedInParentReadLoopNoAutoRead() {
+    public void childQueueIsDrainedAndNewDataIsDispatchedInParentReadLoopNoAutoRead() throws Exception {
         final AtomicInteger numReads = new AtomicInteger(1);
         final AtomicInteger channelReadCompleteCount = new AtomicInteger(0);
         final AtomicBoolean shouldDisableAutoRead = new AtomicBoolean();
@@ -1200,16 +1202,16 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
     }
 
     @Test
-    public void useReadWithoutAutoReadInRead() {
+    public void useReadWithoutAutoReadInRead() throws Exception {
         useReadWithoutAutoReadBuffered(false);
     }
 
     @Test
-    public void useReadWithoutAutoReadInReadComplete() {
+    public void useReadWithoutAutoReadInReadComplete() throws Exception {
         useReadWithoutAutoReadBuffered(true);
     }
 
-    private void useReadWithoutAutoReadBuffered(final boolean triggerOnReadComplete) {
+    private void useReadWithoutAutoReadBuffered(final boolean triggerOnReadComplete) throws Exception {
         LastInboundHandler inboundHandler = new LastInboundHandler();
         Http2StreamChannel childChannel = newInboundStream(3, false, inboundHandler);
         assertTrue(childChannel.config().isAutoRead());
@@ -1276,7 +1278,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
     }
 
     @Test
-    public void windowUpdatesAreFlushed() {
+    public void windowUpdatesAreFlushed() throws Exception {
         LastInboundHandler inboundHandler = new LastInboundHandler();
         FlushSniffer flushSniffer = new FlushSniffer();
         parentChannel.pipeline().addFirst(flushSniffer);

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexTransportTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexTransportTest.java
@@ -255,9 +255,9 @@ public class Http2MultiplexTransportTest {
                     Resource.dispose(msg);
                 }
             });
-            Http2StreamChannel streamChannel = h2Bootstrap.open().syncUninterruptibly().getNow();
+            Http2StreamChannel streamChannel = h2Bootstrap.open().sync().getNow();
             streamChannel.writeAndFlush(new DefaultHttp2HeadersFrame(new DefaultHttp2Headers(), true))
-                    .syncUninterruptibly();
+                    .sync();
 
             latch.await();
         } finally {

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ServerUpgradeCodecTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ServerUpgradeCodecTest.java
@@ -38,22 +38,22 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class Http2ServerUpgradeCodecTest {
 
     @Test
-    public void testUpgradeToHttp2ConnectionHandler() {
+    public void testUpgradeToHttp2ConnectionHandler() throws Exception {
         testUpgrade(new Http2ConnectionHandlerBuilder().frameListener(new Http2FrameAdapter()).build(), null);
     }
 
     @Test
-    public void testUpgradeToHttp2FrameCodec() {
+    public void testUpgradeToHttp2FrameCodec() throws Exception {
         testUpgrade(new Http2FrameCodecBuilder(true).build(), null);
     }
 
     @Test
-    public void testUpgradeToHttp2FrameCodecWithMultiplexer() {
+    public void testUpgradeToHttp2FrameCodecWithMultiplexer() throws Exception {
         testUpgrade(new Http2FrameCodecBuilder(true).build(),
                 new Http2MultiplexHandler(new HttpInboundHandler()));
     }
 
-    private static void testUpgrade(Http2ConnectionHandler handler, ChannelHandler multiplexer) {
+    private static void testUpgrade(Http2ConnectionHandler handler, ChannelHandler multiplexer) throws Exception {
         FullHttpRequest request = new DefaultFullHttpRequest(
                 HttpVersion.HTTP_1_1, HttpMethod.OPTIONS, "*", preferredAllocator().allocate(0));
         request.headers().set(HttpHeaderNames.HOST, "netty.io");

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2StreamChannelBootstrapTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2StreamChannelBootstrapTest.java
@@ -127,7 +127,7 @@ public class Http2StreamChannelBootstrapTest {
     private static void safeClose(Channel channel) {
         if (channel != null) {
             try {
-                channel.close().syncUninterruptibly();
+                channel.close().sync();
             } catch (Exception e) {
                 logger.error(e);
             }

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
@@ -105,24 +105,24 @@ public class HttpToHttp2ConnectionHandlerTest {
     @AfterEach
     public void tearDown() throws Exception {
         if (clientChannel != null) {
-            clientChannel.close().syncUninterruptibly();
+            clientChannel.close().sync();
             clientChannel = null;
         }
         if (serverChannel != null) {
-            serverChannel.close().syncUninterruptibly();
+            serverChannel.close().sync();
             serverChannel = null;
         }
         final Channel serverConnectedChannel = this.serverConnectedChannel;
         if (serverConnectedChannel != null) {
-            serverConnectedChannel.close().syncUninterruptibly();
+            serverConnectedChannel.close().sync();
             this.serverConnectedChannel = null;
         }
         Future<?> serverGroup = sb.config().group().shutdownGracefully(0, 5, SECONDS);
         Future<?> serverChildGroup = sb.config().childGroup().shutdownGracefully(0, 5, SECONDS);
         Future<?> clientGroup = cb.config().group().shutdownGracefully(0, 5, SECONDS);
-        serverGroup.syncUninterruptibly();
-        serverChildGroup.syncUninterruptibly();
-        clientGroup.syncUninterruptibly();
+        serverGroup.sync();
+        serverChildGroup.sync();
+        clientGroup.sync();
     }
 
     @Test
@@ -347,7 +347,7 @@ public class HttpToHttp2ConnectionHandlerTest {
 
         Future<Void> writeFuture = clientChannel.writeAndFlush(request);
 
-        assertTrue(writeFuture.awaitUninterruptibly(WAIT_TIME_SECONDS, SECONDS));
+        assertTrue(writeFuture.await(WAIT_TIME_SECONDS, SECONDS));
         assertTrue(writeFuture.isDone());
         assertFalse(writeFuture.isSuccess());
     }
@@ -364,7 +364,7 @@ public class HttpToHttp2ConnectionHandlerTest {
 
         Future<Void> writeFuture = clientChannel.writeAndFlush(request);
 
-        assertTrue(writeFuture.awaitUninterruptibly(WAIT_TIME_SECONDS, SECONDS));
+        assertTrue(writeFuture.await(WAIT_TIME_SECONDS, SECONDS));
         assertTrue(writeFuture.isDone());
         assertFalse(writeFuture.isSuccess());
         Throwable cause = writeFuture.cause();
@@ -398,7 +398,7 @@ public class HttpToHttp2ConnectionHandlerTest {
 
         Future<Void> writeFuture = clientChannel.writeAndFlush(request);
 
-        assertTrue(writeFuture.awaitUninterruptibly(WAIT_TIME_SECONDS, SECONDS));
+        assertTrue(writeFuture.await(WAIT_TIME_SECONDS, SECONDS));
         assertTrue(writeFuture.isSuccess());
         awaitRequests();
         verify(serverListener).onHeadersRead(any(ChannelHandlerContext.class), eq(3), eq(http2Headers), eq(0),
@@ -441,7 +441,7 @@ public class HttpToHttp2ConnectionHandlerTest {
 
         Future<Void> writeFuture = clientChannel.writeAndFlush(request);
 
-        assertTrue(writeFuture.awaitUninterruptibly(WAIT_TIME_SECONDS, SECONDS));
+        assertTrue(writeFuture.await(WAIT_TIME_SECONDS, SECONDS));
         assertTrue(writeFuture.isSuccess());
         awaitRequests();
         verify(serverListener).onHeadersRead(any(ChannelHandlerContext.class), eq(3), eq(http2Headers), eq(0),
@@ -496,13 +496,13 @@ public class HttpToHttp2ConnectionHandlerTest {
 
         clientChannel.flush();
 
-        assertTrue(writeFuture.awaitUninterruptibly(WAIT_TIME_SECONDS, SECONDS));
+        assertTrue(writeFuture.await(WAIT_TIME_SECONDS, SECONDS));
         assertTrue(writeFuture.isSuccess());
 
-        assertTrue(contentFuture.awaitUninterruptibly(WAIT_TIME_SECONDS, SECONDS));
+        assertTrue(contentFuture.await(WAIT_TIME_SECONDS, SECONDS));
         assertTrue(contentFuture.isSuccess());
 
-        assertTrue(lastContentFuture.awaitUninterruptibly(WAIT_TIME_SECONDS, SECONDS));
+        assertTrue(lastContentFuture.await(WAIT_TIME_SECONDS, SECONDS));
         assertTrue(lastContentFuture.isSuccess());
 
         awaitRequests();
@@ -577,7 +577,7 @@ public class HttpToHttp2ConnectionHandlerTest {
 
     private void verifyHeadersOnly(Http2Headers expected, Future<Void> writeFuture)
             throws Exception {
-        assertTrue(writeFuture.awaitUninterruptibly(WAIT_TIME_SECONDS, SECONDS));
+        assertTrue(writeFuture.await(WAIT_TIME_SECONDS, SECONDS));
         assertTrue(writeFuture.isSuccess());
         awaitRequests();
         verify(serverListener).onHeadersRead(any(ChannelHandlerContext.class), eq(5),

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
@@ -112,24 +112,24 @@ public class InboundHttp2ToHttpAdapterTest {
         cleanupCapturedRequests();
         cleanupCapturedResponses();
         if (clientChannel != null) {
-            clientChannel.close().syncUninterruptibly();
+            clientChannel.close().sync();
             clientChannel = null;
         }
         if (serverChannel != null) {
-            serverChannel.close().syncUninterruptibly();
+            serverChannel.close().sync();
             serverChannel = null;
         }
         final Channel serverConnectedChannel = this.serverConnectedChannel;
         if (serverConnectedChannel != null) {
-            serverConnectedChannel.close().syncUninterruptibly();
+            serverConnectedChannel.close().sync();
             this.serverConnectedChannel = null;
         }
         Future<?> serverGroup = sb.config().group().shutdownGracefully(0, 5, SECONDS);
         Future<?> serverChildGroup = sb.config().childGroup().shutdownGracefully(0, 5, SECONDS);
         Future<?> clientGroup = cb.config().group().shutdownGracefully(0, 5, SECONDS);
-        serverGroup.syncUninterruptibly();
-        serverChildGroup.syncUninterruptibly();
-        clientGroup.syncUninterruptibly();
+        serverGroup.sync();
+        serverChildGroup.sync();
+        clientGroup.sync();
     }
 
     @Test

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/StreamBufferingEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/StreamBufferingEncoderTest.java
@@ -275,14 +275,14 @@ public class StreamBufferingEncoderTest {
     }
 
     @Test
-    public void receivingGoAwayFailsNewStreamIfMaxConcurrentStreamsReached() throws Http2Exception {
+    public void receivingGoAwayFailsNewStreamIfMaxConcurrentStreamsReached() throws Exception {
         encoder.writeSettingsAck(ctx);
         setMaxConcurrentStreams(1);
         encoderWriteHeaders(3);
         connection.goAwayReceived(11, 8, EMPTY_BUFFER);
         Future<Void> f = encoderWriteHeaders(5);
 
-        assertTrue(f.awaitUninterruptibly().cause() instanceof Http2GoAwayException);
+        assertTrue(f.await().cause() instanceof Http2GoAwayException);
         assertEquals(0, encoder.numBufferedStreams());
     }
 
@@ -459,7 +459,7 @@ public class StreamBufferingEncoderTest {
     }
 
     @Test
-    public void exhaustedStreamsDoNotBuffer() throws Http2Exception {
+    public void exhaustedStreamsDoNotBuffer() throws Exception {
         // Write the highest possible stream ID for the client.
         // This will cause the next stream ID to be negative.
         encoderWriteHeaders(Integer.MAX_VALUE);
@@ -471,7 +471,7 @@ public class StreamBufferingEncoderTest {
         Future<Void> f = encoderWriteHeaders(-1);
 
         // Verify that the write fails.
-        assertNotNull(f.awaitUninterruptibly().cause());
+        assertNotNull(f.await().cause());
     }
 
     @Test
@@ -493,7 +493,7 @@ public class StreamBufferingEncoderTest {
     }
 
     @Test
-    public void closeShouldCancelAllBufferedStreams() throws Http2Exception {
+    public void closeShouldCancelAllBufferedStreams() throws Exception {
         encoder.writeSettingsAck(ctx);
         connection.local().maxActiveStreams(0);
 
@@ -502,9 +502,9 @@ public class StreamBufferingEncoderTest {
         Future<Void> f3 = encoderWriteHeaders(7);
 
         encoder.close();
-        assertNotNull(f1.awaitUninterruptibly().cause());
-        assertNotNull(f2.awaitUninterruptibly().cause());
-        assertNotNull(f3.awaitUninterruptibly().cause());
+        assertNotNull(f1.await().cause());
+        assertNotNull(f2.await().cause());
+        assertNotNull(f3.await().cause());
     }
 
     @Test

--- a/common/src/main/java/io/netty5/util/concurrent/AbstractScheduledEventExecutor.java
+++ b/common/src/main/java/io/netty5/util/concurrent/AbstractScheduledEventExecutor.java
@@ -397,20 +397,8 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
         }
 
         @Override
-        public RunnableFuture<V> syncUninterruptibly() {
-            future.syncUninterruptibly();
-            return this;
-        }
-
-        @Override
         public RunnableFuture<V> await() throws InterruptedException {
             future.await();
-            return this;
-        }
-
-        @Override
-        public RunnableFuture<V> awaitUninterruptibly() {
-            future.awaitUninterruptibly();
             return this;
         }
 
@@ -442,16 +430,6 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
         @Override
         public boolean await(long timeoutMillis) throws InterruptedException {
             return future.await(timeoutMillis);
-        }
-
-        @Override
-        public boolean awaitUninterruptibly(long timeout, TimeUnit unit) {
-            return future.awaitUninterruptibly(timeout, unit);
-        }
-
-        @Override
-        public boolean awaitUninterruptibly(long timeoutMillis) {
-            return future.awaitUninterruptibly(timeoutMillis);
         }
 
         @Override

--- a/common/src/main/java/io/netty5/util/concurrent/DefaultFutureCompletionStage.java
+++ b/common/src/main/java/io/netty5/util/concurrent/DefaultFutureCompletionStage.java
@@ -15,7 +15,6 @@
  */
 package io.netty5.util.concurrent;
 
-
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;

--- a/common/src/main/java/io/netty5/util/concurrent/DefaultPromise.java
+++ b/common/src/main/java/io/netty5/util/concurrent/DefaultPromise.java
@@ -266,36 +266,6 @@ public class DefaultPromise<V> implements Promise<V>, Future<V> {
     }
 
     @Override
-    public Future<V> awaitUninterruptibly() {
-        if (isDone()) {
-            return this;
-        }
-
-        checkDeadLock();
-
-        boolean interrupted = false;
-        synchronized (this) {
-            while (!isDone()) {
-                incWaiters();
-                try {
-                    wait();
-                } catch (InterruptedException e) {
-                    // Interrupted while waiting.
-                    interrupted = true;
-                } finally {
-                    decWaiters();
-                }
-            }
-        }
-
-        if (interrupted) {
-            Thread.currentThread().interrupt();
-        }
-
-        return this;
-    }
-
-    @Override
     public boolean await(long timeout, TimeUnit unit) throws InterruptedException {
         return await0(unit.toNanos(timeout), true);
     }
@@ -303,26 +273,6 @@ public class DefaultPromise<V> implements Promise<V>, Future<V> {
     @Override
     public boolean await(long timeoutMillis) throws InterruptedException {
         return await0(MILLISECONDS.toNanos(timeoutMillis), true);
-    }
-
-    @Override
-    public boolean awaitUninterruptibly(long timeout, TimeUnit unit) {
-        try {
-            return await0(unit.toNanos(timeout), false);
-        } catch (InterruptedException e) {
-            // Should not be raised at all.
-            throw new InternalError();
-        }
-    }
-
-    @Override
-    public boolean awaitUninterruptibly(long timeoutMillis) {
-        try {
-            return await0(MILLISECONDS.toNanos(timeoutMillis), false);
-        } catch (InterruptedException e) {
-            // Should not be raised at all.
-            throw new InternalError();
-        }
     }
 
     @SuppressWarnings("unchecked")
@@ -406,13 +356,6 @@ public class DefaultPromise<V> implements Promise<V>, Future<V> {
     @Override
     public Future<V> sync() throws InterruptedException {
         await();
-        rethrowIfFailed();
-        return this;
-    }
-
-    @Override
-    public Future<V> syncUninterruptibly() {
-        awaitUninterruptibly();
         rethrowIfFailed();
         return this;
     }

--- a/common/src/main/java/io/netty5/util/concurrent/Future.java
+++ b/common/src/main/java/io/netty5/util/concurrent/Future.java
@@ -112,9 +112,9 @@ import java.util.function.Function;
  *
  * <h3>Do not confuse I/O timeout and await timeout</h3>
  * <p>
- * The timeout value you specify with {@link #await(long)}, {@link #await(long, TimeUnit)}, {@link
- * #awaitUninterruptibly(long)}, or {@link #awaitUninterruptibly(long, TimeUnit)} are not related with I/O timeout at
- * all.  If an I/O operation times out, the future will be marked as 'completed with failure,' as depicted in the
+ * The timeout value you specify with {@link #await(long)} or {@link #await(long, TimeUnit)} are not related with
+ * I/O timeout at all.
+ * If an I/O operation times out, the future will be marked as 'completed with failure,' as depicted in the
  * diagram above.  For example, connect timeout should be configured via a transport-specific option:
  * <pre>
  * // BAD - NEVER DO THIS
@@ -182,27 +182,11 @@ public interface Future<V> extends AsynchronousResult<V> {
     Future<V> sync() throws InterruptedException;
 
     /**
-     * Waits for this future until it is done, and rethrows the cause of the failure if this future failed.
-     *
-     * @throws CancellationException if the computation was cancelled
-     * @throws CompletionException   if the computation threw an exception.
-     */
-    @Deprecated(forRemoval = true)
-    Future<V> syncUninterruptibly();
-
-    /**
      * Waits for this future to be completed.
      *
      * @throws InterruptedException if the current thread was interrupted
      */
     Future<V> await() throws InterruptedException;
-
-    /**
-     * Waits for this future to be completed without interruption.  This method catches an {@link InterruptedException}
-     * and discards it silently.
-     */
-    @Deprecated(forRemoval = true)
-    Future<V> awaitUninterruptibly();
 
     /**
      * Waits for this future to be completed within the specified time limit.
@@ -219,24 +203,6 @@ public interface Future<V> extends AsynchronousResult<V> {
      * @throws InterruptedException if the current thread was interrupted
      */
     boolean await(long timeoutMillis) throws InterruptedException;
-
-    /**
-     * Waits for this future to be completed within the specified time limit without interruption.  This method catches
-     * an {@link InterruptedException} and discards it silently.
-     *
-     * @return {@code true} if and only if the future was completed within the specified time limit
-     */
-    @Deprecated(forRemoval = true)
-    boolean awaitUninterruptibly(long timeout, TimeUnit unit);
-
-    /**
-     * Waits for this future to be completed within the specified time limit without interruption.  This method catches
-     * an {@link InterruptedException} and discards it silently.
-     *
-     * @return {@code true} if and only if the future was completed within the specified time limit
-     */
-    @Deprecated(forRemoval = true)
-    boolean awaitUninterruptibly(long timeoutMillis);
 
     /**
      * Get the result of this future, if it has completed.

--- a/common/src/main/java/io/netty5/util/concurrent/Future.java
+++ b/common/src/main/java/io/netty5/util/concurrent/Future.java
@@ -88,7 +88,7 @@ import java.util.function.Function;
  * {@code @Override}
  * public void channelRead({@link io.netty5.channel.ChannelHandlerContext} ctx, Object msg) {
  *     {@link Future} future = ctx.channel().close();
- *     future.awaitUninterruptibly();
+ *     future.await();
  *     // Perform post-closure operation
  *     // ...
  * }
@@ -120,7 +120,7 @@ import java.util.function.Function;
  * // BAD - NEVER DO THIS
  * {@link io.netty5.bootstrap.Bootstrap} b = ...;
  * {@link Future} f = b.connect(...);
- * f.awaitUninterruptibly(10, TimeUnit.SECONDS);
+ * f.await(10, TimeUnit.SECONDS);
  * if (f.isCancelled()) {
  *     // Connection attempt cancelled by user
  * } else if (!f.isSuccess()) {
@@ -136,7 +136,7 @@ import java.util.function.Function;
  * // Configure the connect timeout option.
  * <b>b.option({@link io.netty5.channel.ChannelOption}.CONNECT_TIMEOUT_MILLIS, 10000);</b>
  * {@link Future} f = b.connect(...);
- * f.awaitUninterruptibly();
+ * f.await();
  *
  * // Now we are sure the future is completed.
  * assert f.isDone();
@@ -187,6 +187,7 @@ public interface Future<V> extends AsynchronousResult<V> {
      * @throws CancellationException if the computation was cancelled
      * @throws CompletionException   if the computation threw an exception.
      */
+    @Deprecated(forRemoval = true)
     Future<V> syncUninterruptibly();
 
     /**
@@ -200,6 +201,7 @@ public interface Future<V> extends AsynchronousResult<V> {
      * Waits for this future to be completed without interruption.  This method catches an {@link InterruptedException}
      * and discards it silently.
      */
+    @Deprecated(forRemoval = true)
     Future<V> awaitUninterruptibly();
 
     /**
@@ -224,6 +226,7 @@ public interface Future<V> extends AsynchronousResult<V> {
      *
      * @return {@code true} if and only if the future was completed within the specified time limit
      */
+    @Deprecated(forRemoval = true)
     boolean awaitUninterruptibly(long timeout, TimeUnit unit);
 
     /**
@@ -232,6 +235,7 @@ public interface Future<V> extends AsynchronousResult<V> {
      *
      * @return {@code true} if and only if the future was completed within the specified time limit
      */
+    @Deprecated(forRemoval = true)
     boolean awaitUninterruptibly(long timeoutMillis);
 
     /**

--- a/common/src/main/java/io/netty5/util/concurrent/RunnableFuture.java
+++ b/common/src/main/java/io/netty5/util/concurrent/RunnableFuture.java
@@ -30,11 +30,5 @@ public interface RunnableFuture<V> extends Runnable, Future<V> {
     RunnableFuture<V> sync() throws InterruptedException;
 
     @Override
-    RunnableFuture<V> syncUninterruptibly();
-
-    @Override
     RunnableFuture<V> await() throws InterruptedException;
-
-    @Override
-    RunnableFuture<V> awaitUninterruptibly();
 }

--- a/common/src/main/java/io/netty5/util/concurrent/RunnableFutureAdapter.java
+++ b/common/src/main/java/io/netty5/util/concurrent/RunnableFutureAdapter.java
@@ -80,20 +80,8 @@ final class RunnableFutureAdapter<V> implements RunnableFuture<V> {
     }
 
     @Override
-    public RunnableFuture<V> syncUninterruptibly() {
-        future.syncUninterruptibly();
-        return this;
-    }
-
-    @Override
     public RunnableFuture<V> await() throws InterruptedException {
         future.await();
-        return this;
-    }
-
-    @Override
-    public RunnableFuture<V> awaitUninterruptibly() {
-        future.awaitUninterruptibly();
         return this;
     }
 
@@ -105,16 +93,6 @@ final class RunnableFutureAdapter<V> implements RunnableFuture<V> {
     @Override
     public boolean await(long timeoutMillis) throws InterruptedException {
         return future.await(timeoutMillis);
-    }
-
-    @Override
-    public boolean awaitUninterruptibly(long timeout, TimeUnit unit) {
-        return future.awaitUninterruptibly(timeout, unit);
-    }
-
-    @Override
-    public boolean awaitUninterruptibly(long timeoutMillis) {
-        return future.awaitUninterruptibly(timeoutMillis);
     }
 
     @Override

--- a/common/src/main/java/io/netty5/util/concurrent/RunnableScheduledFutureAdapter.java
+++ b/common/src/main/java/io/netty5/util/concurrent/RunnableScheduledFutureAdapter.java
@@ -192,20 +192,8 @@ final class RunnableScheduledFutureAdapter<V> implements AbstractScheduledEventE
     }
 
     @Override
-    public RunnableScheduledFuture<V> syncUninterruptibly() {
-        future.syncUninterruptibly();
-        return this;
-    }
-
-    @Override
     public RunnableScheduledFuture<V> await() throws InterruptedException {
         future.await();
-        return this;
-    }
-
-    @Override
-    public RunnableScheduledFuture<V> awaitUninterruptibly() {
-        future.awaitUninterruptibly();
         return this;
     }
 
@@ -217,16 +205,6 @@ final class RunnableScheduledFutureAdapter<V> implements AbstractScheduledEventE
     @Override
     public boolean await(long timeoutMillis) throws InterruptedException {
         return future.await(timeoutMillis);
-    }
-
-    @Override
-    public boolean awaitUninterruptibly(long timeout, TimeUnit unit) {
-        return future.awaitUninterruptibly(timeout, unit);
-    }
-
-    @Override
-    public boolean awaitUninterruptibly(long timeoutMillis) {
-        return future.awaitUninterruptibly(timeoutMillis);
     }
 
     @Override

--- a/common/src/main/java/io/netty5/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty5/util/concurrent/SingleThreadEventExecutor.java
@@ -690,14 +690,16 @@ public class SingleThreadEventExecutor extends AbstractScheduledEventExecutor im
      * Returns the {@link ThreadProperties} of the {@link Thread} that powers the {@link SingleThreadEventExecutor}.
      * If the {@link SingleThreadEventExecutor} is not started yet, this operation will start it and block until
      * it is fully started.
+     *
+     * @throws InterruptedException if this thread is interrupted while waiting for the thread to start.
      */
-    public final ThreadProperties threadProperties() {
+    public final ThreadProperties threadProperties() throws InterruptedException {
         ThreadProperties threadProperties = this.threadProperties;
         if (threadProperties == null) {
             Thread thread = this.thread;
             if (thread == null) {
                 assert !inEventLoop();
-                submit(NOOP_TASK).syncUninterruptibly();
+                submit(NOOP_TASK).sync();
                 thread = this.thread;
                 assert thread != null;
             }

--- a/common/src/test/java/io/netty5/util/concurrent/DefaultFutureCompletionStageTest.java
+++ b/common/src/test/java/io/netty5/util/concurrent/DefaultFutureCompletionStageTest.java
@@ -93,7 +93,7 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testThenApply() {
+    public void testThenApply() throws Exception {
         testThenApply0(stage -> stage.thenApply(v -> {
             assertSame(INITIAL_BOOLEAN, v);
             assertTrue(stage.executor().inEventLoop());
@@ -103,7 +103,7 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testThenApplyAsync() {
+    public void testThenApplyAsync() throws Exception {
         testThenApply0(stage -> stage.thenApplyAsync(v -> {
             assertSame(INITIAL_BOOLEAN, v);
             assertFalse(stage.executor().inEventLoop());
@@ -113,7 +113,7 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testThenApplyAsyncWithExecutor() {
+    public void testThenApplyAsyncWithExecutor() throws Exception {
         EventExecutor asyncExecutor = asyncExecutor();
         testThenApply0(stage -> stage.thenApplyAsync(v -> {
             assertSame(INITIAL_BOOLEAN, v);
@@ -124,7 +124,7 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testThenApplyCallbackNotExecuted() {
+    public void testThenApplyCallbackNotExecuted() throws Exception {
         testHandle0(newFailedFuture(), stage -> stage.thenApply(v -> {
             fail();
             return null;
@@ -132,7 +132,7 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testThenApplyAsyncCallbackNotExecuted() {
+    public void testThenApplyAsyncCallbackNotExecuted() throws Exception {
         testHandle0(newFailedFuture(), stage -> stage.thenApplyAsync(v -> {
             fail();
             return null;
@@ -140,7 +140,7 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testThenApplyAsyncWithExecutorCallbackNotExecuted() {
+    public void testThenApplyAsyncWithExecutorCallbackNotExecuted() throws Exception {
         EventExecutor asyncExecutor = asyncExecutor();
         testHandle0(newFailedFuture(), stage -> stage.thenApplyAsync(v -> {
             fail();
@@ -149,21 +149,21 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testThenApplyFunctionThrows() {
+    public void testThenApplyFunctionThrows() throws Exception {
         testThenApply0(stage -> stage.thenApply(v -> {
             throw EXPECTED_EXCEPTION;
         }), true);
     }
 
     @Test
-    public void testThenApplyAsyncFunctionThrows() {
+    public void testThenApplyAsyncFunctionThrows() throws Exception {
         testThenApply0(stage -> stage.thenApplyAsync(v -> {
             throw EXPECTED_EXCEPTION;
         }), true);
     }
 
     @Test
-    public void testThenApplyAsyncWithExecutorFunctionThrows() {
+    public void testThenApplyAsyncWithExecutorFunctionThrows() throws Exception {
         EventExecutor asyncExecutor = asyncExecutor();
         testThenApply0(stage -> stage.thenApplyAsync(v -> {
             throw EXPECTED_EXCEPTION;
@@ -172,20 +172,20 @@ public class DefaultFutureCompletionStageTest {
 
     private void testHandle0(Future<Boolean> future,
                              Function<FutureCompletionStage<Boolean>, FutureCompletionStage<Boolean>> fn,
-                             boolean exception) {
+                             boolean exception) throws Exception {
         FutureCompletionStage<Boolean> stage = new DefaultFutureCompletionStage<>(future);
 
-        Future<Boolean> f = fn.apply(stage).future().awaitUninterruptibly();
+        Future<Boolean> f = fn.apply(stage).future().await();
         if (exception) {
             assertSame(EXPECTED_EXCEPTION, f.cause());
         } else {
-            assertSame(EXPECTED_BOOLEAN, f.syncUninterruptibly().getNow());
+            assertSame(EXPECTED_BOOLEAN, f.sync().getNow());
         }
     }
 
     private void testWhenComplete0(Future<Boolean> future,
                              Function<FutureCompletionStage<Boolean>, FutureCompletionStage<Boolean>> fn,
-                             boolean exception) {
+                             boolean exception) throws Exception {
         testHandle0(future, stage -> fn.apply(stage).thenApply(v -> {
             assertSame(INITIAL_BOOLEAN, v);
             return EXPECTED_BOOLEAN;
@@ -193,12 +193,13 @@ public class DefaultFutureCompletionStageTest {
     }
 
     private void testThenApply0(
-            Function<FutureCompletionStage<Boolean>, FutureCompletionStage<Boolean>> fn, boolean exception) {
+            Function<FutureCompletionStage<Boolean>, FutureCompletionStage<Boolean>> fn, boolean exception)
+            throws Exception {
         testHandle0(newSucceededFuture(), fn, exception);
     }
 
     @Test
-    public void testThenAccept() {
+    public void testThenAccept() throws Exception {
         testThenAccept0(stage -> stage.thenAccept(v -> {
             assertSame(INITIAL_BOOLEAN, v);
             assertTrue(stage.executor().inEventLoop());
@@ -206,7 +207,7 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testThenAcceptAsync() {
+    public void testThenAcceptAsync() throws Exception {
         testThenAccept0(stage -> stage.thenAcceptAsync(v -> {
             assertSame(INITIAL_BOOLEAN, v);
 
@@ -215,7 +216,7 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testThenAcceptAsyncWithExecutor() {
+    public void testThenAcceptAsyncWithExecutor() throws Exception {
         EventExecutor asyncExecutor = asyncExecutor();
         testThenAccept0(stage -> stage.thenAcceptAsync(v -> {
             assertSame(INITIAL_BOOLEAN, v);
@@ -226,21 +227,21 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testThenAcceptCallbackNotExecuted() {
+    public void testThenAcceptCallbackNotExecuted() throws Exception {
         testThenAccept0(newFailedFuture(), stage -> stage.thenAccept(v -> {
             fail();
         }), true);
     }
 
     @Test
-    public void testThenAcceptAsyncCallbackNotExecuted() {
+    public void testThenAcceptAsyncCallbackNotExecuted() throws Exception {
         testThenAccept0(newFailedFuture(), stage -> stage.thenAcceptAsync(v -> {
             fail();
         }), true);
     }
 
     @Test
-    public void testThenAcceptAsyncWithExecutorCallbackNotExecuted() {
+    public void testThenAcceptAsyncWithExecutorCallbackNotExecuted() throws Exception {
         EventExecutor asyncExecutor = asyncExecutor();
         testThenAccept0(newFailedFuture(), stage -> stage.thenAcceptAsync(v -> {
            fail();
@@ -248,21 +249,21 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testThenAcceptConsumerThrows() {
+    public void testThenAcceptConsumerThrows() throws Exception {
         testThenAccept0(stage -> stage.thenAccept(v -> {
             throw EXPECTED_EXCEPTION;
         }), true);
     }
 
     @Test
-    public void testThenAcceptAsyncConsumerThrows() {
+    public void testThenAcceptAsyncConsumerThrows() throws Exception {
         testThenAccept0(stage -> stage.thenAcceptAsync(v -> {
             throw EXPECTED_EXCEPTION;
         }), true);
     }
 
     @Test
-    public void testThenAcceptAsyncWithExecutorConsumerThrows() {
+    public void testThenAcceptAsyncWithExecutorConsumerThrows() throws Exception {
         EventExecutor asyncExecutor = asyncExecutor();
         testThenAccept0(stage -> stage.thenAcceptAsync(v -> {
             throw EXPECTED_EXCEPTION;
@@ -270,37 +271,39 @@ public class DefaultFutureCompletionStageTest {
     }
 
     private void testThenAccept0(
-            Function<FutureCompletionStage<Boolean>, FutureCompletionStage<Void>> fn, boolean exception) {
+            Function<FutureCompletionStage<Boolean>, FutureCompletionStage<Void>> fn, boolean exception)
+            throws Exception {
         testThenAccept0(newSucceededFuture(), fn, exception);
     }
 
     private void testThenAccept0(Future<Boolean> future,
-            Function<FutureCompletionStage<Boolean>, FutureCompletionStage<Void>> fn, boolean exception) {
+            Function<FutureCompletionStage<Boolean>, FutureCompletionStage<Void>> fn, boolean exception)
+            throws Exception {
         FutureCompletionStage<Boolean> stage = new DefaultFutureCompletionStage<>(future);
-        Future<Void> f = fn.apply(stage).future().awaitUninterruptibly();
+        Future<Void> f = fn.apply(stage).future().await();
         if (exception) {
             assertSame(EXPECTED_EXCEPTION, f.cause());
         } else {
-            assertNull(f.syncUninterruptibly().getNow());
+            assertNull(f.sync().getNow());
         }
     }
 
     @Test
-    public void testThenRun() {
+    public void testThenRun() throws Exception {
         testThenAccept0(stage -> stage.thenRun(() -> {
             assertTrue(stage.executor().inEventLoop());
         }), false);
     }
 
     @Test
-    public void testThenRunAsync() {
+    public void testThenRunAsync() throws Exception {
         testThenAccept0(stage -> stage.thenRunAsync(() -> {
             assertFalse(stage.executor().inEventLoop());
         }), false);
     }
 
     @Test
-    public void testThenRunAsyncWithExecutor() {
+    public void testThenRunAsyncWithExecutor() throws Exception {
         EventExecutor asyncExecutor = asyncExecutor();
         testThenAccept0(stage -> stage.thenRunAsync(() -> {
             assertFalse(stage.executor().inEventLoop());
@@ -309,21 +312,21 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testThenRunCallbackNotExecuted() {
+    public void testThenRunCallbackNotExecuted() throws Exception {
         testThenAccept0(newFailedFuture(), stage -> stage.thenRun(() -> {
             fail();
         }), true);
     }
 
     @Test
-    public void testThenRunAsyncCallbackNotExecuted() {
+    public void testThenRunAsyncCallbackNotExecuted() throws Exception {
         testThenAccept0(newFailedFuture(), stage -> stage.thenRunAsync(() -> {
             fail();
         }), true);
     }
 
     @Test
-    public void testThenRunAsyncWithExecutorCallbackNotExecuted() {
+    public void testThenRunAsyncWithExecutorCallbackNotExecuted() throws Exception {
         EventExecutor asyncExecutor = asyncExecutor();
         testThenAccept0(newFailedFuture(), stage -> stage.thenRunAsync(() -> {
             fail();
@@ -331,21 +334,21 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testThenRunTaskThrows() {
+    public void testThenRunTaskThrows() throws Exception {
         testThenAccept0(stage -> stage.thenRun(() -> {
             throw EXPECTED_EXCEPTION;
         }), true);
     }
 
     @Test
-    public void testThenRunAsyncTaskThrows() {
+    public void testThenRunAsyncTaskThrows() throws Exception {
         testThenAccept0(stage -> stage.thenRunAsync(() -> {
             throw EXPECTED_EXCEPTION;
         }), true);
     }
 
     @Test
-    public void testThenRunAsyncWithExecutorTaskThrows() {
+    public void testThenRunAsyncWithExecutorTaskThrows() throws Exception {
         EventExecutor asyncExecutor = asyncExecutor();
         testThenAccept0(stage -> stage.thenRunAsync(() -> {
             throw EXPECTED_EXCEPTION;
@@ -353,7 +356,7 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testThenCombine() {
+    public void testThenCombine() throws Exception {
         testCombination0((stage, other) -> stage.thenCombine(other, (v1, v2) -> {
             assertSame(v1, INITIAL_BOOLEAN);
             assertSame(v2, INITIAL_BOOLEAN);
@@ -364,7 +367,7 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testThenCombineAsync() {
+    public void testThenCombineAsync() throws Exception {
         testCombination0((stage, other) -> stage.thenCombineAsync(other, (v1, v2) -> {
             assertSame(v1, INITIAL_BOOLEAN);
             assertSame(v2, INITIAL_BOOLEAN);
@@ -375,7 +378,7 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testThenCombineAsyncWithExecutor() {
+    public void testThenCombineAsyncWithExecutor() throws Exception {
         EventExecutor asyncExecutor = asyncExecutor();
 
         testCombination0((stage, other) -> stage.thenCombineAsync(other, (v1, v2) -> {
@@ -388,7 +391,7 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testThenCombineThrowable() {
+    public void testThenCombineThrowable() throws Exception {
         testCombination0((stage, other) -> stage.thenCombine(other, (v1, v2) -> {
             fail();
             return 1;
@@ -396,7 +399,7 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testThenCombineAsyncThrowable() {
+    public void testThenCombineAsyncThrowable() throws Exception {
         testCombination0((stage, other) -> stage.thenCombineAsync(other, (v1, v2) -> {
             fail();
             return 1;
@@ -404,7 +407,7 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testThenCombineAsyncWithExecutorThrowable() {
+    public void testThenCombineAsyncWithExecutorThrowable() throws Exception {
         EventExecutor asyncExecutor = asyncExecutor();
 
         testCombination0((stage, other) -> stage.thenCombineAsync(other, (v1, v2) -> {
@@ -414,21 +417,21 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testThenCombineThrows() {
+    public void testThenCombineThrows() throws Exception {
         testCombination0((stage, other) -> stage.thenCombine(other, (v1, v2) -> {
             throw EXPECTED_EXCEPTION;
         }), true, CombinationTestMode.THROW);
     }
 
     @Test
-    public void testThenCombineAsyncThrows() {
+    public void testThenCombineAsyncThrows() throws Exception {
         testCombination0((stage, other) -> stage.thenCombineAsync(other, (v1, v2) -> {
             throw EXPECTED_EXCEPTION;
         }), true, CombinationTestMode.THROW);
     }
 
     @Test
-    public void testThenCombineAsyncWithExecutorThrows() {
+    public void testThenCombineAsyncWithExecutorThrows() throws Exception {
         EventExecutor asyncExecutor = asyncExecutor();
 
         testCombination0((stage, other) -> stage.thenCombineAsync(other, (v1, v2) -> {
@@ -437,7 +440,7 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testThenAcceptBoth() {
+    public void testThenAcceptBoth() throws Exception {
         testBoth0((stage, other) -> stage.thenAcceptBoth(other, (v1, v2) -> {
             assertSame(v1, INITIAL_BOOLEAN);
             assertSame(v2, INITIAL_BOOLEAN);
@@ -446,7 +449,7 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testThenAcceptBothAsync() {
+    public void testThenAcceptBothAsync() throws Exception {
         testBoth0((stage, other) -> stage.thenAcceptBothAsync(other, (v1, v2) -> {
             assertSame(v1, INITIAL_BOOLEAN);
             assertSame(v2, INITIAL_BOOLEAN);
@@ -455,7 +458,7 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testThenAcceptBothAsyncWithExecutor() {
+    public void testThenAcceptBothAsyncWithExecutor() throws Exception {
         EventExecutor asyncExecutor = asyncExecutor();
 
         testBoth0((stage, other) -> stage.thenAcceptBothAsync(other, (v1, v2) -> {
@@ -467,21 +470,21 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testThenAcceptBothThrowable() {
+    public void testThenAcceptBothThrowable() throws Exception {
         testBoth0((stage, other) -> stage.thenAcceptBoth(other, (v1, v2) -> {
             fail();
         }), CombinationTestMode.COMPLETE_EXCEPTIONAL);
     }
 
     @Test
-    public void testThenAcceptBothAsyncThrowable() {
+    public void testThenAcceptBothAsyncThrowable() throws Exception {
         testBoth0((stage, other) -> stage.thenAcceptBothAsync(other, (v1, v2) -> {
             fail();
         }), CombinationTestMode.COMPLETE_EXCEPTIONAL);
     }
 
     @Test
-    public void testThenAcceptBothAsyncWithExecutorThrowable() {
+    public void testThenAcceptBothAsyncWithExecutorThrowable() throws Exception {
         EventExecutor asyncExecutor = asyncExecutor();
 
         testBoth0((stage, other) -> stage.thenAcceptBothAsync(other, (v1, v2) -> {
@@ -490,21 +493,21 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testThenAcceptBothThrows() {
+    public void testThenAcceptBothThrows() throws Exception {
         testBoth0((stage, other) -> stage.thenAcceptBoth(other, (v1, v2) -> {
             throw EXPECTED_EXCEPTION;
         }), CombinationTestMode.THROW);
     }
 
     @Test
-    public void testThenAcceptBothAsyncThrows() {
+    public void testThenAcceptBothAsyncThrows() throws Exception {
         testBoth0((stage, other) -> stage.thenCombineAsync(other, (v1, v2) -> {
             throw EXPECTED_EXCEPTION;
         }), CombinationTestMode.THROW);
     }
 
     @Test
-    public void testThenAcceptBothAsyncWithExecutorThrows() {
+    public void testThenAcceptBothAsyncWithExecutorThrows() throws Exception {
         EventExecutor asyncExecutor = asyncExecutor();
 
         testBoth0((stage, other) -> stage.thenCombineAsync(other, (v1, v2) -> {
@@ -513,21 +516,21 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testRunAfterBoth() {
+    public void testRunAfterBoth() throws Exception {
         testBoth0((stage, other) -> stage.runAfterBoth(other, () -> {
             assertTrue(stage.executor().inEventLoop());
         }), CombinationTestMode.COMPLETE);
     }
 
     @Test
-    public void testRunAfterBothAsync() {
+    public void testRunAfterBothAsync() throws Exception {
         testBoth0((stage, other) -> stage.runAfterBothAsync(other, () -> {
             assertFalse(stage.executor().inEventLoop());
         }), CombinationTestMode.COMPLETE);
     }
 
     @Test
-    public void testRunAfterBothAsyncWithExecutor() {
+    public void testRunAfterBothAsyncWithExecutor() throws Exception {
         EventExecutor asyncExecutor = asyncExecutor();
 
         testBoth0((stage, other) -> stage.runAfterBothAsync(other, () -> {
@@ -537,21 +540,21 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testRunAfterBothThrowable() {
+    public void testRunAfterBothThrowable() throws Exception {
         testBoth0((stage, other) -> stage.runAfterBothAsync(other, () -> {
             fail();
         }), CombinationTestMode.COMPLETE_EXCEPTIONAL);
     }
 
     @Test
-    public void testRunAfterBothAsyncThrowable() {
+    public void testRunAfterBothAsyncThrowable() throws Exception {
         testBoth0((stage, other) -> stage.runAfterBothAsync(other, () -> {
             fail();
         }), CombinationTestMode.COMPLETE_EXCEPTIONAL);
     }
 
     @Test
-    public void testRunAfterBothAsyncWithExecutorThrowable() {
+    public void testRunAfterBothAsyncWithExecutorThrowable() throws Exception {
         EventExecutor asyncExecutor = asyncExecutor();
 
         testBoth0((stage, other) -> stage.runAfterBothAsync(other, () -> {
@@ -560,21 +563,21 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testRunAfterBothThrows() {
+    public void testRunAfterBothThrows() throws Exception {
         testBoth0((stage, other) -> stage.runAfterBothAsync(other, () -> {
             throw EXPECTED_EXCEPTION;
         }), CombinationTestMode.THROW);
     }
 
     @Test
-    public void testRunAfterBothAsyncThrows() {
+    public void testRunAfterBothAsyncThrows() throws Exception {
         testBoth0((stage, other) -> stage.runAfterBothAsync(other, () -> {
             throw EXPECTED_EXCEPTION;
         }), CombinationTestMode.THROW);
     }
 
     @Test
-    public void testRunAfterBothAsyncWithExecutorThrows() {
+    public void testRunAfterBothAsyncWithExecutorThrows() throws Exception {
         EventExecutor asyncExecutor = asyncExecutor();
 
         testBoth0((stage, other) -> stage.runAfterBothAsync(other, () -> {
@@ -583,7 +586,7 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testApplyToEither() {
+    public void testApplyToEither() throws Exception {
         testCombination0((stage, other) -> stage.applyToEither(other, v1 -> {
             assertSame(v1, INITIAL_BOOLEAN);
             assertTrue(stage.executor().inEventLoop());
@@ -593,7 +596,7 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testApplyToEitherAsync() {
+    public void testApplyToEitherAsync() throws Exception {
         testCombination0((stage, other) -> stage.applyToEitherAsync(other, v1 -> {
             assertSame(v1, INITIAL_BOOLEAN);
             assertFalse(stage.executor().inEventLoop());
@@ -603,7 +606,7 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testApplyToEitherAsyncWithExecutor() {
+    public void testApplyToEitherAsyncWithExecutor() throws Exception {
         EventExecutor asyncExecutor = asyncExecutor();
 
         testCombination0((stage, other) -> stage.applyToEitherAsync(other, v1 -> {
@@ -615,21 +618,21 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testApplyToEitherThrows() {
+    public void testApplyToEitherThrows() throws Exception {
         testCombination0((stage, other) -> stage.applyToEither(other, v1 -> {
             throw EXPECTED_EXCEPTION;
         }), false, CombinationTestMode.THROW);
     }
 
     @Test
-    public void testApplyToEitherAsyncThrows() {
+    public void testApplyToEitherAsyncThrows() throws Exception {
         testCombination0((stage, other) -> stage.applyToEitherAsync(other, v1 -> {
             throw EXPECTED_EXCEPTION;
         }), false, CombinationTestMode.THROW);
     }
 
     @Test
-    public void testApplyToEitherAsyncWithExecutorThrows() {
+    public void testApplyToEitherAsyncWithExecutorThrows() throws Exception {
         EventExecutor asyncExecutor = asyncExecutor();
 
         testCombination0((stage, other) -> stage.applyToEitherAsync(other, v1 -> {
@@ -638,7 +641,7 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testAcceptEither() {
+    public void testAcceptEither() throws Exception {
         testEither0((stage, other) -> stage.acceptEither(other, v1 -> {
             assertSame(v1, INITIAL_BOOLEAN);
             assertTrue(stage.executor().inEventLoop());
@@ -646,7 +649,7 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testAcceptEitherAsync() {
+    public void testAcceptEitherAsync() throws Exception {
         testEither0((stage, other) -> stage.acceptEitherAsync(other, v1 -> {
             assertSame(v1, INITIAL_BOOLEAN);
             assertFalse(stage.executor().inEventLoop());
@@ -654,7 +657,7 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testAcceptEitherAsyncWithExecutor() {
+    public void testAcceptEitherAsyncWithExecutor() throws Exception {
         EventExecutor asyncExecutor = asyncExecutor();
 
         testEither0((stage, other) -> stage.acceptEitherAsync(other, v1 -> {
@@ -665,21 +668,21 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testAcceptEitherThrows() {
+    public void testAcceptEitherThrows() throws Exception {
         testEither0((stage, other) -> stage.acceptEither(other, v1 -> {
             throw EXPECTED_EXCEPTION;
         }), false, CombinationTestMode.THROW);
     }
 
     @Test
-    public void testAcceptEitherAsyncThrows() {
+    public void testAcceptEitherAsyncThrows() throws Exception {
         testEither0((stage, other) -> stage.acceptEitherAsync(other, v1 -> {
             throw EXPECTED_EXCEPTION;
         }), false, CombinationTestMode.THROW);
     }
 
     @Test
-    public void testAcceptEitherAsyncWithExecutorThrows() {
+    public void testAcceptEitherAsyncWithExecutorThrows() throws Exception {
         EventExecutor asyncExecutor = asyncExecutor();
 
         testEither0((stage, other) -> stage.acceptEitherAsync(other, v1 -> {
@@ -688,21 +691,21 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testRunAfterEither() {
+    public void testRunAfterEither() throws Exception {
         testEither0((stage, other) -> stage.runAfterEither(other, () -> {
             assertTrue(stage.executor().inEventLoop());
         }), false, CombinationTestMode.COMPLETE);
     }
 
     @Test
-    public void testRunAfterEitherAsync() {
+    public void testRunAfterEitherAsync() throws Exception {
         testEither0((stage, other) -> stage.runAfterEitherAsync(other, () -> {
             assertFalse(stage.executor().inEventLoop());
         }), false, CombinationTestMode.COMPLETE);
     }
 
     @Test
-    public void testRunAfterEitherAsyncWithExecutor() {
+    public void testRunAfterEitherAsyncWithExecutor() throws Exception {
         EventExecutor asyncExecutor = asyncExecutor();
 
         testEither0((stage, other) -> stage.runAfterEitherAsync(other, () -> {
@@ -712,21 +715,21 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testRunAfterEitherThrows() {
+    public void testRunAfterEitherThrows() throws Exception {
         testEither0((stage, other) -> stage.runAfterEither(other, () -> {
             throw EXPECTED_EXCEPTION;
         }), false, CombinationTestMode.THROW);
     }
 
     @Test
-    public void testRunAfterEitherAsyncThrows() {
+    public void testRunAfterEitherAsyncThrows() throws Exception {
         testEither0((stage, other) -> stage.runAfterEitherAsync(other, () -> {
             throw EXPECTED_EXCEPTION;
         }), false, CombinationTestMode.THROW);
     }
 
     @Test
-    public void testRunAfterEitherAsyncWithExecutorThrows() {
+    public void testRunAfterEitherAsyncWithExecutorThrows() throws Exception {
         EventExecutor asyncExecutor = asyncExecutor();
 
         testEither0((stage, other) -> stage.runAfterEitherAsync(other, () -> {
@@ -742,7 +745,7 @@ public class DefaultFutureCompletionStageTest {
 
     private void testEither0(BiFunction<FutureCompletionStage<Boolean>,
             CompletionStage<Boolean>, FutureCompletionStage<Void>> fn,
-                             boolean notifyAll, CombinationTestMode testMode) {
+                             boolean notifyAll, CombinationTestMode testMode) throws Exception {
         testCombination0((futureStage, stage) -> fn.apply(futureStage, stage).thenApply(v -> {
             assertNull(v);
             return EXPECTED_INTEGER;
@@ -750,7 +753,7 @@ public class DefaultFutureCompletionStageTest {
     }
 
     private void testBoth0(BiFunction<FutureCompletionStage<Boolean>,
-            CompletionStage<Boolean>, FutureCompletionStage<Void>> fn, CombinationTestMode testMode) {
+            CompletionStage<Boolean>, FutureCompletionStage<Void>> fn, CombinationTestMode testMode) throws Exception {
         testCombination0((futureStage, stage) -> fn.apply(futureStage, stage).thenApply(v -> {
             assertNull(v);
             return EXPECTED_INTEGER;
@@ -759,7 +762,7 @@ public class DefaultFutureCompletionStageTest {
 
     private void testCombination0(BiFunction<FutureCompletionStage<Boolean>,
             CompletionStage<Boolean>, FutureCompletionStage<Integer>> fn,
-                           boolean notifyAll, CombinationTestMode testMode) {
+                           boolean notifyAll, CombinationTestMode testMode) throws Exception {
         EventExecutor executor = executor();
 
         // We run this in a loop as we we need to ensure our implementation is thread-safe as the both stages
@@ -807,7 +810,7 @@ public class DefaultFutureCompletionStageTest {
                 }
             }
 
-            f.awaitUninterruptibly();
+            f.await();
 
             switch (testMode) {
                 case COMPLETE_EXCEPTIONAL:
@@ -815,7 +818,7 @@ public class DefaultFutureCompletionStageTest {
                     assertSame(EXPECTED_EXCEPTION, f.cause());
                     break;
                 case COMPLETE:
-                    assertEquals(EXPECTED_INTEGER, f.syncUninterruptibly().getNow());
+                    assertEquals(EXPECTED_INTEGER, f.sync().getNow());
                     break;
                 default:
                     fail();
@@ -824,7 +827,7 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testThenCompose() {
+    public void testThenCompose() throws Exception {
         testHandle0(newSucceededFuture(), stage -> stage.thenCompose(v -> {
             assertSame(INITIAL_BOOLEAN, v);
 
@@ -835,7 +838,7 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testThenComposeAsync() {
+    public void testThenComposeAsync() throws Exception {
         testHandle0(newSucceededFuture(), stage -> stage.thenComposeAsync(v -> {
             assertSame(INITIAL_BOOLEAN, v);
 
@@ -846,7 +849,7 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testThenComposeAsyncWithExecutor() {
+    public void testThenComposeAsyncWithExecutor() throws Exception {
         EventExecutor asyncExecutor = asyncExecutor();
 
         testHandle0(newSucceededFuture(), stage -> stage.thenComposeAsync(v -> {
@@ -860,21 +863,21 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testThenComposeThrows() {
+    public void testThenComposeThrows() throws Exception {
         testHandle0(newSucceededFuture(), stage -> stage.thenCompose(v -> {
             throw EXPECTED_EXCEPTION;
         }), true);
     }
 
     @Test
-    public void testThenComposeAsyncThrows() {
+    public void testThenComposeAsyncThrows() throws Exception {
         testHandle0(newSucceededFuture(), stage -> stage.thenComposeAsync(v -> {
             throw EXPECTED_EXCEPTION;
         }), true);
     }
 
     @Test
-    public void testThenComposeWithExecutorThrows() {
+    public void testThenComposeWithExecutorThrows() throws Exception {
         EventExecutor asyncExecutor = asyncExecutor();
         testHandle0(newSucceededFuture(), stage -> stage.thenComposeAsync(v -> {
             throw EXPECTED_EXCEPTION;
@@ -882,7 +885,7 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testExceptionally() {
+    public void testExceptionally() throws Exception {
         testHandle0(newFailedFuture(), stage -> stage.exceptionally(error -> {
             assertSame(EXPECTED_EXCEPTION, error);
             return EXPECTED_BOOLEAN;
@@ -890,14 +893,14 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testExceptionallyThrows() {
+    public void testExceptionallyThrows() throws Exception {
         testHandle0(newFailedFuture(), stage -> stage.exceptionally(error -> {
             throw EXPECTED_EXCEPTION;
         }), true);
     }
 
     @Test
-    public void testWhenComplete() {
+    public void testWhenComplete() throws Exception {
         testWhenComplete0(newSucceededFuture(), stage -> stage.whenComplete((v, cause) -> {
             assertSame(INITIAL_BOOLEAN, v);
             assertNull(cause);
@@ -906,7 +909,7 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testWhenCompleteAsync() {
+    public void testWhenCompleteAsync() throws Exception {
         testWhenComplete0(newSucceededFuture(), stage -> stage.whenCompleteAsync((v, cause) -> {
             assertSame(INITIAL_BOOLEAN, v);
             assertNull(cause);
@@ -916,7 +919,7 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testWhenCompleteAsyncWithExecutor() {
+    public void testWhenCompleteAsyncWithExecutor() throws Exception {
         EventExecutor asyncExecutor = asyncExecutor();
 
         testWhenComplete0(newSucceededFuture(), stage -> stage.whenCompleteAsync((v, cause) -> {
@@ -929,7 +932,7 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testWhenCompleteThrowable() {
+    public void testWhenCompleteThrowable() throws Exception {
         testWhenComplete0(newFailedFuture(), stage -> stage.whenComplete((v, cause) -> {
             assertSame(EXPECTED_EXCEPTION, cause);
             assertNull(v);
@@ -939,7 +942,7 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testWhenCompleteAsyncThrowable() {
+    public void testWhenCompleteAsyncThrowable() throws Exception {
         testWhenComplete0(newFailedFuture(), stage -> stage.whenCompleteAsync((v, cause) -> {
             assertSame(EXPECTED_EXCEPTION, cause);
             assertNull(v);
@@ -949,7 +952,7 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testWhenCompleteAsyncWithExecutorThrowable() {
+    public void testWhenCompleteAsyncWithExecutorThrowable() throws Exception {
         EventExecutor asyncExecutor = asyncExecutor();
         testWhenComplete0(newFailedFuture(), stage -> stage.whenCompleteAsync((v, cause) -> {
             assertSame(EXPECTED_EXCEPTION, cause);
@@ -961,21 +964,21 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testWhenCompleteThrows() {
+    public void testWhenCompleteThrows() throws Exception {
         testWhenComplete0(newSucceededFuture(), stage -> stage.whenComplete((v, cause) -> {
             throw EXPECTED_EXCEPTION;
         }), true);
     }
 
     @Test
-    public void testWhenCompleteAsyncThrows() {
+    public void testWhenCompleteAsyncThrows() throws Exception {
         testWhenComplete0(newSucceededFuture(), stage -> stage.whenCompleteAsync((v, cause) -> {
             throw EXPECTED_EXCEPTION;
         }), true);
     }
 
     @Test
-    public void testWhenCompleteAsyncWithExecutorThrows() {
+    public void testWhenCompleteAsyncWithExecutorThrows() throws Exception {
         EventExecutor asyncExecutor = asyncExecutor();
         testWhenComplete0(newSucceededFuture(), stage -> stage.whenCompleteAsync((v, cause) -> {
             throw EXPECTED_EXCEPTION;
@@ -983,7 +986,7 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testHandle() {
+    public void testHandle() throws Exception {
         testHandle0(newSucceededFuture(), stage -> stage.handle((v, cause) -> {
             assertSame(INITIAL_BOOLEAN, v);
             assertNull(cause);
@@ -995,7 +998,7 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testHandleAsync() {
+    public void testHandleAsync() throws Exception {
         testHandle0(newSucceededFuture(), stage -> stage.handleAsync((v, cause) -> {
             assertSame(INITIAL_BOOLEAN, v);
             assertNull(cause);
@@ -1007,7 +1010,7 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testHandleAsyncWithExecutor() {
+    public void testHandleAsyncWithExecutor() throws Exception {
         EventExecutor asyncExecutor = asyncExecutor();
 
         testHandle0(newSucceededFuture(), stage -> stage.handleAsync((v, cause) -> {
@@ -1022,7 +1025,7 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testHandleThrowable() {
+    public void testHandleThrowable() throws Exception {
         testHandle0(newFailedFuture(), stage -> stage.handle((v, cause) -> {
             assertSame(EXPECTED_EXCEPTION, cause);
             assertNull(v);
@@ -1034,7 +1037,7 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testHandleAsyncThrowable() {
+    public void testHandleAsyncThrowable() throws Exception {
         testHandle0(newFailedFuture(), stage -> stage.handleAsync((v, cause) -> {
             assertSame(EXPECTED_EXCEPTION, cause);
             assertNull(v);
@@ -1046,7 +1049,7 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testHandleAsyncWithExecutorThrowable() {
+    public void testHandleAsyncWithExecutorThrowable() throws Exception {
         EventExecutor asyncExecutor = asyncExecutor();
         testHandle0(newFailedFuture(), stage -> stage.handleAsync((v, cause) -> {
             assertSame(EXPECTED_EXCEPTION, cause);
@@ -1060,21 +1063,21 @@ public class DefaultFutureCompletionStageTest {
     }
 
     @Test
-    public void testHandleFunctionThrows() {
+    public void testHandleFunctionThrows() throws Exception {
         testHandle0(newSucceededFuture(), stage -> stage.handle((v, cause) -> {
             throw EXPECTED_EXCEPTION;
         }), true);
     }
 
     @Test
-    public void testHandleAsyncFunctionThrows() {
+    public void testHandleAsyncFunctionThrows() throws Exception {
         testHandle0(newSucceededFuture(), stage -> stage.handleAsync((v, cause) -> {
             throw EXPECTED_EXCEPTION;
         }), true);
     }
 
     @Test
-    public void testHandleAsyncWithExecutorFunctionThrows() {
+    public void testHandleAsyncWithExecutorFunctionThrows() throws Exception {
         EventExecutor asyncExecutor = asyncExecutor();
         testHandle0(newSucceededFuture(), stage -> stage.handleAsync((v, cause) -> {
             throw EXPECTED_EXCEPTION;

--- a/common/src/test/java/io/netty5/util/concurrent/DefaultPromiseTest.java
+++ b/common/src/test/java/io/netty5/util/concurrent/DefaultPromiseTest.java
@@ -332,7 +332,7 @@ public class DefaultPromiseTest {
     }
 
     @Test
-    public void testSignalRace() {
+    public void testSignalRace() throws Exception {
         final long wait = TimeUnit.NANOSECONDS.convert(10, TimeUnit.SECONDS);
         EventExecutor executor = null;
         try {
@@ -349,7 +349,7 @@ public class DefaultPromiseTest {
             for (final Map.Entry<Thread, DefaultPromise<Void>> promise : promises.entrySet()) {
                 promise.getKey().start();
                 final long start = System.nanoTime();
-                promise.getValue().awaitUninterruptibly(wait, TimeUnit.NANOSECONDS);
+                promise.getValue().await(wait, TimeUnit.NANOSECONDS);
                 assertThat(System.nanoTime() - start).isLessThan(wait);
             }
         } finally {
@@ -421,20 +421,6 @@ public class DefaultPromiseTest {
 
         try {
             promise.sync();
-        } catch (CompletionException e) {
-            assertSame(exception, e.getCause());
-        }
-    }
-
-    @Test
-    public void throwUncheckedSyncUninterruptibly() {
-        Exception exception = new Exception();
-        DefaultPromise<String> promise = new DefaultPromise<>(INSTANCE);
-        promise.setFailure(exception);
-        assertTrue(promise.isFailed());
-
-        try {
-            promise.syncUninterruptibly();
         } catch (CompletionException e) {
             assertSame(exception, e.getCause());
         }

--- a/common/src/test/java/io/netty5/util/concurrent/FutureCompletionStageTest.java
+++ b/common/src/test/java/io/netty5/util/concurrent/FutureCompletionStageTest.java
@@ -26,23 +26,23 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 public class FutureCompletionStageTest {
 
     @Test
-    public void testCompleteFuture() {
-        FutureCompletionStage stage = FutureCompletionStage.toFutureCompletionStage(
+    public void testCompleteFuture() throws Exception {
+        FutureCompletionStage<Boolean> stage = FutureCompletionStage.toFutureCompletionStage(
                 CompletableFuture.completedFuture(Boolean.TRUE), ImmediateEventExecutor.INSTANCE);
         assertSame(ImmediateEventExecutor.INSTANCE, stage.executor());
-        assertSame(Boolean.TRUE, stage.future().syncUninterruptibly().getNow());
+        assertSame(Boolean.TRUE, stage.future().sync().getNow());
     }
 
     @Test
-    public void testCompleteFutureFailed() {
+    public void testCompleteFutureFailed() throws Exception {
         IllegalStateException exception = new IllegalStateException();
         CompletableFuture<Boolean> future = new CompletableFuture<>();
         future.completeExceptionally(exception);
 
-        FutureCompletionStage stage = FutureCompletionStage.toFutureCompletionStage(
+        FutureCompletionStage<Boolean> stage = FutureCompletionStage.toFutureCompletionStage(
                 future, ImmediateEventExecutor.INSTANCE);
         assertSame(ImmediateEventExecutor.INSTANCE, stage.executor());
-        assertSame(exception, stage.future().awaitUninterruptibly().cause());
+        assertSame(exception, stage.future().await().cause());
     }
 
     @Test
@@ -53,14 +53,14 @@ public class FutureCompletionStageTest {
     }
 
     @Test
-    public void testFutureCompletionStageWithDifferentExecutor() {
+    public void testFutureCompletionStageWithDifferentExecutor() throws Exception {
         MultithreadEventExecutorGroup group = new MultithreadEventExecutorGroup(1, Executors.defaultThreadFactory());
         try {
             FutureCompletionStage<Boolean> stage = group.next().newSucceededFuture(Boolean.TRUE).asStage();
             FutureCompletionStage<Boolean> stage2 = FutureCompletionStage.toFutureCompletionStage(
                     stage, ImmediateEventExecutor.INSTANCE);
             assertNotSame(stage, stage2);
-            assertSame(stage.future().syncUninterruptibly().getNow(), stage2.future().syncUninterruptibly().getNow());
+            assertSame(stage.future().sync().getNow(), stage2.future().sync().getNow());
         } finally {
             group.shutdownGracefully();
         }

--- a/common/src/test/java/io/netty5/util/concurrent/NonStickyEventExecutorGroupTest.java
+++ b/common/src/test/java/io/netty5/util/concurrent/NonStickyEventExecutorGroupTest.java
@@ -147,7 +147,7 @@ public class NonStickyEventExecutorGroupTest {
         }
         latch.await();
         for (Future<?> future: futures) {
-            future.syncUninterruptibly();
+            future.sync();
         }
         Throwable error = cause.get();
         if (error != null) {

--- a/common/src/test/java/io/netty5/util/concurrent/SingleThreadEventExecutorTest.java
+++ b/common/src/test/java/io/netty5/util/concurrent/SingleThreadEventExecutorTest.java
@@ -70,7 +70,7 @@ public class SingleThreadEventExecutorTest {
     }
 
     @Test
-    public void testThreadProperties() {
+    public void testThreadProperties() throws Exception {
         final AtomicReference<Thread> threadRef = new AtomicReference<Thread>();
         SingleThreadEventExecutor executor = new SingleThreadEventExecutor(new DefaultThreadFactory("test")) {
             @Override

--- a/common/src/test/java/io/netty5/util/concurrent/SingleThreadEventExecutorTest.java
+++ b/common/src/test/java/io/netty5/util/concurrent/SingleThreadEventExecutorTest.java
@@ -60,7 +60,7 @@ public class SingleThreadEventExecutorTest {
         executeShouldFail(executor);
         executeShouldFail(executor);
         var exception = assertThrows(
-                CompletionException.class, () -> executor.shutdownGracefully().syncUninterruptibly());
+                CompletionException.class, () -> executor.shutdownGracefully().sync());
         assertThat(exception).hasCauseInstanceOf(RejectedExecutionException.class);
         assertTrue(executor.isShutdown());
     }

--- a/common/src/test/java/io/netty5/util/concurrent/UnorderedThreadPoolEventExecutorTest.java
+++ b/common/src/test/java/io/netty5/util/concurrent/UnorderedThreadPoolEventExecutorTest.java
@@ -39,7 +39,7 @@ public class UnorderedThreadPoolEventExecutorTest {
             executor.execute(task);
             Future<?> future = executor.submit(task).addListener((FutureListener<Object>) future1 -> latch.countDown());
             latch.await();
-            future.syncUninterruptibly();
+            future.sync();
 
             // Now just check if the queue stays empty multiple times. This is needed as the submit to execute(...)
             // by DefaultPromise may happen in an async fashion

--- a/example/src/main/java/io/netty5/example/http2/helloworld/client/Http2Client.java
+++ b/example/src/main/java/io/netty5/example/http2/helloworld/client/Http2Client.java
@@ -144,7 +144,7 @@ public final class Http2Client {
             System.out.println("Finished HTTP/2 request(s)");
 
             // Wait until the connection is closed.
-            channel.close().syncUninterruptibly();
+            channel.close().sync();
         } finally {
             workerGroup.shutdownGracefully();
         }

--- a/example/src/main/java/io/netty5/example/http2/helloworld/client/Http2SettingsHandler.java
+++ b/example/src/main/java/io/netty5/example/http2/helloworld/client/Http2SettingsHandler.java
@@ -45,7 +45,7 @@ public class Http2SettingsHandler extends SimpleChannelInboundHandler<Http2Setti
      * @throws Exception if timeout or other failure occurs
      */
     public void awaitSettings(long timeout, TimeUnit unit) throws Exception {
-        if (!promise.asFuture().awaitUninterruptibly(timeout, unit)) {
+        if (!promise.asFuture().await(timeout, unit)) {
             throw new IllegalStateException("Timed out waiting for settings");
         }
         if (promise.isFailed()) {

--- a/example/src/main/java/io/netty5/example/http2/helloworld/client/HttpResponseHandler.java
+++ b/example/src/main/java/io/netty5/example/http2/helloworld/client/HttpResponseHandler.java
@@ -63,19 +63,19 @@ public class HttpResponseHandler extends SimpleChannelInboundHandler<FullHttpRes
      * @param unit Units associated with {@code timeout}
      * @see HttpResponseHandler#put(int, Future, Promise)
      */
-    public void awaitResponses(long timeout, TimeUnit unit) {
+    public void awaitResponses(long timeout, TimeUnit unit) throws Exception {
         Iterator<Entry<Integer, Entry<Future<Void>, Promise<Void>>>> itr = streamidPromiseMap.entrySet().iterator();
         while (itr.hasNext()) {
             Entry<Integer, Entry<Future<Void>, Promise<Void>>> entry = itr.next();
             Future<Void> writeFuture = entry.getValue().getKey();
-            if (!writeFuture.awaitUninterruptibly(timeout, unit)) {
+            if (!writeFuture.await(timeout, unit)) {
                 throw new IllegalStateException("Timed out waiting to write for stream id " + entry.getKey());
             }
             if (writeFuture.isFailed()) {
                 throw new RuntimeException(writeFuture.cause());
             }
             Promise<Void> promise = entry.getValue().getValue();
-            if (!promise.asFuture().awaitUninterruptibly(timeout, unit)) {
+            if (!promise.asFuture().await(timeout, unit)) {
                 throw new IllegalStateException("Timed out waiting for response on stream id " + entry.getKey());
             }
             if (promise.isFailed()) {

--- a/example/src/main/java/io/netty5/example/http2/helloworld/frame/client/Http2FrameClient.java
+++ b/example/src/main/java/io/netty5/example/http2/helloworld/frame/client/Http2FrameClient.java
@@ -96,7 +96,7 @@ public final class Http2FrameClient {
                     new Http2ClientStreamFrameResponseHandler();
 
             final Http2StreamChannelBootstrap streamChannelBootstrap = new Http2StreamChannelBootstrap(channel);
-            final Http2StreamChannel streamChannel = streamChannelBootstrap.open().syncUninterruptibly().getNow();
+            final Http2StreamChannel streamChannel = streamChannelBootstrap.open().sync().getNow();
             streamChannel.pipeline().addLast(streamFrameResponseHandler);
 
             // Send request (a HTTP/2 HEADERS frame - with ':method = GET' in this case)
@@ -116,7 +116,7 @@ public final class Http2FrameClient {
             System.out.println("Finished HTTP/2 request, will close the connection.");
 
             // Wait until the connection is closed.
-            channel.close().syncUninterruptibly();
+            channel.close().sync();
         } finally {
             clientWorkerGroup.shutdownGracefully();
         }

--- a/example/src/main/java/io/netty5/example/localecho/LocalEcho.java
+++ b/example/src/main/java/io/netty5/example/localecho/LocalEcho.java
@@ -98,7 +98,7 @@ public final class LocalEcho {
 
             // Wait until all messages are flushed before closing the channel.
             if (lastWriteFuture != null) {
-                lastWriteFuture.awaitUninterruptibly();
+                lastWriteFuture.await();
             }
         } finally {
             serverGroup.shutdownGracefully();

--- a/handler/src/test/java/io/netty5/handler/address/DynamicAddressConnectHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/address/DynamicAddressConnectHandlerTest.java
@@ -34,7 +34,7 @@ public class DynamicAddressConnectHandlerTest {
     private static final SocketAddress REMOTE = new SocketAddress() { };
     private static final SocketAddress REMOTE_NEW = new SocketAddress() { };
     @Test
-    public void testReplaceAddresses() {
+    public void testReplaceAddresses() throws Exception {
 
         EmbeddedChannel channel = new EmbeddedChannel(new ChannelHandler() {
             @Override
@@ -63,7 +63,7 @@ public class DynamicAddressConnectHandlerTest {
                 return REMOTE_NEW;
             }
         });
-        channel.connect(REMOTE, LOCAL).syncUninterruptibly();
+        channel.connect(REMOTE, LOCAL).sync();
         assertNull(channel.pipeline().get(DynamicAddressConnectHandler.class));
         assertFalse(channel.finish());
     }

--- a/handler/src/test/java/io/netty5/handler/address/ResolveAddressHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/address/ResolveAddressHandlerTest.java
@@ -92,16 +92,16 @@ public class ResolveAddressHandlerTest {
 
         // Start server
         Channel sc = sb.bind(RESOLVED).get();
-        Future<Channel> future = cb.connect(UNRESOLVED).awaitUninterruptibly();
+        Future<Channel> future = cb.connect(UNRESOLVED).await();
         try {
             if (fail) {
                 assertSame(ERROR, future.cause());
             } else {
                 assertTrue(future.isSuccess());
-                future.get().close().syncUninterruptibly();
+                future.get().close().sync();
             }
         } finally {
-            sc.close().syncUninterruptibly();
+            sc.close().sync();
             resolverGroup.close();
         }
     }

--- a/handler/src/test/java/io/netty5/handler/flow/FlowControlHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/flow/FlowControlHandlerTest.java
@@ -142,7 +142,7 @@ public class FlowControlHandlerTest {
 
         try {
             client.writeAndFlush(newOneMessage())
-                .syncUninterruptibly();
+                .sync();
 
             // We received three messages even through auto reading
             // was turned off after we received the first message.
@@ -190,7 +190,7 @@ public class FlowControlHandlerTest {
 
             // Write the message
             client.writeAndFlush(newOneMessage())
-                .syncUninterruptibly();
+                .sync();
 
             // Read the message
             peer.read();
@@ -237,7 +237,7 @@ public class FlowControlHandlerTest {
 
             // Write the message
             client.writeAndFlush(newOneMessage())
-                .syncUninterruptibly();
+                .sync();
 
             // We should receive 3 messages
             assertTrue(latch.await(1L, SECONDS));
@@ -309,7 +309,7 @@ public class FlowControlHandlerTest {
             Channel peer = peerRef.exchange(null, 1L, SECONDS);
 
             client.writeAndFlush(newOneMessage())
-                .syncUninterruptibly();
+                .sync();
 
             // channelRead(1)
             assertTrue(msgRcvLatch1.await(1L, SECONDS));
@@ -367,7 +367,7 @@ public class FlowControlHandlerTest {
 
             // Write the message
             client.writeAndFlush(newOneMessage())
-                .syncUninterruptibly();
+                .sync();
 
             // channelRead(1)
             peer.read();
@@ -421,7 +421,7 @@ public class FlowControlHandlerTest {
 
             // Write the message
             client.writeAndFlush(newOneMessage())
-                    .syncUninterruptibly();
+                    .sync();
 
             // channelRead(1)
             peer.read();

--- a/handler/src/test/java/io/netty5/handler/ssl/CipherSuiteCanaryTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/CipherSuiteCanaryTest.java
@@ -212,7 +212,7 @@ public class CipherSuiteCanaryTest {
                     Channel client = client(server, clientHandler);
                     try {
                         client.writeAndFlush(preferredAllocator().copyOf(new byte[] {'P', 'I', 'N', 'G'}))
-                              .syncUninterruptibly();
+                              .sync();
 
                         Future<Object> clientFuture = clientPromise.asFuture();
                         Future<Object> serverFuture = serverPromise.asFuture();

--- a/handler/src/test/java/io/netty5/handler/ssl/OpenSslCertificateCompressionTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/OpenSslCertificateCompressionTest.java
@@ -323,20 +323,20 @@ public class OpenSslCertificateCompressionTest {
             sb.group(group).channel(LocalServerChannel.class)
                     .childHandler(new CertCompressionTestChannelInitializer(serverPromise, serverSslContext));
             Channel serverChannel = sb.bind(new LocalAddress("testCertificateCompression"))
-                    .syncUninterruptibly().getNow();
+                    .sync().getNow();
 
             Bootstrap bootstrap = new Bootstrap();
             bootstrap.group(group).channel(LocalChannel.class)
                     .handler(new CertCompressionTestChannelInitializer(clientPromise, clientSslContext));
 
-            Channel clientChannel = bootstrap.connect(serverChannel.localAddress()).syncUninterruptibly().getNow();
+            Channel clientChannel = bootstrap.connect(serverChannel.localAddress()).sync().getNow();
 
             assertTrue(clientPromise.asFuture().await(5L, TimeUnit.SECONDS), "client timeout");
             assertTrue(serverPromise.asFuture().await(5L, TimeUnit.SECONDS), "server timeout");
             clientPromise.asFuture().sync();
             serverPromise.asFuture().sync();
-            clientChannel.close().syncUninterruptibly();
-            serverChannel.close().syncUninterruptibly();
+            clientChannel.close().sync();
+            serverChannel.close().sync();
         } finally  {
             group.shutdownGracefully();
         }

--- a/handler/src/test/java/io/netty5/handler/ssl/OpenSslPrivateKeyMethodTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/OpenSslPrivateKeyMethodTest.java
@@ -299,7 +299,7 @@ public class OpenSslPrivateKeyMethodTest {
                     Channel client = client(server, clientHandler);
                     try {
                         client.writeAndFlush(offHeapAllocator().copyOf(new byte[] {'P', 'I', 'N', 'G'}))
-                                .syncUninterruptibly();
+                                .sync();
 
                         Future<Object> clientFuture = clientPromise.asFuture();
                         Future<Object> serverFuture = serverPromise.asFuture();

--- a/handler/src/test/java/io/netty5/handler/ssl/ParameterizedSslHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/ParameterizedSslHandlerTest.java
@@ -261,10 +261,10 @@ public class ParameterizedSslHandlerTest {
             donePromise.asFuture().sync();
         } finally {
             if (cc != null) {
-                cc.close().syncUninterruptibly();
+                cc.close().sync();
             }
             if (sc != null) {
-                sc.close().syncUninterruptibly();
+                sc.close().sync();
             }
             group.shutdownGracefully();
 
@@ -359,13 +359,13 @@ public class ParameterizedSslHandlerTest {
                         }
                     }).connect(sc.localAddress()).get();
 
-            promise.asFuture().syncUninterruptibly();
+            promise.asFuture().sync();
         } finally {
             if (cc != null) {
-                cc.close().syncUninterruptibly();
+                cc.close().sync();
             }
             if (sc != null) {
-                sc.close().syncUninterruptibly();
+                sc.close().sync();
             }
             group.shutdownGracefully();
 
@@ -483,8 +483,8 @@ public class ParameterizedSslHandlerTest {
                         }
                     }).connect(sc.localAddress()).get();
 
-            serverPromise.asFuture().awaitUninterruptibly();
-            clientPromise.asFuture().awaitUninterruptibly();
+            serverPromise.asFuture().await();
+            clientPromise.asFuture().await();
 
             // Server always received the close_notify as the client triggers the close sequence.
             assertTrue(serverPromise.isSuccess());
@@ -497,10 +497,10 @@ public class ParameterizedSslHandlerTest {
             }
         } finally {
             if (cc != null) {
-                cc.close().syncUninterruptibly();
+                cc.close().sync();
             }
             if (sc != null) {
-                sc.close().syncUninterruptibly();
+                sc.close().sync();
             }
             group.shutdownGracefully();
 
@@ -613,10 +613,10 @@ public class ParameterizedSslHandlerTest {
             assertEquals(expectedContent, clientQueue.toString());
         } finally {
             if (cc != null) {
-                cc.close().syncUninterruptibly();
+                cc.close().sync();
             }
             if (sc != null) {
-                sc.close().syncUninterruptibly();
+                sc.close().sync();
             }
 
             Resource.dispose(sslServerCtx);

--- a/handler/src/test/java/io/netty5/handler/ssl/RenegotiateTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/RenegotiateTest.java
@@ -133,8 +133,8 @@ public abstract class RenegotiateTest {
 
             Channel clientChannel = bootstrap.connect(channel.localAddress()).get();
             latch.await();
-            clientChannel.close().syncUninterruptibly();
-            channel.close().syncUninterruptibly();
+            clientChannel.close().sync();
+            channel.close().sync();
             verifyResult(error);
         } finally  {
             group.shutdownGracefully();

--- a/handler/src/test/java/io/netty5/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SSLEngineTest.java
@@ -800,7 +800,7 @@ public abstract class SSLEngineTest {
         int port = ((InetSocketAddress) serverChannel.localAddress()).getPort();
 
         Future<Channel> ccf = cb.connect(new InetSocketAddress(NetUtil.LOCALHOST, port));
-        assertTrue(ccf.awaitUninterruptibly().isSuccess());
+        assertTrue(ccf.await().isSuccess());
         clientChannel = ccf.get();
     }
 
@@ -840,7 +840,7 @@ public abstract class SSLEngineTest {
                 "unexpected exception: " + serverException);
 
         // Verify that any pending writes are failed with the cached handshake exception and not a general SSLException.
-        clientWriteFuture.awaitUninterruptibly();
+        clientWriteFuture.await();
         Throwable actualCause = clientWriteFuture.cause();
         assertTrue(clientWriteFuture.isDone());
         assertTrue(clientWriteFuture.isFailed());
@@ -986,7 +986,7 @@ public abstract class SSLEngineTest {
         final int port = ((InetSocketAddress) serverChannel.localAddress()).getPort();
 
         Future<Channel> ccf = cb.connect(new InetSocketAddress(expectedHost, port));
-        assertTrue(ccf.awaitUninterruptibly().isSuccess());
+        assertTrue(ccf.await().isSuccess());
         clientChannel = ccf.get();
         return clientWritePromise.asFuture();
     }
@@ -1154,7 +1154,7 @@ public abstract class SSLEngineTest {
         int port = ((InetSocketAddress) serverChannel.localAddress()).getPort();
 
         Future<Channel> ccf = cb.connect(new InetSocketAddress(NetUtil.LOCALHOST, port));
-        assertTrue(ccf.awaitUninterruptibly().isSuccess());
+        assertTrue(ccf.await().isSuccess());
         clientChannel = ccf.get();
     }
 
@@ -1459,7 +1459,7 @@ public abstract class SSLEngineTest {
                 });
 
         Future<Channel> ccf = cb.connect(serverChannel.localAddress());
-        assertTrue(ccf.syncUninterruptibly().isSuccess());
+        assertTrue(ccf.sync().isSuccess());
         clientChannel = ccf.get();
 
         serverLatch.await();
@@ -1780,7 +1780,7 @@ public abstract class SSLEngineTest {
         serverChannel = sb.bind(new InetSocketAddress(0)).get();
 
         Future<Channel> ccf = cb.connect(serverChannel.localAddress());
-        assertTrue(ccf.syncUninterruptibly().isSuccess());
+        assertTrue(ccf.sync().isSuccess());
         clientChannel = ccf.get();
     }
 
@@ -1892,7 +1892,7 @@ public abstract class SSLEngineTest {
 
         }).connect(serverChannel.localAddress()).get();
 
-        promise.asFuture().syncUninterruptibly();
+        promise.asFuture().sync();
 
         serverCert.delete();
         clientCert.delete();

--- a/handler/src/test/java/io/netty5/handler/ssl/SniClientTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SniClientTest.java
@@ -194,16 +194,16 @@ public class SniClientTest {
             Bootstrap cb = new Bootstrap();
             cc = cb.group(group).channel(LocalChannel.class).handler(sslHandler).connect(address).get();
 
-            promise.asFuture().syncUninterruptibly();
-            sslHandler.handshakeFuture().syncUninterruptibly();
+            promise.asFuture().sync();
+            sslHandler.handshakeFuture().sync();
         } catch (CompletionException e) {
             throw e.getCause();
         } finally {
             if (cc != null) {
-                cc.close().syncUninterruptibly();
+                cc.close().sync();
             }
             if (sc != null) {
-                sc.close().syncUninterruptibly();
+                sc.close().sync();
             }
 
             Resource.dispose(sslServerContext);
@@ -440,20 +440,20 @@ public class SniClientTest {
             SslHandler handler = new SslHandler(
                     sslClientContext.newEngine(offHeapAllocator(), sniHostName, -1));
             cc = cb.group(group).channel(LocalChannel.class).handler(handler).connect(address).get();
-            assertEquals(sniHostName, promise.asFuture().syncUninterruptibly().getNow());
+            assertEquals(sniHostName, promise.asFuture().sync().getNow());
 
             // After we are done with handshaking getHandshakeSession() should return null.
-            handler.handshakeFuture().syncUninterruptibly();
+            handler.handshakeFuture().sync();
             assertNull(handler.engine().getHandshakeSession());
 
             assertSSLSession(
                     handler.engine().getUseClientMode(), handler.engine().getSession(), sniHostName);
         } finally {
             if (cc != null) {
-                cc.close().syncUninterruptibly();
+                cc.close().sync();
             }
             if (sc != null) {
-                sc.close().syncUninterruptibly();
+                sc.close().sync();
             }
             Resource.dispose(sslServerContext);
             Resource.dispose(sslClientContext);

--- a/handler/src/test/java/io/netty5/handler/ssl/SniHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SniHandlerTest.java
@@ -558,15 +558,15 @@ public class SniHandlerTest {
                            .connect(address).get();
 
                     cc.writeAndFlush(cc.bufferAllocator().copyOf("Hello, World!", UTF_8))
-                            .syncUninterruptibly();
+                            .sync();
 
                     // Notice how the server's SslContext refCnt is 2 as it is incremented when the SSLEngine is created
                     // and only decremented once it is destroyed.
                     assertEquals(2, ((ReferenceCounted) sslServerContext).refCnt());
 
                     // The client disconnects
-                    cc.close().syncUninterruptibly();
-                    if (!releasePromise.asFuture().awaitUninterruptibly(10L, TimeUnit.SECONDS)) {
+                    cc.close().sync();
+                    if (!releasePromise.asFuture().await(10L, TimeUnit.SECONDS)) {
                         throw new IllegalStateException("It doesn't seem #replaceHandler() got called.");
                     }
 
@@ -574,10 +574,10 @@ public class SniHandlerTest {
                     assertEquals(0, ((ReferenceCounted) sslServerContext).refCnt());
                 } finally {
                     if (cc != null) {
-                        cc.close().syncUninterruptibly();
+                        cc.close().sync();
                     }
                     if (sc != null) {
-                        sc.close().syncUninterruptibly();
+                        sc.close().sync();
                     }
                     if (sslContext != null) {
                         Resource.dispose(sslContext);

--- a/handler/src/test/java/io/netty5/handler/ssl/SslErrorTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SslErrorTest.java
@@ -185,13 +185,13 @@ public class SslErrorTest {
                         }
                     }).connect(serverChannel.localAddress()).get();
             // Block until we received the correct exception
-            promise.asFuture().syncUninterruptibly();
+            promise.asFuture().sync();
         } finally {
             if (clientChannel != null) {
-                clientChannel.close().syncUninterruptibly();
+                clientChannel.close().sync();
             }
             if (serverChannel != null) {
-                serverChannel.close().syncUninterruptibly();
+                serverChannel.close().sync();
             }
             group.shutdownGracefully();
 

--- a/handler/src/test/java/io/netty5/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SslHandlerTest.java
@@ -264,7 +264,7 @@ public class SslHandlerTest {
                 ch.runPendingTasks();
             }
 
-            handler.handshakeFuture().syncUninterruptibly();
+            handler.handshakeFuture().sync();
         } catch (CompletionException e) {
             throw e.getCause();
         } finally {
@@ -409,7 +409,7 @@ public class SslHandlerTest {
                 assertEquals(1, ((ReferenceCounted) sslEngine).refCnt());
 
                 assertTrue(ch.finishAndReleaseAll());
-                ch.close().syncUninterruptibly();
+                ch.close().sync();
 
                 assertEquals(1, ((ReferenceCounted) sslContext).refCnt());
                 assertEquals(0, ((ReferenceCounted) sslEngine).refCnt());
@@ -496,14 +496,14 @@ public class SslHandlerTest {
             sc = serverBootstrap.bind(new InetSocketAddress(0)).get();
             cc = bootstrap.connect(sc.localAddress()).get();
 
-            serverPromise.asFuture().syncUninterruptibly();
-            clientPromise.asFuture().syncUninterruptibly();
+            serverPromise.asFuture().sync();
+            clientPromise.asFuture().sync();
         } finally {
             if (cc != null) {
-                cc.close().syncUninterruptibly();
+                cc.close().sync();
             }
             if (sc != null) {
-                sc.close().syncUninterruptibly();
+                sc.close().sync();
             }
             group.shutdownGracefully();
         }
@@ -754,14 +754,14 @@ public class SslHandlerTest {
             Buffer secondBuffer = offHeapAllocator().allocate(10);
             secondBuffer.skipWritableBytes(secondBuffer.capacity());
             cc.write(firstBuffer);
-            cc.writeAndFlush(secondBuffer).syncUninterruptibly();
+            cc.writeAndFlush(secondBuffer).sync();
             serverReceiveLatch.countDown();
         } finally {
             if (cc != null) {
-                cc.close().syncUninterruptibly();
+                cc.close().sync();
             }
             if (sc != null) {
-                sc.close().syncUninterruptibly();
+                sc.close().sync();
             }
             group.shutdownGracefully();
 
@@ -814,16 +814,16 @@ public class SslHandlerTest {
                     });
             cc = b.connect(sc.localAddress()).get();
             SslHandler handler = sslHandlerRef.get();
-            handler.handshakeFuture().awaitUninterruptibly();
+            handler.handshakeFuture().await();
             assertFalse(handler.handshakeFuture().isSuccess());
 
-            cc.closeFuture().syncUninterruptibly();
+            cc.closeFuture().sync();
         } finally {
             if (cc != null) {
-                cc.close().syncUninterruptibly();
+                cc.close().sync();
             }
             if (sc != null) {
-                sc.close().syncUninterruptibly();
+                sc.close().sync();
             }
             group.shutdownGracefully();
 
@@ -841,7 +841,7 @@ public class SslHandlerTest {
         assertFalse(channel.finish());
         channel.pipeline().addLast(new SslHandler(engine));
         assertFalse(engine.isOutboundDone());
-        channel.close().syncUninterruptibly();
+        channel.close().sync();
 
         assertTrue(engine.isOutboundDone());
     }
@@ -905,10 +905,10 @@ public class SslHandlerTest {
             assertThat(sslHandler.handshakeFuture().await().cause(), instanceOf(SSLException.class));
         } finally {
             if (cc != null) {
-                cc.close().syncUninterruptibly();
+                cc.close().sync();
             }
             if (sc != null) {
-                sc.close().syncUninterruptibly();
+                sc.close().sync();
             }
             group.shutdownGracefully();
 
@@ -977,10 +977,10 @@ public class SslHandlerTest {
             assertThat(cause.getMessage(), containsString("timed out"));
         } finally {
             if (cc != null) {
-                cc.close().syncUninterruptibly();
+                cc.close().sync();
             }
             if (sc != null) {
-                sc.close().syncUninterruptibly();
+                sc.close().sync();
             }
             group.shutdownGracefully();
             Resource.dispose(sslClientCtx);
@@ -1169,10 +1169,10 @@ public class SslHandlerTest {
             }
         } finally {
             if (cc != null) {
-                cc.close().syncUninterruptibly();
+                cc.close().sync();
             }
             if (sc != null) {
-                sc.close().syncUninterruptibly();
+                sc.close().sync();
             }
             group.shutdownGracefully();
             Resource.dispose(sslClientCtx);
@@ -1248,10 +1248,10 @@ public class SslHandlerTest {
             }
         } finally {
             if (cc != null) {
-                cc.close().syncUninterruptibly();
+                cc.close().sync();
             }
             if (sc != null) {
-                sc.close().syncUninterruptibly();
+                sc.close().sync();
             }
             group.shutdownGracefully();
             Resource.dispose(sslClientCtx);
@@ -1365,7 +1365,7 @@ public class SslHandlerTest {
             }
         } finally {
             if (sc != null) {
-                sc.close().syncUninterruptibly();
+                sc.close().sync();
             }
             group.shutdownGracefully();
             Resource.dispose(sslClientCtx);
@@ -1426,7 +1426,7 @@ public class SslHandlerTest {
             }
         } finally {
             if (cc != null) {
-                cc.close().syncUninterruptibly();
+                cc.close().sync();
             }
         }
     }
@@ -1538,7 +1538,7 @@ public class SslHandlerTest {
             assertNull(errorQueue.poll(1, TimeUnit.MILLISECONDS));
         } finally {
             if (sc != null) {
-                sc.close().syncUninterruptibly();
+                sc.close().sync();
             }
             group.shutdownGracefully();
         }
@@ -1651,8 +1651,8 @@ public class SslHandlerTest {
             Throwable serverCause = serverSslHandler.handshakeFuture().await().cause();
             assertThat(serverCause, instanceOf(SSLException.class));
             assertThat(serverCause.getCause(), not(instanceOf(ClosedChannelException.class)));
-            cc.close().syncUninterruptibly();
-            sc.close().syncUninterruptibly();
+            cc.close().sync();
+            sc.close().sync();
 
             Throwable eventClientCause = clientEvent.get().cause();
             assertThat(eventClientCause, instanceOf(SSLException.class));

--- a/handler/src/test/java/io/netty5/handler/ssl/ocsp/OcspTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/ocsp/OcspTest.java
@@ -380,8 +380,8 @@ public class OcspTest {
                         try {
                             assertTrue(latch.await(10L, TimeUnit.SECONDS));
                         } finally {
-                            client.close().syncUninterruptibly();
-                            server.close().syncUninterruptibly();
+                            client.close().sync();
+                            server.close().sync();
                         }
                     } finally {
                         group.shutdownGracefully(1L, 1L, TimeUnit.SECONDS);

--- a/microbench/src/main/java/io/netty5/microbench/concurrent/RunnableScheduledFutureAdapterBenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/concurrent/RunnableScheduledFutureAdapterBenchmark.java
@@ -49,36 +49,36 @@ public class RunnableScheduledFutureAdapterBenchmark extends AbstractMicrobenchm
         final List<Future<Void>> futures = new ArrayList<>();
 
         @Setup(Level.Invocation)
-        public void reset() {
+        public void reset() throws Exception {
             futures.clear();
             executor.submit(() -> {
                 for (int i = 1; i <= num; i++) {
                     futures.add(executor.schedule(NO_OP, i, TimeUnit.HOURS));
                 }
-            }).syncUninterruptibly();
+            }).sync();
         }
     }
 
     @TearDown(Level.Trial)
     public void stop() throws Exception {
-        executor.shutdownGracefully().syncUninterruptibly();
+        executor.shutdownGracefully().sync();
     }
 
     @Benchmark
-    public Future<?> cancelInOrder(final FuturesHolder futuresHolder) {
+    public Future<?> cancelInOrder(final FuturesHolder futuresHolder) throws Exception {
         return executor.submit(() -> {
             for (int i = 0; i < futuresHolder.num; i++) {
                 futuresHolder.futures.get(i).cancel();
             }
-        }).syncUninterruptibly();
+        }).sync();
     }
 
     @Benchmark
-    public Future<?> cancelInReverseOrder(final FuturesHolder futuresHolder) {
+    public Future<?> cancelInReverseOrder(final FuturesHolder futuresHolder) throws Exception {
         return executor.submit(() -> {
             for (int i = futuresHolder.num - 1; i >= 0; i--) {
                 futuresHolder.futures.get(i).cancel();
             }
-        }).syncUninterruptibly();
+        }).sync();
     }
 }

--- a/resolver-dns/src/main/java/io/netty5/resolver/dns/Cache.java
+++ b/resolver-dns/src/main/java/io/netty5/resolver/dns/Cache.java
@@ -92,17 +92,7 @@ abstract class Cache<E> {
         }
 
         @Override
-        public Future<Object> syncUninterruptibly() {
-            return this;
-        }
-
-        @Override
         public Future<Object> await() throws InterruptedException {
-            return this;
-        }
-
-        @Override
-        public Future<Object> awaitUninterruptibly() {
             return this;
         }
 
@@ -113,16 +103,6 @@ abstract class Cache<E> {
 
         @Override
         public boolean await(long timeoutMillis) throws InterruptedException {
-            return true;
-        }
-
-        @Override
-        public boolean awaitUninterruptibly(long timeout, TimeUnit unit) {
-            return true;
-        }
-
-        @Override
-        public boolean awaitUninterruptibly(long timeoutMillis) {
             return true;
         }
 

--- a/resolver-dns/src/test/java/io/netty5/resolver/dns/DnsNameResolverClientSubnetTest.java
+++ b/resolver-dns/src/test/java/io/netty5/resolver/dns/DnsNameResolverClientSubnetTest.java
@@ -48,7 +48,7 @@ public class DnsNameResolverClientSubnetTest {
                             // 157.88.0.0 / 24
                             new DefaultDnsOptEcsRecord(1024, 24,
                                                        SocketUtils.addressByName("157.88.0.0").getAddress())));
-            for (InetAddress address: future.syncUninterruptibly().getNow()) {
+            for (InetAddress address: future.sync().getNow()) {
                 System.out.println(address);
             }
         } finally {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/AbstractSingleThreadEventLoopTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/AbstractSingleThreadEventLoopTest.java
@@ -71,7 +71,7 @@ public abstract class AbstractSingleThreadEventLoopTest {
 
         Future<?> f = loop.shutdownGracefully(0, 1, TimeUnit.MINUTES);
         assertTrue(loop.awaitTermination(600, TimeUnit.MILLISECONDS));
-        assertTrue(f.syncUninterruptibly().isSuccess());
+        assertTrue(f.sync().isSuccess());
         assertTrue(loop.isShutdown());
         assertTrue(loop.isTerminated());
     }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramConnectNotExistsTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramConnectNotExistsTest.java
@@ -69,8 +69,8 @@ public class DatagramConnectNotExistsTest extends AbstractClientSocketTest {
             assertTrue(datagramChannel.isActive());
             BufferAllocator allocator = datagramChannel.bufferAllocator();
             datagramChannel.writeAndFlush(
-                    allocator.copyOf("test".getBytes(CharsetUtil.US_ASCII))).syncUninterruptibly();
-            assertTrue(promise.asFuture().syncUninterruptibly().getNow() instanceof PortUnreachableException);
+                    allocator.copyOf("test".getBytes(CharsetUtil.US_ASCII))).sync();
+            assertTrue(promise.asFuture().sync().getNow() instanceof PortUnreachableException);
         } finally {
             if (datagramChannel != null) {
                 datagramChannel.close();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramMulticastTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramMulticastTest.java
@@ -114,8 +114,8 @@ public class DatagramMulticastTest extends AbstractDatagramTest {
         assertTrue(cc.config().isLoopbackModeDisabled());
         assertTrue(sc.config().isLoopbackModeDisabled());
 
-        sc.close().awaitUninterruptibly();
-        cc.close().awaitUninterruptibly();
+        sc.close().await();
+        cc.close().await();
     }
 
     private static void assertInterfaceAddress(NetworkInterface networkInterface, InetAddress expected) {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramUnicastTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramUnicastTest.java
@@ -226,7 +226,7 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
             SocketAddress localAddr = sc.localAddress();
             SocketAddress addr = localAddr instanceof InetSocketAddress ?
                     sendToAddress((InetSocketAddress) localAddr) : localAddr;
-            cc.connect(addr).syncUninterruptibly();
+            cc.connect(addr).sync();
 
             List<Future<Void>> futures = new ArrayList<>();
             for (int i = 0; i < count; i++) {
@@ -262,12 +262,12 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
 
             if (supportDisconnect()) {
                 // Test what happens when we call disconnect()
-                cc.disconnect().syncUninterruptibly();
+                cc.disconnect().sync();
                 assertFalse(isConnected(cc));
                 assertNotNull(cc.localAddress());
                 assertNull(cc.remoteAddress());
 
-                Future<Void> future = cc.writeAndFlush(buf.copy()).awaitUninterruptibly();
+                Future<Void> future = cc.writeAndFlush(buf.copy()).await();
                 assertThat(future.cause()).isInstanceOf(NotYetConnectedException.class);
             }
         } finally {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketChannelNotYetConnectedTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketChannelNotYetConnectedTest.java
@@ -53,20 +53,20 @@ public class SocketChannelNotYetConnectedTest extends AbstractClientSocketTest {
                 .bind(newSocketAddress()).get();
         try {
             try {
-                ch.shutdown(ChannelShutdownDirection.Inbound).syncUninterruptibly();
+                ch.shutdown(ChannelShutdownDirection.Inbound).sync();
                 fail();
             } catch (Throwable cause) {
                 assertThat(cause).hasCauseInstanceOf(NotYetConnectedException.class);
             }
 
             try {
-                ch.shutdown(ChannelShutdownDirection.Outbound).syncUninterruptibly();
+                ch.shutdown(ChannelShutdownDirection.Outbound).sync();
                 fail();
             } catch (Throwable cause) {
                 assertThat(cause).hasCauseInstanceOf(NotYetConnectedException.class);
             }
         } finally {
-            ch.close().syncUninterruptibly();
+            ch.close().sync();
         }
     }
 

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketCloseForciblyTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketCloseForciblyTest.java
@@ -50,7 +50,7 @@ public class SocketCloseForciblyTest extends AbstractSocketTest {
 
         Channel channel = cb.register().get();
         channel.connect(sc.localAddress());
-        channel.closeFuture().syncUninterruptibly();
+        channel.closeFuture().sync();
         sc.close().sync();
     }
 }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConnectTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConnectTest.java
@@ -80,10 +80,10 @@ public class SocketConnectTest extends AbstractSocketTest {
             assertLocalAddress(localAddressPromise.asFuture().get());
         } finally {
             if (clientChannel != null) {
-                clientChannel.close().syncUninterruptibly();
+                clientChannel.close().sync();
             }
             if (serverChannel != null) {
-                serverChannel.close().syncUninterruptibly();
+                serverChannel.close().sync();
             }
         }
     }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConnectionAttemptTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConnectionAttemptTest.java
@@ -94,7 +94,7 @@ public class SocketConnectionAttemptTest extends AbstractClientSocketTest {
 
         cb.handler(handler);
         cb.option(ChannelOption.ALLOW_HALF_CLOSURE, halfClosure);
-        Future<Channel> future = cb.connect(NetUtil.LOCALHOST, UNASSIGNED_PORT).awaitUninterruptibly();
+        Future<Channel> future = cb.connect(NetUtil.LOCALHOST, UNASSIGNED_PORT).await();
         assertThat(future.cause()).isInstanceOf(ConnectException.class);
         assertFalse(errorPromise.isFailed());
     }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketDataReadInitialStateTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketDataReadInitialStateTest.java
@@ -98,7 +98,7 @@ public class SocketDataReadInitialStateTest extends AbstractSocketTest {
 
             serverChannel = sb.bind().get();
             clientChannel = cb.connect(serverChannel.localAddress()).get();
-            clientChannel.writeAndFlush(clientChannel.bufferAllocator().copyOf(new byte[] {0})).syncUninterruptibly();
+            clientChannel.writeAndFlush(clientChannel.bufferAllocator().copyOf(new byte[] {0})).sync();
 
             // The acceptor shouldn't read any data until we call read() below, but give it some time to see if it will.
             Thread.sleep(sleepMs);
@@ -174,7 +174,7 @@ public class SocketDataReadInitialStateTest extends AbstractSocketTest {
 
             serverChannel = sb.bind().get();
             clientChannel = cb.connect(serverChannel.localAddress()).get();
-            clientChannel.writeAndFlush(clientChannel.bufferAllocator().copyOf(new byte[] {0})).syncUninterruptibly();
+            clientChannel.writeAndFlush(clientChannel.bufferAllocator().copyOf(new byte[] {0})).sync();
             serverReadLatch.await();
             clientReadLatch.await();
         } finally {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketExceptionHandlingTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketExceptionHandlingTest.java
@@ -65,10 +65,10 @@ public class SocketExceptionHandlingTest extends AbstractSocketTest {
                                         " exceptions when 1 was expected");
         } finally {
             if (serverChannel != null) {
-                serverChannel.close().syncUninterruptibly();
+                serverChannel.close().sync();
             }
             if (clientChannel != null) {
-                clientChannel.close().syncUninterruptibly();
+                clientChannel.close().sync();
             }
         }
     }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketMultipleConnectTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketMultipleConnectTest.java
@@ -50,7 +50,7 @@ public class SocketMultipleConnectTest extends AbstractSocketTest {
 
             cb.handler(new ChannelHandler() { });
             cc = cb.register().get();
-            cc.connect(sc.localAddress()).syncUninterruptibly();
+            cc.connect(sc.localAddress()).sync();
             Future<Void> connectFuture2 = cc.connect(sc.localAddress()).await();
             assertTrue(connectFuture2.cause() instanceof AlreadyConnectedException);
         } finally {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketReadPendingTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketReadPendingTest.java
@@ -84,10 +84,10 @@ public class SocketReadPendingTest extends AbstractSocketTest {
             clientInitializer.readPendingHandler.assertAllRead();
         } finally {
             if (serverChannel != null) {
-                serverChannel.close().syncUninterruptibly();
+                serverChannel.close().sync();
             }
             if (clientChannel != null) {
-                clientChannel.close().syncUninterruptibly();
+                clientChannel.close().sync();
             }
         }
     }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketRstTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketRstTest.java
@@ -134,7 +134,7 @@ public class SocketRstTest extends AbstractSocketTest {
             }
         });
         Channel sc = sb.bind().get();
-        cb.connect(sc.localAddress()).syncUninterruptibly();
+        cb.connect(sc.localAddress()).sync();
 
         // Wait for the server to get setup.
         latch.await();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketShutdownOutputBySelfTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketShutdownOutputBySelfTest.java
@@ -115,15 +115,15 @@ public class SocketShutdownOutputBySelfTest extends AbstractClientSocketTest {
             assertTrue(ch.isActive());
             s = ss.accept();
 
-            ch.close().syncUninterruptibly();
+            ch.close().sync();
             try {
-                ch.shutdown(ChannelShutdownDirection.Inbound).syncUninterruptibly();
+                ch.shutdown(ChannelShutdownDirection.Inbound).sync();
                 fail();
             } catch (Throwable cause) {
                 checkThrowable(cause.getCause());
             }
             try {
-                ch.shutdown(ChannelShutdownDirection.Outbound).syncUninterruptibly();
+                ch.shutdown(ChannelShutdownDirection.Outbound).sync();
                 fail();
             } catch (Throwable cause) {
                 checkThrowable(cause.getCause());

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
@@ -187,9 +187,9 @@ public class SocketSslClientRenegotiateTest extends AbstractSocketTest {
             // Use the first previous enabled ciphersuite and try to renegotiate.
             clientSslHandler.engine().setEnabledCipherSuites(new String[]{renegotiation});
             clientSslHandler.renegotiate().await();
-            serverChannel.close().awaitUninterruptibly();
-            clientChannel.close().awaitUninterruptibly();
-            sc.close().awaitUninterruptibly();
+            serverChannel.close().await();
+            clientChannel.close().await();
+            sc.close().await();
             try {
                 if (serverException.get() != null) {
                     throw serverException.get();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslEchoTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslEchoTest.java
@@ -383,9 +383,9 @@ public class SocketSslEchoTest extends AbstractSocketTest {
             serverHandler.renegoFuture.sync();
         }
 
-        serverChannel.close().awaitUninterruptibly();
-        clientChannel.close().awaitUninterruptibly();
-        sc.close().awaitUninterruptibly();
+        serverChannel.close().await();
+        clientChannel.close().await();
+        sc.close().await();
         delegatedTaskExecutor.shutdown();
 
         if (serverException.get() != null && !(serverException.get() instanceof IOException)) {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslGreetingTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslGreetingTest.java
@@ -154,9 +154,9 @@ public class SocketSslGreetingTest extends AbstractSocketTest {
 
             ch.latch.await();
 
-            sh.channel.close().awaitUninterruptibly();
-            cc.close().awaitUninterruptibly();
-            sc.close().awaitUninterruptibly();
+            sh.channel.close().await();
+            cc.close().await();
+            sc.close().await();
 
             if (sh.exception.get() != null && !(sh.exception.get() instanceof IOException)) {
                 throw sh.exception.get();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslSessionReuseTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslSessionReuseTest.java
@@ -135,7 +135,7 @@ public class SocketSslSessionReuseTest extends AbstractSocketTest {
             assertEquals(sessions, sessionIdSet(clientSessionCtx.getIds()), "Expected no new sessions");
             rethrowHandlerExceptions(sh, ch);
         } finally {
-            sc.close().awaitUninterruptibly();
+            sc.close().await();
         }
     }
 

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketStartTlsTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketStartTlsTest.java
@@ -194,9 +194,9 @@ public class SocketStartTlsTest extends AbstractSocketTest {
             }
         }
 
-        sh.channel.close().awaitUninterruptibly();
-        cc.close().awaitUninterruptibly();
-        sc.close().awaitUninterruptibly();
+        sh.channel.close().await();
+        cc.close().await();
+        sc.close().await();
 
         if (sh.exception.get() != null && !(sh.exception.get() instanceof IOException)) {
             throw sh.exception.get();

--- a/transport-blockhound-tests/src/test/java/io/netty5/util/internal/NettyBlockHoundIntegrationTest.java
+++ b/transport-blockhound-tests/src/test/java/io/netty5/util/internal/NettyBlockHoundIntegrationTest.java
@@ -327,10 +327,10 @@ public class NettyBlockHoundIntegrationTest {
             assertNull(error.get());
         } finally {
             if (cc != null) {
-                cc.close().syncUninterruptibly();
+                cc.close().sync();
             }
             if (sc != null) {
-                sc.close().syncUninterruptibly();
+                sc.close().sync();
             }
             group.shutdownGracefully();
             Resource.dispose(sslClientCtx);
@@ -476,10 +476,10 @@ public class NettyBlockHoundIntegrationTest {
             serverSslHandler.handshakeFuture().await().sync();
         } finally {
             if (cc != null) {
-                cc.close().syncUninterruptibly();
+                cc.close().sync();
             }
             if (sc != null) {
-                sc.close().syncUninterruptibly();
+                sc.close().sync();
             }
             group.shutdownGracefully();
             Resource.dispose(sslClientCtx);

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDatagramChannelTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDatagramChannelTest.java
@@ -94,7 +94,7 @@ public class EpollDatagramChannelTest {
             assertTrue(localAddressAfterBind instanceof InetSocketAddress);
             assertTrue(((InetSocketAddress) localAddressAfterBind).getPort() != 0);
 
-            channel.close().syncUninterruptibly();
+            channel.close().sync();
         } finally {
             group.shutdownGracefully();
         }

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDatagramScatteringReadTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDatagramScatteringReadTest.java
@@ -150,7 +150,7 @@ public class EpollDatagramScatteringReadTest extends AbstractDatagramTest  {
             sc = sb.bind(newSocketAddress()).get();
 
             if (connected) {
-                sc.connect(cc.localAddress()).syncUninterruptibly();
+                sc.connect(cc.localAddress()).sync();
             }
 
             InetSocketAddress addr = (InetSocketAddress) sc.localAddress();
@@ -178,10 +178,10 @@ public class EpollDatagramScatteringReadTest extends AbstractDatagramTest  {
             }
         } finally {
             if (cc != null) {
-                cc.close().syncUninterruptibly();
+                cc.close().sync();
             }
             if (sc != null) {
-                sc.close().syncUninterruptibly();
+                sc.close().sync();
             }
         }
     }
@@ -251,7 +251,7 @@ public class EpollDatagramScatteringReadTest extends AbstractDatagramTest  {
             sc = sb.bind(newSocketAddress()).get();
 
             if (connected) {
-                sc.connect(cc.localAddress()).syncUninterruptibly();
+                sc.connect(cc.localAddress()).sync();
             }
 
             InetSocketAddress addr = (InetSocketAddress) sc.localAddress();
@@ -267,10 +267,10 @@ public class EpollDatagramScatteringReadTest extends AbstractDatagramTest  {
             }
         } finally {
             if (cc != null) {
-                cc.close().syncUninterruptibly();
+                cc.close().sync();
             }
             if (sc != null) {
-                sc.close().syncUninterruptibly();
+                sc.close().sync();
             }
         }
     }

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollEventLoopTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollEventLoopTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class EpollEventLoopTest extends AbstractSingleThreadEventLoopTest {
 
     @Test
-    public void testScheduleBigDelayNotOverflow() {
+    public void testScheduleBigDelayNotOverflow() throws Exception {
         final AtomicReference<Throwable> capture = new AtomicReference<>();
 
         final EventLoopGroup group = new SingleThreadEventLoop(
@@ -60,7 +60,7 @@ public class EpollEventLoopTest extends AbstractSingleThreadEventLoopTest {
                 // NOOP
             }, Long.MAX_VALUE, TimeUnit.MILLISECONDS);
 
-            assertFalse(future.awaitUninterruptibly(1000));
+            assertFalse(future.await(1000));
             assertTrue(future.cancel());
             assertNull(capture.get());
         } finally {

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollReuseAddrTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollReuseAddrTest.java
@@ -105,12 +105,12 @@ public class EpollReuseAddrTest {
         bootstrap.handler(new LoggingHandler(LogLevel.ERROR));
         Channel channel = bootstrap.bind().get();
         try {
-            bootstrap.bind(channel.localAddress()).syncUninterruptibly();
+            bootstrap.bind(channel.localAddress()).sync();
             fail();
         } catch (Exception e) {
             assertTrue(e.getCause() instanceof IOException);
         }
-        channel.close().syncUninterruptibly();
+        channel.close().sync();
     }
 
     @Test
@@ -135,8 +135,8 @@ public class EpollReuseAddrTest {
             socket.setReuseAddress(true);
             socket.close();
         }
-        firstChannel.close().syncUninterruptibly();
-        secondChannel.close().syncUninterruptibly();
+        firstChannel.close().sync();
+        secondChannel.close().sync();
     }
 
     @Test
@@ -184,8 +184,8 @@ public class EpollReuseAddrTest {
         }
         latch.await();
         executor.shutdown();
-        firstChannel.close().syncUninterruptibly();
-        secondChannel.close().syncUninterruptibly();
+        firstChannel.close().sync();
+        secondChannel.close().sync();
         assertTrue(received1.get());
         assertTrue(received2.get());
     }

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollServerSocketChannelConfigTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollServerSocketChannelConfigTest.java
@@ -47,9 +47,9 @@ public class EpollServerSocketChannelConfigTest {
     }
 
     @AfterAll
-    public static void after() {
+    public static void after() throws Exception {
         try {
-            ch.close().syncUninterruptibly();
+            ch.close().sync();
         } finally {
             group.shutdownGracefully();
         }

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollSocketChannelConfigTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollSocketChannelConfigTest.java
@@ -69,8 +69,8 @@ public class EpollSocketChannelConfigTest {
     }
 
     @AfterEach
-    public void teardown() {
-        ch.close().syncUninterruptibly();
+    public void tearDown() throws Exception {
+        ch.close().sync();
     }
 
     private static long randLong(long min, long max) {
@@ -145,8 +145,8 @@ public class EpollSocketChannelConfigTest {
     // This is inherently racy, so we allow getSoLinger to throw ChannelException a few of times, but eventually we do
     // want to see a ClosedChannelException for the test to pass.
     @RepeatedIfExceptionsTest(repeats = 4)
-    public void testSetOptionWhenClosed() {
-        ch.close().syncUninterruptibly();
+    public void testSetOptionWhenClosed() throws Exception {
+        ch.close().sync();
         ChannelException e = assertThrows(ChannelException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
@@ -160,8 +160,8 @@ public class EpollSocketChannelConfigTest {
     // This is inherently racy, so we allow getSoLinger to throw ChannelException a few of times, but eventually we do
     // want to see a ClosedChannelException for the test to pass.
     @RepeatedIfExceptionsTest(repeats = 4)
-    public void testGetOptionWhenClosed() {
-        ch.close().syncUninterruptibly();
+    public void testGetOptionWhenClosed() throws Exception {
+        ch.close().sync();
         ChannelException e = assertThrows(ChannelException.class, new Executable() {
             @Override
             public void execute() throws Throwable {

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollSocketChannelTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollSocketChannelTest.java
@@ -41,7 +41,7 @@ public class EpollSocketChannelTest {
                     .bind(new InetSocketAddress(0)).get();
             EpollTcpInfo info = ch.tcpInfo();
             assertTcpInfo0(info);
-            ch.close().syncUninterruptibly();
+            ch.close().sync();
         } finally {
             group.shutdownGracefully();
         }
@@ -60,7 +60,7 @@ public class EpollSocketChannelTest {
             EpollTcpInfo info = new EpollTcpInfo();
             ch.tcpInfo(info);
             assertTcpInfo0(info);
-            ch.close().syncUninterruptibly();
+            ch.close().sync();
         } finally {
             group.shutdownGracefully();
         }
@@ -115,7 +115,7 @@ public class EpollSocketChannelTest {
                     .option(ChannelOption.SO_LINGER, 10)
                     .handler(new ChannelHandler() { })
                     .bind(new InetSocketAddress(0)).get();
-            ch.close().syncUninterruptibly();
+            ch.close().sync();
         } finally {
             group.shutdownGracefully();
         }

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollSocketTcpMd5Test.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollSocketTcpMd5Test.java
@@ -63,8 +63,8 @@ public class EpollSocketTcpMd5Test {
     }
 
     @AfterEach
-    public void teardown() {
-        server.close().syncUninterruptibly();
+    public void tearDown() throws Exception {
+        server.close().sync();
     }
 
     @Test
@@ -86,7 +86,7 @@ public class EpollSocketTcpMd5Test {
                 Collections.singletonMap(NetUtil.LOCALHOST4, SERVER_KEY));
         ch.config().setOption(EpollChannelOption.TCP_MD5SIG, Collections.emptyMap());
 
-        ch.close().syncUninterruptibly();
+        ch.close().sync();
     }
 
     @Test
@@ -103,7 +103,7 @@ public class EpollSocketTcpMd5Test {
                             Collections.singletonMap(NetUtil.LOCALHOST4, BAD_KEY))
                     .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 1000)
                     .connect(server.localAddress()).get();
-            client.close().syncUninterruptibly();
+            client.close().sync();
         });
         assertThat(completion.getCause())
                 .isInstanceOf(ConnectTimeoutException.class);
@@ -120,6 +120,6 @@ public class EpollSocketTcpMd5Test {
                 .option(EpollChannelOption.TCP_MD5SIG,
                         Collections.singletonMap(NetUtil.LOCALHOST4, SERVER_KEY))
                 .connect(server.localAddress()).get();
-        client.close().syncUninterruptibly();
+        client.close().sync();
     }
 }

--- a/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueChannelConfigTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueChannelConfigTest.java
@@ -88,7 +88,7 @@ public class KQueueChannelConfigTest {
                     .option(ChannelOption.SO_LINGER, 10)
                     .handler(new ChannelHandler() { })
                     .bind(new InetSocketAddress(0)).get();
-            ch.close().syncUninterruptibly();
+            ch.close().sync();
         } finally {
             group.shutdownGracefully();
         }

--- a/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueEventLoopTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueEventLoopTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class KQueueEventLoopTest extends AbstractSingleThreadEventLoopTest {
 
     @Test
-    public void testScheduleBigDelayNotOverflow() {
+    public void testScheduleBigDelayNotOverflow() throws Exception {
         EventLoopGroup group = new MultithreadEventLoopGroup(1, newIoHandlerFactory());
 
         final EventLoop el = group.next();
@@ -40,7 +40,7 @@ public class KQueueEventLoopTest extends AbstractSingleThreadEventLoopTest {
             // NOOP
         }, Long.MAX_VALUE, TimeUnit.MILLISECONDS);
 
-        assertFalse(future.awaitUninterruptibly(1000));
+        assertFalse(future.await(1000));
         assertTrue(future.cancel());
         group.shutdownGracefully();
     }

--- a/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueServerSocketChannelConfigTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueServerSocketChannelConfigTest.java
@@ -46,9 +46,9 @@ public class KQueueServerSocketChannelConfigTest {
     }
 
     @AfterAll
-    public static void after() {
+    public static void after() throws Exception {
         try {
-            ch.close().syncUninterruptibly();
+            ch.close().sync();
         } finally {
             group.shutdownGracefully();
         }

--- a/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueSocketChannelConfigTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueSocketChannelConfigTest.java
@@ -64,8 +64,8 @@ public class KQueueSocketChannelConfigTest {
     }
 
     @AfterEach
-    public void tearDown() {
-        ch.close().syncUninterruptibly();
+    public void tearDown() throws Exception {
+        ch.close().sync();
     }
 
     @Test
@@ -102,8 +102,8 @@ public class KQueueSocketChannelConfigTest {
     }
 
     @Test
-    public void testSetOptionWhenClosed() {
-        ch.close().syncUninterruptibly();
+    public void testSetOptionWhenClosed() throws Exception {
+        ch.close().sync();
         try {
             ch.config().setSoLinger(0);
             fail();
@@ -113,8 +113,8 @@ public class KQueueSocketChannelConfigTest {
     }
 
     @Test
-    public void testGetOptionWhenClosed() {
-        ch.close().syncUninterruptibly();
+    public void testGetOptionWhenClosed() throws Exception {
+        ch.close().sync();
         try {
         ch.config().getSoLinger();
             fail();

--- a/transport-native-unix-common-tests/src/main/java/io/netty5/channel/unix/tests/DetectPeerCloseWithoutReadTest.java
+++ b/transport-native-unix-common-tests/src/main/java/io/netty5/channel/unix/tests/DetectPeerCloseWithoutReadTest.java
@@ -95,7 +95,7 @@ public abstract class DetectPeerCloseWithoutReadTest {
             assertEquals(expectedBytes, bytesRead.get());
         } finally {
             if (serverChannel != null) {
-                serverChannel.close().syncUninterruptibly();
+                serverChannel.close().sync();
             }
             if (serverGroup != null) {
                 serverGroup.shutdownGracefully();
@@ -169,10 +169,10 @@ public abstract class DetectPeerCloseWithoutReadTest {
             assertEquals(expectedBytes, bytesRead.get());
         } finally {
             if (serverChannel != null) {
-                serverChannel.close().syncUninterruptibly();
+                serverChannel.close().sync();
             }
             if (clientChannel != null) {
-                clientChannel.close().syncUninterruptibly();
+                clientChannel.close().sync();
             }
             if (serverGroup != null) {
                 serverGroup.shutdownGracefully();

--- a/transport/src/main/java/io/netty5/channel/group/ChannelGroup.java
+++ b/transport/src/main/java/io/netty5/channel/group/ChannelGroup.java
@@ -79,7 +79,7 @@ import java.util.Set;
  *     ... Wait until the shutdown signal reception ...
  *
  *     // Close the serverChannel and then all accepted connections.
- *     <strong>allChannels.close().awaitUninterruptibly();</strong>
+ *     <strong>allChannels.close().await();</strong>
  * }
  *
  * public class MyHandler implements {@link ChannelHandler} {

--- a/transport/src/main/java/io/netty5/channel/group/ChannelGroupFuture.java
+++ b/transport/src/main/java/io/netty5/channel/group/ChannelGroupFuture.java
@@ -146,12 +146,6 @@ public interface ChannelGroupFuture extends Future<Void>, Iterable<Future<Void>>
     ChannelGroupFuture await() throws InterruptedException;
 
     @Override
-    ChannelGroupFuture awaitUninterruptibly();
-
-    @Override
-    ChannelGroupFuture syncUninterruptibly();
-
-    @Override
     ChannelGroupFuture sync() throws InterruptedException;
 
     /**

--- a/transport/src/main/java/io/netty5/channel/group/ChannelGroupFuture.java
+++ b/transport/src/main/java/io/netty5/channel/group/ChannelGroupFuture.java
@@ -76,7 +76,7 @@ import java.util.Iterator;
  * public void messageReceived({@link ChannelHandlerContext} ctx, ShutdownMessage msg) {
  *     {@link ChannelGroup} allChannels = MyServer.getAllChannels();
  *     {@link ChannelGroupFuture} future = allChannels.close();
- *     future.awaitUninterruptibly();
+ *     future.await();
  *     // Perform post-shutdown operation
  *     // ...
  *

--- a/transport/src/main/java/io/netty5/channel/group/DefaultChannelGroupFuture.java
+++ b/transport/src/main/java/io/netty5/channel/group/DefaultChannelGroupFuture.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-
 /**
  * The default {@link ChannelGroupFuture} implementation.
  */
@@ -122,18 +121,6 @@ final class DefaultChannelGroupFuture extends DefaultPromise<Void> implements Ch
     @Override
     public DefaultChannelGroupFuture await() throws InterruptedException {
         super.await();
-        return this;
-    }
-
-    @Override
-    public DefaultChannelGroupFuture awaitUninterruptibly() {
-        super.awaitUninterruptibly();
-        return this;
-    }
-
-    @Override
-    public DefaultChannelGroupFuture syncUninterruptibly() {
-        super.syncUninterruptibly();
         return this;
     }
 

--- a/transport/src/test/java/io/netty5/bootstrap/BootstrapTest.java
+++ b/transport/src/test/java/io/netty5/bootstrap/BootstrapTest.java
@@ -259,7 +259,7 @@ public class BootstrapTest {
             Future<Channel> future = bootstrapA.connect(LocalAddress.ANY);
             assertFalse(future.isDone());
             registerHandler.registerPromise().setSuccess(null);
-            CompletionException cause = assertThrows(CompletionException.class, future::syncUninterruptibly);
+            CompletionException cause = assertThrows(CompletionException.class, future::sync);
             assertThat(cause.getCause(), instanceOf(ConnectException.class));
         } finally {
             group.shutdownGracefully();
@@ -300,7 +300,7 @@ public class BootstrapTest {
             registerHandler.registerPromise().setSuccess(null);
             registerFuture.sync();
             CompletionException exception =
-                    assertThrows(CompletionException.class, connectFuture::syncUninterruptibly);
+                    assertThrows(CompletionException.class, connectFuture::sync);
             assertTrue(exception.getCause() instanceof ConnectException);
         } finally {
             group.shutdownGracefully();

--- a/transport/src/test/java/io/netty5/bootstrap/BootstrapTest.java
+++ b/transport/src/test/java/io/netty5/bootstrap/BootstrapTest.java
@@ -73,11 +73,11 @@ public class BootstrapTest {
     private static final ChannelHandler dummyHandler = new DummyHandler();
 
     @AfterAll
-    public static void destroy() {
+    public static void destroy() throws Exception {
         groupA.shutdownGracefully();
         groupB.shutdownGracefully();
-        groupA.terminationFuture().syncUninterruptibly();
-        groupB.terminationFuture().syncUninterruptibly();
+        groupA.terminationFuture().sync();
+        groupB.terminationFuture().sync();
     }
 
     @Test
@@ -388,7 +388,7 @@ public class BootstrapTest {
                 .option(ChannelOption.WRITE_BUFFER_LOW_WATER_MARK, 1)
                 .option(ChannelOption.WRITE_BUFFER_HIGH_WATER_MARK, 2);
 
-        bootstrap.register().syncUninterruptibly();
+        bootstrap.register().sync();
 
         latch.await();
 

--- a/transport/src/test/java/io/netty5/bootstrap/ServerBootstrapTest.java
+++ b/transport/src/test/java/io/netty5/bootstrap/ServerBootstrapTest.java
@@ -65,7 +65,7 @@ public class ServerBootstrapTest {
                       }
                   }
               });
-            sb.register().syncUninterruptibly();
+            sb.register().sync();
             latch.await();
             assertNull(error.get());
         } finally {
@@ -136,10 +136,10 @@ public class ServerBootstrapTest {
             readLatch.await();
         } finally {
             if (sch != null) {
-                sch.close().syncUninterruptibly();
+                sch.close().sync();
             }
             if (cch != null) {
-                cch.close().syncUninterruptibly();
+                cch.close().sync();
             }
             group.shutdownGracefully();
         }
@@ -172,8 +172,8 @@ public class ServerBootstrapTest {
                 .channel(LocalChannel.class)
                 .handler(new ChannelHandler() { });
         Channel clientChannel = cb.connect(addr).get();
-        serverChannel.close().syncUninterruptibly();
-        clientChannel.close().syncUninterruptibly();
+        serverChannel.close().sync();
+        clientChannel.close().sync();
         group.shutdownGracefully();
         assertTrue(requestServed.get());
     }

--- a/transport/src/test/java/io/netty5/channel/AbstractEventLoopTest.java
+++ b/transport/src/test/java/io/netty5/channel/AbstractEventLoopTest.java
@@ -41,7 +41,7 @@ public abstract class AbstractEventLoopTest {
 
         Future<?> f = loop.shutdownGracefully(0, 1, TimeUnit.MINUTES);
         assertTrue(loop.awaitTermination(600, TimeUnit.MILLISECONDS));
-        assertTrue(f.syncUninterruptibly().isSuccess());
+        assertTrue(f.sync().isSuccess());
         assertTrue(loop.isShutdown());
         assertTrue(loop.isTerminated());
     }

--- a/transport/src/test/java/io/netty5/channel/ChannelInitializerTest.java
+++ b/transport/src/test/java/io/netty5/channel/ChannelInitializerTest.java
@@ -63,28 +63,28 @@ public class ChannelInitializerTest {
     }
 
     @AfterEach
-    public void tearDown() {
-        group.shutdownGracefully(0, TIMEOUT_MILLIS, TimeUnit.MILLISECONDS).syncUninterruptibly();
+    public void tearDown() throws Exception {
+        group.shutdownGracefully(0, TIMEOUT_MILLIS, TimeUnit.MILLISECONDS).sync();
     }
 
     @Test
-    public void testInitChannelThrowsRegisterFirst() {
+    public void testInitChannelThrowsRegisterFirst() throws Exception {
         testInitChannelThrows(true);
     }
 
     @Test
-    public void testInitChannelThrowsRegisterAfter() {
+    public void testInitChannelThrowsRegisterAfter() throws Exception {
         testInitChannelThrows(false);
     }
 
-    private void testInitChannelThrows(boolean registerFirst) {
+    private void testInitChannelThrows(boolean registerFirst) throws Exception {
         final Exception exception = new Exception();
         final AtomicReference<Throwable> causeRef = new AtomicReference<>();
 
         ChannelPipeline pipeline = new LocalChannel(group.next()).pipeline();
 
         if (registerFirst) {
-           pipeline.channel().register().syncUninterruptibly();
+           pipeline.channel().register().sync();
         }
         pipeline.addFirst(new ChannelInitializer<Channel>() {
             @Override
@@ -100,10 +100,10 @@ public class ChannelInitializerTest {
         });
 
         if (!registerFirst) {
-            assertTrue(pipeline.channel().register().awaitUninterruptibly().cause() instanceof ClosedChannelException);
+            assertTrue(pipeline.channel().register().await().cause() instanceof ClosedChannelException);
         }
-        pipeline.channel().close().syncUninterruptibly();
-        pipeline.channel().closeFuture().syncUninterruptibly();
+        pipeline.channel().close().sync();
+        pipeline.channel().closeFuture().sync();
 
         assertSame(exception, causeRef.get());
     }
@@ -136,7 +136,7 @@ public class ChannelInitializerTest {
             // pipeline.
             channel.executor().submit(() -> {
                 // NOOP
-            }).syncUninterruptibly();
+            }).sync();
             Iterator<Map.Entry<String, ChannelHandler>> handlers = channel.pipeline().iterator();
             assertSame(handler1, handlers.next().getValue());
             assertSame(handler2, handlers.next().getValue());
@@ -144,7 +144,7 @@ public class ChannelInitializerTest {
             assertSame(handler4, handlers.next().getValue());
             assertFalse(handlers.hasNext());
         } finally {
-            channel.close().syncUninterruptibly();
+            channel.close().sync();
         }
     }
 
@@ -173,11 +173,11 @@ public class ChannelInitializerTest {
             // pipeline.
             channel.executor().submit(() -> {
                 // NOOP
-            }).syncUninterruptibly();
+            }).sync();
             assertEquals(1, initChannelCalled.get());
             assertEquals(2, registeredCalled.get());
         } finally {
-            channel.close().syncUninterruptibly();
+            channel.close().sync();
         }
     }
 
@@ -248,9 +248,9 @@ public class ChannelInitializerTest {
         }
     }
 
-    private static void closeChannel(Channel c) {
+    private static void closeChannel(Channel c) throws Exception {
         if (c != null) {
-            c.close().syncUninterruptibly();
+            c.close().sync();
         }
     }
 

--- a/transport/src/test/java/io/netty5/channel/CombinedChannelDuplexHandlerTest.java
+++ b/transport/src/test/java/io/netty5/channel/CombinedChannelDuplexHandlerTest.java
@@ -175,7 +175,7 @@ public class CombinedChannelDuplexHandlerTest {
     }
 
     @Test
-    public void testOutboundEvents() {
+    public void testOutboundEvents() throws Exception {
         ChannelHandler inboundHandler = new ChannelHandlerAdapter() { };
         OutboundEventHandler outboundHandler = new OutboundEventHandler();
 
@@ -206,15 +206,15 @@ public class CombinedChannelDuplexHandlerTest {
         assertNull(outboundHandler.pollEvent());
     }
 
-    private static void doOutboundOperations(Channel channel) {
-        channel.pipeline().bind(LOCAL_ADDRESS).syncUninterruptibly();
-        channel.pipeline().connect(REMOTE_ADDRESS, LOCAL_ADDRESS).syncUninterruptibly();
-        channel.pipeline().write(MSG).syncUninterruptibly();
+    private static void doOutboundOperations(Channel channel) throws Exception {
+        channel.pipeline().bind(LOCAL_ADDRESS).sync();
+        channel.pipeline().connect(REMOTE_ADDRESS, LOCAL_ADDRESS).sync();
+        channel.pipeline().write(MSG).sync();
         channel.pipeline().flush();
         channel.pipeline().read();
-        channel.pipeline().disconnect().syncUninterruptibly();
-        channel.pipeline().close().syncUninterruptibly();
-        channel.pipeline().deregister().syncUninterruptibly();
+        channel.pipeline().disconnect().sync();
+        channel.pipeline().close().sync();
+        channel.pipeline().deregister().sync();
     }
 
     private static void assertOutboundOperations(OutboundEventHandler outboundHandler) {

--- a/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTailTest.java
+++ b/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTailTest.java
@@ -76,7 +76,7 @@ public class DefaultChannelPipelineTailTest {
         };
 
         myChannel.pipeline().fireChannelInactive();
-        myChannel.close().syncUninterruptibly();
+        myChannel.close().sync();
 
         assertTrue(latch.await(1L, TimeUnit.SECONDS));
     }

--- a/transport/src/test/java/io/netty5/channel/PendingWriteQueueTest.java
+++ b/transport/src/test/java/io/netty5/channel/PendingWriteQueueTest.java
@@ -43,7 +43,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class PendingWriteQueueTest {
 
     @Test
-    public void testRemoveAndWrite() {
+    public void testRemoveAndWrite() throws Exception {
         assertWrite(new TestHandler() {
             @Override
             public void flush(ChannelHandlerContext ctx) {
@@ -57,7 +57,7 @@ public class PendingWriteQueueTest {
     }
 
     @Test
-    public void testRemoveAndWriteAll() {
+    public void testRemoveAndWriteAll() throws Exception {
         assertWrite(new TestHandler() {
             @Override
             public void flush(ChannelHandlerContext ctx) {
@@ -71,7 +71,7 @@ public class PendingWriteQueueTest {
     }
 
     @Test
-    public void testRemoveAndFail() {
+    public void testRemoveAndFail() throws Exception {
         assertWriteFails(new TestHandler() {
 
             @Override
@@ -83,7 +83,7 @@ public class PendingWriteQueueTest {
     }
 
     @Test
-    public void testRemoveAndFailAll() {
+    public void testRemoveAndFailAll() throws Exception {
         assertWriteFails(new TestHandler() {
             @Override
             public void flush(ChannelHandlerContext ctx) {
@@ -142,7 +142,7 @@ public class PendingWriteQueueTest {
         assertThat(msg.refCnt(), is(0));
     }
 
-    private static void assertWrite(ChannelHandler handler, int count) {
+    private static void assertWrite(ChannelHandler handler, int count) throws Exception {
         final ByteBuf buffer = Unpooled.copiedBuffer("Test", CharsetUtil.US_ASCII);
         final EmbeddedChannel channel = new EmbeddedChannel(handler);
         channel.config().setWriteBufferLowWaterMark(1);
@@ -154,7 +154,7 @@ public class PendingWriteQueueTest {
         }
         assertTrue(channel.writeOutbound(buffers));
         assertTrue(channel.finish());
-        channel.closeFuture().syncUninterruptibly();
+        channel.closeFuture().sync();
 
         for (int i = 0; i < buffers.length; i++) {
             assertBuffer(channel, buffer);
@@ -178,7 +178,7 @@ public class PendingWriteQueueTest {
         assertNull(queue.removeAndWriteAll());
     }
 
-    private static void assertWriteFails(ChannelHandler handler, int count) {
+    private static void assertWriteFails(ChannelHandler handler, int count) throws Exception {
         final ByteBuf buffer = Unpooled.copiedBuffer("Test", CharsetUtil.US_ASCII);
         final EmbeddedChannel channel = new EmbeddedChannel(handler);
         ByteBuf[] buffers = new ByteBuf[count];
@@ -192,7 +192,7 @@ public class PendingWriteQueueTest {
             assertTrue(e instanceof TestException);
         }
         assertFalse(channel.finish());
-        channel.closeFuture().syncUninterruptibly();
+        channel.closeFuture().sync();
 
         buffer.release();
         assertNull(channel.readOutbound());
@@ -331,10 +331,10 @@ public class PendingWriteQueueTest {
 
     // See https://github.com/netty/netty/issues/3967
     @Test
-    public void testCloseChannelOnCreation() {
+    public void testCloseChannelOnCreation() throws Exception {
         EmbeddedChannel channel = newChannel();
         ChannelHandlerContext context = channel.pipeline().firstContext();
-        channel.close().syncUninterruptibly();
+        channel.close().sync();
 
         final PendingWriteQueue queue = new PendingWriteQueue(context);
 

--- a/transport/src/test/java/io/netty5/channel/SingleThreadEventLoopTest.java
+++ b/transport/src/test/java/io/netty5/channel/SingleThreadEventLoopTest.java
@@ -348,7 +348,7 @@ public class SingleThreadEventLoopTest {
         try {
             Channel channel = new LocalChannel(loopA);
             Future<Void> f = channel.register();
-            f.awaitUninterruptibly();
+            f.await();
             assertFalse(f.isSuccess());
             assertThat(f.cause(), is(instanceOf(RejectedExecutionException.class)));
             // TODO: What to do in this case ?
@@ -378,7 +378,7 @@ public class SingleThreadEventLoopTest {
 
         try {
             Future<Void> f = ch.register().addListener(future -> latch.countDown());
-            f.awaitUninterruptibly();
+            f.await();
             assertFalse(f.isSuccess());
             assertThat(f.cause(), is(instanceOf(RejectedExecutionException.class)));
 

--- a/transport/src/test/java/io/netty5/channel/embedded/EmbeddedChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/embedded/EmbeddedChannelTest.java
@@ -87,7 +87,7 @@ public class EmbeddedChannelTest {
         EmbeddedChannel channel = new EmbeddedChannel();
         channel.closeFuture().addListener(channel, (c, f) -> c.close());
 
-        channel.close().syncUninterruptibly();
+        channel.close().sync();
     }
 
     @Test
@@ -214,7 +214,7 @@ public class EmbeddedChannelTest {
                 latch.countDown();
             }
         });
-        action.doRun(channel).syncUninterruptibly();
+        action.doRun(channel).sync();
         latch.await();
     }
 
@@ -417,7 +417,7 @@ public class EmbeddedChannelTest {
           fail("Nobody called #channelRead() in time.");
       }
 
-      channel.close().syncUninterruptibly();
+      channel.close().sync();
 
       // There was no #flushInbound() call so nobody should have called
       // #channelReadComplete()
@@ -467,7 +467,7 @@ public class EmbeddedChannelTest {
             fail("Nobody called #write() in time.");
         }
 
-        channel.close().syncUninterruptibly();
+        channel.close().sync();
 
         // There was no #flushOutbound() call so nobody should have called #flush()
         assertEquals(0, flushCount.get());
@@ -476,7 +476,7 @@ public class EmbeddedChannelTest {
     @Test
     public void testEnsureOpen() throws InterruptedException {
         EmbeddedChannel channel = new EmbeddedChannel();
-        channel.close().syncUninterruptibly();
+        channel.close().sync();
 
         try {
             channel.writeOutbound("Hello, Netty!");

--- a/transport/src/test/java/io/netty5/channel/group/DefaultChannelGroupTest.java
+++ b/transport/src/test/java/io/netty5/channel/group/DefaultChannelGroupTest.java
@@ -47,11 +47,11 @@ public class DefaultChannelGroupTest {
         });
         b.channel(NioServerSocketChannel.class);
 
-        Future<Channel> f = b.bind(0).syncUninterruptibly();
+        Future<Channel> f = b.bind(0).sync();
 
         if (f.isSuccess()) {
             allChannels.add(f.getNow());
-            allChannels.close().awaitUninterruptibly();
+            allChannels.close().await();
         }
 
         bossGroup.shutdownGracefully();

--- a/transport/src/test/java/io/netty5/channel/local/LocalChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/local/LocalChannelTest.java
@@ -363,7 +363,7 @@ public class LocalChannelTest {
             // Connect to the server
             cc = cb.connect(sc.localAddress()).get();
 
-            cc.deregister().syncUninterruptibly();
+            cc.deregister().sync();
         } finally {
             closeChannel(cc);
             closeChannel(sc);
@@ -833,7 +833,7 @@ public class LocalChannelTest {
             cc.connect(sc.localAddress()).sync();
             Future<Void> f = ref.get().sync();
 
-            assertPromise.asFuture().syncUninterruptibly();
+            assertPromise.asFuture().sync();
             assertTrue(f.isSuccess());
         } finally {
             closeChannel(cc);
@@ -848,7 +848,7 @@ public class LocalChannelTest {
             assertTrue(assertThrows(CompletionException.class, () -> sb.group(group1)
                     .channel(LocalChannel.class)
                     .handler(new TestHandler())
-                    .connect(LocalAddress.ANY).syncUninterruptibly()).getCause() instanceof ConnectException);
+                    .connect(LocalAddress.ANY).sync()).getCause() instanceof ConnectException);
         } catch (CompletionException e) {
             throw e.getCause();
         }
@@ -865,9 +865,9 @@ public class LocalChannelTest {
         }
     }
 
-    private static void closeChannel(Channel cc) {
+    private static void closeChannel(Channel cc) throws Exception {
         if (cc != null) {
-            cc.close().syncUninterruptibly();
+            cc.close().sync();
         }
     }
 

--- a/transport/src/test/java/io/netty5/channel/socket/nio/AbstractNioChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/socket/nio/AbstractNioChannelTest.java
@@ -25,7 +25,6 @@ import io.netty5.util.concurrent.AbstractEventExecutor;
 import io.netty5.util.concurrent.Future;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.net.SocketOption;
 import java.net.StandardSocketOptions;
 import java.nio.channels.NetworkChannel;
@@ -47,7 +46,7 @@ public abstract class AbstractNioChannelTest<T extends AbstractNioChannel> {
     protected abstract SocketOption<?> newInvalidOption();
 
     @Test
-    public void testNioChannelOption() throws IOException {
+    public void testNioChannelOption() throws Exception {
         EventLoopGroup eventLoopGroup = new MultithreadEventLoopGroup(1, NioHandler.newFactory());
         T channel = newNioChannel(eventLoopGroup);
         try {
@@ -64,13 +63,13 @@ public abstract class AbstractNioChannelTest<T extends AbstractNioChannel> {
             assertEquals(value3, value4);
             assertNotEquals(value1, value4);
         } finally {
-            channel.close().syncUninterruptibly();
+            channel.close().sync();
             eventLoopGroup.shutdownGracefully();
         }
     }
 
     @Test
-    public void testInvalidNioChannelOption() {
+    public void testInvalidNioChannelOption() throws Exception {
         EventLoopGroup eventLoopGroup = new MultithreadEventLoopGroup(1, NioHandler.newFactory());
         T channel = newNioChannel(eventLoopGroup);
         try {
@@ -78,25 +77,25 @@ public abstract class AbstractNioChannelTest<T extends AbstractNioChannel> {
             assertFalse(channel.config().setOption(option, null));
             assertNull(channel.config().getOption(option));
         } finally {
-            channel.close().syncUninterruptibly();
+            channel.close().sync();
             eventLoopGroup.shutdownGracefully();
         }
     }
 
     @Test
-    public void testGetOptions()  {
+    public void testGetOptions() throws Exception {
         EventLoopGroup eventLoopGroup = new MultithreadEventLoopGroup(1, NioHandler.newFactory());
         T channel = newNioChannel(eventLoopGroup);
         try {
             channel.config().getOptions();
         } finally {
-            channel.close().syncUninterruptibly();
+            channel.close().sync();
             eventLoopGroup.shutdownGracefully();
         }
     }
 
     @Test
-    public void testWrapping() {
+    public void testWrapping() throws Exception {
         EventLoopGroup eventLoopGroup = new MultithreadEventLoopGroup(1, NioHandler.newFactory());
         final EventLoop eventLoop = eventLoopGroup.next();
 
@@ -183,10 +182,10 @@ public abstract class AbstractNioChannelTest<T extends AbstractNioChannel> {
 
         EventLoop wrapped = new WrappedEventLoop(eventLoop);
         T channel = newNioChannel(wrapped);
-        channel.register().syncUninterruptibly();
+        channel.register().sync();
 
         assertSame(wrapped, channel.executor());
-        channel.close().syncUninterruptibly();
+        channel.close().sync();
         eventLoopGroup.shutdownGracefully();
     }
 }

--- a/transport/src/test/java/io/netty5/channel/socket/nio/NioServerSocketChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/socket/nio/NioServerSocketChannelTest.java
@@ -39,26 +39,26 @@ public class NioServerSocketChannelTest extends AbstractNioChannelTest<NioServer
 
         NioServerSocketChannel serverSocketChannel = new NioServerSocketChannel(group.next(), group, jdkChannel);
         try {
-            serverSocketChannel.register().syncUninterruptibly();
-            serverSocketChannel.bind(new InetSocketAddress(0)).syncUninterruptibly();
+            serverSocketChannel.register().sync();
+            serverSocketChannel.bind(new InetSocketAddress(0)).sync();
             assertFalse(serverSocketChannel.closeOnReadError(new IOException()));
             assertTrue(serverSocketChannel.closeOnReadError(new IllegalArgumentException()));
-            serverSocketChannel.close().syncUninterruptibly();
+            serverSocketChannel.close().sync();
         } finally {
             group.shutdownGracefully();
         }
     }
 
     @Test
-    public void testIsActiveFalseAfterClose()  {
+    public void testIsActiveFalseAfterClose() throws Exception {
         EventLoopGroup group = new MultithreadEventLoopGroup(1, NioHandler.newFactory());
         NioServerSocketChannel channel = new NioServerSocketChannel(group.next(), group);
         try {
-            channel.register().syncUninterruptibly();
-            channel.bind(new InetSocketAddress(0)).syncUninterruptibly();
+            channel.register().sync();
+            channel.bind(new InetSocketAddress(0)).sync();
             assertTrue(channel.isActive());
             assertTrue(channel.isOpen());
-            channel.close().syncUninterruptibly();
+            channel.close().sync();
             assertFalse(channel.isOpen());
             assertFalse(channel.isActive());
         } finally {

--- a/transport/src/test/java/io/netty5/channel/socket/nio/NioSocketChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/socket/nio/NioSocketChannelTest.java
@@ -212,7 +212,7 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
             bootstrap.group(group).channel(NioSocketChannel.class);
             bootstrap.handler(new ChannelHandler() { });
             cc = bootstrap.connect(sc.localAddress()).get();
-            cc.writeAndFlush(onHeapAllocator().copyOf(bytes)).syncUninterruptibly();
+            cc.writeAndFlush(onHeapAllocator().copyOf(bytes)).sync();
             latch.await();
         } finally {
             if (cc != null) {
@@ -240,9 +240,9 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
             SocketChannel channel = (SocketChannel) sb.connect(socket.getLocalSocketAddress()).get();
 
             accepted = socket.accept();
-            channel.shutdown(ChannelShutdownDirection.Outbound).syncUninterruptibly();
+            channel.shutdown(ChannelShutdownDirection.Outbound).sync();
 
-            channel.close().syncUninterruptibly();
+            channel.close().sync();
         } finally {
             if (accepted != null) {
                 try {


### PR DESCRIPTION
Motivation:
We don't want to directly expose blocking methods on our netty Future interface, because they can't be called inside the event loop.
Instead, users of these should convert the future to a JDK future.
As a step towards this, we should remove the uninterruptible blocking methods.
These in particular have no equivalent on the JDK future API.
They are also inherently not behaving properly with regards to interrupts.

Modification:
Remove all Future.*Uninterruptible methods.
Replace nearly all usages with interruptible counterparts.

Result:
Fewer suspicious APIs on the Future interface.