### PR TITLE
The Http2ConnectionRoundtripTest is quite flaky, lets disable it for now

### DIFF
--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -38,6 +38,7 @@ import io.netty5.util.concurrent.ImmediateEventExecutor;
 import io.netty5.util.concurrent.Promise;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 import org.mockito.Mock;
@@ -88,6 +89,7 @@ import static org.mockito.Mockito.verify;
 /**
  * Tests the full HTTP/2 framing stack including the connection and preface handlers.
  */
+@Disabled
 public class Http2ConnectionRoundtripTest {
 
     private static final long DEFAULT_AWAIT_TIMEOUT_SECONDS = 15;


### PR DESCRIPTION
Motivation:

We saw a lot of Http2ConnectionRoundtripTest failures recently which made the build quite flaky. We should disable it for now and investigage

Modifications:

Disable Http2ConnectionRoundtripTest for now

Result:

Hopefully less flaky build
