### PR TITLE
Rename internal method to be consistent

### DIFF
--- a/transport/src/main/java/io/netty5/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty5/channel/DefaultChannelPipeline.java
@@ -810,13 +810,13 @@ public abstract class DefaultChannelPipeline implements ChannelPipeline {
 
     @Override
     public final ChannelPipeline fireChannelExceptionCaught(Throwable cause) {
-        head.invokeExceptionCaught(cause);
+        head.invokeChannelExceptionCaught(cause);
         return this;
     }
 
     @Override
     public final ChannelPipeline fireChannelInboundEvent(Object event) {
-        head.invokeCustomInboundEventTriggered(event);
+        head.invokeChannelInboundEvent(event);
         return this;
     }
 


### PR DESCRIPTION
Motivation:

We did rename the public methods but missed the internal ones.

Modifications:

Rename methods

Result:

Cleanup
