### PR TITLE
Avoid shadowing exceptions with dispose(obj)

### DIFF
--- a/codec-dns/src/test/java/io/netty5/handler/codec/dns/DefaultDnsRecordDecoderTest.java
+++ b/codec-dns/src/test/java/io/netty5/handler/codec/dns/DefaultDnsRecordDecoderTest.java
@@ -17,7 +17,9 @@ package io.netty5.handler.codec.dns;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
-import io.netty5.util.Resource;
+import io.netty5.util.internal.SilentDispose;
+import io.netty5.util.internal.logging.InternalLogger;
+import io.netty5.util.internal.logging.InternalLoggerFactory;
 import org.junit.jupiter.api.Test;
 
 import static io.netty5.buffer.api.DefaultBufferAllocators.onHeapAllocator;
@@ -25,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class DefaultDnsRecordDecoderTest {
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(DefaultDnsRecordDecoderTest.class);
 
     @Test
     public void testDecodeName() {
@@ -104,7 +107,7 @@ public class DefaultDnsRecordDecoderTest {
             buffer.readerOffset(0).writerOffset(10);
             assertEquals(buffer, uncompressed);
         } finally {
-            Resource.dispose(uncompressed);
+            SilentDispose.dispose(uncompressed, logger);
         }
     }
 
@@ -124,7 +127,7 @@ public class DefaultDnsRecordDecoderTest {
             uncompressed = DnsCodecUtil.decompressDomainName(allocator, buffer);
             assertEquals(expected, uncompressed);
         } finally {
-            Resource.dispose(uncompressed);
+            SilentDispose.dispose(uncompressed, logger);
         }
     }
 
@@ -152,8 +155,8 @@ public class DefaultDnsRecordDecoderTest {
                         "The rdata of NS-type record should be decompressed in advance");
             assertEquals("netty.io.", DnsCodecUtil.decodeDomainName(nsRecord.content()));
         } finally {
-            Resource.dispose(cnameRecord);
-            Resource.dispose(nsRecord);
+            SilentDispose.dispose(cnameRecord, logger);
+            SilentDispose.dispose(nsRecord, logger);
         }
     }
 
@@ -214,9 +217,9 @@ public class DefaultDnsRecordDecoderTest {
             assertEquals(uncompressedIndexedName, ptrRecord.name());
             assertEquals(uncompressedIndexedName, ptrRecord.hostname());
         } finally {
-            Resource.dispose(rawPlainRecord);
-            Resource.dispose(rawUncompressedRecord);
-            Resource.dispose(rawUncompressedIndexedRecord);
+            SilentDispose.dispose(rawPlainRecord, logger);
+            SilentDispose.dispose(rawUncompressedRecord, logger);
+            SilentDispose.dispose(rawUncompressedIndexedRecord, logger);
         }
     }
 

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2TestUtil.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2TestUtil.java
@@ -31,6 +31,7 @@ import java.util.concurrent.CountDownLatch;
 import static io.netty5.buffer.api.DefaultBufferAllocators.onHeapAllocator;
 import static io.netty5.handler.codec.http2.Http2CodecUtil.MAX_HEADER_LIST_SIZE;
 import static io.netty5.handler.codec.http2.Http2CodecUtil.MAX_HEADER_TABLE_SIZE;
+import static io.netty5.util.internal.SilentDispose.autoClosing;
 import static java.lang.Math.min;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -420,16 +421,14 @@ public final class Http2TestUtil {
         return onHeapAllocator().allocate(0);
     }
 
