### PR TITLE
Make naming of methods more consistent in terms of if these handle in…

### DIFF
--- a/codec-http/src/main/java/io/netty5/handler/codec/http/HttpClientCodec.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/HttpClientCodec.java
@@ -325,7 +325,7 @@ public final class HttpClientCodec extends CombinedChannelDuplexHandler<HttpResp
             if (failOnMissingResponse) {
                 long missingResponses = requestResponseCounter.get();
                 if (missingResponses > 0) {
-                    ctx.fireExceptionCaught(new PrematureChannelClosureException(
+                    ctx.fireChannelExceptionCaught(new PrematureChannelClosureException(
                             "channel gone inactive with " + missingResponses +
                             " missing response(s)"));
                 }

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/HttpClientUpgradeHandler.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/HttpClientUpgradeHandler.java
@@ -138,7 +138,7 @@ public class HttpClientUpgradeHandler<C extends HttpContent<C>> extends HttpObje
         Future<Void> f = ctx.write(msg);
 
         // Notify that the upgrade request was issued.
-        ctx.fireInboundEventTriggered(UpgradeEvent.UPGRADE_ISSUED);
+        ctx.fireChannelInboundEvent(UpgradeEvent.UPGRADE_ISSUED);
         // Now we wait for the next HTTP response to see if we switch protocols.
         return f;
     }
@@ -159,7 +159,7 @@ public class HttpClientUpgradeHandler<C extends HttpContent<C>> extends HttpObje
                     // and continue processing HTTP.
                     // NOTE: not releasing the response since we're letting it propagate to the
                     // next handler.
-                    ctx.fireInboundEventTriggered(UpgradeEvent.UPGRADE_REJECTED);
+                    ctx.fireChannelInboundEvent(UpgradeEvent.UPGRADE_REJECTED);
                     ctx.fireChannelRead(msg);
                     removeThisHandler(ctx);
                     return;
@@ -186,7 +186,7 @@ public class HttpClientUpgradeHandler<C extends HttpContent<C>> extends HttpObje
             if (response != null && response.isAccessible()) {
                 response.close();
             }
-            ctx.fireExceptionCaught(t);
+            ctx.fireChannelExceptionCaught(t);
             removeThisHandler(ctx);
         }
     }
@@ -204,14 +204,14 @@ public class HttpClientUpgradeHandler<C extends HttpContent<C>> extends HttpObje
             upgradeCodec.upgradeTo(ctx, response.send());
 
             // Notify that the upgrade to the new protocol completed successfully.
