### PR TITLE
ChannelHandlerContext should not extend AttributeMap

### DIFF
--- a/codec-http/src/main/java/io/netty5/handler/codec/http/DelegatingChannelHandlerContext.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/DelegatingChannelHandlerContext.java
@@ -21,8 +21,6 @@ import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
-import io.netty5.util.Attribute;
-import io.netty5.util.AttributeKey;
 import io.netty5.util.concurrent.EventExecutor;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.Promise;
@@ -143,16 +141,6 @@ abstract class DelegatingChannelHandlerContext implements ChannelHandlerContext 
     @Override
     public BufferAllocator bufferAllocator() {
         return ctx.bufferAllocator();
-    }
-
-    @Deprecated
-    public <T> Attribute<T> attr(AttributeKey<T> key) {
-        return ctx.attr(key);
-    }
-
-    @Deprecated
-    public <T> boolean hasAttr(AttributeKey<T> key) {
-        return ctx.hasAttr(key);
     }
 
     @Override

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameInboundWriter.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameInboundWriter.java
@@ -24,8 +24,6 @@ import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
 import io.netty5.channel.embedded.EmbeddedChannel;
-import io.netty5.util.Attribute;
-import io.netty5.util.AttributeKey;
 import io.netty5.util.concurrent.EventExecutor;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.Promise;
