### PR TITLE
Check correct reference for exception during test run

### DIFF
--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslEchoTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslEchoTest.java
@@ -348,7 +348,7 @@ public class SocketSslEchoTest extends AbstractSocketTest {
             if (serverException.get() != null) {
                 break;
             }
-            if (serverException.get() != null) {
+            if (clientException.get() != null) {
                 break;
             }
 


### PR DESCRIPTION
Motivation:

While working on some other problem I noticed that we didnt check the correct reference and so could end up in a timeout without seeing the correct cause of it.

Modifications:

Check the correct reference

Result:

Fix unit test
