### PR TITLE
Move register / deregister methods to EventLoop interface directly

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
@@ -176,25 +176,6 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
                 future.cancel();
                 connectTimeoutFuture = null;
             }
-
-            if (isRegistered()) {
-                // Need to check if we are on the EventLoop as doClose() may be triggered by the GlobalEventExecutor
-                // if SO_LINGER is used.
-                //
-                // See https://github.com/netty/netty/issues/7159
-                EventLoop loop = executor();
-                if (loop.inEventLoop()) {
-                    doDeregister();
-                } else {
-                    loop.execute(() -> {
-                        try {
-                            doDeregister();
-                        } catch (Throwable cause) {
-                            pipeline().fireChannelExceptionCaught(cause);
-                        }
-                    });
-                }
-            }
         } finally {
             socket.close();
         }

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollStreamChannel.java
@@ -420,12 +420,6 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel {
         }
     }
 
-    // Overridden here just to be able to access this method from AbstractEpollStreamChannel
-    @Override
-    protected Executor prepareToClose() {
-        return super.prepareToClose();
-    }
-
     private void handleReadException(ChannelPipeline pipeline, Buffer buffer, Throwable cause, boolean close,
             EpollRecvBufferAllocatorHandle allocHandle) {
         if (buffer.readableBytes() > 0) {

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueStreamChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueStreamChannel.java
@@ -403,12 +403,6 @@ public abstract class AbstractKQueueStreamChannel extends AbstractKQueueChannel 
         }
     }
 
-    // Overridden here just to be able to access this method from AbstractKQueueStreamChannel
-    @Override
-    protected Executor prepareToClose() {
-        return super.prepareToClose();
-    }
-
     @Override
     void readReady(final KQueueRecvBufferAllocatorHandle allocHandle) {
         final ChannelConfig config = config();

--- a/transport/src/main/java/io/netty5/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty5/channel/AbstractChannel.java
@@ -324,26 +324,38 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                 return;
             }
             boolean firstRegistration = neverRegistered;
-            doRegister();
-            neverRegistered = false;
-            registered = true;
+            executor().registerForIO(this).addListener(f -> {
+                if (f.isSuccess()) {
 
-            safeSetSuccess(promise);
-            pipeline.fireChannelRegistered();
-            // Only fire a channelActive if the channel has never been registered. This prevents firing
-            // multiple channel actives if the channel is deregistered and re-registered.
-            if (isActive()) {
-                if (firstRegistration) {
-                    pipeline.fireChannelActive();
+                    neverRegistered = false;
+                    registered = true;
+
+                    safeSetSuccess(promise);
+                    pipeline.fireChannelRegistered();
+                    // Only fire a channelActive if the channel has never been registered. This prevents firing
+                    // multiple channel actives if the channel is deregistered and re-registered.
+                    if (isActive()) {
+                        if (firstRegistration) {
+                            pipeline.fireChannelActive();
+                        }
+                        readIfIsAutoRead();
+                    }
+                } else {
+                    // Close the channel directly to avoid FD leak.
+                    closeNowAndFail(promise, f.cause());
                 }
-                readIfIsAutoRead();
-            }
+            });
+
         } catch (Throwable t) {
             // Close the channel directly to avoid FD leak.
-            closeForciblyTransport();
-            closePromise.setClosed();
-            safeSetFailure(promise, t);
+            closeNowAndFail(promise, t);
         }
