### PR TITLE
Allow to send custom events in both directions of the pipeline

### DIFF
--- a/codec-http/src/main/java/io/netty5/handler/codec/http/HttpClientUpgradeHandler.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/HttpClientUpgradeHandler.java
@@ -138,7 +138,7 @@ public class HttpClientUpgradeHandler<C extends HttpContent<C>> extends HttpObje
         Future<Void> f = ctx.write(msg);
 
         // Notify that the upgrade request was issued.
-        ctx.fireUserEventTriggered(UpgradeEvent.UPGRADE_ISSUED);
+        ctx.fireInboundEventTriggered(UpgradeEvent.UPGRADE_ISSUED);
         // Now we wait for the next HTTP response to see if we switch protocols.
         return f;
     }
@@ -159,7 +159,7 @@ public class HttpClientUpgradeHandler<C extends HttpContent<C>> extends HttpObje
                     // and continue processing HTTP.
                     // NOTE: not releasing the response since we're letting it propagate to the
                     // next handler.
-                    ctx.fireUserEventTriggered(UpgradeEvent.UPGRADE_REJECTED);
+                    ctx.fireInboundEventTriggered(UpgradeEvent.UPGRADE_REJECTED);
                     ctx.fireChannelRead(msg);
                     removeThisHandler(ctx);
                     return;
@@ -204,7 +204,7 @@ public class HttpClientUpgradeHandler<C extends HttpContent<C>> extends HttpObje
             upgradeCodec.upgradeTo(ctx, response.send());
 
             // Notify that the upgrade to the new protocol completed successfully.