@@ -217,16 +215,6 @@ final class Http2FrameInboundWriter {
         @Override
         public BufferAllocator bufferAllocator() {
             return channel.bufferAllocator();
-        }
-
-        @Override
-        public <T> Attribute<T> attr(AttributeKey<T> key) {
-            return channel.attr(key);
-        }
-
-        @Override
-        public <T> boolean hasAttr(AttributeKey<T> key) {
-            return channel.hasAttr(key);
         }
 
         @Override

--- a/codec/src/main/java/io/netty5/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty5/handler/codec/ByteToMessageDecoder.java
@@ -28,8 +28,6 @@ import io.netty5.channel.ChannelHandlerAdapter;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
 import io.netty5.channel.socket.ChannelInputShutdownEvent;
-import io.netty5.util.Attribute;
-import io.netty5.util.AttributeKey;
 import io.netty5.util.concurrent.EventExecutor;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.Promise;
@@ -633,18 +631,6 @@ public abstract class ByteToMessageDecoder extends ChannelHandlerAdapter {
         @Override
         public BufferAllocator bufferAllocator() {
             return ctx.bufferAllocator();
-        }
-
-        @Override
-        @Deprecated
-        public <T> Attribute<T> attr(AttributeKey<T> key) {
-            return ctx.attr(key);
-        }
-
-        @Override
-        @Deprecated
-        public <T> boolean hasAttr(AttributeKey<T> key) {
-            return ctx.hasAttr(key);
         }
 
         @Override

--- a/codec/src/main/java/io/netty5/handler/codec/ByteToMessageDecoderForBuffer.java
+++ b/codec/src/main/java/io/netty5/handler/codec/ByteToMessageDecoderForBuffer.java
@@ -26,8 +26,6 @@ import io.netty5.channel.ChannelHandlerAdapter;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
 import io.netty5.channel.socket.ChannelInputShutdownEvent;
-import io.netty5.util.Attribute;
-import io.netty5.util.AttributeKey;
 import io.netty5.util.Send;
 import io.netty5.util.concurrent.EventExecutor;
 import io.netty5.util.concurrent.Future;
@@ -545,18 +543,6 @@ public abstract class ByteToMessageDecoderForBuffer extends ChannelHandlerAdapte
         @Override
         public BufferAllocator bufferAllocator() {
             return ctx.bufferAllocator();
-        }
-
-        @Override
-        @Deprecated
-        public <T> Attribute<T> attr(AttributeKey<T> key) {
-            return ctx.attr(key);
-        }
-
-        @Override
-        @Deprecated
-        public <T> boolean hasAttr(AttributeKey<T> key) {
-            return ctx.hasAttr(key);
         }
 
         @Override

--- a/handler/src/test/java/io/netty5/handler/adaptor/BufferConversionHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/adaptor/BufferConversionHandlerTest.java
@@ -28,8 +28,6 @@ import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
 import io.netty5.handler.adaptor.BufferConversionHandler.Conversion;
-import io.netty5.util.Attribute;
-import io.netty5.util.AttributeKey;
 import io.netty5.util.concurrent.EventExecutor;
 import io.netty5.util.concurrent.Future;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -353,16 +351,6 @@ class BufferConversionHandlerTest {
 
         @Override
         public BufferAllocator bufferAllocator() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public <T> Attribute<T> attr(AttributeKey<T> key) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public <T> boolean hasAttr(AttributeKey<T> key) {
             throw new UnsupportedOperationException();
         }
     }

--- a/microbench/src/main/java/io/netty5/microbench/channel/EmbeddedChannelHandlerContext.java
+++ b/microbench/src/main/java/io/netty5/microbench/channel/EmbeddedChannelHandlerContext.java
@@ -22,8 +22,6 @@ import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.embedded.EmbeddedChannel;
-import io.netty5.util.Attribute;
-import io.netty5.util.AttributeKey;
 import io.netty5.util.Resource;
 import io.netty5.util.concurrent.EventExecutor;
 import io.netty5.util.concurrent.Future;
@@ -60,16 +58,6 @@ public abstract class EmbeddedChannelHandlerContext implements ChannelHandlerCon
     }
 
     protected abstract void handleException(Throwable t);
-
-    @Override
-    public final <T> Attribute<T> attr(AttributeKey<T> key) {
-        return null;
-    }
-
-    @Override
-    public final <T> boolean hasAttr(AttributeKey<T> key) {
-        return false;
-    }
 
     @Override
     public final Channel channel() {

--- a/transport/src/main/java/io/netty5/channel/Channel.java
+++ b/transport/src/main/java/io/netty5/channel/Channel.java
@@ -71,6 +71,14 @@ import java.net.SocketAddress;
  * operations.  For example, with the old I/O datagram transport, multicast
  * join / leave operations are provided by {@link DatagramChannel}.
  *
+ *
+ * <h3>Storing stateful information</h3>
+ *
+ * {@link #attr(AttributeKey)} allow you to
+ * store and access stateful information that is related with a handler and its
+ * context.  Please refer to {@link ChannelHandler} to learn various recommended
+ * ways to manage stateful information.
+ *
  * <h3>Release resources</h3>
  * <p>
  * It is important to call {@link #close()} to release all

--- a/transport/src/main/java/io/netty5/channel/ChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty5/channel/ChannelHandlerContext.java
@@ -18,9 +18,6 @@ package io.netty5.channel;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty5.buffer.api.BufferAllocator;
-import io.netty5.util.Attribute;
-import io.netty5.util.AttributeKey;
-import io.netty5.util.AttributeMap;
 
 /**
  * Enables a {@link ChannelHandler} to interact with its {@link ChannelPipeline}
@@ -31,13 +28,12 @@ import io.netty5.util.AttributeMap;
  *
  * You can notify the closest handler in the same {@link ChannelPipeline} by calling one of the various methods
  * provided here.
- *
  * Please refer to {@link ChannelPipeline} to understand how an event flows.
  *
  * <h3>Modifying a pipeline</h3>
  *
  * You can get the {@link ChannelPipeline} your handler belongs to by calling
- * {@link #pipeline()}.  A non-trivial application could insert, remove, or
+ * {@link #pipeline()}. A non-trivial application could insert, remove, or
  * replace handlers in the pipeline dynamically at runtime.
  *
  * <h3>Retrieving for later use</h3>
@@ -60,13 +56,6 @@ import io.netty5.util.AttributeMap;
  * }
  * </pre>
  *
- * <h3>Storing stateful information</h3>
- *
- * {@link #attr(AttributeKey)} allow you to
- * store and access stateful information that is related with a handler and its
- * context.  Please refer to {@link ChannelHandler} to learn various recommended
- * ways to manage stateful information.
- *
  * <h3>A handler can have more than one context</h3>
  *
  * Please note that a {@link ChannelHandler} instance can be added to more than
@@ -75,43 +64,6 @@ import io.netty5.util.AttributeMap;
  * the single instance can be invoked with different
  * {@link ChannelHandlerContext}s if it is added to one or more
  * {@link ChannelPipeline}s more than once.
- * <p>
- * For example, the following handler will have as many independent {@link AttributeKey}s
- * as how many times it is added to pipelines, regardless if it is added to the
- * same pipeline multiple times or added to different pipelines multiple times:
- * <pre>
- * public class FactorialHandler implements {@link ChannelHandler} {
- *
- *   private final {@link AttributeKey}&lt;{@link Integer}&gt; counter = {@link AttributeKey}.valueOf("counter");
- *
- *   // This handler will receive a sequence of increasing integers starting
- *   // from 1.
- *   {@code @Override}
- *   public void channelRead({@link ChannelHandlerContext} ctx, Object msg) {
- *     Integer a = ctx.attr(counter).get();
- *
- *     if (a == null) {
- *       a = 1;
- *     }
- *
- *     attr.set(a * (Integer) msg);
- *   }
- * }
- *
- * // Different context objects are given to "f1", "f2", "f3", and "f4" even if
- * // they refer to the same handler instance.  Because the FactorialHandler
- * // stores its state in a context object (using an {@link AttributeKey}), the factorial is
- * // calculated correctly 4 times once the two pipelines (p1 and p2) are active.
- * FactorialHandler fh = new FactorialHandler();
- *
- * {@link ChannelPipeline} p1 = {@link Channel}.pipeline();
- * p1.addLast("f1", fh);
- * p1.addLast("f2", fh);
- *
- * {@link ChannelPipeline} p2 = {@link Channel}.pipeline();
- * p2.addLast("f3", fh);
- * p2.addLast("f4", fh);
- * </pre>
  *
  * <h3>Additional resources worth reading</h3>
  * <p>
@@ -120,12 +72,14 @@ import io.netty5.util.AttributeMap;
  * what fundamental differences they have, how they flow in a  pipeline,  and how to handle
  * the operation in your application.
  */
-public interface ChannelHandlerContext extends AttributeMap, ChannelInboundInvoker, ChannelOutboundInvoker {
+public interface ChannelHandlerContext extends ChannelInboundInvoker, ChannelOutboundInvoker {
 
     /**
      * Return the {@link Channel} which is bound to the {@link ChannelHandlerContext}.
      */
-    Channel channel();
+    default Channel channel() {
+        return pipeline().channel();
+    }
 
     /**
      * The unique name of the {@link ChannelHandlerContext}.The name was used when then {@link ChannelHandler}
@@ -188,24 +142,14 @@ public interface ChannelHandlerContext extends AttributeMap, ChannelInboundInvok
      * Return the assigned {@link ByteBufAllocator} which will be used to allocate {@link ByteBuf}s.
      */
     @Deprecated(forRemoval = true)
-    ByteBufAllocator alloc();
+    default ByteBufAllocator alloc() {
+        return channel().alloc();
+    }
 
     /**
      * Return the assigned {@link ByteBufAllocator} which will be used to allocate {@link ByteBuf}s.
      */
-    BufferAllocator bufferAllocator();
-
-    /**
-     * @deprecated Use {@link Channel#attr(AttributeKey)}
-     */
-    @Deprecated
-    @Override
-    <T> Attribute<T> attr(AttributeKey<T> key);
-
-    /**
-     * @deprecated Use {@link Channel#hasAttr(AttributeKey)}
-     */
-    @Deprecated
-    @Override
-    <T> boolean hasAttr(AttributeKey<T> key);
+    default BufferAllocator bufferAllocator() {
+        return channel().bufferAllocator();
+    }
 }

--- a/transport/src/main/java/io/netty5/channel/CombinedChannelDuplexHandler.java
+++ b/transport/src/main/java/io/netty5/channel/CombinedChannelDuplexHandler.java
@@ -17,8 +17,6 @@ package io.netty5.channel;
 
 import io.netty.buffer.ByteBufAllocator;
 import io.netty5.buffer.api.BufferAllocator;
-import io.netty5.util.Attribute;
-import io.netty5.util.AttributeKey;
 import io.netty5.util.concurrent.EventExecutor;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.Promise;
@@ -512,16 +510,6 @@ public class CombinedChannelDuplexHandler<I extends ChannelHandler, O extends Ch
         @Override
         public Future<Void> newFailedFuture(Throwable cause) {
             return ctx.newFailedFuture(cause);
-        }
-
-        @Override
-        public <T> Attribute<T> attr(AttributeKey<T> key) {
-            return ctx.channel().attr(key);
-        }
-
-        @Override
-        public <T> boolean hasAttr(AttributeKey<T> key) {
-            return ctx.channel().hasAttr(key);
         }
 
         void remove() {

--- a/transport/src/main/java/io/netty5/channel/DefaultChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty5/channel/DefaultChannelHandlerContext.java
@@ -15,11 +15,7 @@
  */
 package io.netty5.channel;
 
-import io.netty.buffer.ByteBufAllocator;
-import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.util.Resource;
-import io.netty5.util.Attribute;
-import io.netty5.util.AttributeKey;
 import io.netty5.util.ResourceLeakHint;
 import io.netty5.util.concurrent.EventExecutor;
 import io.netty5.util.concurrent.Future;
@@ -135,23 +131,8 @@ final class DefaultChannelHandlerContext implements ChannelHandlerContext, Resou
     }
 
     @Override
-    public Channel channel() {
-        return pipeline.channel();
-    }
-
-    @Override
     public ChannelPipeline pipeline() {
         return pipeline;
-    }
-
-    @Override
-    public ByteBufAllocator alloc() {
-        return channel().config().getAllocator();
-    }
-
-    @Override
-    public BufferAllocator bufferAllocator() {
-        return channel().config().getBufferAllocator();
     }
 
     @Override
@@ -845,16 +826,6 @@ final class DefaultChannelHandlerContext implements ChannelHandlerContext, Resou
 
         prev = null;
         next = null;
-    }
-
-    @Override
-    public <T> Attribute<T> attr(AttributeKey<T> key) {
-        return channel().attr(key);
-    }
-
-    @Override
-    public <T> boolean hasAttr(AttributeKey<T> key) {
-        return channel().hasAttr(key);
     }
 
     private static boolean safeExecute(EventExecutor executor, Runnable runnable, Promise<Void> promise, Object msg) {


### PR DESCRIPTION
Motivation:

ChannelHandlerContext should not extend AttributeMap and the user should just use the Channel directly. This removed the confusion on where the attribute and values are stored.

Modifications:

Don't extend AttributeMap and adjust implementations for the API changes

Result:

Cleanup / more clean API