### PR TITLE
Bring back HttpChunkedInput

### DIFF
--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpChunkedInputTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpChunkedInputTest.java
@@ -15,8 +15,32 @@
  */
 package io.netty5.handler.codec.http;
 
+import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.api.BufferAllocator;
+import io.netty5.channel.embedded.EmbeddedChannel;
+import io.netty5.handler.stream.ChunkedFile;
+import io.netty5.handler.stream.ChunkedInput;
+import io.netty5.handler.stream.ChunkedNioFile;
+import io.netty5.handler.stream.ChunkedNioStream;
+import io.netty5.handler.stream.ChunkedStream;
+import io.netty5.handler.stream.ChunkedWriteHandler;
+import io.netty5.util.Resource;
+import io.netty5.util.internal.PlatformDependent;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.channels.Channels;
+
+import static io.netty5.buffer.api.DefaultBufferAllocators.preferredAllocator;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class HttpChunkedInputTest {
-/*
     private static final byte[] BYTES = new byte[1024 * 64];
     private static final File TMP;
 
@@ -47,27 +71,28 @@ public class HttpChunkedInputTest {
 
     @Test
     public void testChunkedStream() {
-        check(new HttpChunkedInput(new ChunkedStream(new ByteArrayInputStream(BYTES))));
+        check(new HttpChunkedInput(new ChunkedStream(new ByteArrayInputStream(BYTES)), emptyLastContent()));
     }
 
     @Test
     public void testChunkedNioStream() {
-        check(new HttpChunkedInput(new ChunkedNioStream(Channels.newChannel(new ByteArrayInputStream(BYTES)))));
+        check(new HttpChunkedInput(
+                new ChunkedNioStream(Channels.newChannel(new ByteArrayInputStream(BYTES))), emptyLastContent()));
     }
 
     @Test
     public void testChunkedFile() throws IOException {
-        check(new HttpChunkedInput(new ChunkedFile(TMP)));
+        check(new HttpChunkedInput(new ChunkedFile(TMP), emptyLastContent()));
     }
 
     @Test
     public void testChunkedNioFile() throws IOException {
-        check(new HttpChunkedInput(new ChunkedNioFile(TMP)));
+        check(new HttpChunkedInput(new ChunkedNioFile(TMP), emptyLastContent()));
     }
 
     @Test
     public void testWrappedReturnNull() throws Exception {
-        HttpChunkedInput input = new HttpChunkedInput(new ChunkedInput<ByteBuf>() {
+        ChunkedInput<Buffer> inputStub = new ChunkedInput<>() {
             @Override
             public boolean isEndOfInput() throws Exception {
                 return false;
@@ -79,12 +104,7 @@ public class HttpChunkedInputTest {
             }
 
             @Override
-            public ByteBuf readChunk(ChannelHandlerContext ctx) throws Exception {
-                return null;
-            }
-
-            @Override
-            public ByteBuf readChunk(ByteBufAllocator allocator) throws Exception {
+            public Buffer readChunk(BufferAllocator allocator) throws Exception {
                 return null;
             }
 
@@ -97,8 +117,13 @@ public class HttpChunkedInputTest {
             public long progress() {
                 return 0;
             }
-        });
-        assertNull(input.readChunk(ByteBufAllocator.DEFAULT));
+        };
+        HttpChunkedInput input = new HttpChunkedInput(inputStub, emptyLastContent());
+        assertNull(input.readChunk(preferredAllocator()));
+    }
+
+    private static EmptyLastHttpContent emptyLastContent() {
+        return new EmptyLastHttpContent(preferredAllocator());
     }
 
     private static void check(ChunkedInput<?>... inputs) {
@@ -112,9 +137,9 @@ public class HttpChunkedInputTest {
 
         int i = 0;
         int read = 0;
-        HttpContent lastHttpContent = null;
+        HttpContent<?> lastHttpContent = null;
         for (;;) {
-            HttpContent httpContent = ch.readOutbound();
+            HttpContent<?> httpContent = ch.readOutbound();
             if (httpContent == null) {
                 break;
             }
@@ -122,23 +147,24 @@ public class HttpChunkedInputTest {
                 assertTrue(lastHttpContent instanceof DefaultHttpContent, "Chunk must be DefaultHttpContent");
             }
 
-            ByteBuf buffer = httpContent.content();
-            while (buffer.isReadable()) {
+            Buffer buffer = httpContent.payload();
+            int roff = buffer.readerOffset();
+            while (buffer.readableBytes() > 0) {
                 assertEquals(BYTES[i++], buffer.readByte());
                 read++;
                 if (i == BYTES.length) {
                     i = 0;
                 }
             }
-            buffer.release();
+            buffer.readerOffset(roff);
 
             // Save last chunk
+            Resource.dispose(lastHttpContent);
             lastHttpContent = httpContent;
         }
 
         assertEquals(BYTES.length * inputs.length, read);
-        assertSame(LastHttpContent.EMPTY_LAST_CONTENT, lastHttpContent,
-                "Last chunk must be LastHttpContent.EMPTY_LAST_CONTENT");
+        assertThat(lastHttpContent).isInstanceOf(LastHttpContent.class);
+        assertThat(lastHttpContent.payload().readableBytes()).isZero();
     }
-*/
 }

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2DataChunkedInputTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2DataChunkedInputTest.java
@@ -104,7 +104,6 @@ public class Http2DataChunkedInputTest {
     @Test
     public void testWrappedReturnNull() throws Exception {
         Http2DataChunkedInput input = new Http2DataChunkedInput(new ChunkedInput<Buffer>() {
-
             @Override
             public boolean isEndOfInput() throws Exception {
                 return false;

--- a/example/src/main/java/io/netty5/example/http/file/HttpStaticFileServerHandler.java
+++ b/example/src/main/java/io/netty5/example/http/file/HttpStaticFileServerHandler.java
@@ -32,6 +32,7 @@ import io.netty5.handler.codec.http.HttpResponse;
 import io.netty5.handler.codec.http.HttpResponseStatus;
 import io.netty5.handler.codec.http.HttpUtil;
 import io.netty5.handler.ssl.SslHandler;
+import io.netty5.handler.stream.ChunkedFile;
 import io.netty5.util.CharsetUtil;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.internal.SystemPropertyUtil;
@@ -209,8 +210,9 @@ public class HttpStaticFileServerHandler extends SimpleChannelInboundHandler<Ful
             lastContentFuture = ctx.writeAndFlush(new EmptyLastHttpContent(ctx.bufferAllocator()));
         } else {
             sendFileFuture =
-//                    ctx.writeAndFlush(new HttpChunkedInput(new ChunkedFile(raf, 0, fileLength, 8192)));
-                    ctx.writeAndFlush(new HttpChunkedInput());
+                    ctx.writeAndFlush(new HttpChunkedInput(
+                            new ChunkedFile(raf, 0, fileLength, 8192),
+                            new EmptyLastHttpContent(ctx.bufferAllocator())));
             // HttpChunkedInput will write the end marker (LastHttpContent) for us.
             lastContentFuture = sendFileFuture;
         }

--- a/handler/src/main/java/io/netty5/handler/stream/ChunkedInput.java
+++ b/handler/src/main/java/io/netty5/handler/stream/ChunkedInput.java
@@ -20,8 +20,7 @@ import io.netty5.buffer.api.BufferAllocator;
 /**
  * A data stream of indefinite length which is consumed by {@link ChunkedWriteHandler}.
  */
-public interface ChunkedInput<B> {
-
+public interface ChunkedInput<B> extends AutoCloseable {
     /**
      * Return {@code true} if and only if there is no data left in the stream
      * and the stream has reached at its end.
@@ -31,6 +30,7 @@ public interface ChunkedInput<B> {
     /**
      * Releases the resources associated with the input.
      */
+    @Override
     void close() throws Exception;
 
     /**

--- a/handler/src/main/java/io/netty5/handler/stream/ChunkedNioFile.java
+++ b/handler/src/main/java/io/netty5/handler/stream/ChunkedNioFile.java
@@ -21,9 +21,9 @@ import io.netty5.channel.FileRegion;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.RandomAccessFile;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.FileChannel;
+import java.nio.file.StandardOpenOption;
 
 import static java.util.Objects.requireNonNull;
 
@@ -47,7 +47,7 @@ public class ChunkedNioFile implements ChunkedInput<Buffer> {
      * Creates a new instance that fetches data from the specified file.
      */
     public ChunkedNioFile(File in) throws IOException {
-        this(new RandomAccessFile(in, "r").getChannel());
+        this(FileChannel.open(in.toPath(), StandardOpenOption.READ));
     }
 
     /**
@@ -56,7 +56,7 @@ public class ChunkedNioFile implements ChunkedInput<Buffer> {
      * @param chunkSize the number of bytes to fetch on each {@link #readChunk(BufferAllocator)} call.
      */
     public ChunkedNioFile(File in, int chunkSize) throws IOException {
-        this(new RandomAccessFile(in, "r").getChannel(), chunkSize);
+        this(FileChannel.open(in.toPath(), StandardOpenOption.READ), chunkSize);
     }
 
     /**

--- a/handler/src/test/java/io/netty5/handler/stream/ChunkedWriteHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/stream/ChunkedWriteHandlerTest.java
@@ -36,6 +36,7 @@ import java.io.RandomAccessFile;
 import java.nio.channels.Channels;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.FileChannel;
+import java.nio.file.StandardOpenOption;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -112,10 +113,8 @@ public class ChunkedWriteHandlerTest {
 
     @Test
     public void testChunkedNioFileLeftPositionUnchanged() throws IOException {
-        FileChannel in = null;
         final long expectedPosition = 10;
-        try {
-            in = new RandomAccessFile(TMP, "r").getChannel();
+        try (FileChannel in = FileChannel.open(TMP.toPath(), StandardOpenOption.READ)) {
             in.position(expectedPosition);
             check(new ChunkedNioFile(in) {
                 @Override
@@ -125,16 +124,12 @@ public class ChunkedWriteHandlerTest {
             });
             assertTrue(in.isOpen());
             assertEquals(expectedPosition, in.position());
-        } finally {
-            if (in != null) {
-                in.close();
-            }
         }
     }
 
     @Test
     public void testChunkedNioFileFailOnClosedFileChannel() throws IOException {
-        final FileChannel in = new RandomAccessFile(TMP, "r").getChannel();
+        final FileChannel in = FileChannel.open(TMP.toPath(), StandardOpenOption.READ);
         in.close();
 
         assertThrows(ClosedChannelException.class, new Executable() {


### PR DESCRIPTION
Motivation:
This was commented out while waiting for HTTP/2 to be migrated to Buffer.

Modification:
Comment the HttpChunkedInput code, and its test, back in.
Migrate it to buffer, and fixes tests and various small issues.

Result:
HttpChunkedInput is back.
