### PR TITLE
Fix mocking in AbstractChannelTest

### DIFF
--- a/transport/src/test/java/io/netty5/channel/AbstractChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/AbstractChannelTest.java
@@ -192,6 +192,8 @@ public class AbstractChannelTest {
     }
 
     private static void registerChannel(Channel channel) throws Exception {
+        when(channel.executor().registerForIO(channel)).thenReturn(INSTANCE.newSucceededFuture(null));
+        when(channel.executor().deregisterForIO(channel)).thenReturn(INSTANCE.newSucceededFuture(null));
         channel.register().sync(); // Cause any exceptions to be thrown
     }
 


### PR DESCRIPTION
Motivation:
The changes to how channels are registered with event loops has broken the mocking in this test.

Modification:
The event loop is now mocked to return completed futures for channel registration and deregistration, which is required to get their listeners to run, instead of throwing a NullPointerException.

Result:
AbstractChannelTest now passes again.