### PR TITLE
Avoid LocalAddress conflicts in tests

### DIFF
--- a/handler/src/test/java/io/netty5/handler/ssl/RenegotiateTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/RenegotiateTest.java
@@ -80,7 +80,7 @@ public abstract class RenegotiateTest {
                                             final SslHandler handler = ctx.pipeline().get(SslHandler.class);
 
                                             renegotiate = true;
-                                            handler.renegotiate().addListener((FutureListener<Channel>) future -> {
+                                            handler.renegotiate().addListener(future -> {
                                                 if (future.isFailed()) {
                                                     error.compareAndSet(null, future.cause());
                                                     ctx.close();
@@ -98,7 +98,7 @@ public abstract class RenegotiateTest {
                             });
                         }
                     });
-            Channel channel = sb.bind(new LocalAddress("test")).get();
+            Channel channel = sb.bind(new LocalAddress("RenegotiateTest")).get();
 
             final SslContext clientContext = SslContextBuilder.forClient()
                     .trustManager(InsecureTrustManagerFactory.INSTANCE)

--- a/handler/src/test/java/io/netty5/handler/ssl/SniClientTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SniClientTest.java
@@ -126,7 +126,7 @@ public class SniClientTest {
             throws Throwable {
         final String sniHost = "sni.netty.io";
         SelfSignedCertificate cert = new SelfSignedCertificate();
-        LocalAddress address = new LocalAddress("test");
+        LocalAddress address = new LocalAddress("SniClientTest");
         EventLoopGroup group = new MultithreadEventLoopGroup(1, LocalHandler.newFactory());
         SslContext sslServerContext = null;
         SslContext sslClientContext = null;
@@ -397,7 +397,7 @@ public class SniClientTest {
     @MethodSource("parameters")
     public void testSniClient(SslProvider sslServerProvider, SslProvider sslClientProvider) throws Exception {
         String sniHostName = "sni.netty.io";
-        LocalAddress address = new LocalAddress("test");
+        LocalAddress address = new LocalAddress("SniClientTest");
         EventLoopGroup group = new MultithreadEventLoopGroup(1, LocalHandler.newFactory());
         SelfSignedCertificate cert = new SelfSignedCertificate();
         SslContext sslServerContext = null;


### PR DESCRIPTION
Motivation:
RenegotiateTest has occasionally been failing because it tries to bind to a LocalAddress that is also being used by SniClientTest.

Modification:
Make both tests use LocalAddresses named after themselves to avoid conflict.

Result:
We should no longer get test failures with "ChannelException: address already in use" from these tests.