### PR TITLE
Fix typo in KQueueChannelConfig

### DIFF
--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueChannelConfig.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueChannelConfig.java
@@ -67,7 +67,7 @@ public class KQueueChannelConfig extends DefaultChannelConfig {
             }
             if (option instanceof RawUnixChannelOption) {
                 RawUnixChannelOption opt = (RawUnixChannelOption) option;
-                ByteBuffer out = ByteBuffer.allocate(opt.level());
+                ByteBuffer out = ByteBuffer.allocate(opt.length());
                 ((AbstractKQueueChannel) channel).socket.getRawOpt(opt.level(), opt.optname(), out);
                 return (T) out.flip();
             }


### PR DESCRIPTION
Motivation:

KQueueChannelConfigTest.testRawOption() fails on MacOS due to the buffer for the RawUnixChannelOption being over-allocated when retrieving the option value. Since the limit is not explicitly set (the buffer is just flipped), the limit of the buffer will be based on its size, causing the test to fail.

Modification:

Changes the buffer allocation for getOption of RawUnixChannelOption in KQueueChannelConfig to be based on the length of the option instead of the level. The use of level is likely a typo. The corresponding code in EpollChannelConfig allocates the buffer based on length rather than level.

Result:

One less test failure when building on MacOS (Intel) with JDK 1.8.