### PR TITLE
Unsafe heap buffers can use uninitialized arrays

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeMemoryManager.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeMemoryManager.java
@@ -78,7 +78,7 @@ public final class UnsafeMemoryManager implements MemoryManager {
                 cleaner.register(memory, freeAddress);
             }
         } else if (allocationType == StandardAllocationTypes.ON_HEAP) {
-            base = new byte[size32];
+            base = PlatformDependent.allocateUninitializedArray(size32);
             address = PlatformDependent.byteArrayBaseOffset();
             memory = new UnsafeMemory(base, address, size32);
         } else if (allocationType instanceof WrappingAllocation) {


### PR DESCRIPTION
Motivation:
We don't promise that the memory will be initialised when a buffer is allocated.

Modification:
Make UnsafeBuffer allocate its heap memory using `PlatformDependent.allocateUninitializedArray()`.
This potentially skips a memory zeroing step and can be faster.

Result:
UnsafeBuffer takes advantage of a potential optimisation.