### PR TITLE
Remove `@Sharable` and replace it with default method

### DIFF
--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/DatagramDnsQueryDecoder.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/DatagramDnsQueryDecoder.java
@@ -15,7 +15,6 @@
  */
 package io.netty5.handler.codec.dns;
 
-import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.socket.DatagramPacket;
 import io.netty5.handler.codec.MessageToMessageDecoder;
@@ -27,7 +26,6 @@ import static java.util.Objects.requireNonNull;
  * Decodes a {@link DatagramPacket} into a {@link DatagramDnsQuery}.
  */
 @UnstableApi
-@ChannelHandler.Sharable
 public class DatagramDnsQueryDecoder extends MessageToMessageDecoder<DatagramPacket> {
 
     private final DnsRecordDecoder recordDecoder;
@@ -44,6 +42,11 @@ public class DatagramDnsQueryDecoder extends MessageToMessageDecoder<DatagramPac
      */
     public DatagramDnsQueryDecoder(DnsRecordDecoder recordDecoder) {
         this.recordDecoder = requireNonNull(recordDecoder, "recordDecoder");
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
     }
 
     @Override

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/DatagramDnsQueryEncoder.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/DatagramDnsQueryEncoder.java
@@ -17,7 +17,6 @@ package io.netty5.handler.codec.dns;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.AddressedEnvelope;
-import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.socket.DatagramPacket;
 import io.netty5.handler.codec.MessageToMessageEncoder;
@@ -31,7 +30,6 @@ import java.util.List;
  * {@link DatagramPacket}.
  */
 @UnstableApi
-@ChannelHandler.Sharable
 public class DatagramDnsQueryEncoder extends MessageToMessageEncoder<AddressedEnvelope<DnsQuery, InetSocketAddress>> {
 
     private final DnsQueryEncoder encoder;
@@ -48,6 +46,11 @@ public class DatagramDnsQueryEncoder extends MessageToMessageEncoder<AddressedEn
      */
     public DatagramDnsQueryEncoder(DnsRecordEncoder recordEncoder) {
         encoder = new DnsQueryEncoder(recordEncoder);
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
     }
 
     @Override

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/DatagramDnsResponseDecoder.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/DatagramDnsResponseDecoder.java
@@ -15,7 +15,6 @@
  */
 package io.netty5.handler.codec.dns;
 
-import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.socket.DatagramPacket;
 import io.netty5.handler.codec.CorruptedFrameException;
@@ -28,7 +27,6 @@ import java.net.InetSocketAddress;
  * Decodes a {@link DatagramPacket} into a {@link DatagramDnsResponse}.
  */
 @UnstableApi
-@ChannelHandler.Sharable
 public class DatagramDnsResponseDecoder extends MessageToMessageDecoder<DatagramPacket> {
 
     private final DnsResponseDecoder<InetSocketAddress> responseDecoder;
@@ -51,6 +49,11 @@ public class DatagramDnsResponseDecoder extends MessageToMessageDecoder<Datagram
                 return new DatagramDnsResponse(sender, recipient, id, opCode, responseCode);
             }
         };
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
     }
 
     @Override

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/DatagramDnsResponseEncoder.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/DatagramDnsResponseEncoder.java
@@ -17,7 +17,6 @@ package io.netty5.handler.codec.dns;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.AddressedEnvelope;
-import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.socket.DatagramPacket;
 import io.netty5.handler.codec.MessageToMessageEncoder;
@@ -33,7 +32,6 @@ import static java.util.Objects.requireNonNull;
  * {@link DatagramPacket}.
  */
 @UnstableApi
