### PR TITLE
Explicitly include allocation in the LifecycleTracer API

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/internal/ResourceSupport.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/internal/ResourceSupport.java
@@ -38,6 +38,7 @@ public abstract class ResourceSupport<I extends Resource<I>, T extends ResourceS
     protected ResourceSupport(Drop<T> drop) {
         this.drop = drop;
         tracer = LifecycleTracer.get();
+        tracer.allocate();
     }
 
     /**


### PR DESCRIPTION
Motivation:
The allocation is currently an implicit trace event, that happens as a side-effect of getting the tracer.
This is an asymmetry that makes it harder to extend the tracer API.

Modification:
Move the allocation trace point out of LifecycleTracer.get, and expose it as an explicit method on the API.
Then make sure it's called from the only place where we get a tracer.

Result:
Cleaner code