-            ctx.fireUserEventTriggered(UpgradeEvent.UPGRADE_SUCCESSFUL);
+            ctx.fireInboundEventTriggered(UpgradeEvent.UPGRADE_SUCCESSFUL);
 
             // We guarantee UPGRADE_SUCCESSFUL event will be arrived at the next handler
             // before http2 setting frame and http response.

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/HttpObjectAggregator.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/HttpObjectAggregator.java
@@ -165,14 +165,14 @@ public class HttpObjectAggregator<C extends HttpContent<C>>
                                                      ChannelPipeline pipeline) {
         if (HttpUtil.isUnsupportedExpectation(start)) {
             // if the request contains an unsupported expectation, we return 417
-            pipeline.fireUserEventTriggered(HttpExpectationFailedEvent.INSTANCE);
+            pipeline.fireInboundEventTriggered(HttpExpectationFailedEvent.INSTANCE);
             return newErrorResponse(EXPECTATION_FAILED, pipeline.channel().bufferAllocator(), true, false);
         } else if (HttpUtil.is100ContinueExpected(start)) {
             // if the request contains 100-continue but the content-length is too large, we return 413
             if (getContentLength(start, -1L) <= maxContentLength) {
                 return newErrorResponse(CONTINUE, pipeline.channel().bufferAllocator(), false, false);
             }
-            pipeline.fireUserEventTriggered(HttpExpectationFailedEvent.INSTANCE);
+            pipeline.fireInboundEventTriggered(HttpExpectationFailedEvent.INSTANCE);
             return newErrorResponse(REQUEST_ENTITY_TOO_LARGE, pipeline.channel().bufferAllocator(), true, false);
         }
 

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/HttpObjectDecoder.java
@@ -458,7 +458,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoderForBuffer {
     }
 
     @Override
-    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
         if (evt instanceof HttpExpectationFailedEvent) {
             switch (currentState) {
             case READ_FIXED_LENGTH_CONTENT:
@@ -470,7 +470,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoderForBuffer {
                 break;
             }
         }
-        super.userEventTriggered(ctx, evt);
+        super.inboundEventTriggered(ctx, evt);
     }
 
     protected boolean isContentAlwaysEmpty(HttpMessage msg) {

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/HttpServerUpgradeHandler.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/HttpServerUpgradeHandler.java
@@ -347,7 +347,7 @@ public class HttpServerUpgradeHandler<C extends HttpContent<C>> extends HttpObje
         upgradeCodec.upgradeTo(ctx, request);
 
         // Notify that the upgrade has occurred.
-        ctx.fireUserEventTriggered(new UpgradeEvent(upgradeProtocol, request));
+        ctx.fireInboundEventTriggered(new UpgradeEvent(upgradeProtocol, request));
 
         // Remove this handler from the pipeline.
         ctx.pipeline().remove(HttpServerUpgradeHandler.this);

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientProtocolHandler.java
@@ -41,7 +41,7 @@ import static io.netty5.handler.codec.http.websocketx.WebSocketServerProtocolCon
  * This implementation will establish the websocket connection once the connection to the remote server was complete.
  *
  * To know once a handshake was done you can intercept the
- * {@link ChannelHandler#userEventTriggered(ChannelHandlerContext, Object)} and check if the event was of type
+ * {@link ChannelHandler#inboundEventTriggered(ChannelHandlerContext, Object)} and check if the event was of type
  * {@link ClientHandshakeStateEvent#HANDSHAKE_ISSUED} or {@link ClientHandshakeStateEvent#HANDSHAKE_COMPLETE}.
  */
 public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientProtocolHandshakeHandler.java
@@ -58,7 +58,7 @@ class WebSocketClientProtocolHandshakeHandler implements ChannelHandler {
                 handshakePromise.tryFailure(future.cause());
                 ctx.fireExceptionCaught(future.cause());
             } else {
-                ctx.fireUserEventTriggered(
+                ctx.fireInboundEventTriggered(
                         WebSocketClientProtocolHandler.ClientHandshakeStateEvent.HANDSHAKE_ISSUED);
             }
         });
@@ -86,7 +86,7 @@ class WebSocketClientProtocolHandshakeHandler implements ChannelHandler {
             if (!handshaker.isHandshakeComplete()) {
                 handshaker.finishHandshake(ctx.channel(), response);
                 handshakePromise.trySuccess(null);
-                ctx.fireUserEventTriggered(
+                ctx.fireInboundEventTriggered(
                         ClientHandshakeStateEvent.HANDSHAKE_COMPLETE);
                 ctx.pipeline().remove(this);
                 return;
@@ -108,7 +108,7 @@ class WebSocketClientProtocolHandshakeHandler implements ChannelHandler {
 
             if (localHandshakePromise.tryFailure(new WebSocketClientHandshakeException("handshake timed out"))) {
                 ctx.flush()
-                   .fireUserEventTriggered(ClientHandshakeStateEvent.HANDSHAKE_TIMEOUT)
+                   .fireInboundEventTriggered(ClientHandshakeStateEvent.HANDSHAKE_TIMEOUT)
                    .close();
             }
         }, handshakeTimeoutMillis, TimeUnit.MILLISECONDS);

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
@@ -46,7 +46,7 @@ import static io.netty5.handler.codec.http.websocketx.WebSocketServerProtocolCon
  * to the <tt>io.netty5.example.http.websocketx.server.WebSocketServer</tt> example.
  *
  * To know once a handshake was done you can intercept the
- * {@link ChannelHandler#userEventTriggered(ChannelHandlerContext, Object)} and check if the event was instance
+ * {@link ChannelHandler#inboundEventTriggered(ChannelHandlerContext, Object)} and check if the event was instance
  * of {@link HandshakeComplete}, the event will contain extra information about the handshake such as the request and
  * selected subprotocol.
  */

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
@@ -96,7 +96,7 @@ class WebSocketServerProtocolHandshakeHandler implements ChannelHandler {
                             ctx.fireExceptionCaught(future.cause());
                         } else {
                             localHandshakePromise.trySuccess(null);
-                            ctx.fireUserEventTriggered(
+                            ctx.fireInboundEventTriggered(
                                     new WebSocketServerProtocolHandler.HandshakeComplete(
                                             req.uri(), req.headers(), handshaker.selectedSubprotocol()));
                         }
@@ -161,7 +161,7 @@ class WebSocketServerProtocolHandshakeHandler implements ChannelHandler {
             if (!localHandshakePromise.isDone() &&
                     localHandshakePromise.tryFailure(new WebSocketServerHandshakeException("handshake timed out"))) {
                 ctx.flush()
-                   .fireUserEventTriggered(ServerHandshakeStateEvent.HANDSHAKE_TIMEOUT)
+                   .fireInboundEventTriggered(ServerHandshakeStateEvent.HANDSHAKE_TIMEOUT)
                    .close();
             }
         }, handshakeTimeoutMillis, TimeUnit.MILLISECONDS);

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpClientUpgradeHandlerTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpClientUpgradeHandlerTest.java
@@ -67,7 +67,7 @@ public class HttpClientUpgradeHandlerTest {
         }
 
         @Override
-        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+        public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
             this.evt = evt;
         }
     }

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketHandshakeHandOverTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketHandshakeHandOverTest.java
@@ -86,7 +86,7 @@ public class WebSocketHandshakeHandOverTest {
     public void testHandover() {
         EmbeddedChannel serverChannel = createServerChannel(new SimpleChannelInboundHandler<>() {
             @Override
-            public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+            public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
                 if (evt instanceof WebSocketServerProtocolHandler.HandshakeComplete) {
                     serverReceivedHandshake = true;
                     serverHandshakeComplete = (WebSocketServerProtocolHandler.HandshakeComplete) evt;
@@ -102,7 +102,7 @@ public class WebSocketHandshakeHandOverTest {
 
         EmbeddedChannel clientChannel = createClientChannel(new SimpleChannelInboundHandler<>() {
             @Override
-            public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+            public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
                 if (evt == ClientHandshakeStateEvent.HANDSHAKE_COMPLETE) {
                     clientReceivedHandshake = true;
                 }
@@ -134,7 +134,7 @@ public class WebSocketHandshakeHandOverTest {
     public void testClientHandshakeTimeout() throws Throwable {
         EmbeddedChannel serverChannel = createServerChannel(new SimpleChannelInboundHandler<>() {
             @Override
-            public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+            public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
                 if (evt instanceof WebSocketServerProtocolHandler.HandshakeComplete) {
                     serverHandshakeComplete = (WebSocketServerProtocolHandler.HandshakeComplete) evt;
                 }
@@ -147,7 +147,7 @@ public class WebSocketHandshakeHandOverTest {
 
         EmbeddedChannel clientChannel = createClientChannel(new SimpleChannelInboundHandler<>() {
             @Override
-            public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+            public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
                 if (evt == ClientHandshakeStateEvent.HANDSHAKE_COMPLETE) {
                     clientReceivedHandshake = true;
                 } else if (evt == ClientHandshakeStateEvent.HANDSHAKE_TIMEOUT) {
@@ -239,7 +239,7 @@ public class WebSocketHandshakeHandOverTest {
 
         EmbeddedChannel clientChannel = createClientChannel(handshaker, new SimpleChannelInboundHandler<>() {
             @Override
-            public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+            public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
                 if (evt == ClientHandshakeStateEvent.HANDSHAKE_COMPLETE) {
                     ctx.channel().closeFuture().addListener(future -> clientForceClosed = true);
                     handshaker.close(ctx.channel(), new CloseWebSocketFrame(

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketServerProtocolHandlerTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketServerProtocolHandlerTest.java
@@ -89,7 +89,7 @@ public class WebSocketServerProtocolHandlerTest {
         ChannelHandlerContext handshakerCtx = ch.pipeline().context(WebSocketServerProtocolHandshakeHandler.class);
         ch.pipeline().addLast(new ChannelHandler() {
             @Override
-            public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+            public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
                 if (evt instanceof WebSocketServerProtocolHandler.HandshakeComplete) {
                     // We should have removed the handler already.
                     ctx.executor().execute(() -> ctx.pipeline().context(WebSocketServerProtocolHandshakeHandler.class));

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/AbstractHttp2StreamChannel.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/AbstractHttp2StreamChannel.java
@@ -964,6 +964,12 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
         }
 
         @Override
+        public void triggerOutboundEvent(Object event, Promise<Void> promise) {
+            Resource.dispose(event);
+            promise.setSuccess(null);
+        }
+
+        @Override
         public ChannelOutboundBuffer outboundBuffer() {
             // Always return null as we not use the ChannelOutboundBuffer and not even support it.
             return null;

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/CleartextHttp2ServerUpgradeHandler.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/CleartextHttp2ServerUpgradeHandler.java
@@ -88,7 +88,7 @@ public final class CleartextHttp2ServerUpgradeHandler extends ByteToMessageDecod
                 String bufferToByteBufName = ctx.name() + "-bufferToByteBuf";
                 ctx.pipeline().addAfter(ctx.name(), bufferToByteBufName, bufferToByteBuf());
                 ctx.pipeline().addAfter(bufferToByteBufName, null, http2ServerHandler);
-                ctx.fireUserEventTriggered(PriorKnowledgeUpgradeEvent.INSTANCE);
+                ctx.fireInboundEventTriggered(PriorKnowledgeUpgradeEvent.INSTANCE);
                 ctx.pipeline().remove(this);
             }
         }

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2ConnectionHandler.java
@@ -377,7 +377,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
                 // If this handler is extended by the user and we directly fire the userEvent from this context then
                 // the user will not see the event. We should fire the event starting with this handler so this class
                 // (and extending classes) have a chance to process the event.
-                userEventTriggered(ctx, Http2ConnectionPrefaceAndSettingsFrameWrittenEvent.INSTANCE);
+                inboundEventTriggered(ctx, Http2ConnectionPrefaceAndSettingsFrameWrittenEvent.INSTANCE);
             }
         }
     }

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2MultiplexHandler.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2MultiplexHandler.java
@@ -179,7 +179,7 @@ public final class Http2MultiplexHandler extends Http2ChannelDuplexHandler {
             if (msg instanceof Http2ResetFrame) {
                 // Reset frames needs to be propagated via user events as these are not flow-controlled and so
                 // must not be controlled by suppressing channel.read() on the child channel.
-                channel.pipeline().fireUserEventTriggered(msg);
+                channel.pipeline().fireInboundEventTriggered(msg);
 
                 // RST frames will also trigger closing of the streams which then will call
                 // AbstractHttp2StreamChannel.streamClosed()
@@ -211,7 +211,7 @@ public final class Http2MultiplexHandler extends Http2ChannelDuplexHandler {
     }
 
     @Override
-    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
         if (evt instanceof Http2FrameStreamEvent) {
             Http2FrameStreamEvent event = (Http2FrameStreamEvent) evt;
             DefaultHttp2FrameStream stream = (DefaultHttp2FrameStream) event.stream();
@@ -246,7 +246,7 @@ public final class Http2MultiplexHandler extends Http2ChannelDuplexHandler {
             }
             return;
         }
-        ctx.fireUserEventTriggered(evt);
+        ctx.fireInboundEventTriggered(evt);
     }
 
     private void createStreamChannelIfNeeded(DefaultHttp2FrameStream stream, boolean shutdownInputOnceRegistered)
@@ -327,7 +327,7 @@ public final class Http2MultiplexHandler extends Http2ChannelDuplexHandler {
                 if (streamId > goAwayFrame.lastStreamId() && Http2CodecUtil.isStreamIdValid(streamId, server)) {
                     final AbstractHttp2StreamChannel childChannel = (AbstractHttp2StreamChannel)
                             ((DefaultHttp2FrameStream) stream).attachment;
-                    childChannel.pipeline().fireUserEventTriggered(goAwayFrame.retainedDuplicate());
+                    childChannel.pipeline().fireInboundEventTriggered(goAwayFrame.retainedDuplicate());
                 }
                 return true;
             });

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/CleartextHttp2ServerUpgradeHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/CleartextHttp2ServerUpgradeHandlerTest.java
@@ -80,7 +80,7 @@ public class CleartextHttp2ServerUpgradeHandlerTest {
                 httpServerCodec, upgradeHandler, http2ConnectionHandler);
         channel = new EmbeddedChannel(handler, new ChannelHandler() {
             @Override
-            public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+            public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
                 userEvents.add(evt);
             }
         });

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/DataCompressionHttp2Test.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/DataCompressionHttp2Test.java
@@ -407,7 +407,7 @@ public class DataCompressionHttp2Test {
                 p.addLast(clientHandler);
                 p.addLast(new ChannelHandler() {
                     @Override
-                    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+                    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
                         if (evt == Http2ConnectionPrefaceAndSettingsFrameWrittenEvent.INSTANCE) {
                             prefaceWrittenLatch.countDown();
                             ctx.pipeline().remove(this);

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -272,7 +272,7 @@ public class Http2ConnectionHandlerTest {
             return null;
         };
 
-        doAnswer(verifier).when(ctx).fireUserEventTriggered(evt);
+        doAnswer(verifier).when(ctx).fireInboundEventTriggered(evt);
 
         handler.channelActive(ctx);
         if (flushPreface) {
@@ -466,7 +466,7 @@ public class Http2ConnectionHandlerTest {
         final CountDownLatch latch = new CountDownLatch(1);
         handler = new Http2ConnectionHandler(decoder, encoder, new Http2Settings()) {
             @Override
-            public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+            public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
                 if (evt == Http2ConnectionPrefaceAndSettingsFrameWrittenEvent.INSTANCE) {
                     latch.countDown();
                 }

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -1071,7 +1071,7 @@ public class Http2ConnectionRoundtripTest {
                         .build());
                 p.addLast(new ChannelHandler() {
                     @Override
-                    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+                    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
                         if (evt == Http2ConnectionPrefaceAndSettingsFrameWrittenEvent.INSTANCE) {
                             prefaceWrittenLatch.countDown();
                             ctx.pipeline().remove(this);

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameCodecTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameCodecTest.java
@@ -878,7 +878,7 @@ public class Http2FrameCodecTest {
                 "HTTP/2", new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/",
                                                      preferredAllocator().allocate(0)));
         assertTrue(upgradeEvent.isAccessible());
-        channel.pipeline().fireUserEventTriggered(upgradeEvent);
+        channel.pipeline().fireInboundEventTriggered(upgradeEvent);
         assertFalse(upgradeEvent.isAccessible());
     }
 
@@ -918,7 +918,7 @@ public class Http2FrameCodecTest {
 
         HttpServerUpgradeHandler.UpgradeEvent upgradeEvent = constructor.newInstance(
             "HTTP/2", request);
-        channel.pipeline().fireUserEventTriggered(upgradeEvent);
+        channel.pipeline().fireInboundEventTriggered(upgradeEvent);
     }
 
     @Test

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameInboundWriter.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameInboundWriter.java
@@ -174,8 +174,8 @@ final class Http2FrameInboundWriter {
         }
 
         @Override
-        public ChannelHandlerContext fireUserEventTriggered(Object evt) {
-            channel.pipeline().fireUserEventTriggered(evt);
+        public ChannelHandlerContext fireInboundEventTriggered(Object evt) {
+            channel.pipeline().fireInboundEventTriggered(evt);
             return this;
         }
 
@@ -207,6 +207,11 @@ final class Http2FrameInboundWriter {
         public ChannelHandlerContext flush() {
             channel.pipeline().fireChannelReadComplete();
             return this;
+        }
+
+        @Override
+        public Future<Void> triggerOutboundEvent(Object event) {
+            return channel.pipeline().triggerOutboundEvent(event);
         }
 
         @Override

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexTest.java
@@ -927,7 +927,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
         Http2StreamChannel childChannel = newOutboundStream(new ChannelHandler() {
 
             @Override
-            public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+            public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
                 ctx.close();
                 throw new Exception("Exception for test");
             }
@@ -954,7 +954,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
             }
         });
 
-        childChannel.pipeline().fireUserEventTriggered(new Object());
+        childChannel.pipeline().fireInboundEventTriggered(new Object());
 
         // The events should have happened in this order because the inactive and deregistration events
         // get deferred as they do in the AbstractChannel.

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexTransportTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexTransportTest.java
@@ -84,7 +84,7 @@ public class Http2MultiplexTransportTest {
         }
 
         @Override
-        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+        public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
             Resource.dispose(evt);
         }
     };
@@ -378,7 +378,7 @@ public class Http2MultiplexTransportTest {
                     ch.pipeline().addLast(new Http2MultiplexHandler(DISCARD_HANDLER));
                     ch.pipeline().addLast(new ChannelHandler() {
                         @Override
-                        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                        public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
                             if (evt instanceof SslHandshakeCompletionEvent) {
                                 SslHandshakeCompletionEvent handshakeCompletionEvent =
                                         (SslHandshakeCompletionEvent) evt;
@@ -537,7 +537,7 @@ public class Http2MultiplexTransportTest {
                     ch.pipeline().addLast(new Http2MultiplexHandler(DISCARD_HANDLER));
                     ch.pipeline().addLast(new ChannelHandler() {
                         @Override
-                        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                        public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
                             if (evt instanceof SslHandshakeCompletionEvent) {
                                 SslHandshakeCompletionEvent handshakeCompletionEvent =
                                         (SslHandshakeCompletionEvent) evt;

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
@@ -558,7 +558,7 @@ public class HttpToHttp2ConnectionHandlerTest {
                 p.addLast(handler);
                 p.addLast(new ChannelHandler() {
                     @Override
-                    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+                    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
                         if (evt == Http2ConnectionPrefaceAndSettingsFrameWrittenEvent.INSTANCE) {
                             prefaceWrittenLatch.countDown();
                             ctx.pipeline().remove(this);

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
@@ -642,7 +642,7 @@ public class InboundHttp2ToHttpAdapterTest {
                 });
                 p.addLast(new ChannelHandler() {
                     @Override
-                    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+                    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
                         if (evt == Http2ConnectionPrefaceAndSettingsFrameWrittenEvent.INSTANCE) {
                             prefaceWrittenLatch.countDown();
                             ctx.pipeline().remove(this);

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/LastInboundHandler.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/LastInboundHandler.java
@@ -109,7 +109,7 @@ public class LastInboundHandler implements ChannelHandler {
     }
 
     @Override
-    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
         queue.add(new UserEvent(evt));
     }
 

--- a/codec/src/main/java/io/netty5/handler/codec/DatagramPacketDecoder.java
+++ b/codec/src/main/java/io/netty5/handler/codec/DatagramPacketDecoder.java
@@ -84,8 +84,8 @@ public class DatagramPacketDecoder extends MessageToMessageDecoder<DatagramPacke
     }
 
     @Override
-    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
-        decoder.userEventTriggered(ctx, evt);
+    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+        decoder.inboundEventTriggered(ctx, evt);
     }
 
     @Override

--- a/codec/src/test/java/io/netty5/handler/codec/ByteToMessageDecoderTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/ByteToMessageDecoderTest.java
@@ -535,7 +535,6 @@ public class ByteToMessageDecoderTest {
         removeHandler.set(true);
         // This should trigger channelInputClosed(...)
         channel.pipeline().fireChannelShutdown(ChannelShutdownDirection.Inbound);
-
         assertTrue(channel.finish());
         assertBuffer(Unpooled.wrappedBuffer(bytes), channel.readInbound());
         assertNull(channel.readInbound());

--- a/example/src/main/java/io/netty5/example/http2/helloworld/client/Http2ClientInitializer.java
+++ b/example/src/main/java/io/netty5/example/http2/helloworld/client/Http2ClientInitializer.java
@@ -169,9 +169,9 @@ public class Http2ClientInitializer extends ChannelInitializer<SocketChannel> {
      */
     private static class UserEventLogger implements ChannelHandler {
         @Override
-        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+        public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
             System.out.println("User Event Triggered: " + evt);
-            ctx.fireUserEventTriggered(evt);
+            ctx.fireInboundEventTriggered(evt);
         }
     }
 }

--- a/example/src/main/java/io/netty5/example/http2/helloworld/frame/server/Http2ServerInitializer.java
+++ b/example/src/main/java/io/netty5/example/http2/helloworld/frame/server/Http2ServerInitializer.java
@@ -110,9 +110,9 @@ public class Http2ServerInitializer extends ChannelInitializer<SocketChannel> {
      */
     private static class UserEventLogger implements ChannelHandler {
         @Override
-        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+        public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
             System.out.println("User Event Triggered: " + evt);
-            ctx.fireUserEventTriggered(evt);
+            ctx.fireInboundEventTriggered(evt);
         }
     }
 }

--- a/example/src/main/java/io/netty5/example/http2/helloworld/multiplex/server/Http2ServerInitializer.java
+++ b/example/src/main/java/io/netty5/example/http2/helloworld/multiplex/server/Http2ServerInitializer.java
@@ -112,9 +112,9 @@ public class Http2ServerInitializer extends ChannelInitializer<SocketChannel> {
      */
     private static class UserEventLogger implements ChannelHandler {
         @Override
-        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+        public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
             System.out.println("User Event Triggered: " + evt);
-            ctx.fireUserEventTriggered(evt);
+            ctx.fireInboundEventTriggered(evt);
         }
     }
 }

--- a/example/src/main/java/io/netty5/example/http2/helloworld/server/HelloWorldHttp2Handler.java
+++ b/example/src/main/java/io/netty5/example/http2/helloworld/server/HelloWorldHttp2Handler.java
@@ -66,13 +66,13 @@ public final class HelloWorldHttp2Handler extends Http2ConnectionHandler impleme
      * on stream 1 (the stream specifically reserved for cleartext HTTP upgrade).
      */
     @Override
-    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
         if (evt instanceof HttpServerUpgradeHandler.UpgradeEvent) {
             HttpServerUpgradeHandler.UpgradeEvent upgradeEvent =
                     (HttpServerUpgradeHandler.UpgradeEvent) evt;
             onHeadersRead(ctx, 1, http1HeadersToHttp2Headers(upgradeEvent.upgradeRequest()), 0 , true);
         }
-        super.userEventTriggered(ctx, evt);
+        super.inboundEventTriggered(ctx, evt);
     }
 
     @Override

--- a/example/src/main/java/io/netty5/example/http2/helloworld/server/Http2ServerInitializer.java
+++ b/example/src/main/java/io/netty5/example/http2/helloworld/server/Http2ServerInitializer.java
@@ -111,9 +111,9 @@ public class Http2ServerInitializer extends ChannelInitializer<SocketChannel> {
      */
     private static class UserEventLogger implements ChannelHandler {
         @Override
-        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+        public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
             System.out.println("User Event Triggered: " + evt);
-            ctx.fireUserEventTriggered(evt);
+            ctx.fireInboundEventTriggered(evt);
         }
     }
 }

--- a/example/src/main/java/io/netty5/example/uptime/UptimeClientHandler.java
+++ b/example/src/main/java/io/netty5/example/uptime/UptimeClientHandler.java
@@ -46,7 +46,7 @@ public class UptimeClientHandler extends SimpleChannelInboundHandler<Object> {
     }
 
     @Override
-    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
         if (!(evt instanceof IdleStateEvent)) {
             return;
         }

--- a/handler/src/main/java/io/netty5/handler/adaptor/BufferConversionHandler.java
+++ b/handler/src/main/java/io/netty5/handler/adaptor/BufferConversionHandler.java
@@ -81,7 +81,7 @@ public final class BufferConversionHandler implements ChannelHandler {
      * @param onWrite The conversion to apply to all outgoing {@linkplain #write(ChannelHandlerContext, Object)}
      *               messages.
      * @param onUserEvent The conversion to apply to all incoming
-     *                    {@linkplain #userEventTriggered(ChannelHandlerContext, Object) user events}.
+     *                    {@linkplain #inboundEventTriggered(ChannelHandlerContext, Object) user events}.
      */
     public BufferConversionHandler(Conversion onRead, Conversion onWrite, Conversion onUserEvent) {
         this.onRead = onRead;
@@ -117,8 +117,8 @@ public final class BufferConversionHandler implements ChannelHandler {
     }
 
     @Override
-    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
-        ctx.fireUserEventTriggered(onUserEvent.convert(evt));
+    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+        ctx.fireInboundEventTriggered(onUserEvent.convert(evt));
     }
 
     @Override

--- a/handler/src/main/java/io/netty5/handler/logging/LoggingHandler.java
+++ b/handler/src/main/java/io/netty5/handler/logging/LoggingHandler.java
@@ -216,11 +216,11 @@ public class LoggingHandler implements ChannelHandler {
     }
 
     @Override
-    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
         if (logger.isEnabled(internalLevel)) {
             logger.log(internalLevel, format(ctx, "USER_EVENT", evt));
         }
-        ctx.fireUserEventTriggered(evt);
+        ctx.fireInboundEventTriggered(evt);
     }
 
     @Override

--- a/handler/src/main/java/io/netty5/handler/ssl/AbstractSniHandler.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/AbstractSniHandler.java
@@ -157,9 +157,9 @@ public abstract class AbstractSniHandler<T> extends SslClientHelloHandler<T> {
     private static void fireSniCompletionEvent(ChannelHandlerContext ctx, String hostname, Future<?> future) {
         Throwable cause = future.cause();
         if (cause == null) {
-            ctx.fireUserEventTriggered(new SniCompletionEvent(hostname));
+            ctx.fireInboundEventTriggered(new SniCompletionEvent(hostname));
         } else {
-            ctx.fireUserEventTriggered(new SniCompletionEvent(hostname, cause));
+            ctx.fireInboundEventTriggered(new SniCompletionEvent(hostname, cause));
         }
     }
 }

--- a/handler/src/main/java/io/netty5/handler/ssl/ApplicationProtocolNegotiationHandler.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/ApplicationProtocolNegotiationHandler.java
@@ -124,10 +124,10 @@ public abstract class ApplicationProtocolNegotiationHandler implements ChannelHa
     }
 
     @Override
-    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
         if (evt instanceof SslHandshakeCompletionEvent) {
             // Let's first fire the event before we try to modify the pipeline.
-            ctx.fireUserEventTriggered(evt);
+            ctx.fireInboundEventTriggered(evt);
 
             SslHandshakeCompletionEvent handshakeEvent = (SslHandshakeCompletionEvent) evt;
             try {
@@ -155,7 +155,7 @@ public abstract class ApplicationProtocolNegotiationHandler implements ChannelHa
                 }
             }
         } else {
-            ctx.fireUserEventTriggered(evt);
+            ctx.fireInboundEventTriggered(evt);
         }
     }
 

--- a/handler/src/main/java/io/netty5/handler/ssl/SslClientHelloHandler.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslClientHelloHandler.java
@@ -65,8 +65,8 @@ public abstract class SslClientHelloHandler<T> extends ByteToMessageDecoderForBu
                                 NotSslRecordException e = new NotSslRecordException(
                                         "not an SSL/TLS record: " + BufferUtil.hexDump(in));
                                 in.skipReadableBytes(in.readableBytes());
-                                ctx.fireUserEventTriggered(new SniCompletionEvent(e));
-                                ctx.fireUserEventTriggered(new SslHandshakeCompletionEvent(e));
+                                ctx.fireInboundEventTriggered(new SniCompletionEvent(e));
+                                ctx.fireInboundEventTriggered(new SslHandshakeCompletionEvent(e));
                                 throw e;
                             }
                             if (len == SslUtils.NOT_ENOUGH_DATA) {

--- a/handler/src/main/java/io/netty5/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslHandler.java
@@ -78,7 +78,7 @@ import static java.util.Objects.requireNonNull;
  * <p>
  * Beside using the handshake {@link Future} to get notified about the completion of the handshake it's
  * also possible to detect it by implement the
- * {@link ChannelHandler#userEventTriggered(ChannelHandlerContext, Object)}
+ * {@link ChannelHandler#inboundEventTriggered(ChannelHandlerContext, Object)}
  * method and check for a {@link SslHandshakeCompletionEvent}.
  *
  * <h3>Handshake</h3>
@@ -585,7 +585,7 @@ public class SslHandler extends ByteToMessageDecoderForBuffer {
             if (!handshakePromise.isDone()) {
                 cause = new SSLHandshakeException("SslHandler removed before handshake completed");
                 if (handshakePromise.tryFailure(cause)) {
-                    ctx.fireUserEventTriggered(new SslHandshakeCompletionEvent(cause));
+                    ctx.fireInboundEventTriggered(new SslHandshakeCompletionEvent(cause));
                 }
             }
             if (!sslClosePromise.isDone()) {
@@ -1093,7 +1093,7 @@ public class SslHandler extends ByteToMessageDecoderForBuffer {
             // listeners immediately close the Channel then we may end up firing the handshake event after the Channel
             // has been closed.
             if (handshakePromise.tryFailure(cause)) {
-                ctx.fireUserEventTriggered(new SslHandshakeCompletionEvent(cause));
+                ctx.fireInboundEventTriggered(new SslHandshakeCompletionEvent(cause));
             }
 
             // We need to flush one time as there may be an alert that we should send to the remote peer because
@@ -1640,7 +1640,7 @@ public class SslHandler extends ByteToMessageDecoderForBuffer {
                         session.getProtocol(),
                         session.getCipherSuite());
             }
-            ctx.fireUserEventTriggered(SslHandshakeCompletionEvent.SUCCESS);
+            ctx.fireInboundEventTriggered(SslHandshakeCompletionEvent.SUCCESS);
         }
         if (isStateSet(STATE_READ_DURING_HANDSHAKE)) {
             clearState(STATE_READ_DURING_HANDSHAKE);
@@ -1702,7 +1702,7 @@ public class SslHandler extends ByteToMessageDecoderForBuffer {
             SSLException transportFailure = new SSLException("failure when writing TLS control frames", cause);
             releaseAndFailAll(ctx, transportFailure);
             if (handshakePromise.tryFailure(transportFailure)) {
-                ctx.fireUserEventTriggered(new SslHandshakeCompletionEvent(transportFailure));
+                ctx.fireInboundEventTriggered(new SslHandshakeCompletionEvent(transportFailure));
             }
         } finally {
             ctx.close();
@@ -1718,11 +1718,11 @@ public class SslHandler extends ByteToMessageDecoderForBuffer {
     private void notifyClosePromise(Throwable cause) {
         if (cause == null) {
             if (sslClosePromise.trySuccess(ctx.channel())) {
-                ctx.fireUserEventTriggered(SslCloseCompletionEvent.SUCCESS);
+                ctx.fireInboundEventTriggered(SslCloseCompletionEvent.SUCCESS);
             }
         } else {
             if (sslClosePromise.tryFailure(cause)) {
-                ctx.fireUserEventTriggered(new SslCloseCompletionEvent(cause));
+                ctx.fireInboundEventTriggered(new SslCloseCompletionEvent(cause));
             }
         }
     }

--- a/handler/src/main/java/io/netty5/handler/ssl/SslMasterKeyHandler.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslMasterKeyHandler.java
@@ -122,7 +122,7 @@ public abstract class SslMasterKeyHandler implements ChannelHandler {
     protected abstract void accept(SecretKey masterKey, SSLSession session);
 
     @Override
-    public final void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+    public final void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
         //only try to log the session info if the ssl handshake has successfully completed.
         if (evt == SslHandshakeCompletionEvent.SUCCESS && masterKeyHandlerEnabled()) {
             final SslHandler handler = ctx.pipeline().get(SslHandler.class);
@@ -145,7 +145,7 @@ public abstract class SslMasterKeyHandler implements ChannelHandler {
             }
         }
 
-        ctx.fireUserEventTriggered(evt);
+        ctx.fireInboundEventTriggered(evt);
     }
 
     /**

--- a/handler/src/main/java/io/netty5/handler/ssl/SslUtils.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslUtils.java
@@ -421,7 +421,7 @@ final class SslUtils {
         // See https://github.com/netty/netty/issues/3900#issuecomment-172481830
         ctx.flush();
         if (notify) {
-            ctx.fireUserEventTriggered(new SslHandshakeCompletionEvent(cause));
+            ctx.fireInboundEventTriggered(new SslHandshakeCompletionEvent(cause));
         }
     }
 

--- a/handler/src/main/java/io/netty5/handler/ssl/ocsp/OcspClientHandler.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/ocsp/OcspClientHandler.java
@@ -47,8 +47,8 @@ public abstract class OcspClientHandler implements ChannelHandler {
     protected abstract boolean verify(ChannelHandlerContext ctx, ReferenceCountedOpenSslEngine engine) throws Exception;
 
     @Override
-    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
-        ctx.fireUserEventTriggered(evt);
+    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+        ctx.fireInboundEventTriggered(evt);
         if (evt instanceof SslHandshakeCompletionEvent) {
             SslHandshakeCompletionEvent event = (SslHandshakeCompletionEvent) evt;
             if (event.isSuccess() && !verify(ctx, engine)) {

--- a/handler/src/main/java/io/netty5/handler/timeout/IdleStateHandler.java
+++ b/handler/src/main/java/io/netty5/handler/timeout/IdleStateHandler.java
@@ -363,10 +363,10 @@ public class IdleStateHandler implements ChannelHandler {
 
     /**
      * Is called when an {@link IdleStateEvent} should be fired. This implementation calls
-     * {@link ChannelHandlerContext#fireUserEventTriggered(Object)}.
+     * {@link ChannelHandlerContext#fireInboundEventTriggered(Object)}.
      */
     protected void channelIdle(ChannelHandlerContext ctx, IdleStateEvent evt) throws Exception {
-        ctx.fireUserEventTriggered(evt);
+        ctx.fireInboundEventTriggered(evt);
     }
 
     /**

--- a/handler/src/test/java/io/netty5/handler/adaptor/BufferConversionHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/adaptor/BufferConversionHandlerTest.java
@@ -141,17 +141,17 @@ class BufferConversionHandlerTest {
             Buffer userEventBuffer;
 
             @Override
-            public ChannelHandlerContext fireUserEventTriggered(Object evt) {
+            public ChannelHandlerContext fireInboundEventTriggered(Object evt) {
                 userEventBuffer = (Buffer) evt;
                 return this;
             }
         }
         UserEventContext ctx = new UserEventContext();
-        handler.userEventTriggered(ctx, testData.byteBuf);
+        handler.inboundEventTriggered(ctx, testData.byteBuf);
         assertThat(ctx.userEventBuffer).isEqualTo(testData.buffer);
 
         ctx.userEventBuffer = null;
-        handler.userEventTriggered(ctx, testData.buffer);
+        handler.inboundEventTriggered(ctx, testData.buffer);
         assertThat(ctx.userEventBuffer).isSameAs(testData.buffer);
     }
 
@@ -266,7 +266,7 @@ class BufferConversionHandlerTest {
         }
 
         @Override
-        public ChannelHandlerContext fireUserEventTriggered(Object evt) {
+        public ChannelHandlerContext fireInboundEventTriggered(Object evt) {
             throw new UnsupportedOperationException();
         }
 
@@ -342,6 +342,11 @@ class BufferConversionHandlerTest {
 
         @Override
         public Future<Void> writeAndFlush(Object msg) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Future<Void> triggerOutboundEvent(Object event) {
             throw new UnsupportedOperationException();
         }
 

--- a/handler/src/test/java/io/netty5/handler/flow/FlowControlHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/flow/FlowControlHandlerTest.java
@@ -466,11 +466,11 @@ public class FlowControlHandlerTest {
                 }
 
                 @Override
-                public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
                     if (evt instanceof IdleStateEvent) {
                         userEvents.add((IdleStateEvent) evt);
                     }
-                    ctx.fireUserEventTriggered(evt);
+                    ctx.fireInboundEventTriggered(evt);
                 }
             }
         );

--- a/handler/src/test/java/io/netty5/handler/logging/LoggingHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/logging/LoggingHandlerTest.java
@@ -192,7 +192,7 @@ public class LoggingHandlerTest {
     public void shouldLogChannelUserEvent() throws Exception {
         String userTriggered = "iAmCustom!";
         EmbeddedChannel channel = new EmbeddedChannel(new LoggingHandler());
-        channel.pipeline().fireUserEventTriggered(new String(userTriggered));
+        channel.pipeline().fireInboundEventTriggered(new String(userTriggered));
         verify(appender).doAppend(argThat(new RegexLogMatcher(".+USER_EVENT: " + userTriggered + '$')));
     }
 

--- a/handler/src/test/java/io/netty5/handler/ssl/ApplicationProtocolNegotiationHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/ApplicationProtocolNegotiationHandlerTest.java
@@ -81,7 +81,7 @@ public class ApplicationProtocolNegotiationHandlerTest {
         EmbeddedChannel channel = new EmbeddedChannel(alpnHandler);
         SSLHandshakeException exception = new SSLHandshakeException("error");
         SslHandshakeCompletionEvent completionEvent = new SslHandshakeCompletionEvent(exception);
-        channel.pipeline().fireUserEventTriggered(completionEvent);
+        channel.pipeline().fireInboundEventTriggered(completionEvent);
         channel.pipeline().fireExceptionCaught(new DecoderException(exception));
         assertNull(channel.pipeline().context(alpnHandler));
         assertFalse(channel.finishAndReleaseAll());
@@ -120,7 +120,7 @@ public class ApplicationProtocolNegotiationHandlerTest {
             channel.pipeline().addLast(new SslHandler(engine));
             channel.pipeline().addLast(alpnHandler);
         }
-        channel.pipeline().fireUserEventTriggered(SslHandshakeCompletionEvent.SUCCESS);
+        channel.pipeline().fireInboundEventTriggered(SslHandshakeCompletionEvent.SUCCESS);
         assertNull(channel.pipeline().context(alpnHandler));
         // Should produce the close_notify messages
         channel.releaseOutbound();
@@ -139,7 +139,7 @@ public class ApplicationProtocolNegotiationHandlerTest {
             }
         };
         final EmbeddedChannel channel = new EmbeddedChannel(alpnHandler);
-        channel.pipeline().fireUserEventTriggered(SslHandshakeCompletionEvent.SUCCESS);
+        channel.pipeline().fireInboundEventTriggered(SslHandshakeCompletionEvent.SUCCESS);
         assertNull(channel.pipeline().context(alpnHandler));
         assertThrows(IllegalStateException.class, new Executable() {
             @Override
@@ -199,14 +199,14 @@ public class ApplicationProtocolNegotiationHandlerTest {
 
         EmbeddedChannel channel = new EmbeddedChannel(new SslHandler(engine), new ChannelHandler() {
             @Override
-            public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+            public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
                 if (evt == SslHandshakeCompletionEvent.SUCCESS) {
                     ctx.fireChannelRead(someBytes);
                 }
-                ctx.fireUserEventTriggered(evt);
+                ctx.fireInboundEventTriggered(evt);
             }
         }, alpnHandler);
-        channel.pipeline().fireUserEventTriggered(SslHandshakeCompletionEvent.SUCCESS);
+        channel.pipeline().fireInboundEventTriggered(SslHandshakeCompletionEvent.SUCCESS);
         assertNull(channel.pipeline().context(alpnHandler));
         assertArrayEquals(someBytes, channelReadData.get());
         assertTrue(channelReadCompleteCalled.get());

--- a/handler/src/test/java/io/netty5/handler/ssl/CloseNotifyTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/CloseNotifyTest.java
@@ -162,7 +162,7 @@ public class CloseNotifyTest {
             }
 
             @Override
-            public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+            public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
                 eventQueue.add(evt);
             }
 

--- a/handler/src/test/java/io/netty5/handler/ssl/OpenSslCertificateCompressionTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/OpenSslCertificateCompressionTest.java
@@ -397,7 +397,7 @@ public class OpenSslCertificateCompressionTest {
                 }
 
                 @Override
-                public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
                     if (evt instanceof SslHandshakeCompletionEvent) {
                         if (((SslHandshakeCompletionEvent) evt).isSuccess()) {
                             channelPromise.trySuccess(evt);
@@ -405,7 +405,7 @@ public class OpenSslCertificateCompressionTest {
                             channelPromise.tryFailure(((SslHandshakeCompletionEvent) evt).cause());
                         }
                     }
-                    ctx.fireUserEventTriggered(evt);
+                    ctx.fireInboundEventTriggered(evt);
                 }
             });
         }

--- a/handler/src/test/java/io/netty5/handler/ssl/ParameterizedSslHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/ParameterizedSslHandlerTest.java
@@ -170,7 +170,7 @@ public class ParameterizedSslHandlerTest {
                                 private Throwable writeCause;
 
                                 @Override
-                                public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                                public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
                                     if (evt instanceof SslHandshakeCompletionEvent) {
                                         SslHandshakeCompletionEvent sslEvt = (SslHandshakeCompletionEvent) evt;
                                         if (sslEvt.isSuccess()) {
@@ -191,7 +191,7 @@ public class ParameterizedSslHandlerTest {
                                             donePromise.tryFailure(sslEvt.cause());
                                         }
                                     }
-                                    ctx.fireUserEventTriggered(evt);
+                                    ctx.fireInboundEventTriggered(evt);
                                 }
 
                                 @Override
@@ -234,7 +234,7 @@ public class ParameterizedSslHandlerTest {
                                 }
 
                                 @Override
-                                public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                                public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
                                     if (evt instanceof SslHandshakeCompletionEvent) {
                                         SslHandshakeCompletionEvent sslEvt = (SslHandshakeCompletionEvent) evt;
                                         if (!sslEvt.isSuccess()) {
@@ -657,7 +657,7 @@ public class ParameterizedSslHandlerTest {
         }
 
         @Override
-        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+        public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
             if (evt instanceof SslHandshakeCompletionEvent) {
                 SslHandshakeCompletionEvent sslEvt = (SslHandshakeCompletionEvent) evt;
                 if (sslEvt.isSuccess()) {
@@ -667,7 +667,7 @@ public class ParameterizedSslHandlerTest {
                     appendError(sslEvt.cause());
                 }
             }
-            ctx.fireUserEventTriggered(evt);
+            ctx.fireInboundEventTriggered(evt);
         }
 
         @Override

--- a/handler/src/test/java/io/netty5/handler/ssl/RenegotiateTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/RenegotiateTest.java
@@ -71,7 +71,7 @@ public abstract class RenegotiateTest {
                                 }
 
                                 @Override
-                                public void userEventTriggered(
+                                public void inboundEventTriggered(
                                         final ChannelHandlerContext ctx, Object evt) {
                                     if (!renegotiate && evt instanceof SslHandshakeCompletionEvent) {
                                         SslHandshakeCompletionEvent event = (SslHandshakeCompletionEvent) evt;
@@ -116,7 +116,7 @@ public abstract class RenegotiateTest {
                             ch.pipeline().addLast(handler);
                             ch.pipeline().addLast(new ChannelHandler() {
                                 @Override
-                                public void userEventTriggered(
+                                public void inboundEventTriggered(
                                         ChannelHandlerContext ctx, Object evt) {
                                     if (evt instanceof SslHandshakeCompletionEvent) {
                                         SslHandshakeCompletionEvent event = (SslHandshakeCompletionEvent) evt;

--- a/handler/src/test/java/io/netty5/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SSLEngineTest.java
@@ -727,7 +727,7 @@ public abstract class SSLEngineTest {
                 p.addLast(new MessageDelegatorChannelHandler(serverReceiver, serverLatch));
                 p.addLast(new ChannelHandler() {
                     @Override
-                    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+                    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
                         if (evt == SslHandshakeCompletionEvent.SUCCESS) {
                             if (failureExpected) {
                                 serverException = new IllegalStateException("handshake complete. expected failure");
@@ -737,7 +737,7 @@ public abstract class SSLEngineTest {
                             serverException = ((SslHandshakeCompletionEvent) evt).cause();
                             serverLatch.countDown();
                         }
-                        ctx.fireUserEventTriggered(evt);
+                        ctx.fireInboundEventTriggered(evt);
                     }
 
                     @Override
@@ -769,7 +769,7 @@ public abstract class SSLEngineTest {
                 p.addLast(new MessageDelegatorChannelHandler(clientReceiver, clientLatch));
                 p.addLast(new ChannelHandler() {
                     @Override
-                    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+                    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
                         if (evt == SslHandshakeCompletionEvent.SUCCESS) {
                             // With TLS1.3 a mutal auth error will not be propagated as a handshake error most of the
                             // time as the handshake needs NO extra roundtrip.
@@ -780,7 +780,7 @@ public abstract class SSLEngineTest {
                             clientException = ((SslHandshakeCompletionEvent) evt).cause();
                             clientLatch.countDown();
                         }
-                        ctx.fireUserEventTriggered(evt);
+                        ctx.fireInboundEventTriggered(evt);
                     }
 
                     @Override
@@ -894,7 +894,7 @@ public abstract class SSLEngineTest {
                 p.addLast(new MessageDelegatorChannelHandler(serverReceiver, serverLatch));
                 p.addLast(new ChannelHandler() {
                     @Override
-                    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+                    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
                         if (evt == SslHandshakeCompletionEvent.SUCCESS) {
                             if (failureExpected) {
                                 serverException = new IllegalStateException("handshake complete. expected failure");
@@ -904,7 +904,7 @@ public abstract class SSLEngineTest {
                             serverException = ((SslHandshakeCompletionEvent) evt).cause();
                             serverLatch.countDown();
                         }
-                        ctx.fireUserEventTriggered(evt);
+                        ctx.fireInboundEventTriggered(evt);
                     }
 
                     @Override
@@ -956,7 +956,7 @@ public abstract class SSLEngineTest {
                     }
 
                     @Override
-                    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+                    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
                         if (evt == SslHandshakeCompletionEvent.SUCCESS) {
                             if (failureExpected) {
                                 clientException = new IllegalStateException("handshake complete. expected failure");
@@ -966,7 +966,7 @@ public abstract class SSLEngineTest {
                             clientException = ((SslHandshakeCompletionEvent) evt).cause();
                             clientLatch.countDown();
                         }
-                        ctx.fireUserEventTriggered(evt);
+                        ctx.fireInboundEventTriggered(evt);
                     }
 
                     @Override
@@ -1094,7 +1094,7 @@ public abstract class SSLEngineTest {
                     }
 
                     @Override
-                    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+                    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
                         if (evt == SslHandshakeCompletionEvent.SUCCESS) {
                             try {
                                 verifySSLSessionForMutualAuth(
@@ -1126,7 +1126,7 @@ public abstract class SSLEngineTest {
                 p.addLast(new MessageDelegatorChannelHandler(clientReceiver, clientLatch));
                 p.addLast(new ChannelHandler() {
                     @Override
-                    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+                    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
                         if (evt == SslHandshakeCompletionEvent.SUCCESS) {
                             try {
                                 verifySSLSessionForMutualAuth(
@@ -1369,7 +1369,7 @@ public abstract class SSLEngineTest {
                         p.addLast(handler);
                         p.addLast(new ChannelHandler() {
                             @Override
-                            public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                            public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
                                 if (evt instanceof SslHandshakeCompletionEvent &&
                                         ((SslHandshakeCompletionEvent) evt).isSuccess()) {
                                     // This data will be sent to the client before any of the re-negotiation data can be
@@ -1377,7 +1377,7 @@ public abstract class SSLEngineTest {
                                     // renegotiation which was expected, and respond with a fatal alert.
                                     ctx.writeAndFlush(ctx.bufferAllocator().copyOf(new byte[] { 100 }));
                                 }
-                                ctx.fireUserEventTriggered(evt);
+                                ctx.fireInboundEventTriggered(evt);
                             }
 
                             @Override
@@ -1431,7 +1431,7 @@ public abstract class SSLEngineTest {
                         p.addLast(new ChannelHandler() {
                             private int handshakeCount;
                             @Override
-                            public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                            public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
                                 // OpenSSL SSLEngine sends a fatal alert for the renegotiation handshake because the
                                 // user data read as part of the handshake. The client receives this fatal alert and is
                                 // expected to shutdown the connection. The "invalid data" during the renegotiation
@@ -1444,7 +1444,7 @@ public abstract class SSLEngineTest {
                                     ctx.close();
                                     return;
                                 }
-                                ctx.fireUserEventTriggered(evt);
+                                ctx.fireInboundEventTriggered(evt);
                             }
 
                             @Override
@@ -1815,7 +1815,7 @@ public abstract class SSLEngineTest {
                 ch.pipeline().addFirst(sslHandler);
                 ch.pipeline().addLast(new ChannelHandler() {
                     @Override
-                    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+                    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
                         if (evt instanceof SslHandshakeCompletionEvent) {
                             Throwable cause = ((SslHandshakeCompletionEvent) evt).cause();
                             if (cause == null) {

--- a/handler/src/test/java/io/netty5/handler/ssl/SniClientTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SniClientTest.java
@@ -157,7 +157,7 @@ public class SniClientTest {
                     ch.pipeline().addFirst(handler);
                     ch.pipeline().addLast(new ChannelHandler() {
                         @Override
-                        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+                        public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
                             if (evt instanceof SslHandshakeCompletionEvent) {
                                 SslHandshakeCompletionEvent event = (SslHandshakeCompletionEvent) evt;
                                 if (match) {

--- a/handler/src/test/java/io/netty5/handler/ssl/SniHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SniHandlerTest.java
@@ -156,7 +156,7 @@ public class SniHandlerTest {
             SniHandler handler = new SniHandler(new DomainNameMappingBuilder<>(nettyContext).build());
             final EmbeddedChannel ch = new EmbeddedChannel(handler, new ChannelHandler() {
                 @Override
-                public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+                public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
                     if (evt instanceof SslHandshakeCompletionEvent) {
                         assertTrue(evtRef.compareAndSet(null, (SslHandshakeCompletionEvent) evt));
                     }
@@ -202,11 +202,11 @@ public class SniHandlerTest {
             SniHandler handler = new SniHandler(mapping);
             EmbeddedChannel ch = new EmbeddedChannel(handler, new ChannelHandler() {
                 @Override
-                public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+                public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
                     if (evt instanceof SniCompletionEvent) {
                         assertTrue(evtRef.compareAndSet(null, (SniCompletionEvent) evt));
                     } else {
-                        ctx.fireUserEventTriggered(evt);
+                        ctx.fireInboundEventTriggered(evt);
                     }
                 }
             });

--- a/handler/src/test/java/io/netty5/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SslHandlerTest.java
@@ -192,7 +192,7 @@ public class SslHandlerTest {
             }
         }, new ChannelHandler() {
             @Override
-            public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+            public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
                 if (evt instanceof SslHandshakeCompletionEvent) {
                     throw (Exception) ((SslHandshakeCompletionEvent) evt).cause();
                 }
@@ -282,7 +282,7 @@ public class SslHandlerTest {
         final AtomicReference<Throwable> closeRef = new AtomicReference<>();
         EmbeddedChannel ch = new EmbeddedChannel(handler, new ChannelHandler() {
             @Override
-            public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+            public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
                 if (evt instanceof SslHandshakeCompletionEvent) {
                     handshakeRef.set(((SslHandshakeCompletionEvent) evt).cause());
                 } else if (evt instanceof SslCloseCompletionEvent) {
@@ -572,7 +572,7 @@ public class SslHandlerTest {
         final BlockingQueue<SslCompletionEvent> events = new LinkedBlockingQueue<>();
         EmbeddedChannel channel = new EmbeddedChannel(new SslHandler(engine), new ChannelHandler() {
             @Override
-            public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+            public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
                 if (evt instanceof SslCompletionEvent) {
                     events.add((SslCompletionEvent) evt);
                 }
@@ -627,7 +627,7 @@ public class SslHandlerTest {
                           }
 
                           @Override
-                          public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                          public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
                               logger.debug("[testHandshakeFailBeforeWritePromise] server user event triggered: " + evt);
                               if (evt instanceof SslCompletionEvent) {
                                   events.add(evt);
@@ -1330,7 +1330,7 @@ public class SslHandlerTest {
                                 private int handshakeCount;
 
                                 @Override
-                                public void userEventTriggered(ChannelHandlerContext ctx, Object evt)  {
+                                public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt)  {
                                     if (evt instanceof SslHandshakeCompletionEvent) {
                                         handshakeCount++;
                                         ReferenceCountedOpenSslEngine engine =
@@ -1610,11 +1610,11 @@ public class SslHandlerTest {
             }
 
             @Override
-            public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+            public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
                 if (evt instanceof SslHandshakeCompletionEvent) {
                     ref.set((SslHandshakeCompletionEvent) evt);
                 }
-                ctx.fireUserEventTriggered(evt);
+                ctx.fireInboundEventTriggered(evt);
             }
         }
         final AtomicReference<SslHandshakeCompletionEvent> clientEvent =
@@ -1771,7 +1771,7 @@ public class SslHandlerTest {
         }
 
         @Override
-        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+        public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
             if (evt instanceof SslHandshakeCompletionEvent) {
                 completionEvents.add((SslHandshakeCompletionEvent) evt);
             }

--- a/handler/src/test/java/io/netty5/handler/timeout/AbstractIdleStateHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/timeout/AbstractIdleStateHandlerTest.java
@@ -73,7 +73,7 @@ public abstract class AbstractIdleStateHandlerTest {
         final List<Object> events = new ArrayList<>();
         ChannelHandler handler = new ChannelHandler() {
             @Override
-            public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+            public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
                 events.add(evt);
             }
         };
@@ -144,7 +144,7 @@ public abstract class AbstractIdleStateHandlerTest {
         final List<Object> events = new ArrayList<>();
         ChannelHandler handler = new ChannelHandler() {
             @Override
-            public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+            public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
                 events.add(evt);
             }
         };
@@ -206,7 +206,7 @@ public abstract class AbstractIdleStateHandlerTest {
         final List<Object> events = new ArrayList<>();
         ChannelHandler handler = new ChannelHandler() {
             @Override
-            public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+            public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
                 events.add(evt);
             }
         };

--- a/microbench/src/main/java/io/netty5/microbench/channel/EmbeddedChannelHandlerContext.java
+++ b/microbench/src/main/java/io/netty5/microbench/channel/EmbeddedChannelHandlerContext.java
@@ -121,7 +121,7 @@ public abstract class EmbeddedChannelHandlerContext implements ChannelHandlerCon
     }
 
     @Override
-    public final ChannelHandlerContext fireUserEventTriggered(Object event) {
+    public final ChannelHandlerContext fireInboundEventTriggered(Object event) {
         Resource.dispose(event);
         return this;
     }
@@ -243,6 +243,11 @@ public abstract class EmbeddedChannelHandlerContext implements ChannelHandlerCon
     public ChannelHandlerContext flush() {
         channel().flush();
         return this;
+    }
+
+    @Override
+    public Future<Void> triggerOutboundEvent(Object event) {
+        return channel().triggerOutboundEvent(event);
     }
 
     @Override

--- a/testsuite-http2/src/main/java/io/netty5/testsuite/http2/HelloWorldHttp2Handler.java
+++ b/testsuite-http2/src/main/java/io/netty5/testsuite/http2/HelloWorldHttp2Handler.java
@@ -70,13 +70,13 @@ public final class HelloWorldHttp2Handler extends Http2ConnectionHandler impleme
      * on stream 1 (the stream specifically reserved for cleartext HTTP upgrade).
      */
     @Override
-    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
         if (evt instanceof HttpServerUpgradeHandler.UpgradeEvent) {
             HttpServerUpgradeHandler.UpgradeEvent upgradeEvent =
                     (HttpServerUpgradeHandler.UpgradeEvent) evt;
             onHeadersRead(ctx, 1, http1HeadersToHttp2Headers(upgradeEvent.upgradeRequest()), 0 , true);
         }
-        super.userEventTriggered(ctx, evt);
+        super.inboundEventTriggered(ctx, evt);
     }
 
     @Override

--- a/testsuite-http2/src/main/java/io/netty5/testsuite/http2/Http2ServerInitializer.java
+++ b/testsuite-http2/src/main/java/io/netty5/testsuite/http2/Http2ServerInitializer.java
@@ -99,9 +99,9 @@ public class Http2ServerInitializer extends ChannelInitializer<SocketChannel> {
      */
     private static class UserEventLogger implements ChannelHandler {
         @Override
-        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+        public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
             System.out.println("User Event Triggered: " + evt);
-            ctx.fireUserEventTriggered(evt);
+            ctx.fireInboundEventTriggered(evt);
         }
     }
 }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
@@ -242,7 +242,7 @@ public class SocketSslClientRenegotiateTest extends AbstractSocketTest {
         }
 
         @Override
-        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+        public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
             if (evt instanceof SslHandshakeCompletionEvent) {
                 SslHandshakeCompletionEvent handshakeEvt = (SslHandshakeCompletionEvent) evt;
                 if (handshakeCounter == 0) {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslEchoTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslEchoTest.java
@@ -298,11 +298,11 @@ public class SocketSslEchoTest extends AbstractSocketTest {
                 sch.pipeline().addLast("clientHandler", clientHandler);
                 sch.pipeline().addLast(new ChannelHandler() {
                     @Override
-                    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
                         if (evt instanceof SslHandshakeCompletionEvent) {
                             clientHandshakeEventLatch.countDown();
                         }
-                        ctx.fireUserEventTriggered(evt);
+                        ctx.fireInboundEventTriggered(evt);
                     }
                 });
             }
@@ -480,7 +480,7 @@ public class SocketSslEchoTest extends AbstractSocketTest {
         }
 
         @Override
-        public final void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+        public final void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
             if (evt instanceof SslHandshakeCompletionEvent) {
                 SslHandshakeCompletionEvent handshakeEvt = (SslHandshakeCompletionEvent) evt;
                 if (handshakeEvt.cause() != null) {
@@ -490,7 +490,7 @@ public class SocketSslEchoTest extends AbstractSocketTest {
                 negoCounter.incrementAndGet();
                 logStats("HANDSHAKEN");
             }
-            ctx.fireUserEventTriggered(evt);
+            ctx.fireInboundEventTriggered(evt);
         }
 
         @Override

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslGreetingTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslGreetingTest.java
@@ -230,7 +230,7 @@ public class SocketSslGreetingTest extends AbstractSocketTest {
         }
 
         @Override
-        public void userEventTriggered(final ChannelHandlerContext ctx, final Object evt) throws Exception {
+        public void inboundEventTriggered(final ChannelHandlerContext ctx, final Object evt) throws Exception {
             if (evt instanceof SslHandshakeCompletionEvent) {
                 final SslHandshakeCompletionEvent event = (SslHandshakeCompletionEvent) evt;
                 if (event.isSuccess()) {
@@ -261,7 +261,7 @@ public class SocketSslGreetingTest extends AbstractSocketTest {
                     }
                 }
             }
-            ctx.fireUserEventTriggered(evt);
+            ctx.fireInboundEventTriggered(evt);
         }
     }
 }

--- a/transport-blockhound-tests/src/test/java/io/netty5/util/internal/NettyBlockHoundIntegrationTest.java
+++ b/transport-blockhound-tests/src/test/java/io/netty5/util/internal/NettyBlockHoundIntegrationTest.java
@@ -307,14 +307,14 @@ public class NettyBlockHoundIntegrationTest {
                                 }
 
                                 @Override
-                                public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                                public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
                                     if (evt instanceof SslHandshakeCompletionEvent &&
                                             ((SslHandshakeCompletionEvent) evt).cause() != null) {
                                         Throwable cause = ((SslHandshakeCompletionEvent) evt).cause();
                                         cause.printStackTrace();
                                         error.set(cause);
                                     }
-                                    ctx.fireUserEventTriggered(evt);
+                                    ctx.fireInboundEventTriggered(evt);
                                 }
                             });
                         }
@@ -460,12 +460,12 @@ public class NettyBlockHoundIntegrationTest {
                               .addLast(new ChannelHandler() {
 
                                   @Override
-                                  public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                                  public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
                                       if (evt instanceof SslHandshakeCompletionEvent &&
                                               ((SslHandshakeCompletionEvent) evt).cause() != null) {
                                           ((SslHandshakeCompletionEvent) evt).cause().printStackTrace();
                                       }
-                                      ctx.fireUserEventTriggered(evt);
+                                      ctx.fireInboundEventTriggered(evt);
                                   }
                               });
                         }

--- a/transport/src/main/java/io/netty5/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty5/channel/AbstractChannel.java
@@ -823,6 +823,12 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             return exception;
         }
 
+        @Override
+        public void triggerOutboundEvent(Object event, Promise<Void> promise) {
+            Resource.dispose(event);
+            promise.setSuccess(null);
+        }
+
         protected final boolean ensureOpen(Promise<Void> promise) {
             if (isOpen()) {
                 return true;

--- a/transport/src/main/java/io/netty5/channel/Channel.java
+++ b/transport/src/main/java/io/netty5/channel/Channel.java
@@ -27,7 +27,6 @@ import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.Promise;
 
 import java.net.InetSocketAddress;
-import java.net.Socket;
 import java.net.SocketAddress;
 
 
@@ -291,6 +290,11 @@ public interface Channel extends AttributeMap, ChannelOutboundInvoker, Comparabl
         return this;
     }
 
+    @Override
+    default Future<Void> triggerOutboundEvent(Object event) {
+        return pipeline().triggerOutboundEvent(event);
+    }
+
     /**
      * <em>Unsafe</em> operations that should <em>never</em> be called from user-code. These methods
      * are only provided to implement the actual transport, and must be invoked from an I/O thread except for the
@@ -389,6 +393,11 @@ public interface Channel extends AttributeMap, ChannelOutboundInvoker, Comparabl
          * Flush out all write operations scheduled via {@link #write(Object, Promise)}.
          */
         void flush();
+
+        /**
+         * Trigger a custom outbound event.
+         */
+        void triggerOutboundEvent(Object event, Promise<Void> promise);
 
         /**
          * Returns the {@link ChannelOutboundBuffer} of the {@link Channel} where the pending write requests are stored.

--- a/transport/src/main/java/io/netty5/channel/ChannelHandler.java
+++ b/transport/src/main/java/io/netty5/channel/ChannelHandler.java
@@ -32,7 +32,6 @@ import java.net.SocketAddress;
  * Handles an I/O event or intercepts an I/O operation, and forwards it to its next handler in
  * its {@link ChannelPipeline}.
  *
- *
  * <h3>The context object</h3>
  * <p>
  * A {@link ChannelHandler} is provided with a {@link ChannelHandlerContext}
@@ -262,11 +261,11 @@ public interface ChannelHandler {
     }
 
     /**
-     * Gets called if an user event was triggered.
+     * Gets called if a custom inbound event was triggered.
      */
     @Skip
-    default void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
-        ctx.fireUserEventTriggered(evt);
+    default void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+        ctx.fireInboundEventTriggered(evt);
     }
 
     /**
@@ -400,5 +399,18 @@ public interface ChannelHandler {
     @Skip
     default void flush(ChannelHandlerContext ctx) {
         ctx.flush();
+    }
+
+    /**
+     * Called once a custom defined outbound event was triggered. This operation will pass the event through the
+     * {@link ChannelPipeline}.
+     *
+     * @param ctx               the {@link ChannelHandlerContext} for which the operation is made.
+     * @param event             the event.
+     * @return                  the {@link Future} which will be notified once the operation completes.
+     */
+    @Skip
+    default Future<Void> triggerOutboundEvent(ChannelHandlerContext ctx, Object event) {
+        return ctx.triggerOutboundEvent(event);
     }
 }

--- a/transport/src/main/java/io/netty5/channel/ChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty5/channel/ChannelHandlerContext.java
@@ -118,7 +118,7 @@ public interface ChannelHandlerContext extends ChannelInboundInvoker, ChannelOut
     ChannelHandlerContext fireExceptionCaught(Throwable cause);
 
     @Override
-    ChannelHandlerContext fireUserEventTriggered(Object evt);
+    ChannelHandlerContext fireInboundEventTriggered(Object evt);
 
     @Override
     ChannelHandlerContext fireChannelRead(Object msg);

--- a/transport/src/main/java/io/netty5/channel/ChannelHandlerMask.java
+++ b/transport/src/main/java/io/netty5/channel/ChannelHandlerMask.java
@@ -41,10 +41,11 @@ final class ChannelHandlerMask {
     static final int MASK_CHANNEL_UNREGISTERED = 1 << 2;
     static final int MASK_CHANNEL_ACTIVE = 1 << 3;
     static final int MASK_CHANNEL_INACTIVE = 1 << 4;
+
     static final int MASK_CHANNEL_SHUTDOWN = 1 << 5;
     static final int MASK_CHANNEL_READ = 1 << 6;
     static final int MASK_CHANNEL_READ_COMPLETE = 1 << 7;
-    static final int MASK_USER_EVENT_TRIGGERED = 1 << 8;
+    static final int MASK_CUSTOM_INBOUND_EVENT_TRIGGERED = 1 << 8;
     static final int MASK_CHANNEL_WRITABILITY_CHANGED = 1 << 9;
     static final int MASK_BIND = 1 << 10;
     static final int MASK_CONNECT = 1 << 11;
@@ -56,13 +57,15 @@ final class ChannelHandlerMask {
     static final int MASK_READ = 1 << 17;
     static final int MASK_WRITE = 1 << 18;
     static final int MASK_FLUSH = 1 << 19;
+    static final int MASK_TRIGGER_CUSTOM_OUTBOUND_EVENT = 1 << 20;
 
     private static final int MASK_ALL_INBOUND = MASK_EXCEPTION_CAUGHT | MASK_CHANNEL_REGISTERED |
             MASK_CHANNEL_UNREGISTERED | MASK_CHANNEL_ACTIVE | MASK_CHANNEL_INACTIVE | MASK_CHANNEL_SHUTDOWN |
-            MASK_CHANNEL_READ | MASK_CHANNEL_READ_COMPLETE | MASK_USER_EVENT_TRIGGERED |
-            MASK_CHANNEL_WRITABILITY_CHANGED;
+            MASK_CHANNEL_READ | MASK_CHANNEL_READ_COMPLETE  | MASK_CHANNEL_WRITABILITY_CHANGED |
+            MASK_CUSTOM_INBOUND_EVENT_TRIGGERED;
     private static final int MASK_ALL_OUTBOUND = MASK_BIND | MASK_CONNECT | MASK_DISCONNECT |
-            MASK_CLOSE | MASK_SHUTDOWN | MASK_REGISTER | MASK_DEREGISTER | MASK_READ | MASK_WRITE | MASK_FLUSH;
+            MASK_CLOSE | MASK_SHUTDOWN | MASK_REGISTER | MASK_DEREGISTER | MASK_READ | MASK_WRITE | MASK_FLUSH |
+            MASK_TRIGGER_CUSTOM_OUTBOUND_EVENT;
 
     private static final FastThreadLocal<Map<Class<? extends ChannelHandler>, Integer>> MASKS =
             new FastThreadLocal<>() {
@@ -133,8 +136,8 @@ final class ChannelHandlerMask {
             if (isSkippable(handlerType, "channelWritabilityChanged", ChannelHandlerContext.class)) {
                 mask &= ~MASK_CHANNEL_WRITABILITY_CHANGED;
             }
-            if (isSkippable(handlerType, "userEventTriggered", ChannelHandlerContext.class, Object.class)) {
-                mask &= ~MASK_USER_EVENT_TRIGGERED;
+            if (isSkippable(handlerType, "inboundEventTriggered", ChannelHandlerContext.class, Object.class)) {
+                mask &= ~MASK_CUSTOM_INBOUND_EVENT_TRIGGERED;
             }
             if (isSkippable(handlerType, "bind", ChannelHandlerContext.class, SocketAddress.class)) {
                 mask &= ~MASK_BIND;
@@ -167,6 +170,9 @@ final class ChannelHandlerMask {
             }
             if (isSkippable(handlerType, "flush", ChannelHandlerContext.class)) {
                 mask &= ~MASK_FLUSH;
+            }
+            if (isSkippable(handlerType, "triggerOutboundEvent", ChannelHandlerContext.class, Object.class)) {
+                mask &= ~MASK_TRIGGER_CUSTOM_OUTBOUND_EVENT;
             }
         } catch (Exception e) {
             // Should never reach here.

--- a/transport/src/main/java/io/netty5/channel/ChannelInboundInvoker.java
+++ b/transport/src/main/java/io/netty5/channel/ChannelInboundInvoker.java
@@ -73,13 +73,13 @@ public interface ChannelInboundInvoker {
     ChannelInboundInvoker fireExceptionCaught(Throwable cause);
 
     /**
-     * A {@link Channel} received an user defined event.
+     * A {@link Channel} received a custom defined inbound event.
      *
-     * This will result in having the  {@link ChannelHandler#userEventTriggered(ChannelHandlerContext, Object)}
-     * method  called of the next  {@link ChannelHandler} contained in the  {@link ChannelPipeline} of the
+     * This will result in having the {@link ChannelHandler#inboundEventTriggered(ChannelHandlerContext, Object)}
+     * method  called of the next {@link ChannelHandler} contained in the {@link ChannelPipeline} of the
      * {@link Channel}.
      */
-    ChannelInboundInvoker fireUserEventTriggered(Object event);
+    ChannelInboundInvoker fireInboundEventTriggered(Object event);
 
     /**
      * A {@link Channel} received a message.

--- a/transport/src/main/java/io/netty5/channel/ChannelOutboundInvoker.java
+++ b/transport/src/main/java/io/netty5/channel/ChannelOutboundInvoker.java
@@ -164,6 +164,17 @@ public interface ChannelOutboundInvoker {
     Future<Void> writeAndFlush(Object msg);
 
     /**
+     * Trigger a custom outbound event via this {@link ChannelOutboundInvoker} through the
+     * {@link ChannelPipeline}.
+     * <p>
+     * This will result in having the
+     * {@link ChannelHandler#triggerOutboundEvent(ChannelHandlerContext, Object)}
+     * method called of the next {@link ChannelHandler} contained in the {@link ChannelPipeline} of the
+     * {@link Channel}.
+     */
+    Future<Void> triggerOutboundEvent(Object event);
+
+    /**
      * Return a new {@link Promise}.
      */
     default Promise<Void> newPromise() {

--- a/transport/src/main/java/io/netty5/channel/ChannelPipeline.java
+++ b/transport/src/main/java/io/netty5/channel/ChannelPipeline.java
@@ -132,7 +132,7 @@ import java.util.NoSuchElementException;
  *     <li>{@link ChannelHandlerContext#fireChannelRead(Object)}</li>
  *     <li>{@link ChannelHandlerContext#fireChannelReadComplete()}</li>
  *     <li>{@link ChannelHandlerContext#fireExceptionCaught(Throwable)}</li>
- *     <li>{@link ChannelHandlerContext#fireUserEventTriggered(Object)}</li>
+ *     <li>{@link ChannelHandlerContext#fireInboundEventTriggered(Object)}</li>
  *     <li>{@link ChannelHandlerContext#fireChannelWritabilityChanged()}</li>
  *     <li>{@link ChannelHandlerContext#fireChannelInactive()}</li>
  *     <li>{@link ChannelHandlerContext#fireChannelShutdown(ChannelShutdownDirection)}</li>
@@ -528,7 +528,7 @@ public interface ChannelPipeline
     ChannelPipeline fireExceptionCaught(Throwable cause);
 
     @Override
-    ChannelPipeline fireUserEventTriggered(Object event);
+    ChannelPipeline fireInboundEventTriggered(Object event);
 
     @Override
     ChannelPipeline fireChannelRead(Object msg);

--- a/transport/src/main/java/io/netty5/channel/CombinedChannelDuplexHandler.java
+++ b/transport/src/main/java/io/netty5/channel/CombinedChannelDuplexHandler.java
@@ -210,12 +210,12 @@ public class CombinedChannelDuplexHandler<I extends ChannelHandler, O extends Ch
     }
 
     @Override
-    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
-        assert ctx == inboundCtx.delegatingCtx();
+    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+            assert ctx == inboundCtx.delegatingCtx();
         if (!inboundCtx.removed) {
-            inboundHandler.userEventTriggered(inboundCtx, evt);
+            inboundHandler.inboundEventTriggered(inboundCtx, evt);
         } else {
-            inboundCtx.fireUserEventTriggered(evt);
+            inboundCtx.fireInboundEventTriggered(evt);
         }
     }
 

--- a/transport/src/main/java/io/netty5/channel/SimpleUserEventChannelHandler.java
+++ b/transport/src/main/java/io/netty5/channel/SimpleUserEventChannelHandler.java
@@ -89,7 +89,7 @@ public abstract class SimpleUserEventChannelHandler<I> implements ChannelHandler
     }
 
     @Override
-    public final void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+    public final void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
         boolean release = true;
         try {
             if (acceptEvent(evt)) {
@@ -98,7 +98,7 @@ public abstract class SimpleUserEventChannelHandler<I> implements ChannelHandler
                 eventReceived(ctx, ievt);
             } else {
                 release = false;
-                ctx.fireUserEventTriggered(evt);
+                ctx.fireInboundEventTriggered(evt);
             }
         } finally {
             if (autoRelease && release) {

--- a/transport/src/main/java/io/netty5/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty5/channel/embedded/EmbeddedChannel.java
@@ -901,6 +901,12 @@ public class EmbeddedChannel extends AbstractChannel {
             }
 
             @Override
+            public void triggerOutboundEvent(Object event, Promise<Void> promise) {
+                EmbeddedUnsafe.this.triggerOutboundEvent(event, promise);
+                mayRunPendingTasks();
+            }
+
+            @Override
             public ChannelOutboundBuffer outboundBuffer() {
                 return EmbeddedUnsafe.this.outboundBuffer();
             }

--- a/transport/src/main/java/io/netty5/channel/internal/DelegatingChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty5/channel/internal/DelegatingChannelHandlerContext.java
@@ -103,8 +103,8 @@ public abstract class DelegatingChannelHandlerContext implements ChannelHandlerC
     }
 
     @Override
-    public ChannelHandlerContext fireUserEventTriggered(Object evt) {
-        ctx.fireUserEventTriggered(evt);
+    public ChannelHandlerContext fireInboundEventTriggered(Object evt) {
+        ctx.fireInboundEventTriggered(evt);
         return this;
     }
 
@@ -137,6 +137,11 @@ public abstract class DelegatingChannelHandlerContext implements ChannelHandlerC
     public ChannelHandlerContext flush() {
         ctx.flush();
         return this;
+    }
+
+    @Override
+    public Future<Void> triggerOutboundEvent(Object event) {
+        return ctx.triggerOutboundEvent(event);
     }
 
     @Override

--- a/transport/src/test/java/io/netty5/channel/CombinedChannelDuplexHandlerTest.java
+++ b/transport/src/test/java/io/netty5/channel/CombinedChannelDuplexHandlerTest.java
@@ -234,7 +234,7 @@ public class CombinedChannelDuplexHandlerTest {
         channel.pipeline().fireChannelRead(MSG);
         channel.pipeline().fireChannelReadComplete();
         channel.pipeline().fireExceptionCaught(CAUSE);
-        channel.pipeline().fireUserEventTriggered(USER_EVENT);
+        channel.pipeline().fireInboundEventTriggered(USER_EVENT);
         channel.pipeline().fireChannelWritabilityChanged();
         channel.pipeline().fireChannelInactive();
         channel.pipeline().fireChannelUnregistered();
@@ -307,7 +307,7 @@ public class CombinedChannelDuplexHandlerTest {
         }
 
         @Override
-        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+        public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
             queue.add(Event.USER_EVENT_TRIGGERED);
         }
 

--- a/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTailTest.java
+++ b/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTailTest.java
@@ -154,7 +154,7 @@ public class DefaultChannelPipelineTailTest {
         };
 
         try {
-            myChannel.pipeline().fireUserEventTriggered("testOnUnhandledInboundUserEventTriggered");
+            myChannel.pipeline().fireInboundEventTriggered("testOnUnhandledInboundUserEventTriggered");
             assertTrue(latch.await(1L, TimeUnit.SECONDS));
         } finally {
             myChannel.close();

--- a/transport/src/test/java/io/netty5/channel/LoggingHandler.java
+++ b/transport/src/test/java/io/netty5/channel/LoggingHandler.java
@@ -143,9 +143,9 @@ final class LoggingHandler implements ChannelHandler {
     }
 
     @Override
-    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
         log(Event.USER, evt.toString());
-        ctx.fireUserEventTriggered(evt);
+        ctx.fireInboundEventTriggered(evt);
     }
 
     String getLog() {

--- a/transport/src/test/java/io/netty5/channel/SimpleUserEventChannelHandlerTest.java
+++ b/transport/src/test/java/io/netty5/channel/SimpleUserEventChannelHandlerTest.java
@@ -44,7 +44,7 @@ public class SimpleUserEventChannelHandlerTest {
     @Test
     public void testTypeMatch() {
         FooEvent fooEvent = new FooEvent();
-        channel.pipeline().fireUserEventTriggered(fooEvent);
+        channel.pipeline().fireInboundEventTriggered(fooEvent);
         assertEquals(1, fooEventCatcher.caughtEvents.size());
         assertEquals(0, allEventCatcher.caughtEvents.size());
         assertEquals(0, fooEvent.refCnt());
@@ -54,7 +54,7 @@ public class SimpleUserEventChannelHandlerTest {
     @Test
     public void testTypeMismatch() {
         BarEvent barEvent = new BarEvent();
-        channel.pipeline().fireUserEventTriggered(barEvent);
+        channel.pipeline().fireInboundEventTriggered(barEvent);
         assertEquals(0, fooEventCatcher.caughtEvents.size());
         assertEquals(1, allEventCatcher.caughtEvents.size());
         assertTrue(barEvent.release());
@@ -96,7 +96,7 @@ public class SimpleUserEventChannelHandlerTest {
         }
 
         @Override
-        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+        public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
             caughtEvents.add(evt);
         }
     }


### PR DESCRIPTION
Motivation:

In the past it was only possible to send "custom events" in the inbound direction of the pipeline. There are some cases when it would also be useful to send these in the outbound direction. In this cases we used write(...) which is kind of odd and not consistent.

Modifications:

- Add triggerOutboundEvent(...) method and callbacks
- Rename userEventTriggered(...) to inboundEventTriggered(...) to make it more clear that its not only for user events and also to make it more consistent in terms of naming

Result:

Be able to let custom events flow in both directions of the pipeline
