### PR TITLE
CombinedChannelDuplexHandler must delegate sendOutboundEvent(...)

### DIFF
--- a/transport/src/main/java/io/netty5/channel/CombinedChannelDuplexHandler.java
+++ b/transport/src/main/java/io/netty5/channel/CombinedChannelDuplexHandler.java
@@ -353,6 +353,16 @@ public class CombinedChannelDuplexHandler<I extends ChannelHandler, O extends Ch
         }
     }
 
+    @Override
+    public Future<Void> sendOutboundEvent(ChannelHandlerContext ctx, Object event) {
+        assert ctx == outboundCtx.delegatingCtx();
+        if (!outboundCtx.removed) {
+            return outboundHandler.sendOutboundEvent(outboundCtx, event);
+        } else {
+            return outboundCtx.sendOutboundEvent(event);
+        }
+    }
+
     private static final class CombinedChannelHandlerContext extends DelegatingChannelHandlerContext {
 
         private final ChannelHandler handler;


### PR DESCRIPTION
Motivation:

CombinedChannelDuplexHandler did miss an override and so did not delegate sendOutboundEvent(...) correctly.

Modifications:

- Add override
- Add unit test

Result:

Correctly delegate CombinedChannelDuplexHandler to outbound handler
