### PR TITLE
Make sure all LocalAddresses are unique

### DIFF
--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -1090,7 +1090,7 @@ public class Http2ConnectionRoundtripTest {
             }
         });
 
-        serverChannel = sb.bind(new LocalAddress("Http2ConnectionRoundtripTest")).get();
+        serverChannel = sb.bind(new LocalAddress(getClass())).get();
 
         clientChannel = cb.connect(serverChannel.localAddress()).get();
         assertTrue(prefaceWrittenLatch.await(DEFAULT_AWAIT_TIMEOUT_SECONDS, SECONDS));

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2StreamChannelBootstrapTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2StreamChannelBootstrapTest.java
@@ -66,7 +66,7 @@ public class Http2StreamChannelBootstrapTest {
         try {
             final CountDownLatch serverChannelLatch = new CountDownLatch(1);
             group = new MultithreadEventLoopGroup(LocalHandler.newFactory());
-            LocalAddress serverAddress = new LocalAddress(getClass().getName());
+            LocalAddress serverAddress = new LocalAddress(getClass());
             ServerBootstrap sb = new ServerBootstrap()
                     .channel(LocalServerChannel.class)
                     .group(group)

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
@@ -568,7 +568,7 @@ public class HttpToHttp2ConnectionHandlerTest {
             }
         });
 
-        serverChannel = sb.bind(new LocalAddress("HttpToHttp2ConnectionHandlerTest")).get();
+        serverChannel = sb.bind(new LocalAddress(getClass())).get();
 
         clientChannel = cb.connect(serverChannel.localAddress()).get();
         assertTrue(prefaceWrittenLatch.await(5, SECONDS));

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
@@ -651,7 +651,7 @@ public class InboundHttp2ToHttpAdapterTest {
             }
         });
 
-        serverChannel = sb.bind(new LocalAddress("InboundHttp2ToHttpAdapterTest")).get();
+        serverChannel = sb.bind(new LocalAddress(getClass())).get();
 
         clientChannel = cb.connect(serverChannel.localAddress()).get();
         assertTrue(prefaceWrittenLatch.await(5, SECONDS));

--- a/handler/src/test/java/io/netty5/handler/ssl/CipherSuiteCanaryTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/CipherSuiteCanaryTest.java
@@ -49,6 +49,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -174,8 +175,9 @@ public class CipherSuiteCanaryTest {
                     }
                 };
 