-    static void assertEqualsAndRelease(Http2Frame expected, Http2Frame actual) {
-        try {
+    static void assertEqualsAndRelease(Http2Frame expected, Http2Frame actual) throws Exception {
+        try (AutoCloseable ignore1 = autoClosing(expected);
+             AutoCloseable ignore2 = autoClosing(actual)) {
             assertEquals(expected, actual);
-        } finally {
-            Resource.dispose(expected);
-            Resource.dispose(actual);
-            // Will return 'false' when not implements Resource or ReferenceCounted.
-            assertFalse(Resource.isAccessible(expected, false));
-            assertFalse(Resource.isAccessible(actual, false));
         }
+        // Will return 'false' when not implements Resource or ReferenceCounted.
+        assertFalse(Resource.isAccessible(expected, false));
+        assertFalse(Resource.isAccessible(actual, false));
     }
 
 }

--- a/codec/src/main/java/io/netty5/handler/codec/MessageAggregator.java
+++ b/codec/src/main/java/io/netty5/handler/codec/MessageAggregator.java
@@ -22,12 +22,12 @@ import io.netty5.channel.ChannelFutureListeners;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
-import io.netty5.util.Resource;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.FutureContextListener;
 
 import static io.netty.buffer.Unpooled.EMPTY_BUFFER;
 import static io.netty5.util.internal.ObjectUtil.checkPositiveOrZero;
+import static io.netty5.util.internal.SilentDispose.autoClosing;
 
 /**
  * An abstract {@link ChannelHandler} that aggregates a series of message objects into a single aggregated message.
@@ -394,11 +394,8 @@ public abstract class MessageAggregator<I, S, C extends ByteBufHolder, O extends
     private void invokeHandleOversizedMessage(ChannelHandlerContext ctx, S oversized) throws Exception {
         handlingOversizedMessage = true;
         currentMessage = null;
-        try {
+        try (AutoCloseable ignore = autoClosing(oversized) /* Release the message in case it is a full one. */) {
             handleOversizedMessage(ctx, oversized);
-        } finally {
-            // Release the message in case it is a full one.
-            Resource.dispose(oversized);
         }
     }
 

