### PR TITLE
Use generics for AbstractChannel

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDatagramChannel.java
@@ -18,6 +18,7 @@ package io.netty5.channel.epoll;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.channel.ChannelShutdownDirection;
+import io.netty5.channel.unix.UnixChannel;
 import io.netty5.util.Resource;
 import io.netty5.channel.AddressedEnvelope;
 import io.netty5.channel.ChannelMetadata;
@@ -56,7 +57,8 @@ import static java.util.Objects.requireNonNull;
  * {@link DatagramChannel} implementation that uses linux EPOLL Edge-Triggered Mode for
  * maximal performance.
  */
-public final class EpollDatagramChannel extends AbstractEpollChannel implements DatagramChannel {
+public final class EpollDatagramChannel extends AbstractEpollChannel<UnixChannel, InetSocketAddress, InetSocketAddress>
+        implements DatagramChannel {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(EpollDatagramChannel.class);
     private static final ChannelMetadata METADATA = new ChannelMetadata(true);
     private static final String EXPECTED_TYPES =
@@ -110,16 +112,6 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
     private EpollDatagramChannel(EventLoop eventLoop, LinuxSocket fd, boolean active) {
         super(null, eventLoop, fd, active);
         config = new EpollDatagramChannelConfig(this);
-    }
-
-    @Override
-    public InetSocketAddress remoteAddress() {
-        return (InetSocketAddress) super.remoteAddress();
-    }
-
-    @Override
-    public InetSocketAddress localAddress() {
-        return (InetSocketAddress) super.localAddress();
     }
 
     @Override

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDomainDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDomainDatagramChannel.java
@@ -33,6 +33,7 @@ import io.netty5.channel.unix.DomainSocketAddress;
 import io.netty5.channel.unix.IovArray;
 import io.netty5.channel.unix.PeerCredentials;
 import io.netty5.channel.unix.RecvFromAddressDomainSocket;
+import io.netty5.channel.unix.UnixChannel;
 import io.netty5.channel.unix.UnixChannelUtil;
 import io.netty5.util.UncheckedBooleanSupplier;
 import io.netty5.util.internal.SilentDispose;
@@ -48,7 +49,9 @@ import static io.netty5.channel.epoll.LinuxSocket.newSocketDomainDgram;
 import static io.netty5.util.CharsetUtil.UTF_8;
 
 @UnstableApi
-public final class EpollDomainDatagramChannel extends AbstractEpollChannel implements DomainDatagramChannel {
+public final class EpollDomainDatagramChannel
+        extends AbstractEpollChannel<UnixChannel, DomainSocketAddress, DomainSocketAddress>
+        implements DomainDatagramChannel {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(EpollDomainDatagramChannel.class);
     private static final ChannelMetadata METADATA = new ChannelMetadata(true);
     private static final String EXPECTED_TYPES =
@@ -295,11 +298,6 @@ public final class EpollDomainDatagramChannel extends AbstractEpollChannel imple
     }
 
     @Override
-    public DomainSocketAddress localAddress() {
-        return (DomainSocketAddress) super.localAddress();
-    }
-
-    @Override
     protected DomainSocketAddress localAddress0() {
         return local;
     }
@@ -315,11 +313,6 @@ public final class EpollDomainDatagramChannel extends AbstractEpollChannel imple
      */
     public PeerCredentials peerCredentials() throws IOException {
         return socket.getPeerCredentials();
-    }
-
-    @Override
-    public DomainSocketAddress remoteAddress() {
-        return (DomainSocketAddress) super.remoteAddress();
     }
 
     @Override

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDomainSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDomainSocketChannel.java
@@ -15,7 +15,6 @@
  */
 package io.netty5.channel.epoll;
 
-import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelConfig;
 import io.netty5.channel.ChannelOutboundBuffer;
 import io.netty5.channel.ChannelPipeline;
@@ -25,6 +24,7 @@ import io.netty5.channel.unix.DomainSocketAddress;
 import io.netty5.channel.unix.DomainSocketChannel;
 import io.netty5.channel.unix.FileDescriptor;
 import io.netty5.channel.unix.PeerCredentials;
+import io.netty5.channel.unix.UnixChannel;
 import io.netty5.util.internal.UnstableApi;
 
 import java.io.IOException;
@@ -32,7 +32,9 @@ import java.net.SocketAddress;
 
 import static io.netty5.channel.epoll.LinuxSocket.newSocketDomain;
 
-public final class EpollDomainSocketChannel extends AbstractEpollStreamChannel implements DomainSocketChannel {
+public final class EpollDomainSocketChannel
+        extends AbstractEpollStreamChannel<UnixChannel, DomainSocketAddress, DomainSocketAddress>
+        implements DomainSocketChannel {
     private final EpollDomainSocketChannelConfig config = new EpollDomainSocketChannelConfig(this);
 
     private volatile DomainSocketAddress local;
@@ -42,7 +44,7 @@ public final class EpollDomainSocketChannel extends AbstractEpollStreamChannel i
         super(eventLoop, newSocketDomain(), false);
     }
 
-    EpollDomainSocketChannel(Channel parent, EventLoop eventLoop, FileDescriptor fd) {
+    EpollDomainSocketChannel(UnixChannel parent, EventLoop eventLoop, FileDescriptor fd) {
         super(parent, eventLoop, new LinuxSocket(fd.intValue()));
     }
 
@@ -50,7 +52,7 @@ public final class EpollDomainSocketChannel extends AbstractEpollStreamChannel i
         super(eventLoop, fd);
     }
 
-    public EpollDomainSocketChannel(Channel parent, EventLoop eventLoop, LinuxSocket fd) {
+    public EpollDomainSocketChannel(UnixChannel parent, EventLoop eventLoop, LinuxSocket fd) {
         super(parent, eventLoop, fd);
     }
 
@@ -87,16 +89,6 @@ public final class EpollDomainSocketChannel extends AbstractEpollStreamChannel i
             return true;
         }
         return false;
-    }
-
-    @Override
-    public DomainSocketAddress remoteAddress() {
-        return (DomainSocketAddress) super.remoteAddress();
-    }
-
-    @Override
-    public DomainSocketAddress localAddress() {
-        return (DomainSocketAddress) super.localAddress();
     }
 
     @Override

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollServerDomainSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollServerDomainSocketChannel.java
@@ -21,6 +21,7 @@ import io.netty5.channel.EventLoopGroup;
 import io.netty5.channel.unix.DomainSocketAddress;
 import io.netty5.channel.unix.ServerDomainSocketChannel;
 import io.netty5.channel.unix.Socket;
+import io.netty5.channel.unix.UnixChannel;
 import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
 
@@ -29,7 +30,8 @@ import java.net.SocketAddress;
 
 import static io.netty5.channel.epoll.LinuxSocket.newSocketDomain;
 
-public final class EpollServerDomainSocketChannel extends AbstractEpollServerChannel
+public final class EpollServerDomainSocketChannel
+        extends AbstractEpollServerChannel<UnixChannel, DomainSocketAddress, DomainSocketAddress>
         implements ServerDomainSocketChannel {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(
             EpollServerDomainSocketChannel.class);
@@ -45,17 +47,8 @@ public final class EpollServerDomainSocketChannel extends AbstractEpollServerCha
         super(eventLoop, childEventLoopGroup, fd);
     }
 
-    EpollServerDomainSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup, LinuxSocket fd) {
-        super(eventLoop, childEventLoopGroup, fd);
-    }
-
-    EpollServerDomainSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup,
-                                   LinuxSocket fd, boolean active) {
-        super(eventLoop, childEventLoopGroup, fd, active);
-    }
-
     @Override
-    protected Channel newChildChannel(int fd, byte[] addr, int offset, int len) throws Exception {
+    protected Channel newChildChannel(int fd, byte[] addr, int offset, int len) {
         return new EpollDomainSocketChannel(this, childEventLoopGroup().next(), new Socket(fd));
     }
 
@@ -92,15 +85,5 @@ public final class EpollServerDomainSocketChannel extends AbstractEpollServerCha
     @Override
     public EpollServerChannelConfig config() {
         return config;
-    }
-
-    @Override
-    public DomainSocketAddress remoteAddress() {
-        return (DomainSocketAddress) super.remoteAddress();
-    }
-
-    @Override
-    public DomainSocketAddress localAddress() {
-        return (DomainSocketAddress) super.localAddress();
     }
 }

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollServerSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollServerSocketChannel.java
@@ -20,6 +20,7 @@ import io.netty5.channel.EventLoop;
 import io.netty5.channel.EventLoopGroup;
 import io.netty5.channel.socket.InternetProtocolFamily;
 import io.netty5.channel.socket.ServerSocketChannel;
+import io.netty5.channel.unix.UnixChannel;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -37,7 +38,9 @@ import static io.netty5.channel.unix.NativeInetAddress.address;
  * {@link ServerSocketChannel} implementation that uses linux EPOLL Edge-Triggered Mode for
  * maximal performance.
  */
-public final class EpollServerSocketChannel extends AbstractEpollServerChannel implements ServerSocketChannel {
+public final class EpollServerSocketChannel
+        extends AbstractEpollServerChannel<UnixChannel, InetSocketAddress, InetSocketAddress>
+        implements ServerSocketChannel {
 
     private final EpollServerSocketChannelConfig config;
     private volatile Collection<InetAddress> tcpMd5SigAddresses = Collections.emptyList();
@@ -55,16 +58,7 @@ public final class EpollServerSocketChannel extends AbstractEpollServerChannel i
     public EpollServerSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup, int fd) {
         // Must call this constructor to ensure this object's local address is configured correctly.
         // The local address can only be obtained from a Socket object.
-        this(eventLoop, childEventLoopGroup, new LinuxSocket(fd));
-    }
-
-    EpollServerSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup, LinuxSocket fd) {
-        super(eventLoop, childEventLoopGroup, fd);
-        config = new EpollServerSocketChannelConfig(this);
-    }
-
-    EpollServerSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup, LinuxSocket fd, boolean active) {
-        super(eventLoop, childEventLoopGroup, fd, active);
+        super(eventLoop, childEventLoopGroup, new LinuxSocket(fd));
         config = new EpollServerSocketChannelConfig(this);
     }
 
