### PR TITLE
Remove unnecessary ByteBuf.retain calls

### DIFF
--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2StreamFrameToHttpObjectCodec.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2StreamFrameToHttpObjectCodec.java
@@ -124,10 +124,10 @@ public class Http2StreamFrameToHttpObjectCodec extends MessageToMessageCodec<Htt
             Http2DataFrame dataFrame = (Http2DataFrame) frame;
             if (dataFrame.isEndStream()) {
                 ctx.fireChannelRead(new DefaultLastHttpContent(
-                        extractOrCopy(ctx.bufferAllocator(), dataFrame.content().retain()), validateHeaders));
+                        extractOrCopy(ctx.bufferAllocator(), dataFrame.content()), validateHeaders));
             } else {
                 ctx.fireChannelRead(new DefaultHttpContent(extractOrCopy(ctx.bufferAllocator(),
-                        dataFrame.content().retain())));
+                        dataFrame.content())));
             }
         }
     }


### PR DESCRIPTION
Motivation:
The Http2StreamFrameToHttpObjectCodec was from using decode() to decodeAndClose().
This means the super-class no longer automatically closes the frame passed to decode.
This in turn let us pass incoming buffers directly down the pipeline without retaining them.

Modification:
Remove ByteBuf.retain() calls that are no longer necessary.

Result:
Cleaner code and no longer leaking data frame buffers that were retained.