### PR TITLE
Add Better Path Handling

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilTest.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.http2;
 
 import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
@@ -172,39 +173,38 @@ public class HttpConversionUtilTest {
         HttpConversionUtil.toHttp2Headers(inHeaders, out);
         assertEquals(1, out.size());
         assertSame("world", out.get("hello"));
-    }  
+    }
 
     @Test
     public void handlesRequest() throws Exception {
         boolean validateHeaders = true;
-        HttpRequest msg = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "http://example.com/path/to/something", validateHeaders);
+        HttpRequest msg = new DefaultHttpRequest(
+            HttpVersion.HTTP_1_1, HttpMethod.GET, "http://example.com/path/to/something", validateHeaders);
         HttpHeaders inHeaders = msg.headers();
         inHeaders.add(CONNECTION, "foo,  bar");
-        inHeaders.add("foo", "baz");
-        inHeaders.add("bar", "qux");
         inHeaders.add("hello", "world");
         Http2Headers out = HttpConversionUtil.toHttp2Headers(msg, validateHeaders);
-        assertEquals("/path/to/something", out.path());
-        assertEquals("http", out.scheme());
-        assertEquals("example.com", out.authority());
+        assertEquals(new AsciiString("/path/to/something"), out.path());
+        assertEquals(new AsciiString("http"), out.scheme());
+        assertEquals(new AsciiString("example.com"), out.authority());
         assertEquals(HttpMethod.GET.asciiName(), out.method());
+        assertEquals("world", out.get("hello"));
     }
 
     @Test
     public void handlesRequestWithDoubleSlashPath() throws Exception {
         boolean validateHeaders = true;
-        HttpRequest msg = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "//path/to/something", validateHeaders);
+        HttpRequest msg = new DefaultHttpRequest(
+            HttpVersion.HTTP_1_1, HttpMethod.GET, "//path/to/something", validateHeaders);
         HttpHeaders inHeaders = msg.headers();
         inHeaders.add(CONNECTION, "foo,  bar");
         inHeaders.add(HOST, "example.com");
         inHeaders.add(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), "http");
-        inHeaders.add("foo", "baz");
-        inHeaders.add("bar", "qux");
         inHeaders.add("hello", "world");
         Http2Headers out = HttpConversionUtil.toHttp2Headers(msg, validateHeaders);
-        assertEquals("//path/to/something", out.path());
-        assertEquals("http", out.scheme());
-        assertEquals("example.com", out.authority());
+        assertEquals(new AsciiString("//path/to/something"), out.path());
+        assertEquals(new AsciiString("http"), out.scheme());
+        assertEquals(new AsciiString("example.com"), out.authority());
         assertEquals(HttpMethod.GET.asciiName(), out.method());
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilTest.java
@@ -187,7 +187,7 @@ public class HttpConversionUtilTest {
         assertEquals("/path/to/something", out.path());
         assertEquals("http", out.scheme());
         assertEquals("example.com", out.authority());
-        assertEquals(HttpMethod.GET..asciiName(), out.method());
+        assertEquals(HttpMethod.GET.asciiName(), out.method());
     }
 
     @Test
@@ -205,7 +205,7 @@ public class HttpConversionUtilTest {
         assertEquals("//path/to/something", out.path());
         assertEquals("http", out.scheme());
         assertEquals("example.com", out.authority());
-        assertEquals(HttpMethod.GET..asciiName(), out.method());
+        assertEquals(HttpMethod.GET.asciiName(), out.method());
     }
 
     @Test

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilTest.java
@@ -172,6 +172,40 @@ public class HttpConversionUtilTest {
         HttpConversionUtil.toHttp2Headers(inHeaders, out);
         assertEquals(1, out.size());
         assertSame("world", out.get("hello"));
+    }  
+
+    @Test
+    public void handlesRequest() throws Exception {
+        boolean validateHeaders = true;
+        HttpRequest msg = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "http://example.com/path/to/something", validateHeaders);
+        HttpHeaders inHeaders = msg.headers();
+        inHeaders.add(CONNECTION, "foo,  bar");
+        inHeaders.add("foo", "baz");
+        inHeaders.add("bar", "qux");
+        inHeaders.add("hello", "world");
+        Http2Headers out = HttpConversionUtil.toHttp2Headers(msg, validateHeaders);
+        assertEquals("/path/to/something", out.path());
+        assertEquals("http", out.scheme());
+        assertEquals("example.com", out.authority());
+        assertEquals(HttpMethod.GET..asciiName(), out.method());
+    }
+
+    @Test
+    public void handlesRequestWithDoubleSlashPath() throws Exception {
+        boolean validateHeaders = true;
+        HttpRequest msg = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "//path/to/something", validateHeaders);
+        HttpHeaders inHeaders = msg.headers();
+        inHeaders.add(CONNECTION, "foo,  bar");
+        inHeaders.add(HOST, "example.com");
+        inHeaders.add(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), "http");
+        inHeaders.add("foo", "baz");
+        inHeaders.add("bar", "qux");
+        inHeaders.add("hello", "world");
+        Http2Headers out = HttpConversionUtil.toHttp2Headers(msg, validateHeaders);
+        assertEquals("//path/to/something", out.path());
+        assertEquals("http", out.scheme());
+        assertEquals("example.com", out.authority());
+        assertEquals(HttpMethod.GET..asciiName(), out.method());
     }
 
     @Test


### PR DESCRIPTION
Motivation:

Paths, especially those of the form "//path/to/resource" are handled as "/path/to/resource" by most browsers and servers, but Netty fails on these, parsing them as having an authority.

Modification:

Directly forward the uri when it's a path instead of trying to parse it.

Also clean up isOriginForm/isAsteriskForm as their logic seems to be incorrect (for example, URI#getSchemeSpecificPart() never returns null so they both return false trivially).

Result:

Netty forwards uris unchanged when they look to be in origin or asterisk form.