@@ -77,16 +71,6 @@ public final class EpollServerSocketChannel extends AbstractEpollServerChannel i
         }
         socket.listen(config.getBacklog());
         active = true;
-    }
-
-    @Override
-    public InetSocketAddress remoteAddress() {
-        return (InetSocketAddress) super.remoteAddress();
-    }
-
-    @Override
-    public InetSocketAddress localAddress() {
-        return (InetSocketAddress) super.localAddress();
     }
 
     @Override

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollSocketChannel.java
@@ -16,12 +16,10 @@
 package io.netty5.channel.epoll;
 
 import io.netty5.buffer.api.Buffer;
-import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelException;
 import io.netty5.channel.ChannelOutboundBuffer;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.socket.InternetProtocolFamily;
-import io.netty5.channel.socket.ServerSocketChannel;
 import io.netty5.channel.socket.SocketChannel;
 import io.netty5.util.concurrent.GlobalEventExecutor;
 
@@ -41,7 +39,9 @@ import static io.netty5.channel.epoll.Native.IS_SUPPORTING_TCP_FASTOPEN_CLIENT;
  * {@link SocketChannel} implementation that uses linux EPOLL Edge-Triggered Mode for
  * maximal performance.
  */
-public final class EpollSocketChannel extends AbstractEpollStreamChannel implements SocketChannel {
+public final class EpollSocketChannel
+        extends AbstractEpollStreamChannel<EpollServerSocketChannel, InetSocketAddress, InetSocketAddress>
+        implements SocketChannel {
 
     private final EpollSocketChannelConfig config;
 
@@ -61,17 +61,13 @@ public final class EpollSocketChannel extends AbstractEpollStreamChannel impleme
         config = new EpollSocketChannelConfig(this);
     }
 
-    EpollSocketChannel(EventLoop eventLoop, LinuxSocket fd, boolean active) {
-        super(eventLoop, fd, active);
-        config = new EpollSocketChannelConfig(this);
-    }
-
-    EpollSocketChannel(Channel parent, EventLoop eventLoop, LinuxSocket fd, InetSocketAddress remoteAddress) {
+    EpollSocketChannel(EpollServerSocketChannel parent, EventLoop eventLoop,
+                       LinuxSocket fd, InetSocketAddress remoteAddress) {
         super(parent, eventLoop, fd, remoteAddress);
         config = new EpollSocketChannelConfig(this);
 
-        if (parent instanceof EpollServerSocketChannel) {
-            tcpMd5SigAddresses = ((EpollServerSocketChannel) parent).tcpMd5SigAddresses();
+        if (parent != null) {
+            tcpMd5SigAddresses = parent.tcpMd5SigAddresses();
         }
     }
 
@@ -97,23 +93,8 @@ public final class EpollSocketChannel extends AbstractEpollStreamChannel impleme
     }
 
     @Override
-    public InetSocketAddress remoteAddress() {
-        return (InetSocketAddress) super.remoteAddress();
-    }
-
-    @Override
-    public InetSocketAddress localAddress() {
-        return (InetSocketAddress) super.localAddress();
-    }
-
-    @Override
     public EpollSocketChannelConfig config() {
         return config;
-    }
-
-    @Override
-    public ServerSocketChannel parent() {
-        return (ServerSocketChannel) super.parent();
     }
 
     @Override

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueDatagramChannel.java
@@ -20,15 +20,19 @@ import io.netty5.channel.ChannelMetadata;
 import io.netty5.channel.ChannelOutboundBuffer;
 import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.EventLoop;
+import io.netty5.channel.unix.Unix;
+import io.netty5.channel.unix.UnixChannel;
 
 import java.io.IOException;
+import java.net.SocketAddress;
 
-abstract class AbstractKQueueDatagramChannel extends AbstractKQueueChannel {
+abstract class AbstractKQueueDatagramChannel<P extends UnixChannel, L extends SocketAddress, R extends SocketAddress>
+        extends AbstractKQueueChannel<P, L, R> {
     private static final ChannelMetadata METADATA = new ChannelMetadata(true);
     private volatile boolean inputShutdown;
     private volatile boolean outputShutdown;
 
-    AbstractKQueueDatagramChannel(Channel parent, EventLoop eventLoop, BsdSocket fd, boolean active) {
+    AbstractKQueueDatagramChannel(P parent, EventLoop eventLoop, BsdSocket fd, boolean active) {
         super(parent, eventLoop, fd, active);
     }
 

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueServerChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueServerChannel.java
@@ -24,15 +24,17 @@ import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.EventLoopGroup;
 import io.netty5.channel.ServerChannel;
+import io.netty5.channel.unix.UnixChannel;
 import io.netty5.util.internal.UnstableApi;
 
-import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 
 import static java.util.Objects.requireNonNull;
 
 @UnstableApi
-public abstract class AbstractKQueueServerChannel extends AbstractKQueueChannel implements ServerChannel {
+public abstract class AbstractKQueueServerChannel
+        <P extends UnixChannel, L extends SocketAddress, R extends SocketAddress>
+        extends AbstractKQueueChannel<P, L, R> implements ServerChannel {
     private static final ChannelMetadata METADATA = new ChannelMetadata(false, 16);
     private final EventLoopGroup childEventLoopGroup;
 
@@ -61,7 +63,7 @@ public abstract class AbstractKQueueServerChannel extends AbstractKQueueChannel 
     }
 
     @Override
-    protected InetSocketAddress remoteAddress0() {
+    protected R remoteAddress0() {
         return null;
     }
 

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueStreamChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueStreamChannel.java
@@ -18,8 +18,8 @@ package io.netty5.channel.kqueue;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.channel.ChannelShutdownDirection;
+import io.netty5.channel.unix.UnixChannel;
 import io.netty5.util.Resource;
-import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelConfig;
 import io.netty5.channel.ChannelMetadata;
 import io.netty5.channel.ChannelOutboundBuffer;
@@ -45,7 +45,9 @@ import static io.netty5.channel.internal.ChannelUtils.MAX_BYTES_PER_GATHERING_WR
 import static io.netty5.channel.internal.ChannelUtils.WRITE_STATUS_SNDBUF_FULL;
 
 @UnstableApi
-public abstract class AbstractKQueueStreamChannel extends AbstractKQueueChannel {
+public abstract class AbstractKQueueStreamChannel
+        <P extends UnixChannel, L extends SocketAddress, R extends SocketAddress>
+        extends AbstractKQueueChannel<P, L, R> {
     private static final ChannelMetadata METADATA = new ChannelMetadata(false, 16);
     private static final String EXPECTED_TYPES =
             " (expected: " + StringUtil.simpleClassName(Buffer.class) + ", " +
@@ -56,11 +58,11 @@ public abstract class AbstractKQueueStreamChannel extends AbstractKQueueChannel 
     // meantime.
     private final Runnable flushTask = this::flush0;
 
-    AbstractKQueueStreamChannel(Channel parent, EventLoop eventLoop, BsdSocket fd, boolean active) {
+    AbstractKQueueStreamChannel(P parent, EventLoop eventLoop, BsdSocket fd, boolean active) {
         super(parent, eventLoop, fd, active);
     }
 
-    AbstractKQueueStreamChannel(Channel parent, EventLoop eventLoop, BsdSocket fd, SocketAddress remote) {
+    AbstractKQueueStreamChannel(P parent, EventLoop eventLoop, BsdSocket fd, R remote) {
         super(parent, eventLoop, fd, remote);
     }
 

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDatagramChannel.java
@@ -28,6 +28,7 @@ import io.netty5.channel.socket.InternetProtocolFamily;
 import io.netty5.channel.unix.DatagramSocketAddress;
 import io.netty5.channel.unix.Errors;
 import io.netty5.channel.unix.IovArray;
+import io.netty5.channel.unix.UnixChannel;
 import io.netty5.channel.unix.UnixChannelUtil;
 import io.netty5.util.UncheckedBooleanSupplier;
 import io.netty5.util.concurrent.Future;
@@ -51,7 +52,9 @@ import static io.netty5.channel.kqueue.BsdSocket.newSocketDgram;
 import static java.util.Objects.requireNonNull;
 
 @UnstableApi
-public final class KQueueDatagramChannel extends AbstractKQueueDatagramChannel implements DatagramChannel {
+public final class KQueueDatagramChannel
+        extends AbstractKQueueDatagramChannel<UnixChannel, InetSocketAddress, InetSocketAddress>
+        implements DatagramChannel {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(KQueueDatagramChannel.class);
     private static final String EXPECTED_TYPES =
             " (expected: " + StringUtil.simpleClassName(DatagramPacket.class) + ", " +
@@ -79,16 +82,6 @@ public final class KQueueDatagramChannel extends AbstractKQueueDatagramChannel i
     KQueueDatagramChannel(EventLoop eventLoop, BsdSocket socket, boolean active) {
         super(null, eventLoop, socket, active);
         config = new KQueueDatagramChannelConfig(this);
-    }
-
-    @Override
-    public InetSocketAddress remoteAddress() {
-        return (InetSocketAddress) super.remoteAddress();
-    }
-
-    @Override
-    public InetSocketAddress localAddress() {
-        return (InetSocketAddress) super.localAddress();
     }
 
     @Override

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDomainDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDomainDatagramChannel.java
@@ -30,6 +30,7 @@ import io.netty5.channel.unix.DomainSocketAddress;
 import io.netty5.channel.unix.IovArray;
 import io.netty5.channel.unix.PeerCredentials;
 import io.netty5.channel.unix.RecvFromAddressDomainSocket;
+import io.netty5.channel.unix.UnixChannel;
 import io.netty5.channel.unix.UnixChannelUtil;
 import io.netty5.util.UncheckedBooleanSupplier;
 import io.netty5.util.internal.SilentDispose;
@@ -45,7 +46,9 @@ import static io.netty5.channel.kqueue.BsdSocket.newSocketDomainDgram;
 import static io.netty5.util.CharsetUtil.UTF_8;
 
 @UnstableApi
-public final class KQueueDomainDatagramChannel extends AbstractKQueueDatagramChannel implements DomainDatagramChannel {
+public final class KQueueDomainDatagramChannel
+        extends AbstractKQueueDatagramChannel<UnixChannel, DomainSocketAddress, DomainSocketAddress>
+        implements DomainDatagramChannel {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(KQueueDomainDatagramChannel.class);
     private static final String EXPECTED_TYPES =
             " (expected: " +
@@ -219,11 +222,6 @@ public final class KQueueDomainDatagramChannel extends AbstractKQueueDatagramCha
     }
 
     @Override
-    public DomainSocketAddress localAddress() {
-        return (DomainSocketAddress) super.localAddress();
-    }
-
-    @Override
     protected DomainSocketAddress localAddress0() {
         return local;
     }
@@ -234,11 +232,6 @@ public final class KQueueDomainDatagramChannel extends AbstractKQueueDatagramCha
      */
     public PeerCredentials peerCredentials() throws IOException {
         return socket.getPeerCredentials();
-    }
-
-    @Override
-    public DomainSocketAddress remoteAddress() {
-        return (DomainSocketAddress) super.remoteAddress();
     }
 
     @Override

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDomainSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDomainSocketChannel.java
@@ -25,6 +25,8 @@ import io.netty5.channel.unix.DomainSocketAddress;
 import io.netty5.channel.unix.DomainSocketChannel;
 import io.netty5.channel.unix.FileDescriptor;
 import io.netty5.channel.unix.PeerCredentials;
+import io.netty5.channel.unix.Unix;
+import io.netty5.channel.unix.UnixChannel;
 import io.netty5.util.internal.UnstableApi;
 
 import java.io.IOException;
@@ -33,7 +35,9 @@ import java.net.SocketAddress;
 import static io.netty5.channel.kqueue.BsdSocket.newSocketDomain;
 
 @UnstableApi
-public final class KQueueDomainSocketChannel extends AbstractKQueueStreamChannel implements DomainSocketChannel {
+public final class KQueueDomainSocketChannel
+        extends AbstractKQueueStreamChannel<UnixChannel, DomainSocketAddress, DomainSocketAddress>
+        implements DomainSocketChannel {
     private final KQueueDomainSocketChannelConfig config = new KQueueDomainSocketChannelConfig(this);
 
     private volatile DomainSocketAddress local;
@@ -47,7 +51,7 @@ public final class KQueueDomainSocketChannel extends AbstractKQueueStreamChannel
         this(null, eventLoop, new BsdSocket(fd));
     }
 
-    KQueueDomainSocketChannel(Channel parent, EventLoop eventLoop, BsdSocket fd) {
+    KQueueDomainSocketChannel(UnixChannel parent, EventLoop eventLoop, BsdSocket fd) {
         super(parent, eventLoop, fd, true);
     }
 
@@ -80,16 +84,6 @@ public final class KQueueDomainSocketChannel extends AbstractKQueueStreamChannel
             return true;
         }
         return false;
-    }
-
-    @Override
-    public DomainSocketAddress remoteAddress() {
-        return (DomainSocketAddress) super.remoteAddress();
-    }
-
-    @Override
-    public DomainSocketAddress localAddress() {
-        return (DomainSocketAddress) super.localAddress();
     }
 
     @Override

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueServerDomainSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueServerDomainSocketChannel.java
@@ -20,6 +20,7 @@ import io.netty5.channel.EventLoop;
 import io.netty5.channel.EventLoopGroup;
 import io.netty5.channel.unix.DomainSocketAddress;
 import io.netty5.channel.unix.ServerDomainSocketChannel;
+import io.netty5.channel.unix.UnixChannel;
 import io.netty5.util.internal.UnstableApi;
 import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
@@ -30,8 +31,9 @@ import java.net.SocketAddress;
 import static io.netty5.channel.kqueue.BsdSocket.newSocketDomain;
 
 @UnstableApi
-public final class KQueueServerDomainSocketChannel extends AbstractKQueueServerChannel
-                                                  implements ServerDomainSocketChannel {
+public final class KQueueServerDomainSocketChannel
+        extends AbstractKQueueServerChannel<UnixChannel, DomainSocketAddress, DomainSocketAddress>
+        implements ServerDomainSocketChannel {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(
             KQueueServerDomainSocketChannel.class);
 
@@ -89,15 +91,5 @@ public final class KQueueServerDomainSocketChannel extends AbstractKQueueServerC
     @Override
     public KQueueServerChannelConfig config() {
         return config;
-    }
-
-    @Override
-    public DomainSocketAddress remoteAddress() {
-        return (DomainSocketAddress) super.remoteAddress();
-    }
-
-    @Override
-    public DomainSocketAddress localAddress() {
-        return (DomainSocketAddress) super.localAddress();
     }
 }

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueServerSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueServerSocketChannel.java
@@ -19,6 +19,7 @@ import io.netty5.channel.Channel;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.EventLoopGroup;
 import io.netty5.channel.socket.ServerSocketChannel;
+import io.netty5.channel.unix.UnixChannel;
 import io.netty5.util.internal.UnstableApi;
 
 import java.net.InetSocketAddress;
@@ -28,7 +29,8 @@ import static io.netty5.channel.kqueue.BsdSocket.newSocketStream;
 import static io.netty5.channel.unix.NativeInetAddress.address;
 
 @UnstableApi
-public final class KQueueServerSocketChannel extends AbstractKQueueServerChannel implements ServerSocketChannel {
+public final class KQueueServerSocketChannel extends
+        AbstractKQueueServerChannel<UnixChannel, InetSocketAddress, InetSocketAddress> implements ServerSocketChannel {
     private final KQueueServerSocketChannelConfig config;
 
     public KQueueServerSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup) {
@@ -60,16 +62,6 @@ public final class KQueueServerSocketChannel extends AbstractKQueueServerChannel
             socket.setTcpFastOpen(true);
         }
         active = true;
-    }
-
-    @Override
-    public InetSocketAddress remoteAddress() {
-        return (InetSocketAddress) super.remoteAddress();
-    }
-
-    @Override
-    public InetSocketAddress localAddress() {
-        return (InetSocketAddress) super.localAddress();
     }
 
     @Override

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueSocketChannel.java
@@ -16,11 +16,9 @@
 package io.netty5.channel.kqueue;
 
 import io.netty5.buffer.api.Buffer;
-import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelOutboundBuffer;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.socket.InternetProtocolFamily;
-import io.netty5.channel.socket.ServerSocketChannel;
 import io.netty5.channel.socket.SocketChannel;
 import io.netty5.channel.unix.IovArray;
 import io.netty5.util.concurrent.GlobalEventExecutor;
@@ -31,7 +29,9 @@ import java.net.SocketAddress;
 import java.util.concurrent.Executor;
 
 @UnstableApi
-public final class KQueueSocketChannel extends AbstractKQueueStreamChannel implements SocketChannel {
+public final class KQueueSocketChannel
+        extends AbstractKQueueStreamChannel<KQueueServerSocketChannel, InetSocketAddress, InetSocketAddress>
+        implements SocketChannel {
     private final KQueueSocketChannelConfig config;
 
     public KQueueSocketChannel(EventLoop eventLoop) {
@@ -48,29 +48,15 @@ public final class KQueueSocketChannel extends AbstractKQueueStreamChannel imple
         config = new KQueueSocketChannelConfig(this);
     }
 
-    KQueueSocketChannel(Channel parent, EventLoop eventLoop, BsdSocket fd, InetSocketAddress remoteAddress) {
+    KQueueSocketChannel(KQueueServerSocketChannel parent, EventLoop eventLoop,
+                        BsdSocket fd, InetSocketAddress remoteAddress) {
         super(parent, eventLoop, fd, remoteAddress);
         config = new KQueueSocketChannelConfig(this);
     }
 
     @Override
-    public InetSocketAddress remoteAddress() {
-        return (InetSocketAddress) super.remoteAddress();
-    }
-
-    @Override
-    public InetSocketAddress localAddress() {
-        return (InetSocketAddress) super.localAddress();
-    }
-
-    @Override
     public KQueueSocketChannelConfig config() {
         return config;
-    }
-
-    @Override
-    public ServerSocketChannel parent() {
-        return (ServerSocketChannel) super.parent();
     }
 
     @Override

--- a/transport/src/main/java/io/netty5/channel/AbstractServerChannel.java
+++ b/transport/src/main/java/io/netty5/channel/AbstractServerChannel.java
@@ -33,7 +33,8 @@ import static java.util.Objects.requireNonNull;
  * <li>and the shortcut methods which calls the methods mentioned above
  * </ul>
  */
-public abstract class AbstractServerChannel extends AbstractChannel implements ServerChannel {
+public abstract class AbstractServerChannel<P extends Channel, L extends SocketAddress, R extends SocketAddress>
+        extends AbstractChannel<P, L, R> implements ServerChannel {
     private static final ChannelMetadata METADATA = new ChannelMetadata(false, 16);
 
     private final EventLoopGroup childEventLoopGroup;
@@ -47,42 +48,37 @@ public abstract class AbstractServerChannel extends AbstractChannel implements S
     }
 
     @Override
-    public EventLoopGroup childEventLoopGroup() {
+    public final EventLoopGroup childEventLoopGroup() {
         return childEventLoopGroup;
     }
 
     @Override
-    public ChannelMetadata metadata() {
+    public final ChannelMetadata metadata() {
         return METADATA;
     }
 
     @Override
-    public SocketAddress remoteAddress() {
+    protected final R remoteAddress0() {
         return null;
     }
 
     @Override
-    protected SocketAddress remoteAddress0() {
-        return null;
-    }
-
-    @Override
-    protected void doDisconnect() {
+    protected final void doDisconnect() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    protected void doShutdown(ChannelShutdownDirection direction) throws Exception {
+    protected final void doShutdown(ChannelShutdownDirection direction) throws Exception {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public boolean isShutdown(ChannelShutdownDirection direction) {
+    public final boolean isShutdown(ChannelShutdownDirection direction) {
         return !isActive();
     }
 
     @Override
-    protected void doWrite(ChannelOutboundBuffer in) throws Exception {
+    protected final void doWrite(ChannelOutboundBuffer in) throws Exception {
         throw new UnsupportedOperationException();
     }
 
@@ -92,7 +88,7 @@ public abstract class AbstractServerChannel extends AbstractChannel implements S
     }
 
     @Override
-    public void connectTransport(SocketAddress remoteAddress, SocketAddress localAddress, Promise<Void> promise) {
+    public final void connectTransport(SocketAddress remoteAddress, SocketAddress localAddress, Promise<Void> promise) {
         safeSetFailure(promise, new UnsupportedOperationException());
     }
 }

--- a/transport/src/main/java/io/netty5/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty5/channel/embedded/EmbeddedChannel.java
@@ -52,7 +52,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * Base class for {@link Channel} implementations that are used in an embedded fashion.
  */
-public class EmbeddedChannel extends AbstractChannel {
+public class EmbeddedChannel extends AbstractChannel<Channel, SocketAddress, SocketAddress> {
 
     private static final SocketAddress LOCAL_ADDRESS = new EmbeddedSocketAddress();
     private static final SocketAddress REMOTE_ADDRESS = new EmbeddedSocketAddress();

--- a/transport/src/main/java/io/netty5/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty5/channel/local/LocalChannel.java
@@ -50,7 +50,8 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 /**
  * A {@link Channel} for the local transport.
  */
-public class LocalChannel extends AbstractChannel implements LocalChannelUnsafe {
+public class LocalChannel extends AbstractChannel<LocalServerChannel, LocalAddress, LocalAddress>
+        implements LocalChannelUnsafe {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(LocalChannel.class);
     @SuppressWarnings("rawtypes")
     private static final AtomicReferenceFieldUpdater<LocalChannel, Future> FINISH_READ_FUTURE_UPDATER =
@@ -105,21 +106,6 @@ public class LocalChannel extends AbstractChannel implements LocalChannelUnsafe 
     }
 
     @Override
-    public LocalServerChannel parent() {
-        return (LocalServerChannel) super.parent();
-    }
-
-    @Override
-    public LocalAddress localAddress() {
-        return (LocalAddress) super.localAddress();
-    }
-
-    @Override
-    public LocalAddress remoteAddress() {
-        return (LocalAddress) super.remoteAddress();
-    }
-
-    @Override
     public boolean isOpen() {
         return state != State.CLOSED;
     }
@@ -130,12 +116,12 @@ public class LocalChannel extends AbstractChannel implements LocalChannelUnsafe 
     }
 
     @Override
-    protected SocketAddress localAddress0() {
+    protected LocalAddress localAddress0() {
         return localAddress;
     }
 
     @Override
-    protected SocketAddress remoteAddress0() {
+    protected LocalAddress remoteAddress0() {
         return remoteAddress;
     }
 

--- a/transport/src/main/java/io/netty5/channel/local/LocalServerChannel.java
+++ b/transport/src/main/java/io/netty5/channel/local/LocalServerChannel.java
@@ -26,7 +26,6 @@ import io.netty5.channel.EventLoopGroup;
 import io.netty5.channel.RecvBufferAllocator;
 import io.netty5.channel.ServerChannel;
 import io.netty5.channel.ServerChannelRecvBufferAllocator;
-import io.netty5.util.concurrent.Promise;
 
 import java.net.SocketAddress;
 import java.util.ArrayDeque;
@@ -35,7 +34,8 @@ import java.util.Queue;
 /**
  * A {@link ServerChannel} for the local transport which allows in VM communication.
  */
-public class LocalServerChannel extends AbstractServerChannel implements LocalChannelUnsafe {
+public class LocalServerChannel extends AbstractServerChannel<LocalChannel, LocalAddress, LocalAddress>
+        implements LocalChannelUnsafe {
 
     private final ChannelConfig config =
             new DefaultChannelConfig(this, new ServerChannelRecvBufferAllocator()) { };
@@ -55,16 +55,6 @@ public class LocalServerChannel extends AbstractServerChannel implements LocalCh
     }
 
     @Override
-    public LocalAddress localAddress() {
-        return (LocalAddress) super.localAddress();
-    }
-
-    @Override
-    public LocalAddress remoteAddress() {
-        return (LocalAddress) super.remoteAddress();
-    }
-
-    @Override
     public boolean isOpen() {
         return state < 2;
     }
@@ -75,7 +65,7 @@ public class LocalServerChannel extends AbstractServerChannel implements LocalCh
     }
 
     @Override
-    protected SocketAddress localAddress0() {
+    protected LocalAddress localAddress0() {
         return localAddress;
     }
 
@@ -153,11 +143,6 @@ public class LocalServerChannel extends AbstractServerChannel implements LocalCh
 
             readInbound();
         }
-    }
-
-    @Override
-    public void connectTransport(SocketAddress remoteAddress, SocketAddress localAddress, Promise<Void> promise) {
-        safeSetFailure(promise, new UnsupportedOperationException());
     }
 
     @Override

--- a/transport/src/main/java/io/netty5/channel/nio/AbstractNioByteChannel.java
+++ b/transport/src/main/java/io/netty5/channel/nio/AbstractNioByteChannel.java
@@ -32,6 +32,7 @@ import io.netty5.channel.socket.SocketChannelConfig;
 import io.netty5.util.internal.StringUtil;
 
 import java.io.IOException;
+import java.net.SocketAddress;
 import java.nio.channels.SelectableChannel;
 import java.nio.channels.SelectionKey;
 
@@ -40,17 +41,16 @@ import static io.netty5.channel.internal.ChannelUtils.WRITE_STATUS_SNDBUF_FULL;
 /**
  * {@link AbstractNioChannel} base class for {@link Channel}s that operate on bytes.
  */
-public abstract class AbstractNioByteChannel extends AbstractNioChannel {
+public abstract class AbstractNioByteChannel<P extends Channel, L extends SocketAddress, R extends SocketAddress>
+        extends AbstractNioChannel<P, L, R> {
     private static final ChannelMetadata METADATA = new ChannelMetadata(false, 16);
     private static final String EXPECTED_TYPES =
             " (expected: " + StringUtil.simpleClassName(Buffer.class) + ", " +
             StringUtil.simpleClassName(FileRegion.class) + ')';
 
-    private final Runnable flushTask = () -> {
-        // Calling flush0 directly to ensure we not try to flush messages that were added via write(...) in the
-        // meantime.
-        flush0();
-    };
+    // Calling flush0 directly to ensure we not try to flush messages that were added via write(...) in the
+    // meantime.
+    private final Runnable flushTask = this::flush0;
     private boolean inputClosedSeenErrorOnRead;
 
     /**
@@ -60,7 +60,7 @@ public abstract class AbstractNioByteChannel extends AbstractNioChannel {
      * @param eventLoop         the {@link EventLoop} to use for IO.
      * @param ch                the underlying {@link SelectableChannel} on which it operates
      */
-    protected AbstractNioByteChannel(Channel parent, EventLoop eventLoop, SelectableChannel ch) {
+    protected AbstractNioByteChannel(P parent, EventLoop eventLoop, SelectableChannel ch) {
         super(parent, eventLoop, ch, SelectionKey.OP_READ);
     }
 

--- a/transport/src/main/java/io/netty5/channel/nio/AbstractNioChannel.java
+++ b/transport/src/main/java/io/netty5/channel/nio/AbstractNioChannel.java
@@ -40,7 +40,8 @@ import java.util.concurrent.TimeUnit;
 /**
  * Abstract base class for {@link Channel} implementations which use a Selector based approach.
  */
-public abstract class AbstractNioChannel extends AbstractChannel {
+public abstract class AbstractNioChannel<P extends Channel, L extends SocketAddress, R extends SocketAddress>
+        extends AbstractChannel<P, L, R> {
 
     private static final InternalLogger logger =
             InternalLoggerFactory.getInstance(AbstractNioChannel.class);
@@ -67,7 +68,7 @@ public abstract class AbstractNioChannel extends AbstractChannel {
      * @param ch             the underlying {@link SelectableChannel} on which it operates
      * @param readInterestOp the ops to set to receive data from the {@link SelectableChannel}
      */
-    protected AbstractNioChannel(Channel parent, EventLoop eventLoop, SelectableChannel ch, int readInterestOp) {
+    protected AbstractNioChannel(P parent, EventLoop eventLoop, SelectableChannel ch, int readInterestOp) {
         super(parent, eventLoop);
         this.ch = ch;
         this.readInterestOp = readInterestOp;

--- a/transport/src/main/java/io/netty5/channel/nio/AbstractNioMessageChannel.java
+++ b/transport/src/main/java/io/netty5/channel/nio/AbstractNioMessageChannel.java
@@ -26,6 +26,7 @@ import io.netty5.channel.ServerChannel;
 
 import java.io.IOException;
 import java.net.PortUnreachableException;
+import java.net.SocketAddress;
 import java.nio.channels.SelectableChannel;
 import java.nio.channels.SelectionKey;
 import java.util.ArrayList;
@@ -34,14 +35,15 @@ import java.util.List;
 /**
  * {@link AbstractNioChannel} base class for {@link Channel}s that operate on messages.
  */
-public abstract class AbstractNioMessageChannel extends AbstractNioChannel {
+public abstract class AbstractNioMessageChannel<P extends Channel, L extends SocketAddress, R extends SocketAddress>
+        extends AbstractNioChannel<P, L, R> {
     boolean inputShutdown;
     private final List<Object> readBuf = new ArrayList<>();
 
     /**
      * @see AbstractNioChannel#AbstractNioChannel(Channel, EventLoop, SelectableChannel, int)
      */
-    protected AbstractNioMessageChannel(Channel parent, EventLoop eventLoop, SelectableChannel ch, int readInterestOp) {
+    protected AbstractNioMessageChannel(P parent, EventLoop eventLoop, SelectableChannel ch, int readInterestOp) {
         super(parent, eventLoop, ch, readInterestOp);
     }
 

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioDatagramChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioDatagramChannel.java
@@ -67,7 +67,8 @@ import static java.util.Objects.requireNonNull;
  * @see DatagramPacket
  */
 public final class NioDatagramChannel
-        extends AbstractNioMessageChannel implements io.netty5.channel.socket.DatagramChannel {
+        extends AbstractNioMessageChannel<Channel, InetSocketAddress, InetSocketAddress>
+        implements io.netty5.channel.socket.DatagramChannel {
 
     private static final ChannelMetadata METADATA = new ChannelMetadata(true);
     private static final SelectorProvider DEFAULT_SELECTOR_PROVIDER = SelectorProvider.provider();
@@ -211,13 +212,13 @@ public final class NioDatagramChannel
     }
 
     @Override
-    protected SocketAddress localAddress0() {
-        return javaChannel().socket().getLocalSocketAddress();
+    protected InetSocketAddress localAddress0() {
+        return (InetSocketAddress) javaChannel().socket().getLocalSocketAddress();
     }
 
     @Override
-    protected SocketAddress remoteAddress0() {
-        return javaChannel().socket().getRemoteSocketAddress();
+    protected InetSocketAddress remoteAddress0() {
+        return (InetSocketAddress) javaChannel().socket().getRemoteSocketAddress();
     }
 
     @Override
@@ -378,16 +379,6 @@ public final class NioDatagramChannel
         //
         // See https://github.com/netty/netty/issues/2665
         return true;
-    }
-
-    @Override
-    public InetSocketAddress localAddress() {
-        return (InetSocketAddress) super.localAddress();
-    }
-
-    @Override
-    public InetSocketAddress remoteAddress() {
-        return (InetSocketAddress) super.remoteAddress();
     }
 
     @Override

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioServerSocketChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioServerSocketChannel.java
@@ -15,6 +15,7 @@
  */
 package io.netty5.channel.socket.nio;
 
+import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelException;
 import io.netty5.channel.ChannelMetadata;
 import io.netty5.channel.ChannelOption;
@@ -48,7 +49,7 @@ import static java.util.Objects.requireNonNull;
  * A {@link io.netty5.channel.socket.ServerSocketChannel} implementation which uses
  * NIO selector based implementation to accept new connections.
  */
-public class NioServerSocketChannel extends AbstractNioMessageChannel
+public class NioServerSocketChannel extends AbstractNioMessageChannel<Channel, InetSocketAddress, InetSocketAddress>
                              implements io.netty5.channel.socket.ServerSocketChannel {
 
     private static final ChannelMetadata METADATA = new ChannelMetadata(false, 16);
@@ -110,11 +111,6 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel
     }
 
     @Override
-    public InetSocketAddress localAddress() {
-        return (InetSocketAddress) super.localAddress();
-    }
-
-    @Override
     public ChannelMetadata metadata() {
         return METADATA;
     }
@@ -132,18 +128,13 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel
     }
 
     @Override
-    public InetSocketAddress remoteAddress() {
-        return null;
-    }
-
-    @Override
     protected ServerSocketChannel javaChannel() {
         return (ServerSocketChannel) super.javaChannel();
     }
 
     @Override
-    protected SocketAddress localAddress0() {
-        return SocketUtils.localSocketAddress(javaChannel().socket());
+    protected InetSocketAddress localAddress0() {
+        return (InetSocketAddress) SocketUtils.localSocketAddress(javaChannel().socket());
     }
 
     @Override
@@ -201,7 +192,7 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel
     }
 
     @Override
-    protected SocketAddress remoteAddress0() {
+    protected InetSocketAddress remoteAddress0() {
         return null;
     }
 

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioSocketChannel.java
@@ -27,7 +27,6 @@ import io.netty5.channel.RecvBufferAllocator;
 import io.netty5.channel.nio.AbstractNioByteChannel;
 import io.netty5.channel.socket.DefaultSocketChannelConfig;
 import io.netty5.channel.socket.InternetProtocolFamily;
-import io.netty5.channel.socket.ServerSocketChannel;
 import io.netty5.channel.socket.SocketChannelConfig;
 import io.netty5.util.concurrent.GlobalEventExecutor;
 import io.netty5.util.internal.SocketUtils;
@@ -49,7 +48,9 @@ import static io.netty5.channel.internal.ChannelUtils.MAX_BYTES_PER_GATHERING_WR
 /**
  * {@link io.netty5.channel.socket.SocketChannel} which uses NIO selector based implementation.
  */
-public class NioSocketChannel extends AbstractNioByteChannel implements io.netty5.channel.socket.SocketChannel {
+public class NioSocketChannel
+        extends AbstractNioByteChannel<NioServerSocketChannel, InetSocketAddress, InetSocketAddress>
+        implements io.netty5.channel.socket.SocketChannel {
     private static final SelectorProvider DEFAULT_SELECTOR_PROVIDER = SelectorProvider.provider();
 
     private static final Method OPEN_SOCKET_CHANNEL_WITH_FAMILY =
@@ -101,14 +102,9 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
      * @param eventLoop the {@link EventLoop} to use for IO.
      * @param socket    the {@link SocketChannel} which will be used
      */
-    public NioSocketChannel(Channel parent, EventLoop eventLoop, SocketChannel socket) {
+    public NioSocketChannel(NioServerSocketChannel parent, EventLoop eventLoop, SocketChannel socket) {
         super(parent, eventLoop, socket);
         config = new NioSocketChannelConfig(this, socket.socket());
-    }
-
-    @Override
-    public ServerSocketChannel parent() {
-        return (ServerSocketChannel) super.parent();
     }
 
     @Override
@@ -143,16 +139,6 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
     }
 
     @Override
-    public InetSocketAddress localAddress() {
-        return (InetSocketAddress) super.localAddress();
-    }
-
-    @Override
-    public InetSocketAddress remoteAddress() {
-        return (InetSocketAddress) super.remoteAddress();
-    }
-
-    @Override
     protected void doShutdown(ChannelShutdownDirection direction) throws Exception {
         switch (direction) {
             case Inbound:
@@ -167,13 +153,13 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
     }
 
     @Override
-    protected SocketAddress localAddress0() {
-        return javaChannel().socket().getLocalSocketAddress();
+    protected InetSocketAddress localAddress0() {
+        return (InetSocketAddress) javaChannel().socket().getLocalSocketAddress();
     }
 
     @Override
-    protected SocketAddress remoteAddress0() {
-        return javaChannel().socket().getRemoteSocketAddress();
+    protected InetSocketAddress remoteAddress0() {
+        return (InetSocketAddress) javaChannel().socket().getRemoteSocketAddress();
     }
 
     @Override

--- a/transport/src/test/java/io/netty5/channel/AbstractChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/AbstractChannelTest.java
@@ -198,7 +198,7 @@ public class AbstractChannelTest {
         channel.register().sync(); // Cause any exceptions to be thrown
     }
 
-    private static class TestChannel extends AbstractChannel {
+    private static class TestChannel extends AbstractChannel<Channel, SocketAddress, SocketAddress> {
         private static final ChannelMetadata TEST_METADATA = new ChannelMetadata(false);
 
         private final ChannelConfig config = new DefaultChannelConfig(this);

--- a/transport/src/test/java/io/netty5/channel/ChannelOutboundBufferTest.java
+++ b/transport/src/test/java/io/netty5/channel/ChannelOutboundBufferTest.java
@@ -223,7 +223,7 @@ public class ChannelOutboundBufferTest {
         }
     }
 
-    private static final class TestChannel extends AbstractChannel {
+    private static final class TestChannel extends AbstractChannel<Channel, SocketAddress, SocketAddress> {
         private static final ChannelMetadata TEST_METADATA = new ChannelMetadata(false);
         private final ChannelConfig config = new DefaultChannelConfig(this);
 

--- a/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTailTest.java
+++ b/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTailTest.java
@@ -180,7 +180,7 @@ public class DefaultChannelPipelineTailTest {
         }
     }
 
-    private abstract static class MyChannel extends AbstractChannel {
+    private abstract static class MyChannel extends AbstractChannel<Channel, SocketAddress, SocketAddress> {
         private static final ChannelMetadata METADATA = new ChannelMetadata(false);
 
         private final ChannelConfig config = new DefaultChannelConfig(this);


### PR DESCRIPTION
Motivation:

We can use generics to tighten up the AbstractChannel and so remove some cast / overrides.

Modifications:

Use generics to define the parent, localaddress and remoteaddress types

Result:

Cleanup
