### PR TITLE
`AbstractChannel.newId()` should be removed

### DIFF
--- a/transport/src/main/java/io/netty5/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty5/channel/AbstractChannel.java
@@ -74,7 +74,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         this.parent = parent;
         this.eventLoop = validateEventLoop(eventLoop);
         closePromise = new ClosePromise(eventLoop);
-        id = newId();
+        id = DefaultChannelId.newInstance();
         unsafe = newUnsafe();
         pipeline = newChannelPipeline();
     }
@@ -113,15 +113,6 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
     @Override
     public final ChannelId id() {
         return id;
-    }
-
-    /**
-     * Returns a new {@link DefaultChannelId} instance. Subclasses may override this method to assign custom
-     * {@link ChannelId}s to {@link Channel}s that use the {@link AbstractChannel#AbstractChannel(Channel, EventLoop)}
-     * constructor.
-     */
-    protected ChannelId newId() {
-        return DefaultChannelId.newInstance();
     }
 
     /**


### PR DESCRIPTION
Motivation:

We should better remove `AbstractChannel.newId()` so it can not be overriden as this method is called from within the constructor. If a sub-class of `AbstractChannel` wants to use its own `ChannelId` implementation it should just use the constructor of `AbstractChannel` that takes a ChannelId.

Modifications:

Remove `newId()` static

Result:

Cleanup code-smell