### PR TITLE
Make ChannelHandlerContext.isRemoved() thread-safe

### DIFF
--- a/transport/src/main/java/io/netty5/channel/ChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty5/channel/ChannelHandlerContext.java
@@ -141,8 +141,7 @@ public interface ChannelHandlerContext extends AttributeMap, ChannelInboundInvok
 
     /**
      * Return {@code true} if the {@link ChannelHandler} which belongs to this context was removed
-     * from the {@link ChannelPipeline}. Note that this method is only meant to be called from with in the
-     * {@link EventLoop}.
+     * from the {@link ChannelPipeline}.
      */
     boolean isRemoved();
 

--- a/transport/src/main/java/io/netty5/channel/DefaultChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty5/channel/DefaultChannelHandlerContext.java
@@ -89,6 +89,8 @@ final class DefaultChannelHandlerContext implements ChannelHandlerContext, Resou
     private Tasks invokeTasks;
     private int handlerState = INIT;
 
+    private volatile boolean removed;
+
     DefaultChannelHandlerContext next;
     DefaultChannelHandlerContext prev;
 
@@ -820,13 +822,14 @@ final class DefaultChannelHandlerContext implements ChannelHandlerContext, Resou
             }
         } finally {
             // Mark the handler as removed in any case.
+            removed = true;
             handlerState = REMOVE_COMPLETE;
         }
     }
 
     @Override
     public boolean isRemoved() {
-        return handlerState == REMOVE_COMPLETE;
+        return removed;
     }
 
     void remove(boolean relink) {

--- a/transport/src/main/java/io/netty5/channel/DefaultChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty5/channel/DefaultChannelHandlerContext.java
@@ -822,8 +822,8 @@ final class DefaultChannelHandlerContext implements ChannelHandlerContext, Resou
             }
         } finally {
             // Mark the handler as removed in any case.
-            removed = true;
             handlerState = REMOVE_COMPLETE;
+            removed = true;
         }
     }
 


### PR DESCRIPTION
Motivation:

All methods of ChannelHandlerContext are thread-safe except ChannelHandlerContext.isRemoved(). This is odd in terms of consistency, let's fix that.

Modifications:

Add extra volatile booleean field to track when a context was removed and use this for isRemoved()

Result:

More consistent API and less surprising