### PR TITLE
Exception from release should not shadow encode exception

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/MessageToMessageEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/MessageToMessageEncoder.java
@@ -23,6 +23,7 @@ import io.netty.channel.ChannelPromise;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.ReferenceCounted;
 import io.netty.util.concurrent.PromiseCombiner;
+import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.TypeParameterMatcher;
 
@@ -89,7 +90,7 @@ public abstract class MessageToMessageEncoder<I> extends ChannelOutboundHandlerA
                     encode(ctx, cast, out);
                 } catch (Throwable th) {
                     ReferenceCountUtil.safeRelease(cast);
-                    throw th;
+                    PlatformDependent.throwException(th);
                 }
                 ReferenceCountUtil.release(cast);
 

--- a/codec/src/main/java/io/netty/handler/codec/MessageToMessageEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/MessageToMessageEncoder.java
@@ -87,9 +87,11 @@ public abstract class MessageToMessageEncoder<I> extends ChannelOutboundHandlerA
                 I cast = (I) msg;
                 try {
                     encode(ctx, cast, out);
-                } finally {
-                    ReferenceCountUtil.release(cast);
+                } catch (Throwable th) {
+                    ReferenceCountUtil.safeRelease(cast);
+                    throw th;
                 }
+                ReferenceCountUtil.release(cast);
 
                 if (out.isEmpty()) {
                     throw new EncoderException(


### PR DESCRIPTION
Motivation:
Since release may throw, we can end up shadowing a root cause exception if we release from a finally-clause.

Modification:
In MessageToMessageEncoder, if encode() throws an exception, we release using safeRelease(), which will not throw.
Otherwise we release with release() like usual.

Result:
Exceptions from encode() in MessageToMessageEncoder can no longer be shadowed by exceptions from release().

Fixes #12499