### PR TITLE
Add method to EmbeddedChannel to check whether tasks are pending

### DIFF
--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
@@ -607,6 +607,18 @@ public class EmbeddedChannel extends AbstractChannel {
     }
 
     /**
+     * Check whether this channel has any pending tasks that would be executed by a call to {@link #runPendingTasks()}.
+     * This includes normal tasks, and scheduled tasks where the deadline has expired. If this method returns
+     * {@code false}, a call to {@link #runPendingTasks()} would do nothing.
+     *
+     * @return Whether
+     */
+    public boolean hasPendingTasks() {
+        return embeddedEventLoop().hasPendingNormalTasks() ||
+                embeddedEventLoop().nextScheduledTask() == 0;
+    }
+
+    /**
      * Run all pending scheduled tasks in the {@link EventLoop} for this {@link Channel} and return the
      * {@code nanoseconds} when the next scheduled task is ready to run. If no other task was scheduled it will return
      * {@code -1}.

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedEventLoop.java
@@ -75,6 +75,10 @@ final class EmbeddedEventLoop extends AbstractScheduledEventExecutor implements 
         }
     }
 
+    boolean hasPendingNormalTasks() {
+        return !tasks.isEmpty();
+    }
+
     long runScheduledTasks() {
         long time = getCurrentTimeNanos();
         for (;;) {

--- a/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
@@ -735,6 +735,34 @@ public class EmbeddedChannelTest {
         assertFalse(future20.isDone());
     }
 
+    @Test
+    void testHasPendingTasks() {
+        EmbeddedChannel channel = new EmbeddedChannel();
+        channel.freezeTime();
+        Runnable runnable = new Runnable() {
+            @Override
+            public void run() {
+            }
+        };
+
+        // simple execute
+        assertFalse(channel.hasPendingTasks());
+        channel.eventLoop().execute(runnable);
+        assertTrue(channel.hasPendingTasks());
+        channel.runPendingTasks();
+        assertFalse(channel.hasPendingTasks());
+
+        // schedule in the future (note: time is frozen above)
+        channel.eventLoop().schedule(runnable, 1, TimeUnit.SECONDS);
+        assertFalse(channel.hasPendingTasks());
+        channel.runPendingTasks();
+        assertFalse(channel.hasPendingTasks());
+        channel.advanceTimeBy(1, TimeUnit.SECONDS);
+        assertTrue(channel.hasPendingTasks());
+        channel.runPendingTasks();
+        assertFalse(channel.hasPendingTasks());
+    }
+
     private static void release(ByteBuf... buffers) {
         for (ByteBuf buffer : buffers) {
             if (buffer.refCnt() > 0) {


### PR DESCRIPTION
Motivation:

Before this patch, there was no way to determine whether `runPendingTasks()` would actually do anything. For an isolated EmbeddedChannel this is not an issue, as you can simply track whether you're adding any new tasks, and rerun the embedded event loop if necessary.

With more complex code that uses multiple channels this is not always possible, though. Consider the following artificial example:

```java
void methodToTest(Channel c1, Channel c2) {
    c1.eventLoop().execute(() -> {
        c2.eventLoop().execute(() -> {
            ...
        });
    });
}
```

Now, to "fully run" this code with embedded channels, it is necessary to repeatedly call `runPendingTasks()` on the two channels. This requires a way to know whether there is any work left to do.

Modification:

Add the `hasPendingTasks()` method. It has the same task selection semantics as `runPendingTasks()`, so it also considers scheduled tasks where the deadline has expired.

A potentially better alternative would have been to make `runPendingTasks()` return a boolean indicating whether any tasks were executed, but this is not possible while retaining binary compatibility.

Result:

Users of EmbeddedChannel can use `hasPendingTasks()` to fully run test code to completion, even in scenarios with multiple embedded event loops.