### PR TITLE
Ensure failures are really propagted to the caller of Http2TestUtil.r…

### DIFF
--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2TestUtil.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2TestUtil.java
@@ -59,14 +59,11 @@ public final class Http2TestUtil {
     /**
      * Runs the given operation within the event loop thread of the given {@link Channel}.
      */
-    static void runInChannel(Channel channel, final Http2Runnable runnable) {
-        channel.executor().execute(() -> {
-            try {
-                runnable.run();
-            } catch (Http2Exception e) {
-                throw new RuntimeException(e);
-            }
-        });
+    static void runInChannel(Channel channel, final Http2Runnable runnable) throws InterruptedException {
+        channel.executor().submit(() -> {
+            runnable.run();
+            return null;
+        }).sync();
     }
 
     /**


### PR DESCRIPTION
…unInChannel(...)

Motivation:

We should use executor.submit(...).sync() to ensure we really propagate any failure to the caller of the method.

Modifications:

Use submit(...).sync()

Result:

Failures will be correctly propagated in tests
