### PR TITLE
Make ChannelOutboundBuffer an interface and so allow to write Channel…

### DIFF
--- a/transport/src/main/java/io/netty5/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty5/channel/AbstractChannel.java
@@ -301,7 +301,8 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
      */
     protected abstract class AbstractUnsafe implements Unsafe {
 
-        private volatile ChannelOutboundBuffer outboundBuffer = new ChannelOutboundBuffer(AbstractChannel.this);
+        private volatile DefaultChannelOutboundBuffer outboundBuffer = new DefaultChannelOutboundBuffer(
+                AbstractChannel.this);
         private RecvBufferAllocator.Handle recvHandle;
         private MessageSizeEstimator.Handle estimatorHandler;
 
@@ -471,7 +472,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                 return;
             }
 
-            final ChannelOutboundBuffer outboundBuffer = this.outboundBuffer;
+            final DefaultChannelOutboundBuffer outboundBuffer = this.outboundBuffer;
             if (outboundBuffer == null) {
                 promise.setFailure(new ClosedChannelException());
                 return;
@@ -498,7 +499,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         }
 
         private void closeOutboundBufferForShutdown(
-                ChannelPipeline pipeline, ChannelOutboundBuffer buffer, Throwable cause) {
+                ChannelPipeline pipeline, DefaultChannelOutboundBuffer buffer, Throwable cause) {
             buffer.failFlushed(cause, false);
             buffer.close(cause, true);
             pipeline.fireUserEventTriggered(ChannelOutputShutdownEvent.INSTANCE);
@@ -524,7 +525,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             closeInitiated = true;
 
             final boolean wasActive = isActive();
-            final ChannelOutboundBuffer outboundBuffer = this.outboundBuffer;
+            final DefaultChannelOutboundBuffer outboundBuffer = this.outboundBuffer;
             this.outboundBuffer = null; // Disallow adding any messages and flushes to outboundBuffer.
             Executor closeExecutor = prepareToClose();
             if (closeExecutor != null) {
@@ -728,7 +729,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                 return;
             }
 
-            final ChannelOutboundBuffer outboundBuffer = this.outboundBuffer;
+            final DefaultChannelOutboundBuffer outboundBuffer = this.outboundBuffer;
             if (outboundBuffer == null || outboundBuffer.isEmpty()) {
                 return;
             }

--- a/transport/src/main/java/io/netty5/channel/ChannelOutboundBuffer.java
+++ b/transport/src/main/java/io/netty5/channel/ChannelOutboundBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The Netty Project
+ * Copyright 2022 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -16,32 +16,11 @@
 package io.netty5.channel;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufConvertible;
-import io.netty.buffer.ByteBufHolder;
-import io.netty.buffer.Unpooled;
 import io.netty5.buffer.api.Buffer;
-import io.netty5.util.Resource;
-import io.netty5.util.concurrent.FastThreadLocal;
 import io.netty5.util.concurrent.Promise;
-import io.netty5.util.internal.ObjectPool;
-import io.netty5.util.internal.ObjectPool.Handle;
-import io.netty5.util.internal.PromiseNotificationUtil;
-import io.netty5.util.internal.SilentDispose;
-import io.netty5.util.internal.SystemPropertyUtil;
-import io.netty5.util.internal.logging.InternalLogger;
-import io.netty5.util.internal.logging.InternalLoggerFactory;
-
-import java.nio.ByteBuffer;
-import java.nio.channels.ClosedChannelException;
-import java.util.Arrays;
-import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
-import static java.lang.Math.min;
-import static java.util.Objects.requireNonNull;
 
 /**
- * (Transport implementors only) an internal data structure used by {@link AbstractChannel} to store its pending
+ * (Transport implementors only) an internal data structure used by {@link Channel} to store its pending
  * outbound write requests.
  * <p>
  * All methods must be called by a transport implementation from an I/O thread, except the following ones:
@@ -52,530 +31,54 @@ import static java.util.Objects.requireNonNull;
  * </ul>
  * </p>
  */
-public final class ChannelOutboundBuffer {
-    // Assuming a 64-bit JVM:
-    //  - 16 bytes object header
-    //  - 6 reference fields
-    //  - 2 long fields
-    //  - 2 int fields
-    //  - 1 boolean field
-    //  - padding
-    static final int CHANNEL_OUTBOUND_BUFFER_ENTRY_OVERHEAD =
-            SystemPropertyUtil.getInt("io.netty5.transport.outboundBufferEntrySizeOverhead", 96);
-
-    private static final InternalLogger logger = InternalLoggerFactory.getInstance(ChannelOutboundBuffer.class);
-
-    private static final FastThreadLocal<BufferCache> NIO_BUFFERS = new FastThreadLocal<>() {
-        @Override
-        protected BufferCache initialValue() {
-            BufferCache cache = new BufferCache();
-            cache.buffers = new ByteBuffer[1024];
-            return cache;
-        }
-    };
-
-    private final Channel channel;
-
-    // Entry(flushedEntry) --> ... Entry(unflushedEntry) --> ... Entry(tailEntry)
-    //
-    // The Entry that is the first in the linked-list structure that was flushed
-    private Entry flushedEntry;
-    // The Entry which is the first unflushed in the linked-list structure
-    private Entry unflushedEntry;
-    // The Entry which represents the tail of the buffer
-    private Entry tailEntry;
-    // The number of flushed entries that are not written yet
-    private int flushed;
-
-    private int nioBufferCount;
-    private long nioBufferSize;
-
-    private boolean inFail;
-
-    private static final AtomicLongFieldUpdater<ChannelOutboundBuffer> TOTAL_PENDING_SIZE_UPDATER =
-            AtomicLongFieldUpdater.newUpdater(ChannelOutboundBuffer.class, "totalPendingSize");
-
-    @SuppressWarnings("UnusedDeclaration")
-    private volatile long totalPendingSize;
-
-    private static final AtomicIntegerFieldUpdater<ChannelOutboundBuffer> UNWRITABLE_UPDATER =
-            AtomicIntegerFieldUpdater.newUpdater(ChannelOutboundBuffer.class, "unwritable");
-
-    @SuppressWarnings("UnusedDeclaration")
-    private volatile int unwritable;
-
-    private volatile Runnable fireChannelWritabilityChangedTask;
-
-    ChannelOutboundBuffer(AbstractChannel channel) {
-        this.channel = channel;
-    }
-
+public interface ChannelOutboundBuffer {
     /**
      * Add given message to this {@link ChannelOutboundBuffer}. The given {@link Promise} will be notified once
      * the message was written.
      */
-    public void addMessage(Object msg, int size, Promise<Void> promise) {
-        Entry entry = Entry.newInstance(msg, size, total(msg), promise);
-        if (tailEntry == null) {
-            flushedEntry = null;
-        } else {
-            Entry tail = tailEntry;
-            tail.next = entry;
-        }
-        tailEntry = entry;
-        if (unflushedEntry == null) {
-            unflushedEntry = entry;
-        }
-
-        // increment pending bytes after adding message to the unflushed arrays.
-        // See https://github.com/netty/netty/issues/1619
-        incrementPendingOutboundBytes(entry.pendingSize, false);
-    }
+    void addMessage(Object msg, int size, Promise<Void> promise);
 
     /**
      * Add a flush to this {@link ChannelOutboundBuffer}. This means all previous added messages are marked as flushed
      * and so you will be able to handle them.
      */
-    public void addFlush() {
-        // There is no need to process all entries if there was already a flush before and no new messages
-        // where added in the meantime.
-        //
-        // See https://github.com/netty/netty/issues/2577
-        Entry entry = unflushedEntry;
-        if (entry != null) {
-            if (flushedEntry == null) {
-                // there is no flushedEntry yet, so start with the entry
-                flushedEntry = entry;
-            }
-            do {
-                flushed ++;
-                if (!entry.promise.setUncancellable()) {
-                    // Was cancelled so make sure we free up memory and notify about the freed bytes
-                    int pending = entry.cancel();
-                    decrementPendingOutboundBytes(pending, false, true);
-                }
-                entry = entry.next;
-            } while (entry != null);
-
-            // All flushed so reset unflushedEntry
-            unflushedEntry = null;
-        }
-    }
-
-    /**
-     * Increment the pending bytes which will be written at some point.
-     * This method is thread-safe!
-     */
-    void incrementPendingOutboundBytes(long size) {
-        incrementPendingOutboundBytes(size, true);
-    }
-
-    private void incrementPendingOutboundBytes(long size, boolean invokeLater) {
-        if (size == 0) {
-            return;
-        }
-
-        long newWriteBufferSize = TOTAL_PENDING_SIZE_UPDATER.addAndGet(this, size);
-        if (newWriteBufferSize > channel.config().getWriteBufferHighWaterMark()) {
-            setUnwritable(invokeLater);
-        }
-    }
-
-    /**
-     * Decrement the pending bytes which will be written at some point.
-     * This method is thread-safe!
-     */
-    void decrementPendingOutboundBytes(long size) {
-        decrementPendingOutboundBytes(size, true, true);
-    }
-
-    private void decrementPendingOutboundBytes(long size, boolean invokeLater, boolean notifyWritability) {
-        if (size == 0) {
-            return;
-        }
-
-        long newWriteBufferSize = TOTAL_PENDING_SIZE_UPDATER.addAndGet(this, -size);
-        if (notifyWritability && newWriteBufferSize < channel.config().getWriteBufferLowWaterMark()) {
-            setWritable(invokeLater);
-        }
-    }
-
-    private static long total(Object msg) {
-        if (msg instanceof Buffer) {
-            return ((Buffer) msg).readableBytes();
-        }
-        if (msg instanceof FileRegion) {
-            return ((FileRegion) msg).count();
-        }
-        if (msg instanceof ByteBufHolder) {
-            return ((ByteBufHolder) msg).content().readableBytes();
-        }
-        if (msg instanceof ByteBufConvertible) {
-            return ((ByteBufConvertible) msg).asByteBuf().readableBytes();
-        }
-        return -1;
-    }
+    void addFlush();
 
     /**
      * Return the current message to write or {@code null} if nothing was flushed before and so is ready to be written.
      */
-    public Object current() {
-        Entry entry = flushedEntry;
-        if (entry == null) {
-            return null;
-        }
-
-        return entry.msg;
-    }
+    Object current();
 
     /**
      * Return the current message flush progress.
      * @return {@code 0} if nothing was flushed before for the current message or there is no current message
      */
-    public long currentProgress() {
-        Entry entry = flushedEntry;
-        if (entry == null) {
-            return 0;
-        }
-        return entry.progress;
-    }
+    long currentProgress();
 
     /**
      * Notify the {@link Promise} of the current message about writing progress.
      */
-    public void progress(long amount) {
-        Entry e = flushedEntry;
-        assert e != null;
-        e.progress += amount;
-    }
+    void progress(long amount);
 
     /**
      * Will remove the current message, mark its {@link Promise} as success and return {@code true}. If no
      * flushed message exists at the time this method is called it will return {@code false} to signal that no more
      * messages are ready to be handled.
      */
-    public boolean remove() {
-        Entry e = flushedEntry;
-        if (e == null) {
-            clearNioBuffers();
-            return false;
-        }
-        Object msg = e.msg;
-
-        Promise<Void> promise = e.promise;
-        int size = e.pendingSize;
-
-        removeEntry(e);
-
-        if (!e.cancelled) {
-            // only release message, notify and decrement if it was not canceled before.
-            SilentDispose.trySilentDispose(msg, logger);
-            safeSuccess(promise);
-            decrementPendingOutboundBytes(size, false, true);
-        }
-
-        // recycle the entry
-        e.recycle();
-
-        return true;
-    }
+    boolean remove();
 
     /**
      * Will remove the current message, mark its {@link Promise} as failure using the given {@link Throwable}
      * and return {@code true}. If no   flushed message exists at the time this method is called it will return
      * {@code false} to signal that no more messages are ready to be handled.
      */
-    public boolean remove(Throwable cause) {
-        return remove0(cause, true);
-    }
-
-    private boolean remove0(Throwable cause, boolean notifyWritability) {
-        Entry e = flushedEntry;
-        if (e == null) {
-            clearNioBuffers();
-            return false;
-        }
-        Object msg = e.msg;
-
-        Promise<Void> promise = e.promise;
-        int size = e.pendingSize;
-
-        removeEntry(e);
-
-        if (!e.cancelled) {
-            // only release message, fail and decrement if it was not canceled before.
-            SilentDispose.trySilentDispose(msg, logger);
-
-            safeFail(promise, cause);
-            decrementPendingOutboundBytes(size, false, notifyWritability);
-        }
-
-        // recycle the entry
-        e.recycle();
-
-        return true;
-    }
-
-    private void removeEntry(Entry e) {
-        if (-- flushed == 0) {
-            // processed everything
-            flushedEntry = null;
-            if (e == tailEntry) {
-                tailEntry = null;
-                unflushedEntry = null;
-            }
-        } else {
-            flushedEntry = e.next;
-        }
-    }
+    boolean remove(Throwable cause);
 
     /**
      * Removes the fully written entries and update the reader index of the partially written entry.
      * This operation assumes all messages in this buffer are either {@link ByteBuf}s or {@link Buffer}s.
      */
-    public void removeBytes(long writtenBytes) {
-        Object msg = current();
-        while (writtenBytes > 0 || hasZeroReadable(msg)) {
-            if (msg instanceof Buffer) {
-                Buffer buf = (Buffer) msg;
-                final int readableBytes = buf.readableBytes();
-                if (readableBytes <= writtenBytes) {
-                    progress(readableBytes);
-                    writtenBytes -= readableBytes;
-                    remove();
-                } else { // readableBytes > writtenBytes
-                    buf.readSplit(Math.toIntExact(writtenBytes)).close();
-                    progress(writtenBytes);
-                    break;
-                }
-            } else if (msg instanceof ByteBufConvertible) {
-                final ByteBuf buf = ((ByteBufConvertible) msg).asByteBuf();
-                final int readerIndex = buf.readerIndex();
-                final int readableBytes = buf.writerIndex() - readerIndex;
-
-                if (readableBytes <= writtenBytes) {
-                    progress(readableBytes);
-                    writtenBytes -= readableBytes;
-                    remove();
-                } else { // readableBytes > writtenBytes
-                    buf.readerIndex(readerIndex + (int) writtenBytes);
-                    progress(writtenBytes);
-                    break;
-                }
-            } else {
-                break; // Don't know how to process this message. Might be null.
-            }
-            msg = current();
-        }
-        clearNioBuffers();
-    }
-
-    private static boolean hasZeroReadable(Object msg) {
-        if (msg instanceof Buffer) {
-            return ((Buffer) msg).readableBytes() == 0;
-        }
-        if (msg instanceof ByteBufConvertible) {
-            return ((ByteBufConvertible) msg).asByteBuf().readableBytes() == 0;
-        }
-        return false;
-    }
-
-    // Clear all ByteBuffer from the array so these can be GC'ed.
-    // See https://github.com/netty/netty/issues/3837
-    private void clearNioBuffers() {
-        int count = nioBufferCount;
-        if (count > 0) {
-            nioBufferCount = 0;
-            Arrays.fill(NIO_BUFFERS.get().buffers, 0, count, null);
-        }
-    }
-
-    /**
-     * Returns an array of direct NIO buffers if the currently pending messages are made of {@link ByteBuf} only.
-     * {@link #nioBufferCount()} and {@link #nioBufferSize()} will return the number of NIO buffers in the returned
-     * array and the total number of readable bytes of the NIO buffers respectively.
-     * <p>
-     * Note that the returned array is reused and thus should not escape
-     * {@link AbstractChannel#doWrite(ChannelOutboundBuffer)}.
-     * </p>
-     */
-    public ByteBuffer[] nioBuffers() {
-        return nioBuffers(Integer.MAX_VALUE, Integer.MAX_VALUE);
-    }
-
-    /**
-     * Returns an array of direct NIO buffers if the currently pending messages are made of {@link ByteBuf} only.
-     * {@link #nioBufferCount()} and {@link #nioBufferSize()} will return the number of NIO buffers in the returned
-     * array and the total number of readable bytes of the NIO buffers respectively.
-     * <p>
-     * Note that the returned array is reused and thus should not escape
-     * {@link AbstractChannel#doWrite(ChannelOutboundBuffer)}.
-     * </p>
-     * @param maxCount The maximum amount of buffers that will be added to the return value.
-     * @param maxBytes A hint toward the maximum number of bytes to include as part of the return value. Note that this
-     *                 value maybe exceeded because we make a best effort to include at least 1 {@link ByteBuffer}
-     *                 in the return value to ensure write progress is made.
-     */
-    public ByteBuffer[] nioBuffers(int maxCount, long maxBytes) {
-        assert maxCount > 0;
-        assert maxBytes > 0;
-        long nioBufferSize = 0;
-        int nioBufferCount = 0;
-        BufferCache cache = NIO_BUFFERS.get();
-        cache.dataSize = 0;
-        cache.bufferCount = 0;
-        ByteBuffer[] nioBuffers = cache.buffers;
-
-        Entry entry = flushedEntry;
-        while (isFlushedEntry(entry) && (entry.msg instanceof ByteBufConvertible || entry.msg instanceof Buffer)) {
-            if (!entry.cancelled) {
-                if (entry.msg instanceof Buffer) {
-                    Buffer buf = (Buffer) entry.msg;
-                    if (buf.readableBytes() > 0) {
-                        int count = buf.forEachReadable(0, (index, component) -> {
-                            ByteBuffer byteBuffer = component.readableBuffer();
-                            if (cache.bufferCount > 0 && cache.dataSize + byteBuffer.remaining() > maxBytes) {
-                                // If the nioBufferSize + readableBytes will overflow maxBytes, and there is at least
-                                // one entry we stop populate the ByteBuffer array. This is done for 2 reasons:
-                                // 1. bsd/osx don't allow to write more bytes then Integer.MAX_VALUE with one
-                                // writev(...) call and so will return 'EINVAL', which will raise an IOException.
-                                // On Linux it may work depending on the architecture and kernel but to be safe we also
-                                // enforce the limit here.
-                                // 2. There is no sense in putting more data in the array than is likely to be accepted
-                                // by the OS.
-                                //
-                                // See also:
-                                // - https://www.freebsd.org/cgi/man.cgi?query=write&sektion=2
-                                // - https://linux.die.net//man/2/writev
-                                return false;
-                            }
-                            cache.dataSize += byteBuffer.remaining();
-                            ByteBuffer[] buffers = cache.buffers;
-                            int bufferCount = cache.bufferCount;
-                            if (buffers.length == bufferCount && bufferCount < maxCount) {
-                                buffers = cache.buffers = expandNioBufferArray(buffers, bufferCount + 1, bufferCount);
-                            }
-                            buffers[cache.bufferCount] = byteBuffer;
-                            bufferCount++;
-                            cache.bufferCount = bufferCount;
-                            return bufferCount < maxCount;
-                        });
-                        if (count < 0) {
-                            break;
-                        }
-                    }
-                } else {
-                    ByteBuf buf = ((ByteBufConvertible) entry.msg).asByteBuf();
-                    final int readerIndex = buf.readerIndex();
-                    final int readableBytes = buf.writerIndex() - readerIndex;
-
-                    if (readableBytes > 0) {
-                        if (maxBytes - readableBytes < nioBufferSize && nioBufferCount != 0) {
-                            // If the nioBufferSize + readableBytes will overflow maxBytes, and there is at least one
-                            // entry we stop populate the ByteBuffer array. This is done for 2 reasons:
-                            // 1. bsd/osx don't allow to write more bytes then Integer.MAX_VALUE with one writev(...)
-                            // call and so will return 'EINVAL', which will raise an IOException. On Linux it may work
-                            // depending on the architecture and kernel but to be safe we also enforce the limit here.
-                            // 2. There is no sense in putting more data in the array than is likely to be accepted by
-                            // the OS.
-                            //
-                            // See also:
-                            // - https://www.freebsd.org/cgi/man.cgi?query=write&sektion=2
-                            // - https://linux.die.net//man/2/writev
-                            break;
-                        }
-                        nioBufferSize += readableBytes;
-                        int count = entry.count;
-                        if (count == -1) {
-                            entry.count = count = buf.nioBufferCount();
-                        }
-                        int neededSpace = min(maxCount, nioBufferCount + count);
-                        if (neededSpace > nioBuffers.length) {
-                            cache.buffers = nioBuffers = expandNioBufferArray(nioBuffers, neededSpace, nioBufferCount);
-                        }
-                        if (count == 1) {
-                            ByteBuffer nioBuf = entry.buf;
-                            if (nioBuf == null) {
-                                // cache ByteBuffer as it may need to create a new ByteBuffer instance if its a
-                                // derived buffer
-                                entry.buf = nioBuf = buf.internalNioBuffer(readerIndex, readableBytes);
-                            }
-                            nioBuffers[nioBufferCount++] = nioBuf;
-                        } else {
-                            // The code exists in an extra method to ensure the method is not too big to inline as this
-                            // branch is not very likely to get hit very frequently.
-                            nioBufferCount = nioBuffers(entry, buf, nioBuffers, nioBufferCount, maxCount);
-                        }
-                        if (nioBufferCount >= maxCount) {
-                            break;
-                        }
-                    }
-                }
-            }
-            entry = entry.next;
-        }
-        this.nioBufferCount = nioBufferCount + cache.bufferCount;
-        this.nioBufferSize = nioBufferSize + cache.dataSize;
-
-        return nioBuffers;
-    }
-
-    private static int nioBuffers(Entry entry, ByteBuf buf, ByteBuffer[] nioBuffers, int nioBufferCount, int maxCount) {
-        ByteBuffer[] nioBufs = entry.bufs;
-        if (nioBufs == null) {
-            // cached ByteBuffers as they may be expensive to create in terms
-            // of Object allocation
-            entry.bufs = nioBufs = buf.nioBuffers();
-        }
-        for (int i = 0; i < nioBufs.length && nioBufferCount < maxCount; ++i) {
-            ByteBuffer nioBuf = nioBufs[i];
-            if (nioBuf == null) {
-                break;
-            }
-            if (!nioBuf.hasRemaining()) {
-                continue;
-            }
-            nioBuffers[nioBufferCount++] = nioBuf;
-        }
-        return nioBufferCount;
-    }
-
-    private static ByteBuffer[] expandNioBufferArray(ByteBuffer[] array, int neededSpace, int size) {
-        int newCapacity = array.length;
-        do {
-            // double capacity until it is big enough
-            // See https://github.com/netty/netty/issues/1890
-            newCapacity <<= 1;
-
-            if (newCapacity < 0) {
-                throw new IllegalStateException();
-            }
-
-        } while (neededSpace > newCapacity);
-
-        ByteBuffer[] newArray = new ByteBuffer[newCapacity];
-        System.arraycopy(array, 0, newArray, 0, size);
-
-        return newArray;
-    }
-
-    /**
-     * Returns the number of {@link ByteBuffer} that can be written out of the {@link ByteBuffer} array that was
-     * obtained via {@link #nioBuffers()}. This method <strong>MUST</strong> be called after {@link #nioBuffers()}
-     * was called.
-     */
-    public int nioBufferCount() {
-        return nioBufferCount;
-    }
-
-    /**
-     * Returns the number of bytes that can be written out of the {@link ByteBuffer} array that was
-     * obtained via {@link #nioBuffers()}. This method <strong>MUST</strong> be called after {@link #nioBuffers()}
-     * was called.
-     */
-    public long nioBufferSize() {
-        return nioBufferSize;
-    }
+    void removeBytes(long writtenBytes);
 
     /**
      * Returns {@code true} if and only if {@linkplain #totalPendingWriteBytes() the total number of pending bytes} did
@@ -583,336 +86,57 @@ public final class ChannelOutboundBuffer {
      * no {@linkplain #setUserDefinedWritability(int, boolean) user-defined writability flag} has been set to
      * {@code false}.
      */
-    public boolean isWritable() {
-        return unwritable == 0;
-    }
-
+    boolean isWritable();
     /**
      * Returns {@code true} if and only if the user-defined writability flag at the specified index is set to
      * {@code true}.
      */
-    public boolean getUserDefinedWritability(int index) {
-        return (unwritable & writabilityMask(index)) == 0;
-    }
+    boolean getUserDefinedWritability(int index);
 
     /**
      * Sets a user-defined writability flag at the specified index.
      */
-    public void setUserDefinedWritability(int index, boolean writable) {
-        if (writable) {
-            setUserDefinedWritability(index);
-        } else {
-            clearUserDefinedWritability(index);
-        }
-    }
-
-    private void setUserDefinedWritability(int index) {
-        final int mask = ~writabilityMask(index);
-        for (;;) {
-            final int oldValue = unwritable;
-            final int newValue = oldValue & mask;
-            if (UNWRITABLE_UPDATER.compareAndSet(this, oldValue, newValue)) {
-                if (oldValue != 0 && newValue == 0) {
-                    fireChannelWritabilityChanged(true);
-                }
-                break;
-            }
-        }
-    }
-
-    private void clearUserDefinedWritability(int index) {
-        final int mask = writabilityMask(index);
-        for (;;) {
-            final int oldValue = unwritable;
-            final int newValue = oldValue | mask;
-            if (UNWRITABLE_UPDATER.compareAndSet(this, oldValue, newValue)) {
-                if (oldValue == 0 && newValue != 0) {
-                    fireChannelWritabilityChanged(true);
-                }
-                break;
-            }
-        }
-    }
-
-    private static int writabilityMask(int index) {
-        if (index < 1 || index > 31) {
-            throw new IllegalArgumentException("index: " + index + " (expected: 1~31)");
-        }
-        return 1 << index;
-    }
-
-    private void setWritable(boolean invokeLater) {
-        for (;;) {
-            final int oldValue = unwritable;
-            final int newValue = oldValue & ~1;
-            if (UNWRITABLE_UPDATER.compareAndSet(this, oldValue, newValue)) {
-                if (oldValue != 0 && newValue == 0) {
-                    fireChannelWritabilityChanged(invokeLater);
-                }
-                break;
-            }
-        }
-    }
-
-    private void setUnwritable(boolean invokeLater) {
-        for (;;) {
-            final int oldValue = unwritable;
-            final int newValue = oldValue | 1;
-            if (UNWRITABLE_UPDATER.compareAndSet(this, oldValue, newValue)) {
-                if (oldValue == 0) {
-                    fireChannelWritabilityChanged(invokeLater);
-                }
-                break;
-            }
-        }
-    }
-
-    private void fireChannelWritabilityChanged(boolean invokeLater) {
-        final ChannelPipeline pipeline = channel.pipeline();
-        if (invokeLater) {
-            Runnable task = fireChannelWritabilityChangedTask;
-            if (task == null) {
-                fireChannelWritabilityChangedTask = task = pipeline::fireChannelWritabilityChanged;
-            }
-            channel.executor().execute(task);
-        } else {
-            pipeline.fireChannelWritabilityChanged();
-        }
-    }
+    void setUserDefinedWritability(int index, boolean writable);
 
     /**
      * Returns the number of flushed messages in this {@link ChannelOutboundBuffer}.
      */
-    public int size() {
-        return flushed;
-    }
+    int size();
 
     /**
      * Returns {@code true} if there are flushed messages in this {@link ChannelOutboundBuffer} or {@code false}
      * otherwise.
      */
-    public boolean isEmpty() {
-        return flushed == 0;
+    default boolean isEmpty() {
+        return size() == 0;
     }
 
-    void failFlushed(Throwable cause, boolean notify) {
-        // Make sure that this method does not reenter.  A listener added to the current promise can be notified by the
-        // current thread in the tryFailure() call of the loop below, and the listener can trigger another fail() call
-        // indirectly (usually by closing the channel.)
-        //
-        // See https://github.com/netty/netty/issues/1501
-        if (inFail) {
-            return;
-        }
-
-        try {
-            inFail = true;
-            for (;;) {
-                if (!remove0(cause, notify)) {
-                    break;
-                }
-            }
-        } finally {
-            inFail = false;
-        }
-    }
-
-    void close(final Throwable cause, final boolean allowChannelOpen) {
-        if (inFail) {
-            channel.executor().execute(() -> close(cause, allowChannelOpen));
-            return;
-        }
-
-        inFail = true;
-
-        if (!allowChannelOpen && channel.isOpen()) {
-            throw new IllegalStateException("close() must be invoked after the channel is closed.");
-        }
-
-        if (!isEmpty()) {
-            throw new IllegalStateException("close() must be invoked after all flushed writes are handled.");
-        }
-
-        // Release all unflushed messages.
-        try {
-            Entry e = unflushedEntry;
-            while (e != null) {
-                // Just decrease; do not trigger any events via decrementPendingOutboundBytes()
-                int size = e.pendingSize;
-                TOTAL_PENDING_SIZE_UPDATER.addAndGet(this, -size);
-
-                if (!e.cancelled) {
-                    SilentDispose.dispose(e.msg, logger);
-                    safeFail(e.promise, cause);
-                }
-                e = e.recycleAndGetNext();
-            }
-        } finally {
-            inFail = false;
-        }
-        clearNioBuffers();
-    }
-
-    void close(ClosedChannelException cause) {
-        close(cause, false);
-    }
-
-    private static void safeSuccess(Promise<Void> promise) {
-        PromiseNotificationUtil.trySuccess(promise, null, logger);
-    }
-
-    private static void safeFail(Promise<Void> promise, Throwable cause) {
-        PromiseNotificationUtil.tryFailure(promise, cause, logger);
-    }
-
-    @Deprecated
-    public void recycle() {
-        // NOOP
-    }
-
-    public long totalPendingWriteBytes() {
-        return totalPendingSize;
-    }
+    long totalPendingWriteBytes();
 
     /**
      * Get how many bytes can be written until {@link #isWritable()} returns {@code false}.
      * This quantity will always be non-negative. If {@link #isWritable()} is {@code false} then 0.
      */
-    public long bytesBeforeUnwritable() {
-        long bytes = channel.config().getWriteBufferHighWaterMark() - totalPendingSize;
-        // If bytes is negative we know we are not writable, but if bytes is non-negative we have to check writability.
-        // Note that totalPendingSize and isWritable() use different volatile variables that are not synchronized
-        // together. totalPendingSize will be updated before isWritable().
-        if (bytes > 0) {
-            return isWritable() ? bytes : 0;
-        }
-        return 0;
-    }
+    long bytesBeforeUnwritable();
 
     /**
      * Get how many bytes must be drained from the underlying buffer until {@link #isWritable()} returns {@code true}.
      * This quantity will always be non-negative. If {@link #isWritable()} is {@code true} then 0.
      */
-    public long bytesBeforeWritable() {
-        long bytes = totalPendingSize - channel.config().getWriteBufferLowWaterMark();
-        // If bytes is negative we know we are writable, but if bytes is non-negative we have to check writability.
-        // Note that totalPendingSize and isWritable() use different volatile variables that are not synchronized
-        // together. totalPendingSize will be updated before isWritable().
-        if (bytes > 0) {
-            return isWritable() ? 0 : bytes;
-        }
-        return 0;
-    }
+    long bytesBeforeWritable();
 
     /**
      * Call {@link MessageProcessor#processMessage(Object)} for each flushed message
      * in this {@link ChannelOutboundBuffer} until {@link MessageProcessor#processMessage(Object)}
      * returns {@code false} or there are no more flushed messages to process.
      */
-    public void forEachFlushedMessage(MessageProcessor processor) throws Exception {
-        requireNonNull(processor, "processor");
+    void forEachFlushedMessage(MessageProcessor processor) throws Exception;
 
-        Entry entry = flushedEntry;
-        if (entry == null) {
-            return;
-        }
-
-        do {
-            if (!entry.cancelled) {
-                if (!processor.processMessage(entry.msg)) {
-                    return;
-                }
-            }
-            entry = entry.next;
-        } while (isFlushedEntry(entry));
-    }
-
-    private boolean isFlushedEntry(Entry e) {
-        return e != null && e != unflushedEntry;
-    }
-
-    public interface MessageProcessor {
+    interface MessageProcessor {
         /**
          * Will be called for each flushed message until it either there are no more flushed messages or this
          * method returns {@code false}.
          */
         boolean processMessage(Object msg) throws Exception;
-    }
-
-    static final class Entry {
-        private static final ObjectPool<Entry> RECYCLER = ObjectPool.newPool(Entry::new);
-
-        private final Handle<Entry> handle;
-        Entry next;
-        Object msg;
-        ByteBuffer[] bufs;
-        ByteBuffer buf;
-        Promise<Void> promise;
-        long progress;
-        long total;
-        int pendingSize;
-        int count = -1;
-        boolean cancelled;
-
-        private Entry(Handle<Entry> handle) {
-            this.handle = handle;
-        }
-
-        static Entry newInstance(Object msg, int size, long total, Promise<Void> promise) {
-            Entry entry = RECYCLER.get();
-            entry.msg = msg;
-            entry.pendingSize = size + CHANNEL_OUTBOUND_BUFFER_ENTRY_OVERHEAD;
-            entry.total = total;
-            entry.promise = promise;
-            return entry;
-        }
-
-        int cancel() {
-            if (!cancelled) {
-                cancelled = true;
-                int pSize = pendingSize;
-
-                // release message and replace with an empty buffer
-                SilentDispose.dispose(msg, logger);
-                msg = Unpooled.EMPTY_BUFFER;
-
-                pendingSize = 0;
-                total = 0;
-                progress = 0;
-                bufs = null;
-                buf = null;
-                return pSize;
-            }
-            return 0;
-        }
-
-        void recycle() {
-            next = null;
-            bufs = null;
-            buf = null;
-            msg = null;
-            promise = null;
-            progress = 0;
-            total = 0;
-            pendingSize = 0;
-            count = -1;
-            cancelled = false;
-            handle.recycle(this);
-        }
-
-        Entry recycleAndGetNext() {
-            Entry next = this.next;
-            recycle();
-            return next;
-        }
-    }
-
-    /**
-     * Thread-local cache of {@link ByteBuffer} array, and processing meta-data.
-     */
-    static final class BufferCache {
-        ByteBuffer[] buffers;
-        long dataSize;
-        int bufferCount;
     }
 }

--- a/transport/src/main/java/io/netty5/channel/DefaultChannelOutboundBuffer.java
+++ b/transport/src/main/java/io/netty5/channel/DefaultChannelOutboundBuffer.java
@@ -1,0 +1,631 @@
+/*
+ * Copyright 2013 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufConvertible;
+import io.netty.buffer.ByteBufHolder;
+import io.netty.buffer.Unpooled;
+import io.netty5.buffer.api.Buffer;
+import io.netty5.util.concurrent.Promise;
+import io.netty5.util.internal.ObjectPool;
+import io.netty5.util.internal.ObjectPool.Handle;
+import io.netty5.util.internal.PromiseNotificationUtil;
+import io.netty5.util.internal.SilentDispose;
+import io.netty5.util.internal.SystemPropertyUtil;
+import io.netty5.util.internal.logging.InternalLogger;
+import io.netty5.util.internal.logging.InternalLoggerFactory;
+
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * (Transport implementors only) an internal data structure used by {@link AbstractChannel} to store its pending
+ * outbound write requests.
+ * <p>
+ * All methods must be called by a transport implementation from an I/O thread, except the following ones:
+ * <ul>
+ * <li>{@link #size()} and {@link #isEmpty()}</li>
+ * <li>{@link #isWritable()}</li>
+ * <li>{@link #getUserDefinedWritability(int)} and {@link #setUserDefinedWritability(int, boolean)}</li>
+ * </ul>
+ * </p>
+ */
+final class DefaultChannelOutboundBuffer implements ChannelOutboundBuffer {
+    // Assuming a 64-bit JVM:
+    //  - 16 bytes object header
+    //  - 6 reference fields
+    //  - 2 long fields
+    //  - 2 int fields
+    //  - 1 boolean field
+    //  - padding
+    static final int CHANNEL_OUTBOUND_BUFFER_ENTRY_OVERHEAD =
+            SystemPropertyUtil.getInt("io.netty5.transport.outboundBufferEntrySizeOverhead", 96);
+
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(DefaultChannelOutboundBuffer.class);
+
+    private final Channel channel;
+
+    // Entry(flushedEntry) --> ... Entry(unflushedEntry) --> ... Entry(tailEntry)
+    //
+    // The Entry that is the first in the linked-list structure that was flushed
+    private Entry flushedEntry;
+    // The Entry which is the first unflushed in the linked-list structure
+    private Entry unflushedEntry;
+    // The Entry which represents the tail of the buffer
+    private Entry tailEntry;
+    // The number of flushed entries that are not written yet
+    private int flushed;
+
+    private boolean inFail;
+
+    private static final AtomicLongFieldUpdater<DefaultChannelOutboundBuffer> TOTAL_PENDING_SIZE_UPDATER =
+            AtomicLongFieldUpdater.newUpdater(DefaultChannelOutboundBuffer.class, "totalPendingSize");
+
+    @SuppressWarnings("UnusedDeclaration")
+    private volatile long totalPendingSize;
+
+    private static final AtomicIntegerFieldUpdater<DefaultChannelOutboundBuffer> UNWRITABLE_UPDATER =
+            AtomicIntegerFieldUpdater.newUpdater(DefaultChannelOutboundBuffer.class, "unwritable");
+
+    @SuppressWarnings("UnusedDeclaration")
+    private volatile int unwritable;
+
+    private volatile Runnable fireChannelWritabilityChangedTask;
+
+    DefaultChannelOutboundBuffer(Channel channel) {
+        this.channel = channel;
+    }
+
+    @Override
+    public void addMessage(Object msg, int size, Promise<Void> promise) {
+        Entry entry = Entry.newInstance(msg, size, total(msg), promise);
+        if (tailEntry == null) {
+            flushedEntry = null;
+        } else {
+            Entry tail = tailEntry;
+            tail.next = entry;
+        }
+        tailEntry = entry;
+        if (unflushedEntry == null) {
+            unflushedEntry = entry;
+        }
+
+        // increment pending bytes after adding message to the unflushed arrays.
+        // See https://github.com/netty/netty/issues/1619
+        incrementPendingOutboundBytes(entry.pendingSize, false);
+    }
+
+    @Override
+    public void addFlush() {
+        // There is no need to process all entries if there was already a flush before and no new messages
+        // where added in the meantime.
+        //
+        // See https://github.com/netty/netty/issues/2577
+        Entry entry = unflushedEntry;
+        if (entry != null) {
+            if (flushedEntry == null) {
+                // there is no flushedEntry yet, so start with the entry
+                flushedEntry = entry;
+            }
+            do {
+                flushed ++;
+                if (!entry.promise.setUncancellable()) {
+                    // Was cancelled so make sure we free up memory and notify about the freed bytes
+                    int pending = entry.cancel();
+                    decrementPendingOutboundBytes(pending, false, true);
+                }
+                entry = entry.next;
+            } while (entry != null);
+
+            // All flushed so reset unflushedEntry
+            unflushedEntry = null;
+        }
+    }
+
+    /**
+     * Increment the pending bytes which will be written at some point.
+     * This method is thread-safe!
+     */
+    void incrementPendingOutboundBytes(long size) {
+        incrementPendingOutboundBytes(size, true);
+    }
+
+    private void incrementPendingOutboundBytes(long size, boolean invokeLater) {
+        if (size == 0) {
+            return;
+        }
+
+        long newWriteBufferSize = TOTAL_PENDING_SIZE_UPDATER.addAndGet(this, size);
+        if (newWriteBufferSize > channel.config().getWriteBufferHighWaterMark()) {
+            setUnwritable(invokeLater);
+        }
+    }
+
+    /**
+     * Decrement the pending bytes which will be written at some point.
+     * This method is thread-safe!
+     */
+    void decrementPendingOutboundBytes(long size) {
+        decrementPendingOutboundBytes(size, true, true);
+    }
+
+    private void decrementPendingOutboundBytes(long size, boolean invokeLater, boolean notifyWritability) {
+        if (size == 0) {
+            return;
+        }
+
+        long newWriteBufferSize = TOTAL_PENDING_SIZE_UPDATER.addAndGet(this, -size);
+        if (notifyWritability && newWriteBufferSize < channel.config().getWriteBufferLowWaterMark()) {
+            setWritable(invokeLater);
+        }
+    }
+
+    private static long total(Object msg) {
+        if (msg instanceof Buffer) {
+            return ((Buffer) msg).readableBytes();
+        }
+        if (msg instanceof FileRegion) {
+            return ((FileRegion) msg).count();
+        }
+        if (msg instanceof ByteBufHolder) {
+            return ((ByteBufHolder) msg).content().readableBytes();
+        }
+        if (msg instanceof ByteBufConvertible) {
+            return ((ByteBufConvertible) msg).asByteBuf().readableBytes();
+        }
+        return -1;
+    }
+
+    @Override
+    public Object current() {
+        Entry entry = flushedEntry;
+        if (entry == null) {
+            return null;
+        }
+
+        return entry.msg;
+    }
+
+    @Override
+    public long currentProgress() {
+        Entry entry = flushedEntry;
+        if (entry == null) {
+            return 0;
+        }
+        return entry.progress;
+    }
+
+    @Override
+    public void progress(long amount) {
+        Entry e = flushedEntry;
+        assert e != null;
+        e.progress += amount;
+    }
+
+    @Override
+    public boolean remove() {
+        Entry e = flushedEntry;
+        if (e == null) {
+            return false;
+        }
+        Object msg = e.msg;
+
+        Promise<Void> promise = e.promise;
+        int size = e.pendingSize;
+
+        removeEntry(e);
+
+        if (!e.cancelled) {
+            // only release message, notify and decrement if it was not canceled before.
+            SilentDispose.trySilentDispose(msg, logger);
+            safeSuccess(promise);
+            decrementPendingOutboundBytes(size, false, true);
+        }
+
+        // recycle the entry
+        e.recycle();
+
+        return true;
+    }
+
+    @Override
+    public boolean remove(Throwable cause) {
+        return remove0(cause, true);
+    }
+
+    private boolean remove0(Throwable cause, boolean notifyWritability) {
+        Entry e = flushedEntry;
+        if (e == null) {
+            return false;
+        }
+        Object msg = e.msg;
+
+        Promise<Void> promise = e.promise;
+        int size = e.pendingSize;
+
+        removeEntry(e);
+
+        if (!e.cancelled) {
+            // only release message, fail and decrement if it was not canceled before.
+            SilentDispose.trySilentDispose(msg, logger);
+
+            safeFail(promise, cause);
+            decrementPendingOutboundBytes(size, false, notifyWritability);
+        }
+
+        // recycle the entry
+        e.recycle();
+
+        return true;
+    }
+
+    private void removeEntry(Entry e) {
+        if (-- flushed == 0) {
+            // processed everything
+            flushedEntry = null;
+            if (e == tailEntry) {
+                tailEntry = null;
+                unflushedEntry = null;
+            }
+        } else {
+            flushedEntry = e.next;
+        }
+    }
+
+    @Override
+    public void removeBytes(long writtenBytes) {
+        Object msg = current();
+        while (writtenBytes > 0 || hasZeroReadable(msg)) {
+            if (msg instanceof Buffer) {
+                Buffer buf = (Buffer) msg;
+                final int readableBytes = buf.readableBytes();
+                if (readableBytes <= writtenBytes) {
+                    progress(readableBytes);
+                    writtenBytes -= readableBytes;
+                    remove();
+                } else { // readableBytes > writtenBytes
+                    buf.readSplit(Math.toIntExact(writtenBytes)).close();
+                    progress(writtenBytes);
+                    break;
+                }
+            } else if (msg instanceof ByteBufConvertible) {
+                final ByteBuf buf = ((ByteBufConvertible) msg).asByteBuf();
+                final int readerIndex = buf.readerIndex();
+                final int readableBytes = buf.writerIndex() - readerIndex;
+
+                if (readableBytes <= writtenBytes) {
+                    progress(readableBytes);
+                    writtenBytes -= readableBytes;
+                    remove();
+                } else { // readableBytes > writtenBytes
+                    buf.readerIndex(readerIndex + (int) writtenBytes);
+                    progress(writtenBytes);
+                    break;
+                }
+            } else {
+                break; // Don't know how to process this message. Might be null.
+            }
+            msg = current();
+        }
+    }
+
+    private static boolean hasZeroReadable(Object msg) {
+        if (msg instanceof Buffer) {
+            return ((Buffer) msg).readableBytes() == 0;
+        }
+        if (msg instanceof ByteBufConvertible) {
+            return ((ByteBufConvertible) msg).asByteBuf().readableBytes() == 0;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean isWritable() {
+        return unwritable == 0;
+    }
+
+    @Override
+    public boolean getUserDefinedWritability(int index) {
+        return (unwritable & writabilityMask(index)) == 0;
+    }
+
+    @Override
+    public void setUserDefinedWritability(int index, boolean writable) {
+        if (writable) {
+            setUserDefinedWritability(index);
+        } else {
+            clearUserDefinedWritability(index);
+        }
+    }
+
+    private void setUserDefinedWritability(int index) {
+        final int mask = ~writabilityMask(index);
+        for (;;) {
+            final int oldValue = unwritable;
+            final int newValue = oldValue & mask;
+            if (UNWRITABLE_UPDATER.compareAndSet(this, oldValue, newValue)) {
+                if (oldValue != 0 && newValue == 0) {
+                    fireChannelWritabilityChanged(true);
+                }
+                break;
+            }
+        }
+    }
+
+    private void clearUserDefinedWritability(int index) {
+        final int mask = writabilityMask(index);
+        for (;;) {
+            final int oldValue = unwritable;
+            final int newValue = oldValue | mask;
+            if (UNWRITABLE_UPDATER.compareAndSet(this, oldValue, newValue)) {
+                if (oldValue == 0 && newValue != 0) {
+                    fireChannelWritabilityChanged(true);
+                }
+                break;
+            }
+        }
+    }
+
+    private static int writabilityMask(int index) {
+        if (index < 1 || index > 31) {
+            throw new IllegalArgumentException("index: " + index + " (expected: 1~31)");
+        }
+        return 1 << index;
+    }
+
+    private void setWritable(boolean invokeLater) {
+        for (;;) {
+            final int oldValue = unwritable;
+            final int newValue = oldValue & ~1;
+            if (UNWRITABLE_UPDATER.compareAndSet(this, oldValue, newValue)) {
+                if (oldValue != 0 && newValue == 0) {
+                    fireChannelWritabilityChanged(invokeLater);
+                }
+                break;
+            }
+        }
+    }
+
+    private void setUnwritable(boolean invokeLater) {
+        for (;;) {
+            final int oldValue = unwritable;
+            final int newValue = oldValue | 1;
+            if (UNWRITABLE_UPDATER.compareAndSet(this, oldValue, newValue)) {
+                if (oldValue == 0) {
+                    fireChannelWritabilityChanged(invokeLater);
+                }
+                break;
+            }
+        }
+    }
+
+    private void fireChannelWritabilityChanged(boolean invokeLater) {
+        final ChannelPipeline pipeline = channel.pipeline();
+        if (invokeLater) {
+            Runnable task = fireChannelWritabilityChangedTask;
+            if (task == null) {
+                fireChannelWritabilityChangedTask = task = pipeline::fireChannelWritabilityChanged;
+            }
+            channel.executor().execute(task);
+        } else {
+            pipeline.fireChannelWritabilityChanged();
+        }
+    }
+
+    @Override
+    public int size() {
+        return flushed;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return flushed == 0;
+    }
+
+    void failFlushed(Throwable cause, boolean notify) {
+        // Make sure that this method does not reenter.  A listener added to the current promise can be notified by the
+        // current thread in the tryFailure() call of the loop below, and the listener can trigger another fail() call
+        // indirectly (usually by closing the channel.)
+        //
+        // See https://github.com/netty/netty/issues/1501
+        if (inFail) {
+            return;
+        }
+
+        try {
+            inFail = true;
+            for (;;) {
+                if (!remove0(cause, notify)) {
+                    break;
+                }
+            }
+        } finally {
+            inFail = false;
+        }
+    }
+
+    void close(final Throwable cause, final boolean allowChannelOpen) {
+        if (inFail) {
+            channel.executor().execute(() -> close(cause, allowChannelOpen));
+            return;
+        }
+
+        inFail = true;
+
+        if (!allowChannelOpen && channel.isOpen()) {
+            throw new IllegalStateException("close() must be invoked after the channel is closed.");
+        }
+
+        if (!isEmpty()) {
+            throw new IllegalStateException("close() must be invoked after all flushed writes are handled.");
+        }
+
+        // Release all unflushed messages.
+        try {
+            Entry e = unflushedEntry;
+            while (e != null) {
+                // Just decrease; do not trigger any events via decrementPendingOutboundBytes()
+                int size = e.pendingSize;
+                TOTAL_PENDING_SIZE_UPDATER.addAndGet(this, -size);
+
+                if (!e.cancelled) {
+                    SilentDispose.dispose(e.msg, logger);
+                    safeFail(e.promise, cause);
+                }
+                e = e.recycleAndGetNext();
+            }
+        } finally {
+            inFail = false;
+        }
+    }
+
+    void close(ClosedChannelException cause) {
+        close(cause, false);
+    }
+
+    private static void safeSuccess(Promise<Void> promise) {
+        PromiseNotificationUtil.trySuccess(promise, null, logger);
+    }
+
+    private static void safeFail(Promise<Void> promise, Throwable cause) {
+        PromiseNotificationUtil.tryFailure(promise, cause, logger);
+    }
+
+    @Override
+    public long totalPendingWriteBytes() {
+        return totalPendingSize;
+    }
+
+    @Override
+    public long bytesBeforeUnwritable() {
+        long bytes = channel.config().getWriteBufferHighWaterMark() - totalPendingSize;
+        // If bytes is negative we know we are not writable, but if bytes is non-negative we have to check writability.
+        // Note that totalPendingSize and isWritable() use different volatile variables that are not synchronized
+        // together. totalPendingSize will be updated before isWritable().
+        if (bytes > 0) {
+            return isWritable() ? bytes : 0;
+        }
+        return 0;
+    }
+
+    @Override
+    public long bytesBeforeWritable() {
+        long bytes = totalPendingSize - channel.config().getWriteBufferLowWaterMark();
+        // If bytes is negative we know we are writable, but if bytes is non-negative we have to check writability.
+        // Note that totalPendingSize and isWritable() use different volatile variables that are not synchronized
+        // together. totalPendingSize will be updated before isWritable().
+        if (bytes > 0) {
+            return isWritable() ? 0 : bytes;
+        }
+        return 0;
+    }
+
+    @Override
+    public void forEachFlushedMessage(MessageProcessor processor) throws Exception {
+        requireNonNull(processor, "processor");
+
+        Entry entry = flushedEntry;
+        if (entry == null) {
+            return;
+        }
+
+        do {
+            if (!entry.cancelled) {
+                if (!processor.processMessage(entry.msg)) {
+                    return;
+                }
+            }
+            entry = entry.next;
+        } while (isFlushedEntry(entry));
+    }
+
+    private boolean isFlushedEntry(Entry e) {
+        return e != null && e != unflushedEntry;
+    }
+
+    private static final class Entry {
+        private static final ObjectPool<Entry> RECYCLER = ObjectPool.newPool(Entry::new);
+
+        private final Handle<Entry> handle;
+        Entry next;
+        Object msg;
+        ByteBuffer[] bufs;
+        ByteBuffer buf;
+        Promise<Void> promise;
+        long progress;
+        long total;
+        int pendingSize;
+        int count = -1;
+        boolean cancelled;
+
+        private Entry(Handle<Entry> handle) {
+            this.handle = handle;
+        }
+
+        static Entry newInstance(Object msg, int size, long total, Promise<Void> promise) {
+            Entry entry = RECYCLER.get();
+            entry.msg = msg;
+            entry.pendingSize = size + CHANNEL_OUTBOUND_BUFFER_ENTRY_OVERHEAD;
+            entry.total = total;
+            entry.promise = promise;
+            return entry;
+        }
+
+        int cancel() {
+            if (!cancelled) {
+                cancelled = true;
+                int pSize = pendingSize;
+
+                // release message and replace with an empty buffer
+                SilentDispose.dispose(msg, logger);
+                msg = Unpooled.EMPTY_BUFFER;
+
+                pendingSize = 0;
+                total = 0;
+                progress = 0;
+                bufs = null;
+                buf = null;
+                return pSize;
+            }
+            return 0;
+        }
+
+        void recycle() {
+            next = null;
+            bufs = null;
+            buf = null;
+            msg = null;
+            promise = null;
+            progress = 0;
+            total = 0;
+            pendingSize = 0;
+            count = -1;
+            cancelled = false;
+            handle.recycle(this);
+        }
+
+        Entry recycleAndGetNext() {
+            Entry next = this.next;
+            recycle();
+            return next;
+        }
+    }
+}

--- a/transport/src/main/java/io/netty5/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty5/channel/DefaultChannelPipeline.java
@@ -978,16 +978,16 @@ public class DefaultChannelPipeline implements ChannelPipeline {
     @UnstableApi
     protected void incrementPendingOutboundBytes(long size) {
         ChannelOutboundBuffer buffer = channel.unsafe().outboundBuffer();
-        if (buffer != null) {
-            buffer.incrementPendingOutboundBytes(size);
+        if (buffer instanceof DefaultChannelOutboundBuffer) {
+            ((DefaultChannelOutboundBuffer) buffer).incrementPendingOutboundBytes(size);
         }
     }
 
     @UnstableApi
     protected void decrementPendingOutboundBytes(long size) {
         ChannelOutboundBuffer buffer = channel.unsafe().outboundBuffer();
-        if (buffer != null) {
-            buffer.decrementPendingOutboundBytes(size);
+        if (buffer instanceof DefaultChannelOutboundBuffer) {
+            ((DefaultChannelOutboundBuffer) buffer).decrementPendingOutboundBytes(size);
         }
     }
 

--- a/transport/src/main/java/io/netty5/channel/PendingBytesTracker.java
+++ b/transport/src/main/java/io/netty5/channel/PendingBytesTracker.java
@@ -41,8 +41,9 @@ abstract class PendingBytesTracker implements MessageSizeEstimator.Handle {
             // We need to guard against null as channel.unsafe().outboundBuffer() may returned null
             // if the channel was already closed when constructing the PendingBytesTracker.
             // See https://github.com/netty/netty/issues/3967
-            return buffer == null ?
-                    new NoopPendingBytesTracker(handle) : new ChannelOutboundBufferPendingBytesTracker(buffer, handle);
+            return buffer instanceof DefaultChannelOutboundBuffer ?
+                   new ChannelOutboundBufferPendingBytesTracker((DefaultChannelOutboundBuffer) buffer, handle) :
+                    new NoopPendingBytesTracker(handle);
         }
     }
 
@@ -66,10 +67,10 @@ abstract class PendingBytesTracker implements MessageSizeEstimator.Handle {
     }
 
     private static final class ChannelOutboundBufferPendingBytesTracker extends PendingBytesTracker {
-        private final ChannelOutboundBuffer buffer;
+        private final DefaultChannelOutboundBuffer buffer;
 
         ChannelOutboundBufferPendingBytesTracker(
-                ChannelOutboundBuffer buffer, MessageSizeEstimator.Handle estimatorHandle) {
+                DefaultChannelOutboundBuffer buffer, MessageSizeEstimator.Handle estimatorHandle) {
             super(estimatorHandle);
             this.buffer = buffer;
         }

--- a/transport/src/main/java/io/netty5/channel/socket/nio/ByteBufferCollector.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/ByteBufferCollector.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.socket.nio;
+
+import io.netty5.buffer.api.Buffer;
+import io.netty5.channel.ChannelOutboundBuffer;
+import io.netty5.util.concurrent.FastThreadLocal;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+final class ByteBufferCollector implements ChannelOutboundBuffer.MessageProcessor {
+    private static final FastThreadLocal<BufferCache> NIO_BUFFERS = new FastThreadLocal<>() {
+        @Override
+        protected BufferCache initialValue() {
+            BufferCache cache = new BufferCache();
+            cache.buffers = new ByteBuffer[1024];
+            return cache;
+        }
+    };
+
+    /**
+     * Thread-local cache of {@link ByteBuffer} array, and processing meta-data.
+     */
+    private static final class BufferCache {
+        ByteBuffer[] buffers;
+        long dataSize;
+        int bufferCount;
+    }
+
+    private int maxCount;
+    private long maxBytes;
+    private long nioBufferSize;
+    private int nioBufferCount;
+    private BufferCache cache;
+
+    /**
+     * Returns an array of direct NIO buffers if the currently pending messages are made of {@link Buffer} only.
+     * {@link #nioBufferCount()} and {@link #nioBufferSize()} will return the number of NIO buffers in the returned
+     * array and the total number of readable bytes of the NIO buffers respectively.
+     * <p>
+     * Note that the returned array is reused and thus should not escape.
+     * </p>
+     *
+     * @param maxCount The maximum amount of buffers that will be added to the return value.
+     * @param maxBytes A hint toward the maximum number of bytes to include as part of the return value. Note that this
+     *                 value maybe exceeded because we make a best effort to include at least 1 {@link ByteBuffer}
+     *                 in the return value to ensure write progress is made.
+     */
+    ByteBuffer[] nioBuffers(ChannelOutboundBuffer buffer, int maxCount, long maxBytes) throws Exception {
+        assert maxCount > 0;
+        assert maxBytes > 0;
+        this.maxCount = maxCount;
+        this.maxBytes = maxBytes;
+        nioBufferSize = 0;
+        nioBufferCount = 0;
+        cache = NIO_BUFFERS.get();
+        cache.dataSize = 0;
+        cache.bufferCount = 0;
+        buffer.forEachFlushedMessage(this);
+        this.nioBufferCount = nioBufferCount + cache.bufferCount;
+        this.nioBufferSize = nioBufferSize + cache.dataSize;
+        return cache.buffers;
+    }
+
+    @Override
+    public boolean processMessage(Object msg) throws Exception {
+        if (!(msg instanceof Buffer)) {
+            return false;
+        }
+        Buffer buf = (Buffer) msg;
+        if (buf.readableBytes() > 0) {
+            int count = buf.forEachReadable(0, (index, component) -> {
+                ByteBuffer byteBuffer = component.readableBuffer();
+                if (cache.bufferCount > 0 && cache.dataSize + byteBuffer.remaining() > maxBytes) {
+                    // If the nioBufferSize + readableBytes will overflow maxBytes, and there is at least
+                    // one entry we stop populate the ByteBuffer array. This is done for 2 reasons:
+                    // 1. bsd/osx don't allow to write more bytes then Integer.MAX_VALUE with one
+                    // writev(...) call and so will return 'EINVAL', which will raise an IOException.
+                    // On Linux it may work depending on the architecture and kernel but to be safe we also
+                    // enforce the limit here.
+                    // 2. There is no sense in putting more data in the array than is likely to be accepted
+                    // by the OS.
+                    //
+                    // See also:
+                    // - https://www.freebsd.org/cgi/man.cgi?query=write&sektion=2
+                    // - https://linux.die.net//man/2/writev
+                    return false;
+                }
+                cache.dataSize += byteBuffer.remaining();
+                ByteBuffer[] buffers = cache.buffers;
+                int bufferCount = cache.bufferCount;
+                if (buffers.length == bufferCount && bufferCount < maxCount) {
+                    buffers = cache.buffers = expandNioBufferArray(buffers, bufferCount + 1, bufferCount);
+                }
+                buffers[cache.bufferCount] = byteBuffer;
+                bufferCount++;
+                cache.bufferCount = bufferCount;
+                return bufferCount < maxCount;
+            });
+            if (count < 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Returns the number of {@link ByteBuffer} that can be written out of the {@link ByteBuffer} array that was
+     * obtained via {@link #nioBuffers(ChannelOutboundBuffer, int, long)}.
+     * This method <strong>MUST</strong> be called after {@link #nioBuffers(ChannelOutboundBuffer, int, long)}
+     * was called.
+     */
+    int nioBufferCount() {
+        return nioBufferCount;
+    }
+
+    /**
+     * Returns the number of bytes that can be written out of the {@link ByteBuffer} array that was
+     * obtained via {@link #nioBuffers(ChannelOutboundBuffer, int, long)}. This method <strong>MUST</strong>
+     * be called after {@link #nioBuffers(ChannelOutboundBuffer, int, long)}
+     * was called.
+     */
+    long nioBufferSize() {
+        return nioBufferSize;
+    }
+
+    // Clear all ByteBuffer from the array so these can be GC'ed.
+    // See https://github.com/netty/netty/issues/3837
+    void clearNioBuffers() {
+        int count = nioBufferCount;
+        if (count > 0) {
+            nioBufferCount = 0;
+            Arrays.fill(NIO_BUFFERS.get().buffers, 0, count, null);
+        }
+    }
+
+    private static ByteBuffer[] expandNioBufferArray(ByteBuffer[] array, int neededSpace, int size) {
+        int newCapacity = array.length;
+        do {
+            // double capacity until it is big enough
+            // See https://github.com/netty/netty/issues/1890
+            newCapacity <<= 1;
+
+            if (newCapacity < 0) {
+                throw new IllegalStateException();
+            }
+
+        } while (neededSpace > newCapacity);
+
+        ByteBuffer[] newArray = new ByteBuffer[newCapacity];
+        System.arraycopy(array, 0, newArray, 0, size);
+
+        return newArray;
+    }
+}

--- a/transport/src/test/java/io/netty5/channel/socket/nio/ByteBufferCollectorTest.java
+++ b/transport/src/test/java/io/netty5/channel/socket/nio/ByteBufferCollectorTest.java
@@ -1,0 +1,305 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.socket.nio;
+
+import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.api.BufferAllocator;
+import io.netty5.buffer.api.CompositeBuffer;
+
+import io.netty5.channel.ChannelOutboundBuffer;
+import io.netty5.util.CharsetUtil;
+import io.netty5.util.Resource;
+import io.netty5.util.concurrent.ImmediateEventExecutor;
+import io.netty5.util.concurrent.Promise;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ByteBufferCollectorTest {
+    private static final class TestChannelOutboundBuffer implements ChannelOutboundBuffer {
+        private static final class Entry {
+            private final Object msg;
+            private final Promise<Void> promise;
+            boolean flushed;
+
+            Entry(Object msg, Promise<Void> promise) {
+                this.msg = msg;
+                this.promise = promise;
+            }
+        }
+
+        private final Queue<Entry> messages = new ArrayDeque<>();
+
+        @Override
+        public void addMessage(Object msg, int size, Promise<Void> promise) {
+            messages.add(new Entry(msg, promise));
+        }
+
+        @Override
+        public void addFlush() {
+            for (Entry entry : messages) {
+                entry.flushed = true;
+            }
+        }
+
+        @Override
+        public Object current() {
+            Entry entry = messages.peek();
+            if (entry == null || entry.flushed) {
+                return null;
+            }
+            return entry.msg;
+        }
+
+        @Override
+        public long currentProgress() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void progress(long amount) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean remove() {
+            Entry entry = messages.peek();
+            if (entry == null || entry.flushed) {
+                return false;
+            }
+            messages.remove();
+
+            entry.promise.setSuccess(null);
+            Resource.dispose(entry.msg);
+            return true;
+        }
+
+        @Override
+        public boolean remove(Throwable cause) {
+            Entry entry = messages.peek();
+            if (entry == null || entry.flushed) {
+                return false;
+            }
+            messages.remove();
+
+            entry.promise.setFailure(cause);
+            Resource.dispose(entry.msg);
+            return true;
+        }
+
+        @Override
+        public void removeBytes(long writtenBytes) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isWritable() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean getUserDefinedWritability(int index) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setUserDefinedWritability(int index, boolean writable) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int size() {
+            int flushed = 0;
+            for (Entry entry: messages) {
+                if (!entry.flushed) {
+                    break;
+                }
+                flushed++;
+            }
+            return flushed;
+        }
+
+        @Override
+        public long totalPendingWriteBytes() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long bytesBeforeUnwritable() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long bytesBeforeWritable() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void forEachFlushedMessage(MessageProcessor processor) throws Exception {
+            for (Entry entry: messages) {
+                if (!entry.flushed) {
+                    break;
+                }
+                if (!processor.processMessage(entry.msg)) {
+                    break;
+                }
+            }
+        }
+    }
+    @Test
+    void testEmptyNioBuffers() throws Exception {
+        ChannelOutboundBuffer buffer = new TestChannelOutboundBuffer();
+        ByteBufferCollector collector = new ByteBufferCollector();
+        assertEquals(0, collector.nioBufferCount());
+        ByteBuffer[] buffers = collector.nioBuffers(buffer, 1024, Integer.MAX_VALUE);
+        assertNotNull(buffers);
+        for (ByteBuffer b: buffers) {
+            assertNull(b);
+        }
+        assertEquals(0, collector.nioBufferCount());
+        release(buffer);
+    }
+
+    @Test
+    public void testNioBuffersSingleBacked() throws Exception {
+        ChannelOutboundBuffer buffer = new TestChannelOutboundBuffer();
+        ByteBufferCollector collector = new ByteBufferCollector();
+        assertEquals(0, collector.nioBufferCount());
+
+        Buffer buf = BufferAllocator.onHeapUnpooled().copyOf("buf1", CharsetUtil.US_ASCII);
+        buffer.addMessage(buf, buf.readableBytes(), ImmediateEventExecutor.INSTANCE.newPromise());
+        assertEquals(0, collector.nioBufferCount(), "Should still be 0 as not flushed yet");
+        buffer.addFlush();
+        ByteBuffer[] buffers = collector.nioBuffers(buffer, 1024, Integer.MAX_VALUE);
+        assertNotNull(buffers);
+        assertEquals(1, collector.nioBufferCount(), "Should still be 0 as not flushed yet");
+        for (int i = 0;  i < collector.nioBufferCount(); i++) {
+            if (i == 0) {
+                assertEquals(1, buf.countReadableComponents());
+                buf.forEachReadable(0, (index, component) -> {
+                    assertEquals(0, index, "Expected buffer to only have a single component.");
+                    assertEquals(buffers[0], component.readableBuffer());
+                    return true;
+                });
+            } else {
+                assertNull(buffers[i]);
+            }
+        }
+        release(buffer);
+    }
+
+    @Test
+    public void testNioBuffersExpand() throws Exception {
+        ChannelOutboundBuffer buffer = new TestChannelOutboundBuffer();
+        ByteBufferCollector collector = new ByteBufferCollector();
+        Buffer buf = BufferAllocator.offHeapUnpooled().copyOf("buf1", CharsetUtil.US_ASCII);
+        for (int i = 0; i < 64; i++) {
+            buffer.addMessage(buf.copy(), buf.readableBytes(), ImmediateEventExecutor.INSTANCE.newPromise());
+        }
+        assertEquals(0, collector.nioBufferCount(), "Should still be 0 as not flushed yet");
+        buffer.addFlush();
+        ByteBuffer[] buffers = collector.nioBuffers(buffer, 1024, Integer.MAX_VALUE);
+        assertEquals(64, collector.nioBufferCount());
+        assertEquals(1, buf.countReadableComponents());
+        buf.forEachReadable(0, (index, component) -> {
+            assertEquals(0, index);
+            ByteBuffer expected = component.readableBuffer();
+            for (int i = 0;  i < collector.nioBufferCount(); i++) {
+                assertEquals(expected, buffers[i]);
+            }
+            return true;
+        });
+
+        release(buffer);
+        buf.close();
+    }
+
+    @Test
+    public void testNioBuffersExpand2() throws Exception {
+        ChannelOutboundBuffer buffer = new TestChannelOutboundBuffer();
+        ByteBufferCollector collector = new ByteBufferCollector();
+        Buffer buf = BufferAllocator.offHeapUnpooled().copyOf("buf1", CharsetUtil.US_ASCII);
+        var sends = Stream.generate(() -> buf.copy().send()).limit(65).collect(Collectors.toList());
+        CompositeBuffer comp = BufferAllocator.offHeapUnpooled().compose(sends);
+
+        buffer.addMessage(comp, comp.readableBytes(), ImmediateEventExecutor.INSTANCE.newPromise());
+
+        assertEquals(0, collector.nioBufferCount(), "Should still be 0 as not flushed yet");
+        buffer.addFlush();
+        ByteBuffer[] buffers = collector.nioBuffers(buffer, 1024, Integer.MAX_VALUE);
+        assertEquals(65, collector.nioBufferCount());
+        assertEquals(1, buf.countReadableComponents());
+        buf.forEachReadable(0, (index, component) -> {
+            assertEquals(0, index);
+            ByteBuffer expected = component.readableBuffer();
+            for (int i = 0;  i < collector.nioBufferCount(); i++) {
+                if (i < 65) {
+                    assertEquals(expected, buffers[i]);
+                } else {
+                    assertNull(buffers[i]);
+                }
+            }
+            return true;
+        });
+
+        release(buffer);
+        buf.close();
+    }
+
+    @Test
+    public void testNioBuffersMaxCount() throws Exception {
+        ChannelOutboundBuffer buffer = new TestChannelOutboundBuffer();
+        ByteBufferCollector collector = new ByteBufferCollector();
+        Buffer buf = BufferAllocator.offHeapUnpooled().copyOf("buf1", CharsetUtil.US_ASCII);
+        assertEquals(4, buf.readableBytes());
+        var sends = Stream.generate(() -> buf.copy().send()).limit(65).collect(Collectors.toList());
+        CompositeBuffer comp = BufferAllocator.offHeapUnpooled().compose(sends);
+
+        assertEquals(65, comp.countComponents());
+        buffer.addMessage(comp, comp.readableBytes(), ImmediateEventExecutor.INSTANCE.newPromise());
+        assertEquals(0, collector.nioBufferCount(), "Should still be 0 as not flushed yet");
+        buffer.addFlush();
+        final int maxCount = 10;    // less than comp.nioBufferCount()
+        ByteBuffer[] buffers = collector.nioBuffers(buffer, maxCount, Integer.MAX_VALUE);
+        assertTrue(collector.nioBufferCount() <= maxCount, "Should not be greater than maxCount");
+        buf.forEachReadable(0, (index, component) -> {
+            assertEquals(0, index);
+            ByteBuffer expected = component.readableBuffer();
+            for (int i = 0;  i < collector.nioBufferCount(); i++) {
+                assertEquals(expected, buffers[i]);
+            }
+            return true;
+        });
+        release(buffer);
+        buf.close();
+    }
+    private static void release(ChannelOutboundBuffer buffer) {
+        for (;;) {
+            if (!buffer.remove()) {
+                break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
… implementations that not extend AbstractChannel

Motivation:

ChannelOutboundBuffer was a final class that had a package-private constructor that took AbstractChannel as argument. Due of this it was impossible to write a Channel implementation that not extend AbstractChannel.

Modifications:

- Make ChannelOutboundBuffer an interface
- Add DefaultChannelOutboundBuffer implementation that is used by AbstractChannel
- Factor out code that produced ByteBuffer to NioSocketChannel as it is the only place we use it
- Add unit tests

Result:

API cleanup