--- a/codec/src/main/java/io/netty5/handler/codec/MessageToByteEncoder.java
+++ b/codec/src/main/java/io/netty5/handler/codec/MessageToByteEncoder.java
@@ -21,9 +21,10 @@ import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerAdapter;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
-import io.netty5.util.Resource;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.internal.TypeParameterMatcher;
+
+import static io.netty5.util.internal.SilentDispose.autoClosing;
 
 
 /**
@@ -103,10 +104,8 @@ public abstract class MessageToByteEncoder<I> extends ChannelHandlerAdapter {
                 @SuppressWarnings("unchecked")
                 I cast = (I) msg;
                 buf = allocateBuffer(ctx, cast, preferDirect);
-                try {
+                try (AutoCloseable ignore = autoClosing(cast)) {
                     encode(ctx, cast, buf);
-                } finally {
-                    Resource.dispose(cast);
                 }
 
                 if (buf.isReadable()) {

--- a/codec/src/main/java/io/netty5/handler/codec/MessageToByteEncoderForBuffer.java
+++ b/codec/src/main/java/io/netty5/handler/codec/MessageToByteEncoderForBuffer.java
@@ -16,7 +16,6 @@
 package io.netty5.handler.codec;
 
 import io.netty5.buffer.api.Buffer;
-import io.netty5.util.Resource;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerAdapter;
 import io.netty5.channel.ChannelHandlerContext;
@@ -24,6 +23,7 @@ import io.netty5.channel.ChannelPipeline;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.internal.TypeParameterMatcher;
 
+import static io.netty5.util.internal.SilentDispose.autoClosing;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -77,10 +77,8 @@ public abstract class MessageToByteEncoderForBuffer<I> extends ChannelHandlerAda
                 @SuppressWarnings("unchecked")
                 I cast = (I) msg;
                 buf = allocateBuffer(ctx, cast);
-                try {
+                try (AutoCloseable ignore = autoClosing(cast)) {
                     encode(ctx, cast, buf);
-                } finally {
-                    Resource.dispose(cast);
                 }
 
                 if (buf.readableBytes() > 0) {

--- a/codec/src/main/java/io/netty5/handler/codec/MessageToMessageCodec.java
+++ b/codec/src/main/java/io/netty5/handler/codec/MessageToMessageCodec.java
@@ -18,11 +18,12 @@ package io.netty5.handler.codec;
 import io.netty5.channel.ChannelHandlerAdapter;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.util.ReferenceCounted;
-import io.netty5.util.Resource;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.internal.TypeParameterMatcher;
 
 import java.util.List;
+
+import static io.netty5.util.internal.SilentDispose.autoClosing;
 
 /**
  * A Codec for on-the-fly encoding/decoding of message.
@@ -147,10 +148,8 @@ public abstract class MessageToMessageCodec<INBOUND_IN, OUTBOUND_IN> extends Cha
      * @see MessageToMessageEncoder#encodeAndClose(ChannelHandlerContext, Object, List)
      */
     protected void encodeAndClose(ChannelHandlerContext ctx, OUTBOUND_IN msg, List<Object> out) throws Exception {
-        try {
+        try (AutoCloseable ignore = autoClosing(msg)) {
             encode(ctx, msg, out);
-        } finally {
-            Resource.dispose(msg);
         }
     }
 
@@ -165,10 +164,8 @@ public abstract class MessageToMessageCodec<INBOUND_IN, OUTBOUND_IN> extends Cha
      * @see MessageToMessageDecoder#decodeAndClose(ChannelHandlerContext, Object)
      */
     protected void decodeAndClose(ChannelHandlerContext ctx, INBOUND_IN msg) throws Exception {
-        try {
+        try (AutoCloseable ignore = autoClosing(msg)) {
             decode(ctx, msg);
-        } finally {
-            Resource.dispose(msg);
         }
     }
 }

--- a/codec/src/main/java/io/netty5/handler/codec/MessageToMessageDecoder.java
+++ b/codec/src/main/java/io/netty5/handler/codec/MessageToMessageDecoder.java
@@ -22,6 +22,8 @@ import io.netty5.channel.ChannelPipeline;
 import io.netty5.util.Resource;
 import io.netty5.util.internal.TypeParameterMatcher;
 
+import static io.netty5.util.internal.SilentDispose.autoClosing;
+
 /**
  * {@link ChannelHandler} which decodes from one message to another message.
  *
@@ -125,10 +127,8 @@ public abstract class MessageToMessageDecoder<I> extends ChannelHandlerAdapter {
      * @throws Exception    is thrown if an error occurs
      */
     protected void decodeAndClose(ChannelHandlerContext ctx, I msg) throws Exception {
-        try {
+        try (AutoCloseable ignore = autoClosing(msg)) {
             decode(ctx, msg);
-        } finally {
-            Resource.dispose(msg);
         }
     }
 }

--- a/codec/src/main/java/io/netty5/handler/codec/MessageToMessageEncoder.java
+++ b/codec/src/main/java/io/netty5/handler/codec/MessageToMessageEncoder.java
@@ -28,6 +28,8 @@ import io.netty5.util.internal.TypeParameterMatcher;
 
 import java.util.List;
 
+import static io.netty5.util.internal.SilentDispose.autoClosing;
+
 /**
  * {@link ChannelHandler} which encodes from one message to another message
  *
@@ -162,10 +164,8 @@ public abstract class MessageToMessageEncoder<I> extends ChannelHandlerAdapter {
      * @throws Exception    is thrown if an error occurs.
      */
     protected void encodeAndClose(ChannelHandlerContext ctx, I msg, List<Object> out) throws Exception {
-        try {
+        try (AutoCloseable ignore = autoClosing(msg)) {
             encode(ctx, msg, out);
-        } finally {
-            Resource.dispose(msg);
         }
     }
 }

--- a/common/src/main/java/io/netty5/util/internal/SilentDispose.java
+++ b/common/src/main/java/io/netty5/util/internal/SilentDispose.java
@@ -83,6 +83,31 @@ public final class SilentDispose {
         }
     }
 
+    /**
+     * Return an {@link AutoCloseable} for the given object, which can be used to dispose of it using a
+     * try-with-resources clause.
+     * <p>
+     * The benefit of this approach is that exceptions are correctly handled if both the try-body, and the resource
+     * disposal, throws.
+     * <p>
+     * This is not a silent operation, in that exceptions from resource disposal will propagate.
+     * However, the try-with-resources clause will guarantee that resource disposal exceptions won't shadow any
+     * exceptions from the try-body
+     *
+     * @param obj The object to dispose of.
+     * @return An {@link AutoCloseable} that will dispose of the given object when closed.
+     */
+    public static AutoCloseable autoClosing(Object obj) {
+        if (obj instanceof AutoCloseable) {
+            return (AutoCloseable) obj;
+        }
+        if (obj instanceof io.netty.util.ReferenceCounted) {
+            return () -> ((io.netty.util.ReferenceCounted) obj).release();
+        }
+        // It is safe to use null in try-with-resources. We can use that for uncloseable/unreleasable things.
+        return null;
+    }
+
     private SilentDispose() {
     }
 }

