### PR TITLE
Completed promises cannot be made uncancellable

### DIFF
--- a/common/src/main/java/io/netty5/util/concurrent/DefaultPromise.java
+++ b/common/src/main/java/io/netty5/util/concurrent/DefaultPromise.java
@@ -150,11 +150,7 @@ public class DefaultPromise<V> implements Promise<V>, Future<V> {
 
     @Override
     public boolean setUncancellable() {
-        if (RESULT_UPDATER.compareAndSet(this, null, UNCANCELLABLE)) {
-            return true;
-        }
-        Object result = this.result;
-        return !isDone0(result) || !isCancelled0(result);
+        return RESULT_UPDATER.compareAndSet(this, null, UNCANCELLABLE);
     }
 
     @Override

--- a/common/src/main/java/io/netty5/util/concurrent/Promise.java
+++ b/common/src/main/java/io/netty5/util/concurrent/Promise.java
@@ -52,8 +52,8 @@ public interface Promise<V> extends AsynchronousResult<V> {
     /**
      * Make this promise impossible to cancel.
      *
-     * @return {@code true} if and only if successfully marked this promise as uncancellable, or it is already done
-     * without being cancelled. Otherwise {@code false} if this promise has been cancelled already.
+     * @return {@code true} if and only if successfully marked this promise as uncancellable.
+     * Otherwise {@code false} if this promise has been cancelled already, or has completed.
      */
     boolean setUncancellable();
 

--- a/common/src/test/java/io/netty5/util/concurrent/DefaultPromiseTest.java
+++ b/common/src/test/java/io/netty5/util/concurrent/DefaultPromiseTest.java
@@ -200,6 +200,23 @@ public class DefaultPromiseTest {
     }
 
     @Test
+    public void donePromiseCannotBeMadeUncancellable() {
+        DefaultPromise<Void> promise;
+
+        promise = new DefaultPromise<>(INSTANCE);
+        promise.setSuccess(null);
+        assertFalse(promise.setUncancellable());
+
+        promise = new DefaultPromise<>(INSTANCE);
+        promise.setFailure(new RuntimeException());
+        assertFalse(promise.setUncancellable());
+
+        promise = new DefaultPromise<>(INSTANCE);
+        promise.cancel();
+        assertFalse(promise.setUncancellable());
+    }
+
+    @Test
     public void testStackOverflowWithImmediateEventExecutorA() throws Exception {
         testStackOverFlowChainedFuturesA(stackOverflowTestDepth(), INSTANCE, true);
         testStackOverFlowChainedFuturesA(stackOverflowTestDepth(), INSTANCE, false);


### PR DESCRIPTION
Motivation:
The setUncancellable method is often used as a gating mechanism, before starting the actual work that will complete a promise.
As such, it makes sense that promises that have already been completed, cannot be made uncancellable.
This new behaviour means the setUncancellable prevents reentrancy.

Modification:
The setUncancellable method is simplified, and now only returns true if the transition from incomplete to uncancellable succeeds.
And it now returns false for promises that have already completed.
Javadocs and tests are likewise updated.

Result:
More logical (in my opinion) behaviour from setUncancellable, that in turn also prevents reentrancy bugs, should such occur.