### PR TITLE
Run handler tests in parallel

### DIFF
--- a/handler/src/test/java/io/netty5/handler/logging/LoggingHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/logging/LoggingHandlerTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.mockito.ArgumentMatcher;
 import org.slf4j.LoggerFactory;
 
@@ -55,7 +56,10 @@ import static org.slf4j.Logger.ROOT_LOGGER_NAME;
 
 /**
  * Verifies the correct functionality of the {@link LoggingHandler}.
+ * <p>
+ * Test is {@link Isolated} because it modifies the shared, static logging configuration.
  */
+@Isolated
 public class LoggingHandlerTest {
 
     private static final String LOGGER_NAME = LoggingHandler.class.getName();
@@ -95,7 +99,7 @@ public class LoggingHandlerTest {
     }
 
     @AfterEach
-    public void teardown() {
+    public void tearDown() {
         logger.detachAppender(appender);
     }
 
@@ -187,8 +191,8 @@ public class LoggingHandlerTest {
         verify(appender).doAppend(argThat(new RegexLogMatcher(".+BIND: 0.0.0.0/0.0.0.0:80$")));
     }
 
+    @SuppressWarnings("StringOperationCanBeSimplified")
     @Test
-    @SuppressWarnings("RedundantStringConstructorCall")
     public void shouldLogChannelUserEvent() throws Exception {
         String userTriggered = "iAmCustom!";
         EmbeddedChannel channel = new EmbeddedChannel(new LoggingHandler());

--- a/handler/src/test/java/io/netty5/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SSLEngineTest.java
@@ -53,6 +53,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.api.parallel.Resources;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
@@ -3875,6 +3877,7 @@ public abstract class SSLEngineTest {
         fail("Array did not contain '" + expected + "':" + Arrays.toString(array));
     }
 
+    @ResourceLock(Resources.SYSTEM_PROPERTIES) // Block parallel test execution across subclasses.
     @MethodSource("newTestParams")
     @ParameterizedTest
     public void testMasterKeyLogging(final SSLEngineTestParam param) throws Exception {

--- a/handler/src/test/resources/junit-platform.properties
+++ b/handler/src/test/resources/junit-platform.properties
@@ -1,0 +1,17 @@
+# Copyright 2022 The Netty Project
+#
+# The Netty Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+junit.jupiter.execution.parallel.enabled = true
+junit.jupiter.execution.parallel.mode.default = same_thread
+junit.jupiter.execution.parallel.mode.classes.default = concurrent


### PR DESCRIPTION
Motivation:
Locally, the tests take 33m20s to run one-by-one.
The time is taking by running the many variants of SslEngineTests and SslEngineInteroptTests, each taking one or two minutes.
By running these in parallel, the local run time is reduced to 10m19s.

Modification:
Add a JUnit platform configuration to the handler module, that tell JUnit to run these tests in parallel.
Make the LoggingHandlerTest isolated, because is mutates shared state in the static logging configuration.

Result:
Running the handler module tests is now much faster.