+    }
+
+    private void closeNowAndFail(Promise<Void> promise, Throwable cause) {
+        closeForciblyTransport();
+        closePromise.setClosed();
+        safeSetFailure(promise, cause);
     }
 
     private void bindTransport(final SocketAddress localAddress, final Promise<Void> promise) {
@@ -475,38 +487,51 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         final boolean wasActive = isActive();
         final ChannelOutboundBuffer outboundBuffer = this.outboundBuffer;
         this.outboundBuffer = null; // Disallow adding any messages and flushes to outboundBuffer.
-        Executor closeExecutor = prepareToClose();
-        if (closeExecutor != null) {
-            closeExecutor.execute(() -> {
-                try {
-                    // Execute the close.
-                    doClose0(promise);
-                } finally {
-                    // Call invokeLater so closeAndDeregister is executed in the EventLoop again!
-                    invokeLater(() -> {
-                        if (outboundBuffer != null) {
-                            // Fail all the queued messages
-                            outboundBuffer.failFlushedAndClose(cause, notify, closeCause, false);
+        Future<Executor> closeExecutorFuture = prepareToClose();
+        if (closeExecutorFuture != null) {
+            closeExecutorFuture.addListener(f -> {
+                if (f.isFailed()) {
+                    logger.warn("We couldnt obtain the closeExecutor", f.cause());
+                    closeNow(outboundBuffer, wasActive, promise, cause, closeCause, notify);
+                } else {
+                    Executor closeExecutor = f.getNow();
+                    closeExecutor.execute(() -> {
+                        try {
+                            // Execute the close.
+                            doClose0(promise);
+                        } finally {
+                            // Call invokeLater so closeAndDeregister is executed in the EventLoop again!
+                            invokeLater(() -> {
+                                if (outboundBuffer != null) {
+                                    // Fail all the queued messages
+                                    outboundBuffer.failFlushedAndClose(cause, notify, closeCause, false);
+                                }
+                                fireChannelInactiveAndDeregister(wasActive);
+                            });
                         }
-                        fireChannelInactiveAndDeregister(wasActive);
                     });
                 }
             });
         } else {
-            try {
-                // Close the channel and fail the queued messages in all cases.
-                doClose0(promise);
-            } finally {
-                if (outboundBuffer != null) {
-                    // Fail all the queued messages.
-                    outboundBuffer.failFlushedAndClose(cause, notify, closeCause, false);
-                }
+            closeNow(outboundBuffer, wasActive, promise, cause, closeCause, notify);
+        }
+    }
+
+    private void closeNow(ChannelOutboundBuffer outboundBuffer, boolean wasActive, Promise<Void> promise,
+                          Throwable cause, ClosedChannelException closeCause, boolean notify) {
+        try {
+            // Close the channel and fail the queued messages in all cases.
+            doClose0(promise);
+        } finally {
+            if (outboundBuffer != null) {
+                // Fail all the queued messages.
+                outboundBuffer.failFlushedAndClose(cause, notify, closeCause, false);
             }
-            if (inFlush0) {
-                invokeLater(() -> fireChannelInactiveAndDeregister(wasActive));
-            } else {
-                fireChannelInactiveAndDeregister(wasActive);
-            }
+        }
+        if (inFlush0) {
+            invokeLater(() -> fireChannelInactiveAndDeregister(wasActive));
+        } else {
+            fireChannelInactiveAndDeregister(wasActive);
         }
     }
 
@@ -575,7 +600,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         }
     }
 
-    private void deregisterTransport(final Promise<Void> promise) {
+    protected void deregisterTransport(final Promise<Void> promise) {
         assertEventLoop();
 
         deregister(promise, false);
@@ -602,40 +627,48 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         // https://github.com/netty/netty/issues/4435
         invokeLater(() -> {
             try {
-                doDeregister();
+                eventLoop.deregisterForIO(this).addListener(f -> {
+                    if (f.isFailed()) {
+                        logger.warn("Unexpected exception occurred while deregistering a channel.", f.cause());
+                    }
+                    deregisterDone(fireChannelInactive, promise);
+                });
             } catch (Throwable t) {
                 logger.warn("Unexpected exception occurred while deregistering a channel.", t);
-            } finally {
-                if (fireChannelInactive) {
-                    pipeline.fireChannelInactive();
-                }
-                // Some transports like local and AIO does not allow the deregistration of
-                // an open channel. Their doDeregister() calls close(). Consequently,
-                // close() calls deregister() again - no need to fire channelUnregistered, so check
-                // if it was registered.
-                if (registered) {
-                    registered = false;
-                    pipeline.fireChannelUnregistered();
-
-                    if (!isOpen()) {
-                        // Remove all handlers from the ChannelPipeline. This is needed to ensure
-                        // handlerRemoved(...) is called and so resources are released.
-                        while (!pipeline.isEmpty()) {
-                            try {
-                                pipeline.removeLast();
-                            } catch (NoSuchElementException ignore) {
-                                // try again as there may be a race when someone outside the EventLoop removes
-                                // handlers concurrently as well.
-                            }
-                        }
-                    }
-                }
-                safeSetSuccess(promise);
+                deregisterDone(fireChannelInactive, promise);
             }
         });
     }
 
-    private  void readTransport() {
+    private void deregisterDone(boolean fireChannelInactive, Promise<Void> promise) {
+        if (fireChannelInactive) {
+            pipeline.fireChannelInactive();
+        }
+        // Some transports like local and AIO does not allow the deregistration of
+        // an open channel. Their doDeregister() calls close(). Consequently,
+        // close() calls deregister() again - no need to fire channelUnregistered, so check
+        // if it was registered.
+        if (registered) {
+            registered = false;
+            pipeline.fireChannelUnregistered();
+
+            if (!isOpen()) {
+                // Remove all handlers from the ChannelPipeline. This is needed to ensure
+                // handlerRemoved(...) is called and so resources are released.
+                while (!pipeline.isEmpty()) {
+                    try {
+                        pipeline.removeLast();
+                    } catch (NoSuchElementException ignore) {
+                        // try again as there may be a race when someone outside the EventLoop removes
+                        // handlers concurrently as well.
+                    }
+                }
+            }
+        }
+        safeSetSuccess(promise);
+    }
+
+    private void readTransport() {
         assertEventLoop();
 
         if (!isActive()) {
@@ -870,7 +903,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
      * {@link #doClose()} on the returned {@link Executor}. If this method returns {@code null},
      * {@link #doClose()} must be called from the caller thread. (i.e. {@link EventLoop})
      */
-    protected Executor prepareToClose() {
+    protected Future<Executor> prepareToClose() {
         return null;
     }
 
@@ -889,15 +922,6 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
     protected abstract SocketAddress remoteAddress0();
 
     /**
-     * Is called after the {@link Channel} is registered with its {@link EventLoop} as part of the register process.
-     *
-     * Sub-classes may override this method
-     */
-    protected void doRegister() throws Exception {
-        executor().unsafe().register(this);
-    }
-
-    /**
      * Bind the {@link Channel} to the {@link SocketAddress}
      */
     protected abstract void doBind(SocketAddress localAddress) throws Exception;
@@ -913,15 +937,6 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
     protected abstract void doClose() throws Exception;
 
     protected abstract void doShutdown(ChannelShutdownDirection direction) throws Exception;
-
-    /**
-     * Deregister the {@link Channel} from its {@link EventLoop}.
-     *
-     * Sub-classes may override this method
-     */
-    protected void doDeregister() throws Exception {
-        executor().unsafe().deregister(this);
-    }
 
     /**
      * Schedule a read operation.

--- a/transport/src/main/java/io/netty5/channel/EventLoop.java
+++ b/transport/src/main/java/io/netty5/channel/EventLoop.java
@@ -15,14 +15,14 @@
  */
 package io.netty5.channel;
 
+import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.OrderedEventExecutor;
 
 /**
  * Will handle all the I/O operations for a {@link Channel} once registered.
- *
+ *<p>
  * One {@link EventLoop} instance will usually handle more than one {@link Channel} but this may depend on
  * implementation details and internals.
- *
  */
 public interface EventLoop extends OrderedEventExecutor, EventLoopGroup {
 
@@ -32,23 +32,18 @@ public interface EventLoop extends OrderedEventExecutor, EventLoopGroup {
     }
 
     /**
-     * Returns an <em>internal-use-only</em> object that provides unsafe operations.
+     * Register the {@link Channel} to the {@link EventLoop} for I/O processing.
+     *
+     * @param channel   the {@link Channel} to register.
+     * @return          the {@link Future} that is notified once the operations completes.
      */
-    Unsafe unsafe();
+    Future<Void> registerForIO(Channel channel);
 
     /**
-     * <em>Unsafe</em> operations that should <em>never</em> be called from user-code. These methods
-     * are only provided to implement the actual transport, and must be invoked from the {@link EventLoop} itself.
+     * Deregister the {@link Channel} from the {@link EventLoop} for I/O processing.
+     *
+     * @param channel   the {@link Channel} to deregister.
+     * @return          the {@link Future} that is notified once the operations completes.
      */
-    interface Unsafe {
-        /**
-         * Register the {@link Channel} to the {@link EventLoop}.
-         */
-        void register(Channel channel) throws Exception;
-
-        /**
-         * Deregister the {@link Channel} from the {@link EventLoop}.
-         */
-        void deregister(Channel channel) throws Exception;
-    }
+    Future<Void> deregisterForIO(Channel channel);
 }

--- a/transport/src/main/java/io/netty5/channel/IoHandler.java
+++ b/transport/src/main/java/io/netty5/channel/IoHandler.java
@@ -20,7 +20,7 @@ package io.netty5.channel;
  * All operations except {@link #wakeup(boolean)} <strong>MUST</strong> be executed
  * on the {@link EventLoop} thread and should never be called from the user-directly.
  */
-public interface IoHandler extends EventLoop.Unsafe {
+public interface IoHandler {
     /**
      * Run the IO handled by this {@link IoHandler}. The {@link IoExecutionContext} should be used
      * to ensure we not execute too long and so block the processing of other task that are
@@ -47,4 +47,20 @@ public interface IoHandler extends EventLoop.Unsafe {
      * Destroy the {@link IoHandler} and free all its resources.
      */
     void destroy();
+
+    /**
+     * Register a {@link Channel} for IO.
+     *
+     * @param channel       the {@link Channel} to register..
+     * @throws Exception    thrown if an error happens during registration.
+     */
+    void register(Channel channel) throws Exception;
+
+    /**
+     * Deregister a {@link Channel} for IO.
+     *
+     * @param channel       the {@link Channel} to deregister..
+     * @throws Exception    thrown if an error happens during deregistration.
+     */
+    void deregister(Channel channel) throws Exception;
 }

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioSocketChannel.java
@@ -29,6 +29,7 @@ import io.netty5.channel.socket.DefaultSocketChannelConfig;
 import io.netty5.channel.socket.InternetProtocolFamily;
 import io.netty5.channel.socket.ServerSocketChannel;
 import io.netty5.channel.socket.SocketChannelConfig;
+import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.GlobalEventExecutor;
 import io.netty5.util.internal.SocketUtils;
 
@@ -320,15 +321,14 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
     }
 
     @Override
-    protected Executor prepareToClose() {
+    protected Future<Executor> prepareToClose() {
         try {
             if (javaChannel().isOpen() && config().getSoLinger() > 0) {
                 // We need to cancel this key of the channel so we may not end up in a eventloop spin
                 // because we try to read or write until the actual close happens which may be later due
                 // SO_LINGER handling.
                 // See https://github.com/netty/netty/issues/4449
-                doDeregister();
-                return GlobalEventExecutor.INSTANCE;
+                return executor().deregisterForIO(this).map(v -> GlobalEventExecutor.INSTANCE);
             }
         } catch (Throwable ignore) {
             // Ignore the error as the underlying channel may be closed in the meantime and so

--- a/transport/src/test/java/io/netty5/channel/AbstractChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/AbstractChannelTest.java
@@ -43,7 +43,6 @@ public class AbstractChannelTest {
         EventLoop eventLoop = mock(EventLoop.class);
         // This allows us to have a single-threaded test
         when(eventLoop.inEventLoop()).thenReturn(true);
-        when(eventLoop.unsafe()).thenReturn(mock(EventLoop.Unsafe.class));
         when(eventLoop.newPromise()).thenReturn(INSTANCE.newPromise());
 
         TestChannel channel = new TestChannel(eventLoop);
@@ -78,7 +77,6 @@ public class AbstractChannelTest {
         final EventLoop eventLoop = mock(EventLoop.class);
         // This allows us to have a single-threaded test
         when(eventLoop.inEventLoop()).thenReturn(true);
-        when(eventLoop.unsafe()).thenReturn(mock(EventLoop.Unsafe.class));
         when(eventLoop.newPromise()).thenAnswer(inv -> INSTANCE.newPromise());
 
         doAnswer(invocationOnMock -> {
@@ -134,7 +132,6 @@ public class AbstractChannelTest {
         final EventLoop eventLoop = mock(EventLoop.class);
         // This allows us to have a single-threaded test
         when(eventLoop.inEventLoop()).thenReturn(true);
-        when(eventLoop.unsafe()).thenReturn(mock(EventLoop.Unsafe.class));
         when(eventLoop.newPromise()).thenAnswer(inv -> INSTANCE.newPromise());
         doAnswer(invocationOnMock -> {
             ((Runnable) invocationOnMock.getArgument(0)).run();

--- a/transport/src/test/java/io/netty5/channel/SingleThreadEventLoopTest.java
+++ b/transport/src/test/java/io/netty5/channel/SingleThreadEventLoopTest.java
@@ -472,8 +472,13 @@ public class SingleThreadEventLoopTest {
         }
 
         @Override
-        public Unsafe unsafe() {
-            return null;
+        public Future<Void> registerForIO(Channel channel) {
+            return newSucceededFuture(null);
+        }
+
+        @Override
+        public Future<Void> deregisterForIO(Channel channel) {
+            return newSucceededFuture(null);
         }
     }
 
@@ -513,18 +518,13 @@ public class SingleThreadEventLoopTest {
         }
 
         @Override
-        public Unsafe unsafe() {
-            return new Unsafe() {
-                @Override
-                public void register(Channel channel)  {
-                    // NOOP
-                }
+        public Future<Void> registerForIO(Channel channel) {
+            return newSucceededFuture(null);
+        }
 
-                @Override
-                public void deregister(Channel channel) {
-                    // NOOP
-                }
-            };
+        @Override
+        public Future<Void> deregisterForIO(Channel channel) {
+            return newSucceededFuture(null);
         }
     }
 }

--- a/transport/src/test/java/io/netty5/channel/local/LocalChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/local/LocalChannelTest.java
@@ -19,7 +19,6 @@ import io.netty5.bootstrap.Bootstrap;
 import io.netty5.bootstrap.ServerBootstrap;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
-import io.netty5.channel.AbstractChannel;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
@@ -276,7 +275,7 @@ public class LocalChannelTest {
                     @Override
                     protected void run() {
                         do {
-                            runIo();
+                            runIO();
                             Runnable task = pollTask();
                             if (task != null) {
                                 /* Only slow down the anonymous class in LocalChannel#doRegister() */

--- a/transport/src/test/java/io/netty5/channel/socket/nio/AbstractNioChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/socket/nio/AbstractNioChannelTest.java
@@ -15,6 +15,7 @@
  */
 package io.netty5.channel.socket.nio;
 
+import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelOption;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.EventLoopGroup;
@@ -113,11 +114,6 @@ public abstract class AbstractNioChannelTest<T extends AbstractNioChannel> {
             }
 
             @Override
-            public Unsafe unsafe() {
-                return eventLoop.unsafe();
-            }
-
-            @Override
             public boolean inEventLoop(Thread thread) {
                 return eventLoop.inEventLoop(thread);
             }
@@ -177,6 +173,16 @@ public abstract class AbstractNioChannelTest<T extends AbstractNioChannel> {
             public Future<Void> scheduleWithFixedDelay(
                     Runnable task, long initialDelay, long delay, TimeUnit unit) {
                 return eventLoop.scheduleWithFixedDelay(task, initialDelay, delay, unit);
+            }
+
+            @Override
+            public Future<Void> registerForIO(Channel channel) {
+                return eventLoop.registerForIO(channel);
+            }
+
+            @Override
+            public Future<Void> deregisterForIO(Channel channel) {
+                return eventLoop.deregisterForIO(channel);
             }
         }
 


### PR DESCRIPTION
Motivation:

There is no need to have the EventLoop.Unsafe interface at all. Let's just streamline this a bit and move the methods to EventLoop directly

Modifications:

- Move register / deregister methods to EventLoop.
- Rewrite implementations

Result:

More user-friendly API
