### PR TITLE
Add methods to override address inference in PcapWriteHandler

### DIFF
--- a/handler/src/main/java/io/netty/handler/pcap/PcapWriteHandler.java
+++ b/handler/src/main/java/io/netty/handler/pcap/PcapWriteHandler.java
@@ -138,7 +138,9 @@ public final class PcapWriteHandler extends ChannelDuplexHandler implements Clos
      *                     OutputStream.
      * @throws NullPointerException If {@link OutputStream} is {@code null} then we'll throw an
      *                              {@link NullPointerException}
+     * @deprecated Use {@link #builder() builder} instead.
      */
+    @Deprecated
     public PcapWriteHandler(OutputStream outputStream) {
         this(outputStream, false, true);
     }
@@ -156,7 +158,9 @@ public final class PcapWriteHandler extends ChannelDuplexHandler implements Clos
      *                              Pcap Global Header is already present.
      * @throws NullPointerException If {@link OutputStream} is {@code null} then we'll throw an
      *                              {@link NullPointerException}
+     * @deprecated Use {@link #builder() builder} instead.
      */
+    @Deprecated
     public PcapWriteHandler(OutputStream outputStream, boolean captureZeroByte, boolean writePcapGlobalHeader) {
         this.outputStream = ObjectUtil.checkNotNull(outputStream, "OutputStream");
         this.captureZeroByte = captureZeroByte;

--- a/handler/src/main/java/io/netty/handler/pcap/PcapWriteHandler.java
+++ b/handler/src/main/java/io/netty/handler/pcap/PcapWriteHandler.java
@@ -639,15 +639,15 @@ public final class PcapWriteHandler extends ChannelDuplexHandler implements Clos
      * Builder for {@link PcapWriteHandler}.
      */
     public static final class Builder {
-        boolean captureZeroByte;
-        boolean writePcapGlobalHeader = true;
+        private boolean captureZeroByte;
+        private boolean writePcapGlobalHeader = true;
 
-        ChannelType channelType;
-        InetSocketAddress initiatiorAddr;
-        InetSocketAddress handlerAddr;
-        boolean isServerPipeline;
+        private ChannelType channelType;
+        private InetSocketAddress initiatiorAddr;
+        private InetSocketAddress handlerAddr;
+        private boolean isServerPipeline;
 
-        Builder() {
+        private Builder() {
         }
 
         /**

--- a/handler/src/main/java/io/netty/handler/pcap/PcapWriteHandler.java
+++ b/handler/src/main/java/io/netty/handler/pcap/PcapWriteHandler.java
@@ -124,7 +124,10 @@ public final class PcapWriteHandler extends ChannelDuplexHandler implements Clos
      */
     private boolean isClosed;
 
-    private boolean initialized = false;
+    /**
+     * Whether this handler is initialized (headers written, channel type inferred)
+     */
+    private boolean initialized;
 
     /**
      * Create new {@link PcapWriteHandler} Instance.
@@ -168,13 +171,15 @@ public final class PcapWriteHandler extends ChannelDuplexHandler implements Clos
      * @param clientAddress The address of the TCP client (initiator)
      * @param localIsServer Whether the handler is part of the server channel
      */
-    public void forceTcpChannel(InetSocketAddress serverAddress, InetSocketAddress clientAddress, boolean localIsServer) {
+    public void forceTcpChannel(
+            InetSocketAddress serverAddress,
+            InetSocketAddress clientAddress,
+            boolean localIsServer) {
         channelType = ChannelType.TCP;
         handlerAddr = serverAddress;
         initiatiorAddr = clientAddress;
         isServerPipeline = localIsServer;
     }
-
 
     /**
      * Force this handler to write data as if they were UDP packets, with the given connection metadata. If this method
@@ -499,7 +504,8 @@ public final class PcapWriteHandler extends ChannelDuplexHandler implements Clos
 
                 UDPPacket.writePacket(udpBuf, datagramPacket.content(), srcAddr.getPort(), dstAddr.getPort());
                 completeUDPWrite(srcAddr, dstAddr, udpBuf, ctx.alloc(), ctx);
-            } else if (msg instanceof ByteBuf && (!(ctx.channel() instanceof DatagramChannel) || ((DatagramChannel) ctx.channel()).isConnected())) {
+            } else if (msg instanceof ByteBuf &&
+                    (!(ctx.channel() instanceof DatagramChannel) || ((DatagramChannel) ctx.channel()).isConnected())) {
 
                 // If bytes are 0 and `captureZeroByte` is false, we won't capture this.
                 if (((ByteBuf) msg).readableBytes() == 0 && !captureZeroByte) {

--- a/handler/src/test/java/io/netty/handler/pcap/PcapWriteHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/pcap/PcapWriteHandlerTest.java
@@ -82,7 +82,7 @@ public class PcapWriteHandlerTest {
         Bootstrap client = new Bootstrap()
                 .group(eventLoopGroup)
                 .channel(NioDatagramChannel.class)
-                .handler(new PcapWriteHandler(new ByteBufOutputStream(byteBuf)));
+                .handler(PcapWriteHandler.builder().build(new ByteBufOutputStream(byteBuf)));
 
         ChannelFuture channelFutureClient =
                 client.connect(channelFutureServer.channel().localAddress(), cltReqAddr).sync();
@@ -191,7 +191,7 @@ public class PcapWriteHandlerTest {
                     @Override
                     public void initChannel(SocketChannel ch) throws Exception {
                         ChannelPipeline p = ch.pipeline();
-                        p.addLast(new PcapWriteHandler(new ByteBufOutputStream(byteBuf)));
+                        p.addLast(PcapWriteHandler.builder().build(new ByteBufOutputStream(byteBuf)));
                         p.addLast(new ChannelInboundHandlerAdapter() {
                             @Override
                             public void channelRead(ChannelHandlerContext ctx, Object msg) {

--- a/handler/src/test/java/io/netty/handler/pcap/PcapWriteHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/pcap/PcapWriteHandlerTest.java
@@ -108,10 +108,10 @@ public class PcapWriteHandlerTest {
 
         // we fake a client
         EmbeddedChannel embeddedChannel = new EmbeddedChannel();
-        PcapWriteHandler pcapWriteHandler = new PcapWriteHandler(new ByteBufOutputStream(byteBuf));
-        pcapWriteHandler.forceUdpChannel(clientAddr, serverAddr);
         embeddedChannel.pipeline()
-                .addLast(pcapWriteHandler);
+                .addLast(PcapWriteHandler.builder()
+                        .forceUdpChannel(clientAddr, serverAddr)
+                        .build(new ByteBufOutputStream(byteBuf)));
 
         embeddedChannel.writeOutbound(Unpooled.wrappedBuffer("Meow".getBytes()));
         assertEquals(Unpooled.wrappedBuffer("Meow".getBytes()), embeddedChannel.readOutbound());
@@ -270,9 +270,9 @@ public class PcapWriteHandlerTest {
         InetSocketAddress clientAddr = new InetSocketAddress("2.2.2.2", 3456);
 
         EmbeddedChannel embeddedChannel = new EmbeddedChannel();
-        PcapWriteHandler pcapWriteHandler = new PcapWriteHandler(new ByteBufOutputStream(byteBuf));
-        pcapWriteHandler.forceTcpChannel(serverAddr, clientAddr, true);
-        embeddedChannel.pipeline().addLast(pcapWriteHandler);
+        embeddedChannel.pipeline().addLast(PcapWriteHandler.builder()
+                .forceTcpChannel(serverAddr, clientAddr, true)
+                .build(new ByteBufOutputStream(byteBuf)));
 
         byte[] payload = "Meow".getBytes();
         embeddedChannel.writeInbound(Unpooled.wrappedBuffer(payload));

--- a/handler/src/test/java/io/netty/handler/pcap/PcapWriteHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/pcap/PcapWriteHandlerTest.java
@@ -30,18 +30,17 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.SimpleChannelInboundHandler;
-import io.netty.channel.local.LocalAddress;
+import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
-import io.netty.handler.logging.LogLevel;
-import io.netty.handler.logging.LoggingHandler;
 import io.netty.util.CharsetUtil;
 import io.netty.util.NetUtil;
 import io.netty.util.concurrent.Promise;
+
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
@@ -92,6 +91,35 @@ public class PcapWriteHandlerTest {
         assertTrue(clientChannel.writeAndFlush(Unpooled.wrappedBuffer("Meow".getBytes())).sync().isSuccess());
         assertTrue(eventLoopGroup.shutdownGracefully().sync().isSuccess());
 
+        verifyUdpCapture(
+                byteBuf,
+                (InetSocketAddress) clientChannel.remoteAddress(),
+                (InetSocketAddress) clientChannel.localAddress()
+        );
+    }
+
+    @Test
+    public void embeddedUdp() {
+
+        ByteBuf byteBuf = Unpooled.buffer();
+
+        InetSocketAddress serverAddr = new InetSocketAddress("1.1.1.1", 1234);
+        InetSocketAddress clientAddr = new InetSocketAddress("2.2.2.2", 3456);
+
+        // we fake a client
+        EmbeddedChannel embeddedChannel = new EmbeddedChannel();
+        PcapWriteHandler pcapWriteHandler = new PcapWriteHandler(new ByteBufOutputStream(byteBuf));
+        pcapWriteHandler.forceUdpChannel(clientAddr, serverAddr);
+        embeddedChannel.pipeline()
+                .addLast(pcapWriteHandler);
+
+        embeddedChannel.writeOutbound(Unpooled.wrappedBuffer("Meow".getBytes()));
+        assertEquals(Unpooled.wrappedBuffer("Meow".getBytes()), embeddedChannel.readOutbound());
+
+        verifyUdpCapture(byteBuf, serverAddr, clientAddr);
+    }
+
+    private void verifyUdpCapture(ByteBuf byteBuf, InetSocketAddress remoteAddress, InetSocketAddress localAddress) {
         // Verify Pcap Global Headers
         verifyGlobalHeaders(byteBuf);
 
@@ -120,17 +148,15 @@ public class PcapWriteHandlerTest {
         assertEquals((byte) 0xff, ipv4Packet.readByte());      // TTL
         assertEquals((byte) 17, ipv4Packet.readByte());        // Protocol
         assertEquals(0, ipv4Packet.readShort());      // Checksum
-        InetSocketAddress localAddr = (InetSocketAddress) clientChannel.remoteAddress();
         // Source IPv4 Address
-        assertEquals(NetUtil.ipv4AddressToInt((Inet4Address) localAddr.getAddress()), ipv4Packet.readInt());
-        InetSocketAddress remoteAddr = (InetSocketAddress) clientChannel.localAddress();
+        assertEquals(NetUtil.ipv4AddressToInt((Inet4Address) localAddress.getAddress()), ipv4Packet.readInt());
         // Destination IPv4 Address
-        assertEquals(NetUtil.ipv4AddressToInt((Inet4Address) remoteAddr.getAddress()), ipv4Packet.readInt());
+        assertEquals(NetUtil.ipv4AddressToInt((Inet4Address) remoteAddress.getAddress()), ipv4Packet.readInt());
 
         // Verify UDP Packet
         ByteBuf udpPacket = ipv4Packet.readBytes(12);
-        assertEquals(remoteAddr.getPort() & 0xffff, udpPacket.readUnsignedShort()); // Source Port
-        assertEquals(localAddr.getPort() & 0xffff, udpPacket.readUnsignedShort()); // Destination Port
+        assertEquals(localAddress.getPort() & 0xffff, udpPacket.readUnsignedShort()); // Source Port
+        assertEquals(remoteAddress.getPort() & 0xffff, udpPacket.readUnsignedShort()); // Destination Port
         assertEquals(12, udpPacket.readShort());     // Length
         assertEquals(0x0001, udpPacket.readShort()); // Checksum
 
@@ -229,6 +255,38 @@ public class PcapWriteHandlerTest {
         assertTrue(clientGroup.shutdownGracefully().sync().isSuccess());
         assertTrue(bossGroup.shutdownGracefully().sync().isSuccess());
 
+        verifyTcpCapture(
+                byteBuf,
+                (InetSocketAddress) serverChannelFuture.channel().localAddress(),
+                (InetSocketAddress) clientChannelFuture.channel().localAddress()
+        );
+    }
+
+    @Test
+    public void embeddedTcp() {
+        ByteBuf byteBuf = Unpooled.buffer();
+
+        InetSocketAddress serverAddr = new InetSocketAddress("1.1.1.1", 1234);
+        InetSocketAddress clientAddr = new InetSocketAddress("2.2.2.2", 3456);
+
+        EmbeddedChannel embeddedChannel = new EmbeddedChannel();
+        PcapWriteHandler pcapWriteHandler = new PcapWriteHandler(new ByteBufOutputStream(byteBuf));
+        pcapWriteHandler.forceTcpChannel(serverAddr, clientAddr, true);
+        embeddedChannel.pipeline().addLast(pcapWriteHandler);
+
+        byte[] payload = "Meow".getBytes();
+        embeddedChannel.writeInbound(Unpooled.wrappedBuffer(payload));
+        assertEquals(Unpooled.wrappedBuffer(payload), embeddedChannel.readInbound());
+        embeddedChannel.writeOutbound(Unpooled.wrappedBuffer(payload));
+        assertEquals(Unpooled.wrappedBuffer(payload), embeddedChannel.readOutbound());
+        embeddedChannel.close();
+
+        verifyTcpCapture(byteBuf, serverAddr, clientAddr);
+    }
+
+    private void verifyTcpCapture(ByteBuf byteBuf, InetSocketAddress serverAddr, InetSocketAddress clientAddr) {
+        // note: right now, this method only checks the first packet, which is part of the fake three-way handshake.
+
         verifyGlobalHeaders(byteBuf);
 
         // Verify Pcap Packet Header
@@ -256,13 +314,10 @@ public class PcapWriteHandlerTest {
         assertEquals((byte) 0xff, ipv4Packet.readByte());      // TTL
         assertEquals((byte) 6, ipv4Packet.readByte());        // Protocol
         assertEquals(0, ipv4Packet.readShort());      // Checksum
-        InetSocketAddress serverAddr = (InetSocketAddress) serverChannelFuture.channel().localAddress();
         // Source IPv4 Address
-        assertEquals(NetUtil.ipv4AddressToInt((Inet4Address) serverAddr.getAddress()), ipv4Packet.readInt());
-        // Destination IPv4 Address
         ipv4Packet.readInt();
-
-        InetSocketAddress clientAddr = (InetSocketAddress) clientChannelFuture.channel().localAddress();
+        // Destination IPv4 Address
+        assertEquals(NetUtil.ipv4AddressToInt((Inet4Address) serverAddr.getAddress()), ipv4Packet.readInt());
 
         // Verify ports
         ByteBuf tcpPacket = ipv4Packet.readSlice(12);


### PR DESCRIPTION
Motivation:

The PcapWriteHandler has requires either a SocketChannel or a DatagramChannel to infer TCP / UDP connection details. This makes it useless for debugging an EmbeddedChannel.

Modification:

- Add `forceTcpChannel` and `forceUdpChannel` methods to allow users to bypass the channel metadata inference and provide their own information.
- Move handler initialization from `channelActive` into a separate method that is also called on any write or read. This ensures the new inference code runs even if channelActive isn't called. With the old inference code, this would have broken further down the line because `handlerAddr` and `initiatiorAddr` are null and the writer code can't deal with that, except the udp DatagramPacket branch. The change is necessary to maintain compatibility with that DatagramPacket branch, and to make use with EmbeddedChannel easier (EmbeddedChannel does not fire channelActive unless requested).
- Add tests for EmbeddedChannel based on the existing tests. This also changes the test case for normal udp/tcp a bit, because the test case mixed up the remote and local address (this was previously not an issue because both were 127.0.0.1).
- Improve error message for incompatible channel type, and elevate it to a warning. It should never appear with proper use of PcapWriteHandler.

Result:

PcapWriteHandler can now be used to debug test cases that use EmbeddedChannel.