-                LocalAddress address = new LocalAddress("test-" + serverSslProvider
-                        + '-' + clientSslProvider + '-' + rfcCipherName);
+                LocalAddress address = new LocalAddress(
+                        "test-" + serverSslProvider + '-' + clientSslProvider + '-' +
+                        rfcCipherName + '-' + UUID.randomUUID());
 
                 Channel server = server(address, serverHandler);
                 try {

--- a/handler/src/test/java/io/netty5/handler/ssl/OpenSslCertificateCompressionTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/OpenSslCertificateCompressionTest.java
@@ -322,7 +322,7 @@ public class OpenSslCertificateCompressionTest {
             ServerBootstrap sb = new ServerBootstrap();
             sb.group(group).channel(LocalServerChannel.class)
                     .childHandler(new CertCompressionTestChannelInitializer(serverPromise, serverSslContext));
-            Channel serverChannel = sb.bind(new LocalAddress("testCertificateCompression"))
+            Channel serverChannel = sb.bind(new LocalAddress(getClass()))
                     .sync().getNow();
 
             Bootstrap bootstrap = new Bootstrap();

--- a/handler/src/test/java/io/netty5/handler/ssl/OpenSslPrivateKeyMethodTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/OpenSslPrivateKeyMethodTest.java
@@ -55,6 +55,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -261,8 +262,9 @@ public class OpenSslPrivateKeyMethodTest {
                 }
             };
 
-            LocalAddress address = new LocalAddress("test-" + SslProvider.OPENSSL
-                                                    + '-' + SslProvider.JDK + '-' + RFC_CIPHER_NAME + '-' + delegate);
+            LocalAddress address = new LocalAddress(
+                    "test-" + SslProvider.OPENSSL + '-' + SslProvider.JDK + '-' + RFC_CIPHER_NAME + '-' + delegate +
+                    '-' + UUID.randomUUID());
 
             Channel server = server(address, serverHandler);
             try {
@@ -355,8 +357,9 @@ public class OpenSslPrivateKeyMethodTest {
 
         try (AutoCloseable ignore1 = autoClosing(sslServerContext);
              AutoCloseable ignore2 = autoClosing(sslClientContext)) {
-            LocalAddress address = new LocalAddress("test-" + SslProvider.OPENSSL
-                                                    + '-' + SslProvider.JDK + '-' + RFC_CIPHER_NAME + '-' + delegate);
+            LocalAddress address = new LocalAddress(
+                    "test-" + SslProvider.OPENSSL + '-' + SslProvider.JDK + '-' + RFC_CIPHER_NAME + '-' + delegate +
+                    '-' + UUID.randomUUID());
 
             Channel server = server(address, serverSslHandler);
             try {

--- a/handler/src/test/java/io/netty5/handler/ssl/ParameterizedSslHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/ParameterizedSslHandlerTest.java
@@ -19,8 +19,6 @@ import io.netty5.bootstrap.Bootstrap;
 import io.netty5.bootstrap.ServerBootstrap;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.CompositeBuffer;
-import io.netty5.util.Resource;
-import io.netty5.util.Send;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
@@ -41,6 +39,8 @@ import io.netty5.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty5.handler.ssl.util.SelfSignedCertificate;
 import io.netty5.handler.ssl.util.SimpleTrustManagerFactory;
 import io.netty5.util.CharsetUtil;
+import io.netty5.util.Resource;
+import io.netty5.util.Send;
 import io.netty5.util.concurrent.Promise;
 import io.netty5.util.internal.EmptyArrays;
 import io.netty5.util.internal.ResourcesUtil;
@@ -72,7 +72,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.netty5.buffer.BufferUtil.writeAscii;
-import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -541,7 +540,7 @@ public class ParameterizedSslHandlerTest {
         try {
             Class<? extends ServerChannel> serverClass = LocalServerChannel.class;
             Class<? extends Channel> clientClass = LocalChannel.class;
-            SocketAddress bindAddress = new LocalAddress(String.valueOf(current().nextLong()));
+            SocketAddress bindAddress = new LocalAddress(getClass());
             reentryOnHandshakeComplete(clientProvider, serverProvider, group, bindAddress,
                     serverClass, clientClass, false, false);
             reentryOnHandshakeComplete(clientProvider, serverProvider, group, bindAddress,

--- a/handler/src/test/java/io/netty5/handler/ssl/RenegotiateTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/RenegotiateTest.java
@@ -30,7 +30,6 @@ import io.netty5.channel.local.LocalServerChannel;
 import io.netty5.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty5.handler.ssl.util.SelfSignedCertificate;
 import io.netty5.util.Resource;
-import io.netty5.util.concurrent.FutureListener;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -98,7 +97,7 @@ public abstract class RenegotiateTest {
                             });
                         }
                     });
-            Channel channel = sb.bind(new LocalAddress("RenegotiateTest")).get();
+            Channel channel = sb.bind(new LocalAddress(getClass())).get();
 
             final SslContext clientContext = SslContextBuilder.forClient()
                     .trustManager(InsecureTrustManagerFactory.INSTANCE)

--- a/handler/src/test/java/io/netty5/handler/ssl/SniClientTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SniClientTest.java
@@ -126,7 +126,7 @@ public class SniClientTest {
             throws Throwable {
         final String sniHost = "sni.netty.io";
         SelfSignedCertificate cert = new SelfSignedCertificate();
-        LocalAddress address = new LocalAddress("SniClientTest");
+        LocalAddress address = new LocalAddress(SniClientTest.class);
         EventLoopGroup group = new MultithreadEventLoopGroup(1, LocalHandler.newFactory());
         SslContext sslServerContext = null;
         SslContext sslClientContext = null;
@@ -397,7 +397,7 @@ public class SniClientTest {
     @MethodSource("parameters")
     public void testSniClient(SslProvider sslServerProvider, SslProvider sslClientProvider) throws Exception {
         String sniHostName = "sni.netty.io";
-        LocalAddress address = new LocalAddress("SniClientTest");
+        LocalAddress address = new LocalAddress(SniClientTest.class);
         EventLoopGroup group = new MultithreadEventLoopGroup(1, LocalHandler.newFactory());
         SelfSignedCertificate cert = new SelfSignedCertificate();
         SslContext sslServerContext = null;

--- a/handler/src/test/java/io/netty5/handler/ssl/SniHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SniHandlerTest.java
@@ -478,7 +478,7 @@ public class SniHandlerTest {
             case OPENSSL:
             case OPENSSL_REFCNT:
                 final String sniHost = "sni.netty.io";
-                LocalAddress address = new LocalAddress("testReplaceHandler-" + Math.random());
+                LocalAddress address = new LocalAddress(getClass());
                 EventLoopGroup group = new MultithreadEventLoopGroup(1, LocalHandler.newFactory());
                 Channel sc = null;
                 Channel cc = null;

--- a/handler/src/test/java/io/netty5/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SslHandlerTest.java
@@ -658,7 +658,7 @@ public class SslHandlerTest {
                   }
               });
 
-            serverChannel = sb.bind(new LocalAddress("SslHandlerTest")).get();
+            serverChannel = sb.bind(new LocalAddress(getClass())).get();
             clientChannel = cb.connect(serverChannel.localAddress()).get();
             try {
                 latch.await();
@@ -784,7 +784,7 @@ public class SslHandlerTest {
         try (AutoCloseable ignore1 = autoClosing(sslServerCtx);
              AutoCloseable ignore2 = autoClosing(sslClientCtx)) {
             try {
-                LocalAddress address = new LocalAddress(getClass().getSimpleName() + ".testCloseOnHandshakeFailure");
+                LocalAddress address = new LocalAddress(getClass());
                 ServerBootstrap sb = new ServerBootstrap()
                         .group(group)
                         .channel(LocalServerChannel.class)

--- a/handler/src/test/java/io/netty5/handler/ssl/ocsp/OcspTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/ocsp/OcspTest.java
@@ -367,7 +367,7 @@ public class OcspTest {
                 try (AutoCloseable ignore2 = autoClosing(clientSslContext)) {
                     EventLoopGroup group = new MultithreadEventLoopGroup(LocalHandler.newFactory());
                     try {
-                        LocalAddress address = new LocalAddress("handshake-" + Math.random());
+                        LocalAddress address = new LocalAddress(OcspTest.class);
                         Channel server = newServer(group, address, serverSslContext, response, serverHandler);
                         Channel client = newClient(group, address, clientSslContext, callback, clientHandler);
                         try {

--- a/handler/src/test/java/io/netty5/handler/traffic/TrafficShapingHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/traffic/TrafficShapingHandlerTest.java
@@ -93,7 +93,7 @@ public class TrafficShapingHandlerTest {
                             });
                         }
                     });
-            final LocalAddress svrAddr = new LocalAddress("foo");
+            final LocalAddress svrAddr = new LocalAddress(TrafficShapingHandlerTest.class);
             svrChannel = serverBootstrap.bind(svrAddr).get();
             Bootstrap bootstrap = new Bootstrap();
             bootstrap.channel(LocalChannel.class).group(GROUP).handler(new ChannelInitializer<Channel>() {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/AbstractSingleThreadEventLoopTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/AbstractSingleThreadEventLoopTest.java
@@ -66,7 +66,7 @@ public abstract class AbstractSingleThreadEventLoopTest {
 
         // Not close the Channel to ensure the EventLoop is still shutdown in time.
         Future<Channel> cf = serverChannelClass() == LocalServerChannel.class
-                ? b.bind(new LocalAddress("local")) : b.bind(0);
+                ? b.bind(new LocalAddress(getClass())) : b.bind(0);
         cf.sync();
 
         Future<?> f = loop.shutdownGracefully(0, 1, TimeUnit.MINUTES);

--- a/transport/src/main/java/io/netty5/channel/local/LocalAddress.java
+++ b/transport/src/main/java/io/netty5/channel/local/LocalAddress.java
@@ -18,6 +18,7 @@ package io.netty5.channel.local;
 import io.netty5.channel.Channel;
 
 import java.net.SocketAddress;
+import java.util.UUID;
 
 import static io.netty5.util.internal.ObjectUtil.checkNonEmptyAfterTrim;
 
@@ -54,6 +55,13 @@ public final class LocalAddress extends SocketAddress implements Comparable<Loca
     public LocalAddress(String id) {
         this.id = checkNonEmptyAfterTrim(id, "id").toLowerCase();
         this.strVal = "local:" + this.id;
+    }
+
+    /**
+     * Creates a new instance with a random ID based on the given class.
+     */
+    public LocalAddress(Class<?> cls) {
+        this(cls.getSimpleName() + '/' + UUID.randomUUID());
     }
 
     /**

--- a/transport/src/test/java/io/netty5/bootstrap/BootstrapTest.java
+++ b/transport/src/test/java/io/netty5/bootstrap/BootstrapTest.java
@@ -192,7 +192,7 @@ public class BootstrapTest {
             bootstrap.handler(registerHandler);
             bootstrap.channel(LocalServerChannel.class);
             bootstrap.childHandler(new DummyHandler());
-            bootstrap.localAddress(new LocalAddress("1"));
+            bootstrap.localAddress(new LocalAddress(getClass()));
             Future<Channel> future = bootstrap.bind();
             assertFalse(future.isDone());
             registerHandler.registerPromise().setSuccess(null);
@@ -228,7 +228,7 @@ public class BootstrapTest {
                     });
             bootstrap.childHandler(new DummyHandler());
             bootstrap.handler(registerHandler);
-            bootstrap.localAddress(new LocalAddress("1"));
+            bootstrap.localAddress(new LocalAddress(getClass()));
             Future<Channel> future = bootstrap.bind();
             assertFalse(future.isDone());
             registerHandler.registerPromise().setSuccess(null);

--- a/transport/src/test/java/io/netty5/bootstrap/ServerBootstrapTest.java
+++ b/transport/src/test/java/io/netty5/bootstrap/ServerBootstrapTest.java
@@ -86,7 +86,7 @@ public class ServerBootstrapTest {
     }
 
     private static void testParentHandler(boolean channelInitializer) throws Exception {
-        final LocalAddress addr = new LocalAddress(UUID.randomUUID().toString());
+        final LocalAddress addr = new LocalAddress(ServerBootstrapTest.class);
         final CountDownLatch readLatch = new CountDownLatch(1);
         final CountDownLatch initLatch = new CountDownLatch(1);
 
@@ -148,7 +148,7 @@ public class ServerBootstrapTest {
     @Test
     public void optionsAndAttributesMustBeAvailableOnChildChannelInit() throws Exception {
         EventLoopGroup group = new MultithreadEventLoopGroup(1, LocalHandler.newFactory());
-        LocalAddress addr = new LocalAddress(UUID.randomUUID().toString());
+        LocalAddress addr = new LocalAddress(ServerBootstrapTest.class);
         final AttributeKey<String> key = AttributeKey.valueOf(UUID.randomUUID().toString());
         final AtomicBoolean requestServed = new AtomicBoolean();
         ServerBootstrap sb = new ServerBootstrap()

--- a/transport/src/test/java/io/netty5/channel/ChannelInitializerTest.java
+++ b/transport/src/test/java/io/netty5/channel/ChannelInitializerTest.java
@@ -42,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ChannelInitializerTest {
     private static final int TIMEOUT_MILLIS = 1000;
-    private static final LocalAddress SERVER_ADDRESS = new LocalAddress("addr");
+    private static final LocalAddress SERVER_ADDRESS = new LocalAddress(ChannelInitializerTest.class);
     private EventLoopGroup group;
     private ServerBootstrap server;
     private Bootstrap client;

--- a/transport/src/test/java/io/netty5/channel/ReentrantChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/ReentrantChannelTest.java
@@ -34,7 +34,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
     @Test
     public void testWritabilityChangedByteBuf() throws Exception {
 
-        LocalAddress addr = new LocalAddress("testWritabilityChangedByteBuf");
+        LocalAddress addr = new LocalAddress(getClass());
 
         ServerBootstrap sb = getLocalServerBootstrap();
         sb.bind(addr).sync();
@@ -103,7 +103,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
     @Test
     public void testWritabilityChanged() throws Exception {
 
-        LocalAddress addr = new LocalAddress("testWritabilityChanged");
+        LocalAddress addr = new LocalAddress(getClass());
 
         ServerBootstrap sb = getLocalServerBootstrap();
         sb.bind(addr).sync();
@@ -175,7 +175,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
     @Test
     public void testFlushInWritabilityChangedByteBuf() throws Exception {
 
-        LocalAddress addr = new LocalAddress("testFlushInWritabilityChangedByteBuf");
+        LocalAddress addr = new LocalAddress(getClass());
 
         ServerBootstrap sb = getLocalServerBootstrap();
         sb.bind(addr).sync();
@@ -228,7 +228,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
     @Test
     public void testFlushInWritabilityChanged() throws Exception {
 
-        LocalAddress addr = new LocalAddress("testFlushInWritabilityChanged");
+        LocalAddress addr = new LocalAddress(getClass());
 
         ServerBootstrap sb = getLocalServerBootstrap();
         sb.bind(addr).sync();
@@ -278,7 +278,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
     @Test
     public void testWriteFlushPingPongByteBuf() throws Exception {
 
-        LocalAddress addr = new LocalAddress("testWriteFlushPingPongByteBuf");
+        LocalAddress addr = new LocalAddress(getClass());
 
         ServerBootstrap sb = getLocalServerBootstrap();
         sb.bind(addr).sync();
@@ -335,7 +335,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
     @Test
     public void testWriteFlushPingPong() throws Exception {
 
-        LocalAddress addr = new LocalAddress("testWriteFlushPingPong");
+        LocalAddress addr = new LocalAddress(getClass());
 
         ServerBootstrap sb = getLocalServerBootstrap();
         sb.bind(addr).sync();
@@ -392,7 +392,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
     @Test
     public void testCloseInFlushByteBuf() throws Exception {
 
-        LocalAddress addr = new LocalAddress("testCloseInFlush");
+        LocalAddress addr = new LocalAddress(getClass());
 
         ServerBootstrap sb = getLocalServerBootstrap();
         sb.bind(addr).sync();
@@ -422,7 +422,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
     @Test
     public void testCloseInFlush() throws Exception {
 
-        LocalAddress addr = new LocalAddress("testCloseInFlushByteBuf");
+        LocalAddress addr = new LocalAddress(getClass());
 
         ServerBootstrap sb = getLocalServerBootstrap();
         sb.bind(addr).sync();
@@ -452,7 +452,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
     @Test
     public void testFlushFailureByteBuf() throws Exception {
 
-        LocalAddress addr = new LocalAddress("testFlushFailureByteBuf");
+        LocalAddress addr = new LocalAddress(getClass());
 
         ServerBootstrap sb = getLocalServerBootstrap();
         sb.bind(addr).sync();
@@ -493,7 +493,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
     @Test
     public void testFlushFailure() throws Exception {
 
-        LocalAddress addr = new LocalAddress("testFlushFailure");
+        LocalAddress addr = new LocalAddress(getClass());
 
         ServerBootstrap sb = getLocalServerBootstrap();
         sb.bind(addr).sync();

--- a/transport/src/test/java/io/netty5/channel/local/LocalChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/local/LocalChannelTest.java
@@ -70,7 +70,7 @@ public class LocalChannelTest {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(LocalChannelTest.class);
 
-    private static final LocalAddress TEST_ADDRESS = new LocalAddress("test.id");
+    private static final LocalAddress TEST_ADDRESS = new LocalAddress(LocalChannelTest.class);
 
     private static EventLoopGroup group1;
     private static EventLoopGroup group2;


### PR DESCRIPTION
Motivation:
As we run more tests in parallel, the risk of colliding local addresses increases, unless we make sure to give them unique names.

Modification:
Add a new constructor to LocalAddress which takes a class and generates a unique name with a UUID.
Use this constructor in place of fixed strings, and add randomness to the remaining dynamically named addresses.

Result:
We shouldn't see any more "address already in use" test failures.