--- a/common/src/test/java/io/netty5/util/internal/OsClassifiersTest.java
+++ b/common/src/test/java/io/netty5/util/internal/OsClassifiersTest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/handler/src/main/java/io/netty5/handler/ssl/JdkSslClientContext.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/JdkSslClientContext.java
@@ -41,7 +41,7 @@ final class JdkSslClientContext extends JdkSslContext {
                         JdkApplicationProtocolNegotiator apn,
                         long sessionCacheSize,
                         long sessionTimeout)
-      throws SSLException {
+      throws Exception {
         super(newSSLContext(provider, toX509CertificatesInternal(trustCertCollectionFile),
           trustManagerFactory, null, null,
           null, null, sessionCacheSize, sessionTimeout, KeyStore.getDefaultType()), true,
@@ -62,7 +62,7 @@ final class JdkSslClientContext extends JdkSslContext {
                         long sessionCacheSize,
                         long sessionTimeout,
                         String keyStore)
-      throws SSLException {
+      throws Exception {
         super(newSSLContext(sslContextProvider, trustCertCollection, trustManagerFactory,
           keyCertChain, key, keyPassword, keyManagerFactory, sessionCacheSize, sessionTimeout, keyStore),
           true, ciphers, cipherFilter, toNegotiator(apn, false), ClientAuth.NONE, protocols, false);

--- a/handler/src/main/java/io/netty5/handler/ssl/JdkSslServerContext.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/JdkSslServerContext.java
@@ -41,7 +41,7 @@ final class JdkSslServerContext extends JdkSslContext {
                         JdkApplicationProtocolNegotiator apn,
                         long sessionCacheSize,
                         long sessionTimeout)
-      throws SSLException {
+      throws Exception {
         super(newSSLContext(provider, null, null,
           toX509CertificatesInternal(certChainFile), toPrivateKeyInternal(keyFile, keyPassword),
           keyPassword, null, sessionCacheSize, sessionTimeout, KeyStore.getDefaultType()), false,
@@ -64,7 +64,7 @@ final class JdkSslServerContext extends JdkSslContext {
                         String[] protocols,
                         boolean startTls,
                         String keyStore)
-      throws SSLException {
+      throws Exception {
         super(newSSLContext(provider, trustCertCollection, trustManagerFactory, keyCertChain, key,
           keyPassword, keyManagerFactory, sessionCacheSize, sessionTimeout, keyStore), false,
           ciphers, cipherFilter, toNegotiator(apn, true), clientAuth, protocols, startTls);

--- a/handler/src/main/java/io/netty5/handler/ssl/SslContext.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslContext.java
@@ -463,10 +463,16 @@ public abstract class SslContext {
             if (enableOcsp) {
                 throw new IllegalArgumentException("OCSP is not supported with this SslProvider: " + provider);
             }
-            return new JdkSslServerContext(sslContextProvider,
-                    trustCertCollection, trustManagerFactory, keyCertChain, key, keyPassword,
-                    keyManagerFactory, ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout,
-                    clientAuth, protocols, startTls, keyStoreType);
+            try {
+                return new JdkSslServerContext(sslContextProvider,
+                        trustCertCollection, trustManagerFactory, keyCertChain, key, keyPassword,
+                        keyManagerFactory, ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout,
+                        clientAuth, protocols, startTls, keyStoreType);
+            } catch (SSLException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new SSLException("Failed to build SslContext", e);
+            }
         case OPENSSL:
             verifyNullSslContextProvider(provider, sslContextProvider);
             return new OpenSslServerContext(
@@ -820,11 +826,17 @@ public abstract class SslContext {
                 if (enableOcsp) {
                     throw new IllegalArgumentException("OCSP is not supported with this SslProvider: " + provider);
                 }
-                return new JdkSslClientContext(sslContextProvider,
-                        trustCert, trustManagerFactory, keyCertChain, key, keyPassword,
-                        keyManagerFactory, ciphers, cipherFilter, apn, protocols, sessionCacheSize,
-                        sessionTimeout, keyStoreType);
-            case OPENSSL:
+                try {
+                    return new JdkSslClientContext(sslContextProvider,
+                            trustCert, trustManagerFactory, keyCertChain, key, keyPassword,
+                            keyManagerFactory, ciphers, cipherFilter, apn, protocols, sessionCacheSize,
+                            sessionTimeout, keyStoreType);
+                } catch (SSLException e) {
+                    throw e;
+                } catch (Exception e) {
+                    throw new SSLException("Failed to build SslContext", e);
+                }
+        case OPENSSL:
                 verifyNullSslContextProvider(provider, sslContextProvider);
                 OpenSsl.ensureAvailability();
                 return new OpenSslClientContext(

--- a/handler/src/main/java/io/netty5/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslHandler.java
@@ -66,6 +66,7 @@ import java.util.regex.Pattern;
 
 import static io.netty5.handler.ssl.SslUtils.getEncryptedPacketLength;
 import static io.netty5.util.internal.ObjectUtil.checkPositiveOrZero;
+import static io.netty5.util.internal.SilentDispose.autoClosing;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -569,7 +570,7 @@ public class SslHandler extends ByteToMessageDecoderForBuffer {
 
     @Override
     public void handlerRemoved0(ChannelHandlerContext ctx) throws Exception {
-        try {
+        try (AutoCloseable ignore = autoClosing(engine)) {
             if (pendingUnencryptedWrites != null && !pendingUnencryptedWrites.isEmpty()) {
                 // Check if queue is not empty first because create a new ChannelException is expensive
                 pendingUnencryptedWrites.releaseAndFailAll(ctx,
@@ -594,8 +595,6 @@ public class SslHandler extends ByteToMessageDecoderForBuffer {
                 }
                 notifyClosePromise(cause);
             }
-        } finally {
-            Resource.dispose(engine);
         }
     }
 

--- a/handler/src/test/java/io/netty5/handler/ssl/PemEncodedTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/PemEncodedTest.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.security.PrivateKey;
 
+import static io.netty5.util.internal.SilentDispose.autoClosing;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -64,13 +65,11 @@ public class PemEncodedTest {
                 .build();
         assertFalse(pemKey.isDestroyed());
         assertTrue(pemCert.isAccessible());
-        try {
+        try (AutoCloseable ignore = autoClosing(context)) {
             assertTrue(context instanceof ReferenceCountedOpenSslContext);
-        } finally {
-            Resource.dispose(context);
-            assertRelease(pemKey);
-            assertRelease(pemCert);
         }
+        assertRelease(pemKey);
+        assertRelease(pemCert);
     }
 
     @Test

--- a/handler/src/test/java/io/netty5/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SslHandlerTest.java
@@ -807,8 +807,8 @@ public class SslHandlerTest {
                                 SslHandler handler = sslClientCtx.newHandler(ch.bufferAllocator());
 
                                 // We propagate the SslHandler via an AtomicReference to the outer-scope as using
-                                // pipeline.get(...) may return null if the pipeline was teared down by the time we call it.
-                                // This will happen if the channel was closed in the meantime.
+                                // pipeline.get(...) may return null if the pipeline was teared down by the time we
+                                // call it. This will happen if the channel was closed in the meantime.
                                 sslHandlerRef.set(handler);
                                 ch.pipeline().addLast(handler);
                             }
@@ -895,9 +895,9 @@ public class SslHandlerTest {
                             future.get().writeAndFlush(offHeapAllocator().copyOf(new byte[] { 1, 2, 3, 4 }));
                         }).get();
 
-                // Ensure there is no AssertionError thrown by having the handshake failed by the writeAndFlush(...) before
-                // channelActive(...) was called. Let's first wait for the activeLatch countdown to happen and after this
-                // check if we saw and AssertionError (even if we timed out waiting).
+                // Ensure there is no AssertionError thrown by having the handshake failed by the writeAndFlush(...)
+                // before channelActive(...) was called. Let's first wait for the activeLatch countdown to happen and
+                // after this check if we saw and AssertionError (even if we timed out waiting).
                 activeLatch.await(5, TimeUnit.SECONDS);
                 AssertionError error = errorRef.get();
                 if (error != null) {
@@ -1340,9 +1340,9 @@ public class SslHandlerTest {
                                             handshakeCount++;
                                             ReferenceCountedOpenSslEngine engine =
                                                     (ReferenceCountedOpenSslEngine) sslHandler.engine();
-                                            // This test only works for non TLSv1.3 as TLSv1.3 will establish sessions after
-                                            // the handshake is done.
-                                            // See https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_sess_set_get_cb.html
+                                            // This test only works for non TLSv1.3 as TLSv1.3 will establish sessions
+                                            // after the handshake is done. See:
+                                            // https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_sess_set_get_cb.html
                                             if (!SslProtocols.TLS_v1_3.equals(engine.getSession().getProtocol())) {
                                                 // First should not re-use the session
                                                 try {

--- a/resolver-dns/src/main/java/io/netty5/resolver/dns/DnsQueryContext.java
+++ b/resolver-dns/src/main/java/io/netty5/resolver/dns/DnsQueryContext.java
@@ -161,7 +161,7 @@ abstract class DnsQueryContext implements FutureListener<AddressedEnvelope<DnsRe
         try {
             promise.tryFailure(cause);
             writePromise.setFailure(cause);
-        } catch (Throwable throwable){
+        } catch (Throwable throwable) {
             SilentDispose.dispose(query, logger);
             throw throwable;
         }

--- a/resolver-dns/src/main/java/io/netty5/resolver/dns/DnsQueryContext.java
+++ b/resolver-dns/src/main/java/io/netty5/resolver/dns/DnsQueryContext.java
@@ -29,6 +29,7 @@ import io.netty5.util.Resource;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.FutureListener;
 import io.netty5.util.concurrent.Promise;
+import io.netty5.util.internal.SilentDispose;
 import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
 
@@ -160,9 +161,11 @@ abstract class DnsQueryContext implements FutureListener<AddressedEnvelope<DnsRe
         try {
             promise.tryFailure(cause);
             writePromise.setFailure(cause);
-        } finally {
-            Resource.dispose(query);
+        } catch (Throwable throwable){
+            SilentDispose.dispose(query, logger);
+            throw throwable;
         }
+        Resource.dispose(query);
     }
 
     private void writeQuery(final DnsQuery query, final boolean flush, final Promise<Void> writePromise) {

--- a/resolver-dns/src/test/java/io/netty5/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty5/resolver/dns/DnsNameResolverTest.java
@@ -71,7 +71,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.function.Executable;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.net.BindException;
 import java.net.DatagramSocket;

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDatagramChannel.java
@@ -37,7 +37,10 @@ import io.netty5.util.UncheckedBooleanSupplier;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.Promise;
 import io.netty5.util.internal.RecyclableArrayList;
+import io.netty5.util.internal.SilentDispose;
 import io.netty5.util.internal.StringUtil;
+import io.netty5.util.internal.logging.InternalLogger;
+import io.netty5.util.internal.logging.InternalLoggerFactory;
 
 import java.io.IOException;
 import java.net.Inet4Address;
@@ -55,6 +58,7 @@ import static java.util.Objects.requireNonNull;
  * maximal performance.
  */
 public final class EpollDatagramChannel extends AbstractEpollChannel implements DatagramChannel {
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(EpollDatagramChannel.class);
     private static final ChannelMetadata METADATA = new ChannelMetadata(true);
     private static final String EXPECTED_TYPES =
             " (expected: " + StringUtil.simpleClassName(DatagramPacket.class) + ", " +
@@ -446,7 +450,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
                         try {
                             return new DefaultBufferAddressedEnvelope<>(newDirectBuffer(buf), recipient);
                         } finally {
-                            Resource.dispose(e);
+                            SilentDispose.dispose(e, logger); // Don't fail here, because we allocated a buffer.
                         }
                     }
                     return e;

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDomainDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDomainDatagramChannel.java
@@ -34,10 +34,12 @@ import io.netty5.channel.unix.IovArray;
 import io.netty5.channel.unix.PeerCredentials;
 import io.netty5.channel.unix.RecvFromAddressDomainSocket;
 import io.netty5.channel.unix.UnixChannelUtil;
-import io.netty5.util.Resource;
 import io.netty5.util.UncheckedBooleanSupplier;
+import io.netty5.util.internal.SilentDispose;
 import io.netty5.util.internal.StringUtil;
 import io.netty5.util.internal.UnstableApi;
+import io.netty5.util.internal.logging.InternalLogger;
+import io.netty5.util.internal.logging.InternalLoggerFactory;
 
 import java.io.IOException;
 import java.net.SocketAddress;
@@ -47,9 +49,8 @@ import static io.netty5.util.CharsetUtil.UTF_8;
 
 @UnstableApi
 public final class EpollDomainDatagramChannel extends AbstractEpollChannel implements DomainDatagramChannel {
-
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(EpollDomainDatagramChannel.class);
     private static final ChannelMetadata METADATA = new ChannelMetadata(true);
-
     private static final String EXPECTED_TYPES =
             " (expected: " +
                     StringUtil.simpleClassName(DomainDatagramPacket.class) + ", " +
@@ -271,7 +272,7 @@ public final class EpollDomainDatagramChannel extends AbstractEpollChannel imple
                         try {
                             return new DefaultBufferAddressedEnvelope<>(newDirectBuffer(null, buf), domainRecipient);
                         } finally {
-                            Resource.dispose(e);
+                            SilentDispose.dispose(e, logger); // Don't fail here, because we allocated a buffer.
                         }
                     }
                     return e;

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDatagramChannel.java
@@ -29,12 +29,14 @@ import io.netty5.channel.unix.DatagramSocketAddress;
 import io.netty5.channel.unix.Errors;
 import io.netty5.channel.unix.IovArray;
 import io.netty5.channel.unix.UnixChannelUtil;
-import io.netty5.util.Resource;
 import io.netty5.util.UncheckedBooleanSupplier;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.Promise;
+import io.netty5.util.internal.SilentDispose;
 import io.netty5.util.internal.StringUtil;
 import io.netty5.util.internal.UnstableApi;
+import io.netty5.util.internal.logging.InternalLogger;
+import io.netty5.util.internal.logging.InternalLoggerFactory;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -50,6 +52,7 @@ import static java.util.Objects.requireNonNull;
 
 @UnstableApi
 public final class KQueueDatagramChannel extends AbstractKQueueDatagramChannel implements DatagramChannel {
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(KQueueDatagramChannel.class);
     private static final String EXPECTED_TYPES =
             " (expected: " + StringUtil.simpleClassName(DatagramPacket.class) + ", " +
                     StringUtil.simpleClassName(AddressedEnvelope.class) + '<' +
@@ -320,7 +323,7 @@ public final class KQueueDatagramChannel extends AbstractKQueueDatagramChannel i
                         try {
                             return new DefaultBufferAddressedEnvelope<>(newDirectBuffer(null, buf), inetRecipient);
                         } finally {
-                            Resource.dispose(e);
+                            SilentDispose.dispose(e, logger); // Don't fail here, because we allocated a buffer.
                         }
                     }
                     return e;

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDomainDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDomainDatagramChannel.java
@@ -18,7 +18,6 @@ package io.netty5.channel.kqueue;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.buffer.api.DefaultBufferAllocators;
-import io.netty5.util.Resource;
 import io.netty5.channel.AddressedEnvelope;
 import io.netty5.channel.ChannelPipeline;
 import io.netty5.channel.DefaultBufferAddressedEnvelope;
@@ -33,8 +32,11 @@ import io.netty5.channel.unix.PeerCredentials;
 import io.netty5.channel.unix.RecvFromAddressDomainSocket;
 import io.netty5.channel.unix.UnixChannelUtil;
 import io.netty5.util.UncheckedBooleanSupplier;
+import io.netty5.util.internal.SilentDispose;
 import io.netty5.util.internal.StringUtil;
 import io.netty5.util.internal.UnstableApi;
+import io.netty5.util.internal.logging.InternalLogger;
+import io.netty5.util.internal.logging.InternalLoggerFactory;
 
 import java.io.IOException;
 import java.net.SocketAddress;
@@ -44,7 +46,7 @@ import static io.netty5.util.CharsetUtil.UTF_8;
 
 @UnstableApi
 public final class KQueueDomainDatagramChannel extends AbstractKQueueDatagramChannel implements DomainDatagramChannel {
-
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(KQueueDomainDatagramChannel.class);
     private static final String EXPECTED_TYPES =
             " (expected: " +
                     StringUtil.simpleClassName(DomainDatagramPacket.class) + ", " +
@@ -194,7 +196,7 @@ public final class KQueueDomainDatagramChannel extends AbstractKQueueDatagramCha
                         try {
                             return new DefaultBufferAddressedEnvelope<>(newDirectBuffer(buf), domainRecipient);
                         } finally {
-                            Resource.dispose(e);
+                            SilentDispose.dispose(e, logger); // Don't fail here, because we allocated a buffer.
                         }
                     }
                     return e;

--- a/transport/src/main/java/io/netty5/channel/AbstractCoalescingBufferQueue.java
+++ b/transport/src/main/java/io/netty5/channel/AbstractCoalescingBufferQueue.java
@@ -182,8 +182,8 @@ public abstract class AbstractCoalescingBufferQueue {
                 entryBuffer = null;
             }
         } catch (Throwable cause) {
-            safeDispose(entryBuffer);
-            safeDispose(toReturn);
+            SilentDispose.dispose(entryBuffer, logger);
+            SilentDispose.dispose(toReturn, logger);
             aggregatePromise.setFailure(cause);
             throw cause;
         }
@@ -340,7 +340,7 @@ public abstract class AbstractCoalescingBufferQueue {
                 if (entry instanceof Buffer) {
                     Buffer buffer = (Buffer) entry;
                     decrementReadableBytes(buffer.readableBytes());
-                    safeDispose(buffer);
+                    SilentDispose.dispose(buffer, logger);
                 } else {
                     ((FutureListener<Void>) entry).operationComplete(future);
                 }
@@ -374,9 +374,5 @@ public abstract class AbstractCoalescingBufferQueue {
         if (tracker != null) {
             tracker.decrementPendingOutboundBytes(decrement);
         }
-    }
-
-    private void safeDispose(Object object) {
-        SilentDispose.dispose(object, logger);
     }
 }

--- a/transport/src/main/java/io/netty5/channel/DefaultChannelConfig.java
+++ b/transport/src/main/java/io/netty5/channel/DefaultChannelConfig.java
@@ -18,7 +18,6 @@ package io.netty5.channel;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.buffer.api.DefaultBufferAllocators;
-import io.netty5.channel.socket.SocketChannelConfig;
 
 import java.util.IdentityHashMap;
 import java.util.Map;

--- a/transport/src/main/java/io/netty5/channel/SimpleChannelInboundHandler.java
+++ b/transport/src/main/java/io/netty5/channel/SimpleChannelInboundHandler.java
@@ -100,10 +100,18 @@ public abstract class SimpleChannelInboundHandler<I> implements ChannelHandler {
                 release = false;
                 ctx.fireChannelRead(msg);
             }
-        } finally {
+        } catch (Throwable throwable) {
             if (autoRelease && release) {
-                Resource.dispose(msg);
+                try {
+                    Resource.dispose(msg);
+                } catch (Exception e) {
+                    throwable.addSuppressed(e);
+                }
             }
+            throw throwable;
+        }
+        if (autoRelease && release) {
+            Resource.dispose(msg);
         }
     }
 

--- a/transport/src/main/java/io/netty5/channel/SimpleUserEventChannelHandler.java
+++ b/transport/src/main/java/io/netty5/channel/SimpleUserEventChannelHandler.java
@@ -100,10 +100,18 @@ public abstract class SimpleUserEventChannelHandler<I> implements ChannelHandler
                 release = false;
                 ctx.fireChannelInboundEvent(evt);
             }
-        } finally {
+        } catch (Throwable throwable) {
             if (autoRelease && release) {
-                Resource.dispose(evt);
+                try {
+                    Resource.dispose(evt);
+                } catch (Exception e) {
+                    throwable.addSuppressed(e);
+                }
             }
+            throw throwable;
+        }
+        if (autoRelease && release) {
+            Resource.dispose(evt);
         }
     }
 


### PR DESCRIPTION
Motivation:
Methods like Resource.dispose(obj) can throw exceptions, and are often used in finally-clauses.
When an exception is thrown from a finally-clause, it can shadow any exception that may have been thrown from the try-clause.

Modification:
Go through all of the places where Resource.dispose() is used in a finally clause, and change the code such that no exception from the try-clause will be shadowed if the dispose() method throws.
In many cases, this can be done by deferring to try-with-resources, but a small number of cases need special care.

Result:
We should no longer miss any root causes, when a Resource.dispose(obj) call throws.