-            ctx.fireInboundEventTriggered(UpgradeEvent.UPGRADE_SUCCESSFUL);
+            ctx.fireChannelInboundEvent(UpgradeEvent.UPGRADE_SUCCESSFUL);
 
             // We guarantee UPGRADE_SUCCESSFUL event will be arrived at the next handler
             // before http2 setting frame and http response.
             sourceCodec.upgradeFrom(ctx);
             removeThisHandler(ctx);
         } catch (Throwable t) {
-            ctx.fireExceptionCaught(t);
+            ctx.fireChannelExceptionCaught(t);
             removeThisHandler(ctx);
         }
     }

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/HttpContentDecoder.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/HttpContentDecoder.java
@@ -259,7 +259,7 @@ public abstract class HttpContentDecoder extends MessageToMessageDecoder<HttpObj
         } catch (Throwable cause) {
             // If cleanup throws any error we need to propagate it through the pipeline
             // so we don't fail to propagate pipeline events.
-            ctx.fireExceptionCaught(cause);
+            ctx.fireChannelExceptionCaught(cause);
         }
     }
 

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/HttpContentEncoder.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/HttpContentEncoder.java
@@ -341,7 +341,7 @@ public abstract class HttpContentEncoder extends MessageToMessageCodec<HttpReque
         } catch (Throwable cause) {
             // If cleanup throws any error we need to propagate it through the pipeline
             // so we don't fail to propagate pipeline events.
-            ctx.fireExceptionCaught(cause);
+            ctx.fireChannelExceptionCaught(cause);
         }
     }
 

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/HttpObjectAggregator.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/HttpObjectAggregator.java
@@ -165,14 +165,14 @@ public class HttpObjectAggregator<C extends HttpContent<C>>
                                                      ChannelPipeline pipeline) {
         if (HttpUtil.isUnsupportedExpectation(start)) {
             // if the request contains an unsupported expectation, we return 417
-            pipeline.fireInboundEventTriggered(HttpExpectationFailedEvent.INSTANCE);
+            pipeline.fireChannelInboundEvent(HttpExpectationFailedEvent.INSTANCE);
             return newErrorResponse(EXPECTATION_FAILED, pipeline.channel().bufferAllocator(), true, false);
         } else if (HttpUtil.is100ContinueExpected(start)) {
             // if the request contains 100-continue but the content-length is too large, we return 413
             if (getContentLength(start, -1L) <= maxContentLength) {
                 return newErrorResponse(CONTINUE, pipeline.channel().bufferAllocator(), false, false);
             }
-            pipeline.fireInboundEventTriggered(HttpExpectationFailedEvent.INSTANCE);
+            pipeline.fireChannelInboundEvent(HttpExpectationFailedEvent.INSTANCE);
             return newErrorResponse(REQUEST_ENTITY_TOO_LARGE, pipeline.channel().bufferAllocator(), true, false);
         }
 
@@ -284,8 +284,8 @@ public class HttpObjectAggregator<C extends HttpContent<C>>
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-        super.exceptionCaught(ctx, cause);
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        super.channelExceptionCaught(ctx, cause);
         if (cause instanceof ResponseTooLargeException) {
             ctx.close();
         }

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/HttpObjectDecoder.java
@@ -458,7 +458,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoderForBuffer {
     }
 
     @Override
-    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+    public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
         if (evt instanceof HttpExpectationFailedEvent) {
             switch (currentState) {
             case READ_FIXED_LENGTH_CONTENT:
@@ -470,7 +470,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoderForBuffer {
                 break;
             }
         }
-        super.inboundEventTriggered(ctx, evt);
+        super.channelInboundEvent(ctx, evt);
     }
 
     protected boolean isContentAlwaysEmpty(HttpMessage msg) {

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/HttpServerUpgradeHandler.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/HttpServerUpgradeHandler.java
@@ -347,7 +347,7 @@ public class HttpServerUpgradeHandler<C extends HttpContent<C>> extends HttpObje
         upgradeCodec.upgradeTo(ctx, request);
 
         // Notify that the upgrade has occurred.
-        ctx.fireInboundEventTriggered(new UpgradeEvent(upgradeProtocol, request));
+        ctx.fireChannelInboundEvent(new UpgradeEvent(upgradeProtocol, request));
 
         // Remove this handler from the pipeline.
         ctx.pipeline().remove(HttpServerUpgradeHandler.this);

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientHandshaker.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientHandshaker.java
@@ -410,7 +410,7 @@ public abstract class WebSocketClientHandshaker {
                 }
 
                 @Override
-                public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+                public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
                     // Remove ourself and fail the handshake promise.
                     ctx.pipeline().remove(this);
                     promise.setFailure(cause);

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientProtocolHandler.java
@@ -41,7 +41,7 @@ import static io.netty5.handler.codec.http.websocketx.WebSocketServerProtocolCon
  * This implementation will establish the websocket connection once the connection to the remote server was complete.
  *
  * To know once a handshake was done you can intercept the
- * {@link ChannelHandler#inboundEventTriggered(ChannelHandlerContext, Object)} and check if the event was of type
+ * {@link ChannelHandler#channelInboundEvent(ChannelHandlerContext, Object)} and check if the event was of type
  * {@link ClientHandshakeStateEvent#HANDSHAKE_ISSUED} or {@link ClientHandshakeStateEvent#HANDSHAKE_COMPLETE}.
  */
 public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientProtocolHandshakeHandler.java
@@ -56,9 +56,9 @@ class WebSocketClientProtocolHandshakeHandler implements ChannelHandler {
         handshaker.handshake(ctx.channel()).addListener(future -> {
             if (future.isFailed()) {
                 handshakePromise.tryFailure(future.cause());
-                ctx.fireExceptionCaught(future.cause());
+                ctx.fireChannelExceptionCaught(future.cause());
             } else {
-                ctx.fireInboundEventTriggered(
+                ctx.fireChannelInboundEvent(
                         WebSocketClientProtocolHandler.ClientHandshakeStateEvent.HANDSHAKE_ISSUED);
             }
         });
@@ -86,7 +86,7 @@ class WebSocketClientProtocolHandshakeHandler implements ChannelHandler {
             if (!handshaker.isHandshakeComplete()) {
                 handshaker.finishHandshake(ctx.channel(), response);
                 handshakePromise.trySuccess(null);
-                ctx.fireInboundEventTriggered(
+                ctx.fireChannelInboundEvent(
                         ClientHandshakeStateEvent.HANDSHAKE_COMPLETE);
                 ctx.pipeline().remove(this);
                 return;
@@ -108,7 +108,7 @@ class WebSocketClientProtocolHandshakeHandler implements ChannelHandler {
 
             if (localHandshakePromise.tryFailure(new WebSocketClientHandshakeException("handshake timed out"))) {
                 ctx.flush()
-                   .fireInboundEventTriggered(ClientHandshakeStateEvent.HANDSHAKE_TIMEOUT)
+                   .fireChannelInboundEvent(ClientHandshakeStateEvent.HANDSHAKE_TIMEOUT)
                    .close();
             }
         }, handshakeTimeoutMillis, TimeUnit.MILLISECONDS);

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketProtocolHandler.java
@@ -145,8 +145,8 @@ abstract class WebSocketProtocolHandler extends MessageToMessageDecoder<WebSocke
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-        ctx.fireExceptionCaught(cause);
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        ctx.fireChannelExceptionCaught(cause);
         ctx.close();
     }
 }

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketServerHandshaker.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketServerHandshaker.java
@@ -291,10 +291,10 @@ public abstract class WebSocketServerHandshaker {
             }
 
             @Override
-            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+            public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
                 // Remove ourself and fail the handshake promise.
                 promise.tryFailure(cause);
-                ctx.fireExceptionCaught(cause);
+                ctx.fireChannelExceptionCaught(cause);
                 ctx.pipeline().remove(this);
             }
 

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
@@ -46,7 +46,7 @@ import static io.netty5.handler.codec.http.websocketx.WebSocketServerProtocolCon
  * to the <tt>io.netty5.example.http.websocketx.server.WebSocketServer</tt> example.
  *
  * To know once a handshake was done you can intercept the
- * {@link ChannelHandler#inboundEventTriggered(ChannelHandlerContext, Object)} and check if the event was instance
+ * {@link ChannelHandler#channelInboundEvent(ChannelHandlerContext, Object)} and check if the event was instance
  * of {@link HandshakeComplete}, the event will contain extra information about the handshake such as the request and
  * selected subprotocol.
  */
@@ -245,7 +245,7 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         if (cause instanceof WebSocketHandshakeException) {
             final byte[] bytes = cause.getMessage().getBytes();
             FullHttpResponse response = new DefaultFullHttpResponse(
@@ -253,7 +253,7 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
                     ctx.bufferAllocator().allocate(bytes.length).writeBytes(bytes));
             ctx.channel().writeAndFlush(response).addListener(ctx, ChannelFutureListeners.CLOSE);
         } else {
-            ctx.fireExceptionCaught(cause);
+            ctx.fireChannelExceptionCaught(cause);
             ctx.close();
         }
     }

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
@@ -93,10 +93,10 @@ class WebSocketServerProtocolHandshakeHandler implements ChannelHandler {
                     handshakeFuture.addListener(future -> {
                         if (future.isFailed()) {
                             localHandshakePromise.tryFailure(future.cause());
-                            ctx.fireExceptionCaught(future.cause());
+                            ctx.fireChannelExceptionCaught(future.cause());
                         } else {
                             localHandshakePromise.trySuccess(null);
-                            ctx.fireInboundEventTriggered(
+                            ctx.fireChannelInboundEvent(
                                     new WebSocketServerProtocolHandler.HandshakeComplete(
                                             req.uri(), req.headers(), handshaker.selectedSubprotocol()));
                         }
@@ -161,7 +161,7 @@ class WebSocketServerProtocolHandshakeHandler implements ChannelHandler {
             if (!localHandshakePromise.isDone() &&
                     localHandshakePromise.tryFailure(new WebSocketServerHandshakeException("handshake timed out"))) {
                 ctx.flush()
-                   .fireInboundEventTriggered(ServerHandshakeStateEvent.HANDSHAKE_TIMEOUT)
+                   .fireChannelInboundEvent(ServerHandshakeStateEvent.HANDSHAKE_TIMEOUT)
                    .close();
             }
         }, handshakeTimeoutMillis, TimeUnit.MILLISECONDS);

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpClientUpgradeHandlerTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpClientUpgradeHandlerTest.java
@@ -67,7 +67,7 @@ public class HttpClientUpgradeHandlerTest {
         }
 
         @Override
-        public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+        public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
             this.evt = evt;
         }
     }

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketHandshakeHandOverTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketHandshakeHandOverTest.java
@@ -86,7 +86,7 @@ public class WebSocketHandshakeHandOverTest {
     public void testHandover() {
         EmbeddedChannel serverChannel = createServerChannel(new SimpleChannelInboundHandler<>() {
             @Override
-            public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+            public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
                 if (evt instanceof WebSocketServerProtocolHandler.HandshakeComplete) {
                     serverReceivedHandshake = true;
                     serverHandshakeComplete = (WebSocketServerProtocolHandler.HandshakeComplete) evt;
@@ -102,7 +102,7 @@ public class WebSocketHandshakeHandOverTest {
 
         EmbeddedChannel clientChannel = createClientChannel(new SimpleChannelInboundHandler<>() {
             @Override
-            public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+            public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
                 if (evt == ClientHandshakeStateEvent.HANDSHAKE_COMPLETE) {
                     clientReceivedHandshake = true;
                 }
@@ -134,7 +134,7 @@ public class WebSocketHandshakeHandOverTest {
     public void testClientHandshakeTimeout() throws Throwable {
         EmbeddedChannel serverChannel = createServerChannel(new SimpleChannelInboundHandler<>() {
             @Override
-            public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+            public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
                 if (evt instanceof WebSocketServerProtocolHandler.HandshakeComplete) {
                     serverHandshakeComplete = (WebSocketServerProtocolHandler.HandshakeComplete) evt;
                 }
@@ -147,7 +147,7 @@ public class WebSocketHandshakeHandOverTest {
 
         EmbeddedChannel clientChannel = createClientChannel(new SimpleChannelInboundHandler<>() {
             @Override
-            public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+            public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
                 if (evt == ClientHandshakeStateEvent.HANDSHAKE_COMPLETE) {
                     clientReceivedHandshake = true;
                 } else if (evt == ClientHandshakeStateEvent.HANDSHAKE_TIMEOUT) {
@@ -239,7 +239,7 @@ public class WebSocketHandshakeHandOverTest {
 
         EmbeddedChannel clientChannel = createClientChannel(handshaker, new SimpleChannelInboundHandler<>() {
             @Override
-            public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+            public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
                 if (evt == ClientHandshakeStateEvent.HANDSHAKE_COMPLETE) {
                     ctx.channel().closeFuture().addListener(future -> clientForceClosed = true);
                     handshaker.close(ctx.channel(), new CloseWebSocketFrame(

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketServerProtocolHandlerTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketServerProtocolHandlerTest.java
@@ -89,7 +89,7 @@ public class WebSocketServerProtocolHandlerTest {
         ChannelHandlerContext handshakerCtx = ch.pipeline().context(WebSocketServerProtocolHandshakeHandler.class);
         ch.pipeline().addLast(new ChannelHandler() {
             @Override
-            public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+            public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
                 if (evt instanceof WebSocketServerProtocolHandler.HandshakeComplete) {
                     // We should have removed the handler already.
                     ctx.executor().execute(() -> ctx.pipeline().context(WebSocketServerProtocolHandshakeHandler.class));

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/AbstractHttp2StreamChannel.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/AbstractHttp2StreamChannel.java
@@ -107,7 +107,7 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
             }
 
             // Notify the child-channel and close it.
-            streamChannel.pipeline().fireExceptionCaught(cause);
+            streamChannel.pipeline().fireChannelExceptionCaught(cause);
             streamChannel.unsafe().close(streamChannel.newPromise());
         }
     }
@@ -964,7 +964,7 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
         }
 
         @Override
-        public void triggerOutboundEvent(Object event, Promise<Void> promise) {
+        public void sendOutboundEvent(Object event, Promise<Void> promise) {
             Resource.dispose(event);
             promise.setSuccess(null);
         }

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/CleartextHttp2ServerUpgradeHandler.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/CleartextHttp2ServerUpgradeHandler.java
@@ -84,7 +84,7 @@ public final class CleartextHttp2ServerUpgradeHandler extends ByteToMessageDecod
                    .remove(httpServerUpgradeHandler);
 
                 ctx.pipeline().addAfter(ctx.name(), null, http2ServerHandler);
-                ctx.fireInboundEventTriggered(PriorKnowledgeUpgradeEvent.INSTANCE);
+                ctx.fireChannelInboundEvent(PriorKnowledgeUpgradeEvent.INSTANCE);
                 ctx.pipeline().remove(this);
             }
         }

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2ClientUpgradeCodec.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2ClientUpgradeCodec.java
@@ -141,7 +141,7 @@ public class Http2ClientUpgradeCodec implements HttpClientUpgradeHandler.Upgrade
             // Reserve local stream 1 for the response.
             connectionHandler.onHttpClientUpgrade();
         } catch (Http2Exception e) {
-            ctx.fireExceptionCaught(e);
+            ctx.fireChannelExceptionCaught(e);
             ctx.close();
         }
     }

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2ConnectionHandler.java
@@ -380,7 +380,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoderForBuffer implem
                 // If this handler is extended by the user and we directly fire the userEvent from this context then
                 // the user will not see the event. We should fire the event starting with this handler so this class
                 // (and extending classes) have a chance to process the event.
-                inboundEventTriggered(ctx, Http2ConnectionPrefaceAndSettingsFrameWrittenEvent.INSTANCE);
+                channelInboundEvent(ctx, Http2ConnectionPrefaceAndSettingsFrameWrittenEvent.INSTANCE);
             }
         }
     }
@@ -538,12 +538,12 @@ public class Http2ConnectionHandler extends ByteToMessageDecoderForBuffer implem
      * Handles {@link Http2Exception} objects that were thrown from other handlers. Ignores all other exceptions.
      */
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         if (getEmbeddedHttp2Exception(cause) != null) {
             // Some exception in the causality chain is an Http2Exception - handle it.
             onError(ctx, false, cause);
         } else {
-            super.exceptionCaught(ctx, cause);
+            super.channelExceptionCaught(ctx, cause);
         }
     }
 

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2ServerUpgradeCodec.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2ServerUpgradeCodec.java
@@ -135,7 +135,7 @@ public class Http2ServerUpgradeCodec implements HttpServerUpgradeHandler.Upgrade
             }
             connectionHandler.onHttpServerUpgrade(settings);
         } catch (Http2Exception e) {
-            ctx.fireExceptionCaught(e);
+            ctx.fireChannelExceptionCaught(e);
             ctx.close();
         }
     }

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/InboundHttp2ToHttpAdapter.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/InboundHttp2ToHttpAdapter.java
@@ -292,7 +292,7 @@ public class InboundHttp2ToHttpAdapter extends Http2EventAdapter {
         if (msg != null) {
             onRstStreamRead(stream, msg);
         }
-        ctx.fireExceptionCaught(Http2Exception.streamError(streamId, Http2Error.valueOf(errorCode),
+        ctx.fireChannelExceptionCaught(Http2Exception.streamError(streamId, Http2Error.valueOf(errorCode),
                 "HTTP/2 to HTTP layer caught stream reset"));
     }
 

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/CleartextHttp2ServerUpgradeHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/CleartextHttp2ServerUpgradeHandlerTest.java
@@ -80,7 +80,7 @@ public class CleartextHttp2ServerUpgradeHandlerTest {
                 httpServerCodec, upgradeHandler, http2ConnectionHandler);
         channel = new EmbeddedChannel(handler, new ChannelHandler() {
             @Override
-            public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+            public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
                 userEvents.add(evt);
             }
         });

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/DataCompressionHttp2Test.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/DataCompressionHttp2Test.java
@@ -377,7 +377,7 @@ public class DataCompressionHttp2Test {
                 p.addLast(clientHandler);
                 p.addLast(new ChannelHandler() {
                     @Override
-                    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+                    public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
                         if (evt == Http2ConnectionPrefaceAndSettingsFrameWrittenEvent.INSTANCE) {
                             prefaceWrittenLatch.countDown();
                             ctx.pipeline().remove(this);

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -273,7 +273,7 @@ public class Http2ConnectionHandlerTest {
             return null;
         };
 
-        doAnswer(verifier).when(ctx).fireInboundEventTriggered(evt);
+        doAnswer(verifier).when(ctx).fireChannelInboundEvent(evt);
 
         handler.channelActive(ctx);
         if (flushPreface) {
@@ -393,7 +393,7 @@ public class Http2ConnectionHandlerTest {
         // processing before it was updated. Thus, it should _not_ be used for the GOAWAY.
         // https://github.com/netty/netty/issues/10670
         when(remote.lastStreamCreated()).thenReturn(STREAM_ID);
-        handler.exceptionCaught(ctx, e);
+        handler.channelExceptionCaught(ctx, e);
         verify(frameWriter).writeGoAway(eq(ctx), eq(Integer.MAX_VALUE), eq(PROTOCOL_ERROR.code()), any(Buffer.class));
     }
 
@@ -411,7 +411,7 @@ public class Http2ConnectionHandlerTest {
         when(frameWriter.writeRstStream(eq(ctx), eq(STREAM_ID),
                 eq(PROTOCOL_ERROR.code()))).thenReturn(future);
 
-        handler.exceptionCaught(ctx, e);
+        handler.channelExceptionCaught(ctx, e);
 
         ArgumentCaptor<Http2Headers> captor = ArgumentCaptor.forClass(Http2Headers.class);
         verify(encoder).writeHeaders(eq(ctx), eq(STREAM_ID),
@@ -435,7 +435,7 @@ public class Http2ConnectionHandlerTest {
         when(frameWriter.writeRstStream(eq(ctx), eq(STREAM_ID),
             eq(PROTOCOL_ERROR.code()))).thenReturn(future);
 
-        handler.exceptionCaught(ctx, e);
+        handler.channelExceptionCaught(ctx, e);
 
         verify(encoder, never()).writeHeaders(eq(ctx), eq(STREAM_ID),
             any(Http2Headers.class), eq(padding), eq(true));
@@ -456,7 +456,7 @@ public class Http2ConnectionHandlerTest {
         when(frameWriter.writeRstStream(eq(ctx), eq(STREAM_ID),
                 eq(PROTOCOL_ERROR.code()))).thenReturn(future);
 
-        handler.exceptionCaught(ctx, e);
+        handler.channelExceptionCaught(ctx, e);
 
         verify(encoder, never()).writeHeaders(eq(ctx), eq(STREAM_ID),
                 any(Http2Headers.class), eq(padding), eq(true));
@@ -468,7 +468,7 @@ public class Http2ConnectionHandlerTest {
         final CountDownLatch latch = new CountDownLatch(1);
         handler = new Http2ConnectionHandler(decoder, encoder, new Http2Settings()) {
             @Override
-            public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+            public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
                 if (evt == Http2ConnectionPrefaceAndSettingsFrameWrittenEvent.INSTANCE) {
                     latch.countDown();
                 }
@@ -491,7 +491,7 @@ public class Http2ConnectionHandlerTest {
         when(remote.lastStreamCreated()).thenReturn(STREAM_ID);
         when(frameWriter.writeRstStream(eq(ctx), eq(STREAM_ID),
             eq(PROTOCOL_ERROR.code()))).thenReturn(future);
-        handler.exceptionCaught(ctx, e);
+        handler.channelExceptionCaught(ctx, e);
 
         verify(encoder, never()).writeHeaders(eq(ctx), eq(STREAM_ID),
             any(Http2Headers.class), eq(padding), eq(true));
@@ -515,7 +515,7 @@ public class Http2ConnectionHandlerTest {
         when(remote.lastStreamCreated()).thenReturn(STREAM_ID);
         when(frameWriter.writeRstStream(eq(ctx), eq(STREAM_ID),
             eq(PROTOCOL_ERROR.code()))).thenReturn(future);
-        handler.exceptionCaught(ctx, e);
+        handler.channelExceptionCaught(ctx, e);
 
         verify(remote).createStream(STREAM_ID, true);
         verify(encoder).writeHeaders(eq(ctx), eq(STREAM_ID),

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -1078,7 +1078,7 @@ public class Http2ConnectionRoundtripTest {
                         .build());
                 p.addLast(new ChannelHandler() {
                     @Override
-                    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+                    public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
                         if (evt == Http2ConnectionPrefaceAndSettingsFrameWrittenEvent.INSTANCE) {
                             prefaceWrittenLatch.countDown();
                             ctx.pipeline().remove(this);

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameCodecTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameCodecTest.java
@@ -430,7 +430,7 @@ public class Http2FrameCodecTest {
         assertNotNull(stream);
 
         StreamException streamEx = new StreamException(3, Http2Error.INTERNAL_ERROR, "foo");
-        channel.pipeline().fireExceptionCaught(streamEx);
+        channel.pipeline().fireChannelExceptionCaught(streamEx);
 
         Http2FrameStreamEvent event = inboundHandler.readInboundMessageOrUserEvent();
         assertEquals(Http2FrameStreamEvent.Type.State, event.type());
@@ -876,7 +876,7 @@ public class Http2FrameCodecTest {
                 "HTTP/2", new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/",
                                                      preferredAllocator().allocate(0)));
         assertTrue(upgradeEvent.isAccessible());
-        channel.pipeline().fireInboundEventTriggered(upgradeEvent);
+        channel.pipeline().fireChannelInboundEvent(upgradeEvent);
         assertFalse(upgradeEvent.isAccessible());
     }
 
@@ -892,7 +892,7 @@ public class Http2FrameCodecTest {
                                               .stream(data.stream())).addListener(future -> {
                         Throwable cause = future.cause();
                         if (cause != null) {
-                            ctx.fireExceptionCaught(cause);
+                            ctx.fireChannelExceptionCaught(cause);
                         }
                     });
                 }
@@ -916,7 +916,7 @@ public class Http2FrameCodecTest {
 
         HttpServerUpgradeHandler.UpgradeEvent upgradeEvent = constructor.newInstance(
             "HTTP/2", request);
-        channel.pipeline().fireInboundEventTriggered(upgradeEvent);
+        channel.pipeline().fireChannelInboundEvent(upgradeEvent);
     }
 
     @Test

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameInboundWriter.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameInboundWriter.java
@@ -168,14 +168,14 @@ final class Http2FrameInboundWriter {
         }
 
         @Override
-        public ChannelHandlerContext fireExceptionCaught(Throwable cause) {
-            channel.pipeline().fireExceptionCaught(cause);
+        public ChannelHandlerContext fireChannelExceptionCaught(Throwable cause) {
+            channel.pipeline().fireChannelExceptionCaught(cause);
             return this;
         }
 
         @Override
-        public ChannelHandlerContext fireInboundEventTriggered(Object evt) {
-            channel.pipeline().fireInboundEventTriggered(evt);
+        public ChannelHandlerContext fireChannelInboundEvent(Object evt) {
+            channel.pipeline().fireChannelInboundEvent(evt);
             return this;
         }
 
@@ -210,8 +210,8 @@ final class Http2FrameInboundWriter {
         }
 
         @Override
-        public Future<Void> triggerOutboundEvent(Object event) {
-            return channel.pipeline().triggerOutboundEvent(event);
+        public Future<Void> sendOutboundEvent(Object event) {
+            return channel.pipeline().sendOutboundEvent(event);
         }
 
         @Override

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexTest.java
@@ -614,7 +614,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
         Http2StreamChannel channel = newInboundStream(3, false, inboundHandler);
         assertTrue(channel.isActive());
         StreamException cause = new StreamException(channel.stream().id(), Http2Error.PROTOCOL_ERROR, "baaam!");
-        parentChannel.pipeline().fireExceptionCaught(cause);
+        parentChannel.pipeline().fireChannelExceptionCaught(cause);
 
         assertFalse(channel.isActive());
 
@@ -933,7 +933,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
         Http2StreamChannel childChannel = newOutboundStream(new ChannelHandler() {
 
             @Override
-            public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+            public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
                 ctx.close();
                 throw new Exception("Exception for test");
             }
@@ -948,9 +948,9 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
             }
 
             @Override
-            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+            public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                 exceptionCaught.set(count.getAndIncrement());
-                ctx.fireExceptionCaught(cause);
+                ctx.fireChannelExceptionCaught(cause);
             }
 
             @Override
@@ -960,7 +960,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
             }
         });
 
-        childChannel.pipeline().fireInboundEventTriggered(new Object());
+        childChannel.pipeline().fireChannelInboundEvent(new Object());
 
         // The events should have happened in this order because the inactive and deregistration events
         // get deferred as they do in the AbstractChannel.

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexTransportTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexTransportTest.java
@@ -82,7 +82,7 @@ public class Http2MultiplexTransportTest {
         }
 
         @Override
-        public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+        public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
             Resource.dispose(evt);
         }
     };
@@ -372,7 +372,7 @@ public class Http2MultiplexTransportTest {
                     ch.pipeline().addLast(new Http2MultiplexHandler(DISCARD_HANDLER));
                     ch.pipeline().addLast(new ChannelHandler() {
                         @Override
-                        public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                        public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
                             if (evt instanceof SslHandshakeCompletionEvent) {
                                 SslHandshakeCompletionEvent handshakeCompletionEvent =
                                         (SslHandshakeCompletionEvent) evt;
@@ -387,7 +387,7 @@ public class Http2MultiplexTransportTest {
                                             new Http2StreamChannelBootstrap(ctx.channel());
                                     h2Bootstrap.handler(new ChannelHandler() {
                                         @Override
-                                        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                                        public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                                             if (cause.getCause() instanceof SSLException) {
                                                 latch.countDown();
                                             } else {
@@ -529,7 +529,7 @@ public class Http2MultiplexTransportTest {
                     ch.pipeline().addLast(new Http2MultiplexHandler(DISCARD_HANDLER));
                     ch.pipeline().addLast(new ChannelHandler() {
                         @Override
-                        public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                        public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
                             if (evt instanceof SslHandshakeCompletionEvent) {
                                 SslHandshakeCompletionEvent handshakeCompletionEvent =
                                         (SslHandshakeCompletionEvent) evt;

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
@@ -558,7 +558,7 @@ public class HttpToHttp2ConnectionHandlerTest {
                 p.addLast(handler);
                 p.addLast(new ChannelHandler() {
                     @Override
-                    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+                    public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
                         if (evt == Http2ConnectionPrefaceAndSettingsFrameWrittenEvent.INSTANCE) {
                             prefaceWrittenLatch.countDown();
                             ctx.pipeline().remove(this);

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
@@ -629,19 +629,19 @@ public class InboundHttp2ToHttpAdapterTest {
                 p.addLast(clientDelegator);
                 p.addLast(new ChannelHandler() {
                     @Override
-                    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+                    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
                         Http2Exception e = getEmbeddedHttp2Exception(cause);
                         if (e != null) {
                             clientException = e;
                             clientLatch.countDown();
                         } else {
-                            ctx.fireExceptionCaught(cause);
+                            ctx.fireChannelExceptionCaught(cause);
                         }
                     }
                 });
                 p.addLast(new ChannelHandler() {
                     @Override
-                    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+                    public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
                         if (evt == Http2ConnectionPrefaceAndSettingsFrameWrittenEvent.INSTANCE) {
                             prefaceWrittenLatch.countDown();
                             ctx.pipeline().remove(this);

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/LastInboundHandler.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/LastInboundHandler.java
@@ -108,12 +108,12 @@ public class LastInboundHandler implements ChannelHandler {
     }
 
     @Override
-    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+    public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
         queue.add(new UserEvent(evt));
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         if (lastException != null) {
             cause.printStackTrace();
         } else {

--- a/codec/src/main/java/io/netty5/handler/codec/DatagramPacketDecoder.java
+++ b/codec/src/main/java/io/netty5/handler/codec/DatagramPacketDecoder.java
@@ -84,8 +84,8 @@ public class DatagramPacketDecoder extends MessageToMessageDecoder<DatagramPacke
     }
 
     @Override
-    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
-        decoder.inboundEventTriggered(ctx, evt);
+    public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
+        decoder.channelInboundEvent(ctx, evt);
     }
 
     @Override
@@ -94,8 +94,8 @@ public class DatagramPacketDecoder extends MessageToMessageDecoder<DatagramPacke
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-        decoder.exceptionCaught(ctx, cause);
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        decoder.channelExceptionCaught(ctx, cause);
     }
 
     @Override

--- a/codec/src/main/java/io/netty5/handler/codec/LineBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty5/handler/codec/LineBasedFrameDecoder.java
@@ -153,7 +153,7 @@ public class LineBasedFrameDecoder extends ByteToMessageDecoderForBuffer {
     }
 
     private void fail(final ChannelHandlerContext ctx, String length) {
-        ctx.fireExceptionCaught(
+        ctx.fireChannelExceptionCaught(
                 new TooLongFrameException(
                         "frame length (" + length + ") exceeds the allowed maximum (" + maxLength + ')'));
     }

--- a/codec/src/main/java/io/netty5/handler/codec/MessageAggregator.java
+++ b/codec/src/main/java/io/netty5/handler/codec/MessageAggregator.java
@@ -224,7 +224,7 @@ public abstract class MessageAggregator<I, S, C extends ByteBufHolder, O extends
                 if (listener == null) {
                     continueResponseWriteListener = listener = (context, future) -> {
                         if (future.isFailed()) {
-                            context.fireExceptionCaught(future.cause());
+                            context.fireChannelExceptionCaught(future.cause());
                         }
                     };
                 }
@@ -410,7 +410,7 @@ public abstract class MessageAggregator<I, S, C extends ByteBufHolder, O extends
      * @param oversized the accumulated message up to this point, whose type is {@code S} or {@code O}
      */
     protected void handleOversizedMessage(ChannelHandlerContext ctx, S oversized) throws Exception {
-        ctx.fireExceptionCaught(
+        ctx.fireChannelExceptionCaught(
                 new TooLongFrameException("content length exceeded " + maxContentLength() + " bytes."));
     }
 

--- a/codec/src/main/java/io/netty5/handler/codec/MessageAggregatorNew.java
+++ b/codec/src/main/java/io/netty5/handler/codec/MessageAggregatorNew.java
@@ -179,7 +179,7 @@ public abstract class MessageAggregatorNew<I, S, C extends AutoCloseable, A exte
                 if (listener == null) {
                     continueResponseWriteListener = listener = (context, future) -> {
                         if (future.isFailed()) {
-                            context.fireExceptionCaught(future.cause());
+                            context.fireChannelExceptionCaught(future.cause());
                         }
                     };
                 }
@@ -340,7 +340,7 @@ public abstract class MessageAggregatorNew<I, S, C extends AutoCloseable, A exte
      */
     protected void handleOversizedMessage(ChannelHandlerContext ctx, @SuppressWarnings("unused") Object oversized)
             throws Exception {
-        ctx.fireExceptionCaught(
+        ctx.fireChannelExceptionCaught(
                 new TooLongFrameException("content length exceeded " + maxContentLength() + " bytes."));
     }
 

--- a/example/src/main/java/io/netty5/example/discard/DiscardClientHandler.java
+++ b/example/src/main/java/io/netty5/example/discard/DiscardClientHandler.java
@@ -51,7 +51,7 @@ public class DiscardClientHandler extends SimpleChannelInboundHandler<Object> {
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         // Close the connection when an exception is raised.
         cause.printStackTrace();
         ctx.close();

--- a/example/src/main/java/io/netty5/example/discard/DiscardServerHandler.java
+++ b/example/src/main/java/io/netty5/example/discard/DiscardServerHandler.java
@@ -29,7 +29,7 @@ public class DiscardServerHandler extends SimpleChannelInboundHandler<Object> {
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         // Close the connection when an exception is raised.
         cause.printStackTrace();
         ctx.close();

--- a/example/src/main/java/io/netty5/example/echo/EchoClientHandler.java
+++ b/example/src/main/java/io/netty5/example/echo/EchoClientHandler.java
@@ -55,7 +55,7 @@ public class EchoClientHandler implements ChannelHandler {
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         // Close the connection when an exception is raised.
         cause.printStackTrace();
         ctx.close();

--- a/example/src/main/java/io/netty5/example/echo/EchoServerHandler.java
+++ b/example/src/main/java/io/netty5/example/echo/EchoServerHandler.java
@@ -36,7 +36,7 @@ public class EchoServerHandler implements ChannelHandler {
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         // Close the connection when an exception is raised.
         cause.printStackTrace();
         ctx.close();

--- a/example/src/main/java/io/netty5/example/factorial/FactorialClientHandler.java
+++ b/example/src/main/java/io/netty5/example/factorial/FactorialClientHandler.java
@@ -74,7 +74,7 @@ public class FactorialClientHandler extends SimpleChannelInboundHandler<BigInteg
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         cause.printStackTrace();
         ctx.close();
     }

--- a/example/src/main/java/io/netty5/example/factorial/FactorialServerHandler.java
+++ b/example/src/main/java/io/netty5/example/factorial/FactorialServerHandler.java
@@ -46,7 +46,7 @@ public class FactorialServerHandler extends SimpleChannelInboundHandler<BigInteg
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         cause.printStackTrace();
         ctx.close();
     }

--- a/example/src/main/java/io/netty5/example/file/FileServerHandler.java
+++ b/example/src/main/java/io/netty5/example/file/FileServerHandler.java
@@ -60,7 +60,7 @@ public class FileServerHandler extends SimpleChannelInboundHandler<String> {
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         cause.printStackTrace();
 
         if (ctx.channel().isActive()) {

--- a/example/src/main/java/io/netty5/example/http/file/HttpStaticFileServerHandler.java
+++ b/example/src/main/java/io/netty5/example/http/file/HttpStaticFileServerHandler.java
@@ -226,7 +226,7 @@ public class HttpStaticFileServerHandler extends SimpleChannelInboundHandler<Ful
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         cause.printStackTrace();
         if (ctx.channel().isActive()) {
             sendError(ctx, INTERNAL_SERVER_ERROR);

--- a/example/src/main/java/io/netty5/example/http/helloworld/HttpHelloWorldServerHandler.java
+++ b/example/src/main/java/io/netty5/example/http/helloworld/HttpHelloWorldServerHandler.java
@@ -72,7 +72,7 @@ public class HttpHelloWorldServerHandler extends SimpleChannelInboundHandler<Htt
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         cause.printStackTrace();
         ctx.close();
     }

--- a/example/src/main/java/io/netty5/example/http/snoop/HttpSnoopClientHandler.java
+++ b/example/src/main/java/io/netty5/example/http/snoop/HttpSnoopClientHandler.java
@@ -64,7 +64,7 @@ public class HttpSnoopClientHandler extends SimpleChannelInboundHandler<HttpObje
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         cause.printStackTrace();
         ctx.close();
     }

--- a/example/src/main/java/io/netty5/example/http/snoop/HttpSnoopServerHandler.java
+++ b/example/src/main/java/io/netty5/example/http/snoop/HttpSnoopServerHandler.java
@@ -194,7 +194,7 @@ public class HttpSnoopServerHandler extends SimpleChannelInboundHandler<Object> 
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         cause.printStackTrace();
         ctx.close();
     }

--- a/example/src/main/java/io/netty5/example/http/websocketx/benchmarkserver/WebSocketServerHandler.java
+++ b/example/src/main/java/io/netty5/example/http/websocketx/benchmarkserver/WebSocketServerHandler.java
@@ -156,7 +156,7 @@ public class WebSocketServerHandler extends SimpleChannelInboundHandler<Object> 
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         cause.printStackTrace();
         ctx.close();
     }

--- a/example/src/main/java/io/netty5/example/http/websocketx/client/WebSocketClientHandler.java
+++ b/example/src/main/java/io/netty5/example/http/websocketx/client/WebSocketClientHandler.java
@@ -114,7 +114,7 @@ public class WebSocketClientHandler extends SimpleChannelInboundHandler<Object> 
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         cause.printStackTrace();
         if (!handshakeFuture.isDone()) {
             handshakeFuture.setFailure(cause);

--- a/example/src/main/java/io/netty5/example/http/websocketx/server/WebSocketIndexPageHandler.java
+++ b/example/src/main/java/io/netty5/example/http/websocketx/server/WebSocketIndexPageHandler.java
@@ -85,7 +85,7 @@ public class WebSocketIndexPageHandler extends SimpleChannelInboundHandler<FullH
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         cause.printStackTrace();
         ctx.close();
     }

--- a/example/src/main/java/io/netty5/example/http2/file/Http2StaticFileServerHandler.java
+++ b/example/src/main/java/io/netty5/example/http2/file/Http2StaticFileServerHandler.java
@@ -199,7 +199,7 @@ public class Http2StaticFileServerHandler implements ChannelHandler {
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         cause.printStackTrace();
         if (ctx.channel().isActive()) {
             sendError(ctx, INTERNAL_SERVER_ERROR);

--- a/example/src/main/java/io/netty5/example/http2/helloworld/client/Http2ClientInitializer.java
+++ b/example/src/main/java/io/netty5/example/http2/helloworld/client/Http2ClientInitializer.java
@@ -167,9 +167,9 @@ public class Http2ClientInitializer extends ChannelInitializer<SocketChannel> {
      */
     private static class UserEventLogger implements ChannelHandler {
         @Override
-        public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+        public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
             System.out.println("User Event Triggered: " + evt);
-            ctx.fireInboundEventTriggered(evt);
+            ctx.fireChannelInboundEvent(evt);
         }
     }
 }

--- a/example/src/main/java/io/netty5/example/http2/helloworld/frame/server/HelloWorldHttp2Handler.java
+++ b/example/src/main/java/io/netty5/example/http2/helloworld/frame/server/HelloWorldHttp2Handler.java
@@ -43,8 +43,8 @@ public class HelloWorldHttp2Handler implements ChannelHandler {
     static final byte[] RESPONSE_BYTES = "Hello World".getBytes(StandardCharsets.UTF_8);
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-        ctx.fireExceptionCaught(cause);
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        ctx.fireChannelExceptionCaught(cause);
         cause.printStackTrace();
         ctx.close();
     }

--- a/example/src/main/java/io/netty5/example/http2/helloworld/frame/server/Http2ServerInitializer.java
+++ b/example/src/main/java/io/netty5/example/http2/helloworld/frame/server/Http2ServerInitializer.java
@@ -110,9 +110,9 @@ public class Http2ServerInitializer extends ChannelInitializer<SocketChannel> {
      */
     private static class UserEventLogger implements ChannelHandler {
         @Override
-        public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+        public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
             System.out.println("User Event Triggered: " + evt);
-            ctx.fireInboundEventTriggered(evt);
+            ctx.fireChannelInboundEvent(evt);
         }
     }
 }

--- a/example/src/main/java/io/netty5/example/http2/helloworld/multiplex/server/HelloWorldHttp2Handler.java
+++ b/example/src/main/java/io/netty5/example/http2/helloworld/multiplex/server/HelloWorldHttp2Handler.java
@@ -42,8 +42,8 @@ public class HelloWorldHttp2Handler implements ChannelHandler {
     static final byte[] RESPONSE_BYTES = "Hello World".getBytes(StandardCharsets.UTF_8);
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-        ctx.fireExceptionCaught(cause);
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        ctx.fireChannelExceptionCaught(cause);
         cause.printStackTrace();
         ctx.close();
     }

--- a/example/src/main/java/io/netty5/example/http2/helloworld/multiplex/server/Http2ServerInitializer.java
+++ b/example/src/main/java/io/netty5/example/http2/helloworld/multiplex/server/Http2ServerInitializer.java
@@ -112,9 +112,9 @@ public class Http2ServerInitializer extends ChannelInitializer<SocketChannel> {
      */
     private static class UserEventLogger implements ChannelHandler {
         @Override
-        public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+        public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
             System.out.println("User Event Triggered: " + evt);
-            ctx.fireInboundEventTriggered(evt);
+            ctx.fireChannelInboundEvent(evt);
         }
     }
 }

--- a/example/src/main/java/io/netty5/example/http2/helloworld/server/HelloWorldHttp1Handler.java
+++ b/example/src/main/java/io/netty5/example/http2/helloworld/server/HelloWorldHttp1Handler.java
@@ -81,7 +81,7 @@ public class HelloWorldHttp1Handler extends SimpleChannelInboundHandler<FullHttp
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         cause.printStackTrace();
         ctx.close();
     }

--- a/example/src/main/java/io/netty5/example/http2/helloworld/server/HelloWorldHttp2Handler.java
+++ b/example/src/main/java/io/netty5/example/http2/helloworld/server/HelloWorldHttp2Handler.java
@@ -64,18 +64,18 @@ public final class HelloWorldHttp2Handler extends Http2ConnectionHandler impleme
      * on stream 1 (the stream specifically reserved for cleartext HTTP upgrade).
      */
     @Override
-    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+    public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
         if (evt instanceof HttpServerUpgradeHandler.UpgradeEvent) {
             HttpServerUpgradeHandler.UpgradeEvent upgradeEvent =
                     (HttpServerUpgradeHandler.UpgradeEvent) evt;
             onHeadersRead(ctx, 1, http1HeadersToHttp2Headers(upgradeEvent.upgradeRequest()), 0 , true);
         }
-        super.inboundEventTriggered(ctx, evt);
+        super.channelInboundEvent(ctx, evt);
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-        super.exceptionCaught(ctx, cause);
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        super.channelExceptionCaught(ctx, cause);
         cause.printStackTrace();
         ctx.close();
     }

--- a/example/src/main/java/io/netty5/example/http2/helloworld/server/Http2ServerInitializer.java
+++ b/example/src/main/java/io/netty5/example/http2/helloworld/server/Http2ServerInitializer.java
@@ -111,9 +111,9 @@ public class Http2ServerInitializer extends ChannelInitializer<SocketChannel> {
      */
     private static class UserEventLogger implements ChannelHandler {
         @Override
-        public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+        public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
             System.out.println("User Event Triggered: " + evt);
-            ctx.fireInboundEventTriggered(evt);
+            ctx.fireChannelInboundEvent(evt);
         }
     }
 }

--- a/example/src/main/java/io/netty5/example/http2/tiles/FallbackRequestHandler.java
+++ b/example/src/main/java/io/netty5/example/http2/tiles/FallbackRequestHandler.java
@@ -65,7 +65,7 @@ public final class FallbackRequestHandler extends SimpleChannelInboundHandler<Ht
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         cause.printStackTrace();
         ctx.close();
     }

--- a/example/src/main/java/io/netty5/example/http2/tiles/Http2RequestHandler.java
+++ b/example/src/main/java/io/netty5/example/http2/tiles/Http2RequestHandler.java
@@ -116,7 +116,7 @@ public class Http2RequestHandler extends SimpleChannelInboundHandler<FullHttpReq
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         cause.printStackTrace();
         ctx.close();
     }

--- a/example/src/main/java/io/netty5/example/localecho/LocalEchoClientHandler.java
+++ b/example/src/main/java/io/netty5/example/localecho/LocalEchoClientHandler.java
@@ -27,7 +27,7 @@ public class LocalEchoClientHandler extends SimpleChannelInboundHandler<Object> 
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         cause.printStackTrace();
         ctx.close();
     }

--- a/example/src/main/java/io/netty5/example/localecho/LocalEchoServerHandler.java
+++ b/example/src/main/java/io/netty5/example/localecho/LocalEchoServerHandler.java
@@ -32,7 +32,7 @@ public class LocalEchoServerHandler implements ChannelHandler {
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         cause.printStackTrace();
         ctx.close();
     }

--- a/example/src/main/java/io/netty5/example/ocsp/OcspClientExample.java
+++ b/example/src/main/java/io/netty5/example/ocsp/OcspClientExample.java
@@ -140,9 +140,9 @@ public class OcspClientExample {
             }
 
             @Override
-            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+            public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
                 if (!promise.tryFailure(cause)) {
-                    ctx.fireExceptionCaught(cause);
+                    ctx.fireChannelExceptionCaught(cause);
                 }
             }
         };
@@ -192,9 +192,9 @@ public class OcspClientExample {
         }
 
         @Override
-        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
             if (!promise.tryFailure(cause)) {
-                ctx.fireExceptionCaught(cause);
+                ctx.fireChannelExceptionCaught(cause);
             }
         }
     }

--- a/example/src/main/java/io/netty5/example/proxy/HexDumpProxyBackendHandler.java
+++ b/example/src/main/java/io/netty5/example/proxy/HexDumpProxyBackendHandler.java
@@ -49,7 +49,7 @@ public class HexDumpProxyBackendHandler implements ChannelHandler {
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         cause.printStackTrace();
         HexDumpProxyFrontendHandler.closeOnFlush(ctx.channel());
     }

--- a/example/src/main/java/io/netty5/example/proxy/HexDumpProxyFrontendHandler.java
+++ b/example/src/main/java/io/netty5/example/proxy/HexDumpProxyFrontendHandler.java
@@ -88,7 +88,7 @@ public class HexDumpProxyFrontendHandler implements ChannelHandler {
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         cause.printStackTrace();
         closeOnFlush(ctx.channel());
     }

--- a/example/src/main/java/io/netty5/example/qotm/QuoteOfTheMomentClientHandler.java
+++ b/example/src/main/java/io/netty5/example/qotm/QuoteOfTheMomentClientHandler.java
@@ -32,7 +32,7 @@ public class QuoteOfTheMomentClientHandler extends SimpleChannelInboundHandler<D
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         cause.printStackTrace();
         ctx.close();
     }

--- a/example/src/main/java/io/netty5/example/qotm/QuoteOfTheMomentServerHandler.java
+++ b/example/src/main/java/io/netty5/example/qotm/QuoteOfTheMomentServerHandler.java
@@ -59,7 +59,7 @@ public class QuoteOfTheMomentServerHandler extends SimpleChannelInboundHandler<D
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         cause.printStackTrace();
         // We don't close the channel because we can keep serving requests.
     }

--- a/example/src/main/java/io/netty5/example/securechat/SecureChatClientHandler.java
+++ b/example/src/main/java/io/netty5/example/securechat/SecureChatClientHandler.java
@@ -29,7 +29,7 @@ public class SecureChatClientHandler extends SimpleChannelInboundHandler<String>
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         cause.printStackTrace();
         ctx.close();
     }

--- a/example/src/main/java/io/netty5/example/securechat/SecureChatServerHandler.java
+++ b/example/src/main/java/io/netty5/example/securechat/SecureChatServerHandler.java
@@ -66,7 +66,7 @@ public class SecureChatServerHandler extends SimpleChannelInboundHandler<String>
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         cause.printStackTrace();
         ctx.close();
     }

--- a/example/src/main/java/io/netty5/example/telnet/TelnetClientHandler.java
+++ b/example/src/main/java/io/netty5/example/telnet/TelnetClientHandler.java
@@ -31,7 +31,7 @@ public class TelnetClientHandler extends SimpleChannelInboundHandler<String> {
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         cause.printStackTrace();
         ctx.close();
     }

--- a/example/src/main/java/io/netty5/example/telnet/TelnetServerHandler.java
+++ b/example/src/main/java/io/netty5/example/telnet/TelnetServerHandler.java
@@ -69,7 +69,7 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         cause.printStackTrace();
         ctx.close();
     }

--- a/example/src/main/java/io/netty5/example/uptime/UptimeClientHandler.java
+++ b/example/src/main/java/io/netty5/example/uptime/UptimeClientHandler.java
@@ -46,7 +46,7 @@ public class UptimeClientHandler extends SimpleChannelInboundHandler<Object> {
     }
 
     @Override
-    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+    public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
         if (!(evt instanceof IdleStateEvent)) {
             return;
         }
@@ -75,7 +75,7 @@ public class UptimeClientHandler extends SimpleChannelInboundHandler<Object> {
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         cause.printStackTrace();
         ctx.close();
     }

--- a/example/src/main/java/io/netty5/example/uptime/UptimeServerHandler.java
+++ b/example/src/main/java/io/netty5/example/uptime/UptimeServerHandler.java
@@ -27,7 +27,7 @@ public class UptimeServerHandler extends SimpleChannelInboundHandler<Object> {
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         // Close the connection when an exception is raised.
         cause.printStackTrace();
         ctx.close();

--- a/handler/src/main/java/io/netty5/handler/adaptor/BufferConversionHandler.java
+++ b/handler/src/main/java/io/netty5/handler/adaptor/BufferConversionHandler.java
@@ -81,7 +81,7 @@ public final class BufferConversionHandler implements ChannelHandler {
      * @param onWrite The conversion to apply to all outgoing {@linkplain #write(ChannelHandlerContext, Object)}
      *               messages.
      * @param onUserEvent The conversion to apply to all incoming
-     *                    {@linkplain #inboundEventTriggered(ChannelHandlerContext, Object) user events}.
+     *                    {@linkplain #channelInboundEvent(ChannelHandlerContext, Object) user events}.
      */
     public BufferConversionHandler(Conversion onRead, Conversion onWrite, Conversion onUserEvent) {
         this.onRead = onRead;
@@ -117,8 +117,8 @@ public final class BufferConversionHandler implements ChannelHandler {
     }
 
     @Override
-    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
-        ctx.fireInboundEventTriggered(onUserEvent.convert(evt));
+    public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
+        ctx.fireChannelInboundEvent(onUserEvent.convert(evt));
     }
 
     @Override

--- a/handler/src/main/java/io/netty5/handler/flush/FlushConsolidationHandler.java
+++ b/handler/src/main/java/io/netty5/handler/flush/FlushConsolidationHandler.java
@@ -145,10 +145,10 @@ public class FlushConsolidationHandler implements ChannelHandler {
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         // To ensure we not miss to flush anything, do it now.
         resetReadAndFlushIfNeeded(ctx);
-        ctx.fireExceptionCaught(cause);
+        ctx.fireChannelExceptionCaught(cause);
     }
 
     @Override

--- a/handler/src/main/java/io/netty5/handler/logging/LoggingHandler.java
+++ b/handler/src/main/java/io/netty5/handler/logging/LoggingHandler.java
@@ -208,19 +208,19 @@ public class LoggingHandler implements ChannelHandler {
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         if (logger.isEnabled(internalLevel)) {
             logger.log(internalLevel, format(ctx, "EXCEPTION", cause), cause);
         }
-        ctx.fireExceptionCaught(cause);
+        ctx.fireChannelExceptionCaught(cause);
     }
 
     @Override
-    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+    public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
         if (logger.isEnabled(internalLevel)) {
             logger.log(internalLevel, format(ctx, "USER_EVENT", evt));
         }
-        ctx.fireInboundEventTriggered(evt);
+        ctx.fireChannelInboundEvent(evt);
     }
 
     @Override

--- a/handler/src/main/java/io/netty5/handler/ssl/AbstractSniHandler.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/AbstractSniHandler.java
@@ -157,9 +157,9 @@ public abstract class AbstractSniHandler<T> extends SslClientHelloHandler<T> {
     private static void fireSniCompletionEvent(ChannelHandlerContext ctx, String hostname, Future<?> future) {
         Throwable cause = future.cause();
         if (cause == null) {
-            ctx.fireInboundEventTriggered(new SniCompletionEvent(hostname));
+            ctx.fireChannelInboundEvent(new SniCompletionEvent(hostname));
         } else {
-            ctx.fireInboundEventTriggered(new SniCompletionEvent(hostname, cause));
+            ctx.fireChannelInboundEvent(new SniCompletionEvent(hostname, cause));
         }
     }
 }

--- a/handler/src/main/java/io/netty5/handler/ssl/ApplicationProtocolNegotiationHandler.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/ApplicationProtocolNegotiationHandler.java
@@ -124,10 +124,10 @@ public abstract class ApplicationProtocolNegotiationHandler implements ChannelHa
     }
 
     @Override
-    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+    public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
         if (evt instanceof SslHandshakeCompletionEvent) {
             // Let's first fire the event before we try to modify the pipeline.
-            ctx.fireInboundEventTriggered(evt);
+            ctx.fireChannelInboundEvent(evt);
 
             SslHandshakeCompletionEvent handshakeEvent = (SslHandshakeCompletionEvent) evt;
             try {
@@ -147,7 +147,7 @@ public abstract class ApplicationProtocolNegotiationHandler implements ChannelHa
                     // See https://github.com/netty/netty/issues/10342
                 }
             } catch (Throwable cause) {
-                exceptionCaught(ctx, cause);
+                channelExceptionCaught(ctx, cause);
             } finally {
                 // Handshake failures are handled in exceptionCaught(...).
                 if (handshakeEvent.isSuccess()) {
@@ -155,7 +155,7 @@ public abstract class ApplicationProtocolNegotiationHandler implements ChannelHa
                 }
             }
         } else {
-            ctx.fireInboundEventTriggered(evt);
+            ctx.fireChannelInboundEvent(evt);
         }
     }
 
@@ -199,7 +199,7 @@ public abstract class ApplicationProtocolNegotiationHandler implements ChannelHa
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         Throwable wrapped;
         if (cause instanceof DecoderException && (wrapped = cause.getCause()) instanceof SSLException) {
             try {
@@ -210,7 +210,7 @@ public abstract class ApplicationProtocolNegotiationHandler implements ChannelHa
             }
         }
         logger.warn("{} Failed to select the application-level protocol:", ctx.channel(), cause);
-        ctx.fireExceptionCaught(cause);
+        ctx.fireChannelExceptionCaught(cause);
         ctx.close();
     }
 }

--- a/handler/src/main/java/io/netty5/handler/ssl/SslClientHelloHandler.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslClientHelloHandler.java
@@ -65,8 +65,8 @@ public abstract class SslClientHelloHandler<T> extends ByteToMessageDecoderForBu
                                 NotSslRecordException e = new NotSslRecordException(
                                         "not an SSL/TLS record: " + BufferUtil.hexDump(in));
                                 in.skipReadableBytes(in.readableBytes());
-                                ctx.fireInboundEventTriggered(new SniCompletionEvent(e));
-                                ctx.fireInboundEventTriggered(new SslHandshakeCompletionEvent(e));
+                                ctx.fireChannelInboundEvent(new SniCompletionEvent(e));
+                                ctx.fireChannelInboundEvent(new SslHandshakeCompletionEvent(e));
                                 throw e;
                             }
                             if (len == SslUtils.NOT_ENOUGH_DATA) {
@@ -194,11 +194,11 @@ public abstract class SslClientHelloHandler<T> extends ByteToMessageDecoderForBu
                         try {
                             onLookupComplete(ctx, f);
                         } catch (DecoderException err) {
-                            ctx.fireExceptionCaught(err);
+                            ctx.fireChannelExceptionCaught(err);
                         } catch (Exception cause) {
-                            ctx.fireExceptionCaught(new DecoderException(cause));
+                            ctx.fireChannelExceptionCaught(new DecoderException(cause));
                         } catch (Throwable cause) {
-                            ctx.fireExceptionCaught(cause);
+                            ctx.fireChannelExceptionCaught(cause);
                         }
                     } finally {
                         if (readPending) {

--- a/handler/src/main/java/io/netty5/handler/ssl/SslMasterKeyHandler.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslMasterKeyHandler.java
@@ -122,7 +122,7 @@ public abstract class SslMasterKeyHandler implements ChannelHandler {
     protected abstract void accept(SecretKey masterKey, SSLSession session);
 
     @Override
-    public final void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+    public final void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
         //only try to log the session info if the ssl handshake has successfully completed.
         if (evt == SslHandshakeCompletionEvent.SUCCESS && masterKeyHandlerEnabled()) {
             final SslHandler handler = ctx.pipeline().get(SslHandler.class);
@@ -145,7 +145,7 @@ public abstract class SslMasterKeyHandler implements ChannelHandler {
             }
         }
 
-        ctx.fireInboundEventTriggered(evt);
+        ctx.fireChannelInboundEvent(evt);
     }
 
     /**

--- a/handler/src/main/java/io/netty5/handler/ssl/SslUtils.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslUtils.java
@@ -421,7 +421,7 @@ final class SslUtils {
         // See https://github.com/netty/netty/issues/3900#issuecomment-172481830
         ctx.flush();
         if (notify) {
-            ctx.fireInboundEventTriggered(new SslHandshakeCompletionEvent(cause));
+            ctx.fireChannelInboundEvent(new SslHandshakeCompletionEvent(cause));
         }
     }
 

--- a/handler/src/main/java/io/netty5/handler/ssl/ocsp/OcspClientHandler.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/ocsp/OcspClientHandler.java
@@ -47,8 +47,8 @@ public abstract class OcspClientHandler implements ChannelHandler {
     protected abstract boolean verify(ChannelHandlerContext ctx, ReferenceCountedOpenSslEngine engine) throws Exception;
 
     @Override
-    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
-        ctx.fireInboundEventTriggered(evt);
+    public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
+        ctx.fireChannelInboundEvent(evt);
         if (evt instanceof SslHandshakeCompletionEvent) {
             SslHandshakeCompletionEvent event = (SslHandshakeCompletionEvent) evt;
             if (event.isSuccess() && !verify(ctx, engine)) {

--- a/handler/src/main/java/io/netty5/handler/timeout/IdleStateHandler.java
+++ b/handler/src/main/java/io/netty5/handler/timeout/IdleStateHandler.java
@@ -363,10 +363,10 @@ public class IdleStateHandler implements ChannelHandler {
 
     /**
      * Is called when an {@link IdleStateEvent} should be fired. This implementation calls
-     * {@link ChannelHandlerContext#fireInboundEventTriggered(Object)}.
+     * {@link ChannelHandlerContext#fireChannelInboundEvent(Object)}.
      */
     protected void channelIdle(ChannelHandlerContext ctx, IdleStateEvent evt) throws Exception {
-        ctx.fireInboundEventTriggered(evt);
+        ctx.fireChannelInboundEvent(evt);
     }
 
     /**
@@ -498,7 +498,7 @@ public class IdleStateHandler implements ChannelHandler {
                     IdleStateEvent event = newIdleStateEvent(IdleState.READER_IDLE, first);
                     channelIdle(ctx, event);
                 } catch (Throwable t) {
-                    ctx.fireExceptionCaught(t);
+                    ctx.fireChannelExceptionCaught(t);
                 }
             } else {
                 // Read occurred before the timeout - set a new timeout with shorter delay.
@@ -533,7 +533,7 @@ public class IdleStateHandler implements ChannelHandler {
                     IdleStateEvent event = newIdleStateEvent(IdleState.WRITER_IDLE, first);
                     channelIdle(ctx, event);
                 } catch (Throwable t) {
-                    ctx.fireExceptionCaught(t);
+                    ctx.fireChannelExceptionCaught(t);
                 }
             } else {
                 // Write occurred before the timeout - set a new timeout with shorter delay.
@@ -571,7 +571,7 @@ public class IdleStateHandler implements ChannelHandler {
                     IdleStateEvent event = newIdleStateEvent(IdleState.ALL_IDLE, first);
                     channelIdle(ctx, event);
                 } catch (Throwable t) {
-                    ctx.fireExceptionCaught(t);
+                    ctx.fireChannelExceptionCaught(t);
                 }
             } else {
                 // Either read or write occurred before the timeout - set a new

--- a/handler/src/main/java/io/netty5/handler/timeout/ReadTimeoutHandler.java
+++ b/handler/src/main/java/io/netty5/handler/timeout/ReadTimeoutHandler.java
@@ -95,7 +95,7 @@ public class ReadTimeoutHandler extends IdleStateHandler {
      */
     protected void readTimedOut(ChannelHandlerContext ctx) throws Exception {
         if (!closed) {
-            ctx.fireExceptionCaught(ReadTimeoutException.INSTANCE);
+            ctx.fireChannelExceptionCaught(ReadTimeoutException.INSTANCE);
             ctx.close();
             closed = true;
         }

--- a/handler/src/main/java/io/netty5/handler/timeout/WriteTimeoutHandler.java
+++ b/handler/src/main/java/io/netty5/handler/timeout/WriteTimeoutHandler.java
@@ -175,7 +175,7 @@ public class WriteTimeoutHandler implements ChannelHandler {
      */
     protected void writeTimedOut(ChannelHandlerContext ctx) throws Exception {
         if (!closed) {
-            ctx.fireExceptionCaught(WriteTimeoutException.INSTANCE);
+            ctx.fireChannelExceptionCaught(WriteTimeoutException.INSTANCE);
             ctx.close();
             closed = true;
         }
@@ -205,7 +205,7 @@ public class WriteTimeoutHandler implements ChannelHandler {
                 try {
                     writeTimedOut(ctx);
                 } catch (Throwable t) {
-                    ctx.fireExceptionCaught(t);
+                    ctx.fireChannelExceptionCaught(t);
                 }
             }
             removeWriteTimeoutTask(this);

--- a/handler/src/test/java/io/netty5/handler/adaptor/BufferConversionHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/adaptor/BufferConversionHandlerTest.java
@@ -141,17 +141,17 @@ class BufferConversionHandlerTest {
             Buffer userEventBuffer;
 
             @Override
-            public ChannelHandlerContext fireInboundEventTriggered(Object evt) {
+            public ChannelHandlerContext fireChannelInboundEvent(Object evt) {
                 userEventBuffer = (Buffer) evt;
                 return this;
             }
         }
         UserEventContext ctx = new UserEventContext();
-        handler.inboundEventTriggered(ctx, testData.byteBuf);
+        handler.channelInboundEvent(ctx, testData.byteBuf);
         assertThat(ctx.userEventBuffer).isEqualTo(testData.buffer);
 
         ctx.userEventBuffer = null;
-        handler.inboundEventTriggered(ctx, testData.buffer);
+        handler.channelInboundEvent(ctx, testData.buffer);
         assertThat(ctx.userEventBuffer).isSameAs(testData.buffer);
     }
 
@@ -261,12 +261,12 @@ class BufferConversionHandlerTest {
         }
 
         @Override
-        public ChannelHandlerContext fireExceptionCaught(Throwable cause) {
+        public ChannelHandlerContext fireChannelExceptionCaught(Throwable cause) {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public ChannelHandlerContext fireInboundEventTriggered(Object evt) {
+        public ChannelHandlerContext fireChannelInboundEvent(Object evt) {
             throw new UnsupportedOperationException();
         }
 
@@ -346,7 +346,7 @@ class BufferConversionHandlerTest {
         }
 
         @Override
-        public Future<Void> triggerOutboundEvent(Object event) {
+        public Future<Void> sendOutboundEvent(Object event) {
             throw new UnsupportedOperationException();
         }
 

--- a/handler/src/test/java/io/netty5/handler/flow/FlowControlHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/flow/FlowControlHandlerTest.java
@@ -407,7 +407,7 @@ public class FlowControlHandlerTest {
             }
 
             @Override
-            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+            public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                 causeRef.set(cause);
             }
         };
@@ -466,11 +466,11 @@ public class FlowControlHandlerTest {
                 }
 
                 @Override
-                public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
                     if (evt instanceof IdleStateEvent) {
                         userEvents.add((IdleStateEvent) evt);
                     }
-                    ctx.fireInboundEventTriggered(evt);
+                    ctx.fireChannelInboundEvent(evt);
                 }
             }
         );

--- a/handler/src/test/java/io/netty5/handler/flush/FlushConsolidationHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/flush/FlushConsolidationHandlerTest.java
@@ -136,7 +136,7 @@ public class FlushConsolidationHandlerTest {
         channel.pipeline().fireChannelRead(1L);
         assertEquals(0, flushCount.get());
         assertNull(channel.readOutbound());
-        channel.pipeline().fireExceptionCaught(new IllegalStateException());
+        channel.pipeline().fireChannelExceptionCaught(new IllegalStateException());
         assertEquals(1, flushCount.get());
         assertEquals(1L, (Long) channel.readOutbound());
         assertNull(channel.readOutbound());

--- a/handler/src/test/java/io/netty5/handler/logging/LoggingHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/logging/LoggingHandlerTest.java
@@ -192,7 +192,7 @@ public class LoggingHandlerTest {
     public void shouldLogChannelUserEvent() throws Exception {
         String userTriggered = "iAmCustom!";
         EmbeddedChannel channel = new EmbeddedChannel(new LoggingHandler());
-        channel.pipeline().fireInboundEventTriggered(new String(userTriggered));
+        channel.pipeline().fireChannelInboundEvent(new String(userTriggered));
         verify(appender).doAppend(argThat(new RegexLogMatcher(".+USER_EVENT: " + userTriggered + '$')));
     }
 
@@ -201,7 +201,7 @@ public class LoggingHandlerTest {
         String msg = "illegalState";
         Throwable cause = new IllegalStateException(msg);
         EmbeddedChannel channel = new EmbeddedChannel(new LoggingHandler());
-        channel.pipeline().fireExceptionCaught(cause);
+        channel.pipeline().fireChannelExceptionCaught(cause);
         verify(appender).doAppend(argThat(new RegexLogMatcher(
                 ".+EXCEPTION: " + cause.getClass().getCanonicalName() + ": " + msg + '$')));
     }

--- a/handler/src/test/java/io/netty5/handler/ssl/ApplicationProtocolNegotiationHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/ApplicationProtocolNegotiationHandlerTest.java
@@ -81,8 +81,8 @@ public class ApplicationProtocolNegotiationHandlerTest {
         EmbeddedChannel channel = new EmbeddedChannel(alpnHandler);
         SSLHandshakeException exception = new SSLHandshakeException("error");
         SslHandshakeCompletionEvent completionEvent = new SslHandshakeCompletionEvent(exception);
-        channel.pipeline().fireInboundEventTriggered(completionEvent);
-        channel.pipeline().fireExceptionCaught(new DecoderException(exception));
+        channel.pipeline().fireChannelInboundEvent(completionEvent);
+        channel.pipeline().fireChannelExceptionCaught(new DecoderException(exception));
         assertNull(channel.pipeline().context(alpnHandler));
         assertFalse(channel.finishAndReleaseAll());
     }
@@ -120,7 +120,7 @@ public class ApplicationProtocolNegotiationHandlerTest {
             channel.pipeline().addLast(new SslHandler(engine));
             channel.pipeline().addLast(alpnHandler);
         }
-        channel.pipeline().fireInboundEventTriggered(SslHandshakeCompletionEvent.SUCCESS);
+        channel.pipeline().fireChannelInboundEvent(SslHandshakeCompletionEvent.SUCCESS);
         assertNull(channel.pipeline().context(alpnHandler));
         // Should produce the close_notify messages
         channel.releaseOutbound();
@@ -139,7 +139,7 @@ public class ApplicationProtocolNegotiationHandlerTest {
             }
         };
         final EmbeddedChannel channel = new EmbeddedChannel(alpnHandler);
-        channel.pipeline().fireInboundEventTriggered(SslHandshakeCompletionEvent.SUCCESS);
+        channel.pipeline().fireChannelInboundEvent(SslHandshakeCompletionEvent.SUCCESS);
         assertNull(channel.pipeline().context(alpnHandler));
         assertThrows(IllegalStateException.class, new Executable() {
             @Override
@@ -199,14 +199,14 @@ public class ApplicationProtocolNegotiationHandlerTest {
 
         EmbeddedChannel channel = new EmbeddedChannel(new SslHandler(engine), new ChannelHandler() {
             @Override
-            public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+            public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
                 if (evt == SslHandshakeCompletionEvent.SUCCESS) {
                     ctx.fireChannelRead(someBytes);
                 }
-                ctx.fireInboundEventTriggered(evt);
+                ctx.fireChannelInboundEvent(evt);
             }
         }, alpnHandler);
-        channel.pipeline().fireInboundEventTriggered(SslHandshakeCompletionEvent.SUCCESS);
+        channel.pipeline().fireChannelInboundEvent(SslHandshakeCompletionEvent.SUCCESS);
         assertNull(channel.pipeline().context(alpnHandler));
         assertArrayEquals(someBytes, channelReadData.get());
         assertTrue(channelReadCompleteCalled.get());

--- a/handler/src/test/java/io/netty5/handler/ssl/CipherSuiteCanaryTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/CipherSuiteCanaryTest.java
@@ -165,9 +165,9 @@ public class CipherSuiteCanaryTest {
                             }
 
                             @Override
-                            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+                            public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                                 if (!serverPromise.tryFailure(cause)) {
-                                    ctx.fireExceptionCaught(cause);
+                                    ctx.fireChannelExceptionCaught(cause);
                                 }
                             }
                         });
@@ -199,10 +199,10 @@ public class CipherSuiteCanaryTest {
                                 }
 
                                 @Override
-                                public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause)
+                                public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause)
                                         throws Exception {
                                     if (!clientPromise.tryFailure(cause)) {
-                                        ctx.fireExceptionCaught(cause);
+                                        ctx.fireChannelExceptionCaught(cause);
                                     }
                                 }
                             });

--- a/handler/src/test/java/io/netty5/handler/ssl/CloseNotifyTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/CloseNotifyTest.java
@@ -162,7 +162,7 @@ public class CloseNotifyTest {
             }
 
             @Override
-            public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+            public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
                 eventQueue.add(evt);
             }
 

--- a/handler/src/test/java/io/netty5/handler/ssl/OpenSslCertificateCompressionTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/OpenSslCertificateCompressionTest.java
@@ -397,7 +397,7 @@ public class OpenSslCertificateCompressionTest {
                 }
 
                 @Override
-                public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
                     if (evt instanceof SslHandshakeCompletionEvent) {
                         if (((SslHandshakeCompletionEvent) evt).isSuccess()) {
                             channelPromise.trySuccess(evt);
@@ -405,7 +405,7 @@ public class OpenSslCertificateCompressionTest {
                             channelPromise.tryFailure(((SslHandshakeCompletionEvent) evt).cause());
                         }
                     }
-                    ctx.fireInboundEventTriggered(evt);
+                    ctx.fireChannelInboundEvent(evt);
                 }
             });
         }

--- a/handler/src/test/java/io/netty5/handler/ssl/OpenSslPrivateKeyMethodTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/OpenSslPrivateKeyMethodTest.java
@@ -252,9 +252,9 @@ public class OpenSslPrivateKeyMethodTest {
                             }
 
                             @Override
-                            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                            public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                                 if (!serverPromise.tryFailure(cause)) {
-                                    ctx.fireExceptionCaught(cause);
+                                    ctx.fireChannelExceptionCaught(cause);
                                 }
                             }
                         });
@@ -287,9 +287,9 @@ public class OpenSslPrivateKeyMethodTest {
                                 }
 
                                 @Override
-                                public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                                public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                                     if (!clientPromise.tryFailure(cause)) {
-                                        ctx.fireExceptionCaught(cause);
+                                        ctx.fireChannelExceptionCaught(cause);
                                     }
                                 }
                             });

--- a/handler/src/test/java/io/netty5/handler/ssl/ParameterizedSslHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/ParameterizedSslHandlerTest.java
@@ -170,7 +170,7 @@ public class ParameterizedSslHandlerTest {
                                 private Throwable writeCause;
 
                                 @Override
-                                public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                                public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
                                     if (evt instanceof SslHandshakeCompletionEvent) {
                                         SslHandshakeCompletionEvent sslEvt = (SslHandshakeCompletionEvent) evt;
                                         if (sslEvt.isSuccess()) {
@@ -191,11 +191,11 @@ public class ParameterizedSslHandlerTest {
                                             donePromise.tryFailure(sslEvt.cause());
                                         }
                                     }
-                                    ctx.fireInboundEventTriggered(evt);
+                                    ctx.fireChannelInboundEvent(evt);
                                 }
 
                                 @Override
-                                public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                                public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                                     donePromise.tryFailure(new IllegalStateException("server exception sentData: " +
                                             sentData + " writeCause: " + writeCause, cause));
                                 }
@@ -234,7 +234,7 @@ public class ParameterizedSslHandlerTest {
                                 }
 
                                 @Override
-                                public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                                public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
                                     if (evt instanceof SslHandshakeCompletionEvent) {
                                         SslHandshakeCompletionEvent sslEvt = (SslHandshakeCompletionEvent) evt;
                                         if (!sslEvt.isSuccess()) {
@@ -244,7 +244,7 @@ public class ParameterizedSslHandlerTest {
                                 }
 
                                 @Override
-                                public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                                public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                                     donePromise.tryFailure(new IllegalStateException("client exception. bytesSeen: " +
                                             bytesSeen, cause));
                                 }
@@ -332,7 +332,7 @@ public class ParameterizedSslHandlerTest {
                             ch.pipeline().addLast(sslServerCtx.newHandler(ch.bufferAllocator()));
                             ch.pipeline().addLast(new ChannelHandler() {
                                 @Override
-                                public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                                public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                                     // Just trigger a close
                                     ctx.close();
                                 }
@@ -349,7 +349,7 @@ public class ParameterizedSslHandlerTest {
                             ch.pipeline().addLast(sslClientCtx.newHandler(ch.bufferAllocator()));
                             ch.pipeline().addLast(new ChannelHandler() {
                                 @Override
-                                public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                                public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                                     if (cause.getCause() instanceof SSLException) {
                                         // We received the alert and so produce an SSLException.
                                         promise.trySuccess(null);
@@ -657,7 +657,7 @@ public class ParameterizedSslHandlerTest {
         }
 
         @Override
-        public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+        public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
             if (evt instanceof SslHandshakeCompletionEvent) {
                 SslHandshakeCompletionEvent sslEvt = (SslHandshakeCompletionEvent) evt;
                 if (sslEvt.isSuccess()) {
@@ -667,13 +667,13 @@ public class ParameterizedSslHandlerTest {
                     appendError(sslEvt.cause());
                 }
             }
-            ctx.fireInboundEventTriggered(evt);
+            ctx.fireChannelInboundEvent(evt);
         }
 
         @Override
-        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
             appendError(cause);
-            ctx.fireExceptionCaught(cause);
+            ctx.fireChannelExceptionCaught(cause);
         }
 
         private void appendError(Throwable cause) {

--- a/handler/src/test/java/io/netty5/handler/ssl/RenegotiateTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/RenegotiateTest.java
@@ -71,7 +71,7 @@ public abstract class RenegotiateTest {
                                 }
 
                                 @Override
-                                public void inboundEventTriggered(
+                                public void channelInboundEvent(
                                         final ChannelHandlerContext ctx, Object evt) {
                                     if (!renegotiate && evt instanceof SslHandshakeCompletionEvent) {
                                         SslHandshakeCompletionEvent event = (SslHandshakeCompletionEvent) evt;
@@ -116,7 +116,7 @@ public abstract class RenegotiateTest {
                             ch.pipeline().addLast(handler);
                             ch.pipeline().addLast(new ChannelHandler() {
                                 @Override
-                                public void inboundEventTriggered(
+                                public void channelInboundEvent(
                                         ChannelHandlerContext ctx, Object evt) {
                                     if (evt instanceof SslHandshakeCompletionEvent) {
                                         SslHandshakeCompletionEvent event = (SslHandshakeCompletionEvent) evt;

--- a/handler/src/test/java/io/netty5/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SSLEngineTest.java
@@ -727,7 +727,7 @@ public abstract class SSLEngineTest {
                 p.addLast(new MessageDelegatorChannelHandler(serverReceiver, serverLatch));
                 p.addLast(new ChannelHandler() {
                     @Override
-                    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+                    public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
                         if (evt == SslHandshakeCompletionEvent.SUCCESS) {
                             if (failureExpected) {
                                 serverException = new IllegalStateException("handshake complete. expected failure");
@@ -737,17 +737,17 @@ public abstract class SSLEngineTest {
                             serverException = ((SslHandshakeCompletionEvent) evt).cause();
                             serverLatch.countDown();
                         }
-                        ctx.fireInboundEventTriggered(evt);
+                        ctx.fireChannelInboundEvent(evt);
                     }
 
                     @Override
-                    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+                    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
                         if (cause.getCause() instanceof SSLHandshakeException) {
                             serverException = cause.getCause();
                             serverLatch.countDown();
                         } else {
                             serverException = cause;
-                            ctx.fireExceptionCaught(cause);
+                            ctx.fireChannelExceptionCaught(cause);
                         }
                     }
                 });
@@ -769,7 +769,7 @@ public abstract class SSLEngineTest {
                 p.addLast(new MessageDelegatorChannelHandler(clientReceiver, clientLatch));
                 p.addLast(new ChannelHandler() {
                     @Override
-                    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+                    public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
                         if (evt == SslHandshakeCompletionEvent.SUCCESS) {
                             // With TLS1.3 a mutal auth error will not be propagated as a handshake error most of the
                             // time as the handshake needs NO extra roundtrip.
@@ -780,16 +780,16 @@ public abstract class SSLEngineTest {
                             clientException = ((SslHandshakeCompletionEvent) evt).cause();
                             clientLatch.countDown();
                         }
-                        ctx.fireInboundEventTriggered(evt);
+                        ctx.fireChannelInboundEvent(evt);
                     }
 
                     @Override
-                    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+                    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
                         if (cause.getCause() instanceof SSLException) {
                             clientException = cause.getCause();
                             clientLatch.countDown();
                         } else {
-                            ctx.fireExceptionCaught(cause);
+                            ctx.fireChannelExceptionCaught(cause);
                         }
                     }
                 });
@@ -894,7 +894,7 @@ public abstract class SSLEngineTest {
                 p.addLast(new MessageDelegatorChannelHandler(serverReceiver, serverLatch));
                 p.addLast(new ChannelHandler() {
                     @Override
-                    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+                    public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
                         if (evt == SslHandshakeCompletionEvent.SUCCESS) {
                             if (failureExpected) {
                                 serverException = new IllegalStateException("handshake complete. expected failure");
@@ -904,17 +904,17 @@ public abstract class SSLEngineTest {
                             serverException = ((SslHandshakeCompletionEvent) evt).cause();
                             serverLatch.countDown();
                         }
-                        ctx.fireInboundEventTriggered(evt);
+                        ctx.fireChannelInboundEvent(evt);
                     }
 
                     @Override
-                    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+                    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
                         if (cause.getCause() instanceof SSLHandshakeException) {
                             serverException = cause.getCause();
                             serverLatch.countDown();
                         } else {
                             serverException = cause;
-                            ctx.fireExceptionCaught(cause);
+                            ctx.fireChannelExceptionCaught(cause);
                         }
                     }
                 });
@@ -956,7 +956,7 @@ public abstract class SSLEngineTest {
                     }
 
                     @Override
-                    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+                    public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
                         if (evt == SslHandshakeCompletionEvent.SUCCESS) {
                             if (failureExpected) {
                                 clientException = new IllegalStateException("handshake complete. expected failure");
@@ -966,16 +966,16 @@ public abstract class SSLEngineTest {
                             clientException = ((SslHandshakeCompletionEvent) evt).cause();
                             clientLatch.countDown();
                         }
-                        ctx.fireInboundEventTriggered(evt);
+                        ctx.fireChannelInboundEvent(evt);
                     }
 
                     @Override
-                    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+                    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
                         if (cause.getCause() instanceof SSLHandshakeException) {
                             clientException = cause.getCause();
                             clientLatch.countDown();
                         } else {
-                            ctx.fireExceptionCaught(cause);
+                            ctx.fireChannelExceptionCaught(cause);
                         }
                     }
                 });
@@ -1083,18 +1083,18 @@ public abstract class SSLEngineTest {
                 p.addLast(new MessageDelegatorChannelHandler(serverReceiver, serverLatch));
                 p.addLast(new ChannelHandler() {
                     @Override
-                    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+                    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
                         if (cause.getCause() instanceof SSLHandshakeException) {
                             serverException = cause.getCause();
                             serverLatch.countDown();
                         } else {
                             serverException = cause;
-                            ctx.fireExceptionCaught(cause);
+                            ctx.fireChannelExceptionCaught(cause);
                         }
                     }
 
                     @Override
-                    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+                    public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
                         if (evt == SslHandshakeCompletionEvent.SUCCESS) {
                             try {
                                 verifySSLSessionForMutualAuth(
@@ -1126,7 +1126,7 @@ public abstract class SSLEngineTest {
                 p.addLast(new MessageDelegatorChannelHandler(clientReceiver, clientLatch));
                 p.addLast(new ChannelHandler() {
                     @Override
-                    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+                    public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
                         if (evt == SslHandshakeCompletionEvent.SUCCESS) {
                             try {
                                 verifySSLSessionForMutualAuth(
@@ -1138,12 +1138,12 @@ public abstract class SSLEngineTest {
                     }
 
                     @Override
-                    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+                    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
                         if (cause.getCause() instanceof SSLHandshakeException) {
                             clientException = cause.getCause();
                             clientLatch.countDown();
                         } else {
-                            ctx.fireExceptionCaught(cause);
+                            ctx.fireChannelExceptionCaught(cause);
                         }
                     }
                 });
@@ -1369,7 +1369,7 @@ public abstract class SSLEngineTest {
                         p.addLast(handler);
                         p.addLast(new ChannelHandler() {
                             @Override
-                            public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                            public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
                                 if (evt instanceof SslHandshakeCompletionEvent &&
                                         ((SslHandshakeCompletionEvent) evt).isSuccess()) {
                                     // This data will be sent to the client before any of the re-negotiation data can be
@@ -1377,7 +1377,7 @@ public abstract class SSLEngineTest {
                                     // renegotiation which was expected, and respond with a fatal alert.
                                     ctx.writeAndFlush(ctx.bufferAllocator().copyOf(new byte[] { 100 }));
                                 }
-                                ctx.fireInboundEventTriggered(evt);
+                                ctx.fireChannelInboundEvent(evt);
                             }
 
                             @Override
@@ -1431,7 +1431,7 @@ public abstract class SSLEngineTest {
                         p.addLast(new ChannelHandler() {
                             private int handshakeCount;
                             @Override
-                            public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                            public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
                                 // OpenSSL SSLEngine sends a fatal alert for the renegotiation handshake because the
                                 // user data read as part of the handshake. The client receives this fatal alert and is
                                 // expected to shutdown the connection. The "invalid data" during the renegotiation
@@ -1444,7 +1444,7 @@ public abstract class SSLEngineTest {
                                     ctx.close();
                                     return;
                                 }
-                                ctx.fireInboundEventTriggered(evt);
+                                ctx.fireChannelInboundEvent(evt);
                             }
 
                             @Override
@@ -1730,12 +1730,12 @@ public abstract class SSLEngineTest {
                 p.addLast(new MessageDelegatorChannelHandler(serverReceiver, serverLatch));
                 p.addLast(new ChannelHandler() {
                     @Override
-                    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+                    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
                         if (cause.getCause() instanceof SSLHandshakeException) {
                             serverException = cause.getCause();
                             serverLatch.countDown();
                         } else {
-                            ctx.fireExceptionCaught(cause);
+                            ctx.fireChannelExceptionCaught(cause);
                         }
                     }
                 });
@@ -1760,12 +1760,12 @@ public abstract class SSLEngineTest {
                 p.addLast(new MessageDelegatorChannelHandler(clientReceiver, clientLatch));
                 p.addLast(new ChannelHandler() {
                     @Override
-                    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+                    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
                         if (cause.getCause() instanceof SSLHandshakeException) {
                             clientException = cause.getCause();
                             clientLatch.countDown();
                         } else {
-                            ctx.fireExceptionCaught(cause);
+                            ctx.fireChannelExceptionCaught(cause);
                         }
                     }
 
@@ -1815,7 +1815,7 @@ public abstract class SSLEngineTest {
                 ch.pipeline().addFirst(sslHandler);
                 ch.pipeline().addLast(new ChannelHandler() {
                     @Override
-                    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+                    public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
                         if (evt instanceof SslHandshakeCompletionEvent) {
                             Throwable cause = ((SslHandshakeCompletionEvent) evt).cause();
                             if (cause == null) {

--- a/handler/src/test/java/io/netty5/handler/ssl/SniClientTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SniClientTest.java
@@ -157,7 +157,7 @@ public class SniClientTest {
                     ch.pipeline().addFirst(handler);
                     ch.pipeline().addLast(new ChannelHandler() {
                         @Override
-                        public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                        public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
                             if (evt instanceof SslHandshakeCompletionEvent) {
                                 SslHandshakeCompletionEvent event = (SslHandshakeCompletionEvent) evt;
                                 if (match) {

--- a/handler/src/test/java/io/netty5/handler/ssl/SniHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SniHandlerTest.java
@@ -156,7 +156,7 @@ public class SniHandlerTest {
             SniHandler handler = new SniHandler(new DomainNameMappingBuilder<>(nettyContext).build());
             final EmbeddedChannel ch = new EmbeddedChannel(handler, new ChannelHandler() {
                 @Override
-                public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+                public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
                     if (evt instanceof SslHandshakeCompletionEvent) {
                         assertTrue(evtRef.compareAndSet(null, (SslHandshakeCompletionEvent) evt));
                     }
@@ -202,11 +202,11 @@ public class SniHandlerTest {
             SniHandler handler = new SniHandler(mapping);
             EmbeddedChannel ch = new EmbeddedChannel(handler, new ChannelHandler() {
                 @Override
-                public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+                public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
                     if (evt instanceof SniCompletionEvent) {
                         assertTrue(evtRef.compareAndSet(null, (SniCompletionEvent) evt));
                     } else {
-                        ctx.fireInboundEventTriggered(evt);
+                        ctx.fireChannelInboundEvent(evt);
                     }
                 }
             });

--- a/handler/src/test/java/io/netty5/handler/ssl/SslErrorTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SslErrorTest.java
@@ -157,7 +157,7 @@ public class SslErrorTest {
                             ch.pipeline().addLast(new ChannelHandler() {
 
                                 @Override
-                                public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                                public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                                     ctx.close();
                                 }
                             });
@@ -178,7 +178,7 @@ public class SslErrorTest {
                             ch.pipeline().addLast(new ChannelHandler() {
 
                                 @Override
-                                public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                                public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                                     ctx.close();
                                 }
                             });
@@ -251,7 +251,7 @@ public class SslErrorTest {
         }
 
         @Override
-        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
             // Unwrap as its wrapped by a DecoderException
             Throwable unwrappedCause = cause.getCause();
             if (unwrappedCause instanceof SSLException) {

--- a/handler/src/test/java/io/netty5/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SslHandlerTest.java
@@ -192,7 +192,7 @@ public class SslHandlerTest {
             }
         }, new ChannelHandler() {
             @Override
-            public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+            public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
                 if (evt instanceof SslHandshakeCompletionEvent) {
                     throw (Exception) ((SslHandshakeCompletionEvent) evt).cause();
                 }
@@ -282,7 +282,7 @@ public class SslHandlerTest {
         final AtomicReference<Throwable> closeRef = new AtomicReference<>();
         EmbeddedChannel ch = new EmbeddedChannel(handler, new ChannelHandler() {
             @Override
-            public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+            public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
                 if (evt instanceof SslHandshakeCompletionEvent) {
                     handshakeRef.set(((SslHandshakeCompletionEvent) evt).cause());
                 } else if (evt instanceof SslCloseCompletionEvent) {
@@ -527,7 +527,7 @@ public class SslHandlerTest {
 
                 ch.pipeline().addLast(new ChannelHandler() {
                     @Override
-                    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                         if (cause instanceof CodecException) {
                             cause = cause.getCause();
                         }
@@ -572,7 +572,7 @@ public class SslHandlerTest {
         final BlockingQueue<SslCompletionEvent> events = new LinkedBlockingQueue<>();
         EmbeddedChannel channel = new EmbeddedChannel(new SslHandler(engine), new ChannelHandler() {
             @Override
-            public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+            public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
                 if (evt instanceof SslCompletionEvent) {
                     events.add((SslCompletionEvent) evt);
                 }
@@ -627,7 +627,7 @@ public class SslHandlerTest {
                           }
 
                           @Override
-                          public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                          public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
                               logger.debug("[testHandshakeFailBeforeWritePromise] server user event triggered: " + evt);
                               if (evt instanceof SslCompletionEvent) {
                                   events.add(evt);
@@ -876,7 +876,7 @@ public class SslHandlerTest {
                             ch.pipeline().addLast(sslHandler);
                             ch.pipeline().addLast(new ChannelHandler() {
                                 @Override
-                                public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause)
+                                public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause)
                                         throws Exception {
                                     if (cause instanceof AssertionError) {
                                         errorRef.set((AssertionError) cause);
@@ -1136,7 +1136,7 @@ public class SslHandlerTest {
                             ch.pipeline().addLast(serverSslHandler);
                             ch.pipeline().addLast(new ChannelHandler() {
                                 @Override
-                                public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                                public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                                     causeRef.compareAndSet(null, cause);
                                 }
                             });
@@ -1153,7 +1153,7 @@ public class SslHandlerTest {
                             ch.pipeline().addLast(clientSslHandler);
                             ch.pipeline().addLast(new ChannelHandler() {
                                 @Override
-                                public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                                public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                                     causeRef.compareAndSet(null, cause);
                                 }
                             });
@@ -1330,7 +1330,7 @@ public class SslHandlerTest {
                                 private int handshakeCount;
 
                                 @Override
-                                public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt)  {
+                                public void channelInboundEvent(ChannelHandlerContext ctx, Object evt)  {
                                     if (evt instanceof SslHandshakeCompletionEvent) {
                                         handshakeCount++;
                                         ReferenceCountedOpenSslEngine engine =
@@ -1398,7 +1398,7 @@ public class SslHandlerTest {
                                 }
 
                                 @Override
-                                public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                                public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                                     queue.add(cause);
                                 }
                             });
@@ -1504,7 +1504,7 @@ public class SslHandlerTest {
                             ch.pipeline().addLast(serverSslHandler);
                             ch.pipeline().addLast(new ChannelHandler() {
                                 @Override
-                                public void exceptionCaught(final ChannelHandlerContext ctx, Throwable cause) {
+                                public void channelExceptionCaught(final ChannelHandlerContext ctx, Throwable cause) {
                                     errorQueue.add(cause);
                                 }
 
@@ -1610,11 +1610,11 @@ public class SslHandlerTest {
             }
 
             @Override
-            public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+            public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
                 if (evt instanceof SslHandshakeCompletionEvent) {
                     ref.set((SslHandshakeCompletionEvent) evt);
                 }
-                ctx.fireInboundEventTriggered(evt);
+                ctx.fireChannelInboundEvent(evt);
             }
         }
         final AtomicReference<SslHandshakeCompletionEvent> clientEvent =
@@ -1771,7 +1771,7 @@ public class SslHandlerTest {
         }
 
         @Override
-        public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+        public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
             if (evt instanceof SslHandshakeCompletionEvent) {
                 completionEvents.add((SslHandshakeCompletionEvent) evt);
             }

--- a/handler/src/test/java/io/netty5/handler/ssl/ocsp/OcspTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/ocsp/OcspTest.java
@@ -240,7 +240,7 @@ public class OcspTest {
 
         ChannelHandler clientHandler = new ChannelHandler() {
             @Override
-            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+            public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
                 try {
                     causeRef.set(cause);
                 } finally {
@@ -334,7 +334,7 @@ public class OcspTest {
 
         ChannelHandler clientHandler = new ChannelHandler() {
             @Override
-            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+            public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
                 try {
                     causeRef.set(cause);
                 } finally {

--- a/handler/src/test/java/io/netty5/handler/timeout/AbstractIdleStateHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/timeout/AbstractIdleStateHandlerTest.java
@@ -73,7 +73,7 @@ public abstract class AbstractIdleStateHandlerTest {
         final List<Object> events = new ArrayList<>();
         ChannelHandler handler = new ChannelHandler() {
             @Override
-            public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+            public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
                 events.add(evt);
             }
         };
@@ -144,7 +144,7 @@ public abstract class AbstractIdleStateHandlerTest {
         final List<Object> events = new ArrayList<>();
         ChannelHandler handler = new ChannelHandler() {
             @Override
-            public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+            public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
                 events.add(evt);
             }
         };
@@ -206,7 +206,7 @@ public abstract class AbstractIdleStateHandlerTest {
         final List<Object> events = new ArrayList<>();
         ChannelHandler handler = new ChannelHandler() {
             @Override
-            public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+            public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
                 events.add(evt);
             }
         };

--- a/microbench/src/main/java/io/netty5/microbench/channel/EmbeddedChannelHandlerContext.java
+++ b/microbench/src/main/java/io/netty5/microbench/channel/EmbeddedChannelHandlerContext.java
@@ -111,9 +111,9 @@ public abstract class EmbeddedChannelHandlerContext implements ChannelHandlerCon
     }
 
     @Override
-    public final ChannelHandlerContext fireExceptionCaught(Throwable cause) {
+    public final ChannelHandlerContext fireChannelExceptionCaught(Throwable cause) {
         try {
-            handler().exceptionCaught(this, cause);
+            handler().channelExceptionCaught(this, cause);
         } catch (Exception e) {
             handleException(e);
         }
@@ -121,7 +121,7 @@ public abstract class EmbeddedChannelHandlerContext implements ChannelHandlerCon
     }
 
     @Override
-    public final ChannelHandlerContext fireInboundEventTriggered(Object event) {
+    public final ChannelHandlerContext fireChannelInboundEvent(Object event) {
         Resource.dispose(event);
         return this;
     }
@@ -246,8 +246,8 @@ public abstract class EmbeddedChannelHandlerContext implements ChannelHandlerCon
     }
 
     @Override
-    public Future<Void> triggerOutboundEvent(Object event) {
-        return channel().triggerOutboundEvent(event);
+    public Future<Void> sendOutboundEvent(Object event) {
+        return channel().sendOutboundEvent(event);
     }
 
     @Override

--- a/resolver-dns/src/main/java/io/netty5/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty5/resolver/dns/DnsNameResolver.java
@@ -1317,7 +1317,7 @@ public class DnsNameResolver extends InetNameResolver {
                     }
 
                     @Override
-                    public void exceptionCaught(ChannelHandlerContext ctx1, Throwable cause) {
+                    public void channelExceptionCaught(ChannelHandlerContext ctx1, Throwable cause) {
                         if (tcpCtx.tryFailure("TCP fallback error", cause, false) && logger.isDebugEnabled()) {
                             logger.debug("{} Error during processing response: TCP [{}: {}]",
                                     ctx1.channel(), queryId,
@@ -1348,7 +1348,7 @@ public class DnsNameResolver extends InetNameResolver {
         }
 
         @Override
-        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
             if (cause instanceof CorruptedFrameException) {
                 logger.debug("Unable to decode DNS response: UDP [{}]", ctx.channel(), cause);
             } else {

--- a/testsuite-autobahn/src/main/java/io/netty5/testsuite/autobahn/AutobahnServerHandler.java
+++ b/testsuite-autobahn/src/main/java/io/netty5/testsuite/autobahn/AutobahnServerHandler.java
@@ -134,7 +134,7 @@ public class AutobahnServerHandler implements ChannelHandler {
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         ctx.close();
     }
 

--- a/testsuite-http2/src/main/java/io/netty5/testsuite/http2/HelloWorldHttp1Handler.java
+++ b/testsuite-http2/src/main/java/io/netty5/testsuite/http2/HelloWorldHttp1Handler.java
@@ -75,7 +75,7 @@ public class HelloWorldHttp1Handler extends SimpleChannelInboundHandler<FullHttp
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         cause.printStackTrace();
         ctx.close();
     }

--- a/testsuite-http2/src/main/java/io/netty5/testsuite/http2/HelloWorldHttp2Handler.java
+++ b/testsuite-http2/src/main/java/io/netty5/testsuite/http2/HelloWorldHttp2Handler.java
@@ -68,18 +68,18 @@ public final class HelloWorldHttp2Handler extends Http2ConnectionHandler impleme
      * on stream 1 (the stream specifically reserved for cleartext HTTP upgrade).
      */
     @Override
-    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+    public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
         if (evt instanceof HttpServerUpgradeHandler.UpgradeEvent) {
             HttpServerUpgradeHandler.UpgradeEvent upgradeEvent =
                     (HttpServerUpgradeHandler.UpgradeEvent) evt;
             onHeadersRead(ctx, 1, http1HeadersToHttp2Headers(upgradeEvent.upgradeRequest()), 0 , true);
         }
-        super.inboundEventTriggered(ctx, evt);
+        super.channelInboundEvent(ctx, evt);
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-        super.exceptionCaught(ctx, cause);
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        super.channelExceptionCaught(ctx, cause);
         cause.printStackTrace();
         ctx.close();
     }

--- a/testsuite-http2/src/main/java/io/netty5/testsuite/http2/Http2ServerInitializer.java
+++ b/testsuite-http2/src/main/java/io/netty5/testsuite/http2/Http2ServerInitializer.java
@@ -99,9 +99,9 @@ public class Http2ServerInitializer extends ChannelInitializer<SocketChannel> {
      */
     private static class UserEventLogger implements ChannelHandler {
         @Override
-        public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+        public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
             System.out.println("User Event Triggered: " + evt);
-            ctx.fireInboundEventTriggered(evt);
+            ctx.fireChannelInboundEvent(evt);
         }
     }
 }

--- a/testsuite-native-image/src/main/java/io/netty5/testsuite/svm/HttpNativeServerHandler.java
+++ b/testsuite-native-image/src/main/java/io/netty5/testsuite/svm/HttpNativeServerHandler.java
@@ -62,7 +62,7 @@ public class HttpNativeServerHandler extends SimpleChannelInboundHandler<HttpObj
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         cause.printStackTrace();
         ctx.close();
     }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/AbstractSocketReuseFdTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/AbstractSocketReuseFdTest.java
@@ -157,7 +157,7 @@ public abstract class AbstractSocketReuseFdTest extends AbstractSocketTest {
         }
 
         @Override
-        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
             if (exception.compareAndSet(null, cause)) {
                 donePromise.tryFailure(new IllegalStateException("exceptionCaught: " + ctx.channel(), cause));
                 ctx.close();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/CompositeBufferGatheringWriteTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/CompositeBufferGatheringWriteTest.java
@@ -89,7 +89,7 @@ public class CompositeBufferGatheringWriteTest extends AbstractSocketTest {
                         }
 
                         @Override
-                        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+                        public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                             // IOException is fine as it will also close the channel and may just be a connection reset.
                             if (!(cause instanceof IOException)) {
                                 closeAggregator();
@@ -195,7 +195,7 @@ public class CompositeBufferGatheringWriteTest extends AbstractSocketTest {
                           }
 
                           @Override
-                          public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+                          public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                               // IOException is fine as it will also close the channel
                               // and may just be a connection reset.
                               if (!(cause instanceof IOException)) {
@@ -227,7 +227,7 @@ public class CompositeBufferGatheringWriteTest extends AbstractSocketTest {
                         }
 
                         @Override
-                        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+                        public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                             // IOException is fine as it will also close the channel
                             // and may just be a connection reset.
                             if (!(cause instanceof IOException)) {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramConnectNotExistsTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramConnectNotExistsTest.java
@@ -58,7 +58,7 @@ public class DatagramConnectNotExistsTest extends AbstractClientSocketTest {
         final Promise<Throwable> promise = ImmediateEventExecutor.INSTANCE.newPromise();
         cb.handler(new ChannelHandler() {
             @Override
-            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+            public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                 promise.trySuccess(cause);
             }
         });

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramUnicastInetTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramUnicastInetTest.java
@@ -85,7 +85,7 @@ public class DatagramUnicastInetTest extends DatagramUnicastTest {
             }
 
             @Override
-            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+            public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                 errorRef.compareAndSet(null, cause);
             }
         });
@@ -134,7 +134,7 @@ public class DatagramUnicastInetTest extends DatagramUnicastTest {
                     }
 
                     @Override
-                    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                         errorRef.compareAndSet(null, cause);
                     }
                 });

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketCancelWriteTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketCancelWriteTest.java
@@ -123,8 +123,8 @@ public class SocketCancelWriteTest extends AbstractSocketTest {
         }
 
         @Override
-        public void exceptionCaught(ChannelHandlerContext ctx,
-                Throwable cause) throws Exception {
+        public void channelExceptionCaught(ChannelHandlerContext ctx,
+                                           Throwable cause) throws Exception {
             if (exception.compareAndSet(null, cause)) {
                 ctx.close();
             }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConnectionAttemptTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConnectionAttemptTest.java
@@ -140,7 +140,7 @@ public class SocketConnectionAttemptTest extends AbstractClientSocketTest {
 
     private static class TestHandler implements ChannelHandler {
         @Override
-        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
             InternalLoggerFactory.getInstance(
                     SocketConnectionAttemptTest.class).warn("Unexpected exception:", cause);
         }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketEchoTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketEchoTest.java
@@ -73,7 +73,7 @@ public class SocketEchoTest extends AbstractSocketTest {
         sb.childHandler(sh);
         sb.handler(new ChannelHandler() {
             @Override
-            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+            public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
                 cause.printStackTrace();
             }
         });
@@ -188,7 +188,7 @@ public class SocketEchoTest extends AbstractSocketTest {
         }
 
         @Override
-        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
             if (exception.compareAndSet(null, cause)) {
                 cause.printStackTrace();
                 ctx.close();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketExceptionHandlingTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketExceptionHandlingTest.java
@@ -99,13 +99,13 @@ public class SocketExceptionHandlingTest extends AbstractSocketTest {
     private static class ExceptionHandler implements ChannelHandler {
         final AtomicLong count = new AtomicLong();
         /**
-         * We expect to get 1 call to {@link #exceptionCaught(ChannelHandlerContext, Throwable)}.
+         * We expect to get 1 call to {@link #channelExceptionCaught(ChannelHandlerContext, Throwable)}.
          */
         final CountDownLatch latch1 = new CountDownLatch(1);
         final CountDownLatch latch2 = new CountDownLatch(1);
 
         @Override
-        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
             if (count.incrementAndGet() <= 2) {
                 latch1.countDown();
             } else {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketFileRegionTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketFileRegionTest.java
@@ -152,7 +152,7 @@ public class SocketFileRegionTest extends AbstractSocketTest {
             }
 
             @Override
-            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+            public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
                 ctx.close();
             }
         };
@@ -250,7 +250,7 @@ public class SocketFileRegionTest extends AbstractSocketTest {
         }
 
         @Override
-        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
             if (exception.compareAndSet(null, cause)) {
                 ctx.close();
             }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketFixedLengthEchoTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketFixedLengthEchoTest.java
@@ -182,7 +182,7 @@ public class SocketFixedLengthEchoTest extends AbstractSocketTest {
         }
 
         @Override
-        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
             if (exception.compareAndSet(null, cause)) {
                 ctx.close();
             }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketGatheringWriteTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketGatheringWriteTest.java
@@ -249,11 +249,11 @@ public class SocketGatheringWriteTest extends AbstractSocketTest {
         }
 
         @Override
-        public final void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        public final void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
             if (exception.compareAndSet(null, cause)) {
                 handleException(ctx, cause);
             }
-            super.exceptionCaught(ctx, cause);
+            super.channelExceptionCaught(ctx, cause);
         }
 
         void handleException(ChannelHandlerContext ctx, Throwable cause) {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -134,7 +134,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                         }
 
                         @Override
-                        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                        public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                             ctx.close();
                         }
                     });
@@ -157,7 +157,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                         }
 
                         @Override
-                        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                        public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                             ctx.close();
                         }
                     });
@@ -214,7 +214,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                         }
 
                         @Override
-                        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                        public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                             ctx.close();
                         }
                     });
@@ -254,7 +254,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                         }
 
                         @Override
-                        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                        public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                             ctx.close();
                         }
                     });
@@ -366,7 +366,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
         }
 
         @Override
-        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
             ctx.close();
             checkPrematureClose();
         }
@@ -460,7 +460,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
         }
 
         @Override
-        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
             ctx.close();
             checkPrematureClose();
         }
@@ -514,7 +514,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                         }
 
                         @Override
-                        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                        public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                             ctx.close();
                         }
                     });
@@ -561,7 +561,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                         }
 
                         @Override
-                        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                        public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                             ctx.close();
                         }
                     });

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketRstTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketRstTest.java
@@ -68,7 +68,7 @@ public class SocketRstTest extends AbstractSocketTest {
             protected void initChannel(Channel ch) throws Exception {
                 ch.pipeline().addLast(new ChannelHandler() {
                     @Override
-                    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                         throwableRef.compareAndSet(null, cause);
                     }
 
@@ -122,7 +122,7 @@ public class SocketRstTest extends AbstractSocketTest {
             protected void initChannel(Channel ch) throws Exception {
                 ch.pipeline().addLast(new ChannelHandler() {
                     @Override
-                    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                         throwableRef.compareAndSet(null, cause);
                     }
 

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
@@ -236,13 +236,13 @@ public class SocketSslClientRenegotiateTest extends AbstractSocketTest {
         }
 
         @Override
-        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
             exception.compareAndSet(null, cause);
             ctx.close();
         }
 
         @Override
-        public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+        public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
             if (evt instanceof SslHandshakeCompletionEvent) {
                 SslHandshakeCompletionEvent handshakeEvt = (SslHandshakeCompletionEvent) evt;
                 if (handshakeCounter == 0) {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslEchoTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslEchoTest.java
@@ -298,11 +298,11 @@ public class SocketSslEchoTest extends AbstractSocketTest {
                 sch.pipeline().addLast("clientHandler", clientHandler);
                 sch.pipeline().addLast(new ChannelHandler() {
                     @Override
-                    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                    public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
                         if (evt instanceof SslHandshakeCompletionEvent) {
                             clientHandshakeEventLatch.countDown();
                         }
-                        ctx.fireInboundEventTriggered(evt);
+                        ctx.fireChannelInboundEvent(evt);
                     }
                 });
             }
@@ -480,7 +480,7 @@ public class SocketSslEchoTest extends AbstractSocketTest {
         }
 
         @Override
-        public final void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+        public final void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
             if (evt instanceof SslHandshakeCompletionEvent) {
                 SslHandshakeCompletionEvent handshakeEvt = (SslHandshakeCompletionEvent) evt;
                 if (handshakeEvt.cause() != null) {
@@ -490,11 +490,11 @@ public class SocketSslEchoTest extends AbstractSocketTest {
                 negoCounter.incrementAndGet();
                 logStats("HANDSHAKEN");
             }
-            ctx.fireInboundEventTriggered(evt);
+            ctx.fireChannelInboundEvent(evt);
         }
 
         @Override
-        public final void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        public final void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
             if (logger.isWarnEnabled()) {
                 logger.warn("Unexpected exception from the client side:", cause);
             }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslGreetingTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslGreetingTest.java
@@ -191,8 +191,8 @@ public class SocketSslGreetingTest extends AbstractSocketTest {
         }
 
         @Override
-        public void exceptionCaught(ChannelHandlerContext ctx,
-                                    Throwable cause) throws Exception {
+        public void channelExceptionCaught(ChannelHandlerContext ctx,
+                                           Throwable cause) throws Exception {
             if (logger.isWarnEnabled()) {
                 logger.warn("Unexpected exception from the client side", cause);
             }
@@ -219,8 +219,8 @@ public class SocketSslGreetingTest extends AbstractSocketTest {
         }
 
         @Override
-        public void exceptionCaught(ChannelHandlerContext ctx,
-                                    Throwable cause) throws Exception {
+        public void channelExceptionCaught(ChannelHandlerContext ctx,
+                                           Throwable cause) throws Exception {
             if (logger.isWarnEnabled()) {
                 logger.warn("Unexpected exception from the server side", cause);
             }
@@ -230,7 +230,7 @@ public class SocketSslGreetingTest extends AbstractSocketTest {
         }
 
         @Override
-        public void inboundEventTriggered(final ChannelHandlerContext ctx, final Object evt) throws Exception {
+        public void channelInboundEvent(final ChannelHandlerContext ctx, final Object evt) throws Exception {
             if (evt instanceof SslHandshakeCompletionEvent) {
                 final SslHandshakeCompletionEvent event = (SslHandshakeCompletionEvent) evt;
                 if (event.isSuccess()) {
@@ -261,7 +261,7 @@ public class SocketSslGreetingTest extends AbstractSocketTest {
                     }
                 }
             }
-            ctx.fireInboundEventTriggered(evt);
+            ctx.fireChannelInboundEvent(evt);
         }
     }
 }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslSessionReuseTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslSessionReuseTest.java
@@ -194,8 +194,8 @@ public class SocketSslSessionReuseTest extends AbstractSocketTest {
         }
 
         @Override
-        public void exceptionCaught(ChannelHandlerContext ctx,
-                Throwable cause) throws Exception {
+        public void channelExceptionCaught(ChannelHandlerContext ctx,
+                                           Throwable cause) throws Exception {
             if (logger.isWarnEnabled()) {
                 logger.warn(
                         "Unexpected exception from the " +

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketStartTlsTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketStartTlsTest.java
@@ -256,8 +256,8 @@ public class SocketStartTlsTest extends AbstractSocketTest {
         }
 
         @Override
-        public void exceptionCaught(ChannelHandlerContext ctx,
-                Throwable cause) throws Exception {
+        public void channelExceptionCaught(ChannelHandlerContext ctx,
+                                           Throwable cause) throws Exception {
             if (logger.isWarnEnabled()) {
                 logger.warn("Unexpected exception from the client side", cause);
             }
@@ -307,8 +307,8 @@ public class SocketStartTlsTest extends AbstractSocketTest {
         }
 
         @Override
-        public void exceptionCaught(ChannelHandlerContext ctx,
-                                    Throwable cause) throws Exception {
+        public void channelExceptionCaught(ChannelHandlerContext ctx,
+                                           Throwable cause) throws Exception {
             if (logger.isWarnEnabled()) {
                 logger.warn("Unexpected exception from the server side", cause);
             }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketStringEchoTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketStringEchoTest.java
@@ -181,7 +181,7 @@ public class SocketStringEchoTest extends AbstractSocketTest {
         }
 
         @Override
-        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
             if (exception.compareAndSet(null, cause)) {
                 donePromise.tryFailure(new IllegalStateException("exceptionCaught: " + ctx.channel(), cause));
                 ctx.close();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/TrafficShapingHandlerTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/TrafficShapingHandlerTest.java
@@ -452,7 +452,7 @@ public class TrafficShapingHandlerTest extends AbstractSocketTest {
         }
 
         @Override
-        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
             if (exception.compareAndSet(null, cause)) {
                 cause.printStackTrace();
                 promise.setFailure(cause);
@@ -542,7 +542,7 @@ public class TrafficShapingHandlerTest extends AbstractSocketTest {
         }
 
         @Override
-        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
             if (exception.compareAndSet(null, cause)) {
                 cause.printStackTrace();
                 ctx.close();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/WriteBeforeRegisteredTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/WriteBeforeRegisteredTest.java
@@ -51,7 +51,7 @@ public class WriteBeforeRegisteredTest extends AbstractClientSocketTest {
 
     private static class TestHandler implements ChannelHandler {
         @Override
-        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
             cause.printStackTrace();
         }
     }

--- a/transport-blockhound-tests/src/test/java/io/netty5/util/internal/NettyBlockHoundIntegrationTest.java
+++ b/transport-blockhound-tests/src/test/java/io/netty5/util/internal/NettyBlockHoundIntegrationTest.java
@@ -307,14 +307,14 @@ public class NettyBlockHoundIntegrationTest {
                                 }
 
                                 @Override
-                                public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                                public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
                                     if (evt instanceof SslHandshakeCompletionEvent &&
                                             ((SslHandshakeCompletionEvent) evt).cause() != null) {
                                         Throwable cause = ((SslHandshakeCompletionEvent) evt).cause();
                                         cause.printStackTrace();
                                         error.set(cause);
                                     }
-                                    ctx.fireInboundEventTriggered(evt);
+                                    ctx.fireChannelInboundEvent(evt);
                                 }
                             });
                         }
@@ -460,12 +460,12 @@ public class NettyBlockHoundIntegrationTest {
                               .addLast(new ChannelHandler() {
 
                                   @Override
-                                  public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                                  public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
                                       if (evt instanceof SslHandshakeCompletionEvent &&
                                               ((SslHandshakeCompletionEvent) evt).cause() != null) {
                                           ((SslHandshakeCompletionEvent) evt).cause().printStackTrace();
                                       }
-                                      ctx.fireInboundEventTriggered(evt);
+                                      ctx.fireChannelInboundEvent(evt);
                                   }
                               });
                         }

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
@@ -179,7 +179,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
                         try {
                             doDeregister();
                         } catch (Throwable cause) {
-                            pipeline().fireExceptionCaught(cause);
+                            pipeline().fireChannelExceptionCaught(cause);
                         }
                     });
                 }
@@ -449,7 +449,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
             try {
                 clearFlag(Native.EPOLLRDHUP);
             } catch (IOException e) {
-                pipeline().fireExceptionCaught(e);
+                pipeline().fireChannelExceptionCaught(e);
                 close(newPromise());
             }
         }
@@ -517,7 +517,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
             } catch (IOException e) {
                 // When this happens there is something completely wrong with either the filedescriptor or epoll,
                 // so fire the exception through the pipeline and close the Channel.
-                pipeline().fireExceptionCaught(e);
+                pipeline().fireChannelExceptionCaught(e);
                 unsafe().close(newPromise());
             }
         }

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollServerChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollServerChannel.java
@@ -134,7 +134,7 @@ public abstract class AbstractEpollServerChannel extends AbstractEpollChannel im
                 pipeline.fireChannelReadComplete();
 
                 if (exception != null) {
-                    pipeline.fireExceptionCaught(exception);
+                    pipeline.fireChannelExceptionCaught(exception);
                 }
                 readIfIsAutoRead();
             } finally {

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollStreamChannel.java
@@ -444,7 +444,7 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel {
             }
             allocHandle.readComplete();
             pipeline.fireChannelReadComplete();
-            pipeline.fireExceptionCaught(cause);
+            pipeline.fireChannelExceptionCaught(cause);
 
             // If oom will close the read event, release connection.
             // See https://github.com/netty/netty/issues/10434

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDatagramChannel.java
@@ -507,7 +507,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
                 pipeline.fireChannelReadComplete();
 
                 if (exception != null) {
-                    pipeline.fireExceptionCaught(exception);
+                    pipeline.fireChannelExceptionCaught(exception);
                 }
                 readIfIsAutoRead();
             } finally {

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDomainDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDomainDatagramChannel.java
@@ -354,7 +354,7 @@ public final class EpollDomainDatagramChannel extends AbstractEpollChannel imple
                 pipeline.fireChannelReadComplete();
 
                 if (exception != null) {
-                    pipeline.fireExceptionCaught(exception);
+                    pipeline.fireChannelExceptionCaught(exception);
                 }
                 readIfIsAutoRead();
             } finally {

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDomainSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDomainSocketChannel.java
@@ -184,7 +184,7 @@ public final class EpollDomainSocketChannel extends AbstractEpollStreamChannel i
             } catch (Throwable t) {
                 allocHandle.readComplete();
                 pipeline.fireChannelReadComplete();
-                pipeline.fireExceptionCaught(t);
+                pipeline.fireChannelExceptionCaught(t);
             } finally {
                 readIfIsAutoRead();
                 epollInFinally(config);

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueChannel.java
@@ -491,7 +491,7 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
             } catch (IOException e) {
                 // When this happens there is something completely wrong with either the filedescriptor or epoll,
                 // so fire the exception through the pipeline and close the Channel.
-                pipeline().fireExceptionCaught(e);
+                pipeline().fireChannelExceptionCaught(e);
                 unsafe().close(newPromise());
             }
         }

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueServerChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueServerChannel.java
@@ -135,7 +135,7 @@ public abstract class AbstractKQueueServerChannel extends AbstractKQueueChannel 
                 pipeline.fireChannelReadComplete();
 
                 if (exception != null) {
-                    pipeline.fireExceptionCaught(exception);
+                    pipeline.fireChannelExceptionCaught(exception);
                 }
                 readIfIsAutoRead();
             } finally {

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueStreamChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueStreamChannel.java
@@ -494,7 +494,7 @@ public abstract class AbstractKQueueStreamChannel extends AbstractKQueueChannel 
             if (!failConnectPromise(cause)) {
                 allocHandle.readComplete();
                 pipeline.fireChannelReadComplete();
-                pipeline.fireExceptionCaught(cause);
+                pipeline.fireChannelExceptionCaught(cause);
 
                 // If oom will close the read event, release connection.
                 // See https://github.com/netty/netty/issues/10434

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDatagramChannel.java
@@ -455,7 +455,7 @@ public final class KQueueDatagramChannel extends AbstractKQueueDatagramChannel i
                 pipeline.fireChannelReadComplete();
 
                 if (exception != null) {
-                    pipeline.fireExceptionCaught(exception);
+                    pipeline.fireChannelExceptionCaught(exception);
                 } else {
                     readIfIsAutoRead();
                 }

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDomainDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDomainDatagramChannel.java
@@ -270,7 +270,7 @@ public final class KQueueDomainDatagramChannel extends AbstractKQueueDatagramCha
                 pipeline.fireChannelReadComplete();
 
                 if (exception != null) {
-                    pipeline.fireExceptionCaught(exception);
+                    pipeline.fireChannelExceptionCaught(exception);
                 } else {
                     readIfIsAutoRead();
                 }

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDomainSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDomainSocketChannel.java
@@ -180,7 +180,7 @@ public final class KQueueDomainSocketChannel extends AbstractKQueueStreamChannel
             } catch (Throwable t) {
                 allocHandle.readComplete();
                 pipeline.fireChannelReadComplete();
-                pipeline.fireExceptionCaught(t);
+                pipeline.fireChannelExceptionCaught(t);
             } finally {
                 readIfIsAutoRead();
                 readReadyFinally(config);

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDatagramScatteringReadTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDatagramScatteringReadTest.java
@@ -141,7 +141,7 @@ public class EpollDatagramScatteringReadTest extends AbstractDatagramTest  {
                 }
 
                 @Override
-                public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause)  {
+                public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause)  {
                     errorRef.compareAndSet(null, cause);
                 }
             });
@@ -243,7 +243,7 @@ public class EpollDatagramScatteringReadTest extends AbstractDatagramTest  {
                 }
 
                 @Override
-                public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause)  {
+                public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause)  {
                     errorRef.compareAndSet(null, cause);
                 }
             });

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDatagramUnicastTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDatagramUnicastTest.java
@@ -137,7 +137,7 @@ public class EpollDatagramUnicastTest extends DatagramUnicastInetTest {
                 }
 
                 @Override
-                public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+                public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
                     do {
                         Throwable throwable = errorRef.get();
                         if (throwable != null) {
@@ -147,7 +147,7 @@ public class EpollDatagramUnicastTest extends DatagramUnicastInetTest {
                             break;
                         }
                     } while (!errorRef.compareAndSet(null, cause));
-                    super.exceptionCaught(ctx, cause);
+                    super.channelExceptionCaught(ctx, cause);
                 }
             }).bind(newSocketAddress()).get();
 

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDomainDatagramUnicastTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDomainDatagramUnicastTest.java
@@ -100,7 +100,7 @@ class EpollDomainDatagramUnicastTest extends DatagramUnicastTest {
             }
 
             @Override
-            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+            public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                 errorRef.compareAndSet(null, cause);
             }
         });
@@ -142,7 +142,7 @@ class EpollDomainDatagramUnicastTest extends DatagramUnicastTest {
                     }
 
                     @Override
-                    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                         errorRef.compareAndSet(null, cause);
                     }
                 });

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDomainSocketFdTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDomainSocketFdTest.java
@@ -80,7 +80,7 @@ public class EpollDomainSocketFdTest extends AbstractSocketTest {
             }
 
             @Override
-            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+            public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
                 queue.add(cause);
                 ctx.close();
             }

--- a/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueDomainDatagramUnicastTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueDomainDatagramUnicastTest.java
@@ -99,7 +99,7 @@ class KQueueDomainDatagramUnicastTest extends DatagramUnicastTest {
             }
 
             @Override
-            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+            public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                 errorRef.compareAndSet(null, cause);
             }
         });
@@ -142,7 +142,7 @@ class KQueueDomainDatagramUnicastTest extends DatagramUnicastTest {
                     }
 
                     @Override
-                    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                         errorRef.compareAndSet(null, cause);
                     }
                 });

--- a/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueDomainSocketFdTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueDomainSocketFdTest.java
@@ -80,7 +80,7 @@ public class KQueueDomainSocketFdTest extends AbstractSocketTest {
             }
 
             @Override
-            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+            public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
                 queue.add(cause);
                 ctx.close();
             }

--- a/transport/src/main/java/io/netty5/bootstrap/ServerBootstrap.java
+++ b/transport/src/main/java/io/netty5/bootstrap/ServerBootstrap.java
@@ -277,7 +277,7 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
         }
 
         @Override
-        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
             final ChannelConfig config = ctx.channel().config();
             if (config.isAutoRead()) {
                 // stop accept new connections for 1 second to allow the channel to recover
@@ -287,7 +287,7 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
             }
             // still let the exceptionCaught event flow through the pipeline to give the user
             // a chance to do something with it
-            ctx.fireExceptionCaught(cause);
+            ctx.fireChannelExceptionCaught(cause);
         }
     }
 

--- a/transport/src/main/java/io/netty5/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty5/channel/AbstractChannel.java
@@ -682,7 +682,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             try {
                 doBeginRead();
             } catch (final Exception e) {
-                invokeLater(() -> pipeline.fireExceptionCaught(e));
+                invokeLater(() -> pipeline.fireChannelExceptionCaught(e));
                 close(newPromise());
             }
         }
@@ -824,7 +824,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         }
 
         @Override
-        public void triggerOutboundEvent(Object event, Promise<Void> promise) {
+        public void sendOutboundEvent(Object event, Promise<Void> promise) {
             Resource.dispose(event);
             promise.setSuccess(null);
         }

--- a/transport/src/main/java/io/netty5/channel/Channel.java
+++ b/transport/src/main/java/io/netty5/channel/Channel.java
@@ -22,6 +22,7 @@ import io.netty5.channel.socket.DatagramChannel;
 import io.netty5.channel.socket.DatagramPacket;
 import io.netty5.channel.socket.ServerSocketChannel;
 import io.netty5.channel.socket.SocketChannel;
+import io.netty5.util.AttributeKey;
 import io.netty5.util.AttributeMap;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.Promise;
@@ -291,8 +292,8 @@ public interface Channel extends AttributeMap, ChannelOutboundInvoker, Comparabl
     }
 
     @Override
-    default Future<Void> triggerOutboundEvent(Object event) {
-        return pipeline().triggerOutboundEvent(event);
+    default Future<Void> sendOutboundEvent(Object event) {
+        return pipeline().sendOutboundEvent(event);
     }
 
     /**
@@ -395,9 +396,9 @@ public interface Channel extends AttributeMap, ChannelOutboundInvoker, Comparabl
         void flush();
 
         /**
-         * Trigger a custom outbound event.
+         * Send a custom outbound event.
          */
-        void triggerOutboundEvent(Object event, Promise<Void> promise);
+        void sendOutboundEvent(Object event, Promise<Void> promise);
 
         /**
          * Returns the {@link ChannelOutboundBuffer} of the {@link Channel} where the pending write requests are stored.

--- a/transport/src/main/java/io/netty5/channel/ChannelFutureListeners.java
+++ b/transport/src/main/java/io/netty5/channel/ChannelFutureListeners.java
@@ -67,7 +67,7 @@ public final class ChannelFutureListeners {
         @Override
         public void operationComplete(Channel context, Future<?> future) throws Exception {
             if (future.isFailed()) {
-                context.pipeline().fireExceptionCaught(future.cause());
+                context.pipeline().fireChannelExceptionCaught(future.cause());
             }
         }
     }

--- a/transport/src/main/java/io/netty5/channel/ChannelHandler.java
+++ b/transport/src/main/java/io/netty5/channel/ChannelHandler.java
@@ -261,11 +261,11 @@ public interface ChannelHandler {
     }
 
     /**
-     * Gets called if a custom inbound event was triggered.
+     * Gets called if a custom inbound event happened.
      */
     @Skip
-    default void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
-        ctx.fireInboundEventTriggered(evt);
+    default void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
+        ctx.fireChannelInboundEvent(evt);
     }
 
     /**
@@ -278,11 +278,11 @@ public interface ChannelHandler {
     }
 
     /**
-     * Gets called if a {@link Throwable} was thrown.
+     * Gets called if a {@link Throwable} was thrown when handling inbound events.
      */
     @Skip
-    default void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-        ctx.fireExceptionCaught(cause);
+    default void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        ctx.fireChannelExceptionCaught(cause);
     }
 
     /**
@@ -402,15 +402,15 @@ public interface ChannelHandler {
     }
 
     /**
-     * Called once a custom defined outbound event was triggered. This operation will pass the event through the
-     * {@link ChannelPipeline}.
+     * Called once a custom defined outbound event was sent. This operation will pass the event through the
+     * {@link ChannelPipeline} in the outbound direction.
      *
      * @param ctx               the {@link ChannelHandlerContext} for which the operation is made.
      * @param event             the event.
      * @return                  the {@link Future} which will be notified once the operation completes.
      */
     @Skip
-    default Future<Void> triggerOutboundEvent(ChannelHandlerContext ctx, Object event) {
-        return ctx.triggerOutboundEvent(event);
+    default Future<Void> sendOutboundEvent(ChannelHandlerContext ctx, Object event) {
+        return ctx.sendOutboundEvent(event);
     }
 }

--- a/transport/src/main/java/io/netty5/channel/ChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty5/channel/ChannelHandlerContext.java
@@ -115,10 +115,10 @@ public interface ChannelHandlerContext extends ChannelInboundInvoker, ChannelOut
     ChannelHandlerContext fireChannelShutdown(ChannelShutdownDirection direction);
 
     @Override
-    ChannelHandlerContext fireExceptionCaught(Throwable cause);
+    ChannelHandlerContext fireChannelExceptionCaught(Throwable cause);
 
     @Override
-    ChannelHandlerContext fireInboundEventTriggered(Object evt);
+    ChannelHandlerContext fireChannelInboundEvent(Object evt);
 
     @Override
     ChannelHandlerContext fireChannelRead(Object msg);

--- a/transport/src/main/java/io/netty5/channel/ChannelHandlerMask.java
+++ b/transport/src/main/java/io/netty5/channel/ChannelHandlerMask.java
@@ -36,16 +36,15 @@ final class ChannelHandlerMask {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(ChannelHandlerMask.class);
 
     // Using to mask which methods must be called for a ChannelHandler.
-    static final int MASK_EXCEPTION_CAUGHT = 1;
+    static final int MASK_CHANNEL_EXCEPTION_CAUGHT = 1;
     static final int MASK_CHANNEL_REGISTERED = 1 << 1;
     static final int MASK_CHANNEL_UNREGISTERED = 1 << 2;
     static final int MASK_CHANNEL_ACTIVE = 1 << 3;
     static final int MASK_CHANNEL_INACTIVE = 1 << 4;
-
     static final int MASK_CHANNEL_SHUTDOWN = 1 << 5;
     static final int MASK_CHANNEL_READ = 1 << 6;
     static final int MASK_CHANNEL_READ_COMPLETE = 1 << 7;
-    static final int MASK_CUSTOM_INBOUND_EVENT_TRIGGERED = 1 << 8;
+    static final int MASK_CHANNEL_INBOUND_EVENT = 1 << 8;
     static final int MASK_CHANNEL_WRITABILITY_CHANGED = 1 << 9;
     static final int MASK_BIND = 1 << 10;
     static final int MASK_CONNECT = 1 << 11;
@@ -57,15 +56,15 @@ final class ChannelHandlerMask {
     static final int MASK_READ = 1 << 17;
     static final int MASK_WRITE = 1 << 18;
     static final int MASK_FLUSH = 1 << 19;
-    static final int MASK_TRIGGER_CUSTOM_OUTBOUND_EVENT = 1 << 20;
+    static final int MASK_SEND_OUTBOUND_EVENT = 1 << 20;
 
-    private static final int MASK_ALL_INBOUND = MASK_EXCEPTION_CAUGHT | MASK_CHANNEL_REGISTERED |
+    private static final int MASK_ALL_INBOUND = MASK_CHANNEL_EXCEPTION_CAUGHT | MASK_CHANNEL_REGISTERED |
             MASK_CHANNEL_UNREGISTERED | MASK_CHANNEL_ACTIVE | MASK_CHANNEL_INACTIVE | MASK_CHANNEL_SHUTDOWN |
             MASK_CHANNEL_READ | MASK_CHANNEL_READ_COMPLETE  | MASK_CHANNEL_WRITABILITY_CHANGED |
-            MASK_CUSTOM_INBOUND_EVENT_TRIGGERED;
+            MASK_CHANNEL_INBOUND_EVENT;
     private static final int MASK_ALL_OUTBOUND = MASK_BIND | MASK_CONNECT | MASK_DISCONNECT |
             MASK_CLOSE | MASK_SHUTDOWN | MASK_REGISTER | MASK_DEREGISTER | MASK_READ | MASK_WRITE | MASK_FLUSH |
-            MASK_TRIGGER_CUSTOM_OUTBOUND_EVENT;
+            MASK_SEND_OUTBOUND_EVENT;
 
     private static final FastThreadLocal<Map<Class<? extends ChannelHandler>, Integer>> MASKS =
             new FastThreadLocal<>() {
@@ -107,8 +106,8 @@ final class ChannelHandlerMask {
         mask |= MASK_ALL_OUTBOUND;
 
         try {
-            if (isSkippable(handlerType, "exceptionCaught", ChannelHandlerContext.class, Throwable.class)) {
-                mask &= ~MASK_EXCEPTION_CAUGHT;
+            if (isSkippable(handlerType, "channelExceptionCaught", ChannelHandlerContext.class, Throwable.class)) {
+                mask &= ~MASK_CHANNEL_EXCEPTION_CAUGHT;
             }
 
             if (isSkippable(handlerType, "channelRegistered", ChannelHandlerContext.class)) {
@@ -136,8 +135,8 @@ final class ChannelHandlerMask {
             if (isSkippable(handlerType, "channelWritabilityChanged", ChannelHandlerContext.class)) {
                 mask &= ~MASK_CHANNEL_WRITABILITY_CHANGED;
             }
-            if (isSkippable(handlerType, "inboundEventTriggered", ChannelHandlerContext.class, Object.class)) {
-                mask &= ~MASK_CUSTOM_INBOUND_EVENT_TRIGGERED;
+            if (isSkippable(handlerType, "channelInboundEvent", ChannelHandlerContext.class, Object.class)) {
+                mask &= ~MASK_CHANNEL_INBOUND_EVENT;
             }
             if (isSkippable(handlerType, "bind", ChannelHandlerContext.class, SocketAddress.class)) {
                 mask &= ~MASK_BIND;
@@ -171,8 +170,8 @@ final class ChannelHandlerMask {
             if (isSkippable(handlerType, "flush", ChannelHandlerContext.class)) {
                 mask &= ~MASK_FLUSH;
             }
-            if (isSkippable(handlerType, "triggerOutboundEvent", ChannelHandlerContext.class, Object.class)) {
-                mask &= ~MASK_TRIGGER_CUSTOM_OUTBOUND_EVENT;
+            if (isSkippable(handlerType, "sendOutboundEvent", ChannelHandlerContext.class, Object.class)) {
+                mask &= ~MASK_SEND_OUTBOUND_EVENT;
             }
         } catch (Exception e) {
             // Should never reach here.

--- a/transport/src/main/java/io/netty5/channel/ChannelInboundInvoker.java
+++ b/transport/src/main/java/io/netty5/channel/ChannelInboundInvoker.java
@@ -66,20 +66,20 @@ public interface ChannelInboundInvoker {
     /**
      * A {@link Channel} received an {@link Throwable} in one of its inbound operations.
      *
-     * This will result in having the  {@link ChannelHandler#exceptionCaught(ChannelHandlerContext, Throwable)}
+     * This will result in having the  {@link ChannelHandler#channelExceptionCaught(ChannelHandlerContext, Throwable)}
      * method  called of the next  {@link ChannelHandler} contained in the  {@link ChannelPipeline} of the
      * {@link Channel}.
      */
-    ChannelInboundInvoker fireExceptionCaught(Throwable cause);
+    ChannelInboundInvoker fireChannelExceptionCaught(Throwable cause);
 
     /**
      * A {@link Channel} received a custom defined inbound event.
      *
-     * This will result in having the {@link ChannelHandler#inboundEventTriggered(ChannelHandlerContext, Object)}
+     * This will result in having the {@link ChannelHandler#channelInboundEvent(ChannelHandlerContext, Object)}
      * method  called of the next {@link ChannelHandler} contained in the {@link ChannelPipeline} of the
      * {@link Channel}.
      */
-    ChannelInboundInvoker fireInboundEventTriggered(Object event);
+    ChannelInboundInvoker fireChannelInboundEvent(Object event);
 
     /**
      * A {@link Channel} received a message.

--- a/transport/src/main/java/io/netty5/channel/ChannelInitializer.java
+++ b/transport/src/main/java/io/netty5/channel/ChannelInitializer.java
@@ -57,8 +57,8 @@ public abstract class ChannelInitializer<C extends Channel> implements ChannelHa
      *
      * @param ch            the {@link Channel} which was registered.
      * @throws Exception    is thrown if an error occurs. In that case it will be handled by
-     *                      {@link #exceptionCaught(ChannelHandlerContext, Throwable)} which will by default close
-     *                      the {@link Channel}.
+     *                      {@link #channelExceptionCaught(ChannelHandlerContext, Throwable)} which will by
+     *                      default close the {@link Channel}.
      */
     protected abstract void initChannel(C ch) throws Exception;
 
@@ -66,7 +66,7 @@ public abstract class ChannelInitializer<C extends Channel> implements ChannelHa
      * Handle the {@link Throwable} by logging and closing the {@link Channel}. Sub-classes may override this.
      */
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         if (logger.isWarnEnabled()) {
             logger.warn("Failed to initialize a channel. Closing: " + ctx.channel(), cause);
         }
@@ -84,7 +84,7 @@ public abstract class ChannelInitializer<C extends Channel> implements ChannelHa
         } catch (Throwable cause) {
             // Explicitly call exceptionCaught(...) as we removed the handler before calling initChannel(...).
             // We do so to prevent multiple calls to initChannel(...).
-            exceptionCaught(ctx, cause);
+            channelExceptionCaught(ctx, cause);
         } finally {
             if (!ctx.isRemoved()) {
                 ctx.pipeline().remove(this);

--- a/transport/src/main/java/io/netty5/channel/ChannelOutboundInvoker.java
+++ b/transport/src/main/java/io/netty5/channel/ChannelOutboundInvoker.java
@@ -164,15 +164,15 @@ public interface ChannelOutboundInvoker {
     Future<Void> writeAndFlush(Object msg);
 
     /**
-     * Trigger a custom outbound event via this {@link ChannelOutboundInvoker} through the
+     * Send a custom outbound event via this {@link ChannelOutboundInvoker} through the
      * {@link ChannelPipeline}.
      * <p>
      * This will result in having the
-     * {@link ChannelHandler#triggerOutboundEvent(ChannelHandlerContext, Object)}
+     * {@link ChannelHandler#sendOutboundEvent(ChannelHandlerContext, Object)}
      * method called of the next {@link ChannelHandler} contained in the {@link ChannelPipeline} of the
      * {@link Channel}.
      */
-    Future<Void> triggerOutboundEvent(Object event);
+    Future<Void> sendOutboundEvent(Object event);
 
     /**
      * Return a new {@link Promise}.

--- a/transport/src/main/java/io/netty5/channel/ChannelPipeline.java
+++ b/transport/src/main/java/io/netty5/channel/ChannelPipeline.java
@@ -131,8 +131,8 @@ import java.util.NoSuchElementException;
  *     <li>{@link ChannelHandlerContext#fireChannelActive()}</li>
  *     <li>{@link ChannelHandlerContext#fireChannelRead(Object)}</li>
  *     <li>{@link ChannelHandlerContext#fireChannelReadComplete()}</li>
- *     <li>{@link ChannelHandlerContext#fireExceptionCaught(Throwable)}</li>
- *     <li>{@link ChannelHandlerContext#fireInboundEventTriggered(Object)}</li>
+ *     <li>{@link ChannelHandlerContext#fireChannelExceptionCaught(Throwable)}</li>
+ *     <li>{@link ChannelHandlerContext#fireChannelInboundEvent(Object)}</li>
  *     <li>{@link ChannelHandlerContext#fireChannelWritabilityChanged()}</li>
  *     <li>{@link ChannelHandlerContext#fireChannelInactive()}</li>
  *     <li>{@link ChannelHandlerContext#fireChannelShutdown(ChannelShutdownDirection)}</li>
@@ -525,10 +525,10 @@ public interface ChannelPipeline
     ChannelPipeline fireChannelShutdown(ChannelShutdownDirection direction);
 
     @Override
-    ChannelPipeline fireExceptionCaught(Throwable cause);
+    ChannelPipeline fireChannelExceptionCaught(Throwable cause);
 
     @Override
-    ChannelPipeline fireInboundEventTriggered(Object event);
+    ChannelPipeline fireChannelInboundEvent(Object event);
 
     @Override
     ChannelPipeline fireChannelRead(Object msg);

--- a/transport/src/main/java/io/netty5/channel/CombinedChannelDuplexHandler.java
+++ b/transport/src/main/java/io/netty5/channel/CombinedChannelDuplexHandler.java
@@ -200,22 +200,22 @@ public class CombinedChannelDuplexHandler<I extends ChannelHandler, O extends Ch
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         assert ctx == inboundCtx.delegatingCtx();
         if (!inboundCtx.removed) {
-            inboundHandler.exceptionCaught(inboundCtx, cause);
+            inboundHandler.channelExceptionCaught(inboundCtx, cause);
         } else {
-            inboundCtx.fireExceptionCaught(cause);
+            inboundCtx.fireChannelExceptionCaught(cause);
         }
     }
 
     @Override
-    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+    public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
             assert ctx == inboundCtx.delegatingCtx();
         if (!inboundCtx.removed) {
-            inboundHandler.inboundEventTriggered(inboundCtx, evt);
+            inboundHandler.channelInboundEvent(inboundCtx, evt);
         } else {
-            inboundCtx.fireInboundEventTriggered(evt);
+            inboundCtx.fireChannelInboundEvent(evt);
         }
     }
 
@@ -388,7 +388,7 @@ public class CombinedChannelDuplexHandler<I extends ChannelHandler, O extends Ch
                 try {
                     handler.handlerRemoved(this);
                 } catch (Throwable cause) {
-                    fireExceptionCaught(new ChannelPipelineException(
+                    this.fireChannelExceptionCaught(new ChannelPipelineException(
                             handler.getClass().getName() + ".handlerRemoved() has thrown an exception.", cause));
                 }
             }

--- a/transport/src/main/java/io/netty5/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty5/channel/DefaultChannelPipeline.java
@@ -569,11 +569,11 @@ public class DefaultChannelPipeline implements ChannelPipeline {
             }
 
             if (removed) {
-                fireExceptionCaught(new ChannelPipelineException(
+                fireChannelExceptionCaught(new ChannelPipelineException(
                         ctx.handler().getClass().getName() +
                         ".handlerAdded() has thrown an exception; removed.", t));
             } else {
-                fireExceptionCaught(new ChannelPipelineException(
+                fireChannelExceptionCaught(new ChannelPipelineException(
                         ctx.handler().getClass().getName() +
                         ".handlerAdded() has thrown an exception; also failed to remove.", t));
             }
@@ -585,7 +585,7 @@ public class DefaultChannelPipeline implements ChannelPipeline {
         try {
             ctx.callHandlerRemoved();
         } catch (Throwable t) {
-            fireExceptionCaught(new ChannelPipelineException(
+            fireChannelExceptionCaught(new ChannelPipelineException(
                     ctx.handler().getClass().getName() + ".handlerRemoved() has thrown an exception.", t));
         }
     }
@@ -810,13 +810,13 @@ public class DefaultChannelPipeline implements ChannelPipeline {
     }
 
     @Override
-    public final ChannelPipeline fireExceptionCaught(Throwable cause) {
+    public final ChannelPipeline fireChannelExceptionCaught(Throwable cause) {
         head.invokeExceptionCaught(cause);
         return this;
     }
 
     @Override
-    public final ChannelPipeline fireInboundEventTriggered(Object event) {
+    public final ChannelPipeline fireChannelInboundEvent(Object event) {
         head.invokeCustomInboundEventTriggered(event);
         return this;
     }
@@ -902,8 +902,8 @@ public class DefaultChannelPipeline implements ChannelPipeline {
     }
 
     @Override
-    public final Future<Void> triggerOutboundEvent(Object event) {
-        return tail.triggerOutboundEvent(event);
+    public final Future<Void> sendOutboundEvent(Object event) {
+        return tail.sendOutboundEvent(event);
     }
 
     @Override
@@ -923,7 +923,7 @@ public class DefaultChannelPipeline implements ChannelPipeline {
 
     /**
      * Called once a {@link Throwable} hit the end of the {@link ChannelPipeline} without been handled by the user
-     * in {@link ChannelHandler#exceptionCaught(ChannelHandlerContext, Throwable)}.
+     * in {@link ChannelHandler#channelExceptionCaught(ChannelHandlerContext, Throwable)}.
      */
     protected void onUnhandledInboundException(Throwable cause) {
         try {
@@ -982,7 +982,7 @@ public class DefaultChannelPipeline implements ChannelPipeline {
 
     /**
      * Called once an user event hit the end of the {@link ChannelPipeline} without been handled by the user
-     * in {@link ChannelHandler#inboundEventTriggered(ChannelHandlerContext, Object)}. This method is responsible
+     * in {@link ChannelHandler#channelInboundEvent(ChannelHandlerContext, Object)}. This method is responsible
      * to call {@link Resource#dispose(Object)} on the given event at some point.
      */
     protected void onUnhandledInboundUserEventTriggered(Object evt) {
@@ -1048,12 +1048,12 @@ public class DefaultChannelPipeline implements ChannelPipeline {
         }
 
         @Override
-        public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+        public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
             ((DefaultChannelPipeline) ctx.pipeline()).onUnhandledInboundUserEventTriggered(evt);
         }
 
         @Override
-        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
             ((DefaultChannelPipeline) ctx.pipeline()).onUnhandledInboundException(cause);
         }
 
@@ -1140,9 +1140,9 @@ public class DefaultChannelPipeline implements ChannelPipeline {
         }
 
         @Override
-        public Future<Void> triggerOutboundEvent(ChannelHandlerContext ctx, Object event) {
+        public Future<Void> sendOutboundEvent(ChannelHandlerContext ctx, Object event) {
             Promise<Void> promise = ctx.newPromise();
-            ctx.channel().unsafe().triggerOutboundEvent(event, promise);
+            ctx.channel().unsafe().sendOutboundEvent(event, promise);
             return promise.asFuture();
         }
     }

--- a/transport/src/main/java/io/netty5/channel/SimpleUserEventChannelHandler.java
+++ b/transport/src/main/java/io/netty5/channel/SimpleUserEventChannelHandler.java
@@ -89,7 +89,7 @@ public abstract class SimpleUserEventChannelHandler<I> implements ChannelHandler
     }
 
     @Override
-    public final void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+    public final void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
         boolean release = true;
         try {
             if (acceptEvent(evt)) {
@@ -98,7 +98,7 @@ public abstract class SimpleUserEventChannelHandler<I> implements ChannelHandler
                 eventReceived(ctx, ievt);
             } else {
                 release = false;
-                ctx.fireInboundEventTriggered(evt);
+                ctx.fireChannelInboundEvent(evt);
             }
         } finally {
             if (autoRelease && release) {

--- a/transport/src/main/java/io/netty5/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty5/channel/embedded/EmbeddedChannel.java
@@ -901,8 +901,8 @@ public class EmbeddedChannel extends AbstractChannel {
             }
 
             @Override
-            public void triggerOutboundEvent(Object event, Promise<Void> promise) {
-                EmbeddedUnsafe.this.triggerOutboundEvent(event, promise);
+            public void sendOutboundEvent(Object event, Promise<Void> promise) {
+                EmbeddedUnsafe.this.sendOutboundEvent(event, promise);
                 mayRunPendingTasks();
             }
 

--- a/transport/src/main/java/io/netty5/channel/internal/DelegatingChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty5/channel/internal/DelegatingChannelHandlerContext.java
@@ -97,14 +97,14 @@ public abstract class DelegatingChannelHandlerContext implements ChannelHandlerC
     }
 
     @Override
-    public ChannelHandlerContext fireExceptionCaught(Throwable cause) {
-        ctx.fireExceptionCaught(cause);
+    public ChannelHandlerContext fireChannelExceptionCaught(Throwable cause) {
+        ctx.fireChannelExceptionCaught(cause);
         return this;
     }
 
     @Override
-    public ChannelHandlerContext fireInboundEventTriggered(Object evt) {
-        ctx.fireInboundEventTriggered(evt);
+    public ChannelHandlerContext fireChannelInboundEvent(Object evt) {
+        ctx.fireChannelInboundEvent(evt);
         return this;
     }
 
@@ -140,8 +140,8 @@ public abstract class DelegatingChannelHandlerContext implements ChannelHandlerC
     }
 
     @Override
-    public Future<Void> triggerOutboundEvent(Object event) {
-        return ctx.triggerOutboundEvent(event);
+    public Future<Void> sendOutboundEvent(Object event) {
+        return ctx.sendOutboundEvent(event);
     }
 
     @Override

--- a/transport/src/main/java/io/netty5/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty5/channel/local/LocalChannel.java
@@ -460,7 +460,7 @@ public class LocalChannel extends AbstractChannel {
             if (state == State.CONNECTED) {
                 Exception cause = new AlreadyConnectedException();
                 safeSetFailure(promise, cause);
-                pipeline().fireExceptionCaught(cause);
+                pipeline().fireChannelExceptionCaught(cause);
                 return;
             }
 

--- a/transport/src/main/java/io/netty5/channel/nio/AbstractNioByteChannel.java
+++ b/transport/src/main/java/io/netty5/channel/nio/AbstractNioByteChannel.java
@@ -108,7 +108,7 @@ public abstract class AbstractNioByteChannel extends AbstractNioChannel {
             }
             allocHandle.readComplete();
             pipeline.fireChannelReadComplete();
-            pipeline.fireExceptionCaught(cause);
+            pipeline.fireChannelExceptionCaught(cause);
 
             // If oom will close the read event, release connection.
             // See https://github.com/netty/netty/issues/10434

--- a/transport/src/main/java/io/netty5/channel/nio/AbstractNioMessageChannel.java
+++ b/transport/src/main/java/io/netty5/channel/nio/AbstractNioMessageChannel.java
@@ -105,7 +105,7 @@ public abstract class AbstractNioMessageChannel extends AbstractNioChannel {
                 if (exception != null) {
                     closed = closeOnReadError(exception);
 
-                    pipeline.fireExceptionCaught(exception);
+                    pipeline.fireChannelExceptionCaught(exception);
                 }
 
                 if (closed) {

--- a/transport/src/test/java/io/netty5/channel/ChannelInitializerTest.java
+++ b/transport/src/test/java/io/netty5/channel/ChannelInitializerTest.java
@@ -93,9 +93,9 @@ public class ChannelInitializerTest {
             }
 
             @Override
-            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+            public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
                 causeRef.set(cause);
-                super.exceptionCaught(ctx, cause);
+                super.channelExceptionCaught(ctx, cause);
             }
         });
 

--- a/transport/src/test/java/io/netty5/channel/CombinedChannelDuplexHandlerTest.java
+++ b/transport/src/test/java/io/netty5/channel/CombinedChannelDuplexHandlerTest.java
@@ -117,15 +117,15 @@ public class CombinedChannelDuplexHandlerTest {
 
         ChannelHandler inboundHandler = new ChannelHandler() {
             @Override
-            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+            public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
                 assertSame(exception, cause);
                 queue.add(this);
-                ctx.fireExceptionCaught(cause);
+                ctx.fireChannelExceptionCaught(cause);
             }
         };
         ChannelHandler lastHandler = new ChannelHandler() {
             @Override
-            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+            public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
                 assertSame(exception, cause);
                 queue.add(this);
             }
@@ -133,7 +133,7 @@ public class CombinedChannelDuplexHandlerTest {
         EmbeddedChannel channel = new EmbeddedChannel(
                 new CombinedChannelDuplexHandler<>(
                         inboundHandler, new ChannelHandler() { }), lastHandler);
-        channel.pipeline().fireExceptionCaught(exception);
+        channel.pipeline().fireChannelExceptionCaught(exception);
         assertFalse(channel.finish());
         assertSame(inboundHandler, queue.poll());
         assertSame(lastHandler, queue.poll());
@@ -233,8 +233,8 @@ public class CombinedChannelDuplexHandlerTest {
         channel.pipeline().fireChannelActive();
         channel.pipeline().fireChannelRead(MSG);
         channel.pipeline().fireChannelReadComplete();
-        channel.pipeline().fireExceptionCaught(CAUSE);
-        channel.pipeline().fireInboundEventTriggered(USER_EVENT);
+        channel.pipeline().fireChannelExceptionCaught(CAUSE);
+        channel.pipeline().fireChannelInboundEvent(USER_EVENT);
         channel.pipeline().fireChannelWritabilityChanged();
         channel.pipeline().fireChannelInactive();
         channel.pipeline().fireChannelUnregistered();
@@ -307,7 +307,7 @@ public class CombinedChannelDuplexHandlerTest {
         }
 
         @Override
-        public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+        public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
             queue.add(Event.USER_EVENT_TRIGGERED);
         }
 
@@ -317,7 +317,7 @@ public class CombinedChannelDuplexHandlerTest {
         }
 
         @Override
-        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
             queue.add(Event.EXCEPTION_CAUGHT);
         }
 

--- a/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTailTest.java
+++ b/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTailTest.java
@@ -96,7 +96,7 @@ public class DefaultChannelPipelineTailTest {
 
         try {
             IOException ex = new IOException("testOnUnhandledInboundException");
-            myChannel.pipeline().fireExceptionCaught(ex);
+            myChannel.pipeline().fireChannelExceptionCaught(ex);
             assertTrue(latch.await(1L, TimeUnit.SECONDS));
             assertSame(ex, causeRef.get());
         } finally {
@@ -154,7 +154,7 @@ public class DefaultChannelPipelineTailTest {
         };
 
         try {
-            myChannel.pipeline().fireInboundEventTriggered("testOnUnhandledInboundUserEventTriggered");
+            myChannel.pipeline().fireChannelInboundEvent("testOnUnhandledInboundUserEventTriggered");
             assertTrue(latch.await(1L, TimeUnit.SECONDS));
         } finally {
             myChannel.close();

--- a/transport/src/test/java/io/netty5/channel/LoggingHandler.java
+++ b/transport/src/test/java/io/netty5/channel/LoggingHandler.java
@@ -102,7 +102,7 @@ final class LoggingHandler implements ChannelHandler {
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         log(Event.EXCEPTION, cause.toString());
     }
 
@@ -143,9 +143,9 @@ final class LoggingHandler implements ChannelHandler {
     }
 
     @Override
-    public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+    public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
         log(Event.USER, evt.toString());
-        ctx.fireInboundEventTriggered(evt);
+        ctx.fireChannelInboundEvent(evt);
     }
 
     String getLog() {

--- a/transport/src/test/java/io/netty5/channel/ReentrantChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/ReentrantChannelTest.java
@@ -472,7 +472,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
 
         }, new ChannelHandler() {
             @Override
-            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+            public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                 ctx.close();
             }
         });
@@ -513,7 +513,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
 
         }, new ChannelHandler() {
             @Override
-            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+            public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                 ctx.close();
             }
         });

--- a/transport/src/test/java/io/netty5/channel/SimpleUserEventChannelHandlerTest.java
+++ b/transport/src/test/java/io/netty5/channel/SimpleUserEventChannelHandlerTest.java
@@ -44,7 +44,7 @@ public class SimpleUserEventChannelHandlerTest {
     @Test
     public void testTypeMatch() {
         FooEvent fooEvent = new FooEvent();
-        channel.pipeline().fireInboundEventTriggered(fooEvent);
+        channel.pipeline().fireChannelInboundEvent(fooEvent);
         assertEquals(1, fooEventCatcher.caughtEvents.size());
         assertEquals(0, allEventCatcher.caughtEvents.size());
         assertEquals(0, fooEvent.refCnt());
@@ -54,7 +54,7 @@ public class SimpleUserEventChannelHandlerTest {
     @Test
     public void testTypeMismatch() {
         BarEvent barEvent = new BarEvent();
-        channel.pipeline().fireInboundEventTriggered(barEvent);
+        channel.pipeline().fireChannelInboundEvent(barEvent);
         assertEquals(0, fooEventCatcher.caughtEvents.size());
         assertEquals(1, allEventCatcher.caughtEvents.size());
         assertTrue(barEvent.release());
@@ -96,7 +96,7 @@ public class SimpleUserEventChannelHandlerTest {
         }
 
         @Override
-        public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+        public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
             caughtEvents.add(evt);
         }
     }

--- a/transport/src/test/java/io/netty5/channel/embedded/EmbeddedChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/embedded/EmbeddedChannelTest.java
@@ -539,7 +539,7 @@ public class EmbeddedChannelTest {
         final AtomicBoolean inactive = new AtomicBoolean();
         EmbeddedChannel channel = new EmbeddedChannel(new ChannelHandler() {
             @Override
-            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+            public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
                 ctx.close();
             }
 
@@ -548,7 +548,7 @@ public class EmbeddedChannelTest {
                 inactive.set(true);
             }
         });
-        channel.pipeline().fireExceptionCaught(new IllegalStateException());
+        channel.pipeline().fireChannelExceptionCaught(new IllegalStateException());
 
         assertTrue(inactive.get());
     }

--- a/transport/src/test/java/io/netty5/channel/local/LocalChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/local/LocalChannelTest.java
@@ -1192,8 +1192,8 @@ public class LocalChannelTest {
         }
 
         @Override
-        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-            ctx.fireExceptionCaught(cause);
+        public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+            ctx.fireChannelExceptionCaught(cause);
             ctx.close();
         }
     }


### PR DESCRIPTION
…bound or outbound events / data

Motivation:

We didnt have a consistent naming which could make it easy to use the wrong methods.

Modifications:

- Ensure all inbound handling methods have `Channel` in the name

Result:

More consistent naming
