### PR TITLE
Make SslHandler.handlerRemoved(...) more rebust in case it is called …

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -674,7 +674,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
     @Override
     public void handlerRemoved0(ChannelHandlerContext ctx) throws Exception {
         try {
-            if (!pendingUnencryptedWrites.isEmpty()) {
+            if (pendingUnencryptedWrites != null && !pendingUnencryptedWrites.isEmpty()) {
                 // Check if queue is not empty first because create a new ChannelException is expensive
                 pendingUnencryptedWrites.releaseAndFailAll(ctx,
                   new ChannelException("Pending write on removal of SslHandler"));
@@ -1975,10 +1975,10 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
     @Override
     public void handlerAdded(final ChannelHandlerContext ctx) throws Exception {
         this.ctx = ctx;
-
         Channel channel = ctx.channel();
-        setOpensslEngineSocketFd(channel);
         pendingUnencryptedWrites = new SslHandlerCoalescingBufferQueue(channel, 16);
+
+        setOpensslEngineSocketFd(channel);
         boolean fastOpen = Boolean.TRUE.equals(channel.config().getOption(ChannelOption.TCP_FASTOPEN_CONNECT));
         boolean active = channel.isActive();
         if (active || fastOpen) {


### PR DESCRIPTION
…because handlerAdded(...) throws.

Motivation:

We should ensure we do a null check in handlerRemoved(...) as handlerAdded(...) might throw before it inits the pendingUnencryptedWrites .

Modifications:

- Add null check
- init pendingUnencryptedWrites before we try to do anything else that might throw

Result:

More robust handling of failures during handlerAdded(...). Related to https://github.com/netty/netty/issues/12473.