-@ChannelHandler.Sharable
 public class DatagramDnsResponseEncoder
     extends MessageToMessageEncoder<AddressedEnvelope<DnsResponse, InetSocketAddress>> {
 
@@ -51,6 +49,11 @@ public class DatagramDnsResponseEncoder
      */
     public DatagramDnsResponseEncoder(DnsRecordEncoder recordEncoder) {
         this.recordEncoder = requireNonNull(recordEncoder, "recordEncoder");
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
     }
 
     @Override

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/TcpDnsQueryEncoder.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/TcpDnsQueryEncoder.java
@@ -16,12 +16,10 @@
 package io.netty5.handler.codec.dns;
 
 import io.netty5.buffer.api.Buffer;
-import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.MessageToByteEncoderForBuffer;
 import io.netty5.util.internal.UnstableApi;
 
-@ChannelHandler.Sharable
 @UnstableApi
 public final class TcpDnsQueryEncoder extends MessageToByteEncoderForBuffer<DnsQuery> {
 
@@ -39,6 +37,11 @@ public final class TcpDnsQueryEncoder extends MessageToByteEncoderForBuffer<DnsQ
      */
     public TcpDnsQueryEncoder(DnsRecordEncoder recordEncoder) {
         encoder = new DnsQueryEncoder(recordEncoder);
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
     }
 
     @Override

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/TcpDnsResponseEncoder.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/TcpDnsResponseEncoder.java
@@ -16,7 +16,6 @@
 package io.netty5.handler.codec.dns;
 
 import io.netty5.buffer.api.Buffer;
-import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.MessageToMessageEncoder;
 import io.netty5.util.internal.UnstableApi;
@@ -26,7 +25,6 @@ import java.util.List;
 import static java.util.Objects.requireNonNull;
 
 @UnstableApi
-@ChannelHandler.Sharable
 public final class TcpDnsResponseEncoder extends MessageToMessageEncoder<DnsResponse> {
     private final DnsRecordEncoder encoder;
 
@@ -42,6 +40,11 @@ public final class TcpDnsResponseEncoder extends MessageToMessageEncoder<DnsResp
      */
     public TcpDnsResponseEncoder(DnsRecordEncoder encoder) {
         this.encoder = requireNonNull(encoder, "encoder");
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/extensions/compression/WebSocketClientCompressionHandler.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/extensions/compression/WebSocketClientCompressionHandler.java
@@ -15,7 +15,6 @@
  */
 package io.netty5.handler.codec.http.websocketx.extensions.compression;
 
-import io.netty5.channel.ChannelHandler;
 import io.netty5.handler.codec.http.websocketx.extensions.WebSocketClientExtensionHandler;
 
 /**
@@ -24,10 +23,14 @@ import io.netty5.handler.codec.http.websocketx.extensions.WebSocketClientExtensi
  *
  * See <tt>io.netty5.example.http.websocketx.client.WebSocketClient</tt> for usage.
  */
-@ChannelHandler.Sharable
 public final class WebSocketClientCompressionHandler extends WebSocketClientExtensionHandler {
 
     public static final WebSocketClientCompressionHandler INSTANCE = new WebSocketClientCompressionHandler();
+
+    @Override
+    public boolean isSharable() {
+        return true;
+    }
 
     private WebSocketClientCompressionHandler() {
         super(new PerMessageDeflateClientExtensionHandshaker(),

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2StreamFrameToHttpObjectCodec.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2StreamFrameToHttpObjectCodec.java
@@ -19,7 +19,6 @@ import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandler;
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.EncoderException;
 import io.netty5.handler.codec.MessageToMessageCodec;
@@ -49,14 +48,13 @@ import java.util.List;
 /**
  * This handler converts from {@link Http2StreamFrame} to {@link HttpObject},
  * and back. It can be used as an adapter in conjunction with {@link
- * Http2MultiplexCodec} to make http/2 connections backward-compatible with
+ * Http2MultiplexHandler} to make http/2 connections backward-compatible with
  * {@link ChannelHandler}s expecting {@link HttpObject}
  *
  * For simplicity, it converts to chunked encoding unless the entire stream
  * is a single header.
  */
 @UnstableApi
-@Sharable
 public class Http2StreamFrameToHttpObjectCodec extends MessageToMessageCodec<Http2StreamFrame, HttpObject> {
 
     private static final AttributeKey<HttpScheme> SCHEME_ATTR_KEY =
@@ -73,6 +71,11 @@ public class Http2StreamFrameToHttpObjectCodec extends MessageToMessageCodec<Htt
 
     public Http2StreamFrameToHttpObjectCodec(final boolean isServer) {
         this(isServer, true);
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
     }
 
     @Override

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ClientUpgradeCodecTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ClientUpgradeCodecTest.java
@@ -82,6 +82,10 @@ public class Http2ClientUpgradeCodecTest {
         assertTrue(channel.finishAndReleaseAll());
     }
 
-    @ChannelHandler.Sharable
-    private static final class HttpInboundHandler implements ChannelHandler { }
+    private static final class HttpInboundHandler implements ChannelHandler {
+        @Override
+        public boolean isSharable() {
+            return true;
+        }
+    }
 }

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexClientUpgradeTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexClientUpgradeTest.java
@@ -28,8 +28,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class Http2MultiplexClientUpgradeTest {
 
-    @ChannelHandler.Sharable
     static final class NoopHandler implements ChannelHandler {
+        @Override
+        public boolean isSharable() {
+            return true;
+        }
+
         @Override
         public void channelActive(ChannelHandlerContext ctx) {
             ctx.channel().close();

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ServerUpgradeCodecTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ServerUpgradeCodecTest.java
@@ -100,6 +100,10 @@ public class Http2ServerUpgradeCodecTest {
         assertNull(channel.readOutbound());
     }
 
-    @ChannelHandler.Sharable
-    private static final class HttpInboundHandler implements ChannelHandler { }
+    private static final class HttpInboundHandler implements ChannelHandler {
+        @Override
+        public boolean isSharable() {
+            return true;
+        }
+    }
 }

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/TestChannelInitializer.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/TestChannelInitializer.java
@@ -20,7 +20,6 @@ import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelConfig;
 import io.netty5.channel.ChannelHandler;
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelInitializer;
 import io.netty5.channel.RecvBufferAllocator;
 import io.netty5.util.UncheckedBooleanSupplier;
@@ -30,10 +29,14 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * Channel initializer useful in tests.
  */
-@Sharable
 public class TestChannelInitializer extends ChannelInitializer<Channel> {
     ChannelHandler handler;
     AtomicInteger maxReads;
+
+    @Override
+    public boolean isSharable() {
+        return true;
+    }
 
     @Override
     public void initChannel(Channel channel) {

--- a/codec/src/main/java/io/netty5/handler/codec/ByteToMessageCodec.java
+++ b/codec/src/main/java/io/netty5/handler/codec/ByteToMessageCodec.java
@@ -68,7 +68,6 @@ public abstract class ByteToMessageCodec<I> extends ChannelHandlerAdapter {
      *                              {@link ByteBuf}, which is backed by an byte array.
      */
     protected ByteToMessageCodec(boolean preferDirect) {
-        ensureNotSharable();
         outboundMsgMatcher = TypeParameterMatcher.find(this, ByteToMessageCodec.class, "I");
         encoder = new Encoder(preferDirect);
     }
@@ -82,9 +81,14 @@ public abstract class ByteToMessageCodec<I> extends ChannelHandlerAdapter {
      *                              {@link ByteBuf}, which is backed by an byte array.
      */
     protected ByteToMessageCodec(Class<? extends I> outboundMessageType, boolean preferDirect) {
-        ensureNotSharable();
         outboundMsgMatcher = TypeParameterMatcher.get(outboundMessageType);
         encoder = new Encoder(preferDirect);
+    }
+
+    @Override
+    public final boolean isSharable() {
+        // Can't be sharable as we keep state.
+        return false;
     }
 
     /**

--- a/codec/src/main/java/io/netty5/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty5/handler/codec/ByteToMessageDecoder.java
@@ -163,8 +163,10 @@ public abstract class ByteToMessageDecoder extends ChannelHandlerAdapter {
     private int numReads;
     private ByteToMessageDecoderContext context;
 
-    protected ByteToMessageDecoder() {
-        ensureNotSharable();
+    @Override
+    public final boolean isSharable() {
+        // Can't be sharable as we keep state.
+        return false;
     }
 
     /**

--- a/codec/src/main/java/io/netty5/handler/codec/ByteToMessageDecoderForBuffer.java
+++ b/codec/src/main/java/io/netty5/handler/codec/ByteToMessageDecoderForBuffer.java
@@ -105,7 +105,12 @@ public abstract class ByteToMessageDecoderForBuffer extends ChannelHandlerAdapte
 
     protected ByteToMessageDecoderForBuffer(Cumulator cumulator) {
         this.cumulator = requireNonNull(cumulator, "cumulator");
-        ensureNotSharable();
+    }
+
+    @Override
+    public final boolean isSharable() {
+        // Can't be sharable as we keep state.
+        return false;
     }
 
     /**

--- a/codec/src/main/java/io/netty5/handler/codec/LengthFieldPrepender.java
+++ b/codec/src/main/java/io/netty5/handler/codec/LengthFieldPrepender.java
@@ -17,7 +17,6 @@ package io.netty5.handler.codec;
 
 import io.netty5.buffer.BufferUtil;
 import io.netty5.buffer.api.Buffer;
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 
 import java.nio.ByteOrder;
@@ -52,7 +51,6 @@ import static java.util.Objects.requireNonNull;
  * +--------+----------------+
  * </pre>
  */
-@Sharable
 public class LengthFieldPrepender extends MessageToMessageEncoder<Buffer> {
 
     private final ByteOrder byteOrder;
@@ -131,6 +129,11 @@ public class LengthFieldPrepender extends MessageToMessageEncoder<Buffer> {
         this.lengthFieldLength = lengthFieldLength;
         this.lengthIncludesLengthFieldLength = lengthIncludesLengthFieldLength;
         this.lengthAdjustment = lengthAdjustment;
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
     }
 
     @Override

--- a/codec/src/main/java/io/netty5/handler/codec/base64/Base64Decoder.java
+++ b/codec/src/main/java/io/netty5/handler/codec/base64/Base64Decoder.java
@@ -17,7 +17,6 @@ package io.netty5.handler.codec.base64;
 
 import io.netty.buffer.ByteBuf;
 import io.netty5.buffer.api.Buffer;
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
 import io.netty5.handler.codec.ByteToMessageDecoder;
@@ -44,7 +43,6 @@ import static java.util.Objects.requireNonNull;
  * pipeline.addLast("base64Encoder", new {@link Base64Encoder}());
  * </pre>
  */
-@Sharable
 public class Base64Decoder extends MessageToMessageDecoder<Buffer> {
 
     private final Base64Dialect dialect;
@@ -56,6 +54,11 @@ public class Base64Decoder extends MessageToMessageDecoder<Buffer> {
     public Base64Decoder(Base64Dialect dialect) {
         requireNonNull(dialect, "dialect");
         this.dialect = dialect;
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
     }
 
     @Override

--- a/codec/src/main/java/io/netty5/handler/codec/base64/Base64Encoder.java
+++ b/codec/src/main/java/io/netty5/handler/codec/base64/Base64Encoder.java
@@ -17,7 +17,6 @@ package io.netty5.handler.codec.base64;
 
 import io.netty.buffer.ByteBuf;
 import io.netty5.buffer.api.Buffer;
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
 import io.netty5.handler.codec.DelimiterBasedFrameDecoder;
@@ -42,7 +41,6 @@ import static java.util.Objects.requireNonNull;
  * pipeline.addLast("base64Encoder", new {@link Base64Encoder}());
  * </pre>
  */
-@Sharable
 public class Base64Encoder extends MessageToMessageEncoder<Buffer> {
 
     private final boolean breakLines;
@@ -61,6 +59,11 @@ public class Base64Encoder extends MessageToMessageEncoder<Buffer> {
 
         this.breakLines = breakLines;
         this.dialect = dialect;
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
     }
 
     @Override

--- a/codec/src/main/java/io/netty5/handler/codec/bytes/ByteArrayEncoder.java
+++ b/codec/src/main/java/io/netty5/handler/codec/bytes/ByteArrayEncoder.java
@@ -17,7 +17,6 @@ package io.netty5.handler.codec.bytes;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
 import io.netty5.handler.codec.LengthFieldBasedFrameDecoder;
@@ -50,8 +49,13 @@ import java.util.List;
  * }
  * </pre>
  */
-@Sharable
 public class ByteArrayEncoder extends MessageToMessageEncoder<byte[]> {
+
+    @Override
+    public boolean isSharable() {
+        return true;
+    }
+
     @Override
     protected void encode(ChannelHandlerContext ctx, byte[] msg, List<Object> out) throws Exception {
         out.add(Unpooled.wrappedBuffer(msg));

--- a/codec/src/main/java/io/netty5/handler/codec/string/LineEncoder.java
+++ b/codec/src/main/java/io/netty5/handler/codec/string/LineEncoder.java
@@ -17,7 +17,6 @@ package io.netty5.handler.codec.string;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
 import io.netty5.handler.codec.LineBasedFrameDecoder;
@@ -51,7 +50,6 @@ import static java.util.Objects.requireNonNull;
  * }
  * </pre>
  */
-@Sharable
 public class LineEncoder extends MessageToMessageEncoder<CharSequence> {
 
     private final Charset charset;
@@ -84,6 +82,11 @@ public class LineEncoder extends MessageToMessageEncoder<CharSequence> {
     public LineEncoder(LineSeparator lineSeparator, Charset charset) {
         this.charset = requireNonNull(charset, "charset");
         this.lineSeparator = requireNonNull(lineSeparator, "lineSeparator").value().getBytes(charset);
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
     }
 
     @Override

--- a/codec/src/main/java/io/netty5/handler/codec/string/StringDecoder.java
+++ b/codec/src/main/java/io/netty5/handler/codec/string/StringDecoder.java
@@ -16,7 +16,6 @@
 package io.netty5.handler.codec.string;
 
 import io.netty5.buffer.api.Buffer;
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
 import io.netty5.handler.codec.ByteToMessageDecoder;
@@ -52,7 +51,6 @@ import static java.util.Objects.requireNonNull;
  * }
  * </pre>
  */
-@Sharable
 public class StringDecoder extends MessageToMessageDecoder<Buffer> {
 
     // TODO Use CharsetDecoder instead.
@@ -71,6 +69,11 @@ public class StringDecoder extends MessageToMessageDecoder<Buffer> {
     public StringDecoder(Charset charset) {
         requireNonNull(charset, "charset");
         this.charset = charset;
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
     }
 
     @Override

--- a/codec/src/main/java/io/netty5/handler/codec/string/StringEncoder.java
+++ b/codec/src/main/java/io/netty5/handler/codec/string/StringEncoder.java
@@ -16,7 +16,6 @@
 package io.netty5.handler.codec.string;
 
 import io.netty5.buffer.api.Buffer;
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
 import io.netty5.handler.codec.LineBasedFrameDecoder;
@@ -48,7 +47,6 @@ import static java.util.Objects.requireNonNull;
  * }
  * </pre>
  */
-@Sharable
 public class StringEncoder extends MessageToMessageEncoder<CharSequence> {
 
     private final Charset charset;
@@ -66,6 +64,11 @@ public class StringEncoder extends MessageToMessageEncoder<CharSequence> {
     public StringEncoder(Charset charset) {
         requireNonNull(charset, "charset");
         this.charset = charset;
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
     }
 
     @Override

--- a/codec/src/test/java/io/netty5/handler/codec/ByteToMessageCodecTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/ByteToMessageCodecTest.java
@@ -17,27 +17,15 @@ package io.netty5.handler.codec;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ByteToMessageCodecTest {
-
-    @Test
-    public void testSharable() {
-        assertThrows(IllegalStateException.class, InvalidByteToMessageCodec::new);
-    }
-
-    @Test
-    public void testSharable2() {
-        assertThrows(IllegalStateException.class, InvalidByteToMessageCodec2::new);
-    }
 
     @Test
     public void testForwardPendingData() {
@@ -70,31 +58,5 @@ public class ByteToMessageCodecTest {
         buf.release();
         assertNull(ch.readInbound());
         assertNull(ch.readOutbound());
-    }
-
-    @ChannelHandler.Sharable
-    private static final class InvalidByteToMessageCodec extends ByteToMessageCodec<Integer> {
-        InvalidByteToMessageCodec() {
-            super(true);
-        }
-
-        @Override
-        protected void encode(ChannelHandlerContext ctx, Integer msg, ByteBuf out) throws Exception { }
-
-        @Override
-        protected void decode(ChannelHandlerContext ctx, ByteBuf in) throws Exception { }
-    }
-
-    @ChannelHandler.Sharable
-    private static final class InvalidByteToMessageCodec2 extends ByteToMessageCodec<Integer> {
-        InvalidByteToMessageCodec2() {
-            super(Integer.class, true);
-        }
-
-        @Override
-        protected void encode(ChannelHandlerContext ctx, Integer msg, ByteBuf out) throws Exception { }
-
-        @Override
-        protected void decode(ChannelHandlerContext ctx, ByteBuf in) throws Exception { }
     }
 }

--- a/example/src/main/java/io/netty5/example/echo/EchoServerHandler.java
+++ b/example/src/main/java/io/netty5/example/echo/EchoServerHandler.java
@@ -16,14 +16,17 @@
 package io.netty5.example.echo;
 
 import io.netty5.channel.ChannelHandler;
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 
 /**
  * Handler implementation for the echo server.
  */
-@Sharable
 public class EchoServerHandler implements ChannelHandler {
+
+    @Override
+    public boolean isSharable() {
+        return true;
+    }
 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) {

--- a/example/src/main/java/io/netty5/example/http2/helloworld/frame/server/HelloWorldHttp2Handler.java
+++ b/example/src/main/java/io/netty5/example/http2/helloworld/frame/server/HelloWorldHttp2Handler.java
@@ -17,7 +17,6 @@ package io.netty5.example.http2.helloworld.frame.server;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandler;
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.http2.DefaultHttp2DataFrame;
 import io.netty5.handler.codec.http2.DefaultHttp2Headers;
@@ -37,10 +36,14 @@ import static io.netty5.handler.codec.http.HttpResponseStatus.OK;
  *
  * <p>This example is making use of the "frame codec" http2 API. This API is very experimental and incomplete.
  */
-@Sharable
 public class HelloWorldHttp2Handler implements ChannelHandler {
 
     static final byte[] RESPONSE_BYTES = "Hello World".getBytes(StandardCharsets.UTF_8);
+
+    @Override
+    public boolean isSharable() {
+        return true;
+    }
 
     @Override
     public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {

--- a/example/src/main/java/io/netty5/example/http2/helloworld/multiplex/server/HelloWorldHttp2Handler.java
+++ b/example/src/main/java/io/netty5/example/http2/helloworld/multiplex/server/HelloWorldHttp2Handler.java
@@ -17,7 +17,6 @@ package io.netty5.example.http2.helloworld.multiplex.server;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandler;
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.http2.DefaultHttp2DataFrame;
 import io.netty5.handler.codec.http2.DefaultHttp2Headers;
@@ -36,10 +35,14 @@ import static io.netty5.handler.codec.http.HttpResponseStatus.OK;
  * <p>This example is making use of the "multiplexing" http2 API, where streams are mapped to child
  * Channels. This API is very experimental and incomplete.
  */
-@Sharable
 public class HelloWorldHttp2Handler implements ChannelHandler {
 
     static final byte[] RESPONSE_BYTES = "Hello World".getBytes(StandardCharsets.UTF_8);
+
+    @Override
+    public boolean isSharable() {
+        return true;
+    }
 
     @Override
     public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {

--- a/example/src/main/java/io/netty5/example/telnet/TelnetClientHandler.java
+++ b/example/src/main/java/io/netty5/example/telnet/TelnetClientHandler.java
@@ -15,15 +15,18 @@
  */
 package io.netty5.example.telnet;
 
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.SimpleChannelInboundHandler;
 
 /**
  * Handles a client-side channel.
  */
-@Sharable
 public class TelnetClientHandler extends SimpleChannelInboundHandler<String> {
+
+    @Override
+    public boolean isSharable() {
+        return true;
+    }
 
     @Override
     protected void messageReceived(ChannelHandlerContext ctx, String msg) throws Exception {

--- a/example/src/main/java/io/netty5/example/telnet/TelnetServerHandler.java
+++ b/example/src/main/java/io/netty5/example/telnet/TelnetServerHandler.java
@@ -16,7 +16,6 @@
 package io.netty5.example.telnet;
 
 import io.netty5.channel.ChannelFutureListeners;
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.SimpleChannelInboundHandler;
 import io.netty5.util.concurrent.Future;
@@ -27,8 +26,12 @@ import java.util.Date;
 /**
  * Handles a server-side channel.
  */
-@Sharable
 public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
+
+    @Override
+    public boolean isSharable() {
+        return true;
+    }
 
     @Override
     public void channelActive(ChannelHandlerContext ctx) throws Exception {

--- a/example/src/main/java/io/netty5/example/uptime/UptimeClientHandler.java
+++ b/example/src/main/java/io/netty5/example/uptime/UptimeClientHandler.java
@@ -15,7 +15,6 @@
  */
 package io.netty5.example.uptime;
 
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.SimpleChannelInboundHandler;
 import io.netty5.handler.timeout.IdleState;
@@ -27,7 +26,6 @@ import java.util.concurrent.TimeUnit;
  * Keep reconnecting to the server while printing out the current uptime and
  * connection attempt getStatus.
  */
-@Sharable
 public class UptimeClientHandler extends SimpleChannelInboundHandler<Object> {
 
     long startTime = -1;

--- a/example/src/main/java/io/netty5/example/uptime/UptimeServerHandler.java
+++ b/example/src/main/java/io/netty5/example/uptime/UptimeServerHandler.java
@@ -15,12 +15,15 @@
  */
 package io.netty5.example.uptime;
 
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.SimpleChannelInboundHandler;
 
-@Sharable
 public class UptimeServerHandler extends SimpleChannelInboundHandler<Object> {
+    @Override
+    public boolean isSharable() {
+        return true;
+    }
+
     @Override
     public void messageReceived(ChannelHandlerContext ctx, Object msg) throws Exception {
         // discard

--- a/handler/src/main/java/io/netty5/handler/adaptor/BufferConversionHandler.java
+++ b/handler/src/main/java/io/netty5/handler/adaptor/BufferConversionHandler.java
@@ -20,7 +20,6 @@ import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.adaptor.ByteBufAdaptor;
 import io.netty5.buffer.api.adaptor.ByteBufBuffer;
 import io.netty5.channel.ChannelHandler;
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.util.concurrent.Future;
 
@@ -35,14 +34,13 @@ import io.netty5.util.concurrent.Future;
  * It is, however, recommended that all handlers eventually be converted to use the {@link Buffer} API, as that is more
  * future-proof.
  * <p>
- * Instances of this handler are {@link Sharable} and can be added to multiple pipelines.
+ * Instances of this handler are sharable and can be added to multiple pipelines.
  * This is safe because the instances are immutable and thread-safe.
  *
  * @deprecated This handler will be moved out of Netty core and into a contrib repository, before Netty 5.0.0.Final
  * is released.
  */
 @Deprecated
-@Sharable
 public final class BufferConversionHandler implements ChannelHandler {
     private final Conversion onRead;
     private final Conversion onWrite;
@@ -109,6 +107,11 @@ public final class BufferConversionHandler implements ChannelHandler {
      */
     public static BufferConversionHandler byteBufToBuffer() {
         return LazyByteBufToBuffer.HANDLER;
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
     }
 
     @Override

--- a/handler/src/main/java/io/netty5/handler/address/ResolveAddressHandler.java
+++ b/handler/src/main/java/io/netty5/handler/address/ResolveAddressHandler.java
@@ -16,7 +16,6 @@
 package io.netty5.handler.address;
 
 import io.netty5.channel.ChannelHandler;
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.resolver.AddressResolver;
 import io.netty5.resolver.AddressResolverGroup;
@@ -32,13 +31,17 @@ import java.util.Objects;
  * {@link #connect(ChannelHandlerContext, SocketAddress, SocketAddress)} if it is not already resolved
  * and the {@link AddressResolver} supports the type of {@link SocketAddress}.
  */
-@Sharable
 public class ResolveAddressHandler implements ChannelHandler {
 
     private final AddressResolverGroup<? extends SocketAddress> resolverGroup;
 
     public ResolveAddressHandler(AddressResolverGroup<? extends SocketAddress> resolverGroup) {
         this.resolverGroup = Objects.requireNonNull(resolverGroup, "resolverGroup");
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
     }
 
     @Override

--- a/handler/src/main/java/io/netty5/handler/ipfilter/IpSubnetFilter.java
+++ b/handler/src/main/java/io/netty5/handler/ipfilter/IpSubnetFilter.java
@@ -16,7 +16,6 @@
 package io.netty5.handler.ipfilter;
 
 import io.netty5.channel.Channel;
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 
 import java.net.Inet4Address;
@@ -52,7 +51,6 @@ import static java.util.Objects.requireNonNull;
  * </p>
  *
  */
-@Sharable
 public class IpSubnetFilter extends AbstractRemoteAddressFilter<InetSocketAddress> {
 
     private final boolean acceptIfNotFound;
@@ -163,6 +161,11 @@ public class IpSubnetFilter extends AbstractRemoteAddressFilter<InetSocketAddres
 
         this.ipv4Rules = sortAndFilter(unsortedIPv4Rules);
         this.ipv6Rules = sortAndFilter(unsortedIPv6Rules);
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
     }
 
     @Override

--- a/handler/src/main/java/io/netty5/handler/ipfilter/RuleBasedIpFilter.java
+++ b/handler/src/main/java/io/netty5/handler/ipfilter/RuleBasedIpFilter.java
@@ -16,7 +16,6 @@
 package io.netty5.handler.ipfilter;
 
 import io.netty5.channel.Channel;
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 
 import java.net.InetSocketAddress;
@@ -41,7 +40,6 @@ import static java.util.Objects.requireNonNull;
  * <p> Consider using {@link IpSubnetFilter} for better performance while not as
  * general purpose as this filter. </p>
  */
-@Sharable
 public class RuleBasedIpFilter extends AbstractRemoteAddressFilter<InetSocketAddress> {
 
     private final boolean acceptIfNotFound;
@@ -78,6 +76,11 @@ public class RuleBasedIpFilter extends AbstractRemoteAddressFilter<InetSocketAdd
                 this.rules.add(rule);
             }
         }
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
     }
 
     @Override

--- a/handler/src/main/java/io/netty5/handler/ipfilter/UniqueIpFilter.java
+++ b/handler/src/main/java/io/netty5/handler/ipfilter/UniqueIpFilter.java
@@ -16,7 +16,6 @@
 package io.netty5.handler.ipfilter;
 
 import io.netty5.channel.Channel;
-import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 
 import java.net.InetAddress;
@@ -28,10 +27,14 @@ import java.util.concurrent.ConcurrentHashMap;
  * This class allows one to ensure that at all times for every IP address there is at most one
  * {@link Channel} connected to the server.
  */
-@ChannelHandler.Sharable
 public class UniqueIpFilter extends AbstractRemoteAddressFilter<InetSocketAddress> {
 
     private final Set<InetAddress> connected = ConcurrentHashMap.newKeySet();
+
+    @Override
+    public boolean isSharable() {
+        return true;
+    }
 
     @Override
     protected boolean accept(ChannelHandlerContext ctx, InetSocketAddress remoteAddress) {

--- a/handler/src/main/java/io/netty5/handler/logging/LoggingHandler.java
+++ b/handler/src/main/java/io/netty5/handler/logging/LoggingHandler.java
@@ -21,7 +21,6 @@ import io.netty.buffer.ByteBufHolder;
 import io.netty5.buffer.BufferUtil;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandler;
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.internal.logging.InternalLogLevel;
@@ -38,7 +37,6 @@ import static java.util.Objects.requireNonNull;
  * A {@link ChannelHandler} that logs all events using a logging framework.
  * By default, all events are logged at <tt>DEBUG</tt> level and full hex dumps are recorded for ByteBufs.
  */
-@Sharable
 @SuppressWarnings("StringBufferReplaceableByString")
 public class LoggingHandler implements ChannelHandler {
 
@@ -159,6 +157,11 @@ public class LoggingHandler implements ChannelHandler {
         this.bufferFormat = requireNonNull(bufferFormat, "bufferFormat");
         logger = InternalLoggerFactory.getInstance(name);
         internalLevel = level.toInternalLevel();
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
     }
 
     /**

--- a/handler/src/main/java/io/netty5/handler/traffic/GlobalChannelTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty5/handler/traffic/GlobalChannelTrafficShapingHandler.java
@@ -18,7 +18,6 @@ package io.netty5.handler.traffic;
 import io.netty.buffer.ByteBufConvertible;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelConfig;
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.util.Attribute;
 import io.netty5.util.concurrent.EventExecutor;
@@ -88,7 +87,6 @@ import static io.netty5.util.internal.ObjectUtil.checkPositiveOrZero;
  * Be sure to call {@link #release()} once this handler is not needed anymore to release all internal resources.
  * This will not shutdown the {@link EventExecutor} as it may be shared, so you need to do this by your own.
  */
-@Sharable
 public class GlobalChannelTrafficShapingHandler extends AbstractTrafficShapingHandler {
     private static final InternalLogger logger =
             InternalLoggerFactory.getInstance(GlobalChannelTrafficShapingHandler.class);
@@ -264,6 +262,11 @@ public class GlobalChannelTrafficShapingHandler extends AbstractTrafficShapingHa
      */
     public GlobalChannelTrafficShapingHandler(EventExecutorGroup executor) {
         createGlobalTrafficCounter(executor);
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
     }
 
     /**

--- a/handler/src/main/java/io/netty5/handler/traffic/GlobalTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty5/handler/traffic/GlobalTrafficShapingHandler.java
@@ -17,7 +17,6 @@ package io.netty5.handler.traffic;
 
 import io.netty.buffer.ByteBufConvertible;
 import io.netty5.channel.Channel;
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.util.concurrent.EventExecutor;
 import io.netty5.util.concurrent.EventExecutorGroup;
@@ -76,7 +75,6 @@ import static java.util.Objects.requireNonNull;
  * Be sure to call {@link #release()} once this handler is not needed anymore to release all internal resources.
  * This will not shutdown the {@link EventExecutor} as it may be shared, so you need to do this by your own.
  */
-@Sharable
 public class GlobalTrafficShapingHandler extends AbstractTrafficShapingHandler {
     /**
      * All queues per channel
@@ -109,6 +107,11 @@ public class GlobalTrafficShapingHandler extends AbstractTrafficShapingHandler {
         TrafficCounter tc = new TrafficCounter(this, executor, "GlobalTC", checkInterval);
         setTrafficCounter(tc);
         tc.start();
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
     }
 
     @Override

--- a/microbench/src/main/java/io/netty5/microbench/channel/DefaultChannelPipelineBenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/channel/DefaultChannelPipelineBenchmark.java
@@ -36,11 +36,19 @@ import org.openjdk.jmh.infra.Blackhole;
 @State(Scope.Benchmark)
 public class DefaultChannelPipelineBenchmark extends AbstractMicrobenchmark {
 
-    @ChannelHandler.Sharable
-    private static final ChannelHandler NOOP_HANDLER = new ChannelHandler() { };
+    private static final ChannelHandler NOOP_HANDLER = new ChannelHandler() {
+        @Override
+        public boolean isSharable() {
+            return true;
+        }
+    };
 
-    @ChannelHandler.Sharable
     private static final ChannelHandler CONSUMING_HANDLER = new ChannelHandler() {
+        @Override
+        public boolean isSharable() {
+            return true;
+        }
+
         @Override
         public void channelReadComplete(ChannelHandlerContext ctx) {
             // NOOP

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/ServerSocketSuspendTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/ServerSocketSuspendTest.java
@@ -93,13 +93,17 @@ public class ServerSocketSuspendTest extends AbstractServerSocketTest {
         }
     }
 
-    @ChannelHandler.Sharable
     private static final class AcceptedChannelCounter implements ChannelHandler {
 
         final CountDownLatch latch;
 
         AcceptedChannelCounter(int nChannels) {
             latch = new CountDownLatch(nChannels);
+        }
+
+        @Override
+        public boolean isSharable() {
+            return true;
         }
 
         @Override

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
@@ -20,7 +20,6 @@ import io.netty5.bootstrap.ServerBootstrap;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.channel.Channel;
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelInitializer;
 import io.netty5.channel.SimpleChannelInboundHandler;
@@ -220,7 +219,6 @@ public class SocketSslClientRenegotiateTest extends AbstractSocketTest {
         serverSslHandler = null;
     }
 
-    @Sharable
     private static final class TestHandler extends SimpleChannelInboundHandler<Buffer> {
 
         private final AtomicReference<Throwable> exception;
@@ -228,6 +226,11 @@ public class SocketSslClientRenegotiateTest extends AbstractSocketTest {
 
         TestHandler(AtomicReference<Throwable> exception) {
             this.exception = exception;
+        }
+
+        @Override
+        public boolean isSharable() {
+            return true;
         }
 
         @Override

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslEchoTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslEchoTest.java
@@ -22,7 +22,6 @@ import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.buffer.api.DefaultBufferAllocators;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandler;
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelInitializer;
 import io.netty5.channel.ChannelOption;
@@ -453,7 +452,6 @@ public class SocketSslEchoTest extends AbstractSocketTest {
                 serverSslHandler.engine().getSession().getCipherSuite());
     }
 
-    @Sharable
     private abstract class EchoHandler extends SimpleChannelInboundHandler<Buffer> {
 
         protected final AtomicInteger recvCounter;
@@ -467,6 +465,11 @@ public class SocketSslEchoTest extends AbstractSocketTest {
             this.recvCounter = recvCounter;
             this.negoCounter = negoCounter;
             this.exception = exception;
+        }
+
+        @Override
+        public boolean isSharable() {
+            return true;
         }
 
         @Override

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslSessionReuseTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslSessionReuseTest.java
@@ -21,7 +21,6 @@ import io.netty5.buffer.BufferUtil;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.DefaultBufferAllocators;
 import io.netty5.channel.Channel;
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelInitializer;
 import io.netty5.channel.SimpleChannelInboundHandler;
@@ -164,7 +163,6 @@ public class SocketSslSessionReuseTest extends AbstractSocketTest {
         return idSet;
     }
 
-    @Sharable
     private static class ReadAndDiscardHandler extends SimpleChannelInboundHandler<Buffer> {
         final AtomicReference<Throwable> exception = new AtomicReference<>();
         private final boolean server;
@@ -173,6 +171,11 @@ public class SocketSslSessionReuseTest extends AbstractSocketTest {
         ReadAndDiscardHandler(boolean server, boolean autoRead) {
             this.server = server;
             this.autoRead = autoRead;
+        }
+
+        @Override
+        public boolean isSharable() {
+            return true;
         }
 
         @Override

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollReuseAddrTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollReuseAddrTest.java
@@ -223,12 +223,16 @@ public class EpollReuseAddrTest {
         return false;
     }
 
-    @ChannelHandler.Sharable
     private static class ServerSocketTestHandler implements ChannelHandler {
         private final AtomicBoolean accepted;
 
         ServerSocketTestHandler(AtomicBoolean accepted) {
             this.accepted = accepted;
+        }
+
+        @Override
+        public boolean isSharable() {
+            return true;
         }
 
         @Override
@@ -238,12 +242,16 @@ public class EpollReuseAddrTest {
         }
     }
 
-    @ChannelHandler.Sharable
     private static class DatagramSocketTestHandler implements ChannelHandler {
         private final AtomicBoolean received;
 
         DatagramSocketTestHandler(AtomicBoolean received) {
             this.received = received;
+        }
+
+        @Override
+        public boolean isSharable() {
+            return true;
         }
 
         @Override
@@ -253,6 +261,10 @@ public class EpollReuseAddrTest {
         }
     }
 
-    @ChannelHandler.Sharable
-    private static final class DummyHandler implements ChannelHandler { }
+    private static final class DummyHandler implements ChannelHandler {
+        @Override
+        public boolean isSharable() {
+            return true;
+        }
+    }
 }

--- a/transport/src/main/java/io/netty5/channel/ChannelHandler.java
+++ b/transport/src/main/java/io/netty5/channel/ChannelHandler.java
@@ -20,12 +20,6 @@ import io.netty5.util.Attribute;
 import io.netty5.util.AttributeKey;
 import io.netty5.util.concurrent.Future;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Inherited;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
 import java.net.SocketAddress;
 
 /**
@@ -97,11 +91,14 @@ import java.net.SocketAddress;
  *     // your methods here
  * }
  *
- * {@code @Sharable}
  * public class DataServerHandler extends {@link SimpleChannelInboundHandler}&lt;Message&gt; {
  *     private final {@link AttributeKey}&lt;{@link Boolean}&gt; auth =
  *           {@link AttributeKey#valueOf(String) AttributeKey.valueOf("auth")};
  *
+ *     {@code @Override}
+ *     public boolean isSharable() {
+ *         return true;
+ *     }
  *     {@code @Override}
  *     public void channelRead({@link ChannelHandlerContext} ctx, Message message) {
  *         {@link Attribute}&lt;{@link Boolean}&gt; attr = ctx.attr(auth);
@@ -134,22 +131,19 @@ import java.net.SocketAddress;
  * </pre>
  *
  *
- * <h4>The {@code @Sharable} annotation</h4>
+ * <h4>The {@link #isSharable()} method</h4>
  * <p>
  * In the example above which used an {@link AttributeKey},
- * you might have noticed the {@code @Sharable} annotation.
+ * you might have noticed the {@link #isSharable()} method is override to return {@code true}.
  * <p>
- * If a {@link ChannelHandler} is annotated with the {@code @Sharable}
- * annotation, it means you can create an instance of the handler just once and
+ * If the {@link ChannelHandler#isSharable()} is returning{@code true},
+ * it means you can create an instance of the handler just once and
  * add it to one or more {@link ChannelPipeline}s multiple times without
  * a race condition.
  * <p>
- * If this annotation is not specified, you have to create a new handler
+ * If this method is not implemented and return {@code true}, you have to create a new handler
  * instance every time you add it to a pipeline because it has unshared state
  * such as member variables.
- * <p>
- * This annotation is provided for documentation purpose, just like
- * <a href="http://www.javaconcurrencyinpractice.com/annotations/doc/">the JCIP annotations</a>.
  *
  * <h3>Additional resources worth reading</h3>
  * <p>
@@ -176,23 +170,14 @@ public interface ChannelHandler {
     }
 
     /**
-     * Indicates that the same instance of the annotated {@link ChannelHandler}
-     * can be added to one or more {@link ChannelPipeline}s multiple times
-     * without a race condition.
-     * <p>
-     * If this annotation is not specified, you have to create a new handler
+     * Return {@code true} if the implementation is sharable and so can be added
+     * to different {@link ChannelPipeline}s. By default, this returns {@code false}.
+     * If this method returns {@code false}, you have to create a new handler
      * instance every time you add it to a pipeline because it has unshared
      * state such as member variables.
-     * <p>
-     * This annotation is provided for documentation purpose, just like
-     * <a href="http://www.javaconcurrencyinpractice.com/annotations/doc/">the JCIP annotations</a>.
      */
-    @Inherited
-    @Documented
-    @Target({ElementType.TYPE, ElementType.TYPE_USE})
-    @Retention(RetentionPolicy.RUNTIME)
-    @interface Sharable {
-        // no value
+    default boolean isSharable() {
+        return false;
     }
 
     /**

--- a/transport/src/main/java/io/netty5/channel/ChannelHandlerAdapter.java
+++ b/transport/src/main/java/io/netty5/channel/ChannelHandlerAdapter.java
@@ -16,62 +16,11 @@
 
 package io.netty5.channel;
 
-import io.netty5.util.concurrent.FastThreadLocal;
-
-import java.lang.reflect.AnnotatedType;
-import java.util.Map;
-import java.util.WeakHashMap;
-
 /**
  * Skeleton implementation of a {@link ChannelHandler}.
  */
 public abstract class ChannelHandlerAdapter implements ChannelHandler {
 
-    private static final int HANDLER_SHARABLE_CACHE_INITIAL_CAPACITY = 4;
-    private static final FastThreadLocal<Map<Class<?>, Boolean>> CACHE = new FastThreadLocal<>() {
-        @Override
-        protected Map<Class<?>, Boolean> initialValue() {
-            // Start with small capacity to keep memory overhead as low as possible.
-            return new WeakHashMap<>(HANDLER_SHARABLE_CACHE_INITIAL_CAPACITY);
-        }
-    };
-
     // Not using volatile because it's used only for a sanity check.
     boolean added;
-
-    /**
-     * Throws {@link IllegalStateException} if {@link ChannelHandlerAdapter#isSharable()} returns {@code true}
-     */
-    protected void ensureNotSharable() {
-        if (isSharable()) {
-            throw new IllegalStateException("ChannelHandler " + getClass().getName() + " is not allowed to be shared");
-        }
-    }
-
-    /**
-     * Return {@code true} if the implementation is {@link Sharable} and so can be added
-     * to different {@link ChannelPipeline}s.
-     */
-    public boolean isSharable() {
-        /**
-         * Cache the result of {@link Sharable} annotation detection to workaround a condition. We use a
-         * {@link ThreadLocal} and {@link WeakHashMap} to eliminate the volatile write/reads. Using different
-         * {@link WeakHashMap} instances per {@link Thread} is good enough for us and the number of
-         * {@link Thread}s are quite limited anyway.
-         *
-         * See <a href="https://github.com/netty/netty/issues/2289">#2289</a>.
-         */
-        Class<?> clazz = getClass();
-        Map<Class<?>, Boolean> cache = CACHE.get();
-        Boolean sharable = cache.get(clazz);
-        if (sharable == null) {
-            sharable = clazz.isAnnotationPresent(Sharable.class);
-            if (!sharable) {
-                AnnotatedType annotatedType = clazz.getAnnotatedSuperclass();
-                sharable = annotatedType.isAnnotationPresent(Sharable.class);
-            }
-            cache.put(clazz, sharable);
-        }
-        return sharable;
-    }
 }

--- a/transport/src/main/java/io/netty5/channel/ChannelInitializer.java
+++ b/transport/src/main/java/io/netty5/channel/ChannelInitializer.java
@@ -17,7 +17,6 @@ package io.netty5.channel;
 
 import io.netty5.bootstrap.Bootstrap;
 import io.netty5.bootstrap.ServerBootstrap;
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
 
@@ -42,14 +41,18 @@ import io.netty5.util.internal.logging.InternalLoggerFactory;
  * bootstrap.childHandler(new MyChannelInitializer());
  * ...
  * </pre>
- * Be aware that this class is marked as {@link Sharable} and so the implementation must be safe to be re-used.
+ * Be aware that this class is marked as {@link #isSharable()} and so the implementation must be safe to be re-used.
  *
  * @param <C>   A sub-type of {@link Channel}
  */
-@Sharable
 public abstract class ChannelInitializer<C extends Channel> implements ChannelHandler {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(ChannelInitializer.class);
+
+    @Override
+    public boolean isSharable() {
+        return true;
+    }
 
     /**
      * This method will be called once the {@link Channel} was registered. After the method returns this instance

--- a/transport/src/main/java/io/netty5/channel/CombinedChannelDuplexHandler.java
+++ b/transport/src/main/java/io/netty5/channel/CombinedChannelDuplexHandler.java
@@ -43,15 +43,19 @@ public class CombinedChannelDuplexHandler<I extends ChannelHandler, O extends Ch
      * {@link ChannelPipeline}.
      */
     protected CombinedChannelDuplexHandler() {
-        ensureNotSharable();
     }
 
     /**
      * Creates a new instance that combines the specified two handlers into one.
      */
     public CombinedChannelDuplexHandler(I inboundHandler, O outboundHandler) {
-        ensureNotSharable();
         init(inboundHandler, outboundHandler);
+    }
+
+    @Override
+    public final boolean isSharable() {
+        // Can't be sharable as we keep state.
+        return false;
     }
 
     /**

--- a/transport/src/test/java/io/netty5/bootstrap/BootstrapTest.java
+++ b/transport/src/test/java/io/netty5/bootstrap/BootstrapTest.java
@@ -20,7 +20,6 @@ import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelConfig;
 import io.netty5.channel.ChannelFactory;
 import io.netty5.channel.ChannelHandler;
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelInitializer;
 import io.netty5.channel.ChannelOption;
@@ -419,8 +418,12 @@ public class BootstrapTest {
         }
     }
 
-    @Sharable
-    private static final class DummyHandler implements ChannelHandler { }
+    private static final class DummyHandler implements ChannelHandler {
+        @Override
+        public boolean isSharable() {
+            return true;
+        }
+    }
 
     private static final class TestAddressResolverGroup extends AddressResolverGroup<SocketAddress> {
 

--- a/transport/src/test/java/io/netty5/channel/ChannelHandlerAdapterTest.java
+++ b/transport/src/test/java/io/netty5/channel/ChannelHandlerAdapterTest.java
@@ -15,7 +15,6 @@
  */
 package io.netty5.channel;
 
-import io.netty5.channel.ChannelHandler.Sharable;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -23,19 +22,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ChannelHandlerAdapterTest {
 
-    @Sharable
     private static final class SharableChannelHandlerAdapter extends ChannelHandlerAdapter {
+        @Override
+        public boolean isSharable() {
+            return true;
+        }
     }
 
     @Test
     public void testSharable() {
         ChannelHandlerAdapter handler = new SharableChannelHandlerAdapter();
-        assertTrue(handler.isSharable());
-    }
-
-    @Test
-    public void testInnerClassSharable() {
-        ChannelHandlerAdapter handler = new @Sharable ChannelHandlerAdapter() { };
         assertTrue(handler.isSharable());
     }
 

--- a/transport/src/test/java/io/netty5/channel/CombinedChannelDuplexHandlerTest.java
+++ b/transport/src/test/java/io/netty5/channel/CombinedChannelDuplexHandlerTest.java
@@ -252,17 +252,6 @@ public class CombinedChannelDuplexHandlerTest {
         assertEquals(Event.UNREGISTERED, handler.pollEvent());
     }
 
-    @Test
-    public void testNotSharable() {
-        assertThrows(IllegalStateException.class,
-            () -> new CombinedChannelDuplexHandler<ChannelHandler, ChannelHandler>() {
-                @Override
-                public boolean isSharable() {
-                    return true;
-                }
-            });
-    }
-
     private static final class InboundEventHandler implements ChannelHandler {
         private final Queue<Object> queue = new ArrayDeque<Object>();
 

--- a/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTest.java
+++ b/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTest.java
@@ -18,7 +18,6 @@ package io.netty5.channel;
 
 import io.netty5.bootstrap.Bootstrap;
 import io.netty5.bootstrap.ServerBootstrap;
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerMask.Skip;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.channel.local.LocalAddress;
@@ -1704,12 +1703,16 @@ public class DefaultChannelPipelineTest {
         return new TestHandler(latch);
     }
 
-    @Sharable
     private static class TestHandler implements ChannelHandler {
         private final CountDownLatch latch;
 
         TestHandler(CountDownLatch latch) {
             this.latch = latch;
+        }
+
+        @Override
+        public boolean isSharable() {
+            return true;
         }
 
         @Override

--- a/transport/src/test/java/io/netty5/channel/local/LocalTransportThreadModelTest2.java
+++ b/transport/src/test/java/io/netty5/channel/local/LocalTransportThreadModelTest2.java
@@ -19,7 +19,6 @@ import io.netty5.bootstrap.Bootstrap;
 import io.netty5.bootstrap.ServerBootstrap;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandler;
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.MultithreadEventLoopGroup;
 import io.netty5.util.Resource;
@@ -95,7 +94,6 @@ public class LocalTransportThreadModelTest2 {
         localChannel.closeFuture().await();
     }
 
-    @Sharable
     static class LocalHandler implements ChannelHandler {
         private final String name;
 
@@ -105,6 +103,11 @@ public class LocalTransportThreadModelTest2 {
 
         LocalHandler(String name) {
             this.name = name;
+        }
+
+        @Override
+        public boolean isSharable() {
+            return true;
         }
 
         @Override


### PR DESCRIPTION
Motivation:

Now that we depend on java8+ we should just use a default method that can be override to declare a handler sharable. This makes things a bit cheaper and also allow to fail to restrict sharable when compiling by let implementations declare the method final.

Modifications:

- Remove annotation and add default method to ChannelHandler interface
- Adjust implementations

Result:

Better way to declare a handler sharable or not
