### PR TITLE
Move blocking JDK Future methods to FutureCompletableStage

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
@@ -47,7 +47,6 @@ import java.nio.channels.WritableByteChannel;
 import static io.netty5.buffer.api.internal.Statics.MAX_BUFFER_SIZE;
 import static io.netty5.buffer.api.internal.Statics.bbput;
 import static io.netty5.buffer.api.internal.Statics.bbslice;
-import static io.netty5.buffer.api.internal.Statics.bufferIsClosed;
 import static io.netty5.buffer.api.internal.Statics.bufferIsReadOnly;
 import static io.netty5.buffer.api.internal.Statics.checkImplicitCapacity;
 import static io.netty5.buffer.api.internal.Statics.checkLength;

--- a/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
@@ -49,7 +49,6 @@ import java.nio.channels.WritableByteChannel;
 
 import static io.netty5.buffer.api.internal.Statics.MAX_BUFFER_SIZE;
 import static io.netty5.buffer.api.internal.Statics.bbslice;
-import static io.netty5.buffer.api.internal.Statics.bufferIsClosed;
 import static io.netty5.buffer.api.internal.Statics.bufferIsReadOnly;
 import static io.netty5.buffer.api.internal.Statics.checkImplicitCapacity;
 import static io.netty5.buffer.api.internal.Statics.checkLength;

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpClientCodecTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpClientCodecTest.java
@@ -188,12 +188,12 @@ public class HttpClientCodecTest {
                 }
             });
 
-            Channel serverChannel = sb.bind(new InetSocketAddress(0)).asJdkFuture().get();
+            Channel serverChannel = sb.bind(new InetSocketAddress(0)).asStage().get();
             int port = ((InetSocketAddress) serverChannel.localAddress()).getPort();
 
             Future<Channel> ccf = cb.connect(new InetSocketAddress(NetUtil.LOCALHOST, port));
             assertTrue(ccf.await().isSuccess());
-            Channel clientChannel = ccf.asJdkFuture().get();
+            Channel clientChannel = ccf.asStage().get();
             assertTrue(serverChannelLatch.await(5, SECONDS));
             clientChannel.writeAndFlush(new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/"));
             assertTrue(responseReceivedLatch.await(5, SECONDS));

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpClientCodecTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpClientCodecTest.java
@@ -188,12 +188,12 @@ public class HttpClientCodecTest {
                 }
             });
 
-            Channel serverChannel = sb.bind(new InetSocketAddress(0)).get();
+            Channel serverChannel = sb.bind(new InetSocketAddress(0)).asJdkFuture().get();
             int port = ((InetSocketAddress) serverChannel.localAddress()).getPort();
 
             Future<Channel> ccf = cb.connect(new InetSocketAddress(NetUtil.LOCALHOST, port));
             assertTrue(ccf.await().isSuccess());
-            Channel clientChannel = ccf.get();
+            Channel clientChannel = ccf.asJdkFuture().get();
             assertTrue(serverChannelLatch.await(5, SECONDS));
             clientChannel.writeAndFlush(new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/"));
             assertTrue(responseReceivedLatch.await(5, SECONDS));

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpRequestEncoderTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpRequestEncoderTest.java
@@ -131,7 +131,8 @@ public class HttpRequestEncoderTest {
         final EmbeddedChannel channel = new EmbeddedChannel(encoder);
         Buffer buf = preferredAllocator().allocate(10);
         buf.close();
-        ExecutionException e = assertThrows(ExecutionException.class, () -> channel.writeAndFlush(buf).get());
+        ExecutionException e = assertThrows(ExecutionException.class,
+                                            () -> channel.writeAndFlush(buf).asJdkFuture().get());
         assertThat(e.getCause()).hasCauseInstanceOf(BufferClosedException.class);
 
         channel.finishAndReleaseAll();
@@ -142,7 +143,7 @@ public class HttpRequestEncoderTest {
         HttpRequestEncoder encoder = new HttpRequestEncoder();
         EmbeddedChannel channel = new EmbeddedChannel(encoder);
         Buffer buf = preferredAllocator().allocate(0);
-        channel.writeAndFlush(buf).get();
+        channel.writeAndFlush(buf).asJdkFuture().get();
         channel.finishAndReleaseAll();
         assertFalse(buf.isAccessible());
     }

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpRequestEncoderTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpRequestEncoderTest.java
@@ -132,7 +132,7 @@ public class HttpRequestEncoderTest {
         Buffer buf = preferredAllocator().allocate(10);
         buf.close();
         ExecutionException e = assertThrows(ExecutionException.class,
-                                            () -> channel.writeAndFlush(buf).asJdkFuture().get());
+                                            () -> channel.writeAndFlush(buf).asStage().get());
         assertThat(e.getCause()).hasCauseInstanceOf(BufferClosedException.class);
 
         channel.finishAndReleaseAll();
@@ -143,7 +143,7 @@ public class HttpRequestEncoderTest {
         HttpRequestEncoder encoder = new HttpRequestEncoder();
         EmbeddedChannel channel = new EmbeddedChannel(encoder);
         Buffer buf = preferredAllocator().allocate(0);
-        channel.writeAndFlush(buf).asJdkFuture().get();
+        channel.writeAndFlush(buf).asStage().get();
         channel.finishAndReleaseAll();
         assertFalse(buf.isAccessible());
     }

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateDecoderTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateDecoderTest.java
@@ -15,7 +15,6 @@
  */
 package io.netty5.handler.codec.http.websocketx.extensions.compression;
 
-import io.netty5.buffer.BufferUtil;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.handler.codec.DecoderException;

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/DefaultHttp2FrameWriter.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/DefaultHttp2FrameWriter.java
@@ -23,8 +23,6 @@ import io.netty5.handler.codec.http2.Http2HeadersEncoder.SensitivityDetector;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.internal.UnstableApi;
 
-import java.util.function.Supplier;
-
 import static io.netty5.handler.codec.http2.Http2CodecUtil.CONTINUATION_FRAME_HEADER_LENGTH;
 import static io.netty5.handler.codec.http2.Http2CodecUtil.DATA_FRAME_HEADER_LENGTH;
 import static io.netty5.handler.codec.http2.Http2CodecUtil.DEFAULT_MAX_FRAME_SIZE;

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/DataCompressionHttp2Test.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/DataCompressionHttp2Test.java
@@ -387,10 +387,10 @@ public class DataCompressionHttp2Test {
             }
         });
 
-        serverChannel = sb.bind(new InetSocketAddress(0)).asJdkFuture().get();
+        serverChannel = sb.bind(new InetSocketAddress(0)).asStage().get();
         int port = ((InetSocketAddress) serverChannel.localAddress()).getPort();
 
-        clientChannel = cb.connect(new InetSocketAddress(NetUtil.LOCALHOST, port)).asJdkFuture().get();
+        clientChannel = cb.connect(new InetSocketAddress(NetUtil.LOCALHOST, port)).asStage().get();
         assertTrue(prefaceWrittenLatch.await(5, SECONDS));
         assertTrue(serverChannelLatch.await(5, SECONDS));
     }

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/DataCompressionHttp2Test.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/DataCompressionHttp2Test.java
@@ -387,10 +387,10 @@ public class DataCompressionHttp2Test {
             }
         });
 
-        serverChannel = sb.bind(new InetSocketAddress(0)).get();
+        serverChannel = sb.bind(new InetSocketAddress(0)).asJdkFuture().get();
         int port = ((InetSocketAddress) serverChannel.localAddress()).getPort();
 
-        clientChannel = cb.connect(new InetSocketAddress(NetUtil.LOCALHOST, port)).get();
+        clientChannel = cb.connect(new InetSocketAddress(NetUtil.LOCALHOST, port)).asJdkFuture().get();
         assertTrue(prefaceWrittenLatch.await(5, SECONDS));
         assertTrue(serverChannelLatch.await(5, SECONDS));
     }

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/DefaultHttp2PushPromiseFrameTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/DefaultHttp2PushPromiseFrameTest.java
@@ -69,7 +69,7 @@ public class DefaultHttp2PushPromiseFrameTest {
                     }
                 });
 
-        Channel channel = serverBootstrap.bind(0).asJdkFuture().get();
+        Channel channel = serverBootstrap.bind(0).asStage().get();
 
         final Bootstrap bootstrap = new Bootstrap()
                 .group(eventLoopGroup)

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/DefaultHttp2PushPromiseFrameTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/DefaultHttp2PushPromiseFrameTest.java
@@ -69,7 +69,7 @@ public class DefaultHttp2PushPromiseFrameTest {
                     }
                 });
 
-        Channel channel = serverBootstrap.bind(0).get();
+        Channel channel = serverBootstrap.bind(0).asJdkFuture().get();
 
         final Bootstrap bootstrap = new Bootstrap()
                 .group(eventLoopGroup)

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -625,7 +625,7 @@ public class Http2ConnectionRoundtripTest {
         ExecutionException e = assertThrows(ExecutionException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
-                promise.asFuture().asJdkFuture().get();
+                promise.asFuture().asStage().get();
             }
         });
         assertThat(e).hasCauseInstanceOf(BufferClosedException.class);
@@ -678,7 +678,7 @@ public class Http2ConnectionRoundtripTest {
         ExecutionException e = assertThrows(ExecutionException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
-                dataPromise.asFuture().asJdkFuture().get();
+                dataPromise.asFuture().asStage().get();
             }
         });
         assertThat(e).hasCauseInstanceOf(IllegalStateException.class);
@@ -1090,9 +1090,9 @@ public class Http2ConnectionRoundtripTest {
             }
         });
 
-        serverChannel = sb.bind(new LocalAddress(getClass())).asJdkFuture().get();
+        serverChannel = sb.bind(new LocalAddress(getClass())).asStage().get();
 
-        clientChannel = cb.connect(serverChannel.localAddress()).asJdkFuture().get();
+        clientChannel = cb.connect(serverChannel.localAddress()).asStage().get();
         assertTrue(prefaceWrittenLatch.await(DEFAULT_AWAIT_TIMEOUT_SECONDS, SECONDS));
         http2Client = clientChannel.pipeline().get(Http2ConnectionHandler.class);
         assertTrue(serverInitLatch.await(DEFAULT_AWAIT_TIMEOUT_SECONDS, SECONDS));

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -625,7 +625,7 @@ public class Http2ConnectionRoundtripTest {
         ExecutionException e = assertThrows(ExecutionException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
-                promise.asFuture().get();
+                promise.asFuture().asJdkFuture().get();
             }
         });
         assertThat(e).hasCauseInstanceOf(BufferClosedException.class);
@@ -678,7 +678,7 @@ public class Http2ConnectionRoundtripTest {
         ExecutionException e = assertThrows(ExecutionException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
-                dataPromise.asFuture().get();
+                dataPromise.asFuture().asJdkFuture().get();
             }
         });
         assertThat(e).hasCauseInstanceOf(IllegalStateException.class);
@@ -1090,9 +1090,9 @@ public class Http2ConnectionRoundtripTest {
             }
         });
 
-        serverChannel = sb.bind(new LocalAddress(getClass())).get();
+        serverChannel = sb.bind(new LocalAddress(getClass())).asJdkFuture().get();
 
-        clientChannel = cb.connect(serverChannel.localAddress()).get();
+        clientChannel = cb.connect(serverChannel.localAddress()).asJdkFuture().get();
         assertTrue(prefaceWrittenLatch.await(DEFAULT_AWAIT_TIMEOUT_SECONDS, SECONDS));
         http2Client = clientChannel.pipeline().get(Http2ConnectionHandler.class);
         assertTrue(serverInitLatch.await(DEFAULT_AWAIT_TIMEOUT_SECONDS, SECONDS));

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexClientUpgradeTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexClientUpgradeTest.java
@@ -17,7 +17,6 @@ package io.netty5.handler.codec.http2;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.embedded.EmbeddedChannel;
-import org.checkerframework.checker.units.qual.C;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -26,7 +25,6 @@ import java.util.concurrent.CountDownLatch;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class Http2MultiplexClientUpgradeTest {

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexTransportTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexTransportTest.java
@@ -155,7 +155,7 @@ public class Http2MultiplexTransportTest {
                 });
             }
         });
-        serverChannel = sb.bind(new InetSocketAddress(NetUtil.LOCALHOST, 0)).get();
+        serverChannel = sb.bind(new InetSocketAddress(NetUtil.LOCALHOST, 0)).asJdkFuture().get();
 
         Bootstrap bs = new Bootstrap();
         bs.group(eventLoopGroup);
@@ -176,7 +176,7 @@ public class Http2MultiplexTransportTest {
                 }));
             }
         });
-        clientChannel = bs.connect(serverChannel.localAddress()).get();
+        clientChannel = bs.connect(serverChannel.localAddress()).asJdkFuture().get();
         serverConnectedChannelLatch.await();
         serverConnectedChannel = serverConnectedChannelRef.get();
 
@@ -227,7 +227,7 @@ public class Http2MultiplexTransportTest {
                     }));
                 }
             });
-            serverChannel = sb.bind(new InetSocketAddress(NetUtil.LOCALHOST, 0)).get();
+            serverChannel = sb.bind(new InetSocketAddress(NetUtil.LOCALHOST, 0)).asJdkFuture().get();
 
             final CountDownLatch latch = new CountDownLatch(1);
             Bootstrap bs = new Bootstrap();
@@ -240,7 +240,7 @@ public class Http2MultiplexTransportTest {
                     ch.pipeline().addLast(new Http2MultiplexHandler(DISCARD_HANDLER));
                 }
             });
-            clientChannel = bs.connect(serverChannel.localAddress()).get();
+            clientChannel = bs.connect(serverChannel.localAddress()).asJdkFuture().get();
             Http2StreamChannelBootstrap h2Bootstrap = new Http2StreamChannelBootstrap(clientChannel);
             h2Bootstrap.handler(new ChannelHandler() {
                 @Override
@@ -339,7 +339,7 @@ public class Http2MultiplexTransportTest {
                     ch.pipeline().addLast(new Http2MultiplexHandler(DISCARD_HANDLER));
                 }
             });
-            serverChannel = sb.bind(new InetSocketAddress(NetUtil.LOCALHOST, 0)).get();
+            serverChannel = sb.bind(new InetSocketAddress(NetUtil.LOCALHOST, 0)).asJdkFuture().get();
 
             final SslContext clientCtx = SslContextBuilder.forClient()
                     .keyManager(ssc.key(), ssc.cert())
@@ -427,7 +427,7 @@ public class Http2MultiplexTransportTest {
                     });
                 }
             });
-            clientChannel = bs.connect(serverChannel.localAddress()).get();
+            clientChannel = bs.connect(serverChannel.localAddress()).asJdkFuture().get();
             latch.await();
             AssertionError error = errorRef.get();
             if (error != null) {
@@ -503,7 +503,7 @@ public class Http2MultiplexTransportTest {
                     });
                 }
             });
-            serverChannel = sb.bind(new InetSocketAddress(NetUtil.LOCALHOST, 0)).get();
+            serverChannel = sb.bind(new InetSocketAddress(NetUtil.LOCALHOST, 0)).asJdkFuture().get();
 
             final SslContext clientCtx = SslContextBuilder.forClient()
                     .sslProvider(provider)
@@ -557,7 +557,7 @@ public class Http2MultiplexTransportTest {
                     });
                 }
             });
-            clientChannel = bs.connect(serverChannel.localAddress()).get();
+            clientChannel = bs.connect(serverChannel.localAddress()).asJdkFuture().get();
 
             latch.await();
         } finally {

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexTransportTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexTransportTest.java
@@ -155,7 +155,7 @@ public class Http2MultiplexTransportTest {
                 });
             }
         });
-        serverChannel = sb.bind(new InetSocketAddress(NetUtil.LOCALHOST, 0)).asJdkFuture().get();
+        serverChannel = sb.bind(new InetSocketAddress(NetUtil.LOCALHOST, 0)).asStage().get();
 
         Bootstrap bs = new Bootstrap();
         bs.group(eventLoopGroup);
@@ -176,7 +176,7 @@ public class Http2MultiplexTransportTest {
                 }));
             }
         });
-        clientChannel = bs.connect(serverChannel.localAddress()).asJdkFuture().get();
+        clientChannel = bs.connect(serverChannel.localAddress()).asStage().get();
         serverConnectedChannelLatch.await();
         serverConnectedChannel = serverConnectedChannelRef.get();
 
@@ -227,7 +227,7 @@ public class Http2MultiplexTransportTest {
                     }));
                 }
             });
-            serverChannel = sb.bind(new InetSocketAddress(NetUtil.LOCALHOST, 0)).asJdkFuture().get();
+            serverChannel = sb.bind(new InetSocketAddress(NetUtil.LOCALHOST, 0)).asStage().get();
 
             final CountDownLatch latch = new CountDownLatch(1);
             Bootstrap bs = new Bootstrap();
@@ -240,7 +240,7 @@ public class Http2MultiplexTransportTest {
                     ch.pipeline().addLast(new Http2MultiplexHandler(DISCARD_HANDLER));
                 }
             });
-            clientChannel = bs.connect(serverChannel.localAddress()).asJdkFuture().get();
+            clientChannel = bs.connect(serverChannel.localAddress()).asStage().get();
             Http2StreamChannelBootstrap h2Bootstrap = new Http2StreamChannelBootstrap(clientChannel);
             h2Bootstrap.handler(new ChannelHandler() {
                 @Override
@@ -339,7 +339,7 @@ public class Http2MultiplexTransportTest {
                     ch.pipeline().addLast(new Http2MultiplexHandler(DISCARD_HANDLER));
                 }
             });
-            serverChannel = sb.bind(new InetSocketAddress(NetUtil.LOCALHOST, 0)).asJdkFuture().get();
+            serverChannel = sb.bind(new InetSocketAddress(NetUtil.LOCALHOST, 0)).asStage().get();
 
             final SslContext clientCtx = SslContextBuilder.forClient()
                     .keyManager(ssc.key(), ssc.cert())
@@ -427,7 +427,7 @@ public class Http2MultiplexTransportTest {
                     });
                 }
             });
-            clientChannel = bs.connect(serverChannel.localAddress()).asJdkFuture().get();
+            clientChannel = bs.connect(serverChannel.localAddress()).asStage().get();
             latch.await();
             AssertionError error = errorRef.get();
             if (error != null) {
@@ -503,7 +503,7 @@ public class Http2MultiplexTransportTest {
                     });
                 }
             });
-            serverChannel = sb.bind(new InetSocketAddress(NetUtil.LOCALHOST, 0)).asJdkFuture().get();
+            serverChannel = sb.bind(new InetSocketAddress(NetUtil.LOCALHOST, 0)).asStage().get();
 
             final SslContext clientCtx = SslContextBuilder.forClient()
                     .sslProvider(provider)
@@ -557,7 +557,7 @@ public class Http2MultiplexTransportTest {
                     });
                 }
             });
-            clientChannel = bs.connect(serverChannel.localAddress()).asJdkFuture().get();
+            clientChannel = bs.connect(serverChannel.localAddress()).asStage().get();
 
             latch.await();
         } finally {

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2StreamChannelBootstrapTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2StreamChannelBootstrapTest.java
@@ -78,7 +78,7 @@ public class Http2StreamChannelBootstrapTest {
                             serverChannelLatch.countDown();
                         }
                     });
-            serverChannel = sb.bind(serverAddress).asJdkFuture().get();
+            serverChannel = sb.bind(serverAddress).asStage().get();
 
             Bootstrap cb = new Bootstrap()
                     .channel(LocalChannel.class)
@@ -89,7 +89,7 @@ public class Http2StreamChannelBootstrapTest {
                             ch.pipeline().addLast(forClient().build(), newMultiplexedHandler());
                         }
                     });
-            clientChannel = cb.connect(serverAddress).asJdkFuture().get();
+            clientChannel = cb.connect(serverAddress).asStage().get();
             assertTrue(serverChannelLatch.await(3, SECONDS));
 
             Http2StreamChannelBootstrap bootstrap = new Http2StreamChannelBootstrap(clientChannel);
@@ -101,7 +101,7 @@ public class Http2StreamChannelBootstrapTest {
             ExecutionException exception = assertThrows(ExecutionException.class, new Executable() {
                 @Override
                 public void execute() throws Throwable {
-                    promise.asFuture().asJdkFuture().get(3, SECONDS);
+                    promise.asFuture().asStage().get(3, SECONDS);
                 }
             });
             assertThat(exception.getCause(), IsInstanceOf.instanceOf(ClosedChannelException.class));

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2StreamChannelBootstrapTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2StreamChannelBootstrapTest.java
@@ -78,7 +78,7 @@ public class Http2StreamChannelBootstrapTest {
                             serverChannelLatch.countDown();
                         }
                     });
-            serverChannel = sb.bind(serverAddress).get();
+            serverChannel = sb.bind(serverAddress).asJdkFuture().get();
 
             Bootstrap cb = new Bootstrap()
                     .channel(LocalChannel.class)
@@ -89,7 +89,7 @@ public class Http2StreamChannelBootstrapTest {
                             ch.pipeline().addLast(forClient().build(), newMultiplexedHandler());
                         }
                     });
-            clientChannel = cb.connect(serverAddress).get();
+            clientChannel = cb.connect(serverAddress).asJdkFuture().get();
             assertTrue(serverChannelLatch.await(3, SECONDS));
 
             Http2StreamChannelBootstrap bootstrap = new Http2StreamChannelBootstrap(clientChannel);
@@ -101,7 +101,7 @@ public class Http2StreamChannelBootstrapTest {
             ExecutionException exception = assertThrows(ExecutionException.class, new Executable() {
                 @Override
                 public void execute() throws Throwable {
-                    promise.asFuture().get(3, SECONDS);
+                    promise.asFuture().asJdkFuture().get(3, SECONDS);
                 }
             });
             assertThat(exception.getCause(), IsInstanceOf.instanceOf(ClosedChannelException.class));

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
@@ -568,9 +568,9 @@ public class HttpToHttp2ConnectionHandlerTest {
             }
         });
 
-        serverChannel = sb.bind(new LocalAddress(getClass())).asJdkFuture().get();
+        serverChannel = sb.bind(new LocalAddress(getClass())).asStage().get();
 
-        clientChannel = cb.connect(serverChannel.localAddress()).asJdkFuture().get();
+        clientChannel = cb.connect(serverChannel.localAddress()).asStage().get();
         assertTrue(prefaceWrittenLatch.await(5, SECONDS));
         assertTrue(serverChannelLatch.await(WAIT_TIME_SECONDS, SECONDS));
     }

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
@@ -568,9 +568,9 @@ public class HttpToHttp2ConnectionHandlerTest {
             }
         });
 
-        serverChannel = sb.bind(new LocalAddress(getClass())).get();
+        serverChannel = sb.bind(new LocalAddress(getClass())).asJdkFuture().get();
 
-        clientChannel = cb.connect(serverChannel.localAddress()).get();
+        clientChannel = cb.connect(serverChannel.localAddress()).asJdkFuture().get();
         assertTrue(prefaceWrittenLatch.await(5, SECONDS));
         assertTrue(serverChannelLatch.await(WAIT_TIME_SECONDS, SECONDS));
     }

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
@@ -661,9 +661,9 @@ public class InboundHttp2ToHttpAdapterTest {
             }
         });
 
-        serverChannel = sb.bind(new LocalAddress(getClass())).asJdkFuture().get();
+        serverChannel = sb.bind(new LocalAddress(getClass())).asStage().get();
 
-        clientChannel = cb.connect(serverChannel.localAddress()).asJdkFuture().get();
+        clientChannel = cb.connect(serverChannel.localAddress()).asStage().get();
         assertTrue(prefaceWrittenLatch.await(5, SECONDS));
         assertTrue(serverChannelLatch.await(5, SECONDS));
         // Block until we are sure the handlers are added

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
@@ -661,9 +661,9 @@ public class InboundHttp2ToHttpAdapterTest {
             }
         });
 
-        serverChannel = sb.bind(new LocalAddress(getClass())).get();
+        serverChannel = sb.bind(new LocalAddress(getClass())).asJdkFuture().get();
 
-        clientChannel = cb.connect(serverChannel.localAddress()).get();
+        clientChannel = cb.connect(serverChannel.localAddress()).asJdkFuture().get();
         assertTrue(prefaceWrittenLatch.await(5, SECONDS));
         assertTrue(serverChannelLatch.await(5, SECONDS));
         // Block until we are sure the handlers are added

--- a/common/src/main/java/io/netty5/util/concurrent/AbstractScheduledEventExecutor.java
+++ b/common/src/main/java/io/netty5/util/concurrent/AbstractScheduledEventExecutor.java
@@ -421,11 +421,6 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
         }
 
         @Override
-        public boolean await(long timeoutMillis) throws InterruptedException {
-            return future.await(timeoutMillis);
-        }
-
-        @Override
         public V getNow() {
             return future.getNow();
         }

--- a/common/src/main/java/io/netty5/util/concurrent/AbstractScheduledEventExecutor.java
+++ b/common/src/main/java/io/netty5/util/concurrent/AbstractScheduledEventExecutor.java
@@ -22,9 +22,7 @@ import io.netty5.util.internal.PriorityQueueNode;
 import java.util.Comparator;
 import java.util.Queue;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.callable;
@@ -378,11 +376,6 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
         @Override
         public FutureCompletionStage<V> asStage() {
             return future.asStage();
-        }
-
-        @Override
-        public java.util.concurrent.Future<V> asJdkFuture() {
-            return future.asJdkFuture();
         }
 
         @Override

--- a/common/src/main/java/io/netty5/util/concurrent/AbstractScheduledEventExecutor.java
+++ b/common/src/main/java/io/netty5/util/concurrent/AbstractScheduledEventExecutor.java
@@ -376,16 +376,6 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
         }
 
         @Override
-        public V get() throws InterruptedException, ExecutionException {
-            return future.get();
-        }
-
-        @Override
-        public V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
-            return future.get(timeout, unit);
-        }
-
-        @Override
         public FutureCompletionStage<V> asStage() {
             return future.asStage();
         }

--- a/common/src/main/java/io/netty5/util/concurrent/DefaultPromise.java
+++ b/common/src/main/java/io/netty5/util/concurrent/DefaultPromise.java
@@ -268,11 +268,6 @@ public class DefaultPromise<V> implements Promise<V>, Future<V>,
         return await0(unit.toNanos(timeout), true);
     }
 
-    @Override
-    public boolean await(long timeoutMillis) throws InterruptedException {
-        return await0(MILLISECONDS.toNanos(timeoutMillis), true);
-    }
-
     @SuppressWarnings("unchecked")
     @Override
     public V getNow() {

--- a/common/src/main/java/io/netty5/util/concurrent/DefaultPromise.java
+++ b/common/src/main/java/io/netty5/util/concurrent/DefaultPromise.java
@@ -617,11 +617,6 @@ public class DefaultPromise<V> implements Promise<V>, Future<V>,
         return this;
     }
 
-    @Override
-    public java.util.concurrent.Future<V> asJdkFuture() {
-        return this;
-    }
-
     // <editor-fold defaultstate="collapsed" desc="CompletionStage and JDK Future implementation.">
     private enum Marker {
         EMPTY,

--- a/common/src/main/java/io/netty5/util/concurrent/Future.java
+++ b/common/src/main/java/io/netty5/util/concurrent/Future.java
@@ -110,7 +110,7 @@ import java.util.function.Function;
  *
  * <h3>Do not confuse I/O timeout and await timeout</h3>
  * <p>
- * The timeout value you specify with {@link #await(long)} or {@link #await(long, TimeUnit)} are not related with
+ * The timeout value you specify with {@link #await(long, TimeUnit)} are not related with
  * I/O timeout at all.
  * If an I/O operation times out, the future will be marked as 'completed with failure,' as depicted in the
  * diagram above.  For example, connect timeout should be configured via a transport-specific option:
@@ -193,14 +193,6 @@ public interface Future<V> extends AsynchronousResult<V> {
      * @throws InterruptedException if the current thread was interrupted
      */
     boolean await(long timeout, TimeUnit unit) throws InterruptedException;
-
-    /**
-     * Waits for this future to be completed within the specified time limit.
-     *
-     * @return {@code true} if and only if the future was completed within the specified time limit
-     * @throws InterruptedException if the current thread was interrupted
-     */
-    boolean await(long timeoutMillis) throws InterruptedException;
 
     /**
      * Returns a {@link FutureCompletionStage} that reflects the state of this {@link Future} and so will receive all

--- a/common/src/main/java/io/netty5/util/concurrent/Future.java
+++ b/common/src/main/java/io/netty5/util/concurrent/Future.java
@@ -205,38 +205,6 @@ public interface Future<V> extends AsynchronousResult<V> {
     boolean await(long timeoutMillis) throws InterruptedException;
 
     /**
-     * Get the result of this future, if it has completed.
-     * If the future has failed, then an {@link ExecutionException} will be thrown instead.
-     * If the future has not yet completed, then this method will block until it completes.
-     *
-     * @return The result of the task execution, if it completed successfully.
-     * @throws InterruptedException If the call was blocked, waiting for the future to complete, and the thread was
-     * {@linkplain Thread#interrupt() interrupted}.
-     * @throws ExecutionException If the task failed, either by throwing an exception or through cancellation.
-     */
-    V get() throws InterruptedException, ExecutionException;
-
-    /**
-     * Get the result of this future, if it has completed.
-     * If the future has failed, then an {@link ExecutionException} will be thrown instead.
-     * If the future has not yet completed, then this method will block, waiting up to the given timeout for the future
-     * to complete.
-     * If the future does not complete within the specified timeout, then a {@link TimeoutException} will be thrown.
-     * If the timeout is zero, then this method will not block, and instead either get the result or failure of the
-     * future if completed, or immediately throw a {@link TimeoutException} if not yet completed.
-     *
-     * @param timeout The non-negative maximum amount of time, in terms of the given time unit, to wait for the
-     *                completion of the future.
-     * @param unit The time unit for the timeout.
-     * @return The value of the successfully completed future.
-     * @throws InterruptedException If this call was blocking and this thread got
-     * {@linkplain Thread#interrupt() interrupted}.
-     * @throws ExecutionException If the task failed, either by throwing an exception, or through cancellation.
-     * @throws TimeoutException If the future did not complete within the specified timeout.
-     */
-    V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException;
-
-    /**
      * Returns a {@link FutureCompletionStage} that reflects the state of this {@link Future} and so will receive all
      * updates as well.
      */

--- a/common/src/main/java/io/netty5/util/concurrent/Future.java
+++ b/common/src/main/java/io/netty5/util/concurrent/Future.java
@@ -17,9 +17,7 @@ package io.netty5.util.concurrent;
 
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 
 /**
@@ -207,13 +205,11 @@ public interface Future<V> extends AsynchronousResult<V> {
     /**
      * Returns a {@link FutureCompletionStage} that reflects the state of this {@link Future} and so will receive all
      * updates as well.
+     * <p>
+     * The returned {@link FutureCompletionStage} also implements the JDK {@link java.util.concurrent.Future},
+     * and has blocking methods not found on the Netty {@code Future} interface, for awaiting the completion.
      */
     FutureCompletionStage<V> asStage();
-
-    /**
-     * Returns a {@link java.util.concurrent.Future JDK Future that reflects the state of this {@link Future}.
-     */
-    java.util.concurrent.Future<V> asJdkFuture();
 
     /**
      * Creates a <strong>new</strong> {@link Future} that will complete with the result of this {@link Future} mapped

--- a/common/src/main/java/io/netty5/util/concurrent/Future.java
+++ b/common/src/main/java/io/netty5/util/concurrent/Future.java
@@ -214,18 +214,7 @@ public interface Future<V> extends AsynchronousResult<V> {
      * {@linkplain Thread#interrupt() interrupted}.
      * @throws ExecutionException If the task failed, either by throwing an exception or through cancellation.
      */
-    default V get() throws InterruptedException, ExecutionException {
-        await();
-
-        Throwable cause = cause();
-        if (cause == null) {
-            return getNow();
-        }
-        if (cause instanceof CancellationException) {
-            throw (CancellationException) cause;
-        }
-        throw new ExecutionException(cause);
-    }
+    V get() throws InterruptedException, ExecutionException;
 
     /**
      * Get the result of this future, if it has completed.
@@ -245,19 +234,7 @@ public interface Future<V> extends AsynchronousResult<V> {
      * @throws ExecutionException If the task failed, either by throwing an exception, or through cancellation.
      * @throws TimeoutException If the future did not complete within the specified timeout.
      */
-    default V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
-        if (await(timeout, unit)) {
-            Throwable cause = cause();
-            if (cause == null) {
-                return getNow();
-            }
-            if (cause instanceof CancellationException) {
-                throw (CancellationException) cause;
-            }
-            throw new ExecutionException(cause);
-        }
-        throw new TimeoutException();
-    }
+    V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException;
 
     /**
      * Returns a {@link FutureCompletionStage} that reflects the state of this {@link Future} and so will receive all

--- a/common/src/main/java/io/netty5/util/concurrent/FutureCompletionStage.java
+++ b/common/src/main/java/io/netty5/util/concurrent/FutureCompletionStage.java
@@ -30,13 +30,17 @@ import java.util.function.Function;
  * A {@link CompletionStage} that provides the same threading semantics and guarantees as the underlying
  * {@link Future}, which means that all the callbacks will be executed by {@link #executor()}
  * if not specified otherwise (by calling the corresponding *Async methods).
- *
+ * <p>
+ * This interface also extends {@link java.util.concurrent.Future}, to provide blocking methods for awaiting the result
+ * of the future.
+ * This is in contrast to the Netty {@link Future}, which is entirely non-blocking.
+ * <p>
  * Please be aware that {@link FutureCompletionStage#toCompletableFuture()} is not supported and so will throw
- * a {@link UnsupportedOperationException} when invoked.
+ * an {@link UnsupportedOperationException} when invoked.
  *
  * @param <V> the value type.
  */
-public interface FutureCompletionStage<V> extends CompletionStage<V> {
+public interface FutureCompletionStage<V> extends CompletionStage<V>, java.util.concurrent.Future<V> {
 
     /**
      * Returns the underlying {@link Future} of this {@link FutureCompletionStage}.

--- a/common/src/main/java/io/netty5/util/concurrent/RunnableFutureAdapter.java
+++ b/common/src/main/java/io/netty5/util/concurrent/RunnableFutureAdapter.java
@@ -128,16 +128,6 @@ final class RunnableFutureAdapter<V> implements RunnableFuture<V> {
     }
 
     @Override
-    public V get() throws InterruptedException, ExecutionException {
-        return future.get();
-    }
-
-    @Override
-    public V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
-        return future.get(timeout, unit);
-    }
-
-    @Override
     public FutureCompletionStage<V> asStage() {
         return future.asStage();
     }

--- a/common/src/main/java/io/netty5/util/concurrent/RunnableFutureAdapter.java
+++ b/common/src/main/java/io/netty5/util/concurrent/RunnableFutureAdapter.java
@@ -89,11 +89,6 @@ final class RunnableFutureAdapter<V> implements RunnableFuture<V> {
     }
 
     @Override
-    public boolean await(long timeoutMillis) throws InterruptedException {
-        return future.await(timeoutMillis);
-    }
-
-    @Override
     public V getNow() {
         return promise.getNow();
     }

--- a/common/src/main/java/io/netty5/util/concurrent/RunnableFutureAdapter.java
+++ b/common/src/main/java/io/netty5/util/concurrent/RunnableFutureAdapter.java
@@ -18,9 +18,7 @@ package io.netty5.util.concurrent;
 import io.netty5.util.internal.StringUtil;
 
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import static java.util.Objects.requireNonNull;
 
@@ -130,11 +128,6 @@ final class RunnableFutureAdapter<V> implements RunnableFuture<V> {
     @Override
     public FutureCompletionStage<V> asStage() {
         return future.asStage();
-    }
-
-    @Override
-    public java.util.concurrent.Future<V> asJdkFuture() {
-        return future.asJdkFuture();
     }
 
     @Override

--- a/common/src/main/java/io/netty5/util/concurrent/RunnableScheduledFutureAdapter.java
+++ b/common/src/main/java/io/netty5/util/concurrent/RunnableScheduledFutureAdapter.java
@@ -20,9 +20,7 @@ import io.netty5.util.internal.DefaultPriorityQueue;
 import io.netty5.util.internal.StringUtil;
 
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static java.util.Objects.requireNonNull;
@@ -230,11 +228,6 @@ final class RunnableScheduledFutureAdapter<V> implements AbstractScheduledEventE
     @Override
     public FutureCompletionStage<V> asStage() {
         return future.asStage();
-    }
-
-    @Override
-    public java.util.concurrent.Future<V> asJdkFuture() {
-        return future.asJdkFuture();
     }
 
     @Override

--- a/common/src/main/java/io/netty5/util/concurrent/RunnableScheduledFutureAdapter.java
+++ b/common/src/main/java/io/netty5/util/concurrent/RunnableScheduledFutureAdapter.java
@@ -201,11 +201,6 @@ final class RunnableScheduledFutureAdapter<V> implements AbstractScheduledEventE
     }
 
     @Override
-    public boolean await(long timeoutMillis) throws InterruptedException {
-        return future.await(timeoutMillis);
-    }
-
-    @Override
     public V getNow() {
         return promise.getNow();
     }

--- a/common/src/main/java/io/netty5/util/concurrent/RunnableScheduledFutureAdapter.java
+++ b/common/src/main/java/io/netty5/util/concurrent/RunnableScheduledFutureAdapter.java
@@ -228,16 +228,6 @@ final class RunnableScheduledFutureAdapter<V> implements AbstractScheduledEventE
     }
 
     @Override
-    public V get() throws InterruptedException, ExecutionException {
-        return future.get();
-    }
-
-    @Override
-    public V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
-        return future.get(timeout, unit);
-    }
-
-    @Override
     public FutureCompletionStage<V> asStage() {
         return future.asStage();
     }

--- a/common/src/test/java/io/netty5/util/concurrent/DefaultPromiseTest.java
+++ b/common/src/test/java/io/netty5/util/concurrent/DefaultPromiseTest.java
@@ -171,14 +171,14 @@ public class DefaultPromiseTest {
     public void testCancellationExceptionIsThrownWhenBlockingGet() throws Exception {
         DefaultPromise<Void> promise = new DefaultPromise<>(INSTANCE);
         assertTrue(promise.cancel());
-        assertThrows(CancellationException.class, promise::get);
+        assertThrows(CancellationException.class, promise.asJdkFuture()::get);
     }
 
     @Test
     public void testCancellationExceptionIsThrownWhenBlockingGetWithTimeout() throws Exception {
         DefaultPromise<Void> promise = new DefaultPromise<>(INSTANCE);
         assertTrue(promise.cancel());
-        assertThrows(CancellationException.class, () -> promise.get(1, TimeUnit.SECONDS));
+        assertThrows(CancellationException.class, () -> promise.asJdkFuture().get(1, TimeUnit.SECONDS));
     }
 
     @Test

--- a/common/src/test/java/io/netty5/util/concurrent/DefaultPromiseTest.java
+++ b/common/src/test/java/io/netty5/util/concurrent/DefaultPromiseTest.java
@@ -171,14 +171,14 @@ public class DefaultPromiseTest {
     public void testCancellationExceptionIsThrownWhenBlockingGet() throws Exception {
         DefaultPromise<Void> promise = new DefaultPromise<>(INSTANCE);
         assertTrue(promise.cancel());
-        assertThrows(CancellationException.class, promise.asJdkFuture()::get);
+        assertThrows(CancellationException.class, promise.asStage()::get);
     }
 
     @Test
     public void testCancellationExceptionIsThrownWhenBlockingGetWithTimeout() throws Exception {
         DefaultPromise<Void> promise = new DefaultPromise<>(INSTANCE);
         assertTrue(promise.cancel());
-        assertThrows(CancellationException.class, () -> promise.asJdkFuture().get(1, TimeUnit.SECONDS));
+        assertThrows(CancellationException.class, () -> promise.asStage().get(1, TimeUnit.SECONDS));
     }
 
     @Test

--- a/common/src/test/java/io/netty5/util/concurrent/FuturesTest.java
+++ b/common/src/test/java/io/netty5/util/concurrent/FuturesTest.java
@@ -211,7 +211,7 @@ class FuturesTest {
         mappingLatchEnter.await();
         assertFalse(strFut.await(100));
         mappingLatchExit.countDown();
-        assertThat(strFut.asJdkFuture().get(5, SECONDS)).isEqualTo("42");
+        assertThat(strFut.asStage().get(5, SECONDS)).isEqualTo("42");
     }
 
     @Test
@@ -229,7 +229,7 @@ class FuturesTest {
         promise.cascadeTo(promise2);
         promise.setSuccess(1);
         assertTrue(promise.isSuccess());
-        assertThat(promise2.asJdkFuture().get(1, SECONDS)).isEqualTo(1);
+        assertThat(promise2.asStage().get(1, SECONDS)).isEqualTo(1);
     }
 
     @Test

--- a/common/src/test/java/io/netty5/util/concurrent/FuturesTest.java
+++ b/common/src/test/java/io/netty5/util/concurrent/FuturesTest.java
@@ -211,7 +211,7 @@ class FuturesTest {
         mappingLatchEnter.await();
         assertFalse(strFut.await(100));
         mappingLatchExit.countDown();
-        assertThat(strFut.get(5, SECONDS)).isEqualTo("42");
+        assertThat(strFut.asJdkFuture().get(5, SECONDS)).isEqualTo("42");
     }
 
     @Test
@@ -229,7 +229,7 @@ class FuturesTest {
         promise.cascadeTo(promise2);
         promise.setSuccess(1);
         assertTrue(promise.isSuccess());
-        assertThat(promise2.get(1, SECONDS)).isEqualTo(1);
+        assertThat(promise2.asJdkFuture().get(1, SECONDS)).isEqualTo(1);
     }
 
     @Test

--- a/common/src/test/java/io/netty5/util/concurrent/FuturesTest.java
+++ b/common/src/test/java/io/netty5/util/concurrent/FuturesTest.java
@@ -18,6 +18,7 @@ package io.netty5.util.concurrent;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static io.netty5.util.concurrent.ImmediateEventExecutor.INSTANCE;
@@ -209,7 +210,7 @@ class FuturesTest {
 
         executor.submit(() -> promise.setSuccess(42));
         mappingLatchEnter.await();
-        assertFalse(strFut.await(100));
+        assertFalse(strFut.await(100, TimeUnit.MILLISECONDS));
         mappingLatchExit.countDown();
         assertThat(strFut.asStage().get(5, SECONDS)).isEqualTo("42");
     }

--- a/common/src/test/java/io/netty5/util/concurrent/UnorderedThreadPoolEventExecutorTest.java
+++ b/common/src/test/java/io/netty5/util/concurrent/UnorderedThreadPoolEventExecutorTest.java
@@ -82,7 +82,7 @@ public class UnorderedThreadPoolEventExecutorTest {
                 }
             });
 
-            assertEquals(expected, f.get());
+            assertEquals(expected, f.asJdkFuture().get());
         } finally {
             executor.shutdownGracefully();
         }

--- a/common/src/test/java/io/netty5/util/concurrent/UnorderedThreadPoolEventExecutorTest.java
+++ b/common/src/test/java/io/netty5/util/concurrent/UnorderedThreadPoolEventExecutorTest.java
@@ -82,7 +82,7 @@ public class UnorderedThreadPoolEventExecutorTest {
                 }
             });
 
-            assertEquals(expected, f.asJdkFuture().get());
+            assertEquals(expected, f.asStage().get());
         } finally {
             executor.shutdownGracefully();
         }

--- a/example/src/main/java/io/netty5/example/discard/DiscardClient.java
+++ b/example/src/main/java/io/netty5/example/discard/DiscardClient.java
@@ -65,7 +65,7 @@ public final class DiscardClient {
              });
 
             // Make the connection attempt.
-            Channel channel = b.connect(HOST, PORT).asJdkFuture().get();
+            Channel channel = b.connect(HOST, PORT).asStage().get();
 
             // Wait until the connection is closed.
             channel.closeFuture().sync();

--- a/example/src/main/java/io/netty5/example/discard/DiscardClient.java
+++ b/example/src/main/java/io/netty5/example/discard/DiscardClient.java
@@ -65,7 +65,7 @@ public final class DiscardClient {
              });
 
             // Make the connection attempt.
-            Channel channel = b.connect(HOST, PORT).get();
+            Channel channel = b.connect(HOST, PORT).asJdkFuture().get();
 
             // Wait until the connection is closed.
             channel.closeFuture().sync();

--- a/example/src/main/java/io/netty5/example/discard/DiscardServer.java
+++ b/example/src/main/java/io/netty5/example/discard/DiscardServer.java
@@ -67,7 +67,7 @@ public final class DiscardServer {
              });
 
             // Bind and start to accept incoming connections.
-            Channel channel = b.bind(PORT).asJdkFuture().get();
+            Channel channel = b.bind(PORT).asStage().get();
 
             // Wait until the server socket is closed.
             // In this example, this does not happen, but you can do that to gracefully

--- a/example/src/main/java/io/netty5/example/discard/DiscardServer.java
+++ b/example/src/main/java/io/netty5/example/discard/DiscardServer.java
@@ -67,7 +67,7 @@ public final class DiscardServer {
              });
 
             // Bind and start to accept incoming connections.
-            Channel channel = b.bind(PORT).get();
+            Channel channel = b.bind(PORT).asJdkFuture().get();
 
             // Wait until the server socket is closed.
             // In this example, this does not happen, but you can do that to gracefully

--- a/example/src/main/java/io/netty5/example/dns/dot/DoTClient.java
+++ b/example/src/main/java/io/netty5/example/dns/dot/DoTClient.java
@@ -99,7 +99,7 @@ public final class DoTClient {
                       });
                  }
              });
-            final Channel ch = b.connect(DNS_SERVER_HOST, DNS_SERVER_PORT).get();
+            final Channel ch = b.connect(DNS_SERVER_HOST, DNS_SERVER_PORT).asJdkFuture().get();
 
             int randomID = new Random().nextInt(60000 - 1000) + 1000;
             DnsQuery query = new DefaultDnsQuery(randomID, DnsOpCode.QUERY)

--- a/example/src/main/java/io/netty5/example/dns/dot/DoTClient.java
+++ b/example/src/main/java/io/netty5/example/dns/dot/DoTClient.java
@@ -99,7 +99,7 @@ public final class DoTClient {
                       });
                  }
              });
-            final Channel ch = b.connect(DNS_SERVER_HOST, DNS_SERVER_PORT).asJdkFuture().get();
+            final Channel ch = b.connect(DNS_SERVER_HOST, DNS_SERVER_PORT).asStage().get();
 
             int randomID = new Random().nextInt(60000 - 1000) + 1000;
             DnsQuery query = new DefaultDnsQuery(randomID, DnsOpCode.QUERY)

--- a/example/src/main/java/io/netty5/example/dns/tcp/TcpDnsClient.java
+++ b/example/src/main/java/io/netty5/example/dns/tcp/TcpDnsClient.java
@@ -93,7 +93,7 @@ public final class TcpDnsClient {
                         }
                     });
 
-            final Channel ch = b.connect(DNS_SERVER_HOST, DNS_SERVER_PORT).get();
+            final Channel ch = b.connect(DNS_SERVER_HOST, DNS_SERVER_PORT).asJdkFuture().get();
 
             int randomID = new Random().nextInt(60000 - 1000) + 1000;
             DnsQuery query = new DefaultDnsQuery(randomID, DnsOpCode.QUERY)

--- a/example/src/main/java/io/netty5/example/dns/tcp/TcpDnsClient.java
+++ b/example/src/main/java/io/netty5/example/dns/tcp/TcpDnsClient.java
@@ -93,7 +93,7 @@ public final class TcpDnsClient {
                         }
                     });
 
-            final Channel ch = b.connect(DNS_SERVER_HOST, DNS_SERVER_PORT).asJdkFuture().get();
+            final Channel ch = b.connect(DNS_SERVER_HOST, DNS_SERVER_PORT).asStage().get();
 
             int randomID = new Random().nextInt(60000 - 1000) + 1000;
             DnsQuery query = new DefaultDnsQuery(randomID, DnsOpCode.QUERY)

--- a/example/src/main/java/io/netty5/example/dns/tcp/TcpDnsServer.java
+++ b/example/src/main/java/io/netty5/example/dns/tcp/TcpDnsServer.java
@@ -97,7 +97,7 @@ public final class TcpDnsServer {
                                 });
                     }
                 });
-        final Channel channel = bootstrap.bind(DNS_SERVER_PORT).get();
+        final Channel channel = bootstrap.bind(DNS_SERVER_PORT).asJdkFuture().get();
         Executors.newSingleThreadScheduledExecutor().schedule(() -> {
             try {
                 clientQuery();
@@ -135,7 +135,7 @@ public final class TcpDnsServer {
                         }
                     });
 
-            final Channel ch = b.connect(DNS_SERVER_HOST, DNS_SERVER_PORT).get();
+            final Channel ch = b.connect(DNS_SERVER_HOST, DNS_SERVER_PORT).asJdkFuture().get();
 
             int randomID = new Random().nextInt(60000 - 1000) + 1000;
             DnsQuery query = new DefaultDnsQuery(randomID, DnsOpCode.QUERY)

--- a/example/src/main/java/io/netty5/example/dns/tcp/TcpDnsServer.java
+++ b/example/src/main/java/io/netty5/example/dns/tcp/TcpDnsServer.java
@@ -97,7 +97,7 @@ public final class TcpDnsServer {
                                 });
                     }
                 });
-        final Channel channel = bootstrap.bind(DNS_SERVER_PORT).asJdkFuture().get();
+        final Channel channel = bootstrap.bind(DNS_SERVER_PORT).asStage().get();
         Executors.newSingleThreadScheduledExecutor().schedule(() -> {
             try {
                 clientQuery();
@@ -135,7 +135,7 @@ public final class TcpDnsServer {
                         }
                     });
 
-            final Channel ch = b.connect(DNS_SERVER_HOST, DNS_SERVER_PORT).asJdkFuture().get();
+            final Channel ch = b.connect(DNS_SERVER_HOST, DNS_SERVER_PORT).asStage().get();
 
             int randomID = new Random().nextInt(60000 - 1000) + 1000;
             DnsQuery query = new DefaultDnsQuery(randomID, DnsOpCode.QUERY)

--- a/example/src/main/java/io/netty5/example/dns/udp/DnsClient.java
+++ b/example/src/main/java/io/netty5/example/dns/udp/DnsClient.java
@@ -91,7 +91,7 @@ public final class DnsClient {
                     });
                  }
              });
-            final Channel ch = b.bind(0).asJdkFuture().get();
+            final Channel ch = b.bind(0).asStage().get();
             DnsQuery query = new DatagramDnsQuery(null, addr, 1).setRecord(
                     DnsSection.QUESTION,
                     new DefaultDnsQuestion(QUERY_DOMAIN, DnsRecordType.A));

--- a/example/src/main/java/io/netty5/example/dns/udp/DnsClient.java
+++ b/example/src/main/java/io/netty5/example/dns/udp/DnsClient.java
@@ -91,7 +91,7 @@ public final class DnsClient {
                     });
                  }
              });
-            final Channel ch = b.bind(0).get();
+            final Channel ch = b.bind(0).asJdkFuture().get();
             DnsQuery query = new DatagramDnsQuery(null, addr, 1).setRecord(
                     DnsSection.QUESTION,
                     new DefaultDnsQuestion(QUERY_DOMAIN, DnsRecordType.A));

--- a/example/src/main/java/io/netty5/example/echo/EchoClient.java
+++ b/example/src/main/java/io/netty5/example/echo/EchoClient.java
@@ -72,7 +72,7 @@ public final class EchoClient {
              });
 
             // Start the client.
-            Channel channel = b.connect(HOST, PORT).asJdkFuture().get();
+            Channel channel = b.connect(HOST, PORT).asStage().get();
 
             // Wait until the connection is closed.
             channel.closeFuture().sync();

--- a/example/src/main/java/io/netty5/example/echo/EchoClient.java
+++ b/example/src/main/java/io/netty5/example/echo/EchoClient.java
@@ -72,7 +72,7 @@ public final class EchoClient {
              });
 
             // Start the client.
-            Channel channel = b.connect(HOST, PORT).get();
+            Channel channel = b.connect(HOST, PORT).asJdkFuture().get();
 
             // Wait until the connection is closed.
             channel.closeFuture().sync();

--- a/example/src/main/java/io/netty5/example/echo/EchoServer.java
+++ b/example/src/main/java/io/netty5/example/echo/EchoServer.java
@@ -72,7 +72,7 @@ public final class EchoServer {
              });
 
             // Start the server.
-            Channel channel = b.bind(PORT).asJdkFuture().get();
+            Channel channel = b.bind(PORT).asStage().get();
 
             // Wait until the server socket is closed.
             channel.closeFuture().sync();

--- a/example/src/main/java/io/netty5/example/echo/EchoServer.java
+++ b/example/src/main/java/io/netty5/example/echo/EchoServer.java
@@ -72,7 +72,7 @@ public final class EchoServer {
              });
 
             // Start the server.
-            Channel channel = b.bind(PORT).get();
+            Channel channel = b.bind(PORT).asJdkFuture().get();
 
             // Wait until the server socket is closed.
             channel.closeFuture().sync();

--- a/example/src/main/java/io/netty5/example/factorial/FactorialClient.java
+++ b/example/src/main/java/io/netty5/example/factorial/FactorialClient.java
@@ -54,7 +54,7 @@ public final class FactorialClient {
              .handler(new FactorialClientInitializer(sslCtx));
 
             // Make a new connection.
-            Channel channel = b.connect(HOST, PORT).asJdkFuture().get();
+            Channel channel = b.connect(HOST, PORT).asStage().get();
 
             // Get the handler instance to retrieve the answer.
             FactorialClientHandler handler = (FactorialClientHandler) channel.pipeline().last();

--- a/example/src/main/java/io/netty5/example/factorial/FactorialClient.java
+++ b/example/src/main/java/io/netty5/example/factorial/FactorialClient.java
@@ -54,7 +54,7 @@ public final class FactorialClient {
              .handler(new FactorialClientInitializer(sslCtx));
 
             // Make a new connection.
-            Channel channel = b.connect(HOST, PORT).get();
+            Channel channel = b.connect(HOST, PORT).asJdkFuture().get();
 
             // Get the handler instance to retrieve the answer.
             FactorialClientHandler handler = (FactorialClientHandler) channel.pipeline().last();

--- a/example/src/main/java/io/netty5/example/factorial/FactorialServer.java
+++ b/example/src/main/java/io/netty5/example/factorial/FactorialServer.java
@@ -54,7 +54,7 @@ public final class FactorialServer {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new FactorialServerInitializer(sslCtx));
 
-            b.bind(PORT).asJdkFuture().get().closeFuture().sync();
+            b.bind(PORT).asStage().get().closeFuture().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty5/example/factorial/FactorialServer.java
+++ b/example/src/main/java/io/netty5/example/factorial/FactorialServer.java
@@ -54,7 +54,7 @@ public final class FactorialServer {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new FactorialServerInitializer(sslCtx));
 
-            b.bind(PORT).get().closeFuture().sync();
+            b.bind(PORT).asJdkFuture().get().closeFuture().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty5/example/file/FileServer.java
+++ b/example/src/main/java/io/netty5/example/file/FileServer.java
@@ -81,7 +81,7 @@ public final class FileServer {
              });
 
             // Start the server.
-            Channel channel = b.bind(PORT).get();
+            Channel channel = b.bind(PORT).asJdkFuture().get();
 
             // Wait until the server socket is closed.
             channel.closeFuture().sync();

--- a/example/src/main/java/io/netty5/example/file/FileServer.java
+++ b/example/src/main/java/io/netty5/example/file/FileServer.java
@@ -81,7 +81,7 @@ public final class FileServer {
              });
 
             // Start the server.
-            Channel channel = b.bind(PORT).asJdkFuture().get();
+            Channel channel = b.bind(PORT).asStage().get();
 
             // Wait until the server socket is closed.
             channel.closeFuture().sync();

--- a/example/src/main/java/io/netty5/example/http/cors/HttpCorsServer.java
+++ b/example/src/main/java/io/netty5/example/http/cors/HttpCorsServer.java
@@ -96,7 +96,7 @@ public final class HttpCorsServer {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new HttpCorsServerInitializer(sslCtx));
 
-            b.bind(PORT).get().closeFuture().sync();
+            b.bind(PORT).asJdkFuture().get().closeFuture().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty5/example/http/cors/HttpCorsServer.java
+++ b/example/src/main/java/io/netty5/example/http/cors/HttpCorsServer.java
@@ -96,7 +96,7 @@ public final class HttpCorsServer {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new HttpCorsServerInitializer(sslCtx));
 
-            b.bind(PORT).asJdkFuture().get().closeFuture().sync();
+            b.bind(PORT).asStage().get().closeFuture().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty5/example/http/file/HttpStaticFileServer.java
+++ b/example/src/main/java/io/netty5/example/http/file/HttpStaticFileServer.java
@@ -53,7 +53,7 @@ public final class HttpStaticFileServer {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new HttpStaticFileServerInitializer(sslCtx));
 
-            Channel ch = b.bind(PORT).get();
+            Channel ch = b.bind(PORT).asJdkFuture().get();
 
             System.err.println("Open your web browser and navigate to " +
                     (SSL? "https" : "http") + "://127.0.0.1:" + PORT + '/');

--- a/example/src/main/java/io/netty5/example/http/file/HttpStaticFileServer.java
+++ b/example/src/main/java/io/netty5/example/http/file/HttpStaticFileServer.java
@@ -53,7 +53,7 @@ public final class HttpStaticFileServer {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new HttpStaticFileServerInitializer(sslCtx));
 
-            Channel ch = b.bind(PORT).asJdkFuture().get();
+            Channel ch = b.bind(PORT).asStage().get();
 
             System.err.println("Open your web browser and navigate to " +
                     (SSL? "https" : "http") + "://127.0.0.1:" + PORT + '/');

--- a/example/src/main/java/io/netty5/example/http/helloworld/HttpHelloWorldServer.java
+++ b/example/src/main/java/io/netty5/example/http/helloworld/HttpHelloWorldServer.java
@@ -58,7 +58,7 @@ public final class HttpHelloWorldServer {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new HttpHelloWorldServerInitializer(sslCtx));
 
-            Channel ch = b.bind(PORT).asJdkFuture().get();
+            Channel ch = b.bind(PORT).asStage().get();
 
             System.err.println("Open your web browser and navigate to " +
                     (SSL? "https" : "http") + "://127.0.0.1:" + PORT + '/');

--- a/example/src/main/java/io/netty5/example/http/helloworld/HttpHelloWorldServer.java
+++ b/example/src/main/java/io/netty5/example/http/helloworld/HttpHelloWorldServer.java
@@ -58,7 +58,7 @@ public final class HttpHelloWorldServer {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new HttpHelloWorldServerInitializer(sslCtx));
 
-            Channel ch = b.bind(PORT).get();
+            Channel ch = b.bind(PORT).asJdkFuture().get();
 
             System.err.println("Open your web browser and navigate to " +
                     (SSL? "https" : "http") + "://127.0.0.1:" + PORT + '/');

--- a/example/src/main/java/io/netty5/example/http/snoop/HttpSnoopClient.java
+++ b/example/src/main/java/io/netty5/example/http/snoop/HttpSnoopClient.java
@@ -80,7 +80,7 @@ public final class HttpSnoopClient {
              .handler(new HttpSnoopClientInitializer(sslCtx));
 
             // Make the connection attempt.
-            Channel ch = b.connect(host, port).get();
+            Channel ch = b.connect(host, port).asJdkFuture().get();
 
             // Prepare the HTTP request.
             HttpRequest request = new DefaultFullHttpRequest(

--- a/example/src/main/java/io/netty5/example/http/snoop/HttpSnoopClient.java
+++ b/example/src/main/java/io/netty5/example/http/snoop/HttpSnoopClient.java
@@ -80,7 +80,7 @@ public final class HttpSnoopClient {
              .handler(new HttpSnoopClientInitializer(sslCtx));
 
             // Make the connection attempt.
-            Channel ch = b.connect(host, port).asJdkFuture().get();
+            Channel ch = b.connect(host, port).asStage().get();
 
             // Prepare the HTTP request.
             HttpRequest request = new DefaultFullHttpRequest(

--- a/example/src/main/java/io/netty5/example/http/snoop/HttpSnoopServer.java
+++ b/example/src/main/java/io/netty5/example/http/snoop/HttpSnoopServer.java
@@ -56,7 +56,7 @@ public final class HttpSnoopServer {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new HttpSnoopServerInitializer(sslCtx));
 
-            Channel ch = b.bind(PORT).get();
+            Channel ch = b.bind(PORT).asJdkFuture().get();
 
             System.err.println("Open your web browser and navigate to " +
                     (SSL? "https" : "http") + "://127.0.0.1:" + PORT + '/');

--- a/example/src/main/java/io/netty5/example/http/snoop/HttpSnoopServer.java
+++ b/example/src/main/java/io/netty5/example/http/snoop/HttpSnoopServer.java
@@ -56,7 +56,7 @@ public final class HttpSnoopServer {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new HttpSnoopServerInitializer(sslCtx));
 
-            Channel ch = b.bind(PORT).asJdkFuture().get();
+            Channel ch = b.bind(PORT).asStage().get();
 
             System.err.println("Open your web browser and navigate to " +
                     (SSL? "https" : "http") + "://127.0.0.1:" + PORT + '/');

--- a/example/src/main/java/io/netty5/example/http/websocketx/benchmarkserver/WebSocketServer.java
+++ b/example/src/main/java/io/netty5/example/http/websocketx/benchmarkserver/WebSocketServer.java
@@ -56,7 +56,7 @@ public final class WebSocketServer {
              .channel(NioServerSocketChannel.class)
              .childHandler(new WebSocketServerInitializer(sslCtx));
 
-            Channel ch = b.bind(PORT).get();
+            Channel ch = b.bind(PORT).asJdkFuture().get();
 
             System.out.println("Open your web browser and navigate to " +
                     (SSL? "https" : "http") + "://127.0.0.1:" + PORT + '/');

--- a/example/src/main/java/io/netty5/example/http/websocketx/benchmarkserver/WebSocketServer.java
+++ b/example/src/main/java/io/netty5/example/http/websocketx/benchmarkserver/WebSocketServer.java
@@ -56,7 +56,7 @@ public final class WebSocketServer {
              .channel(NioServerSocketChannel.class)
              .childHandler(new WebSocketServerInitializer(sslCtx));
 
-            Channel ch = b.bind(PORT).asJdkFuture().get();
+            Channel ch = b.bind(PORT).asStage().get();
 
             System.out.println("Open your web browser and navigate to " +
                     (SSL? "https" : "http") + "://127.0.0.1:" + PORT + '/');

--- a/example/src/main/java/io/netty5/example/http/websocketx/client/WebSocketClient.java
+++ b/example/src/main/java/io/netty5/example/http/websocketx/client/WebSocketClient.java
@@ -119,7 +119,7 @@ public final class WebSocketClient {
                  }
              });
 
-            Channel ch = b.connect(uri.getHost(), port).asJdkFuture().get();
+            Channel ch = b.connect(uri.getHost(), port).asStage().get();
             handler.handshakeFuture().sync();
 
             BufferedReader console = new BufferedReader(new InputStreamReader(System.in));

--- a/example/src/main/java/io/netty5/example/http/websocketx/client/WebSocketClient.java
+++ b/example/src/main/java/io/netty5/example/http/websocketx/client/WebSocketClient.java
@@ -119,7 +119,7 @@ public final class WebSocketClient {
                  }
              });
 
-            Channel ch = b.connect(uri.getHost(), port).get();
+            Channel ch = b.connect(uri.getHost(), port).asJdkFuture().get();
             handler.handshakeFuture().sync();
 
             BufferedReader console = new BufferedReader(new InputStreamReader(System.in));

--- a/example/src/main/java/io/netty5/example/http/websocketx/server/WebSocketServer.java
+++ b/example/src/main/java/io/netty5/example/http/websocketx/server/WebSocketServer.java
@@ -70,7 +70,7 @@ public final class WebSocketServer {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new WebSocketServerInitializer(sslCtx));
 
-            Channel ch = b.bind(PORT).asJdkFuture().get();
+            Channel ch = b.bind(PORT).asStage().get();
 
             System.out.println("Open your web browser and navigate to " +
                     (SSL? "https" : "http") + "://127.0.0.1:" + PORT + '/');

--- a/example/src/main/java/io/netty5/example/http/websocketx/server/WebSocketServer.java
+++ b/example/src/main/java/io/netty5/example/http/websocketx/server/WebSocketServer.java
@@ -70,7 +70,7 @@ public final class WebSocketServer {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new WebSocketServerInitializer(sslCtx));
 
-            Channel ch = b.bind(PORT).get();
+            Channel ch = b.bind(PORT).asJdkFuture().get();
 
             System.out.println("Open your web browser and navigate to " +
                     (SSL? "https" : "http") + "://127.0.0.1:" + PORT + '/');

--- a/example/src/main/java/io/netty5/example/http2/helloworld/client/Http2Client.java
+++ b/example/src/main/java/io/netty5/example/http2/helloworld/client/Http2Client.java
@@ -106,7 +106,7 @@ public final class Http2Client {
             b.handler(initializer);
 
             // Start the client.
-            Channel channel = b.connect().asJdkFuture().get();
+            Channel channel = b.connect().asStage().get();
             System.out.println("Connected to [" + HOST + ':' + PORT + ']');
 
             // Wait for the HTTP/2 upgrade to occur.

--- a/example/src/main/java/io/netty5/example/http2/helloworld/client/Http2Client.java
+++ b/example/src/main/java/io/netty5/example/http2/helloworld/client/Http2Client.java
@@ -106,7 +106,7 @@ public final class Http2Client {
             b.handler(initializer);
 
             // Start the client.
-            Channel channel = b.connect().get();
+            Channel channel = b.connect().asJdkFuture().get();
             System.out.println("Connected to [" + HOST + ':' + PORT + ']');
 
             // Wait for the HTTP/2 upgrade to occur.

--- a/example/src/main/java/io/netty5/example/http2/helloworld/frame/client/Http2FrameClient.java
+++ b/example/src/main/java/io/netty5/example/http2/helloworld/frame/client/Http2FrameClient.java
@@ -89,7 +89,7 @@ public final class Http2FrameClient {
             b.handler(new Http2ClientFrameInitializer(sslCtx));
 
             // Start the client.
-            final Channel channel = b.connect().get();
+            final Channel channel = b.connect().asJdkFuture().get();
             System.out.println("Connected to [" + HOST + ':' + PORT + ']');
 
             final Http2ClientStreamFrameResponseHandler streamFrameResponseHandler =

--- a/example/src/main/java/io/netty5/example/http2/helloworld/frame/client/Http2FrameClient.java
+++ b/example/src/main/java/io/netty5/example/http2/helloworld/frame/client/Http2FrameClient.java
@@ -89,7 +89,7 @@ public final class Http2FrameClient {
             b.handler(new Http2ClientFrameInitializer(sslCtx));
 
             // Start the client.
-            final Channel channel = b.connect().asJdkFuture().get();
+            final Channel channel = b.connect().asStage().get();
             System.out.println("Connected to [" + HOST + ':' + PORT + ']');
 
             final Http2ClientStreamFrameResponseHandler streamFrameResponseHandler =

--- a/example/src/main/java/io/netty5/example/http2/helloworld/frame/server/Http2Server.java
+++ b/example/src/main/java/io/netty5/example/http2/helloworld/frame/server/Http2Server.java
@@ -85,7 +85,7 @@ public final class Http2Server {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new Http2ServerInitializer(sslCtx));
 
-            Channel ch = b.bind(PORT).get();
+            Channel ch = b.bind(PORT).asJdkFuture().get();
 
             System.err.println("Open your HTTP/2-enabled web browser and navigate to " +
                     (SSL? "https" : "http") + "://127.0.0.1:" + PORT + '/');

--- a/example/src/main/java/io/netty5/example/http2/helloworld/frame/server/Http2Server.java
+++ b/example/src/main/java/io/netty5/example/http2/helloworld/frame/server/Http2Server.java
@@ -85,7 +85,7 @@ public final class Http2Server {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new Http2ServerInitializer(sslCtx));
 
-            Channel ch = b.bind(PORT).asJdkFuture().get();
+            Channel ch = b.bind(PORT).asStage().get();
 
             System.err.println("Open your HTTP/2-enabled web browser and navigate to " +
                     (SSL? "https" : "http") + "://127.0.0.1:" + PORT + '/');

--- a/example/src/main/java/io/netty5/example/http2/helloworld/multiplex/server/Http2Server.java
+++ b/example/src/main/java/io/netty5/example/http2/helloworld/multiplex/server/Http2Server.java
@@ -87,7 +87,7 @@ public final class Http2Server {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new Http2ServerInitializer(sslCtx));
 
-            Channel ch = b.bind(PORT).get();
+            Channel ch = b.bind(PORT).asJdkFuture().get();
 
             System.err.println("Open your HTTP/2-enabled web browser and navigate to " +
                     (SSL? "https" : "http") + "://127.0.0.1:" + PORT + '/');

--- a/example/src/main/java/io/netty5/example/http2/helloworld/multiplex/server/Http2Server.java
+++ b/example/src/main/java/io/netty5/example/http2/helloworld/multiplex/server/Http2Server.java
@@ -87,7 +87,7 @@ public final class Http2Server {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new Http2ServerInitializer(sslCtx));
 
-            Channel ch = b.bind(PORT).asJdkFuture().get();
+            Channel ch = b.bind(PORT).asStage().get();
 
             System.err.println("Open your HTTP/2-enabled web browser and navigate to " +
                     (SSL? "https" : "http") + "://127.0.0.1:" + PORT + '/');

--- a/example/src/main/java/io/netty5/example/http2/helloworld/server/Http2Server.java
+++ b/example/src/main/java/io/netty5/example/http2/helloworld/server/Http2Server.java
@@ -82,7 +82,7 @@ public final class Http2Server {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new Http2ServerInitializer(sslCtx));
 
-            Channel ch = b.bind(PORT).asJdkFuture().get();
+            Channel ch = b.bind(PORT).asStage().get();
 
             System.err.println("Open your HTTP/2-enabled web browser and navigate to " +
                     (SSL? "https" : "http") + "://127.0.0.1:" + PORT + '/');

--- a/example/src/main/java/io/netty5/example/http2/helloworld/server/Http2Server.java
+++ b/example/src/main/java/io/netty5/example/http2/helloworld/server/Http2Server.java
@@ -82,7 +82,7 @@ public final class Http2Server {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new Http2ServerInitializer(sslCtx));
 
-            Channel ch = b.bind(PORT).get();
+            Channel ch = b.bind(PORT).asJdkFuture().get();
 
             System.err.println("Open your HTTP/2-enabled web browser and navigate to " +
                     (SSL? "https" : "http") + "://127.0.0.1:" + PORT + '/');

--- a/example/src/main/java/io/netty5/example/http2/tiles/Http2Server.java
+++ b/example/src/main/java/io/netty5/example/http2/tiles/Http2Server.java
@@ -65,7 +65,7 @@ public class Http2Server {
             }
         });
 
-        Channel ch = b.bind(PORT).get();
+        Channel ch = b.bind(PORT).asJdkFuture().get();
         return ch.closeFuture();
     }
 

--- a/example/src/main/java/io/netty5/example/http2/tiles/Http2Server.java
+++ b/example/src/main/java/io/netty5/example/http2/tiles/Http2Server.java
@@ -65,7 +65,7 @@ public class Http2Server {
             }
         });
 
-        Channel ch = b.bind(PORT).asJdkFuture().get();
+        Channel ch = b.bind(PORT).asStage().get();
         return ch.closeFuture();
     }
 

--- a/example/src/main/java/io/netty5/example/http2/tiles/HttpServer.java
+++ b/example/src/main/java/io/netty5/example/http2/tiles/HttpServer.java
@@ -60,7 +60,7 @@ public final class HttpServer {
             }
         });
 
-        Channel ch = b.bind(PORT).asJdkFuture().get();
+        Channel ch = b.bind(PORT).asStage().get();
         return ch.closeFuture();
     }
 }

--- a/example/src/main/java/io/netty5/example/http2/tiles/HttpServer.java
+++ b/example/src/main/java/io/netty5/example/http2/tiles/HttpServer.java
@@ -60,7 +60,7 @@ public final class HttpServer {
             }
         });
 
-        Channel ch = b.bind(PORT).get();
+        Channel ch = b.bind(PORT).asJdkFuture().get();
         return ch.closeFuture();
     }
 }

--- a/example/src/main/java/io/netty5/example/localecho/LocalEcho.java
+++ b/example/src/main/java/io/netty5/example/localecho/LocalEcho.java
@@ -80,7 +80,7 @@ public final class LocalEcho {
             sb.bind(addr).sync();
 
             // Start the client.
-            Channel ch = cb.connect(addr).get();
+            Channel ch = cb.connect(addr).asJdkFuture().get();
 
             // Read commands from the stdin.
             System.out.println("Enter text (quit to end)");

--- a/example/src/main/java/io/netty5/example/localecho/LocalEcho.java
+++ b/example/src/main/java/io/netty5/example/localecho/LocalEcho.java
@@ -80,7 +80,7 @@ public final class LocalEcho {
             sb.bind(addr).sync();
 
             // Start the client.
-            Channel ch = cb.connect(addr).asJdkFuture().get();
+            Channel ch = cb.connect(addr).asStage().get();
 
             // Read commands from the stdin.
             System.out.println("Enter text (quit to end)");

--- a/example/src/main/java/io/netty5/example/ocsp/OcspClientExample.java
+++ b/example/src/main/java/io/netty5/example/ocsp/OcspClientExample.java
@@ -96,10 +96,10 @@ public class OcspClientExample {
                         .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5 * 1000)
                         .handler(newClientHandler(context, host, promise));
 
-                Channel channel = bootstrap.connect(host, 443).get();
+                Channel channel = bootstrap.connect(host, 443).asJdkFuture().get();
 
                 try {
-                    FullHttpResponse response = promise.asFuture().get();
+                    FullHttpResponse response = promise.asFuture().asJdkFuture().get();
                     Resource.dispose(response);
                 } finally {
                     channel.close();

--- a/example/src/main/java/io/netty5/example/ocsp/OcspClientExample.java
+++ b/example/src/main/java/io/netty5/example/ocsp/OcspClientExample.java
@@ -96,10 +96,10 @@ public class OcspClientExample {
                         .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5 * 1000)
                         .handler(newClientHandler(context, host, promise));
 
-                Channel channel = bootstrap.connect(host, 443).asJdkFuture().get();
+                Channel channel = bootstrap.connect(host, 443).asStage().get();
 
                 try {
-                    FullHttpResponse response = promise.asFuture().asJdkFuture().get();
+                    FullHttpResponse response = promise.asFuture().asStage().get();
                     Resource.dispose(response);
                 } finally {
                     channel.close();

--- a/example/src/main/java/io/netty5/example/portunification/PortUnificationServer.java
+++ b/example/src/main/java/io/netty5/example/portunification/PortUnificationServer.java
@@ -60,7 +60,7 @@ public final class PortUnificationServer {
             });
 
             // Bind and start to accept incoming connections.
-            b.bind(PORT).get().closeFuture().sync();
+            b.bind(PORT).asJdkFuture().get().closeFuture().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty5/example/portunification/PortUnificationServer.java
+++ b/example/src/main/java/io/netty5/example/portunification/PortUnificationServer.java
@@ -60,7 +60,7 @@ public final class PortUnificationServer {
             });
 
             // Bind and start to accept incoming connections.
-            b.bind(PORT).asJdkFuture().get().closeFuture().sync();
+            b.bind(PORT).asStage().get().closeFuture().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty5/example/proxy/HexDumpProxy.java
+++ b/example/src/main/java/io/netty5/example/proxy/HexDumpProxy.java
@@ -43,7 +43,7 @@ public final class HexDumpProxy {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new HexDumpProxyInitializer(REMOTE_HOST, REMOTE_PORT))
              .childOption(ChannelOption.AUTO_READ, false)
-             .bind(LOCAL_PORT).asJdkFuture().get().closeFuture().sync();
+             .bind(LOCAL_PORT).asStage().get().closeFuture().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty5/example/proxy/HexDumpProxy.java
+++ b/example/src/main/java/io/netty5/example/proxy/HexDumpProxy.java
@@ -43,7 +43,7 @@ public final class HexDumpProxy {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new HexDumpProxyInitializer(REMOTE_HOST, REMOTE_PORT))
              .childOption(ChannelOption.AUTO_READ, false)
-             .bind(LOCAL_PORT).get().closeFuture().sync();
+             .bind(LOCAL_PORT).asJdkFuture().get().closeFuture().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty5/example/qotm/QuoteOfTheMomentClient.java
+++ b/example/src/main/java/io/netty5/example/qotm/QuoteOfTheMomentClient.java
@@ -49,7 +49,7 @@ public final class QuoteOfTheMomentClient {
              .option(ChannelOption.SO_BROADCAST, true)
              .handler(new QuoteOfTheMomentClientHandler());
 
-            Channel ch = b.bind(0).asJdkFuture().get();
+            Channel ch = b.bind(0).asStage().get();
 
             // Broadcast the QOTM request to port 8080.
             Buffer message = DefaultBufferAllocators.preferredAllocator().copyOf("QOTM?", UTF_8);

--- a/example/src/main/java/io/netty5/example/qotm/QuoteOfTheMomentClient.java
+++ b/example/src/main/java/io/netty5/example/qotm/QuoteOfTheMomentClient.java
@@ -27,6 +27,8 @@ import io.netty5.channel.socket.DatagramPacket;
 import io.netty5.channel.socket.nio.NioDatagramChannel;
 import io.netty5.util.internal.SocketUtils;
 
+import java.util.concurrent.TimeUnit;
+
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
@@ -58,7 +60,7 @@ public final class QuoteOfTheMomentClient {
             // QuoteOfTheMomentClientHandler will close the DatagramChannel when a
             // response is received.  If the channel is not closed within 5 seconds,
             // print an error message and quit.
-            if (!ch.closeFuture().await(5000)) {
+            if (!ch.closeFuture().await(5000, TimeUnit.MILLISECONDS)) {
                 System.err.println("QOTM request timed out.");
             }
         } finally {

--- a/example/src/main/java/io/netty5/example/qotm/QuoteOfTheMomentClient.java
+++ b/example/src/main/java/io/netty5/example/qotm/QuoteOfTheMomentClient.java
@@ -49,7 +49,7 @@ public final class QuoteOfTheMomentClient {
              .option(ChannelOption.SO_BROADCAST, true)
              .handler(new QuoteOfTheMomentClientHandler());
 
-            Channel ch = b.bind(0).get();
+            Channel ch = b.bind(0).asJdkFuture().get();
 
             // Broadcast the QOTM request to port 8080.
             Buffer message = DefaultBufferAllocators.preferredAllocator().copyOf("QOTM?", UTF_8);

--- a/example/src/main/java/io/netty5/example/qotm/QuoteOfTheMomentServer.java
+++ b/example/src/main/java/io/netty5/example/qotm/QuoteOfTheMomentServer.java
@@ -41,7 +41,7 @@ public final class QuoteOfTheMomentServer {
              .option(ChannelOption.SO_BROADCAST, true)
              .handler(new QuoteOfTheMomentServerHandler());
 
-            b.bind(PORT).get().closeFuture().await();
+            b.bind(PORT).asJdkFuture().get().closeFuture().await();
         } finally {
             group.shutdownGracefully();
         }

--- a/example/src/main/java/io/netty5/example/qotm/QuoteOfTheMomentServer.java
+++ b/example/src/main/java/io/netty5/example/qotm/QuoteOfTheMomentServer.java
@@ -41,7 +41,7 @@ public final class QuoteOfTheMomentServer {
              .option(ChannelOption.SO_BROADCAST, true)
              .handler(new QuoteOfTheMomentServerHandler());
 
-            b.bind(PORT).asJdkFuture().get().closeFuture().await();
+            b.bind(PORT).asStage().get().closeFuture().await();
         } finally {
             group.shutdownGracefully();
         }

--- a/example/src/main/java/io/netty5/example/securechat/SecureChatClient.java
+++ b/example/src/main/java/io/netty5/example/securechat/SecureChatClient.java
@@ -51,7 +51,7 @@ public final class SecureChatClient {
              .handler(new SecureChatClientInitializer(sslCtx));
 
             // Start the connection attempt.
-            Channel ch = b.connect(HOST, PORT).asJdkFuture().get();
+            Channel ch = b.connect(HOST, PORT).asStage().get();
 
             // Read commands from the stdin.
             Future<Void> lastWriteFuture = null;

--- a/example/src/main/java/io/netty5/example/securechat/SecureChatClient.java
+++ b/example/src/main/java/io/netty5/example/securechat/SecureChatClient.java
@@ -51,7 +51,7 @@ public final class SecureChatClient {
              .handler(new SecureChatClientInitializer(sslCtx));
 
             // Start the connection attempt.
-            Channel ch = b.connect(HOST, PORT).get();
+            Channel ch = b.connect(HOST, PORT).asJdkFuture().get();
 
             // Read commands from the stdin.
             Future<Void> lastWriteFuture = null;

--- a/example/src/main/java/io/netty5/example/securechat/SecureChatServer.java
+++ b/example/src/main/java/io/netty5/example/securechat/SecureChatServer.java
@@ -48,7 +48,7 @@ public final class SecureChatServer {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new SecureChatServerInitializer(sslCtx));
 
-            b.bind(PORT).get().closeFuture().sync();
+            b.bind(PORT).asJdkFuture().get().closeFuture().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty5/example/securechat/SecureChatServer.java
+++ b/example/src/main/java/io/netty5/example/securechat/SecureChatServer.java
@@ -48,7 +48,7 @@ public final class SecureChatServer {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new SecureChatServerInitializer(sslCtx));
 
-            b.bind(PORT).asJdkFuture().get().closeFuture().sync();
+            b.bind(PORT).asStage().get().closeFuture().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty5/example/telnet/TelnetClient.java
+++ b/example/src/main/java/io/netty5/example/telnet/TelnetClient.java
@@ -56,7 +56,7 @@ public final class TelnetClient {
              .handler(new TelnetClientInitializer(sslCtx));
 
             // Start the connection attempt.
-            Channel ch = b.connect(HOST, PORT).get();
+            Channel ch = b.connect(HOST, PORT).asJdkFuture().get();
 
             // Read commands from the stdin.
             Future<Void> lastWriteFuture = null;

--- a/example/src/main/java/io/netty5/example/telnet/TelnetClient.java
+++ b/example/src/main/java/io/netty5/example/telnet/TelnetClient.java
@@ -56,7 +56,7 @@ public final class TelnetClient {
              .handler(new TelnetClientInitializer(sslCtx));
 
             // Start the connection attempt.
-            Channel ch = b.connect(HOST, PORT).asJdkFuture().get();
+            Channel ch = b.connect(HOST, PORT).asStage().get();
 
             // Read commands from the stdin.
             Future<Void> lastWriteFuture = null;

--- a/example/src/main/java/io/netty5/example/telnet/TelnetServer.java
+++ b/example/src/main/java/io/netty5/example/telnet/TelnetServer.java
@@ -53,7 +53,7 @@ public final class TelnetServer {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new TelnetServerInitializer(sslCtx));
 
-            b.bind(PORT).asJdkFuture().get().closeFuture().sync();
+            b.bind(PORT).asStage().get().closeFuture().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty5/example/telnet/TelnetServer.java
+++ b/example/src/main/java/io/netty5/example/telnet/TelnetServer.java
@@ -53,7 +53,7 @@ public final class TelnetServer {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new TelnetServerInitializer(sslCtx));
 
-            b.bind(PORT).get().closeFuture().sync();
+            b.bind(PORT).asJdkFuture().get().closeFuture().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty5/example/uptime/UptimeServer.java
+++ b/example/src/main/java/io/netty5/example/uptime/UptimeServer.java
@@ -54,7 +54,7 @@ public final class UptimeServer {
                     });
 
             // Bind and start to accept incoming connections.
-            Channel channel = b.bind(PORT).asJdkFuture().get();
+            Channel channel = b.bind(PORT).asStage().get();
 
             // Wait until the server socket is closed.
             // In this example, this does not happen, but you can do that to gracefully

--- a/example/src/main/java/io/netty5/example/uptime/UptimeServer.java
+++ b/example/src/main/java/io/netty5/example/uptime/UptimeServer.java
@@ -54,7 +54,7 @@ public final class UptimeServer {
                     });
 
             // Bind and start to accept incoming connections.
-            Channel channel = b.bind(PORT).get();
+            Channel channel = b.bind(PORT).asJdkFuture().get();
 
             // Wait until the server socket is closed.
             // In this example, this does not happen, but you can do that to gracefully

--- a/handler/src/main/java/io/netty5/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/OpenSsl.java
@@ -15,7 +15,6 @@
  */
 package io.netty5.handler.ssl;
 
-import io.netty.internal.tcnative.Buffer;
 import io.netty.internal.tcnative.Library;
 import io.netty.internal.tcnative.SSL;
 import io.netty.internal.tcnative.SSLContext;

--- a/handler/src/main/java/io/netty5/handler/traffic/AbstractTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty5/handler/traffic/AbstractTrafficShapingHandler.java
@@ -20,7 +20,6 @@ import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelConfig;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.channel.ChannelOutboundBuffer;
 import io.netty5.channel.FileRegion;
 import io.netty5.util.Attribute;
 import io.netty5.util.AttributeKey;

--- a/handler/src/test/java/io/netty5/handler/address/ResolveAddressHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/address/ResolveAddressHandlerTest.java
@@ -91,14 +91,14 @@ public class ResolveAddressHandlerTest {
                 });
 
         // Start server
-        Channel sc = sb.bind(RESOLVED).asJdkFuture().get();
+        Channel sc = sb.bind(RESOLVED).asStage().get();
         Future<Channel> future = cb.connect(UNRESOLVED).await();
         try {
             if (fail) {
                 assertSame(ERROR, future.cause());
             } else {
                 assertTrue(future.isSuccess());
-                future.asJdkFuture().get().close().sync();
+                future.asStage().get().close().sync();
             }
         } finally {
             sc.close().sync();

--- a/handler/src/test/java/io/netty5/handler/address/ResolveAddressHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/address/ResolveAddressHandlerTest.java
@@ -91,14 +91,14 @@ public class ResolveAddressHandlerTest {
                 });
 
         // Start server
-        Channel sc = sb.bind(RESOLVED).get();
+        Channel sc = sb.bind(RESOLVED).asJdkFuture().get();
         Future<Channel> future = cb.connect(UNRESOLVED).await();
         try {
             if (fail) {
                 assertSame(ERROR, future.cause());
             } else {
                 assertTrue(future.isSuccess());
-                future.get().close().sync();
+                future.asJdkFuture().get().close().sync();
             }
         } finally {
             sc.close().sync();

--- a/handler/src/test/java/io/netty5/handler/flow/FlowControlHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/flow/FlowControlHandlerTest.java
@@ -92,7 +92,7 @@ public class FlowControlHandlerTest {
                 }
             });
 
-        return serverBootstrap.bind(0).get();
+        return serverBootstrap.bind(0).asJdkFuture().get();
     }
 
     private static Channel newClient(SocketAddress server) throws Exception {
@@ -108,7 +108,7 @@ public class FlowControlHandlerTest {
                 }
             });
 
-        return bootstrap.connect(server).get();
+        return bootstrap.connect(server).asJdkFuture().get();
     }
 
     /**
@@ -241,7 +241,7 @@ public class FlowControlHandlerTest {
             // We should receive 3 messages
             assertTrue(latch.await(1L, SECONDS));
 
-            assertTrue(peer.executor().submit(flow::isQueueEmpty).get());
+            assertTrue(peer.executor().submit(flow::isQueueEmpty).asJdkFuture().get());
         } finally {
             client.close();
             server.close();
@@ -323,7 +323,7 @@ public class FlowControlHandlerTest {
             setAutoReadLatch2.countDown();
             assertTrue(msgRcvLatch3.await(1L, SECONDS));
 
-            assertTrue(peer.executor().submit(flow::isQueueEmpty).get());
+            assertTrue(peer.executor().submit(flow::isQueueEmpty).asJdkFuture().get());
         } finally {
             client.close();
             server.close();
@@ -380,7 +380,7 @@ public class FlowControlHandlerTest {
             peer.read();
             assertTrue(msgRcvLatch3.await(1L, SECONDS));
 
-            assertTrue(peer.executor().submit(flow::isQueueEmpty).get());
+            assertTrue(peer.executor().submit(flow::isQueueEmpty).asJdkFuture().get());
         } finally {
             client.close();
             server.close();
@@ -426,7 +426,7 @@ public class FlowControlHandlerTest {
             peer.read();
             assertTrue(latch.await(1L, SECONDS));
 
-            assertTrue(peer.executor().submit(flow::isQueueEmpty).get());
+            assertTrue(peer.executor().submit(flow::isQueueEmpty).asJdkFuture().get());
 
             Throwable cause = causeRef.get();
             if (cause != null) {
@@ -555,7 +555,7 @@ public class FlowControlHandlerTest {
 
             // We should receive 3 messages
             assertTrue(latch.await(1L, SECONDS));
-            assertTrue(peer.executor().submit(flow::isQueueEmpty).get());
+            assertTrue(peer.executor().submit(flow::isQueueEmpty).asJdkFuture().get());
         } finally {
             client.close();
             server.close();

--- a/handler/src/test/java/io/netty5/handler/flow/FlowControlHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/flow/FlowControlHandlerTest.java
@@ -92,7 +92,7 @@ public class FlowControlHandlerTest {
                 }
             });
 
-        return serverBootstrap.bind(0).asJdkFuture().get();
+        return serverBootstrap.bind(0).asStage().get();
     }
 
     private static Channel newClient(SocketAddress server) throws Exception {
@@ -108,7 +108,7 @@ public class FlowControlHandlerTest {
                 }
             });
 
-        return bootstrap.connect(server).asJdkFuture().get();
+        return bootstrap.connect(server).asStage().get();
     }
 
     /**
@@ -241,7 +241,7 @@ public class FlowControlHandlerTest {
             // We should receive 3 messages
             assertTrue(latch.await(1L, SECONDS));
 
-            assertTrue(peer.executor().submit(flow::isQueueEmpty).asJdkFuture().get());
+            assertTrue(peer.executor().submit(flow::isQueueEmpty).asStage().get());
         } finally {
             client.close();
             server.close();
@@ -323,7 +323,7 @@ public class FlowControlHandlerTest {
             setAutoReadLatch2.countDown();
             assertTrue(msgRcvLatch3.await(1L, SECONDS));
 
-            assertTrue(peer.executor().submit(flow::isQueueEmpty).asJdkFuture().get());
+            assertTrue(peer.executor().submit(flow::isQueueEmpty).asStage().get());
         } finally {
             client.close();
             server.close();
@@ -380,7 +380,7 @@ public class FlowControlHandlerTest {
             peer.read();
             assertTrue(msgRcvLatch3.await(1L, SECONDS));
 
-            assertTrue(peer.executor().submit(flow::isQueueEmpty).asJdkFuture().get());
+            assertTrue(peer.executor().submit(flow::isQueueEmpty).asStage().get());
         } finally {
             client.close();
             server.close();
@@ -426,7 +426,7 @@ public class FlowControlHandlerTest {
             peer.read();
             assertTrue(latch.await(1L, SECONDS));
 
-            assertTrue(peer.executor().submit(flow::isQueueEmpty).asJdkFuture().get());
+            assertTrue(peer.executor().submit(flow::isQueueEmpty).asStage().get());
 
             Throwable cause = causeRef.get();
             if (cause != null) {
@@ -555,7 +555,7 @@ public class FlowControlHandlerTest {
 
             // We should receive 3 messages
             assertTrue(latch.await(1L, SECONDS));
-            assertTrue(peer.executor().submit(flow::isQueueEmpty).asJdkFuture().get());
+            assertTrue(peer.executor().submit(flow::isQueueEmpty).asStage().get());
         } finally {
             client.close();
             server.close();

--- a/handler/src/test/java/io/netty5/handler/ssl/CipherSuiteCanaryTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/CipherSuiteCanaryTest.java
@@ -248,7 +248,7 @@ public class CipherSuiteCanaryTest {
                 .group(GROUP)
                 .childHandler(handler);
 
-        return bootstrap.bind(address).asJdkFuture().get();
+        return bootstrap.bind(address).asStage().get();
     }
 
     private static Channel client(Channel server, ChannelHandler handler) throws Exception {
@@ -259,7 +259,7 @@ public class CipherSuiteCanaryTest {
                 .group(GROUP)
                 .handler(handler);
 
-        return bootstrap.connect(remoteAddress).asJdkFuture().get();
+        return bootstrap.connect(remoteAddress).asStage().get();
     }
 
     private static List<Object[]> expand(String rfcCipherName) {

--- a/handler/src/test/java/io/netty5/handler/ssl/CipherSuiteCanaryTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/CipherSuiteCanaryTest.java
@@ -248,7 +248,7 @@ public class CipherSuiteCanaryTest {
                 .group(GROUP)
                 .childHandler(handler);
 
-        return bootstrap.bind(address).get();
+        return bootstrap.bind(address).asJdkFuture().get();
     }
 
     private static Channel client(Channel server, ChannelHandler handler) throws Exception {
@@ -259,7 +259,7 @@ public class CipherSuiteCanaryTest {
                 .group(GROUP)
                 .handler(handler);
 
-        return bootstrap.connect(remoteAddress).get();
+        return bootstrap.connect(remoteAddress).asJdkFuture().get();
     }
 
     private static List<Object[]> expand(String rfcCipherName) {

--- a/handler/src/test/java/io/netty5/handler/ssl/OpenSslPrivateKeyMethodTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/OpenSslPrivateKeyMethodTest.java
@@ -384,7 +384,7 @@ public class OpenSslPrivateKeyMethodTest {
                 .group(GROUP)
                 .childHandler(handler);
 
-        return bootstrap.bind(address).asJdkFuture().get();
+        return bootstrap.bind(address).asStage().get();
     }
 
     private static Channel client(Channel server, ChannelHandler handler) throws Exception {
@@ -395,7 +395,7 @@ public class OpenSslPrivateKeyMethodTest {
                 .group(GROUP)
                 .handler(handler);
 
-        return bootstrap.connect(remoteAddress).asJdkFuture().get();
+        return bootstrap.connect(remoteAddress).asStage().get();
     }
 
     private static final class DelegateThread extends Thread {

--- a/handler/src/test/java/io/netty5/handler/ssl/OpenSslPrivateKeyMethodTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/OpenSslPrivateKeyMethodTest.java
@@ -384,7 +384,7 @@ public class OpenSslPrivateKeyMethodTest {
                 .group(GROUP)
                 .childHandler(handler);
 
-        return bootstrap.bind(address).get();
+        return bootstrap.bind(address).asJdkFuture().get();
     }
 
     private static Channel client(Channel server, ChannelHandler handler) throws Exception {
@@ -395,7 +395,7 @@ public class OpenSslPrivateKeyMethodTest {
                 .group(GROUP)
                 .handler(handler);
 
-        return bootstrap.connect(remoteAddress).get();
+        return bootstrap.connect(remoteAddress).asJdkFuture().get();
     }
 
     private static final class DelegateThread extends Thread {

--- a/handler/src/test/java/io/netty5/handler/ssl/ParameterizedSslHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/ParameterizedSslHandlerTest.java
@@ -206,7 +206,7 @@ public class ParameterizedSslHandlerTest {
                                 }
                             });
                         }
-                    }).bind(new InetSocketAddress(0)).get();
+                    }).bind(new InetSocketAddress(0)).asJdkFuture().get();
 
             cc = new Bootstrap()
                     .group(group)
@@ -255,7 +255,7 @@ public class ParameterizedSslHandlerTest {
                                 }
                             });
                         }
-                    }).connect(sc.localAddress()).get();
+                    }).connect(sc.localAddress()).asJdkFuture().get();
 
             donePromise.asFuture().sync();
         } finally {
@@ -337,7 +337,7 @@ public class ParameterizedSslHandlerTest {
                                 }
                             });
                         }
-                    }).bind(new InetSocketAddress(0)).get();
+                    }).bind(new InetSocketAddress(0)).asJdkFuture().get();
 
             cc = new Bootstrap()
                     .group(group)
@@ -356,7 +356,7 @@ public class ParameterizedSslHandlerTest {
                                 }
                             });
                         }
-                    }).connect(sc.localAddress()).get();
+                    }).connect(sc.localAddress()).asJdkFuture().get();
 
             promise.asFuture().sync();
         } finally {
@@ -442,7 +442,7 @@ public class ParameterizedSslHandlerTest {
                             });
                             ch.pipeline().addLast(handler);
                         }
-                    }).bind(new InetSocketAddress(0)).get();
+                    }).bind(new InetSocketAddress(0)).asJdkFuture().get();
 
             cc = new Bootstrap()
                     .group(group)
@@ -480,7 +480,7 @@ public class ParameterizedSslHandlerTest {
                             });
                             ch.pipeline().addLast(handler);
                         }
-                    }).connect(sc.localAddress()).get();
+                    }).connect(sc.localAddress()).asJdkFuture().get();
 
             serverPromise.asFuture().await();
             clientPromise.asFuture().await();
@@ -590,7 +590,7 @@ public class ParameterizedSslHandlerTest {
                             ch.pipeline().addLast(new ReentryWriteSslHandshakeHandler(expectedContent, serverQueue,
                                     serverLatch));
                         }
-                    }).bind(bindAddress).get();
+                    }).bind(bindAddress).asJdkFuture().get();
 
             cc = new Bootstrap()
                     .group(group)
@@ -604,7 +604,7 @@ public class ParameterizedSslHandlerTest {
                             ch.pipeline().addLast(new ReentryWriteSslHandshakeHandler(expectedContent, clientQueue,
                                     clientLatch));
                         }
-                    }).connect(sc.localAddress()).get();
+                    }).connect(sc.localAddress()).asJdkFuture().get();
 
             serverLatch.await();
             assertEquals(expectedContent, serverQueue.toString());

--- a/handler/src/test/java/io/netty5/handler/ssl/ParameterizedSslHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/ParameterizedSslHandlerTest.java
@@ -195,18 +195,19 @@ public class ParameterizedSslHandlerTest {
 
                                 @Override
                                 public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-                                    donePromise.tryFailure(new IllegalStateException("server exception sentData: " +
-                                            sentData + " writeCause: " + writeCause, cause));
+                                    donePromise.tryFailure(new IllegalStateException(
+                                            "server exception sentData: " + sentData + " writeCause: " + writeCause,
+                                            cause));
                                 }
 
                                 @Override
                                 public void channelInactive(ChannelHandlerContext ctx) {
-                                    donePromise.tryFailure(new IllegalStateException("server closed sentData: " +
-                                            sentData + " writeCause: " + writeCause));
+                                    donePromise.tryFailure(new IllegalStateException(
+                                            "server closed sentData: " + sentData + " writeCause: " + writeCause));
                                 }
                             });
                         }
-                    }).bind(new InetSocketAddress(0)).asJdkFuture().get();
+                    }).bind(new InetSocketAddress(0)).asStage().get();
 
             cc = new Bootstrap()
                     .group(group)
@@ -221,6 +222,7 @@ public class ParameterizedSslHandlerTest {
                             }
                             ch.pipeline().addLast(new ChannelHandler() {
                                 private int bytesSeen;
+
                                 @Override
                                 public void channelRead(ChannelHandlerContext ctx, Object msg) {
                                     if (msg instanceof Buffer) {
@@ -245,17 +247,17 @@ public class ParameterizedSslHandlerTest {
                                 @Override
                                 public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                                     donePromise.tryFailure(new IllegalStateException("client exception. bytesSeen: " +
-                                            bytesSeen, cause));
+                                                                                     bytesSeen, cause));
                                 }
 
                                 @Override
                                 public void channelInactive(ChannelHandlerContext ctx) {
                                     donePromise.tryFailure(new IllegalStateException("client closed. bytesSeen: " +
-                                            bytesSeen));
+                                                                                     bytesSeen));
                                 }
                             });
                         }
-                    }).connect(sc.localAddress()).asJdkFuture().get();
+                    }).connect(sc.localAddress()).asStage().get();
 
             donePromise.asFuture().sync();
         } finally {
@@ -337,7 +339,7 @@ public class ParameterizedSslHandlerTest {
                                 }
                             });
                         }
-                    }).bind(new InetSocketAddress(0)).asJdkFuture().get();
+                    }).bind(new InetSocketAddress(0)).asStage().get();
 
             cc = new Bootstrap()
                     .group(group)
@@ -356,7 +358,7 @@ public class ParameterizedSslHandlerTest {
                                 }
                             });
                         }
-                    }).connect(sc.localAddress()).asJdkFuture().get();
+                    }).connect(sc.localAddress()).asStage().get();
 
             promise.asFuture().sync();
         } finally {
@@ -442,7 +444,7 @@ public class ParameterizedSslHandlerTest {
                             });
                             ch.pipeline().addLast(handler);
                         }
-                    }).bind(new InetSocketAddress(0)).asJdkFuture().get();
+                    }).bind(new InetSocketAddress(0)).asStage().get();
 
             cc = new Bootstrap()
                     .group(group)
@@ -480,7 +482,7 @@ public class ParameterizedSslHandlerTest {
                             });
                             ch.pipeline().addLast(handler);
                         }
-                    }).connect(sc.localAddress()).asJdkFuture().get();
+                    }).connect(sc.localAddress()).asStage().get();
 
             serverPromise.asFuture().await();
             clientPromise.asFuture().await();
@@ -588,9 +590,9 @@ public class ParameterizedSslHandlerTest {
                             ch.pipeline().addLast(
                                     disableHandshakeTimeout(sslServerCtx.newHandler(ch.bufferAllocator())));
                             ch.pipeline().addLast(new ReentryWriteSslHandshakeHandler(expectedContent, serverQueue,
-                                    serverLatch));
+                                                                                      serverLatch));
                         }
-                    }).bind(bindAddress).asJdkFuture().get();
+                    }).bind(bindAddress).asStage().get();
 
             cc = new Bootstrap()
                     .group(group)
@@ -602,9 +604,9 @@ public class ParameterizedSslHandlerTest {
                             ch.pipeline().addLast(
                                     disableHandshakeTimeout(sslClientCtx.newHandler(ch.bufferAllocator())));
                             ch.pipeline().addLast(new ReentryWriteSslHandshakeHandler(expectedContent, clientQueue,
-                                    clientLatch));
+                                                                                      clientLatch));
                         }
-                    }).connect(sc.localAddress()).asJdkFuture().get();
+                    }).connect(sc.localAddress()).asStage().get();
 
             serverLatch.await();
             assertEquals(expectedContent, serverQueue.toString());

--- a/handler/src/test/java/io/netty5/handler/ssl/RenegotiateTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/RenegotiateTest.java
@@ -97,7 +97,7 @@ public abstract class RenegotiateTest {
                             });
                         }
                     });
-            Channel channel = sb.bind(new LocalAddress(getClass())).asJdkFuture().get();
+            Channel channel = sb.bind(new LocalAddress(getClass())).asStage().get();
 
             final SslContext clientContext = SslContextBuilder.forClient()
                     .trustManager(InsecureTrustManagerFactory.INSTANCE)
@@ -130,7 +130,7 @@ public abstract class RenegotiateTest {
                         }
                     });
 
-            Channel clientChannel = bootstrap.connect(channel.localAddress()).asJdkFuture().get();
+            Channel clientChannel = bootstrap.connect(channel.localAddress()).asStage().get();
             latch.await();
             clientChannel.close().sync();
             channel.close().sync();

--- a/handler/src/test/java/io/netty5/handler/ssl/RenegotiateTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/RenegotiateTest.java
@@ -97,7 +97,7 @@ public abstract class RenegotiateTest {
                             });
                         }
                     });
-            Channel channel = sb.bind(new LocalAddress(getClass())).get();
+            Channel channel = sb.bind(new LocalAddress(getClass())).asJdkFuture().get();
 
             final SslContext clientContext = SslContextBuilder.forClient()
                     .trustManager(InsecureTrustManagerFactory.INSTANCE)
@@ -130,7 +130,7 @@ public abstract class RenegotiateTest {
                         }
                     });
 
-            Channel clientChannel = bootstrap.connect(channel.localAddress()).get();
+            Channel clientChannel = bootstrap.connect(channel.localAddress()).asJdkFuture().get();
             latch.await();
             clientChannel.close().sync();
             channel.close().sync();

--- a/handler/src/test/java/io/netty5/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SSLEngineTest.java
@@ -1833,9 +1833,8 @@ public abstract class SSLEngineTest {
                                         promise.setFailure(new NullPointerException("peerCertificateChain"));
                                     } else if (peerCertificateChain.length + peerCertificates.length != 4) {
                                         String excTxtFmt = "peerCertificateChain.length:%s, peerCertificates.length:%s";
-                                        promise.setFailure(new IllegalStateException(String.format(excTxtFmt,
-                                                                                                   peerCertificateChain.length,
-                                                                                                   peerCertificates.length)));
+                                        promise.setFailure(new IllegalStateException(String.format(
+                                                excTxtFmt, peerCertificateChain.length, peerCertificates.length)));
                                     } else {
                                         for (int i = 0; i < peerCertificateChain.length; i++) {
                                             if (peerCertificateChain[i] == null || peerCertificates[i] == null) {

--- a/handler/src/test/java/io/netty5/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SSLEngineTest.java
@@ -798,12 +798,12 @@ public abstract class SSLEngineTest {
             }
         });
 
-        serverChannel = sb.bind(new InetSocketAddress(0)).asJdkFuture().get();
+        serverChannel = sb.bind(new InetSocketAddress(0)).asStage().get();
         int port = ((InetSocketAddress) serverChannel.localAddress()).getPort();
 
         Future<Channel> ccf = cb.connect(new InetSocketAddress(NetUtil.LOCALHOST, port));
         assertTrue(ccf.await().isSuccess());
-        clientChannel = ccf.asJdkFuture().get();
+        clientChannel = ccf.asStage().get();
     }
 
     protected static void rethrowIfNotNull(Throwable error) {
@@ -984,12 +984,12 @@ public abstract class SSLEngineTest {
             }
         });
 
-        serverChannel = sb.bind(new InetSocketAddress(expectedHost, 0)).asJdkFuture().get();
+        serverChannel = sb.bind(new InetSocketAddress(expectedHost, 0)).asStage().get();
         final int port = ((InetSocketAddress) serverChannel.localAddress()).getPort();
 
         Future<Channel> ccf = cb.connect(new InetSocketAddress(expectedHost, port));
         assertTrue(ccf.await().isSuccess());
-        clientChannel = ccf.asJdkFuture().get();
+        clientChannel = ccf.asStage().get();
         return clientWritePromise.asFuture();
     }
 
@@ -1152,12 +1152,12 @@ public abstract class SSLEngineTest {
             }
         });
 
-        serverChannel = sb.bind(new InetSocketAddress(0)).asJdkFuture().get();
+        serverChannel = sb.bind(new InetSocketAddress(0)).asStage().get();
         int port = ((InetSocketAddress) serverChannel.localAddress()).getPort();
 
         Future<Channel> ccf = cb.connect(new InetSocketAddress(NetUtil.LOCALHOST, port));
         assertTrue(ccf.await().isSuccess());
-        clientChannel = ccf.asJdkFuture().get();
+        clientChannel = ccf.asStage().get();
     }
 
     protected void runTest(String expectedApplicationProtocol) throws Exception {
@@ -1402,7 +1402,7 @@ public abstract class SSLEngineTest {
                     }
                 });
 
-        serverChannel = sb.bind(new InetSocketAddress(0)).asJdkFuture().get();
+        serverChannel = sb.bind(new InetSocketAddress(0)).asStage().get();
 
         clientSslCtx = wrapContext(param, SslContextBuilder.forClient()
                                         // OpenSslEngine doesn't support renegotiation on client side
@@ -1462,7 +1462,7 @@ public abstract class SSLEngineTest {
 
         Future<Channel> ccf = cb.connect(serverChannel.localAddress());
         assertTrue(ccf.sync().isSuccess());
-        clientChannel = ccf.asJdkFuture().get();
+        clientChannel = ccf.asStage().get();
 
         serverLatch.await();
         ssc.delete();
@@ -1779,11 +1779,11 @@ public abstract class SSLEngineTest {
             }
         });
 
-        serverChannel = sb.bind(new InetSocketAddress(0)).asJdkFuture().get();
+        serverChannel = sb.bind(new InetSocketAddress(0)).asStage().get();
 
         Future<Channel> ccf = cb.connect(serverChannel.localAddress());
         assertTrue(ccf.sync().isSuccess());
-        clientChannel = ccf.asJdkFuture().get();
+        clientChannel = ccf.asStage().get();
     }
 
     @MethodSource("newTestParams")
@@ -1810,7 +1810,7 @@ public abstract class SSLEngineTest {
             protected void initChannel(Channel ch) throws Exception {
                 ch.config().setBufferAllocator(new TestBufferAllocator(param.type()));
 
-                SslHandler sslHandler = !param.delegate ?
+                SslHandler sslHandler = !param.delegate?
                         serverSslCtx.newHandler(ch.bufferAllocator()) :
                         serverSslCtx.newHandler(ch.bufferAllocator(), delegatingExecutor);
 
@@ -1834,8 +1834,8 @@ public abstract class SSLEngineTest {
                                     } else if (peerCertificateChain.length + peerCertificates.length != 4) {
                                         String excTxtFmt = "peerCertificateChain.length:%s, peerCertificates.length:%s";
                                         promise.setFailure(new IllegalStateException(String.format(excTxtFmt,
-                                                peerCertificateChain.length,
-                                                peerCertificates.length)));
+                                                                                                   peerCertificateChain.length,
+                                                                                                   peerCertificates.length)));
                                     } else {
                                         for (int i = 0; i < peerCertificateChain.length; i++) {
                                             if (peerCertificateChain[i] == null || peerCertificates[i] == null) {
@@ -1867,7 +1867,7 @@ public abstract class SSLEngineTest {
                 });
                 serverConnectedChannel = ch;
             }
-        }).bind(new InetSocketAddress(0)).asJdkFuture().get();
+        }).bind(new InetSocketAddress(0)).asStage().get();
 
         // We create a new chain for certificates which contains 2 certificates
         ByteArrayOutputStream chainStream = new ByteArrayOutputStream();
@@ -1892,7 +1892,7 @@ public abstract class SSLEngineTest {
                 ch.pipeline().addLast(new SslHandler(wrapEngine(clientSslCtx.newEngine(ch.bufferAllocator()))));
             }
 
-        }).connect(serverChannel.localAddress()).asJdkFuture().get();
+        }).connect(serverChannel.localAddress()).asStage().get();
 
         promise.asFuture().sync();
 
@@ -3918,7 +3918,7 @@ public abstract class SSLEngineTest {
                 protected void initChannel(Channel ch) {
                     ch.config().setBufferAllocator(new TestBufferAllocator(param.type()));
 
-                    SslHandler sslHandler = !param.delegate() ?
+                    SslHandler sslHandler = !param.delegate()?
                             serverSslCtx.newHandler(ch.bufferAllocator()) :
                             serverSslCtx.newHandler(ch.bufferAllocator(), delegatingExecutor);
 
@@ -3931,7 +3931,7 @@ public abstract class SSLEngineTest {
                     });
                     serverConnectedChannel = ch;
                 }
-            }).bind(new InetSocketAddress(0)).asJdkFuture().get();
+            }).bind(new InetSocketAddress(0)).asStage().get();
 
             int port = ((InetSocketAddress) serverChannel.localAddress()).getPort();
 
@@ -3944,7 +3944,7 @@ public abstract class SSLEngineTest {
 
             Future<SecretKey> future = promise.asFuture();
             assertTrue(future.await(10, TimeUnit.SECONDS));
-            SecretKey key = future.asJdkFuture().get();
+            SecretKey key = future.asStage().get();
             assertEquals(48, key.getEncoded().length, "AES secret key must be 48 bytes");
         } finally {
             closeQuietly(socket);

--- a/handler/src/test/java/io/netty5/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SSLEngineTest.java
@@ -798,12 +798,12 @@ public abstract class SSLEngineTest {
             }
         });
 
-        serverChannel = sb.bind(new InetSocketAddress(0)).get();
+        serverChannel = sb.bind(new InetSocketAddress(0)).asJdkFuture().get();
         int port = ((InetSocketAddress) serverChannel.localAddress()).getPort();
 
         Future<Channel> ccf = cb.connect(new InetSocketAddress(NetUtil.LOCALHOST, port));
         assertTrue(ccf.await().isSuccess());
-        clientChannel = ccf.get();
+        clientChannel = ccf.asJdkFuture().get();
     }
 
     protected static void rethrowIfNotNull(Throwable error) {
@@ -984,12 +984,12 @@ public abstract class SSLEngineTest {
             }
         });
 
-        serverChannel = sb.bind(new InetSocketAddress(expectedHost, 0)).get();
+        serverChannel = sb.bind(new InetSocketAddress(expectedHost, 0)).asJdkFuture().get();
         final int port = ((InetSocketAddress) serverChannel.localAddress()).getPort();
 
         Future<Channel> ccf = cb.connect(new InetSocketAddress(expectedHost, port));
         assertTrue(ccf.await().isSuccess());
-        clientChannel = ccf.get();
+        clientChannel = ccf.asJdkFuture().get();
         return clientWritePromise.asFuture();
     }
 
@@ -1152,12 +1152,12 @@ public abstract class SSLEngineTest {
             }
         });
 
-        serverChannel = sb.bind(new InetSocketAddress(0)).get();
+        serverChannel = sb.bind(new InetSocketAddress(0)).asJdkFuture().get();
         int port = ((InetSocketAddress) serverChannel.localAddress()).getPort();
 
         Future<Channel> ccf = cb.connect(new InetSocketAddress(NetUtil.LOCALHOST, port));
         assertTrue(ccf.await().isSuccess());
-        clientChannel = ccf.get();
+        clientChannel = ccf.asJdkFuture().get();
     }
 
     protected void runTest(String expectedApplicationProtocol) throws Exception {
@@ -1402,7 +1402,7 @@ public abstract class SSLEngineTest {
                     }
                 });
 
-        serverChannel = sb.bind(new InetSocketAddress(0)).get();
+        serverChannel = sb.bind(new InetSocketAddress(0)).asJdkFuture().get();
 
         clientSslCtx = wrapContext(param, SslContextBuilder.forClient()
                                         // OpenSslEngine doesn't support renegotiation on client side
@@ -1462,7 +1462,7 @@ public abstract class SSLEngineTest {
 
         Future<Channel> ccf = cb.connect(serverChannel.localAddress());
         assertTrue(ccf.sync().isSuccess());
-        clientChannel = ccf.get();
+        clientChannel = ccf.asJdkFuture().get();
 
         serverLatch.await();
         ssc.delete();
@@ -1779,11 +1779,11 @@ public abstract class SSLEngineTest {
             }
         });
 
-        serverChannel = sb.bind(new InetSocketAddress(0)).get();
+        serverChannel = sb.bind(new InetSocketAddress(0)).asJdkFuture().get();
 
         Future<Channel> ccf = cb.connect(serverChannel.localAddress());
         assertTrue(ccf.sync().isSuccess());
-        clientChannel = ccf.get();
+        clientChannel = ccf.asJdkFuture().get();
     }
 
     @MethodSource("newTestParams")
@@ -1867,7 +1867,7 @@ public abstract class SSLEngineTest {
                 });
                 serverConnectedChannel = ch;
             }
-        }).bind(new InetSocketAddress(0)).get();
+        }).bind(new InetSocketAddress(0)).asJdkFuture().get();
 
         // We create a new chain for certificates which contains 2 certificates
         ByteArrayOutputStream chainStream = new ByteArrayOutputStream();
@@ -1892,7 +1892,7 @@ public abstract class SSLEngineTest {
                 ch.pipeline().addLast(new SslHandler(wrapEngine(clientSslCtx.newEngine(ch.bufferAllocator()))));
             }
 
-        }).connect(serverChannel.localAddress()).get();
+        }).connect(serverChannel.localAddress()).asJdkFuture().get();
 
         promise.asFuture().sync();
 
@@ -3931,7 +3931,7 @@ public abstract class SSLEngineTest {
                     });
                     serverConnectedChannel = ch;
                 }
-            }).bind(new InetSocketAddress(0)).get();
+            }).bind(new InetSocketAddress(0)).asJdkFuture().get();
 
             int port = ((InetSocketAddress) serverChannel.localAddress()).getPort();
 
@@ -3944,7 +3944,7 @@ public abstract class SSLEngineTest {
 
             Future<SecretKey> future = promise.asFuture();
             assertTrue(future.await(10, TimeUnit.SECONDS));
-            SecretKey key = future.get();
+            SecretKey key = future.asJdkFuture().get();
             assertEquals(48, key.getEncoded().length, "AES secret key must be 48 bytes");
         } finally {
             closeQuietly(socket);

--- a/handler/src/test/java/io/netty5/handler/ssl/SniClientTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SniClientTest.java
@@ -184,7 +184,7 @@ public class SniClientTest {
                         }
                     });
                 }
-            }).bind(address).get();
+            }).bind(address).asJdkFuture().get();
 
             sslClientContext = SslContextBuilder.forClient().trustManager(InsecureTrustManagerFactory.INSTANCE)
                     .sslProvider(sslClientProvider).build();
@@ -192,7 +192,7 @@ public class SniClientTest {
             SslHandler sslHandler = new SslHandler(
                     sslClientContext.newEngine(offHeapAllocator(), sniHost, -1));
             Bootstrap cb = new Bootstrap();
-            cc = cb.group(group).channel(LocalChannel.class).handler(sslHandler).connect(address).get();
+            cc = cb.group(group).channel(LocalChannel.class).handler(sslHandler).connect(address).asJdkFuture().get();
 
             promise.asFuture().sync();
             sslHandler.handshakeFuture().sync();
@@ -430,7 +430,7 @@ public class SniClientTest {
                         return finalContext;
                     }));
                 }
-            }).bind(address).get();
+            }).bind(address).asJdkFuture().get();
 
             TrustManagerFactory tmf = newSniX509TrustmanagerFactory(sniHostName);
             sslClientContext = SslContextBuilder.forClient().trustManager(tmf)
@@ -439,7 +439,7 @@ public class SniClientTest {
 
             SslHandler handler = new SslHandler(
                     sslClientContext.newEngine(offHeapAllocator(), sniHostName, -1));
-            cc = cb.group(group).channel(LocalChannel.class).handler(handler).connect(address).get();
+            cc = cb.group(group).channel(LocalChannel.class).handler(handler).connect(address).asJdkFuture().get();
             assertEquals(sniHostName, promise.asFuture().sync().getNow());
 
             // After we are done with handshaking getHandshakeSession() should return null.

--- a/handler/src/test/java/io/netty5/handler/ssl/SniClientTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SniClientTest.java
@@ -176,7 +176,7 @@ public class SniClientTest {
                                         } else {
                                             promise.setFailure(
                                                     new AssertionError("cause not of type SSLException: "
-                                                            + ThrowableUtil.stackTraceToString(cause)));
+                                                                       + ThrowableUtil.stackTraceToString(cause)));
                                         }
                                     }
                                 }
@@ -184,7 +184,7 @@ public class SniClientTest {
                         }
                     });
                 }
-            }).bind(address).asJdkFuture().get();
+            }).bind(address).asStage().get();
 
             sslClientContext = SslContextBuilder.forClient().trustManager(InsecureTrustManagerFactory.INSTANCE)
                     .sslProvider(sslClientProvider).build();
@@ -192,7 +192,7 @@ public class SniClientTest {
             SslHandler sslHandler = new SslHandler(
                     sslClientContext.newEngine(offHeapAllocator(), sniHost, -1));
             Bootstrap cb = new Bootstrap();
-            cc = cb.group(group).channel(LocalChannel.class).handler(sslHandler).connect(address).asJdkFuture().get();
+            cc = cb.group(group).channel(LocalChannel.class).handler(sslHandler).connect(address).asStage().get();
 
             promise.asFuture().sync();
             sslHandler.handshakeFuture().sync();
@@ -430,7 +430,7 @@ public class SniClientTest {
                         return finalContext;
                     }));
                 }
-            }).bind(address).asJdkFuture().get();
+            }).bind(address).asStage().get();
 
             TrustManagerFactory tmf = newSniX509TrustmanagerFactory(sniHostName);
             sslClientContext = SslContextBuilder.forClient().trustManager(tmf)
@@ -439,7 +439,7 @@ public class SniClientTest {
 
             SslHandler handler = new SslHandler(
                     sslClientContext.newEngine(offHeapAllocator(), sniHostName, -1));
-            cc = cb.group(group).channel(LocalChannel.class).handler(handler).connect(address).asJdkFuture().get();
+            cc = cb.group(group).channel(LocalChannel.class).handler(handler).connect(address).asStage().get();
             assertEquals(sniHostName, promise.asFuture().sync().getNow());
 
             // After we are done with handshaking getHandshakeSession() should return null.

--- a/handler/src/test/java/io/netty5/handler/ssl/SniHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SniHandlerTest.java
@@ -447,8 +447,8 @@ public class SniHandlerTest {
                     }
                 });
 
-                serverChannel = sb.bind(new InetSocketAddress(0)).get();
-                clientChannel = cb.connect(serverChannel.localAddress()).get();
+                serverChannel = sb.bind(new InetSocketAddress(0)).asJdkFuture().get();
+                clientChannel = cb.connect(serverChannel.localAddress()).asJdkFuture().get();
 
                 assertTrue(serverApnDoneLatch.await(5, TimeUnit.SECONDS));
                 assertTrue(clientApnDoneLatch.await(5, TimeUnit.SECONDS));
@@ -546,7 +546,7 @@ public class SniHandlerTest {
                         protected void initChannel(Channel ch) throws Exception {
                             ch.pipeline().addFirst(handler);
                         }
-                    }).bind(address).get();
+                    }).bind(address).asJdkFuture().get();
 
                     sslContext = SslContextBuilder.forClient().sslProvider(provider)
                             .trustManager(InsecureTrustManagerFactory.INSTANCE).build();
@@ -555,7 +555,7 @@ public class SniHandlerTest {
                     cc = cb.group(group).channel(LocalChannel.class)
                            .handler(new SslHandler(
                                    sslContext.newEngine(offHeapAllocator(), sniHost, -1)))
-                           .connect(address).get();
+                           .connect(address).asJdkFuture().get();
 
                     cc.writeAndFlush(cc.bufferAllocator().copyOf("Hello, World!", UTF_8))
                             .sync();

--- a/handler/src/test/java/io/netty5/handler/ssl/SniHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SniHandlerTest.java
@@ -447,8 +447,8 @@ public class SniHandlerTest {
                     }
                 });
 
-                serverChannel = sb.bind(new InetSocketAddress(0)).asJdkFuture().get();
-                clientChannel = cb.connect(serverChannel.localAddress()).asJdkFuture().get();
+                serverChannel = sb.bind(new InetSocketAddress(0)).asStage().get();
+                clientChannel = cb.connect(serverChannel.localAddress()).asStage().get();
 
                 assertTrue(serverApnDoneLatch.await(5, TimeUnit.SECONDS));
                 assertTrue(clientApnDoneLatch.await(5, TimeUnit.SECONDS));
@@ -541,12 +541,12 @@ public class SniHandlerTest {
 
                     ServerBootstrap sb = new ServerBootstrap();
                     sc = sb.group(group).channel(LocalServerChannel.class)
-                            .childHandler(new ChannelInitializer<Channel>() {
-                        @Override
-                        protected void initChannel(Channel ch) throws Exception {
-                            ch.pipeline().addFirst(handler);
-                        }
-                    }).bind(address).asJdkFuture().get();
+                           .childHandler(new ChannelInitializer<Channel>() {
+                               @Override
+                               protected void initChannel(Channel ch) throws Exception {
+                                   ch.pipeline().addFirst(handler);
+                               }
+                           }).bind(address).asStage().get();
 
                     sslContext = SslContextBuilder.forClient().sslProvider(provider)
                             .trustManager(InsecureTrustManagerFactory.INSTANCE).build();
@@ -555,7 +555,7 @@ public class SniHandlerTest {
                     cc = cb.group(group).channel(LocalChannel.class)
                            .handler(new SslHandler(
                                    sslContext.newEngine(offHeapAllocator(), sniHost, -1)))
-                           .connect(address).asJdkFuture().get();
+                           .connect(address).asStage().get();
 
                     cc.writeAndFlush(cc.bufferAllocator().copyOf("Hello, World!", UTF_8))
                             .sync();

--- a/handler/src/test/java/io/netty5/handler/ssl/SslErrorTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SslErrorTest.java
@@ -164,7 +164,7 @@ public class SslErrorTest {
                                 }
                             });
                         }
-                    }).bind(0).get();
+                    }).bind(0).asJdkFuture().get();
 
             clientChannel = new Bootstrap().group(group)
                     .channel(NioSocketChannel.class)
@@ -185,7 +185,7 @@ public class SslErrorTest {
                                 }
                             });
                         }
-                    }).connect(serverChannel.localAddress()).get();
+                    }).connect(serverChannel.localAddress()).asJdkFuture().get();
             // Block until we received the correct exception
             promise.asFuture().sync();
         } finally {

--- a/handler/src/test/java/io/netty5/handler/ssl/SslErrorTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SslErrorTest.java
@@ -145,7 +145,8 @@ public class SslErrorTest {
         final Promise<Void> promise = group.next().newPromise();
         try (AutoCloseable ignore1 = autoClosing(sslServerCtx);
              AutoCloseable ignore2 = autoClosing(sslClientCtx)) {
-            serverChannel = new ServerBootstrap().group(group)
+            serverChannel = new ServerBootstrap()
+                    .group(group)
                     .channel(NioServerSocketChannel.class)
                     .handler(new LoggingHandler(LogLevel.INFO))
                     .childHandler(new ChannelInitializer<Channel>() {
@@ -153,8 +154,8 @@ public class SslErrorTest {
                         protected void initChannel(Channel ch) {
                             ch.pipeline().addLast(sslServerCtx.newHandler(ch.bufferAllocator()));
                             if (!serverProduceError) {
-                                ch.pipeline().addLast(new AlertValidationHandler(clientProvider, serverProduceError,
-                                        exception, promise));
+                                ch.pipeline().addLast(new AlertValidationHandler(
+                                        clientProvider, serverProduceError, exception, promise));
                             }
                             ch.pipeline().addLast(new ChannelHandler() {
 
@@ -164,9 +165,10 @@ public class SslErrorTest {
                                 }
                             });
                         }
-                    }).bind(0).asJdkFuture().get();
+                    }).bind(0).asStage().get();
 
-            clientChannel = new Bootstrap().group(group)
+            clientChannel = new Bootstrap()
+                    .group(group)
                     .channel(NioSocketChannel.class)
                     .handler(new ChannelInitializer<Channel>() {
                         @Override
@@ -174,8 +176,8 @@ public class SslErrorTest {
                             ch.pipeline().addLast(sslClientCtx.newHandler(ch.bufferAllocator()));
 
                             if (serverProduceError) {
-                                ch.pipeline().addLast(new AlertValidationHandler(clientProvider, serverProduceError,
-                                        exception, promise));
+                                ch.pipeline().addLast(new AlertValidationHandler(
+                                        clientProvider, serverProduceError, exception, promise));
                             }
                             ch.pipeline().addLast(new ChannelHandler() {
 
@@ -185,7 +187,7 @@ public class SslErrorTest {
                                 }
                             });
                         }
-                    }).connect(serverChannel.localAddress()).asJdkFuture().get();
+                    }).connect(serverChannel.localAddress()).asStage().get();
             // Block until we received the correct exception
             promise.asFuture().sync();
         } finally {

--- a/handler/src/test/java/io/netty5/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SslHandlerTest.java
@@ -356,7 +356,7 @@ public class SslHandlerTest {
         ExecutionException e = assertThrows(ExecutionException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
-                ch.write(referenceCounted).get();
+                ch.write(referenceCounted).asJdkFuture().get();
             }
         });
         assertThat(e.getCause(), is(instanceOf(UnsupportedMessageTypeException.class)));
@@ -491,8 +491,8 @@ public class SslHandlerTest {
                     .channel(NioServerSocketChannel.class)
                     .childHandler(newHandler(SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey()).build(),
                             serverPromise));
-            sc = serverBootstrap.bind(new InetSocketAddress(0)).get();
-            cc = bootstrap.connect(sc.localAddress()).get();
+            sc = serverBootstrap.bind(new InetSocketAddress(0)).asJdkFuture().get();
+            cc = bootstrap.connect(sc.localAddress()).asJdkFuture().get();
 
             serverPromise.asFuture().sync();
             clientPromise.asFuture().sync();
@@ -658,8 +658,8 @@ public class SslHandlerTest {
                   }
               });
 
-            serverChannel = sb.bind(new LocalAddress(getClass())).get();
-            clientChannel = cb.connect(serverChannel.localAddress()).get();
+            serverChannel = sb.bind(new LocalAddress(getClass())).asJdkFuture().get();
+            clientChannel = cb.connect(serverChannel.localAddress()).asJdkFuture().get();
             try {
                 latch.await();
             } catch (InterruptedException e) {
@@ -733,7 +733,7 @@ public class SslHandlerTest {
                                     }
                                 });
                             }
-                        }).bind(new InetSocketAddress(0)).get();
+                        }).bind(new InetSocketAddress(0)).asJdkFuture().get();
 
                 cc = new Bootstrap()
                         .group(group)
@@ -743,7 +743,7 @@ public class SslHandlerTest {
                             protected void initChannel(Channel ch) throws Exception {
                                 ch.pipeline().addLast(sslClientCtx.newHandler(ch.bufferAllocator()));
                             }
-                        }).connect(sc.localAddress()).get();
+                        }).connect(sc.localAddress()).asJdkFuture().get();
 
                 // We first write a ReadOnlyBuffer because SslHandler will attempt to take the first buffer and append
                 // to it until there is no room, or the aggregation size threshold is exceeded. We want to verify that
@@ -794,7 +794,7 @@ public class SslHandlerTest {
                                 ch.pipeline().addLast(sslServerCtx.newHandler(ch.bufferAllocator()));
                             }
                         });
-                sc = sb.bind(address).get();
+                sc = sb.bind(address).asJdkFuture().get();
 
                 final AtomicReference<SslHandler> sslHandlerRef = new AtomicReference<>();
                 Bootstrap b = new Bootstrap()
@@ -812,7 +812,7 @@ public class SslHandlerTest {
                                 ch.pipeline().addLast(handler);
                             }
                         });
-                cc = b.connect(sc.localAddress()).get();
+                cc = b.connect(sc.localAddress()).asJdkFuture().get();
                 SslHandler handler = sslHandlerRef.get();
                 handler.handshakeFuture().await();
                 assertFalse(handler.handshakeFuture().isSuccess());
@@ -865,7 +865,7 @@ public class SslHandlerTest {
                         .channel(NioServerSocketChannel.class)
                         .childHandler(new ChannelHandler() {
                         })
-                        .bind(new InetSocketAddress(0)).get();
+                        .bind(new InetSocketAddress(0)).asJdkFuture().get();
 
                 cc = new Bootstrap()
                         .group(group)
@@ -891,8 +891,8 @@ public class SslHandlerTest {
                             }
                         }).connect(sc.localAddress()).addListener(future -> {
                             // Write something to trigger the handshake before fireChannelActive is called.
-                            future.get().writeAndFlush(offHeapAllocator().copyOf(new byte[] { 1, 2, 3, 4 }));
-                        }).get();
+                            future.asJdkFuture().get().writeAndFlush(offHeapAllocator().copyOf(new byte[] { 1, 2, 3, 4 }));
+                        }).asJdkFuture().get();
 
                 // Ensure there is no AssertionError thrown by having the handshake failed by the writeAndFlush(...)
                 // before channelActive(...) was called. Let's first wait for the activeLatch countdown to happen and
@@ -946,7 +946,7 @@ public class SslHandlerTest {
                         .channel(NioServerSocketChannel.class)
                         .childHandler(new ChannelHandler() {
                         })
-                        .bind(new InetSocketAddress(0)).get();
+                        .bind(new InetSocketAddress(0)).asJdkFuture().get();
 
                 Future<Channel> future = new Bootstrap()
                         .group(group)
@@ -971,7 +971,7 @@ public class SslHandlerTest {
                         future1.getNow().writeAndFlush(offHeapAllocator().copyOf(new byte[] { 1, 2, 3, 4 }));
                     });
                 }
-                cc = future.get();
+                cc = future.asJdkFuture().get();
 
                 Throwable cause = sslHandler.handshakeFuture().await().cause();
                 assertThat(cause, instanceOf(SSLException.class));
@@ -1144,7 +1144,7 @@ public class SslHandlerTest {
                                 });
                             }
                         })
-                        .bind(new InetSocketAddress(0)).get();
+                        .bind(new InetSocketAddress(0)).asJdkFuture().get();
 
                 Future<Channel> future = new Bootstrap()
                         .group(group)
@@ -1161,7 +1161,7 @@ public class SslHandlerTest {
                                 });
                             }
                         }).connect(sc.localAddress());
-                cc = future.get();
+                cc = future.asJdkFuture().get();
 
                 assertTrue(clientSslHandler.handshakeFuture().await().isSuccess());
                 assertTrue(serverSslHandler.handshakeFuture().await().isSuccess());
@@ -1227,7 +1227,7 @@ public class SslHandlerTest {
                         .group(group)
                         .channel(NioServerSocketChannel.class)
                         .childHandler(serverSslHandler)
-                        .bind(new InetSocketAddress(0)).get();
+                        .bind(new InetSocketAddress(0)).asJdkFuture().get();
 
                 Future<Channel> future = new Bootstrap()
                         .group(group)
@@ -1238,7 +1238,7 @@ public class SslHandlerTest {
                                 ch.pipeline().addLast(clientSslHandler);
                             }
                         }).connect(sc.localAddress());
-                cc = future.get();
+                cc = future.asJdkFuture().get();
 
                 if (client) {
                     Throwable cause = clientSslHandler.handshakeFuture().await().cause();
@@ -1358,7 +1358,7 @@ public class SslHandlerTest {
                                 });
                             }
                         })
-                        .bind(new InetSocketAddress(0)).get();
+                        .bind(new InetSocketAddress(0)).asJdkFuture().get();
 
                 InetSocketAddress serverAddr = (InetSocketAddress) sc.localAddress();
                 testSessionTickets(serverAddr, group, sslClientCtx, bytes, false);
@@ -1408,7 +1408,7 @@ public class SslHandlerTest {
                             });
                         }
                     }).connect(serverAddress);
-            cc = future.get();
+            cc = future.asJdkFuture().get();
 
             assertTrue(clientSslHandler.handshakeFuture().sync().isSuccess());
 
@@ -1519,7 +1519,7 @@ public class SslHandlerTest {
                             });
                         }
                     })
-                    .bind(new InetSocketAddress(0)).get();
+                    .bind(new InetSocketAddress(0)).asJdkFuture().get();
             Channel channel = new Bootstrap()
                     .group(group)
                     .channel(NioSocketChannel.class)
@@ -1528,7 +1528,7 @@ public class SslHandlerTest {
                         protected void initChannel(Channel ch) {
                             ch.pipeline().addLast(clientSslHandler);
                         }
-                    }).connect(sc.localAddress()).get();
+                    }).connect(sc.localAddress()).asJdkFuture().get();
             clientSslHandler.handshakeFuture().addListener(f -> channel.close());
             assertFalse(clientSslHandler.handshakeFuture().await().isSuccess());
             assertFalse(serverSslHandler.handshakeFuture().await().isSuccess());
@@ -1637,7 +1637,7 @@ public class SslHandlerTest {
                                 ch.pipeline().addLast(new SslEventHandler(serverEvent));
                             }
                         })
-                        .bind(new InetSocketAddress(0)).get();
+                        .bind(new InetSocketAddress(0)).asJdkFuture().get();
 
                 cc = new Bootstrap()
                         .group(group)
@@ -1648,7 +1648,7 @@ public class SslHandlerTest {
                                 ch.pipeline().addLast(clientSslHandler);
                                 ch.pipeline().addLast(new SslEventHandler(clientEvent));
                             }
-                        }).connect(sc.localAddress()).get();
+                        }).connect(sc.localAddress()).asJdkFuture().get();
 
                 Throwable clientCause = clientSslHandler.handshakeFuture().await().cause();
                 assertThat(clientCause, instanceOf(SSLException.class));
@@ -1729,7 +1729,7 @@ public class SslHandlerTest {
                                 ch.pipeline().addLast(new SslHandshakeCompletionEventHandler(serverCompletionEvents));
                             }
                         })
-                        .bind(new InetSocketAddress(0)).get();
+                        .bind(new InetSocketAddress(0)).asJdkFuture().get();
 
                 Bootstrap bs = new Bootstrap()
                         .group(group)
@@ -1744,8 +1744,8 @@ public class SslHandlerTest {
                         })
                         .remoteAddress(sc.localAddress());
 
-                Channel cc1 = bs.connect().get();
-                Channel cc2 = bs.connect().get();
+                Channel cc1 = bs.connect().asJdkFuture().get();
+                Channel cc2 = bs.connect().asJdkFuture().get();
 
                 // We expect 4 events as we have 2 connections and for each connection there should be one event
                 // on the server-side and one on the client-side.

--- a/handler/src/test/java/io/netty5/handler/ssl/ocsp/OcspTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/ocsp/OcspTest.java
@@ -394,7 +394,7 @@ public class OcspTest {
                 .group(group)
                 .childHandler(newServerHandler(context, response, handler));
 
-        return bootstrap.bind(address).asJdkFuture().get();
+        return bootstrap.bind(address).asStage().get();
     }
 
     private static Channel newClient(EventLoopGroup group, SocketAddress address,
@@ -405,7 +405,7 @@ public class OcspTest {
                 .group(group)
                 .handler(newClientHandler(context, callback, handler));
 
-        return bootstrap.connect(address).asJdkFuture().get();
+        return bootstrap.connect(address).asStage().get();
     }
 
     private static ChannelHandler newServerHandler(final SslContext context,

--- a/handler/src/test/java/io/netty5/handler/ssl/ocsp/OcspTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/ocsp/OcspTest.java
@@ -394,7 +394,7 @@ public class OcspTest {
                 .group(group)
                 .childHandler(newServerHandler(context, response, handler));
 
-        return bootstrap.bind(address).get();
+        return bootstrap.bind(address).asJdkFuture().get();
     }
 
     private static Channel newClient(EventLoopGroup group, SocketAddress address,
@@ -405,7 +405,7 @@ public class OcspTest {
                 .group(group)
                 .handler(newClientHandler(context, callback, handler));
 
-        return bootstrap.connect(address).get();
+        return bootstrap.connect(address).asJdkFuture().get();
     }
 
     private static ChannelHandler newServerHandler(final SslContext context,

--- a/handler/src/test/java/io/netty5/handler/stream/ChunkedWriteHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/stream/ChunkedWriteHandlerTest.java
@@ -32,7 +32,6 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.RandomAccessFile;
 import java.nio.channels.Channels;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.FileChannel;

--- a/handler/src/test/java/io/netty5/handler/traffic/FileRegionThrottleTest.java
+++ b/handler/src/test/java/io/netty5/handler/traffic/FileRegionThrottleTest.java
@@ -98,7 +98,7 @@ public class FileRegionThrottleTest {
                 ch.pipeline().addLast(gtsh);
             }
         });
-        Channel sc = bs.bind(0).asJdkFuture().get();
+        Channel sc = bs.bind(0).asStage().get();
         Channel cc = clientConnect(sc.localAddress(), new ReadHandler(latch));
 
         long start = TrafficCounter.milliSecondFromNano();
@@ -118,7 +118,7 @@ public class FileRegionThrottleTest {
                 ch.pipeline().addLast(readHandler);
             }
         });
-        return bc.connect(server).asJdkFuture().get();
+        return bc.connect(server).asStage().get();
     }
 
     private static final class MessageDecoder implements ChannelHandler {

--- a/handler/src/test/java/io/netty5/handler/traffic/FileRegionThrottleTest.java
+++ b/handler/src/test/java/io/netty5/handler/traffic/FileRegionThrottleTest.java
@@ -98,7 +98,7 @@ public class FileRegionThrottleTest {
                 ch.pipeline().addLast(gtsh);
             }
         });
-        Channel sc = bs.bind(0).get();
+        Channel sc = bs.bind(0).asJdkFuture().get();
         Channel cc = clientConnect(sc.localAddress(), new ReadHandler(latch));
 
         long start = TrafficCounter.milliSecondFromNano();
@@ -118,7 +118,7 @@ public class FileRegionThrottleTest {
                 ch.pipeline().addLast(readHandler);
             }
         });
-        return bc.connect(server).get();
+        return bc.connect(server).asJdkFuture().get();
     }
 
     private static final class MessageDecoder implements ChannelHandler {

--- a/handler/src/test/java/io/netty5/handler/traffic/TrafficShapingHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/traffic/TrafficShapingHandlerTest.java
@@ -94,7 +94,7 @@ public class TrafficShapingHandlerTest {
                         }
                     });
             final LocalAddress svrAddr = new LocalAddress(TrafficShapingHandlerTest.class);
-            svrChannel = serverBootstrap.bind(svrAddr).asJdkFuture().get();
+            svrChannel = serverBootstrap.bind(svrAddr).asStage().get();
             Bootstrap bootstrap = new Bootstrap();
             bootstrap.channel(LocalChannel.class).group(GROUP).handler(new ChannelInitializer<Channel>() {
                 @Override
@@ -102,7 +102,7 @@ public class TrafficShapingHandlerTest {
                     ch.pipeline().addLast("traffic-shaping", trafficHandler);
                 }
             });
-            ch = bootstrap.connect(svrAddr).asJdkFuture().get();
+            ch = bootstrap.connect(svrAddr).asStage().get();
             Attribute<Runnable> attr = ch.attr(AbstractTrafficShapingHandler.REOPEN_TASK);
             assertNull(attr.get());
             ch.writeAndFlush(preferredAllocator().copyOf("foo".getBytes(CharsetUtil.UTF_8)));

--- a/handler/src/test/java/io/netty5/handler/traffic/TrafficShapingHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/traffic/TrafficShapingHandlerTest.java
@@ -94,7 +94,7 @@ public class TrafficShapingHandlerTest {
                         }
                     });
             final LocalAddress svrAddr = new LocalAddress(TrafficShapingHandlerTest.class);
-            svrChannel = serverBootstrap.bind(svrAddr).get();
+            svrChannel = serverBootstrap.bind(svrAddr).asJdkFuture().get();
             Bootstrap bootstrap = new Bootstrap();
             bootstrap.channel(LocalChannel.class).group(GROUP).handler(new ChannelInitializer<Channel>() {
                 @Override
@@ -102,7 +102,7 @@ public class TrafficShapingHandlerTest {
                     ch.pipeline().addLast("traffic-shaping", trafficHandler);
                 }
             });
-            ch = bootstrap.connect(svrAddr).get();
+            ch = bootstrap.connect(svrAddr).asJdkFuture().get();
             Attribute<Runnable> attr = ch.attr(AbstractTrafficShapingHandler.REOPEN_TASK);
             assertNull(attr.get());
             ch.writeAndFlush(preferredAllocator().copyOf("foo".getBytes(CharsetUtil.UTF_8)));

--- a/microbench/src/main/java/io/netty5/microbench/buffer/Utf8EncodingBenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/buffer/Utf8EncodingBenchmark.java
@@ -20,7 +20,6 @@ import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.microbench.util.AbstractMicrobenchmark;
 import io.netty5.util.AsciiString;
 import io.netty5.util.CharsetUtil;
-import io.netty5.util.internal.EmptyArrays;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.CompilerControl;
 import org.openjdk.jmh.annotations.CompilerControl.Mode;

--- a/microbench/src/main/java/io/netty5/microbench/channel/epoll/EpollSocketChannelBenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/channel/epoll/EpollSocketChannelBenchmark.java
@@ -73,7 +73,7 @@ public class EpollSocketChannelBenchmark extends AbstractMicrobenchmark {
                 }
             })
             .bind(0)
-            .get();
+            .asJdkFuture().get();
     chan = new Bootstrap()
         .channel(EpollSocketChannel.class)
         .handler(new ChannelInitializer<>() {
@@ -112,7 +112,7 @@ public class EpollSocketChannelBenchmark extends AbstractMicrobenchmark {
         })
         .group(group)
         .connect(serverChan.localAddress())
-        .get();
+        .asJdkFuture().get();
 
         abyte = chan.bufferAllocator().allocate(1);
         abyte.writeByte((byte) 'a').makeReadOnly();
@@ -134,12 +134,12 @@ public class EpollSocketChannelBenchmark extends AbstractMicrobenchmark {
 
     @Benchmark
     public Object executeSingle() throws Exception {
-        return chan.executor().submit(runnable).get();
+        return chan.executor().submit(runnable).asJdkFuture().get();
     }
 
     @Benchmark
     @GroupThreads(3)
     public Object executeMulti() throws Exception {
-        return chan.executor().submit(runnable).get();
+        return chan.executor().submit(runnable).asJdkFuture().get();
     }
 }

--- a/resolver-dns/src/main/java/io/netty5/resolver/dns/Cache.java
+++ b/resolver-dns/src/main/java/io/netty5/resolver/dns/Cache.java
@@ -102,11 +102,6 @@ abstract class Cache<E> {
         }
 
         @Override
-        public boolean await(long timeoutMillis) throws InterruptedException {
-            return true;
-        }
-
-        @Override
         public Object getNow() {
             return null;
         }

--- a/resolver-dns/src/main/java/io/netty5/resolver/dns/Cache.java
+++ b/resolver-dns/src/main/java/io/netty5/resolver/dns/Cache.java
@@ -127,16 +127,6 @@ abstract class Cache<E> {
         }
 
         @Override
-        public Object get() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public Object get(long timeout, TimeUnit unit) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
         public FutureCompletionStage<Object> asStage() {
             throw new UnsupportedOperationException();
         }

--- a/resolver-dns/src/main/java/io/netty5/resolver/dns/Cache.java
+++ b/resolver-dns/src/main/java/io/netty5/resolver/dns/Cache.java
@@ -132,11 +132,6 @@ abstract class Cache<E> {
         }
 
         @Override
-        public java.util.concurrent.Future<Object> asJdkFuture() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
         public <R> Future<R> map(Function<Object, R> mapper) {
             throw new UnsupportedOperationException();
         }

--- a/resolver-dns/src/test/java/io/netty5/resolver/dns/DefaultAuthoritativeDnsServerCacheTest.java
+++ b/resolver-dns/src/test/java/io/netty5/resolver/dns/DefaultAuthoritativeDnsServerCacheTest.java
@@ -53,7 +53,7 @@ public class DefaultAuthoritativeDnsServerCacheTest {
                 } catch (Throwable cause) {
                     return cause;
                 }
-            }, 1, TimeUnit.SECONDS).asJdkFuture().get();
+            }, 1, TimeUnit.SECONDS).asStage().get();
             if (error != null) {
                 throw error;
             }

--- a/resolver-dns/src/test/java/io/netty5/resolver/dns/DefaultAuthoritativeDnsServerCacheTest.java
+++ b/resolver-dns/src/test/java/io/netty5/resolver/dns/DefaultAuthoritativeDnsServerCacheTest.java
@@ -53,7 +53,7 @@ public class DefaultAuthoritativeDnsServerCacheTest {
                 } catch (Throwable cause) {
                     return cause;
                 }
-            }, 1, TimeUnit.SECONDS).get();
+            }, 1, TimeUnit.SECONDS).asJdkFuture().get();
             if (error != null) {
                 throw error;
             }

--- a/resolver-dns/src/test/java/io/netty5/resolver/dns/DefaultDnsCacheTest.java
+++ b/resolver-dns/src/test/java/io/netty5/resolver/dns/DefaultDnsCacheTest.java
@@ -53,7 +53,7 @@ public class DefaultDnsCacheTest {
                 } catch (Throwable cause) {
                     return cause;
                 }
-            }, 1, TimeUnit.SECONDS).get();
+            }, 1, TimeUnit.SECONDS).asJdkFuture().get();
             if (error != null) {
                 throw error;
             }

--- a/resolver-dns/src/test/java/io/netty5/resolver/dns/DefaultDnsCacheTest.java
+++ b/resolver-dns/src/test/java/io/netty5/resolver/dns/DefaultDnsCacheTest.java
@@ -53,7 +53,7 @@ public class DefaultDnsCacheTest {
                 } catch (Throwable cause) {
                     return cause;
                 }
-            }, 1, TimeUnit.SECONDS).asJdkFuture().get();
+            }, 1, TimeUnit.SECONDS).asStage().get();
             if (error != null) {
                 throw error;
             }

--- a/resolver-dns/src/test/java/io/netty5/resolver/dns/DefaultDnsCnameCacheTest.java
+++ b/resolver-dns/src/test/java/io/netty5/resolver/dns/DefaultDnsCnameCacheTest.java
@@ -46,7 +46,7 @@ public class DefaultDnsCnameCacheTest {
                 } catch (Throwable cause) {
                     return cause;
                 }
-            }, 1, TimeUnit.SECONDS).get();
+            }, 1, TimeUnit.SECONDS).asJdkFuture().get();
             if (error != null) {
                 throw error;
             }

--- a/resolver-dns/src/test/java/io/netty5/resolver/dns/DefaultDnsCnameCacheTest.java
+++ b/resolver-dns/src/test/java/io/netty5/resolver/dns/DefaultDnsCnameCacheTest.java
@@ -46,7 +46,7 @@ public class DefaultDnsCnameCacheTest {
                 } catch (Throwable cause) {
                     return cause;
                 }
-            }, 1, TimeUnit.SECONDS).asJdkFuture().get();
+            }, 1, TimeUnit.SECONDS).asStage().get();
             if (error != null) {
                 throw error;
             }

--- a/resolver-dns/src/test/java/io/netty5/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty5/resolver/dns/DnsNameResolverTest.java
@@ -1930,7 +1930,7 @@ public class DnsNameResolverTest {
                 .build();
 
         try {
-            final List<InetAddress> addresses = resolver.resolveAll(unresolved).sync().get();
+            final List<InetAddress> addresses = resolver.resolveAll(unresolved).sync().asJdkFuture().get();
             assertThat(addresses, hasSize(greaterThan(0)));
             for (InetAddress address : addresses) {
                 assertThat(address.getHostName(), startsWith(unresolved));
@@ -3431,7 +3431,7 @@ public class DnsNameResolverTest {
     }
 
     private static void assertNotEmptyAndRelease(Future<List<DnsRecord>> recordsFuture) throws Exception {
-        List<DnsRecord> records = recordsFuture.get();
+        List<DnsRecord> records = recordsFuture.asJdkFuture().get();
         assertFalse(records.isEmpty());
         for (DnsRecord record : records) {
             Resource.dispose(record);

--- a/resolver-dns/src/test/java/io/netty5/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty5/resolver/dns/DnsNameResolverTest.java
@@ -1930,7 +1930,7 @@ public class DnsNameResolverTest {
                 .build();
 
         try {
-            final List<InetAddress> addresses = resolver.resolveAll(unresolved).sync().asJdkFuture().get();
+            final List<InetAddress> addresses = resolver.resolveAll(unresolved).sync().asStage().get();
             assertThat(addresses, hasSize(greaterThan(0)));
             for (InetAddress address : addresses) {
                 assertThat(address.getHostName(), startsWith(unresolved));
@@ -3431,7 +3431,7 @@ public class DnsNameResolverTest {
     }
 
     private static void assertNotEmptyAndRelease(Future<List<DnsRecord>> recordsFuture) throws Exception {
-        List<DnsRecord> records = recordsFuture.asJdkFuture().get();
+        List<DnsRecord> records = recordsFuture.asStage().get();
         assertFalse(records.isEmpty());
         for (DnsRecord record : records) {
             Resource.dispose(record);

--- a/testsuite-autobahn/src/main/java/io/netty5/testsuite/autobahn/AutobahnServer.java
+++ b/testsuite-autobahn/src/main/java/io/netty5/testsuite/autobahn/AutobahnServer.java
@@ -46,7 +46,7 @@ public class AutobahnServer {
              .childOption(ChannelOption.BUFFER_ALLOCATOR, DefaultBufferAllocators.preferredAllocator())
              .childHandler(new AutobahnServerInitializer());
 
-            Channel channel = b.bind(port).asJdkFuture().get();
+            Channel channel = b.bind(port).asStage().get();
             System.out.println("Web Socket Server started at port " + port);
             channel.closeFuture().sync();
         } finally {

--- a/testsuite-autobahn/src/main/java/io/netty5/testsuite/autobahn/AutobahnServer.java
+++ b/testsuite-autobahn/src/main/java/io/netty5/testsuite/autobahn/AutobahnServer.java
@@ -46,7 +46,7 @@ public class AutobahnServer {
              .childOption(ChannelOption.BUFFER_ALLOCATOR, DefaultBufferAllocators.preferredAllocator())
              .childHandler(new AutobahnServerInitializer());
 
-            Channel channel = b.bind(port).get();
+            Channel channel = b.bind(port).asJdkFuture().get();
             System.out.println("Web Socket Server started at port " + port);
             channel.closeFuture().sync();
         } finally {

--- a/testsuite-http2/src/main/java/io/netty5/testsuite/http2/Http2Server.java
+++ b/testsuite-http2/src/main/java/io/netty5/testsuite/http2/Http2Server.java
@@ -49,7 +49,7 @@ public final class Http2Server {
                     .handler(new LoggingHandler(LogLevel.INFO))
                     .childHandler(new Http2ServerInitializer());
 
-            Channel ch = b.bind(port).asJdkFuture().get();
+            Channel ch = b.bind(port).asStage().get();
 
             ch.closeFuture().sync();
         } finally {

--- a/testsuite-http2/src/main/java/io/netty5/testsuite/http2/Http2Server.java
+++ b/testsuite-http2/src/main/java/io/netty5/testsuite/http2/Http2Server.java
@@ -49,7 +49,7 @@ public final class Http2Server {
                     .handler(new LoggingHandler(LogLevel.INFO))
                     .childHandler(new Http2ServerInitializer());
 
-            Channel ch = b.bind(port).get();
+            Channel ch = b.bind(port).asJdkFuture().get();
 
             ch.closeFuture().sync();
         } finally {

--- a/testsuite-native-image-client/src/main/java/io/netty5/testsuite/svm/client/DnsNativeClient.java
+++ b/testsuite-native-image-client/src/main/java/io/netty5/testsuite/svm/client/DnsNativeClient.java
@@ -45,6 +45,6 @@ public final class DnsNativeClient {
         System.out.println(resolver);
 
         resolver.close();
-        group.shutdownGracefully().asJdkFuture().get();
+        group.shutdownGracefully().asStage().get();
     }
 }

--- a/testsuite-native-image-client/src/main/java/io/netty5/testsuite/svm/client/DnsNativeClient.java
+++ b/testsuite-native-image-client/src/main/java/io/netty5/testsuite/svm/client/DnsNativeClient.java
@@ -45,6 +45,6 @@ public final class DnsNativeClient {
         System.out.println(resolver);
 
         resolver.close();
-        group.shutdownGracefully().get();
+        group.shutdownGracefully().asJdkFuture().get();
     }
 }

--- a/testsuite-native-image/src/main/java/io/netty5/testsuite/svm/HttpNativeServer.java
+++ b/testsuite-native-image/src/main/java/io/netty5/testsuite/svm/HttpNativeServer.java
@@ -51,7 +51,7 @@ public final class HttpNativeServer {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new HttpNativeServerInitializer());
 
-            Channel channel = b.bind(0).get();
+            Channel channel = b.bind(0).asJdkFuture().get();
             System.err.println("Server started, will shutdown now.");
             channel.close().sync();
             serverStartSucess = true;

--- a/testsuite-native-image/src/main/java/io/netty5/testsuite/svm/HttpNativeServer.java
+++ b/testsuite-native-image/src/main/java/io/netty5/testsuite/svm/HttpNativeServer.java
@@ -51,7 +51,7 @@ public final class HttpNativeServer {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new HttpNativeServerInitializer());
 
-            Channel channel = b.bind(0).asJdkFuture().get();
+            Channel channel = b.bind(0).asStage().get();
             System.err.println("Server started, will shutdown now.");
             channel.close().sync();
             serverStartSucess = true;

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/AbstractSingleThreadEventLoopTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/AbstractSingleThreadEventLoopTest.java
@@ -51,7 +51,7 @@ public abstract class AbstractSingleThreadEventLoopTest {
     @Test
     public void shutdownGracefullyZeroQuietBeforeStart() throws Exception {
         EventLoopGroup group =  new MultithreadEventLoopGroup(newIoHandlerFactory());
-        assertTrue(group.shutdownGracefully(0L, 2L, TimeUnit.SECONDS).await(200L));
+        assertTrue(group.shutdownGracefully(0L, 2L, TimeUnit.SECONDS).await(200, TimeUnit.MILLISECONDS));
     }
 
     // Copied from AbstractEventLoopTest
@@ -79,7 +79,7 @@ public abstract class AbstractSingleThreadEventLoopTest {
     @Test
     public void shutdownGracefullyBeforeStart() throws Exception {
         EventLoopGroup group = new MultithreadEventLoopGroup(newIoHandlerFactory());
-        assertTrue(group.shutdownGracefully(200L, 1000L, TimeUnit.MILLISECONDS).await(500L));
+        assertTrue(group.shutdownGracefully(200L, 1000L, TimeUnit.MILLISECONDS).await(500, TimeUnit.MILLISECONDS));
     }
 
     @Test

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/AbstractSocketReuseFdTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/AbstractSocketReuseFdTest.java
@@ -97,7 +97,7 @@ public abstract class AbstractSocketReuseFdTest extends AbstractSocketTest {
             }
         };
 
-        Channel sc = sb.bind().asJdkFuture().get();
+        Channel sc = sb.bind().asStage().get();
         for (int i = 0; i < numChannels; i++) {
             cb.connect(sc.localAddress()).addListener(listener);
         }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/AbstractSocketReuseFdTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/AbstractSocketReuseFdTest.java
@@ -97,7 +97,7 @@ public abstract class AbstractSocketReuseFdTest extends AbstractSocketTest {
             }
         };
 
-        Channel sc = sb.bind().get();
+        Channel sc = sb.bind().asJdkFuture().get();
         for (int i = 0; i < numChannels; i++) {
             cb.connect(sc.localAddress()).addListener(listener);
         }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/AbstractSocketShutdownOutputByPeerTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/AbstractSocketShutdownOutputByPeerTest.java
@@ -52,7 +52,7 @@ public abstract class AbstractSocketShutdownOutputByPeerTest<Socket> extends Abs
         Socket s = newSocket();
         Channel sc = null;
         try {
-            sc = sb.childHandler(h).childOption(ChannelOption.ALLOW_HALF_CLOSURE, true).bind().asJdkFuture().get();
+            sc = sb.childHandler(h).childOption(ChannelOption.ALLOW_HALF_CLOSURE, true).bind().asStage().get();
 
             connect(s, sc.localAddress());
             write(s, 1);
@@ -95,7 +95,7 @@ public abstract class AbstractSocketShutdownOutputByPeerTest<Socket> extends Abs
         Socket s = newSocket();
         Channel sc = null;
         try {
-            sc = sb.childHandler(h).bind().asJdkFuture().get();
+            sc = sb.childHandler(h).bind().asStage().get();
 
             connect(s, sc.localAddress());
             write(s, 1);

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/AbstractSocketShutdownOutputByPeerTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/AbstractSocketShutdownOutputByPeerTest.java
@@ -52,7 +52,7 @@ public abstract class AbstractSocketShutdownOutputByPeerTest<Socket> extends Abs
         Socket s = newSocket();
         Channel sc = null;
         try {
-            sc = sb.childHandler(h).childOption(ChannelOption.ALLOW_HALF_CLOSURE, true).bind().get();
+            sc = sb.childHandler(h).childOption(ChannelOption.ALLOW_HALF_CLOSURE, true).bind().asJdkFuture().get();
 
             connect(s, sc.localAddress());
             write(s, 1);
@@ -95,7 +95,7 @@ public abstract class AbstractSocketShutdownOutputByPeerTest<Socket> extends Abs
         Socket s = newSocket();
         Channel sc = null;
         try {
-            sc = sb.childHandler(h).bind().get();
+            sc = sb.childHandler(h).bind().asJdkFuture().get();
 
             connect(s, sc.localAddress());
             write(s, 1);

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/CompositeBufferGatheringWriteTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/CompositeBufferGatheringWriteTest.java
@@ -122,8 +122,8 @@ public class CompositeBufferGatheringWriteTest extends AbstractSocketTest {
                 }
             });
 
-            serverChannel = sb.bind().get();
-            clientChannel = cb.connect(serverChannel.localAddress()).get();
+            serverChannel = sb.bind().asJdkFuture().get();
+            clientChannel = cb.connect(serverChannel.localAddress()).asJdkFuture().get();
 
             try (Buffer expected = newCompositeBuffer(clientChannel.bufferAllocator())) {
                 latch.await();
@@ -261,8 +261,8 @@ public class CompositeBufferGatheringWriteTest extends AbstractSocketTest {
                 }
             });
 
-            serverChannel = sb.bind().get();
-            clientChannel = cb.connect(serverChannel.localAddress()).get();
+            serverChannel = sb.bind().asJdkFuture().get();
+            clientChannel = cb.connect(serverChannel.localAddress()).asJdkFuture().get();
 
             latch.await();
             Object received = clientReceived.get();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/CompositeBufferGatheringWriteTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/CompositeBufferGatheringWriteTest.java
@@ -122,8 +122,8 @@ public class CompositeBufferGatheringWriteTest extends AbstractSocketTest {
                 }
             });
 
-            serverChannel = sb.bind().asJdkFuture().get();
-            clientChannel = cb.connect(serverChannel.localAddress()).asJdkFuture().get();
+            serverChannel = sb.bind().asStage().get();
+            clientChannel = cb.connect(serverChannel.localAddress()).asStage().get();
 
             try (Buffer expected = newCompositeBuffer(clientChannel.bufferAllocator())) {
                 latch.await();
@@ -261,8 +261,8 @@ public class CompositeBufferGatheringWriteTest extends AbstractSocketTest {
                 }
             });
 
-            serverChannel = sb.bind().asJdkFuture().get();
-            clientChannel = cb.connect(serverChannel.localAddress()).asJdkFuture().get();
+            serverChannel = sb.bind().asStage().get();
+            clientChannel = cb.connect(serverChannel.localAddress()).asStage().get();
 
             latch.await();
             Object received = clientReceived.get();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramConnectNotExistsTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramConnectNotExistsTest.java
@@ -65,7 +65,7 @@ public class DatagramConnectNotExistsTest extends AbstractClientSocketTest {
         Future<Channel> future = cb.connect(NetUtil.LOCALHOST, SocketTestPermutation.BAD_PORT);
         Channel datagramChannel = null;
         try {
-            datagramChannel = future.asJdkFuture().get();
+            datagramChannel = future.asStage().get();
             assertTrue(datagramChannel.isActive());
             BufferAllocator allocator = datagramChannel.bufferAllocator();
             datagramChannel.writeAndFlush(

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramConnectNotExistsTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramConnectNotExistsTest.java
@@ -65,7 +65,7 @@ public class DatagramConnectNotExistsTest extends AbstractClientSocketTest {
         Future<Channel> future = cb.connect(NetUtil.LOCALHOST, SocketTestPermutation.BAD_PORT);
         Channel datagramChannel = null;
         try {
-            datagramChannel = future.get();
+            datagramChannel = future.asJdkFuture().get();
             assertTrue(datagramChannel.isActive());
             BufferAllocator allocator = datagramChannel.bufferAllocator();
             datagramChannel.writeAndFlush(

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramMulticastTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramMulticastTest.java
@@ -73,14 +73,14 @@ public class DatagramMulticastTest extends AbstractDatagramTest {
         cb.option(ChannelOption.IP_MULTICAST_IF, iface);
         cb.option(ChannelOption.SO_REUSEADDR, true);
 
-        DatagramChannel sc = (DatagramChannel) sb.bind(newSocketAddress(iface)).asJdkFuture().get();
+        DatagramChannel sc = (DatagramChannel) sb.bind(newSocketAddress(iface)).asStage().get();
         assertEquals(iface, sc.config().getNetworkInterface());
         assertInterfaceAddress(iface, sc.config().getInterface());
 
         InetSocketAddress addr = sc.localAddress();
         cb.localAddress(addr.getPort());
 
-        DatagramChannel cc = (DatagramChannel) cb.bind().asJdkFuture().get();
+        DatagramChannel cc = (DatagramChannel) cb.bind().asStage().get();
         assertEquals(iface, cc.config().getNetworkInterface());
         assertInterfaceAddress(iface, cc.config().getInterface());
 

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramMulticastTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramMulticastTest.java
@@ -73,14 +73,14 @@ public class DatagramMulticastTest extends AbstractDatagramTest {
         cb.option(ChannelOption.IP_MULTICAST_IF, iface);
         cb.option(ChannelOption.SO_REUSEADDR, true);
 
-        DatagramChannel sc = (DatagramChannel) sb.bind(newSocketAddress(iface)).get();
+        DatagramChannel sc = (DatagramChannel) sb.bind(newSocketAddress(iface)).asJdkFuture().get();
         assertEquals(iface, sc.config().getNetworkInterface());
         assertInterfaceAddress(iface, sc.config().getInterface());
 
         InetSocketAddress addr = sc.localAddress();
         cb.localAddress(addr.getPort());
 
-        DatagramChannel cc = (DatagramChannel) cb.bind().get();
+        DatagramChannel cc = (DatagramChannel) cb.bind().asJdkFuture().get();
         assertEquals(iface, cc.config().getNetworkInterface());
         assertInterfaceAddress(iface, cc.config().getInterface());
 

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramUnicastInetTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramUnicastInetTest.java
@@ -47,7 +47,7 @@ public class DatagramUnicastInetTest extends DatagramUnicastTest {
         Channel channel = null;
         try {
             cb.handler(new ChannelHandlerAdapter() { });
-            channel = cb.bind(0).asJdkFuture().get();
+            channel = cb.bind(0).asStage().get();
         } finally {
             closeChannel(channel);
         }
@@ -89,7 +89,7 @@ public class DatagramUnicastInetTest extends DatagramUnicastTest {
                 errorRef.compareAndSet(null, cause);
             }
         });
-        return cb.bind(newSocketAddress()).asJdkFuture().get();
+        return cb.bind(newSocketAddress()).asStage().get();
     }
 
     @Override
@@ -140,7 +140,7 @@ public class DatagramUnicastInetTest extends DatagramUnicastTest {
                 });
             }
         });
-        return sb.bind(newSocketAddress()).asJdkFuture().get();
+        return sb.bind(newSocketAddress()).asStage().get();
     }
 
     @Override

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramUnicastInetTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramUnicastInetTest.java
@@ -47,7 +47,7 @@ public class DatagramUnicastInetTest extends DatagramUnicastTest {
         Channel channel = null;
         try {
             cb.handler(new ChannelHandlerAdapter() { });
-            channel = cb.bind(0).get();
+            channel = cb.bind(0).asJdkFuture().get();
         } finally {
             closeChannel(channel);
         }
@@ -89,7 +89,7 @@ public class DatagramUnicastInetTest extends DatagramUnicastTest {
                 errorRef.compareAndSet(null, cause);
             }
         });
-        return cb.bind(newSocketAddress()).get();
+        return cb.bind(newSocketAddress()).asJdkFuture().get();
     }
 
     @Override
@@ -140,7 +140,7 @@ public class DatagramUnicastInetTest extends DatagramUnicastTest {
                 });
             }
         });
-        return sb.bind(newSocketAddress()).get();
+        return sb.bind(newSocketAddress()).asJdkFuture().get();
     }
 
     @Override

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramUnicastTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramUnicastTest.java
@@ -167,11 +167,11 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
 
             final SocketAddress sender;
             if (bindClient) {
-                cc = cb.bind(newSocketAddress()).get();
+                cc = cb.bind(newSocketAddress()).asJdkFuture().get();
                 sender = cc.localAddress();
             } else {
                 cb.option(ChannelOption.DATAGRAM_CHANNEL_ACTIVE_ON_REGISTRATION, true);
-                cc = cb.register().get();
+                cc = cb.register().asJdkFuture().get();
                 sender = null;
             }
 

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramUnicastTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramUnicastTest.java
@@ -167,11 +167,11 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
 
             final SocketAddress sender;
             if (bindClient) {
-                cc = cb.bind(newSocketAddress()).asJdkFuture().get();
+                cc = cb.bind(newSocketAddress()).asStage().get();
                 sender = cc.localAddress();
             } else {
                 cb.option(ChannelOption.DATAGRAM_CHANNEL_ACTIVE_ON_REGISTRATION, true);
-                cc = cb.register().asJdkFuture().get();
+                cc = cb.register().asStage().get();
                 sender = null;
             }
 

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/ServerSocketSuspendTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/ServerSocketSuspendTest.java
@@ -50,7 +50,7 @@ public class ServerSocketSuspendTest extends AbstractServerSocketTest {
         sb.option(ChannelOption.AUTO_READ, false);
         sb.childHandler(counter);
 
-        Channel sc = sb.bind().asJdkFuture().get();
+        Channel sc = sb.bind().asStage().get();
 
         List<Socket> sockets = new ArrayList<>();
 

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/ServerSocketSuspendTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/ServerSocketSuspendTest.java
@@ -50,7 +50,7 @@ public class ServerSocketSuspendTest extends AbstractServerSocketTest {
         sb.option(ChannelOption.AUTO_READ, false);
         sb.childHandler(counter);
 
-        Channel sc = sb.bind().get();
+        Channel sc = sb.bind().asJdkFuture().get();
 
         List<Socket> sockets = new ArrayList<>();
 

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketAutoReadTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketAutoReadTest.java
@@ -65,7 +65,7 @@ public class SocketAutoReadTest extends AbstractSocketTest {
                     .childOption(ChannelOption.RCVBUF_ALLOCATOR, new TestRecvBufferAllocator())
                     .childHandler(serverInitializer);
 
-            serverChannel = sb.bind().get();
+            serverChannel = sb.bind().asJdkFuture().get();
 
             cb.option(ChannelOption.AUTO_READ, true)
                     // We want to ensure that we attempt multiple individual read operations per read loop so we can
@@ -73,7 +73,7 @@ public class SocketAutoReadTest extends AbstractSocketTest {
                     .option(ChannelOption.RCVBUF_ALLOCATOR, new TestRecvBufferAllocator())
                     .handler(clientInitializer);
 
-            clientChannel = cb.connect(serverChannel.localAddress()).get();
+            clientChannel = cb.connect(serverChannel.localAddress()).asJdkFuture().get();
             BufferAllocator alloc = DefaultBufferAllocators.onHeapAllocator();
 
             // 3 bytes means 3 independent reads for TestRecvBufferAllocator

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketAutoReadTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketAutoReadTest.java
@@ -65,7 +65,7 @@ public class SocketAutoReadTest extends AbstractSocketTest {
                     .childOption(ChannelOption.RCVBUF_ALLOCATOR, new TestRecvBufferAllocator())
                     .childHandler(serverInitializer);
 
-            serverChannel = sb.bind().asJdkFuture().get();
+            serverChannel = sb.bind().asStage().get();
 
             cb.option(ChannelOption.AUTO_READ, true)
                     // We want to ensure that we attempt multiple individual read operations per read loop so we can
@@ -73,7 +73,7 @@ public class SocketAutoReadTest extends AbstractSocketTest {
                     .option(ChannelOption.RCVBUF_ALLOCATOR, new TestRecvBufferAllocator())
                     .handler(clientInitializer);
 
-            clientChannel = cb.connect(serverChannel.localAddress()).asJdkFuture().get();
+            clientChannel = cb.connect(serverChannel.localAddress()).asStage().get();
             BufferAllocator alloc = DefaultBufferAllocators.onHeapAllocator();
 
             // 3 bytes means 3 independent reads for TestRecvBufferAllocator

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketBufReleaseTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketBufReleaseTest.java
@@ -54,8 +54,8 @@ public class SocketBufReleaseTest extends AbstractSocketTest {
         sb.childHandler(serverHandler);
         cb.handler(clientHandler);
 
-        Channel sc = sb.bind().asJdkFuture().get();
-        Channel cc = cb.connect(sc.localAddress()).asJdkFuture().get();
+        Channel sc = sb.bind().asStage().get();
+        Channel cc = cb.connect(sc.localAddress()).asStage().get();
 
         // Ensure the server socket accepted the client connection *and* initialized pipeline successfully.
         serverHandler.awaitPipelineInit();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketBufReleaseTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketBufReleaseTest.java
@@ -54,8 +54,8 @@ public class SocketBufReleaseTest extends AbstractSocketTest {
         sb.childHandler(serverHandler);
         cb.handler(clientHandler);
 
-        Channel sc = sb.bind().get();
-        Channel cc = cb.connect(sc.localAddress()).get();
+        Channel sc = sb.bind().asJdkFuture().get();
+        Channel cc = cb.connect(sc.localAddress()).asJdkFuture().get();
 
         // Ensure the server socket accepted the client connection *and* initialized pipeline successfully.
         serverHandler.awaitPipelineInit();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketCancelWriteTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketCancelWriteTest.java
@@ -56,8 +56,8 @@ public class SocketCancelWriteTest extends AbstractSocketTest {
         cb.handler(ch);
         sb.childHandler(sh);
 
-        Channel sc = sb.bind().asJdkFuture().get();
-        Channel cc = cb.connect(sc.localAddress()).asJdkFuture().get();
+        Channel sc = sb.bind().asStage().get();
+        Channel cc = cb.connect(sc.localAddress()).asStage().get();
 
         Future<Void> f = cc.write(a);
         assertTrue(f.cancel());

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketCancelWriteTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketCancelWriteTest.java
@@ -56,8 +56,8 @@ public class SocketCancelWriteTest extends AbstractSocketTest {
         cb.handler(ch);
         sb.childHandler(sh);
 
-        Channel sc = sb.bind().get();
-        Channel cc = cb.connect(sc.localAddress()).get();
+        Channel sc = sb.bind().asJdkFuture().get();
+        Channel cc = cb.connect(sc.localAddress()).asJdkFuture().get();
 
         Future<Void> f = cc.write(a);
         assertTrue(f.cancel());

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketChannelNotYetConnectedTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketChannelNotYetConnectedTest.java
@@ -50,7 +50,7 @@ public class SocketChannelNotYetConnectedTest extends AbstractClientSocketTest {
 
     public void testShutdownNotYetConnected(Bootstrap cb) throws Throwable {
         SocketChannel ch = (SocketChannel) cb.handler(new ChannelHandler() { })
-                .bind(newSocketAddress()).get();
+                .bind(newSocketAddress()).asJdkFuture().get();
         try {
             try {
                 ch.shutdown(ChannelShutdownDirection.Inbound).sync();
@@ -84,7 +84,7 @@ public class SocketChannelNotYetConnectedTest extends AbstractClientSocketTest {
                     public void channelActive(ChannelHandlerContext ctx) throws Exception {
                         ctx.writeAndFlush(DefaultBufferAllocators.preferredAllocator().allocate(4).writeInt(42));
                     }
-                }).channel(NioServerSocketChannel.class).bind(0).get();
+                }).channel(NioServerSocketChannel.class).bind(0).asJdkFuture().get();
 
                 final CountDownLatch readLatch = new CountDownLatch(1);
                 bootstrap.handler(new ByteToMessageDecoder() {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketChannelNotYetConnectedTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketChannelNotYetConnectedTest.java
@@ -50,7 +50,7 @@ public class SocketChannelNotYetConnectedTest extends AbstractClientSocketTest {
 
     public void testShutdownNotYetConnected(Bootstrap cb) throws Throwable {
         SocketChannel ch = (SocketChannel) cb.handler(new ChannelHandler() { })
-                .bind(newSocketAddress()).asJdkFuture().get();
+                                             .bind(newSocketAddress()).asStage().get();
         try {
             try {
                 ch.shutdown(ChannelShutdownDirection.Inbound).sync();
@@ -84,7 +84,7 @@ public class SocketChannelNotYetConnectedTest extends AbstractClientSocketTest {
                     public void channelActive(ChannelHandlerContext ctx) throws Exception {
                         ctx.writeAndFlush(DefaultBufferAllocators.preferredAllocator().allocate(4).writeInt(42));
                     }
-                }).channel(NioServerSocketChannel.class).bind(0).asJdkFuture().get();
+                }).channel(NioServerSocketChannel.class).bind(0).asStage().get();
 
                 final CountDownLatch readLatch = new CountDownLatch(1);
                 bootstrap.handler(new ByteToMessageDecoder() {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConditionalWritabilityTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConditionalWritabilityTest.java
@@ -90,7 +90,7 @@ public class SocketConditionalWritabilityTest extends AbstractSocketTest {
                 }
             });
 
-            serverChannel = sb.bind().get();
+            serverChannel = sb.bind().asJdkFuture().get();
 
             cb.handler(new ChannelInitializer<>() {
                 @Override
@@ -119,7 +119,7 @@ public class SocketConditionalWritabilityTest extends AbstractSocketTest {
                     });
                 }
             });
-            clientChannel = cb.connect(serverChannel.localAddress()).get();
+            clientChannel = cb.connect(serverChannel.localAddress()).asJdkFuture().get();
             latch.await();
         } finally {
             if (serverChannel != null) {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConditionalWritabilityTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConditionalWritabilityTest.java
@@ -90,7 +90,7 @@ public class SocketConditionalWritabilityTest extends AbstractSocketTest {
                 }
             });
 
-            serverChannel = sb.bind().asJdkFuture().get();
+            serverChannel = sb.bind().asStage().get();
 
             cb.handler(new ChannelInitializer<>() {
                 @Override
@@ -119,7 +119,7 @@ public class SocketConditionalWritabilityTest extends AbstractSocketTest {
                     });
                 }
             });
-            clientChannel = cb.connect(serverChannel.localAddress()).asJdkFuture().get();
+            clientChannel = cb.connect(serverChannel.localAddress()).asStage().get();
             latch.await();
         } finally {
             if (serverChannel != null) {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConnectTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConnectTest.java
@@ -66,18 +66,18 @@ public class SocketConnectTest extends AbstractSocketTest {
                         public void channelActive(ChannelHandlerContext ctx) throws Exception {
                             localAddressPromise.setSuccess((InetSocketAddress) ctx.channel().localAddress());
                         }
-                    }).bind().get();
+                    }).bind().asJdkFuture().get();
 
-            clientChannel = cb.handler(new ChannelHandler() { }).register().get();
+            clientChannel = cb.handler(new ChannelHandler() { }).register().asJdkFuture().get();
 
             assertNull(clientChannel.localAddress());
             assertNull(clientChannel.remoteAddress());
 
-            clientChannel.connect(serverChannel.localAddress()).get();
+            clientChannel.connect(serverChannel.localAddress()).asJdkFuture().get();
             assertLocalAddress((InetSocketAddress) clientChannel.localAddress());
             assertNotNull(clientChannel.remoteAddress());
 
-            assertLocalAddress(localAddressPromise.asFuture().get());
+            assertLocalAddress(localAddressPromise.asFuture().asJdkFuture().get());
         } finally {
             if (clientChannel != null) {
                 clientChannel.close().sync();
@@ -101,7 +101,7 @@ public class SocketConnectTest extends AbstractSocketTest {
         Channel cc = null;
         try {
             sb.childHandler(new ChannelHandler() { });
-            sc = sb.bind().get();
+            sc = sb.bind().asJdkFuture().get();
 
             cb.handler(new ChannelHandler() {
                 @Override
@@ -115,7 +115,7 @@ public class SocketConnectTest extends AbstractSocketTest {
                 }
             });
             // Connect and directly close again.
-            cc = cb.connect(sc.localAddress()).addListener(future -> future.getNow().close()).get();
+            cc = cb.connect(sc.localAddress()).addListener(future -> future.getNow().close()).asJdkFuture().get();
             assertEquals(0, events.take().intValue());
             assertEquals(1, events.take().intValue());
         } finally {
@@ -146,7 +146,7 @@ public class SocketConnectTest extends AbstractSocketTest {
             }
         });
 
-        Channel sc = sb.bind().get();
+        Channel sc = sb.bind().asJdkFuture().get();
         connectAndVerifyDataTransfer(cb, sc);
         connectAndVerifyDataTransfer(cb, sc);
     }
@@ -156,7 +156,7 @@ public class SocketConnectTest extends AbstractSocketTest {
         BufferingClientHandler handler = new BufferingClientHandler();
         cb.handler(handler);
         Future<Channel> register = cb.register();
-        Channel channel = register.get();
+        Channel channel = register.asJdkFuture().get();
         Future<Void> write = channel.write(writeAsciiBuffer(sc, "[fastopen]"));
         SocketAddress remoteAddress = sc.localAddress();
         Future<Void> connectFuture = channel.connect(remoteAddress);

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConnectTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConnectTest.java
@@ -62,22 +62,22 @@ public class SocketConnectTest extends AbstractSocketTest {
         try {
             final Promise<InetSocketAddress> localAddressPromise = ImmediateEventExecutor.INSTANCE.newPromise();
             serverChannel = sb.childHandler(new ChannelHandler() {
-                        @Override
-                        public void channelActive(ChannelHandlerContext ctx) throws Exception {
-                            localAddressPromise.setSuccess((InetSocketAddress) ctx.channel().localAddress());
-                        }
-                    }).bind().asJdkFuture().get();
+                @Override
+                public void channelActive(ChannelHandlerContext ctx) throws Exception {
+                    localAddressPromise.setSuccess((InetSocketAddress) ctx.channel().localAddress());
+                }
+            }).bind().asStage().get();
 
-            clientChannel = cb.handler(new ChannelHandler() { }).register().asJdkFuture().get();
+            clientChannel = cb.handler(new ChannelHandler() { }).register().asStage().get();
 
             assertNull(clientChannel.localAddress());
             assertNull(clientChannel.remoteAddress());
 
-            clientChannel.connect(serverChannel.localAddress()).asJdkFuture().get();
+            clientChannel.connect(serverChannel.localAddress()).asStage().get();
             assertLocalAddress((InetSocketAddress) clientChannel.localAddress());
             assertNotNull(clientChannel.remoteAddress());
 
-            assertLocalAddress(localAddressPromise.asFuture().asJdkFuture().get());
+            assertLocalAddress(localAddressPromise.asFuture().asStage().get());
         } finally {
             if (clientChannel != null) {
                 clientChannel.close().sync();
@@ -101,7 +101,7 @@ public class SocketConnectTest extends AbstractSocketTest {
         Channel cc = null;
         try {
             sb.childHandler(new ChannelHandler() { });
-            sc = sb.bind().asJdkFuture().get();
+            sc = sb.bind().asStage().get();
 
             cb.handler(new ChannelHandler() {
                 @Override
@@ -115,7 +115,7 @@ public class SocketConnectTest extends AbstractSocketTest {
                 }
             });
             // Connect and directly close again.
-            cc = cb.connect(sc.localAddress()).addListener(future -> future.getNow().close()).asJdkFuture().get();
+            cc = cb.connect(sc.localAddress()).addListener(future -> future.getNow().close()).asStage().get();
             assertEquals(0, events.take().intValue());
             assertEquals(1, events.take().intValue());
         } finally {
@@ -146,7 +146,7 @@ public class SocketConnectTest extends AbstractSocketTest {
             }
         });
 
-        Channel sc = sb.bind().asJdkFuture().get();
+        Channel sc = sb.bind().asStage().get();
         connectAndVerifyDataTransfer(cb, sc);
         connectAndVerifyDataTransfer(cb, sc);
     }
@@ -156,7 +156,7 @@ public class SocketConnectTest extends AbstractSocketTest {
         BufferingClientHandler handler = new BufferingClientHandler();
         cb.handler(handler);
         Future<Channel> register = cb.register();
-        Channel channel = register.asJdkFuture().get();
+        Channel channel = register.asStage().get();
         Future<Void> write = channel.write(writeAsciiBuffer(sc, "[fastopen]"));
         SocketAddress remoteAddress = sc.localAddress();
         Future<Void> connectFuture = channel.connect(remoteAddress);

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConnectionAttemptTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConnectionAttemptTest.java
@@ -58,7 +58,7 @@ public class SocketConnectionAttemptTest extends AbstractClientSocketTest {
     public void testConnectTimeout(Bootstrap cb) throws Throwable {
         cb.handler(new TestHandler()).option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 2000);
         Future<Channel> future = cb.connect(BAD_HOST, BAD_PORT);
-        assertThat(future.await(3000)).isTrue();
+        assertThat(future.await(3000, TimeUnit.MILLISECONDS)).isTrue();
         ExecutionException e = assertThrows(ExecutionException.class, future.asStage()::get);
         assertThat(e).hasCauseInstanceOf(ConnectTimeoutException.class);
     }
@@ -122,7 +122,7 @@ public class SocketConnectionAttemptTest extends AbstractClientSocketTest {
     public void testConnectCancellation(Bootstrap cb) throws Throwable {
         cb.handler(new TestHandler()).option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 4000);
         Future<Channel> future = cb.connect(BAD_HOST, BAD_PORT);
-        if (future.await(1000)) {
+        if (future.await(1000, TimeUnit.MILLISECONDS)) {
             if (future.isSuccess()) {
                 fail("A connection attempt to " + BAD_HOST + " must not succeed.");
             } else {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConnectionAttemptTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConnectionAttemptTest.java
@@ -59,7 +59,7 @@ public class SocketConnectionAttemptTest extends AbstractClientSocketTest {
         cb.handler(new TestHandler()).option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 2000);
         Future<Channel> future = cb.connect(BAD_HOST, BAD_PORT);
         assertThat(future.await(3000)).isTrue();
-        ExecutionException e = assertThrows(ExecutionException.class, future.asJdkFuture()::get);
+        ExecutionException e = assertThrows(ExecutionException.class, future.asStage()::get);
         assertThat(e).hasCauseInstanceOf(ConnectTimeoutException.class);
     }
 
@@ -134,7 +134,7 @@ public class SocketConnectionAttemptTest extends AbstractClientSocketTest {
             assertThat(future.isCancelled()).isTrue();
         } else {
             // Cancellation not supported by the transport.
-            future.asJdkFuture().get().close();
+            future.asStage().get().close();
         }
     }
 

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConnectionAttemptTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConnectionAttemptTest.java
@@ -59,7 +59,7 @@ public class SocketConnectionAttemptTest extends AbstractClientSocketTest {
         cb.handler(new TestHandler()).option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 2000);
         Future<Channel> future = cb.connect(BAD_HOST, BAD_PORT);
         assertThat(future.await(3000)).isTrue();
-        ExecutionException e = assertThrows(ExecutionException.class, future::get);
+        ExecutionException e = assertThrows(ExecutionException.class, future.asJdkFuture()::get);
         assertThat(e).hasCauseInstanceOf(ConnectTimeoutException.class);
     }
 
@@ -134,7 +134,7 @@ public class SocketConnectionAttemptTest extends AbstractClientSocketTest {
             assertThat(future.isCancelled()).isTrue();
         } else {
             // Cancellation not supported by the transport.
-            future.get().close();
+            future.asJdkFuture().get().close();
         }
     }
 

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketDataReadInitialStateTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketDataReadInitialStateTest.java
@@ -96,8 +96,8 @@ public class SocketDataReadInitialStateTest extends AbstractSocketTest {
                 }
             });
 
-            serverChannel = sb.bind().get();
-            clientChannel = cb.connect(serverChannel.localAddress()).get();
+            serverChannel = sb.bind().asJdkFuture().get();
+            clientChannel = cb.connect(serverChannel.localAddress()).asJdkFuture().get();
             clientChannel.writeAndFlush(clientChannel.bufferAllocator().copyOf(new byte[] {0})).sync();
 
             // The acceptor shouldn't read any data until we call read() below, but give it some time to see if it will.
@@ -172,8 +172,8 @@ public class SocketDataReadInitialStateTest extends AbstractSocketTest {
                 }
             });
 
-            serverChannel = sb.bind().get();
-            clientChannel = cb.connect(serverChannel.localAddress()).get();
+            serverChannel = sb.bind().asJdkFuture().get();
+            clientChannel = cb.connect(serverChannel.localAddress()).asJdkFuture().get();
             clientChannel.writeAndFlush(clientChannel.bufferAllocator().copyOf(new byte[] {0})).sync();
             serverReadLatch.await();
             clientReadLatch.await();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketDataReadInitialStateTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketDataReadInitialStateTest.java
@@ -96,8 +96,8 @@ public class SocketDataReadInitialStateTest extends AbstractSocketTest {
                 }
             });
 
-            serverChannel = sb.bind().asJdkFuture().get();
-            clientChannel = cb.connect(serverChannel.localAddress()).asJdkFuture().get();
+            serverChannel = sb.bind().asStage().get();
+            clientChannel = cb.connect(serverChannel.localAddress()).asStage().get();
             clientChannel.writeAndFlush(clientChannel.bufferAllocator().copyOf(new byte[] {0})).sync();
 
             // The acceptor shouldn't read any data until we call read() below, but give it some time to see if it will.
@@ -172,8 +172,8 @@ public class SocketDataReadInitialStateTest extends AbstractSocketTest {
                 }
             });
 
-            serverChannel = sb.bind().asJdkFuture().get();
-            clientChannel = cb.connect(serverChannel.localAddress()).asJdkFuture().get();
+            serverChannel = sb.bind().asStage().get();
+            clientChannel = cb.connect(serverChannel.localAddress()).asStage().get();
             clientChannel.writeAndFlush(clientChannel.bufferAllocator().copyOf(new byte[] {0})).sync();
             serverReadLatch.await();
             clientReadLatch.await();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketEchoTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketEchoTest.java
@@ -81,8 +81,8 @@ public class SocketEchoTest extends AbstractSocketTest {
         sb.childOption(ChannelOption.AUTO_READ, autoRead);
         cb.option(ChannelOption.AUTO_READ, autoRead);
 
-        Channel sc = sb.bind().asJdkFuture().get();
-        Channel cc = cb.connect(sc.localAddress()).asJdkFuture().get();
+        Channel sc = sb.bind().asStage().get();
+        Channel cc = cb.connect(sc.localAddress()).asStage().get();
 
         try (Buffer src = DefaultBufferAllocators.preferredAllocator().copyOf(data)) {
             for (int i = 0; i < data.length;) {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketEchoTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketEchoTest.java
@@ -81,8 +81,8 @@ public class SocketEchoTest extends AbstractSocketTest {
         sb.childOption(ChannelOption.AUTO_READ, autoRead);
         cb.option(ChannelOption.AUTO_READ, autoRead);
 
-        Channel sc = sb.bind().get();
-        Channel cc = cb.connect(sc.localAddress()).get();
+        Channel sc = sb.bind().asJdkFuture().get();
+        Channel cc = cb.connect(sc.localAddress()).asJdkFuture().get();
 
         try (Buffer src = DefaultBufferAllocators.preferredAllocator().copyOf(data)) {
             for (int i = 0; i < data.length;) {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketExceptionHandlingTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketExceptionHandlingTest.java
@@ -49,10 +49,10 @@ public class SocketExceptionHandlingTest extends AbstractSocketTest {
             sb.option(ChannelOption.SO_BACKLOG, 1024);
             sb.childHandler(serverInitializer);
 
-            serverChannel = sb.bind().asJdkFuture().get();
+            serverChannel = sb.bind().asStage().get();
 
             cb.handler(new MyInitializer());
-            clientChannel = cb.connect(serverChannel.localAddress()).asJdkFuture().get();
+            clientChannel = cb.connect(serverChannel.localAddress()).asStage().get();
 
             clientChannel.writeAndFlush(DefaultBufferAllocators.preferredAllocator().copyOf(new byte[1024]));
 

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketExceptionHandlingTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketExceptionHandlingTest.java
@@ -49,10 +49,10 @@ public class SocketExceptionHandlingTest extends AbstractSocketTest {
             sb.option(ChannelOption.SO_BACKLOG, 1024);
             sb.childHandler(serverInitializer);
 
-            serverChannel = sb.bind().get();
+            serverChannel = sb.bind().asJdkFuture().get();
 
             cb.handler(new MyInitializer());
-            clientChannel = cb.connect(serverChannel.localAddress()).get();
+            clientChannel = cb.connect(serverChannel.localAddress()).asJdkFuture().get();
 
             clientChannel.writeAndFlush(DefaultBufferAllocators.preferredAllocator().copyOf(new byte[1024]));
 

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketFileRegionTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketFileRegionTest.java
@@ -98,8 +98,8 @@ public class SocketFileRegionTest extends AbstractSocketTest {
         });
         cb.handler(new ChannelHandler() { });
 
-        Channel sc = sb.bind().get();
-        Channel cc = cb.connect(sc.localAddress()).get();
+        Channel sc = sb.bind().asJdkFuture().get();
+        Channel cc = cb.connect(sc.localAddress()).asJdkFuture().get();
 
         // Request file region which is bigger then the underlying file.
         FileRegion region = new DefaultFileRegion(
@@ -161,9 +161,9 @@ public class SocketFileRegionTest extends AbstractSocketTest {
         sb.childHandler(sh);
         cb.handler(ch);
 
-        Channel sc = sb.bind().get();
+        Channel sc = sb.bind().asJdkFuture().get();
 
-        Channel cc = cb.connect(sc.localAddress()).get();
+        Channel cc = cb.connect(sc.localAddress()).asJdkFuture().get();
         FileRegion region = new DefaultFileRegion(
                 new RandomAccessFile(file, "r").getChannel(), startOffset, data.length - bufferSize);
         FileRegion emptyRegion = new DefaultFileRegion(new RandomAccessFile(file, "r").getChannel(), 0, 0);

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketFileRegionTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketFileRegionTest.java
@@ -98,8 +98,8 @@ public class SocketFileRegionTest extends AbstractSocketTest {
         });
         cb.handler(new ChannelHandler() { });
 
-        Channel sc = sb.bind().asJdkFuture().get();
-        Channel cc = cb.connect(sc.localAddress()).asJdkFuture().get();
+        Channel sc = sb.bind().asStage().get();
+        Channel cc = cb.connect(sc.localAddress()).asStage().get();
 
         // Request file region which is bigger then the underlying file.
         FileRegion region = new DefaultFileRegion(
@@ -161,9 +161,9 @@ public class SocketFileRegionTest extends AbstractSocketTest {
         sb.childHandler(sh);
         cb.handler(ch);
 
-        Channel sc = sb.bind().asJdkFuture().get();
+        Channel sc = sb.bind().asStage().get();
 
-        Channel cc = cb.connect(sc.localAddress()).asJdkFuture().get();
+        Channel cc = cb.connect(sc.localAddress()).asStage().get();
         FileRegion region = new DefaultFileRegion(
                 new RandomAccessFile(file, "r").getChannel(), startOffset, data.length - bufferSize);
         FileRegion emptyRegion = new DefaultFileRegion(new RandomAccessFile(file, "r").getChannel(), 0, 0);

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketFixedLengthEchoTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketFixedLengthEchoTest.java
@@ -82,8 +82,8 @@ public class SocketFixedLengthEchoTest extends AbstractSocketTest {
             }
         });
 
-        Channel sc = sb.bind().asJdkFuture().get();
-        Channel cc = cb.connect(sc.localAddress()).asJdkFuture().get();
+        Channel sc = sb.bind().asStage().get();
+        Channel cc = cb.connect(sc.localAddress()).asStage().get();
 
         try (Buffer buffer = sc.bufferAllocator().copyOf(data)) {
             for (int i = 0; i < data.length;) {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketFixedLengthEchoTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketFixedLengthEchoTest.java
@@ -82,8 +82,8 @@ public class SocketFixedLengthEchoTest extends AbstractSocketTest {
             }
         });
 
-        Channel sc = sb.bind().get();
-        Channel cc = cb.connect(sc.localAddress()).get();
+        Channel sc = sb.bind().asJdkFuture().get();
+        Channel cc = cb.connect(sc.localAddress()).asJdkFuture().get();
 
         try (Buffer buffer = sc.bufferAllocator().copyOf(data)) {
             for (int i = 0; i < data.length;) {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketGatheringWriteTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketGatheringWriteTest.java
@@ -150,7 +150,7 @@ public class SocketGatheringWriteTest extends AbstractSocketTest {
 
         Future<Void> cf = cc.writeAndFlush(preferredAllocator().allocate(0));
         try {
-            assertTrue(cf.await(60000));
+            assertTrue(cf.await(60000, TimeUnit.MILLISECONDS));
             cf.sync();
         } catch (Throwable t) {
             // TODO: Remove this once we fix this test.

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketGatheringWriteTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketGatheringWriteTest.java
@@ -127,8 +127,8 @@ public class SocketGatheringWriteTest extends AbstractSocketTest {
         cb.handler(ch);
         sb.childHandler(sh);
 
-        Channel sc = sb.bind().get();
-        Channel cc = cb.connect(sc.localAddress()).get();
+        Channel sc = sb.bind().asJdkFuture().get();
+        Channel cc = cb.connect(sc.localAddress()).asJdkFuture().get();
 
         BufferAllocator alloc = preferredAllocator();
         try (Buffer src = MemoryManager.unsafeWrap(data)) {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketGatheringWriteTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketGatheringWriteTest.java
@@ -127,8 +127,8 @@ public class SocketGatheringWriteTest extends AbstractSocketTest {
         cb.handler(ch);
         sb.childHandler(sh);
 
-        Channel sc = sb.bind().asJdkFuture().get();
-        Channel cc = cb.connect(sc.localAddress()).asJdkFuture().get();
+        Channel sc = sb.bind().asStage().get();
+        Channel cc = cb.connect(sc.localAddress()).asStage().get();
 
         BufferAllocator alloc = preferredAllocator();
         try (Buffer src = MemoryManager.unsafeWrap(data)) {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -99,8 +99,8 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                   }
               });
 
-            serverChannel = sb.bind().get();
-            clientChannel = cb.connect(serverChannel.localAddress()).get();
+            serverChannel = sb.bind().asJdkFuture().get();
+            clientChannel = cb.connect(serverChannel.localAddress()).asJdkFuture().get();
             waitHalfClosureDone.await();
         } finally {
             if (clientChannel != null) {
@@ -164,8 +164,8 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                 }
             });
 
-            serverChannel = sb.bind().get();
-            Channel clientChannel = cb.connect(serverChannel.localAddress()).get();
+            serverChannel = sb.bind().asJdkFuture().get();
+            Channel clientChannel = cb.connect(serverChannel.localAddress()).asJdkFuture().get();
             clientChannel.closeFuture().await();
             assertEquals(1, shutdownEventReceivedCounter.get());
         } finally {
@@ -261,8 +261,8 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                 }
             });
 
-            serverChannel = sb.bind().get();
-            clientChannel = cb.connect(serverChannel.localAddress()).get();
+            serverChannel = sb.bind().asJdkFuture().get();
+            clientChannel = cb.connect(serverChannel.localAddress()).asJdkFuture().get();
             clientChannel.read();
 
             serverInitializedLatch.await();
@@ -330,8 +330,8 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                 }
             });
 
-            serverChannel = sb.bind().get();
-            clientChannel = cb.connect(serverChannel.localAddress()).get();
+            serverChannel = sb.bind().asJdkFuture().get();
+            clientChannel = cb.connect(serverChannel.localAddress()).asJdkFuture().get();
 
             doneLatch.await();
             assertNull(causeRef.get());
@@ -568,8 +568,8 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                 }
             });
 
-            serverChannel = sb.bind().get();
-            clientChannel = cb.connect(serverChannel.localAddress()).get();
+            serverChannel = sb.bind().asJdkFuture().get();
+            clientChannel = cb.connect(serverChannel.localAddress()).asJdkFuture().get();
             clientChannel.read();
 
             serverInitializedLatch.await();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -99,8 +99,8 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                   }
               });
 
-            serverChannel = sb.bind().asJdkFuture().get();
-            clientChannel = cb.connect(serverChannel.localAddress()).asJdkFuture().get();
+            serverChannel = sb.bind().asStage().get();
+            clientChannel = cb.connect(serverChannel.localAddress()).asStage().get();
             waitHalfClosureDone.await();
         } finally {
             if (clientChannel != null) {
@@ -164,8 +164,8 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                 }
             });
 
-            serverChannel = sb.bind().asJdkFuture().get();
-            Channel clientChannel = cb.connect(serverChannel.localAddress()).asJdkFuture().get();
+            serverChannel = sb.bind().asStage().get();
+            Channel clientChannel = cb.connect(serverChannel.localAddress()).asStage().get();
             clientChannel.closeFuture().await();
             assertEquals(1, shutdownEventReceivedCounter.get());
         } finally {
@@ -261,8 +261,8 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                 }
             });
 
-            serverChannel = sb.bind().asJdkFuture().get();
-            clientChannel = cb.connect(serverChannel.localAddress()).asJdkFuture().get();
+            serverChannel = sb.bind().asStage().get();
+            clientChannel = cb.connect(serverChannel.localAddress()).asStage().get();
             clientChannel.read();
 
             serverInitializedLatch.await();
@@ -330,8 +330,8 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                 }
             });
 
-            serverChannel = sb.bind().asJdkFuture().get();
-            clientChannel = cb.connect(serverChannel.localAddress()).asJdkFuture().get();
+            serverChannel = sb.bind().asStage().get();
+            clientChannel = cb.connect(serverChannel.localAddress()).asStage().get();
 
             doneLatch.await();
             assertNull(causeRef.get());
@@ -568,8 +568,8 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                 }
             });
 
-            serverChannel = sb.bind().asJdkFuture().get();
-            clientChannel = cb.connect(serverChannel.localAddress()).asJdkFuture().get();
+            serverChannel = sb.bind().asStage().get();
+            clientChannel = cb.connect(serverChannel.localAddress()).asStage().get();
             clientChannel.read();
 
             serverInitializedLatch.await();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketMultipleConnectTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketMultipleConnectTest.java
@@ -46,10 +46,10 @@ public class SocketMultipleConnectTest extends AbstractSocketTest {
         Channel cc = null;
         try {
             sb.childHandler(new ChannelHandler() { });
-            sc = sb.bind(NetUtil.LOCALHOST, 0).asJdkFuture().get();
+            sc = sb.bind(NetUtil.LOCALHOST, 0).asStage().get();
 
             cb.handler(new ChannelHandler() { });
-            cc = cb.register().asJdkFuture().get();
+            cc = cb.register().asStage().get();
             cc.connect(sc.localAddress()).sync();
             Future<Void> connectFuture2 = cc.connect(sc.localAddress()).await();
             assertTrue(connectFuture2.cause() instanceof AlreadyConnectedException);

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketMultipleConnectTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketMultipleConnectTest.java
@@ -46,10 +46,10 @@ public class SocketMultipleConnectTest extends AbstractSocketTest {
         Channel cc = null;
         try {
             sb.childHandler(new ChannelHandler() { });
-            sc = sb.bind(NetUtil.LOCALHOST, 0).get();
+            sc = sb.bind(NetUtil.LOCALHOST, 0).asJdkFuture().get();
 
             cb.handler(new ChannelHandler() { });
-            cc = cb.register().get();
+            cc = cb.register().asJdkFuture().get();
             cc.connect(sc.localAddress()).sync();
             Future<Void> connectFuture2 = cc.connect(sc.localAddress()).await();
             assertTrue(connectFuture2.cause() instanceof AlreadyConnectedException);

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketReadPendingTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketReadPendingTest.java
@@ -62,13 +62,13 @@ public class SocketReadPendingTest extends AbstractSocketTest {
               .childOption(ChannelOption.RCVBUF_ALLOCATOR, new TestNumReadsRecvBufferAllocator(2))
               .childHandler(serverInitializer);
 
-            serverChannel = sb.bind().get();
+            serverChannel = sb.bind().asJdkFuture().get();
 
             cb.option(ChannelOption.AUTO_READ, false)
               // We intend to do 2 reads per read loop wakeup
               .option(ChannelOption.RCVBUF_ALLOCATOR, new TestNumReadsRecvBufferAllocator(2))
               .handler(clientInitializer);
-            clientChannel = cb.connect(serverChannel.localAddress()).get();
+            clientChannel = cb.connect(serverChannel.localAddress()).asJdkFuture().get();
 
             // 4 bytes means 2 read loops for TestNumReadsRecvBufferAllocator
             clientChannel.writeAndFlush(preferredAllocator().copyOf(new byte[4]));

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketReadPendingTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketReadPendingTest.java
@@ -62,13 +62,13 @@ public class SocketReadPendingTest extends AbstractSocketTest {
               .childOption(ChannelOption.RCVBUF_ALLOCATOR, new TestNumReadsRecvBufferAllocator(2))
               .childHandler(serverInitializer);
 
-            serverChannel = sb.bind().asJdkFuture().get();
+            serverChannel = sb.bind().asStage().get();
 
             cb.option(ChannelOption.AUTO_READ, false)
               // We intend to do 2 reads per read loop wakeup
               .option(ChannelOption.RCVBUF_ALLOCATOR, new TestNumReadsRecvBufferAllocator(2))
               .handler(clientInitializer);
-            clientChannel = cb.connect(serverChannel.localAddress()).asJdkFuture().get();
+            clientChannel = cb.connect(serverChannel.localAddress()).asStage().get();
 
             // 4 bytes means 2 read loops for TestNumReadsRecvBufferAllocator
             clientChannel.writeAndFlush(preferredAllocator().copyOf(new byte[4]));

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketRstTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketRstTest.java
@@ -79,8 +79,8 @@ public class SocketRstTest extends AbstractSocketTest {
                 });
             }
         });
-        Channel sc = sb.bind().asJdkFuture().get();
-        Channel cc = cb.connect(sc.localAddress()).asJdkFuture().get();
+        Channel sc = sb.bind().asStage().get();
+        Channel cc = cb.connect(sc.localAddress()).asStage().get();
 
         // Wait for the server to get setup.
         latch.await();
@@ -133,7 +133,7 @@ public class SocketRstTest extends AbstractSocketTest {
                 });
             }
         });
-        Channel sc = sb.bind().asJdkFuture().get();
+        Channel sc = sb.bind().asStage().get();
         cb.connect(sc.localAddress()).sync();
 
         // Wait for the server to get setup.

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketRstTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketRstTest.java
@@ -79,8 +79,8 @@ public class SocketRstTest extends AbstractSocketTest {
                 });
             }
         });
-        Channel sc = sb.bind().get();
-        Channel cc = cb.connect(sc.localAddress()).get();
+        Channel sc = sb.bind().asJdkFuture().get();
+        Channel cc = cb.connect(sc.localAddress()).asJdkFuture().get();
 
         // Wait for the server to get setup.
         latch.await();
@@ -133,7 +133,7 @@ public class SocketRstTest extends AbstractSocketTest {
                 });
             }
         });
-        Channel sc = sb.bind().get();
+        Channel sc = sb.bind().asJdkFuture().get();
         cb.connect(sc.localAddress()).sync();
 
         // Wait for the server to get setup.

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketShutdownOutputBySelfTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketShutdownOutputBySelfTest.java
@@ -63,7 +63,7 @@ public class SocketShutdownOutputBySelfTest extends AbstractClientSocketTest {
         SocketChannel ch = null;
         try {
             ss.bind(newSocketAddress());
-            ch = (SocketChannel) cb.handler(h).connect(ss.getLocalSocketAddress()).asJdkFuture().get();
+            ch = (SocketChannel) cb.handler(h).connect(ss.getLocalSocketAddress()).asStage().get();
             assertTrue(ch.isActive());
             assertFalse(ch.isShutdown(ChannelShutdownDirection.Outbound));
 
@@ -111,7 +111,7 @@ public class SocketShutdownOutputBySelfTest extends AbstractClientSocketTest {
         Socket s = null;
         try {
             ss.bind(newSocketAddress());
-            SocketChannel ch = (SocketChannel) cb.handler(h).connect(ss.getLocalSocketAddress()).asJdkFuture().get();
+            SocketChannel ch = (SocketChannel) cb.handler(h).connect(ss.getLocalSocketAddress()).asStage().get();
             assertTrue(ch.isActive());
             s = ss.accept();
 
@@ -151,7 +151,7 @@ public class SocketShutdownOutputBySelfTest extends AbstractClientSocketTest {
         try {
             ss.bind(newSocketAddress());
             cb.option(ChannelOption.WRITE_BUFFER_WATER_MARK, new WriteBufferWaterMark(2, 4));
-            ch = (SocketChannel) cb.handler(h).connect(ss.getLocalSocketAddress()).asJdkFuture().get();
+            ch = (SocketChannel) cb.handler(h).connect(ss.getLocalSocketAddress()).asStage().get();
             assertTrue(ch.isActive());
             assertFalse(ch.isShutdown(ChannelShutdownDirection.Outbound));
 
@@ -228,7 +228,7 @@ public class SocketShutdownOutputBySelfTest extends AbstractClientSocketTest {
         try {
             ss.bind(newSocketAddress());
             client = cb.option(ChannelOption.SO_LINGER, 1).handler(new ChannelHandler() { })
-                    .connect(ss.getLocalSocketAddress()).asJdkFuture().get();
+                       .connect(ss.getLocalSocketAddress()).asStage().get();
             s = ss.accept();
 
             client.shutdown(ChannelShutdownDirection.Outbound).sync();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketShutdownOutputBySelfTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketShutdownOutputBySelfTest.java
@@ -63,7 +63,7 @@ public class SocketShutdownOutputBySelfTest extends AbstractClientSocketTest {
         SocketChannel ch = null;
         try {
             ss.bind(newSocketAddress());
-            ch = (SocketChannel) cb.handler(h).connect(ss.getLocalSocketAddress()).get();
+            ch = (SocketChannel) cb.handler(h).connect(ss.getLocalSocketAddress()).asJdkFuture().get();
             assertTrue(ch.isActive());
             assertFalse(ch.isShutdown(ChannelShutdownDirection.Outbound));
 
@@ -111,7 +111,7 @@ public class SocketShutdownOutputBySelfTest extends AbstractClientSocketTest {
         Socket s = null;
         try {
             ss.bind(newSocketAddress());
-            SocketChannel ch = (SocketChannel) cb.handler(h).connect(ss.getLocalSocketAddress()).get();
+            SocketChannel ch = (SocketChannel) cb.handler(h).connect(ss.getLocalSocketAddress()).asJdkFuture().get();
             assertTrue(ch.isActive());
             s = ss.accept();
 
@@ -151,7 +151,7 @@ public class SocketShutdownOutputBySelfTest extends AbstractClientSocketTest {
         try {
             ss.bind(newSocketAddress());
             cb.option(ChannelOption.WRITE_BUFFER_WATER_MARK, new WriteBufferWaterMark(2, 4));
-            ch = (SocketChannel) cb.handler(h).connect(ss.getLocalSocketAddress()).get();
+            ch = (SocketChannel) cb.handler(h).connect(ss.getLocalSocketAddress()).asJdkFuture().get();
             assertTrue(ch.isActive());
             assertFalse(ch.isShutdown(ChannelShutdownDirection.Outbound));
 
@@ -228,7 +228,7 @@ public class SocketShutdownOutputBySelfTest extends AbstractClientSocketTest {
         try {
             ss.bind(newSocketAddress());
             client = cb.option(ChannelOption.SO_LINGER, 1).handler(new ChannelHandler() { })
-                    .connect(ss.getLocalSocketAddress()).get();
+                    .connect(ss.getLocalSocketAddress()).asJdkFuture().get();
             s = ss.accept();
 
             client.shutdown(ChannelShutdownDirection.Outbound).sync();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
@@ -176,7 +176,7 @@ public class SocketSslClientRenegotiateTest extends AbstractSocketTest {
                 }
             });
 
-            Channel sc = sb.bind().get();
+            Channel sc = sb.bind().asJdkFuture().get();
             cb.connect(sc.localAddress()).sync();
 
             Future<Channel> clientHandshakeFuture = clientSslHandler.handshakeFuture();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
@@ -176,7 +176,7 @@ public class SocketSslClientRenegotiateTest extends AbstractSocketTest {
                 }
             });
 
-            Channel sc = sb.bind().asJdkFuture().get();
+            Channel sc = sb.bind().asStage().get();
             cb.connect(sc.localAddress()).sync();
 
             Future<Channel> clientHandshakeFuture = clientSslHandler.handshakeFuture();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslEchoTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslEchoTest.java
@@ -307,7 +307,7 @@ public class SocketSslEchoTest extends AbstractSocketTest {
             }
         });
 
-        final Channel sc = sb.bind().asJdkFuture().get();
+        final Channel sc = sb.bind().asStage().get();
         cb.connect(sc.localAddress()).sync();
 
         final Future<Channel> clientHandshakeFuture = clientSslHandler.handshakeFuture();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslEchoTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslEchoTest.java
@@ -307,7 +307,7 @@ public class SocketSslEchoTest extends AbstractSocketTest {
             }
         });
 
-        final Channel sc = sb.bind().get();
+        final Channel sc = sb.bind().asJdkFuture().get();
         cb.connect(sc.localAddress()).sync();
 
         final Future<Channel> clientHandshakeFuture = clientSslHandler.handshakeFuture();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslGreetingTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslGreetingTest.java
@@ -149,8 +149,8 @@ public class SocketSslGreetingTest extends AbstractSocketTest {
                 }
             });
 
-            Channel sc = sb.bind().asJdkFuture().get();
-            Channel cc = cb.connect(sc.localAddress()).asJdkFuture().get();
+            Channel sc = sb.bind().asStage().get();
+            Channel cc = cb.connect(sc.localAddress()).asStage().get();
 
             ch.latch.await();
 

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslGreetingTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslGreetingTest.java
@@ -149,8 +149,8 @@ public class SocketSslGreetingTest extends AbstractSocketTest {
                 }
             });
 
-            Channel sc = sb.bind().get();
-            Channel cc = cb.connect(sc.localAddress()).get();
+            Channel sc = sb.bind().asJdkFuture().get();
+            Channel cc = cb.connect(sc.localAddress()).asJdkFuture().get();
 
             ch.latch.await();
 

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslSessionReuseTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslSessionReuseTest.java
@@ -102,7 +102,7 @@ public class SocketSslSessionReuseTest extends AbstractSocketTest {
                 sch.pipeline().addLast(sh);
             }
         });
-        final Channel sc = sb.bind().asJdkFuture().get();
+        final Channel sc = sb.bind().asStage().get();
 
         cb.handler(new ChannelInitializer<SocketChannel>() {
             @Override
@@ -121,14 +121,14 @@ public class SocketSslSessionReuseTest extends AbstractSocketTest {
         try {
             SSLSessionContext clientSessionCtx = clientCtx.sessionContext();
             Buffer msg = DefaultBufferAllocators.preferredAllocator().copyOf(new byte[] { 0xa, 0xb, 0xc, 0xd });
-            Channel cc = cb.connect(sc.localAddress()).asJdkFuture().get();
+            Channel cc = cb.connect(sc.localAddress()).asStage().get();
             cc.writeAndFlush(msg).sync();
             cc.closeFuture().sync();
             rethrowHandlerExceptions(sh, ch);
             Set<String> sessions = sessionIdSet(clientSessionCtx.getIds());
 
             msg = DefaultBufferAllocators.preferredAllocator().copyOf(new byte[] { 0xa, 0xb, 0xc, 0xd });
-            cc = cb.connect(sc.localAddress()).asJdkFuture().get();
+            cc = cb.connect(sc.localAddress()).asStage().get();
             cc.writeAndFlush(msg).sync();
             cc.closeFuture().sync();
             assertEquals(sessions, sessionIdSet(clientSessionCtx.getIds()), "Expected no new sessions");

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslSessionReuseTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslSessionReuseTest.java
@@ -102,7 +102,7 @@ public class SocketSslSessionReuseTest extends AbstractSocketTest {
                 sch.pipeline().addLast(sh);
             }
         });
-        final Channel sc = sb.bind().get();
+        final Channel sc = sb.bind().asJdkFuture().get();
 
         cb.handler(new ChannelInitializer<SocketChannel>() {
             @Override
@@ -121,14 +121,14 @@ public class SocketSslSessionReuseTest extends AbstractSocketTest {
         try {
             SSLSessionContext clientSessionCtx = clientCtx.sessionContext();
             Buffer msg = DefaultBufferAllocators.preferredAllocator().copyOf(new byte[] { 0xa, 0xb, 0xc, 0xd });
-            Channel cc = cb.connect(sc.localAddress()).get();
+            Channel cc = cb.connect(sc.localAddress()).asJdkFuture().get();
             cc.writeAndFlush(msg).sync();
             cc.closeFuture().sync();
             rethrowHandlerExceptions(sh, ch);
             Set<String> sessions = sessionIdSet(clientSessionCtx.getIds());
 
             msg = DefaultBufferAllocators.preferredAllocator().copyOf(new byte[] { 0xa, 0xb, 0xc, 0xd });
-            cc = cb.connect(sc.localAddress()).get();
+            cc = cb.connect(sc.localAddress()).asJdkFuture().get();
             cc.writeAndFlush(msg).sync();
             cc.closeFuture().sync();
             assertEquals(sessions, sessionIdSet(clientSessionCtx.getIds()), "Expected no new sessions");

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketStartTlsTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketStartTlsTest.java
@@ -161,8 +161,8 @@ public class SocketStartTlsTest extends AbstractSocketTest {
             }
         });
 
-        Channel sc = sb.bind().asJdkFuture().get();
-        Channel cc = cb.connect(sc.localAddress()).asJdkFuture().get();
+        Channel sc = sb.bind().asStage().get();
+        Channel cc = cb.connect(sc.localAddress()).asStage().get();
 
         while (cc.isActive()) {
             if (sh.exception.get() != null) {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketStartTlsTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketStartTlsTest.java
@@ -161,8 +161,8 @@ public class SocketStartTlsTest extends AbstractSocketTest {
             }
         });
 
-        Channel sc = sb.bind().get();
-        Channel cc = cb.connect(sc.localAddress()).get();
+        Channel sc = sb.bind().asJdkFuture().get();
+        Channel cc = cb.connect(sc.localAddress()).asJdkFuture().get();
 
         while (cc.isActive()) {
             if (sh.exception.get() != null) {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketStringEchoTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketStringEchoTest.java
@@ -104,8 +104,8 @@ public class SocketStringEchoTest extends AbstractSocketTest {
             }
         });
 
-        Channel sc = sb.bind().asJdkFuture().get();
-        Channel cc = cb.connect(sc.localAddress()).asJdkFuture().get();
+        Channel sc = sb.bind().asStage().get();
+        Channel cc = cb.connect(sc.localAddress()).asStage().get();
         for (String element : data) {
             String delimiter = random.nextBoolean() ? "\r\n" : "\n";
             cc.writeAndFlush(element + delimiter);

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketStringEchoTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketStringEchoTest.java
@@ -104,8 +104,8 @@ public class SocketStringEchoTest extends AbstractSocketTest {
             }
         });
 
-        Channel sc = sb.bind().get();
-        Channel cc = cb.connect(sc.localAddress()).get();
+        Channel sc = sb.bind().asJdkFuture().get();
+        Channel cc = cb.connect(sc.localAddress()).asJdkFuture().get();
         for (String element : data) {
             String delimiter = random.nextBoolean() ? "\r\n" : "\n";
             cc.writeAndFlush(element + delimiter);

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/TrafficShapingHandlerTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/TrafficShapingHandlerTest.java
@@ -333,8 +333,8 @@ public class TrafficShapingHandlerTest extends AbstractSocketTest {
             }
         });
 
-        Channel sc = sb.bind().asJdkFuture().get();
-        Channel cc = cb.connect(sc.localAddress()).asJdkFuture().get();
+        Channel sc = sb.bind().asStage().get();
+        Channel cc = cb.connect(sc.localAddress()).asStage().get();
 
         int totalNb = 0;
         for (int i = 1; i < multipleMessage.length; i++) {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/TrafficShapingHandlerTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/TrafficShapingHandlerTest.java
@@ -333,8 +333,8 @@ public class TrafficShapingHandlerTest extends AbstractSocketTest {
             }
         });
 
-        Channel sc = sb.bind().get();
-        Channel cc = cb.connect(sc.localAddress()).get();
+        Channel sc = sb.bind().asJdkFuture().get();
+        Channel cc = cb.connect(sc.localAddress()).asJdkFuture().get();
 
         int totalNb = 0;
         for (int i = 1; i < multipleMessage.length; i++) {

--- a/transport-blockhound-tests/src/test/java/io/netty5/util/internal/NettyBlockHoundIntegrationTest.java
+++ b/transport-blockhound-tests/src/test/java/io/netty5/util/internal/NettyBlockHoundIntegrationTest.java
@@ -187,8 +187,8 @@ public class NettyBlockHoundIntegrationTest {
     @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
     public void testHashedWheelTimerStartStop() throws Exception {
         HashedWheelTimer timer = new HashedWheelTimer();
-        GlobalEventExecutor.INSTANCE.submit(timer::start).asJdkFuture().get(5, TimeUnit.SECONDS);
-        GlobalEventExecutor.INSTANCE.submit(timer::stop).asJdkFuture().get(5, TimeUnit.SECONDS);
+        GlobalEventExecutor.INSTANCE.submit(timer::start).asStage().get(5, TimeUnit.SECONDS);
+        GlobalEventExecutor.INSTANCE.submit(timer::stop).asStage().get(5, TimeUnit.SECONDS);
     }
 
     // Tests copied from io.netty5.handler.ssl.SslHandlerTest
@@ -290,8 +290,7 @@ public class NettyBlockHoundIntegrationTest {
                         .channel(NioServerSocketChannel.class)
                         .childHandler(new ChannelHandler() {
                         })
-                        .bind(new InetSocketAddress(0))
-                        .asJdkFuture().get();
+                        .bind(new InetSocketAddress(0)).asStage().get();
 
                 cc = new Bootstrap()
                         .group(group)
@@ -322,9 +321,9 @@ public class NettyBlockHoundIntegrationTest {
                             }
                         })
                         .connect(sc.localAddress())
-                        .addListener(future -> future.asJdkFuture().get().writeAndFlush(
-                                alloc.copyOf(new byte[] { 1, 2, 3, 4 })))
-                        .asJdkFuture().get();
+                        .addListener(future -> future.asStage().get().writeAndFlush(
+                                    alloc.copyOf(new byte[] { 1, 2, 3, 4 })))
+                        .asStage().get();
 
                 assertTrue(activeLatch.await(5, TimeUnit.SECONDS));
                 assertNull(error.get());
@@ -451,7 +450,7 @@ public class NettyBlockHoundIntegrationTest {
                         .group(group)
                         .channel(NioServerSocketChannel.class)
                         .childHandler(serverSslHandler)
-                        .bind(new InetSocketAddress(0)).asJdkFuture().get();
+                        .bind(new InetSocketAddress(0)).asStage().get();
 
                 Future<Channel> future = new Bootstrap()
                         .group(group)
@@ -474,7 +473,7 @@ public class NettyBlockHoundIntegrationTest {
                                   });
                             }
                         }).connect(sc.localAddress());
-                cc = future.asJdkFuture().get();
+                cc = future.asStage().get();
 
                 clientSslHandler.handshakeFuture().await().sync();
                 serverSslHandler.handshakeFuture().await().sync();

--- a/transport-blockhound-tests/src/test/java/io/netty5/util/internal/NettyBlockHoundIntegrationTest.java
+++ b/transport-blockhound-tests/src/test/java/io/netty5/util/internal/NettyBlockHoundIntegrationTest.java
@@ -187,8 +187,8 @@ public class NettyBlockHoundIntegrationTest {
     @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
     public void testHashedWheelTimerStartStop() throws Exception {
         HashedWheelTimer timer = new HashedWheelTimer();
-        GlobalEventExecutor.INSTANCE.submit(timer::start).get(5, TimeUnit.SECONDS);
-        GlobalEventExecutor.INSTANCE.submit(timer::stop).get(5, TimeUnit.SECONDS);
+        GlobalEventExecutor.INSTANCE.submit(timer::start).asJdkFuture().get(5, TimeUnit.SECONDS);
+        GlobalEventExecutor.INSTANCE.submit(timer::stop).asJdkFuture().get(5, TimeUnit.SECONDS);
     }
 
     // Tests copied from io.netty5.handler.ssl.SslHandlerTest
@@ -291,7 +291,7 @@ public class NettyBlockHoundIntegrationTest {
                         .childHandler(new ChannelHandler() {
                         })
                         .bind(new InetSocketAddress(0))
-                        .get();
+                        .asJdkFuture().get();
 
                 cc = new Bootstrap()
                         .group(group)
@@ -322,8 +322,9 @@ public class NettyBlockHoundIntegrationTest {
                             }
                         })
                         .connect(sc.localAddress())
-                        .addListener(future -> future.get().writeAndFlush(alloc.copyOf(new byte[] { 1, 2, 3, 4 })))
-                        .get();
+                        .addListener(future -> future.asJdkFuture().get().writeAndFlush(
+                                alloc.copyOf(new byte[] { 1, 2, 3, 4 })))
+                        .asJdkFuture().get();
 
                 assertTrue(activeLatch.await(5, TimeUnit.SECONDS));
                 assertNull(error.get());
@@ -450,7 +451,7 @@ public class NettyBlockHoundIntegrationTest {
                         .group(group)
                         .channel(NioServerSocketChannel.class)
                         .childHandler(serverSslHandler)
-                        .bind(new InetSocketAddress(0)).get();
+                        .bind(new InetSocketAddress(0)).asJdkFuture().get();
 
                 Future<Channel> future = new Bootstrap()
                         .group(group)
@@ -473,7 +474,7 @@ public class NettyBlockHoundIntegrationTest {
                                   });
                             }
                         }).connect(sc.localAddress());
-                cc = future.get();
+                cc = future.asJdkFuture().get();
 
                 clientSslHandler.handshakeFuture().await().sync();
                 serverSslHandler.handshakeFuture().await().sync();

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
@@ -21,7 +21,6 @@ import io.netty5.buffer.api.DefaultBufferAllocators;
 import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.util.Resource;
 import io.netty5.channel.AbstractChannel;
-import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelConfig;
 import io.netty5.channel.ChannelException;
 import io.netty5.channel.ChannelMetadata;

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollServerChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollServerChannel.java
@@ -27,7 +27,6 @@ import io.netty5.channel.ServerChannel;
 import io.netty5.channel.unix.UnixChannel;
 import io.netty5.util.concurrent.Promise;
 
-import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 
 import static java.util.Objects.requireNonNull;

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollStreamChannel.java
@@ -20,7 +20,6 @@ import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.unix.UnixChannel;
 import io.netty5.util.Resource;
-import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelConfig;
 import io.netty5.channel.ChannelMetadata;
 import io.netty5.channel.ChannelOutboundBuffer;
@@ -40,7 +39,6 @@ import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.NotYetConnectedException;
 import java.nio.channels.WritableByteChannel;
-import java.util.concurrent.Executor;
 
 import static io.netty5.channel.internal.ChannelUtils.MAX_BYTES_PER_GATHERING_WRITE_ATTEMPTED_LOW_THRESHOLD;
 import static io.netty5.channel.internal.ChannelUtils.WRITE_STATUS_SNDBUF_FULL;

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueDatagramChannel.java
@@ -15,12 +15,10 @@
  */
 package io.netty5.channel.kqueue;
 
-import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelMetadata;
 import io.netty5.channel.ChannelOutboundBuffer;
 import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.EventLoop;
-import io.netty5.channel.unix.Unix;
 import io.netty5.channel.unix.UnixChannel;
 
 import java.io.IOException;

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueStreamChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueStreamChannel.java
@@ -39,7 +39,6 @@ import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.NotYetConnectedException;
 import java.nio.channels.WritableByteChannel;
-import java.util.concurrent.Executor;
 
 import static io.netty5.channel.internal.ChannelUtils.MAX_BYTES_PER_GATHERING_WRITE_ATTEMPTED_LOW_THRESHOLD;
 import static io.netty5.channel.internal.ChannelUtils.WRITE_STATUS_SNDBUF_FULL;

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDomainSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDomainSocketChannel.java
@@ -15,7 +15,6 @@
  */
 package io.netty5.channel.kqueue;
 
-import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelConfig;
 import io.netty5.channel.ChannelOutboundBuffer;
 import io.netty5.channel.ChannelPipeline;
@@ -25,7 +24,6 @@ import io.netty5.channel.unix.DomainSocketAddress;
 import io.netty5.channel.unix.DomainSocketChannel;
 import io.netty5.channel.unix.FileDescriptor;
 import io.netty5.channel.unix.PeerCredentials;
-import io.netty5.channel.unix.Unix;
 import io.netty5.channel.unix.UnixChannel;
 import io.netty5.util.internal.UnstableApi;
 

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDatagramChannelTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDatagramChannelTest.java
@@ -85,7 +85,7 @@ public class EpollDatagramChannelTest {
                     .localAddress(localAddressBeforeBind)
                     .handler(handler);
 
-            Channel channel = bootstrap.bind().asJdkFuture().get();
+            Channel channel = bootstrap.bind().asStage().get();
 
             assertNull(handler.localAddress);
 

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDatagramChannelTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDatagramChannelTest.java
@@ -85,7 +85,7 @@ public class EpollDatagramChannelTest {
                     .localAddress(localAddressBeforeBind)
                     .handler(handler);
 
-            Channel channel = bootstrap.bind().get();
+            Channel channel = bootstrap.bind().asJdkFuture().get();
 
             assertNull(handler.localAddress);
 

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDatagramScatteringReadTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDatagramScatteringReadTest.java
@@ -110,7 +110,7 @@ public class EpollDatagramScatteringReadTest extends AbstractDatagramTest  {
                     // Nothing will be sent.
                 }
             });
-            cc = cb.bind(newSocketAddress()).asJdkFuture().get();
+            cc = cb.bind(newSocketAddress()).asStage().get();
             final SocketAddress ccAddress = cc.localAddress();
 
             final AtomicReference<Throwable> errorRef = new AtomicReference<Throwable>();
@@ -147,7 +147,7 @@ public class EpollDatagramScatteringReadTest extends AbstractDatagramTest  {
             });
 
             sb.option(ChannelOption.AUTO_READ, false);
-            sc = sb.bind(newSocketAddress()).asJdkFuture().get();
+            sc = sb.bind(newSocketAddress()).asStage().get();
 
             if (connected) {
                 sc.connect(cc.localAddress()).sync();
@@ -220,7 +220,7 @@ public class EpollDatagramScatteringReadTest extends AbstractDatagramTest  {
                     // Nothing will be sent.
                 }
             });
-            cc = cb.bind(newSocketAddress()).asJdkFuture().get();
+            cc = cb.bind(newSocketAddress()).asStage().get();
             final SocketAddress ccAddress = cc.localAddress();
 
             final AtomicReference<Throwable> errorRef = new AtomicReference<Throwable>();
@@ -248,7 +248,7 @@ public class EpollDatagramScatteringReadTest extends AbstractDatagramTest  {
                 }
             });
 
-            sc = sb.bind(newSocketAddress()).asJdkFuture().get();
+            sc = sb.bind(newSocketAddress()).asStage().get();
 
             if (connected) {
                 sc.connect(cc.localAddress()).sync();

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDatagramScatteringReadTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDatagramScatteringReadTest.java
@@ -110,7 +110,7 @@ public class EpollDatagramScatteringReadTest extends AbstractDatagramTest  {
                     // Nothing will be sent.
                 }
             });
-            cc = cb.bind(newSocketAddress()).get();
+            cc = cb.bind(newSocketAddress()).asJdkFuture().get();
             final SocketAddress ccAddress = cc.localAddress();
 
             final AtomicReference<Throwable> errorRef = new AtomicReference<Throwable>();
@@ -147,7 +147,7 @@ public class EpollDatagramScatteringReadTest extends AbstractDatagramTest  {
             });
 
             sb.option(ChannelOption.AUTO_READ, false);
-            sc = sb.bind(newSocketAddress()).get();
+            sc = sb.bind(newSocketAddress()).asJdkFuture().get();
 
             if (connected) {
                 sc.connect(cc.localAddress()).sync();
@@ -220,7 +220,7 @@ public class EpollDatagramScatteringReadTest extends AbstractDatagramTest  {
                     // Nothing will be sent.
                 }
             });
-            cc = cb.bind(newSocketAddress()).get();
+            cc = cb.bind(newSocketAddress()).asJdkFuture().get();
             final SocketAddress ccAddress = cc.localAddress();
 
             final AtomicReference<Throwable> errorRef = new AtomicReference<Throwable>();
@@ -248,7 +248,7 @@ public class EpollDatagramScatteringReadTest extends AbstractDatagramTest  {
                 }
             });
 
-            sc = sb.bind(newSocketAddress()).get();
+            sc = sb.bind(newSocketAddress()).asJdkFuture().get();
 
             if (connected) {
                 sc.connect(cc.localAddress()).sync();

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDatagramUnicastTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDatagramUnicastTest.java
@@ -107,7 +107,7 @@ public class EpollDatagramUnicastTest extends DatagramUnicastInetTest {
                 }
             });
 
-            cc = cb.bind(newSocketAddress()).asJdkFuture().get();
+            cc = cb.bind(newSocketAddress()).asStage().get();
             if (!(cc instanceof EpollDatagramChannel)) {
                 // Only supported for the native epoll transport.
                 return;
@@ -149,7 +149,7 @@ public class EpollDatagramUnicastTest extends DatagramUnicastInetTest {
                     } while (!errorRef.compareAndSet(null, cause));
                     super.channelExceptionCaught(ctx, cause);
                 }
-            }).bind(newSocketAddress()).asJdkFuture().get();
+            }).bind(newSocketAddress()).asStage().get();
 
             if (gro && !(sc instanceof EpollDatagramChannel)) {
                 // Only supported for the native epoll transport.

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDatagramUnicastTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDatagramUnicastTest.java
@@ -107,7 +107,7 @@ public class EpollDatagramUnicastTest extends DatagramUnicastInetTest {
                 }
             });
 
-            cc = cb.bind(newSocketAddress()).get();
+            cc = cb.bind(newSocketAddress()).asJdkFuture().get();
             if (!(cc instanceof EpollDatagramChannel)) {
                 // Only supported for the native epoll transport.
                 return;
@@ -149,7 +149,7 @@ public class EpollDatagramUnicastTest extends DatagramUnicastInetTest {
                     } while (!errorRef.compareAndSet(null, cause));
                     super.channelExceptionCaught(ctx, cause);
                 }
-            }).bind(newSocketAddress()).get();
+            }).bind(newSocketAddress()).asJdkFuture().get();
 
             if (gro && !(sc instanceof EpollDatagramChannel)) {
                 // Only supported for the native epoll transport.

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDomainDatagramPathTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDomainDatagramPathTest.java
@@ -38,7 +38,7 @@ class EpollDomainDatagramPathTest extends AbstractClientSocketTest {
         run(testInfo, bootstrap -> {
             try {
                 bootstrap.handler(new ChannelHandlerAdapter() { })
-                         .connect(EpollSocketTestPermutation.newDomainSocketAddress()).get();
+                         .connect(EpollSocketTestPermutation.newDomainSocketAddress()).asJdkFuture().get();
                 fail("Expected FileNotFoundException");
             } catch (Exception e) {
                 assertTrue(e.getCause() instanceof FileNotFoundException);
@@ -51,7 +51,7 @@ class EpollDomainDatagramPathTest extends AbstractClientSocketTest {
         run(testInfo, bootstrap -> {
             try {
                 Channel ch = bootstrap.handler(new ChannelHandlerAdapter() { })
-                                      .bind(EpollSocketTestPermutation.newDomainSocketAddress()).get();
+                                      .bind(EpollSocketTestPermutation.newDomainSocketAddress()).asJdkFuture().get();
                 ch.writeAndFlush(new DomainDatagramPacket(
                         ch.bufferAllocator().copyOf("test", CharsetUtil.US_ASCII),
                         EpollSocketTestPermutation.newDomainSocketAddress())).sync();

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDomainDatagramPathTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDomainDatagramPathTest.java
@@ -38,7 +38,7 @@ class EpollDomainDatagramPathTest extends AbstractClientSocketTest {
         run(testInfo, bootstrap -> {
             try {
                 bootstrap.handler(new ChannelHandlerAdapter() { })
-                         .connect(EpollSocketTestPermutation.newDomainSocketAddress()).asJdkFuture().get();
+                         .connect(EpollSocketTestPermutation.newDomainSocketAddress()).asStage().get();
                 fail("Expected FileNotFoundException");
             } catch (Exception e) {
                 assertTrue(e.getCause() instanceof FileNotFoundException);
@@ -51,7 +51,7 @@ class EpollDomainDatagramPathTest extends AbstractClientSocketTest {
         run(testInfo, bootstrap -> {
             try {
                 Channel ch = bootstrap.handler(new ChannelHandlerAdapter() { })
-                                      .bind(EpollSocketTestPermutation.newDomainSocketAddress()).asJdkFuture().get();
+                                      .bind(EpollSocketTestPermutation.newDomainSocketAddress()).asStage().get();
                 ch.writeAndFlush(new DomainDatagramPacket(
                         ch.bufferAllocator().copyOf("test", CharsetUtil.US_ASCII),
                         EpollSocketTestPermutation.newDomainSocketAddress())).sync();

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDomainDatagramUnicastTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDomainDatagramUnicastTest.java
@@ -51,7 +51,7 @@ class EpollDomainDatagramUnicastTest extends DatagramUnicastTest {
         Channel channel = null;
         try {
             channel = cb.handler(new ChannelHandlerAdapter() { })
-                    .bind(newSocketAddress()).get();
+                    .bind(newSocketAddress()).asJdkFuture().get();
             assertThat(channel.localAddress()).isNotNull()
                     .isInstanceOf(DomainSocketAddress.class);
         } finally {
@@ -104,7 +104,7 @@ class EpollDomainDatagramUnicastTest extends DatagramUnicastTest {
                 errorRef.compareAndSet(null, cause);
             }
         });
-        return cb.bind(newSocketAddress()).get();
+        return cb.bind(newSocketAddress()).asJdkFuture().get();
     }
 
     @Override
@@ -148,7 +148,7 @@ class EpollDomainDatagramUnicastTest extends DatagramUnicastTest {
                 });
             }
         });
-        return sb.bind(newSocketAddress()).get();
+        return sb.bind(newSocketAddress()).asJdkFuture().get();
     }
 
     @Override

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDomainDatagramUnicastTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDomainDatagramUnicastTest.java
@@ -51,7 +51,7 @@ class EpollDomainDatagramUnicastTest extends DatagramUnicastTest {
         Channel channel = null;
         try {
             channel = cb.handler(new ChannelHandlerAdapter() { })
-                    .bind(newSocketAddress()).asJdkFuture().get();
+                        .bind(newSocketAddress()).asStage().get();
             assertThat(channel.localAddress()).isNotNull()
                     .isInstanceOf(DomainSocketAddress.class);
         } finally {
@@ -104,7 +104,7 @@ class EpollDomainDatagramUnicastTest extends DatagramUnicastTest {
                 errorRef.compareAndSet(null, cause);
             }
         });
-        return cb.bind(newSocketAddress()).asJdkFuture().get();
+        return cb.bind(newSocketAddress()).asStage().get();
     }
 
     @Override
@@ -148,7 +148,7 @@ class EpollDomainDatagramUnicastTest extends DatagramUnicastTest {
                 });
             }
         });
-        return sb.bind(newSocketAddress()).asJdkFuture().get();
+        return sb.bind(newSocketAddress()).asStage().get();
     }
 
     @Override

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDomainSocketFdTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDomainSocketFdTest.java
@@ -87,8 +87,8 @@ public class EpollDomainSocketFdTest extends AbstractSocketTest {
         });
         cb.option(UnixChannelOption.DOMAIN_SOCKET_READ_MODE,
                   DomainSocketReadMode.FILE_DESCRIPTORS);
-        Channel sc = sb.bind().asJdkFuture().get();
-        Channel cc = cb.connect(sc.localAddress()).asJdkFuture().get();
+        Channel sc = sb.bind().asStage().get();
+        Channel cc = cb.connect(sc.localAddress()).asStage().get();
 
         Object received = queue.take();
         cc.close().sync();

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDomainSocketFdTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDomainSocketFdTest.java
@@ -87,8 +87,8 @@ public class EpollDomainSocketFdTest extends AbstractSocketTest {
         });
         cb.option(UnixChannelOption.DOMAIN_SOCKET_READ_MODE,
                   DomainSocketReadMode.FILE_DESCRIPTORS);
-        Channel sc = sb.bind().get();
-        Channel cc = cb.connect(sc.localAddress()).get();
+        Channel sc = sb.bind().asJdkFuture().get();
+        Channel cc = cb.connect(sc.localAddress()).asJdkFuture().get();
 
         Object received = queue.take();
         cc.close().sync();

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollEventLoopTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollEventLoopTest.java
@@ -60,7 +60,7 @@ public class EpollEventLoopTest extends AbstractSingleThreadEventLoopTest {
                 // NOOP
             }, Long.MAX_VALUE, TimeUnit.MILLISECONDS);
 
-            assertFalse(future.await(1000));
+            assertFalse(future.await(1000, TimeUnit.MILLISECONDS));
             assertTrue(future.cancel());
             assertNull(capture.get());
         } finally {

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollReuseAddrTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollReuseAddrTest.java
@@ -103,7 +103,7 @@ public class EpollReuseAddrTest {
     private static void testMultipleBindDatagramChannelWithoutReusePortFails0(AbstractBootstrap<?, ?, ?> bootstrap)
             throws Exception {
         bootstrap.handler(new LoggingHandler(LogLevel.ERROR));
-        Channel channel = bootstrap.bind().get();
+        Channel channel = bootstrap.bind().asJdkFuture().get();
         try {
             bootstrap.bind(channel.localAddress()).sync();
             fail();
@@ -121,12 +121,12 @@ public class EpollReuseAddrTest {
         bootstrap.option(UnixChannelOption.SO_REUSEPORT, true);
         final AtomicBoolean accepted1 = new AtomicBoolean();
         bootstrap.childHandler(new ServerSocketTestHandler(accepted1));
-        Channel firstChannel = bootstrap.bind().get();
+        Channel firstChannel = bootstrap.bind().asJdkFuture().get();
         InetSocketAddress address1 = (InetSocketAddress) firstChannel.localAddress();
 
         final AtomicBoolean accepted2 = new AtomicBoolean();
         bootstrap.childHandler(new ServerSocketTestHandler(accepted2));
-        Channel secondChannel = bootstrap.bind(address1).get();
+        Channel secondChannel = bootstrap.bind(address1).asJdkFuture().get();
         InetSocketAddress address2 = (InetSocketAddress) secondChannel.localAddress();
 
         assertEquals(address1, address2);
@@ -149,12 +149,12 @@ public class EpollReuseAddrTest {
         bootstrap.option(UnixChannelOption.SO_REUSEPORT, true);
         final AtomicBoolean received1 = new AtomicBoolean();
         bootstrap.handler(new DatagramSocketTestHandler(received1));
-        Channel firstChannel = bootstrap.bind().get();
+        Channel firstChannel = bootstrap.bind().asJdkFuture().get();
         final InetSocketAddress address1 = (InetSocketAddress) firstChannel.localAddress();
 
         final AtomicBoolean received2 = new AtomicBoolean();
         bootstrap.handler(new DatagramSocketTestHandler(received2));
-        Channel secondChannel = bootstrap.bind(address1).get();
+        Channel secondChannel = bootstrap.bind(address1).asJdkFuture().get();
         final InetSocketAddress address2 = (InetSocketAddress) secondChannel.localAddress();
 
         assertEquals(address1, address2);

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollReuseAddrTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollReuseAddrTest.java
@@ -103,7 +103,7 @@ public class EpollReuseAddrTest {
     private static void testMultipleBindDatagramChannelWithoutReusePortFails0(AbstractBootstrap<?, ?, ?> bootstrap)
             throws Exception {
         bootstrap.handler(new LoggingHandler(LogLevel.ERROR));
-        Channel channel = bootstrap.bind().asJdkFuture().get();
+        Channel channel = bootstrap.bind().asStage().get();
         try {
             bootstrap.bind(channel.localAddress()).sync();
             fail();
@@ -121,12 +121,12 @@ public class EpollReuseAddrTest {
         bootstrap.option(UnixChannelOption.SO_REUSEPORT, true);
         final AtomicBoolean accepted1 = new AtomicBoolean();
         bootstrap.childHandler(new ServerSocketTestHandler(accepted1));
-        Channel firstChannel = bootstrap.bind().asJdkFuture().get();
+        Channel firstChannel = bootstrap.bind().asStage().get();
         InetSocketAddress address1 = (InetSocketAddress) firstChannel.localAddress();
 
         final AtomicBoolean accepted2 = new AtomicBoolean();
         bootstrap.childHandler(new ServerSocketTestHandler(accepted2));
-        Channel secondChannel = bootstrap.bind(address1).asJdkFuture().get();
+        Channel secondChannel = bootstrap.bind(address1).asStage().get();
         InetSocketAddress address2 = (InetSocketAddress) secondChannel.localAddress();
 
         assertEquals(address1, address2);
@@ -149,12 +149,12 @@ public class EpollReuseAddrTest {
         bootstrap.option(UnixChannelOption.SO_REUSEPORT, true);
         final AtomicBoolean received1 = new AtomicBoolean();
         bootstrap.handler(new DatagramSocketTestHandler(received1));
-        Channel firstChannel = bootstrap.bind().asJdkFuture().get();
+        Channel firstChannel = bootstrap.bind().asStage().get();
         final InetSocketAddress address1 = (InetSocketAddress) firstChannel.localAddress();
 
         final AtomicBoolean received2 = new AtomicBoolean();
         bootstrap.handler(new DatagramSocketTestHandler(received2));
-        Channel secondChannel = bootstrap.bind(address1).asJdkFuture().get();
+        Channel secondChannel = bootstrap.bind(address1).asStage().get();
         final InetSocketAddress address2 = (InetSocketAddress) secondChannel.localAddress();
 
         assertEquals(address1, address2);

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollServerSocketChannelConfigTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollServerSocketChannelConfigTest.java
@@ -41,9 +41,9 @@ public class EpollServerSocketChannelConfigTest {
         group = new MultithreadEventLoopGroup(1, EpollHandler.newFactory());
         ServerBootstrap bootstrap = new ServerBootstrap();
         ch = (EpollServerSocketChannel) bootstrap.group(group)
-                .channel(EpollServerSocketChannel.class)
-                .childHandler(new ChannelHandler() { })
-                .bind(new InetSocketAddress(0)).asJdkFuture().get();
+                                                 .channel(EpollServerSocketChannel.class)
+                                                 .childHandler(new ChannelHandler() { })
+                                                 .bind(new InetSocketAddress(0)).asStage().get();
     }
 
     @AfterAll

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollServerSocketChannelConfigTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollServerSocketChannelConfigTest.java
@@ -43,7 +43,7 @@ public class EpollServerSocketChannelConfigTest {
         ch = (EpollServerSocketChannel) bootstrap.group(group)
                 .channel(EpollServerSocketChannel.class)
                 .childHandler(new ChannelHandler() { })
-                .bind(new InetSocketAddress(0)).get();
+                .bind(new InetSocketAddress(0)).asJdkFuture().get();
     }
 
     @AfterAll

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollSocketChannelConfigTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollSocketChannelConfigTest.java
@@ -63,9 +63,9 @@ public class EpollSocketChannelConfigTest {
     public void setup() throws Exception {
         Bootstrap bootstrap = new Bootstrap();
         ch = (EpollSocketChannel) bootstrap.group(group)
-                .channel(EpollSocketChannel.class)
-                .handler(new ChannelHandler() { })
-                .bind(new InetSocketAddress(0)).asJdkFuture().get();
+                                           .channel(EpollSocketChannel.class)
+                                           .handler(new ChannelHandler() { })
+                                           .bind(new InetSocketAddress(0)).asStage().get();
     }
 
     @AfterEach

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollSocketChannelConfigTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollSocketChannelConfigTest.java
@@ -65,7 +65,7 @@ public class EpollSocketChannelConfigTest {
         ch = (EpollSocketChannel) bootstrap.group(group)
                 .channel(EpollSocketChannel.class)
                 .handler(new ChannelHandler() { })
-                .bind(new InetSocketAddress(0)).get();
+                .bind(new InetSocketAddress(0)).asJdkFuture().get();
     }
 
     @AfterEach

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollSocketChannelTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollSocketChannelTest.java
@@ -38,7 +38,7 @@ public class EpollSocketChannelTest {
             EpollSocketChannel ch = (EpollSocketChannel) bootstrap.group(group)
                     .channel(EpollSocketChannel.class)
                     .handler(new ChannelHandler() { })
-                    .bind(new InetSocketAddress(0)).get();
+                    .bind(new InetSocketAddress(0)).asJdkFuture().get();
             EpollTcpInfo info = ch.tcpInfo();
             assertTcpInfo0(info);
             ch.close().sync();
@@ -56,7 +56,7 @@ public class EpollSocketChannelTest {
             EpollSocketChannel ch = (EpollSocketChannel) bootstrap.group(group)
                     .channel(EpollSocketChannel.class)
                     .handler(new ChannelHandler() { })
-                    .bind(new InetSocketAddress(0)).get();
+                    .bind(new InetSocketAddress(0)).asJdkFuture().get();
             EpollTcpInfo info = new EpollTcpInfo();
             ch.tcpInfo(info);
             assertTcpInfo0(info);
@@ -114,7 +114,7 @@ public class EpollSocketChannelTest {
                     .channel(EpollSocketChannel.class)
                     .option(ChannelOption.SO_LINGER, 10)
                     .handler(new ChannelHandler() { })
-                    .bind(new InetSocketAddress(0)).get();
+                    .bind(new InetSocketAddress(0)).asJdkFuture().get();
             ch.close().sync();
         } finally {
             group.shutdownGracefully();

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollSocketChannelTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollSocketChannelTest.java
@@ -36,9 +36,9 @@ public class EpollSocketChannelTest {
         try {
             Bootstrap bootstrap = new Bootstrap();
             EpollSocketChannel ch = (EpollSocketChannel) bootstrap.group(group)
-                    .channel(EpollSocketChannel.class)
-                    .handler(new ChannelHandler() { })
-                    .bind(new InetSocketAddress(0)).asJdkFuture().get();
+                                                                  .channel(EpollSocketChannel.class)
+                                                                  .handler(new ChannelHandler() { })
+                                                                  .bind(new InetSocketAddress(0)).asStage().get();
             EpollTcpInfo info = ch.tcpInfo();
             assertTcpInfo0(info);
             ch.close().sync();
@@ -54,9 +54,9 @@ public class EpollSocketChannelTest {
         try {
             Bootstrap bootstrap = new Bootstrap();
             EpollSocketChannel ch = (EpollSocketChannel) bootstrap.group(group)
-                    .channel(EpollSocketChannel.class)
-                    .handler(new ChannelHandler() { })
-                    .bind(new InetSocketAddress(0)).asJdkFuture().get();
+                                                                  .channel(EpollSocketChannel.class)
+                                                                  .handler(new ChannelHandler() { })
+                                                                  .bind(new InetSocketAddress(0)).asStage().get();
             EpollTcpInfo info = new EpollTcpInfo();
             ch.tcpInfo(info);
             assertTcpInfo0(info);
@@ -111,10 +111,10 @@ public class EpollSocketChannelTest {
         try {
             Bootstrap bootstrap = new Bootstrap();
             EpollSocketChannel ch = (EpollSocketChannel) bootstrap.group(group)
-                    .channel(EpollSocketChannel.class)
-                    .option(ChannelOption.SO_LINGER, 10)
-                    .handler(new ChannelHandler() { })
-                    .bind(new InetSocketAddress(0)).asJdkFuture().get();
+                                                                  .channel(EpollSocketChannel.class)
+                                                                  .option(ChannelOption.SO_LINGER, 10)
+                                                                  .handler(new ChannelHandler() { })
+                                                                  .bind(new InetSocketAddress(0)).asStage().get();
             ch.close().sync();
         } finally {
             group.shutdownGracefully();

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollSocketTcpMd5Test.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollSocketTcpMd5Test.java
@@ -56,10 +56,11 @@ public class EpollSocketTcpMd5Test {
     @BeforeEach
     public void setup() throws Exception {
         ServerBootstrap bootstrap = new ServerBootstrap();
-        server = (EpollServerSocketChannel) bootstrap.group(GROUP)
+        server = (EpollServerSocketChannel) bootstrap
+                .group(GROUP)
                 .channel(EpollServerSocketChannel.class)
                 .childHandler(new ChannelHandler() { })
-                .bind(new InetSocketAddress(NetUtil.LOCALHOST4, 0)).asJdkFuture().get();
+                .bind(new InetSocketAddress(NetUtil.LOCALHOST4, 0)).asStage().get();
     }
 
     @AfterEach
@@ -77,10 +78,12 @@ public class EpollSocketTcpMd5Test {
     @Test
     public void testServerOption() throws Exception {
         ServerBootstrap bootstrap = new ServerBootstrap();
-        EpollServerSocketChannel ch = (EpollServerSocketChannel) bootstrap.group(GROUP)
+        EpollServerSocketChannel ch = (EpollServerSocketChannel) bootstrap
+                .group(GROUP)
                 .channel(EpollServerSocketChannel.class)
                 .childHandler(new ChannelHandler() { })
-                .bind(new InetSocketAddress(0)).asJdkFuture().get();
+                .bind(new InetSocketAddress(0))
+                .asStage().get();
 
         ch.config().setOption(EpollChannelOption.TCP_MD5SIG,
                 Collections.singletonMap(NetUtil.LOCALHOST4, SERVER_KEY));
@@ -95,14 +98,15 @@ public class EpollSocketTcpMd5Test {
                 Collections.singletonMap(NetUtil.LOCALHOST4, SERVER_KEY));
 
         ExecutionException completion = assertThrows(ExecutionException.class, () -> {
-            EpollSocketChannel client = (EpollSocketChannel) new Bootstrap().group(GROUP)
+            EpollSocketChannel client = (EpollSocketChannel) new Bootstrap()
+                    .group(GROUP)
                     .channel(EpollSocketChannel.class)
                     .handler(new ChannelHandler() {
                     })
                     .option(EpollChannelOption.TCP_MD5SIG,
                             Collections.singletonMap(NetUtil.LOCALHOST4, BAD_KEY))
                     .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 1000)
-                    .connect(server.localAddress()).asJdkFuture().get();
+                    .connect(server.localAddress()).asStage().get();
             client.close().sync();
         });
         assertThat(completion.getCause())
@@ -114,12 +118,12 @@ public class EpollSocketTcpMd5Test {
         server.config().setOption(EpollChannelOption.TCP_MD5SIG,
                 Collections.singletonMap(NetUtil.LOCALHOST4, SERVER_KEY));
 
-        EpollSocketChannel client = (EpollSocketChannel) new Bootstrap().group(GROUP)
+        EpollSocketChannel client = (EpollSocketChannel) new Bootstrap()
+                .group(GROUP)
                 .channel(EpollSocketChannel.class)
                 .handler(new ChannelHandler() { })
-                .option(EpollChannelOption.TCP_MD5SIG,
-                        Collections.singletonMap(NetUtil.LOCALHOST4, SERVER_KEY))
-                .connect(server.localAddress()).asJdkFuture().get();
+                .option(EpollChannelOption.TCP_MD5SIG, Collections.singletonMap(NetUtil.LOCALHOST4, SERVER_KEY))
+                .connect(server.localAddress()).asStage().get();
         client.close().sync();
     }
 }

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollSocketTcpMd5Test.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollSocketTcpMd5Test.java
@@ -59,7 +59,7 @@ public class EpollSocketTcpMd5Test {
         server = (EpollServerSocketChannel) bootstrap.group(GROUP)
                 .channel(EpollServerSocketChannel.class)
                 .childHandler(new ChannelHandler() { })
-                .bind(new InetSocketAddress(NetUtil.LOCALHOST4, 0)).get();
+                .bind(new InetSocketAddress(NetUtil.LOCALHOST4, 0)).asJdkFuture().get();
     }
 
     @AfterEach
@@ -80,7 +80,7 @@ public class EpollSocketTcpMd5Test {
         EpollServerSocketChannel ch = (EpollServerSocketChannel) bootstrap.group(GROUP)
                 .channel(EpollServerSocketChannel.class)
                 .childHandler(new ChannelHandler() { })
-                .bind(new InetSocketAddress(0)).get();
+                .bind(new InetSocketAddress(0)).asJdkFuture().get();
 
         ch.config().setOption(EpollChannelOption.TCP_MD5SIG,
                 Collections.singletonMap(NetUtil.LOCALHOST4, SERVER_KEY));
@@ -102,7 +102,7 @@ public class EpollSocketTcpMd5Test {
                     .option(EpollChannelOption.TCP_MD5SIG,
                             Collections.singletonMap(NetUtil.LOCALHOST4, BAD_KEY))
                     .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 1000)
-                    .connect(server.localAddress()).get();
+                    .connect(server.localAddress()).asJdkFuture().get();
             client.close().sync();
         });
         assertThat(completion.getCause())
@@ -119,7 +119,7 @@ public class EpollSocketTcpMd5Test {
                 .handler(new ChannelHandler() { })
                 .option(EpollChannelOption.TCP_MD5SIG,
                         Collections.singletonMap(NetUtil.LOCALHOST4, SERVER_KEY))
-                .connect(server.localAddress()).get();
+                .connect(server.localAddress()).asJdkFuture().get();
         client.close().sync();
     }
 }

--- a/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueChannelConfigTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueChannelConfigTest.java
@@ -87,7 +87,7 @@ public class KQueueChannelConfigTest {
                     .channel(KQueueSocketChannel.class)
                     .option(ChannelOption.SO_LINGER, 10)
                     .handler(new ChannelHandler() { })
-                    .bind(new InetSocketAddress(0)).get();
+                    .bind(new InetSocketAddress(0)).asJdkFuture().get();
             ch.close().sync();
         } finally {
             group.shutdownGracefully();

--- a/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueChannelConfigTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueChannelConfigTest.java
@@ -83,11 +83,12 @@ public class KQueueChannelConfigTest {
 
         try {
             Bootstrap bootstrap = new Bootstrap();
-            KQueueSocketChannel ch = (KQueueSocketChannel) bootstrap.group(group)
+            KQueueSocketChannel ch = (KQueueSocketChannel) bootstrap
+                    .group(group)
                     .channel(KQueueSocketChannel.class)
                     .option(ChannelOption.SO_LINGER, 10)
                     .handler(new ChannelHandler() { })
-                    .bind(new InetSocketAddress(0)).asJdkFuture().get();
+                    .bind(new InetSocketAddress(0)).asStage().get();
             ch.close().sync();
         } finally {
             group.shutdownGracefully();

--- a/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueDomainDatagramPathTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueDomainDatagramPathTest.java
@@ -38,7 +38,7 @@ class KQueueDomainDatagramPathTest extends AbstractClientSocketTest {
         run(testInfo, bootstrap -> {
             try {
                 bootstrap.handler(new ChannelHandlerAdapter() { })
-                         .connect(KQueueSocketTestPermutation.newSocketAddress()).asJdkFuture().get();
+                         .connect(KQueueSocketTestPermutation.newSocketAddress()).asStage().get();
                 fail("Expected FileNotFoundException");
             } catch (Exception e) {
                 assertTrue(e.getCause() instanceof FileNotFoundException);
@@ -51,7 +51,7 @@ class KQueueDomainDatagramPathTest extends AbstractClientSocketTest {
         run(testInfo, bootstrap -> {
             try {
                 Channel ch = bootstrap.handler(new ChannelHandlerAdapter() { })
-                                      .bind(KQueueSocketTestPermutation.newSocketAddress()).asJdkFuture().get();
+                                      .bind(KQueueSocketTestPermutation.newSocketAddress()).asStage().get();
                 ch.writeAndFlush(new DomainDatagramPacket(
                         ch.bufferAllocator().copyOf("test", US_ASCII),
                         KQueueSocketTestPermutation.newSocketAddress())).sync();

--- a/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueDomainDatagramPathTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueDomainDatagramPathTest.java
@@ -38,7 +38,7 @@ class KQueueDomainDatagramPathTest extends AbstractClientSocketTest {
         run(testInfo, bootstrap -> {
             try {
                 bootstrap.handler(new ChannelHandlerAdapter() { })
-                         .connect(KQueueSocketTestPermutation.newSocketAddress()).get();
+                         .connect(KQueueSocketTestPermutation.newSocketAddress()).asJdkFuture().get();
                 fail("Expected FileNotFoundException");
             } catch (Exception e) {
                 assertTrue(e.getCause() instanceof FileNotFoundException);
@@ -51,7 +51,7 @@ class KQueueDomainDatagramPathTest extends AbstractClientSocketTest {
         run(testInfo, bootstrap -> {
             try {
                 Channel ch = bootstrap.handler(new ChannelHandlerAdapter() { })
-                                      .bind(KQueueSocketTestPermutation.newSocketAddress()).get();
+                                      .bind(KQueueSocketTestPermutation.newSocketAddress()).asJdkFuture().get();
                 ch.writeAndFlush(new DomainDatagramPacket(
                         ch.bufferAllocator().copyOf("test", US_ASCII),
                         KQueueSocketTestPermutation.newSocketAddress())).sync();

--- a/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueDomainDatagramUnicastTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueDomainDatagramUnicastTest.java
@@ -51,7 +51,7 @@ class KQueueDomainDatagramUnicastTest extends DatagramUnicastTest {
         Channel channel = null;
         try {
             channel = cb.handler(new ChannelHandlerAdapter() { })
-                        .bind(newSocketAddress()).get();
+                        .bind(newSocketAddress()).asJdkFuture().get();
             assertThat(channel.localAddress()).isNotNull()
                     .isInstanceOf(DomainSocketAddress.class);
         } finally {
@@ -103,7 +103,7 @@ class KQueueDomainDatagramUnicastTest extends DatagramUnicastTest {
                 errorRef.compareAndSet(null, cause);
             }
         });
-        return cb.bind(newSocketAddress()).get();
+        return cb.bind(newSocketAddress()).asJdkFuture().get();
     }
 
     @Override
@@ -148,7 +148,7 @@ class KQueueDomainDatagramUnicastTest extends DatagramUnicastTest {
                 });
             }
         });
-        return sb.bind(newSocketAddress()).get();
+        return sb.bind(newSocketAddress()).asJdkFuture().get();
     }
 
     @Override

--- a/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueDomainDatagramUnicastTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueDomainDatagramUnicastTest.java
@@ -51,7 +51,7 @@ class KQueueDomainDatagramUnicastTest extends DatagramUnicastTest {
         Channel channel = null;
         try {
             channel = cb.handler(new ChannelHandlerAdapter() { })
-                        .bind(newSocketAddress()).asJdkFuture().get();
+                        .bind(newSocketAddress()).asStage().get();
             assertThat(channel.localAddress()).isNotNull()
                     .isInstanceOf(DomainSocketAddress.class);
         } finally {
@@ -103,7 +103,7 @@ class KQueueDomainDatagramUnicastTest extends DatagramUnicastTest {
                 errorRef.compareAndSet(null, cause);
             }
         });
-        return cb.bind(newSocketAddress()).asJdkFuture().get();
+        return cb.bind(newSocketAddress()).asStage().get();
     }
 
     @Override
@@ -148,7 +148,7 @@ class KQueueDomainDatagramUnicastTest extends DatagramUnicastTest {
                 });
             }
         });
-        return sb.bind(newSocketAddress()).asJdkFuture().get();
+        return sb.bind(newSocketAddress()).asStage().get();
     }
 
     @Override

--- a/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueDomainSocketFdTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueDomainSocketFdTest.java
@@ -87,8 +87,8 @@ public class KQueueDomainSocketFdTest extends AbstractSocketTest {
         });
         cb.option(UnixChannelOption.DOMAIN_SOCKET_READ_MODE,
                   DomainSocketReadMode.FILE_DESCRIPTORS);
-        Channel sc = sb.bind().get();
-        Channel cc = cb.connect(sc.localAddress()).get();
+        Channel sc = sb.bind().asJdkFuture().get();
+        Channel cc = cb.connect(sc.localAddress()).asJdkFuture().get();
 
         Object received = queue.take();
         cc.close().sync();

--- a/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueDomainSocketFdTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueDomainSocketFdTest.java
@@ -87,8 +87,8 @@ public class KQueueDomainSocketFdTest extends AbstractSocketTest {
         });
         cb.option(UnixChannelOption.DOMAIN_SOCKET_READ_MODE,
                   DomainSocketReadMode.FILE_DESCRIPTORS);
-        Channel sc = sb.bind().asJdkFuture().get();
-        Channel cc = cb.connect(sc.localAddress()).asJdkFuture().get();
+        Channel sc = sb.bind().asStage().get();
+        Channel cc = cb.connect(sc.localAddress()).asStage().get();
 
         Object received = queue.take();
         cc.close().sync();

--- a/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueEventLoopTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueEventLoopTest.java
@@ -40,7 +40,7 @@ public class KQueueEventLoopTest extends AbstractSingleThreadEventLoopTest {
             // NOOP
         }, Long.MAX_VALUE, TimeUnit.MILLISECONDS);
 
-        assertFalse(future.await(1000));
+        assertFalse(future.await(1000, TimeUnit.MILLISECONDS));
         assertTrue(future.cancel());
         group.shutdownGracefully();
     }

--- a/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueServerSocketChannelConfigTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueServerSocketChannelConfigTest.java
@@ -40,9 +40,9 @@ public class KQueueServerSocketChannelConfigTest {
         group = new MultithreadEventLoopGroup(1, KQueueHandler.newFactory());
         ServerBootstrap bootstrap = new ServerBootstrap();
         ch = (KQueueServerSocketChannel) bootstrap.group(group)
-                .channel(KQueueServerSocketChannel.class)
-                .childHandler(new ChannelHandler() { })
-                .bind(new InetSocketAddress(0)).asJdkFuture().get();
+                                                  .channel(KQueueServerSocketChannel.class)
+                                                  .childHandler(new ChannelHandler() { })
+                                                  .bind(new InetSocketAddress(0)).asStage().get();
     }
 
     @AfterAll

--- a/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueServerSocketChannelConfigTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueServerSocketChannelConfigTest.java
@@ -42,7 +42,7 @@ public class KQueueServerSocketChannelConfigTest {
         ch = (KQueueServerSocketChannel) bootstrap.group(group)
                 .channel(KQueueServerSocketChannel.class)
                 .childHandler(new ChannelHandler() { })
-                .bind(new InetSocketAddress(0)).get();
+                .bind(new InetSocketAddress(0)).asJdkFuture().get();
     }
 
     @AfterAll

--- a/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueSocketChannelConfigTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueSocketChannelConfigTest.java
@@ -58,9 +58,9 @@ public class KQueueSocketChannelConfigTest {
     public void setUp() throws Exception {
         Bootstrap bootstrap = new Bootstrap();
         ch = (KQueueSocketChannel) bootstrap.group(group)
-                .channel(KQueueSocketChannel.class)
-                .handler(new ChannelHandler() { })
-                .bind(new InetSocketAddress(0)).asJdkFuture().get();
+                                            .channel(KQueueSocketChannel.class)
+                                            .handler(new ChannelHandler() { })
+                                            .bind(new InetSocketAddress(0)).asStage().get();
     }
 
     @AfterEach

--- a/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueSocketChannelConfigTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueSocketChannelConfigTest.java
@@ -60,7 +60,7 @@ public class KQueueSocketChannelConfigTest {
         ch = (KQueueSocketChannel) bootstrap.group(group)
                 .channel(KQueueSocketChannel.class)
                 .handler(new ChannelHandler() { })
-                .bind(new InetSocketAddress(0)).get();
+                .bind(new InetSocketAddress(0)).asJdkFuture().get();
     }
 
     @AfterEach

--- a/transport-native-unix-common-tests/src/main/java/io/netty5/channel/unix/tests/DetectPeerCloseWithoutReadTest.java
+++ b/transport-native-unix-common-tests/src/main/java/io/netty5/channel/unix/tests/DetectPeerCloseWithoutReadTest.java
@@ -80,13 +80,13 @@ public abstract class DetectPeerCloseWithoutReadTest {
                 }
             });
 
-            serverChannel = sb.bind(new InetSocketAddress(0)).get();
+            serverChannel = sb.bind(new InetSocketAddress(0)).asJdkFuture().get();
 
             Bootstrap cb = new Bootstrap();
             cb.group(serverGroup);
             cb.channel(clientChannel());
             cb.handler(new ChannelHandler() { });
-            Channel clientChannel = cb.connect(serverChannel.localAddress()).get();
+            Channel clientChannel = cb.connect(serverChannel.localAddress()).asJdkFuture().get();
             Buffer buf = clientChannel.bufferAllocator().allocate(expectedBytes);
             buf.skipWritableBytes(expectedBytes);
             clientChannel.writeAndFlush(buf).addListener(clientChannel, ChannelFutureListeners.CLOSE);
@@ -147,7 +147,7 @@ public abstract class DetectPeerCloseWithoutReadTest {
                 }
             });
 
-            serverChannel = sb.bind(new InetSocketAddress(0)).get();
+            serverChannel = sb.bind(new InetSocketAddress(0)).asJdkFuture().get();
 
             Bootstrap cb = new Bootstrap();
             cb.group(serverGroup);
@@ -163,7 +163,7 @@ public abstract class DetectPeerCloseWithoutReadTest {
                     ch.pipeline().addLast(new TestHandler(bytesRead, extraReadRequested, latch));
                 }
             });
-            clientChannel = cb.connect(serverChannel.localAddress()).get();
+            clientChannel = cb.connect(serverChannel.localAddress()).asJdkFuture().get();
 
             latch.await();
             assertEquals(expectedBytes, bytesRead.get());

--- a/transport-native-unix-common-tests/src/main/java/io/netty5/channel/unix/tests/DetectPeerCloseWithoutReadTest.java
+++ b/transport-native-unix-common-tests/src/main/java/io/netty5/channel/unix/tests/DetectPeerCloseWithoutReadTest.java
@@ -80,13 +80,13 @@ public abstract class DetectPeerCloseWithoutReadTest {
                 }
             });
 
-            serverChannel = sb.bind(new InetSocketAddress(0)).asJdkFuture().get();
+            serverChannel = sb.bind(new InetSocketAddress(0)).asStage().get();
 
             Bootstrap cb = new Bootstrap();
             cb.group(serverGroup);
             cb.channel(clientChannel());
             cb.handler(new ChannelHandler() { });
-            Channel clientChannel = cb.connect(serverChannel.localAddress()).asJdkFuture().get();
+            Channel clientChannel = cb.connect(serverChannel.localAddress()).asStage().get();
             Buffer buf = clientChannel.bufferAllocator().allocate(expectedBytes);
             buf.skipWritableBytes(expectedBytes);
             clientChannel.writeAndFlush(buf).addListener(clientChannel, ChannelFutureListeners.CLOSE);
@@ -147,7 +147,7 @@ public abstract class DetectPeerCloseWithoutReadTest {
                 }
             });
 
-            serverChannel = sb.bind(new InetSocketAddress(0)).asJdkFuture().get();
+            serverChannel = sb.bind(new InetSocketAddress(0)).asStage().get();
 
             Bootstrap cb = new Bootstrap();
             cb.group(serverGroup);
@@ -163,7 +163,7 @@ public abstract class DetectPeerCloseWithoutReadTest {
                     ch.pipeline().addLast(new TestHandler(bytesRead, extraReadRequested, latch));
                 }
             });
-            clientChannel = cb.connect(serverChannel.localAddress()).asJdkFuture().get();
+            clientChannel = cb.connect(serverChannel.localAddress()).asStage().get();
 
             latch.await();
             assertEquals(expectedBytes, bytesRead.get());

--- a/transport/src/main/java/io/netty5/channel/Channel.java
+++ b/transport/src/main/java/io/netty5/channel/Channel.java
@@ -24,7 +24,6 @@ import io.netty5.channel.socket.SocketChannel;
 import io.netty5.util.AttributeKey;
 import io.netty5.util.AttributeMap;
 import io.netty5.util.concurrent.Future;
-import io.netty5.util.concurrent.Promise;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;

--- a/transport/src/main/java/io/netty5/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty5/channel/DefaultChannelPipeline.java
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.WeakHashMap;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.IntSupplier;

--- a/transport/src/test/java/io/netty5/bootstrap/BootstrapTest.java
+++ b/transport/src/test/java/io/netty5/bootstrap/BootstrapTest.java
@@ -324,7 +324,7 @@ public class BootstrapTest {
         Future<Channel> connectFuture = bootstrapA.connect(localAddress);
 
         // Should fail with the UnknownHostException.
-        assertTrue(connectFuture.await(10000));
+        assertTrue(connectFuture.await(10000, TimeUnit.MILLISECONDS));
         assertThat(connectFuture.cause(), instanceOf(UnknownHostException.class));
     }
 
@@ -342,7 +342,7 @@ public class BootstrapTest {
         Future<Channel> connectFuture = bootstrap.connect(LocalAddress.ANY);
 
         // Should fail with the RuntimeException.
-        assertTrue(connectFuture.await(10000));
+        assertTrue(connectFuture.await(10000, TimeUnit.MILLISECONDS));
         assertSame(connectFuture.cause(), exception);
     }
 

--- a/transport/src/test/java/io/netty5/bootstrap/BootstrapTest.java
+++ b/transport/src/test/java/io/netty5/bootstrap/BootstrapTest.java
@@ -277,7 +277,7 @@ public class BootstrapTest {
         bootstrapB.group(groupB);
         bootstrapB.channel(LocalServerChannel.class);
         bootstrapB.childHandler(dummyHandler);
-        SocketAddress localAddress = bootstrapB.bind(LocalAddress.ANY).get().localAddress();
+        SocketAddress localAddress = bootstrapB.bind(LocalAddress.ANY).asJdkFuture().get().localAddress();
 
         // Connect to the server using the asynchronous resolver.
         bootstrapA.connect(localAddress).sync();
@@ -318,7 +318,7 @@ public class BootstrapTest {
         bootstrapB.group(groupB);
         bootstrapB.channel(LocalServerChannel.class);
         bootstrapB.childHandler(dummyHandler);
-        SocketAddress localAddress = bootstrapB.bind(LocalAddress.ANY).get().localAddress();
+        SocketAddress localAddress = bootstrapB.bind(LocalAddress.ANY).asJdkFuture().get().localAddress();
 
         // Connect to the server using the asynchronous resolver.
         Future<Channel> connectFuture = bootstrapA.connect(localAddress);

--- a/transport/src/test/java/io/netty5/bootstrap/BootstrapTest.java
+++ b/transport/src/test/java/io/netty5/bootstrap/BootstrapTest.java
@@ -277,7 +277,7 @@ public class BootstrapTest {
         bootstrapB.group(groupB);
         bootstrapB.channel(LocalServerChannel.class);
         bootstrapB.childHandler(dummyHandler);
-        SocketAddress localAddress = bootstrapB.bind(LocalAddress.ANY).asJdkFuture().get().localAddress();
+        SocketAddress localAddress = bootstrapB.bind(LocalAddress.ANY).asStage().get().localAddress();
 
         // Connect to the server using the asynchronous resolver.
         bootstrapA.connect(localAddress).sync();
@@ -318,7 +318,7 @@ public class BootstrapTest {
         bootstrapB.group(groupB);
         bootstrapB.channel(LocalServerChannel.class);
         bootstrapB.childHandler(dummyHandler);
-        SocketAddress localAddress = bootstrapB.bind(LocalAddress.ANY).asJdkFuture().get().localAddress();
+        SocketAddress localAddress = bootstrapB.bind(LocalAddress.ANY).asStage().get().localAddress();
 
         // Connect to the server using the asynchronous resolver.
         Future<Channel> connectFuture = bootstrapA.connect(localAddress);

--- a/transport/src/test/java/io/netty5/bootstrap/ServerBootstrapTest.java
+++ b/transport/src/test/java/io/netty5/bootstrap/ServerBootstrapTest.java
@@ -128,9 +128,9 @@ public class ServerBootstrapTest {
                     .channel(LocalChannel.class)
                     .handler(new ChannelHandler() { });
 
-            sch = sb.bind(addr).asJdkFuture().get();
+            sch = sb.bind(addr).asStage().get();
 
-            cch = cb.connect(addr).asJdkFuture().get();
+            cch = cb.connect(addr).asStage().get();
 
             initLatch.await();
             readLatch.await();
@@ -165,13 +165,13 @@ public class ServerBootstrapTest {
                         requestServed.set(true);
                     }
                 });
-        Channel serverChannel = sb.bind(addr).asJdkFuture().get();
+        Channel serverChannel = sb.bind(addr).asStage().get();
 
         Bootstrap cb = new Bootstrap();
         cb.group(group)
                 .channel(LocalChannel.class)
                 .handler(new ChannelHandler() { });
-        Channel clientChannel = cb.connect(addr).asJdkFuture().get();
+        Channel clientChannel = cb.connect(addr).asStage().get();
         serverChannel.close().sync();
         clientChannel.close().sync();
         group.shutdownGracefully();

--- a/transport/src/test/java/io/netty5/bootstrap/ServerBootstrapTest.java
+++ b/transport/src/test/java/io/netty5/bootstrap/ServerBootstrapTest.java
@@ -128,9 +128,9 @@ public class ServerBootstrapTest {
                     .channel(LocalChannel.class)
                     .handler(new ChannelHandler() { });
 
-            sch = sb.bind(addr).get();
+            sch = sb.bind(addr).asJdkFuture().get();
 
-            cch = cb.connect(addr).get();
+            cch = cb.connect(addr).asJdkFuture().get();
 
             initLatch.await();
             readLatch.await();
@@ -165,13 +165,13 @@ public class ServerBootstrapTest {
                         requestServed.set(true);
                     }
                 });
-        Channel serverChannel = sb.bind(addr).get();
+        Channel serverChannel = sb.bind(addr).asJdkFuture().get();
 
         Bootstrap cb = new Bootstrap();
         cb.group(group)
                 .channel(LocalChannel.class)
                 .handler(new ChannelHandler() { });
-        Channel clientChannel = cb.connect(addr).get();
+        Channel clientChannel = cb.connect(addr).asJdkFuture().get();
         serverChannel.close().sync();
         clientChannel.close().sync();
         group.shutdownGracefully();

--- a/transport/src/test/java/io/netty5/channel/ChannelInitializerTest.java
+++ b/transport/src/test/java/io/netty5/channel/ChannelInitializerTest.java
@@ -130,7 +130,7 @@ public class ChannelInitializerTest {
             }
         }).localAddress(LocalAddress.ANY);
 
-        Channel channel = client.bind().asJdkFuture().get();
+        Channel channel = client.bind().asStage().get();
         try {
             // Execute some task on the EventLoop and wait until its done to be sure all handlers are added to the
             // pipeline.
@@ -167,7 +167,7 @@ public class ChannelInitializerTest {
             }
         }).localAddress(LocalAddress.ANY);
 
-        Channel channel = client.bind().asJdkFuture().get();
+        Channel channel = client.bind().asStage().get();
         try {
             // Execute some task on the EventLoop and wait until its done to be sure all handlers are added to the
             // pipeline.
@@ -239,8 +239,8 @@ public class ChannelInitializerTest {
         Channel clientChannel = null, serverChannel = null;
         try {
             server.childHandler(init);
-            serverChannel = server.bind().asJdkFuture().get();
-            clientChannel = client.connect(SERVER_ADDRESS).asJdkFuture().get();
+            serverChannel = server.bind().asStage().get();
+            clientChannel = client.connect(SERVER_ADDRESS).asStage().get();
             assertEquals(1, testHandler.channelRegisteredCount.get());
         } finally {
             closeChannel(clientChannel);

--- a/transport/src/test/java/io/netty5/channel/ChannelInitializerTest.java
+++ b/transport/src/test/java/io/netty5/channel/ChannelInitializerTest.java
@@ -130,7 +130,7 @@ public class ChannelInitializerTest {
             }
         }).localAddress(LocalAddress.ANY);
 
-        Channel channel = client.bind().get();
+        Channel channel = client.bind().asJdkFuture().get();
         try {
             // Execute some task on the EventLoop and wait until its done to be sure all handlers are added to the
             // pipeline.
@@ -167,7 +167,7 @@ public class ChannelInitializerTest {
             }
         }).localAddress(LocalAddress.ANY);
 
-        Channel channel = client.bind().get();
+        Channel channel = client.bind().asJdkFuture().get();
         try {
             // Execute some task on the EventLoop and wait until its done to be sure all handlers are added to the
             // pipeline.
@@ -239,8 +239,8 @@ public class ChannelInitializerTest {
         Channel clientChannel = null, serverChannel = null;
         try {
             server.childHandler(init);
-            serverChannel = server.bind().get();
-            clientChannel = client.connect(SERVER_ADDRESS).get();
+            serverChannel = server.bind().asJdkFuture().get();
+            clientChannel = client.connect(SERVER_ADDRESS).asJdkFuture().get();
             assertEquals(1, testHandler.channelRegisteredCount.get());
         } finally {
             closeChannel(clientChannel);

--- a/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTest.java
+++ b/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTest.java
@@ -91,7 +91,7 @@ public class DefaultChannelPipelineTest {
             }
         });
 
-        Channel channel = sb.bind(LocalAddress.ANY).asJdkFuture().get();
+        Channel channel = sb.bind(LocalAddress.ANY).asStage().get();
 
         Bootstrap b = new Bootstrap();
         b.group(group).channel(LocalChannel.class);
@@ -102,7 +102,7 @@ public class DefaultChannelPipelineTest {
             }
         });
 
-        self = b.connect(channel.localAddress()).asJdkFuture().get();
+        self = b.connect(channel.localAddress()).asStage().get();
         peer = peerRef.get();
 
         channel.close().sync();
@@ -770,32 +770,32 @@ public class DefaultChannelPipelineTest {
         CallbackCheckHandler handler = new CallbackCheckHandler();
         pipeline.addFirst(handler);
         pipeline.remove(handler);
-        assertTrue(handler.addedHandler.asJdkFuture().get());
-        assertTrue(handler.removedHandler.asJdkFuture().get());
+        assertTrue(handler.addedHandler.asStage().get());
+        assertTrue(handler.removedHandler.asStage().get());
 
         CallbackCheckHandler handlerType = new CallbackCheckHandler();
         pipeline.addFirst(handlerType);
         pipeline.remove(handlerType.getClass());
-        assertTrue(handlerType.addedHandler.asJdkFuture().get());
-        assertTrue(handlerType.removedHandler.asJdkFuture().get());
+        assertTrue(handlerType.addedHandler.asStage().get());
+        assertTrue(handlerType.removedHandler.asStage().get());
 
         CallbackCheckHandler handlerName = new CallbackCheckHandler();
         pipeline.addFirst("handler", handlerName);
         pipeline.remove("handler");
-        assertTrue(handlerName.addedHandler.asJdkFuture().get());
-        assertTrue(handlerName.removedHandler.asJdkFuture().get());
+        assertTrue(handlerName.addedHandler.asStage().get());
+        assertTrue(handlerName.removedHandler.asStage().get());
 
         CallbackCheckHandler first = new CallbackCheckHandler();
         pipeline.addFirst(first);
         pipeline.removeFirst();
-        assertTrue(first.addedHandler.asJdkFuture().get());
-        assertTrue(first.removedHandler.asJdkFuture().get());
+        assertTrue(first.addedHandler.asStage().get());
+        assertTrue(first.removedHandler.asStage().get());
 
         CallbackCheckHandler last = new CallbackCheckHandler();
         pipeline.addFirst(last);
         pipeline.removeLast();
-        assertTrue(last.addedHandler.asJdkFuture().get());
-        assertTrue(last.removedHandler.asJdkFuture().get());
+        assertTrue(last.addedHandler.asStage().get());
+        assertTrue(last.removedHandler.asStage().get());
 
         pipeline.channel().register().sync();
         Throwable cause = handler.error.get();
@@ -935,9 +935,9 @@ public class DefaultChannelPipelineTest {
         pipeline.addFirst(handler);
         pipeline.replace(handler, null, handler2);
 
-        assertTrue(handler.addedHandler.asJdkFuture().get());
-        assertTrue(handler.removedHandler.asJdkFuture().get());
-        assertTrue(handler2.addedHandler.asJdkFuture().get());
+        assertTrue(handler.addedHandler.asStage().get());
+        assertTrue(handler.removedHandler.asStage().get());
+        assertTrue(handler2.addedHandler.asStage().get());
         assertFalse(handler2.removedHandler.isDone());
 
         pipeline.channel().register().sync();
@@ -953,7 +953,7 @@ public class DefaultChannelPipelineTest {
 
         assertFalse(handler2.removedHandler.isDone());
         pipeline.remove(handler2);
-        assertTrue(handler2.removedHandler.asJdkFuture().get());
+        assertTrue(handler2.removedHandler.asStage().get());
         pipeline.channel().close().sync();
     }
 

--- a/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTest.java
+++ b/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTest.java
@@ -91,7 +91,7 @@ public class DefaultChannelPipelineTest {
             }
         });
 
-        Channel channel = sb.bind(LocalAddress.ANY).get();
+        Channel channel = sb.bind(LocalAddress.ANY).asJdkFuture().get();
 
         Bootstrap b = new Bootstrap();
         b.group(group).channel(LocalChannel.class);
@@ -102,7 +102,7 @@ public class DefaultChannelPipelineTest {
             }
         });
 
-        self = b.connect(channel.localAddress()).get();
+        self = b.connect(channel.localAddress()).asJdkFuture().get();
         peer = peerRef.get();
 
         channel.close().sync();
@@ -770,32 +770,32 @@ public class DefaultChannelPipelineTest {
         CallbackCheckHandler handler = new CallbackCheckHandler();
         pipeline.addFirst(handler);
         pipeline.remove(handler);
-        assertTrue(handler.addedHandler.get());
-        assertTrue(handler.removedHandler.get());
+        assertTrue(handler.addedHandler.asJdkFuture().get());
+        assertTrue(handler.removedHandler.asJdkFuture().get());
 
         CallbackCheckHandler handlerType = new CallbackCheckHandler();
         pipeline.addFirst(handlerType);
         pipeline.remove(handlerType.getClass());
-        assertTrue(handlerType.addedHandler.get());
-        assertTrue(handlerType.removedHandler.get());
+        assertTrue(handlerType.addedHandler.asJdkFuture().get());
+        assertTrue(handlerType.removedHandler.asJdkFuture().get());
 
         CallbackCheckHandler handlerName = new CallbackCheckHandler();
         pipeline.addFirst("handler", handlerName);
         pipeline.remove("handler");
-        assertTrue(handlerName.addedHandler.get());
-        assertTrue(handlerName.removedHandler.get());
+        assertTrue(handlerName.addedHandler.asJdkFuture().get());
+        assertTrue(handlerName.removedHandler.asJdkFuture().get());
 
         CallbackCheckHandler first = new CallbackCheckHandler();
         pipeline.addFirst(first);
         pipeline.removeFirst();
-        assertTrue(first.addedHandler.get());
-        assertTrue(first.removedHandler.get());
+        assertTrue(first.addedHandler.asJdkFuture().get());
+        assertTrue(first.removedHandler.asJdkFuture().get());
 
         CallbackCheckHandler last = new CallbackCheckHandler();
         pipeline.addFirst(last);
         pipeline.removeLast();
-        assertTrue(last.addedHandler.get());
-        assertTrue(last.removedHandler.get());
+        assertTrue(last.addedHandler.asJdkFuture().get());
+        assertTrue(last.removedHandler.asJdkFuture().get());
 
         pipeline.channel().register().sync();
         Throwable cause = handler.error.get();
@@ -935,9 +935,9 @@ public class DefaultChannelPipelineTest {
         pipeline.addFirst(handler);
         pipeline.replace(handler, null, handler2);
 
-        assertTrue(handler.addedHandler.get());
-        assertTrue(handler.removedHandler.get());
-        assertTrue(handler2.addedHandler.get());
+        assertTrue(handler.addedHandler.asJdkFuture().get());
+        assertTrue(handler.removedHandler.asJdkFuture().get());
+        assertTrue(handler2.addedHandler.asJdkFuture().get());
         assertFalse(handler2.removedHandler.isDone());
 
         pipeline.channel().register().sync();
@@ -953,7 +953,7 @@ public class DefaultChannelPipelineTest {
 
         assertFalse(handler2.removedHandler.isDone());
         pipeline.remove(handler2);
-        assertTrue(handler2.removedHandler.get());
+        assertTrue(handler2.removedHandler.asJdkFuture().get());
         pipeline.channel().close().sync();
     }
 

--- a/transport/src/test/java/io/netty5/channel/ReentrantChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/ReentrantChannelTest.java
@@ -43,7 +43,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
 
         setInterest(Event.WRITE, Event.FLUSH, Event.WRITABILITY);
 
-        Channel clientChannel = cb.connect(addr).get();
+        Channel clientChannel = cb.connect(addr).asJdkFuture().get();
         clientChannel.config().setWriteBufferLowWaterMark(512);
         clientChannel.config().setWriteBufferHighWaterMark(1024);
 
@@ -110,7 +110,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
 
         setInterest(Event.WRITE, Event.FLUSH, Event.WRITABILITY);
 
-        Channel clientChannel = cb.connect(addr).get();
+        Channel clientChannel = cb.connect(addr).asJdkFuture().get();
         clientChannel.config().setWriteBufferLowWaterMark(512);
         clientChannel.config().setWriteBufferHighWaterMark(1024);
 
@@ -179,7 +179,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
 
         setInterest(Event.WRITE, Event.FLUSH, Event.WRITABILITY);
 
-        Channel clientChannel = cb.connect(addr).get();
+        Channel clientChannel = cb.connect(addr).asJdkFuture().get();
         clientChannel.config().setWriteBufferLowWaterMark(512);
         clientChannel.config().setWriteBufferHighWaterMark(1024);
 
@@ -228,7 +228,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
 
         setInterest(Event.WRITE, Event.FLUSH, Event.WRITABILITY);
 
-        Channel clientChannel = cb.connect(addr).get();
+        Channel clientChannel = cb.connect(addr).asJdkFuture().get();
         clientChannel.config().setWriteBufferLowWaterMark(512);
         clientChannel.config().setWriteBufferHighWaterMark(1024);
 
@@ -274,7 +274,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
 
         setInterest(Event.WRITE, Event.FLUSH, Event.CLOSE, Event.EXCEPTION);
 
-        Channel clientChannel = cb.connect(addr).get();
+        Channel clientChannel = cb.connect(addr).asJdkFuture().get();
 
         clientChannel.pipeline().addLast(new ChannelHandler() {
 
@@ -330,7 +330,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
 
         setInterest(Event.WRITE, Event.FLUSH, Event.CLOSE, Event.EXCEPTION);
 
-        Channel clientChannel = cb.connect(addr).get();
+        Channel clientChannel = cb.connect(addr).asJdkFuture().get();
 
         clientChannel.pipeline().addLast(new ChannelHandler() {
 
@@ -386,7 +386,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
 
         setInterest(Event.WRITE, Event.FLUSH, Event.CLOSE, Event.EXCEPTION);
 
-        Channel clientChannel = cb.connect(addr).get();
+        Channel clientChannel = cb.connect(addr).asJdkFuture().get();
 
         clientChannel.pipeline().addLast(new ChannelHandler() {
 
@@ -416,7 +416,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
 
         setInterest(Event.WRITE, Event.FLUSH, Event.CLOSE, Event.EXCEPTION);
 
-        Channel clientChannel = cb.connect(addr).get();
+        Channel clientChannel = cb.connect(addr).asJdkFuture().get();
 
         clientChannel.pipeline().addLast(new ChannelHandler() {
 
@@ -446,7 +446,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
 
         setInterest(Event.WRITE, Event.FLUSH, Event.CLOSE, Event.EXCEPTION);
 
-        Channel clientChannel = cb.connect(addr).get();
+        Channel clientChannel = cb.connect(addr).asJdkFuture().get();
 
         clientChannel.pipeline().addLast(new ChannelHandler() {
 
@@ -487,7 +487,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
 
         setInterest(Event.WRITE, Event.FLUSH, Event.CLOSE, Event.EXCEPTION);
 
-        Channel clientChannel = cb.connect(addr).get();
+        Channel clientChannel = cb.connect(addr).asJdkFuture().get();
 
         clientChannel.pipeline().addLast(new ChannelHandler() {
 

--- a/transport/src/test/java/io/netty5/channel/ReentrantChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/ReentrantChannelTest.java
@@ -43,7 +43,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
 
         setInterest(Event.WRITE, Event.FLUSH, Event.WRITABILITY);
 
-        Channel clientChannel = cb.connect(addr).asJdkFuture().get();
+        Channel clientChannel = cb.connect(addr).asStage().get();
         clientChannel.config().setWriteBufferLowWaterMark(512);
         clientChannel.config().setWriteBufferHighWaterMark(1024);
 
@@ -110,7 +110,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
 
         setInterest(Event.WRITE, Event.FLUSH, Event.WRITABILITY);
 
-        Channel clientChannel = cb.connect(addr).asJdkFuture().get();
+        Channel clientChannel = cb.connect(addr).asStage().get();
         clientChannel.config().setWriteBufferLowWaterMark(512);
         clientChannel.config().setWriteBufferHighWaterMark(1024);
 
@@ -179,7 +179,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
 
         setInterest(Event.WRITE, Event.FLUSH, Event.WRITABILITY);
 
-        Channel clientChannel = cb.connect(addr).asJdkFuture().get();
+        Channel clientChannel = cb.connect(addr).asStage().get();
         clientChannel.config().setWriteBufferLowWaterMark(512);
         clientChannel.config().setWriteBufferHighWaterMark(1024);
 
@@ -228,7 +228,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
 
         setInterest(Event.WRITE, Event.FLUSH, Event.WRITABILITY);
 
-        Channel clientChannel = cb.connect(addr).asJdkFuture().get();
+        Channel clientChannel = cb.connect(addr).asStage().get();
         clientChannel.config().setWriteBufferLowWaterMark(512);
         clientChannel.config().setWriteBufferHighWaterMark(1024);
 
@@ -274,7 +274,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
 
         setInterest(Event.WRITE, Event.FLUSH, Event.CLOSE, Event.EXCEPTION);
 
-        Channel clientChannel = cb.connect(addr).asJdkFuture().get();
+        Channel clientChannel = cb.connect(addr).asStage().get();
 
         clientChannel.pipeline().addLast(new ChannelHandler() {
 
@@ -330,7 +330,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
 
         setInterest(Event.WRITE, Event.FLUSH, Event.CLOSE, Event.EXCEPTION);
 
-        Channel clientChannel = cb.connect(addr).asJdkFuture().get();
+        Channel clientChannel = cb.connect(addr).asStage().get();
 
         clientChannel.pipeline().addLast(new ChannelHandler() {
 
@@ -386,7 +386,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
 
         setInterest(Event.WRITE, Event.FLUSH, Event.CLOSE, Event.EXCEPTION);
 
-        Channel clientChannel = cb.connect(addr).asJdkFuture().get();
+        Channel clientChannel = cb.connect(addr).asStage().get();
 
         clientChannel.pipeline().addLast(new ChannelHandler() {
 
@@ -416,7 +416,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
 
         setInterest(Event.WRITE, Event.FLUSH, Event.CLOSE, Event.EXCEPTION);
 
-        Channel clientChannel = cb.connect(addr).asJdkFuture().get();
+        Channel clientChannel = cb.connect(addr).asStage().get();
 
         clientChannel.pipeline().addLast(new ChannelHandler() {
 
@@ -446,7 +446,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
 
         setInterest(Event.WRITE, Event.FLUSH, Event.CLOSE, Event.EXCEPTION);
 
-        Channel clientChannel = cb.connect(addr).asJdkFuture().get();
+        Channel clientChannel = cb.connect(addr).asStage().get();
 
         clientChannel.pipeline().addLast(new ChannelHandler() {
 
@@ -487,7 +487,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
 
         setInterest(Event.WRITE, Event.FLUSH, Event.CLOSE, Event.EXCEPTION);
 
-        Channel clientChannel = cb.connect(addr).asJdkFuture().get();
+        Channel clientChannel = cb.connect(addr).asStage().get();
 
         clientChannel.pipeline().addLast(new ChannelHandler() {
 

--- a/transport/src/test/java/io/netty5/channel/SingleThreadEventLoopTest.java
+++ b/transport/src/test/java/io/netty5/channel/SingleThreadEventLoopTest.java
@@ -141,7 +141,7 @@ public class SingleThreadEventLoopTest {
     private static void testScheduleTask(EventLoop loopA) throws InterruptedException, ExecutionException {
         long startTime = System.nanoTime();
         final AtomicLong endTime = new AtomicLong();
-        loopA.schedule(() -> endTime.set(System.nanoTime()), 500, TimeUnit.MILLISECONDS).get();
+        loopA.schedule(() -> endTime.set(System.nanoTime()), 500, TimeUnit.MILLISECONDS).asJdkFuture().get();
         assertThat(endTime.get() - startTime,
                    is(greaterThanOrEqualTo(TimeUnit.MILLISECONDS.toNanos(500))));
     }

--- a/transport/src/test/java/io/netty5/channel/SingleThreadEventLoopTest.java
+++ b/transport/src/test/java/io/netty5/channel/SingleThreadEventLoopTest.java
@@ -141,7 +141,7 @@ public class SingleThreadEventLoopTest {
     private static void testScheduleTask(EventLoop loopA) throws InterruptedException, ExecutionException {
         long startTime = System.nanoTime();
         final AtomicLong endTime = new AtomicLong();
-        loopA.schedule(() -> endTime.set(System.nanoTime()), 500, TimeUnit.MILLISECONDS).asJdkFuture().get();
+        loopA.schedule(() -> endTime.set(System.nanoTime()), 500, TimeUnit.MILLISECONDS).asStage().get();
         assertThat(endTime.get() - startTime,
                    is(greaterThanOrEqualTo(TimeUnit.MILLISECONDS.toNanos(500))));
     }

--- a/transport/src/test/java/io/netty5/channel/local/LocalChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/local/LocalChannelTest.java
@@ -155,11 +155,11 @@ public class LocalChannelTest {
             Channel cc = null;
             try {
                 // Start server
-                sc = sb.bind(TEST_ADDRESS).get();
+                sc = sb.bind(TEST_ADDRESS).asJdkFuture().get();
 
                 final CountDownLatch latch = new CountDownLatch(1);
                 // Connect to the server
-                cc = cb.connect(sc.localAddress()).get();
+                cc = cb.connect(sc.localAddress()).asJdkFuture().get();
                 final Channel ccCpy = cc;
                 cc.executor().execute(() -> {
                     // Send a message event up the pipeline.
@@ -205,10 +205,10 @@ public class LocalChannelTest {
         Channel cc = null;
         try {
             // Start server
-            sc = sb.bind(TEST_ADDRESS).get();
+            sc = sb.bind(TEST_ADDRESS).asJdkFuture().get();
 
             // Connect to the server
-            cc = cb.connect(sc.localAddress()).get();
+            cc = cb.connect(sc.localAddress()).asJdkFuture().get();
 
             // Close the channel and write something.
             cc.close().sync();
@@ -241,7 +241,7 @@ public class LocalChannelTest {
         Channel sc = null;
         Channel cc = null;
         try {
-            sc = sb.bind(TEST_ADDRESS).get();
+            sc = sb.bind(TEST_ADDRESS).asJdkFuture().get();
 
             Bootstrap b = new Bootstrap()
                     .group(group2)
@@ -252,7 +252,7 @@ public class LocalChannelTest {
                             // discard
                         }
                     });
-            cc = b.connect(sc.localAddress()).get();
+            cc = b.connect(sc.localAddress()).asJdkFuture().get();
             cc.writeAndFlush(new Object());
             assertTrue(latch.await(5, SECONDS));
         } finally {
@@ -307,7 +307,7 @@ public class LocalChannelTest {
                             closeLatch.countDown();
                         }
                     }).
-                    bind(TEST_ADDRESS).get();
+                    bind(TEST_ADDRESS).asJdkFuture().get();
             Bootstrap bootstrap = new Bootstrap();
             bootstrap.group(clientGroup).
                     channel(LocalChannel.class).
@@ -319,7 +319,7 @@ public class LocalChannelTest {
                     });
             Future<Channel> future = bootstrap.connect(sc.localAddress());
             assertTrue(future.await(2000), "Connection should finish, not time out");
-            cc = future.await().isSuccess() ? future.get() : null;
+            cc = future.await().isSuccess() ? future.asJdkFuture().get() : null;
         } finally {
             closeChannel(cc);
             closeChannel(sc);
@@ -349,10 +349,10 @@ public class LocalChannelTest {
         Channel cc = null;
         try {
             // Start server
-            sc = sb.bind(TEST_ADDRESS).get();
+            sc = sb.bind(TEST_ADDRESS).asJdkFuture().get();
 
             // Connect to the server
-            cc = cb.connect(sc.localAddress()).get();
+            cc = cb.connect(sc.localAddress()).asJdkFuture().get();
 
             cc.deregister().sync();
         } finally {
@@ -396,10 +396,10 @@ public class LocalChannelTest {
         Channel cc = null;
         try {
             // Start server
-            sc = sb.bind(TEST_ADDRESS).get();
+            sc = sb.bind(TEST_ADDRESS).asJdkFuture().get();
 
             // Connect to the server
-            cc = cb.connect(sc.localAddress()).get();
+            cc = cb.connect(sc.localAddress()).asJdkFuture().get();
 
             final Channel ccCpy = cc;
             // Make sure a write operation is executed in the eventloop
@@ -468,10 +468,10 @@ public class LocalChannelTest {
         Channel cc = null;
         try {
             // Start server
-            sc = sb.bind(TEST_ADDRESS).get();
+            sc = sb.bind(TEST_ADDRESS).asJdkFuture().get();
 
             // Connect to the server
-            cc = cb.connect(sc.localAddress()).get();
+            cc = cb.connect(sc.localAddress()).asJdkFuture().get();
             assertTrue(messageLatch.await(5, SECONDS));
             assertFalse(cc.isOpen());
         } finally {
@@ -512,10 +512,10 @@ public class LocalChannelTest {
         Channel cc = null;
         try {
             // Start server
-            sc = sb.bind(TEST_ADDRESS).get();
+            sc = sb.bind(TEST_ADDRESS).asJdkFuture().get();
 
             // Connect to the server
-            cc = cb.connect(sc.localAddress()).get();
+            cc = cb.connect(sc.localAddress()).asJdkFuture().get();
 
             final Channel ccCpy = cc;
             // Make sure a write operation is executed in the eventloop
@@ -582,10 +582,10 @@ public class LocalChannelTest {
         Channel cc = null;
         try {
             // Start server
-            sc = sb.bind(TEST_ADDRESS).get();
+            sc = sb.bind(TEST_ADDRESS).asJdkFuture().get();
 
             // Connect to the server
-            cc = cb.connect(sc.localAddress()).get();
+            cc = cb.connect(sc.localAddress()).asJdkFuture().get();
             assertTrue(serverChannelLatch.await(5, SECONDS));
 
             final Channel ccCpy = cc;
@@ -655,10 +655,10 @@ public class LocalChannelTest {
         Channel cc = null;
         try {
             // Start server
-            sc = sb.bind(TEST_ADDRESS).get();
+            sc = sb.bind(TEST_ADDRESS).asJdkFuture().get();
 
             // Connect to the server
-            cc = cb.connect(sc.localAddress()).get();
+            cc = cb.connect(sc.localAddress()).asJdkFuture().get();
             assertTrue(serverChannelLatch.await(5, SECONDS));
 
             final Channel ccCpy = cc;
@@ -720,10 +720,10 @@ public class LocalChannelTest {
         Channel cc = null;
         try {
             // Start server
-            sc = sb.bind(TEST_ADDRESS).get();
+            sc = sb.bind(TEST_ADDRESS).asJdkFuture().get();
 
             // Connect to the server
-            cc = cb.connect(sc.localAddress()).get();
+            cc = cb.connect(sc.localAddress()).asJdkFuture().get();
             assertTrue(serverChannelLatch.await(5, SECONDS));
 
             final Channel ccCpy = cc;
@@ -794,9 +794,9 @@ public class LocalChannelTest {
         Channel cc = null;
         try {
             // Start server
-            sc = sb.bind(TEST_ADDRESS).get();
+            sc = sb.bind(TEST_ADDRESS).asJdkFuture().get();
 
-            cc = cb.register().get();
+            cc = cb.register().asJdkFuture().get();
 
             final AtomicReference<Future<Void>> ref = new AtomicReference<>();
             final Promise<Void> assertPromise = cc.executor().newPromise();
@@ -916,10 +916,10 @@ public class LocalChannelTest {
         LocalChannel cc = null;
         try {
             // Start server
-            sc = sb.bind(TEST_ADDRESS).get();
+            sc = sb.bind(TEST_ADDRESS).asJdkFuture().get();
 
             // Connect to the server
-            cc = (LocalChannel) cb.connect(sc.localAddress()).get();
+            cc = (LocalChannel) cb.connect(sc.localAddress()).asJdkFuture().get();
 
             // Close the channel
             closeChannel(cc);
@@ -994,8 +994,8 @@ public class LocalChannelTest {
         Channel cc = null;
         try {
             // Start server
-            sc = sb.bind(TEST_ADDRESS).get();
-            cc = cb.connect(TEST_ADDRESS).get();
+            sc = sb.bind(TEST_ADDRESS).asJdkFuture().get();
+            cc = cb.connect(TEST_ADDRESS).asJdkFuture().get();
 
             latch.await();
         } finally {
@@ -1055,8 +1055,8 @@ public class LocalChannelTest {
         Channel cc = null;
         try {
             // Start server
-            sc = sb.bind(TEST_ADDRESS).get();
-            cc = cb.connect(TEST_ADDRESS).get();
+            sc = sb.bind(TEST_ADDRESS).asJdkFuture().get();
+            cc = cb.connect(TEST_ADDRESS).asJdkFuture().get();
 
             countDownLatch.await();
         } finally {
@@ -1120,10 +1120,10 @@ public class LocalChannelTest {
         Channel cc = null;
         try {
             // Start server
-            sc = sb.bind(TEST_ADDRESS).get();
+            sc = sb.bind(TEST_ADDRESS).asJdkFuture().get();
             for (int i = 0; i < 5; i++) {
                 try {
-                    cc = cb.connect(TEST_ADDRESS).get();
+                    cc = cb.connect(TEST_ADDRESS).asJdkFuture().get();
                 } finally {
                     closeChannel(cc);
                 }

--- a/transport/src/test/java/io/netty5/channel/local/LocalChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/local/LocalChannelTest.java
@@ -155,11 +155,11 @@ public class LocalChannelTest {
             Channel cc = null;
             try {
                 // Start server
-                sc = sb.bind(TEST_ADDRESS).asJdkFuture().get();
+                sc = sb.bind(TEST_ADDRESS).asStage().get();
 
                 final CountDownLatch latch = new CountDownLatch(1);
                 // Connect to the server
-                cc = cb.connect(sc.localAddress()).asJdkFuture().get();
+                cc = cb.connect(sc.localAddress()).asStage().get();
                 final Channel ccCpy = cc;
                 cc.executor().execute(() -> {
                     // Send a message event up the pipeline.
@@ -205,10 +205,10 @@ public class LocalChannelTest {
         Channel cc = null;
         try {
             // Start server
-            sc = sb.bind(TEST_ADDRESS).asJdkFuture().get();
+            sc = sb.bind(TEST_ADDRESS).asStage().get();
 
             // Connect to the server
-            cc = cb.connect(sc.localAddress()).asJdkFuture().get();
+            cc = cb.connect(sc.localAddress()).asStage().get();
 
             // Close the channel and write something.
             cc.close().sync();
@@ -241,7 +241,7 @@ public class LocalChannelTest {
         Channel sc = null;
         Channel cc = null;
         try {
-            sc = sb.bind(TEST_ADDRESS).asJdkFuture().get();
+            sc = sb.bind(TEST_ADDRESS).asStage().get();
 
             Bootstrap b = new Bootstrap()
                     .group(group2)
@@ -252,7 +252,7 @@ public class LocalChannelTest {
                             // discard
                         }
                     });
-            cc = b.connect(sc.localAddress()).asJdkFuture().get();
+            cc = b.connect(sc.localAddress()).asStage().get();
             cc.writeAndFlush(new Object());
             assertTrue(latch.await(5, SECONDS));
         } finally {
@@ -299,15 +299,15 @@ public class LocalChannelTest {
         try {
             ServerBootstrap sb = new ServerBootstrap();
             sc = sb.group(group2).
-                    channel(LocalServerChannel.class).
-                    childHandler(new ChannelInitializer<Channel>() {
-                        @Override
-                        protected void initChannel(Channel ch) throws Exception {
-                            ch.close();
-                            closeLatch.countDown();
-                        }
-                    }).
-                    bind(TEST_ADDRESS).asJdkFuture().get();
+                   channel(LocalServerChannel.class).
+                   childHandler(new ChannelInitializer<Channel>() {
+                       @Override
+                       protected void initChannel(Channel ch) throws Exception {
+                           ch.close();
+                           closeLatch.countDown();
+                       }
+                   }).
+                   bind(TEST_ADDRESS).asStage().get();
             Bootstrap bootstrap = new Bootstrap();
             bootstrap.group(clientGroup).
                     channel(LocalChannel.class).
@@ -319,7 +319,7 @@ public class LocalChannelTest {
                     });
             Future<Channel> future = bootstrap.connect(sc.localAddress());
             assertTrue(future.await(2000), "Connection should finish, not time out");
-            cc = future.await().isSuccess() ? future.asJdkFuture().get() : null;
+            cc = future.await().isSuccess() ? future.asStage().get() : null;
         } finally {
             closeChannel(cc);
             closeChannel(sc);
@@ -349,10 +349,10 @@ public class LocalChannelTest {
         Channel cc = null;
         try {
             // Start server
-            sc = sb.bind(TEST_ADDRESS).asJdkFuture().get();
+            sc = sb.bind(TEST_ADDRESS).asStage().get();
 
             // Connect to the server
-            cc = cb.connect(sc.localAddress()).asJdkFuture().get();
+            cc = cb.connect(sc.localAddress()).asStage().get();
 
             cc.deregister().sync();
         } finally {
@@ -396,10 +396,10 @@ public class LocalChannelTest {
         Channel cc = null;
         try {
             // Start server
-            sc = sb.bind(TEST_ADDRESS).asJdkFuture().get();
+            sc = sb.bind(TEST_ADDRESS).asStage().get();
 
             // Connect to the server
-            cc = cb.connect(sc.localAddress()).asJdkFuture().get();
+            cc = cb.connect(sc.localAddress()).asStage().get();
 
             final Channel ccCpy = cc;
             // Make sure a write operation is executed in the eventloop
@@ -468,10 +468,10 @@ public class LocalChannelTest {
         Channel cc = null;
         try {
             // Start server
-            sc = sb.bind(TEST_ADDRESS).asJdkFuture().get();
+            sc = sb.bind(TEST_ADDRESS).asStage().get();
 
             // Connect to the server
-            cc = cb.connect(sc.localAddress()).asJdkFuture().get();
+            cc = cb.connect(sc.localAddress()).asStage().get();
             assertTrue(messageLatch.await(5, SECONDS));
             assertFalse(cc.isOpen());
         } finally {
@@ -512,10 +512,10 @@ public class LocalChannelTest {
         Channel cc = null;
         try {
             // Start server
-            sc = sb.bind(TEST_ADDRESS).asJdkFuture().get();
+            sc = sb.bind(TEST_ADDRESS).asStage().get();
 
             // Connect to the server
-            cc = cb.connect(sc.localAddress()).asJdkFuture().get();
+            cc = cb.connect(sc.localAddress()).asStage().get();
 
             final Channel ccCpy = cc;
             // Make sure a write operation is executed in the eventloop
@@ -582,10 +582,10 @@ public class LocalChannelTest {
         Channel cc = null;
         try {
             // Start server
-            sc = sb.bind(TEST_ADDRESS).asJdkFuture().get();
+            sc = sb.bind(TEST_ADDRESS).asStage().get();
 
             // Connect to the server
-            cc = cb.connect(sc.localAddress()).asJdkFuture().get();
+            cc = cb.connect(sc.localAddress()).asStage().get();
             assertTrue(serverChannelLatch.await(5, SECONDS));
 
             final Channel ccCpy = cc;
@@ -655,10 +655,10 @@ public class LocalChannelTest {
         Channel cc = null;
         try {
             // Start server
-            sc = sb.bind(TEST_ADDRESS).asJdkFuture().get();
+            sc = sb.bind(TEST_ADDRESS).asStage().get();
 
             // Connect to the server
-            cc = cb.connect(sc.localAddress()).asJdkFuture().get();
+            cc = cb.connect(sc.localAddress()).asStage().get();
             assertTrue(serverChannelLatch.await(5, SECONDS));
 
             final Channel ccCpy = cc;
@@ -720,10 +720,10 @@ public class LocalChannelTest {
         Channel cc = null;
         try {
             // Start server
-            sc = sb.bind(TEST_ADDRESS).asJdkFuture().get();
+            sc = sb.bind(TEST_ADDRESS).asStage().get();
 
             // Connect to the server
-            cc = cb.connect(sc.localAddress()).asJdkFuture().get();
+            cc = cb.connect(sc.localAddress()).asStage().get();
             assertTrue(serverChannelLatch.await(5, SECONDS));
 
             final Channel ccCpy = cc;
@@ -794,9 +794,9 @@ public class LocalChannelTest {
         Channel cc = null;
         try {
             // Start server
-            sc = sb.bind(TEST_ADDRESS).asJdkFuture().get();
+            sc = sb.bind(TEST_ADDRESS).asStage().get();
 
-            cc = cb.register().asJdkFuture().get();
+            cc = cb.register().asStage().get();
 
             final AtomicReference<Future<Void>> ref = new AtomicReference<>();
             final Promise<Void> assertPromise = cc.executor().newPromise();
@@ -916,10 +916,10 @@ public class LocalChannelTest {
         LocalChannel cc = null;
         try {
             // Start server
-            sc = sb.bind(TEST_ADDRESS).asJdkFuture().get();
+            sc = sb.bind(TEST_ADDRESS).asStage().get();
 
             // Connect to the server
-            cc = (LocalChannel) cb.connect(sc.localAddress()).asJdkFuture().get();
+            cc = (LocalChannel) cb.connect(sc.localAddress()).asStage().get();
 
             // Close the channel
             closeChannel(cc);
@@ -994,8 +994,8 @@ public class LocalChannelTest {
         Channel cc = null;
         try {
             // Start server
-            sc = sb.bind(TEST_ADDRESS).asJdkFuture().get();
-            cc = cb.connect(TEST_ADDRESS).asJdkFuture().get();
+            sc = sb.bind(TEST_ADDRESS).asStage().get();
+            cc = cb.connect(TEST_ADDRESS).asStage().get();
 
             latch.await();
         } finally {
@@ -1055,8 +1055,8 @@ public class LocalChannelTest {
         Channel cc = null;
         try {
             // Start server
-            sc = sb.bind(TEST_ADDRESS).asJdkFuture().get();
-            cc = cb.connect(TEST_ADDRESS).asJdkFuture().get();
+            sc = sb.bind(TEST_ADDRESS).asStage().get();
+            cc = cb.connect(TEST_ADDRESS).asStage().get();
 
             countDownLatch.await();
         } finally {
@@ -1120,10 +1120,10 @@ public class LocalChannelTest {
         Channel cc = null;
         try {
             // Start server
-            sc = sb.bind(TEST_ADDRESS).asJdkFuture().get();
+            sc = sb.bind(TEST_ADDRESS).asStage().get();
             for (int i = 0; i < 5; i++) {
                 try {
-                    cc = cb.connect(TEST_ADDRESS).asJdkFuture().get();
+                    cc = cb.connect(TEST_ADDRESS).asStage().get();
                 } finally {
                     closeChannel(cc);
                 }

--- a/transport/src/test/java/io/netty5/channel/local/LocalChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/local/LocalChannelTest.java
@@ -318,7 +318,7 @@ public class LocalChannelTest {
                         }
                     });
             Future<Channel> future = bootstrap.connect(sc.localAddress());
-            assertTrue(future.await(2000), "Connection should finish, not time out");
+            assertTrue(future.await(2000, TimeUnit.MILLISECONDS), "Connection should finish, not time out");
             cc = future.await().isSuccess() ? future.asStage().get() : null;
         } finally {
             closeChannel(cc);

--- a/transport/src/test/java/io/netty5/channel/local/LocalTransportThreadModelTest2.java
+++ b/transport/src/test/java/io/netty5/channel/local/LocalTransportThreadModelTest2.java
@@ -59,7 +59,7 @@ public class LocalTransportThreadModelTest2 {
 
         int count = 100;
         for (int i = 1; i < count + 1; i ++) {
-            Channel ch = clientBootstrap.connect().get();
+            Channel ch = clientBootstrap.connect().asJdkFuture().get();
 
             // SPIN until we get what we are looking for.
             int target = i * messageCountPerRun;

--- a/transport/src/test/java/io/netty5/channel/local/LocalTransportThreadModelTest2.java
+++ b/transport/src/test/java/io/netty5/channel/local/LocalTransportThreadModelTest2.java
@@ -59,7 +59,7 @@ public class LocalTransportThreadModelTest2 {
 
         int count = 100;
         for (int i = 1; i < count + 1; i ++) {
-            Channel ch = clientBootstrap.connect().asJdkFuture().get();
+            Channel ch = clientBootstrap.connect().asStage().get();
 
             // SPIN until we get what we are looking for.
             int target = i * messageCountPerRun;

--- a/transport/src/test/java/io/netty5/channel/nio/NioEventLoopTest.java
+++ b/transport/src/test/java/io/netty5/channel/nio/NioEventLoopTest.java
@@ -97,7 +97,7 @@ public class NioEventLoopTest extends AbstractEventLoopTest {
             // NOOP
         }, Long.MAX_VALUE, TimeUnit.MILLISECONDS);
 
-        assertFalse(future.await(1000));
+        assertFalse(future.await(1000, TimeUnit.MILLISECONDS));
         assertTrue(future.cancel());
         group.shutdownGracefully();
     }

--- a/transport/src/test/java/io/netty5/channel/socket/nio/NioDatagramChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/socket/nio/NioDatagramChannelTest.java
@@ -57,7 +57,7 @@ public class NioDatagramChannelTest extends AbstractNioChannelTest<NioDatagramCh
                             }
                         });
                 DatagramChannel datagramChannel = (DatagramChannel) udpBootstrap
-                        .bind(new InetSocketAddress(0)).get();
+                        .bind(new InetSocketAddress(0)).asJdkFuture().get();
                 channelGroup.add(datagramChannel);
             }
             assertEquals(100, channelGroup.size());

--- a/transport/src/test/java/io/netty5/channel/socket/nio/NioDatagramChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/socket/nio/NioDatagramChannelTest.java
@@ -57,7 +57,7 @@ public class NioDatagramChannelTest extends AbstractNioChannelTest<NioDatagramCh
                             }
                         });
                 DatagramChannel datagramChannel = (DatagramChannel) udpBootstrap
-                        .bind(new InetSocketAddress(0)).asJdkFuture().get();
+                        .bind(new InetSocketAddress(0)).asStage().get();
                 channelGroup.add(datagramChannel);
             }
             assertEquals(100, channelGroup.size());

--- a/transport/src/test/java/io/netty5/channel/socket/nio/NioSocketChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/socket/nio/NioSocketChannelTest.java
@@ -94,7 +94,7 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
                 }
             });
 
-            SocketAddress address = sb.bind(0).asJdkFuture().get().localAddress();
+            SocketAddress address = sb.bind(0).asStage().get().localAddress();
 
             Socket s = new Socket(NetUtil.LOCALHOST, ((InetSocketAddress) address).getPort());
 
@@ -145,7 +145,7 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
                 }
             });
 
-            SocketAddress address = sb.bind(0).asJdkFuture().get().localAddress();
+            SocketAddress address = sb.bind(0).asStage().get().localAddress();
 
             Socket s = new Socket(NetUtil.LOCALHOST, ((InetSocketAddress) address).getPort());
 
@@ -206,12 +206,12 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
                  }
              });
 
-            sc = b.bind(0).asJdkFuture().get();
+            sc = b.bind(0).asStage().get();
 
             Bootstrap bootstrap = new Bootstrap();
             bootstrap.group(group).channel(NioSocketChannel.class);
             bootstrap.handler(new ChannelHandler() { });
-            cc = bootstrap.connect(sc.localAddress()).asJdkFuture().get();
+            cc = bootstrap.connect(sc.localAddress()).asStage().get();
             cc.writeAndFlush(onHeapAllocator().copyOf(bytes)).sync();
             latch.await();
         } finally {
@@ -237,7 +237,7 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
             sb.group(group).channel(NioSocketChannel.class);
             sb.handler(new ChannelHandler() { });
 
-            SocketChannel channel = (SocketChannel) sb.connect(socket.getLocalSocketAddress()).asJdkFuture().get();
+            SocketChannel channel = (SocketChannel) sb.connect(socket.getLocalSocketAddress()).asStage().get();
 
             accepted = socket.accept();
             channel.shutdown(ChannelShutdownDirection.Outbound).sync();

--- a/transport/src/test/java/io/netty5/channel/socket/nio/NioSocketChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/socket/nio/NioSocketChannelTest.java
@@ -94,7 +94,7 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
                 }
             });
 
-            SocketAddress address = sb.bind(0).get().localAddress();
+            SocketAddress address = sb.bind(0).asJdkFuture().get().localAddress();
 
             Socket s = new Socket(NetUtil.LOCALHOST, ((InetSocketAddress) address).getPort());
 
@@ -145,7 +145,7 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
                 }
             });
 
-            SocketAddress address = sb.bind(0).get().localAddress();
+            SocketAddress address = sb.bind(0).asJdkFuture().get().localAddress();
 
             Socket s = new Socket(NetUtil.LOCALHOST, ((InetSocketAddress) address).getPort());
 
@@ -206,12 +206,12 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
                  }
              });
 
-            sc = b.bind(0).get();
+            sc = b.bind(0).asJdkFuture().get();
 
             Bootstrap bootstrap = new Bootstrap();
             bootstrap.group(group).channel(NioSocketChannel.class);
             bootstrap.handler(new ChannelHandler() { });
-            cc = bootstrap.connect(sc.localAddress()).get();
+            cc = bootstrap.connect(sc.localAddress()).asJdkFuture().get();
             cc.writeAndFlush(onHeapAllocator().copyOf(bytes)).sync();
             latch.await();
         } finally {
@@ -237,7 +237,7 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
             sb.group(group).channel(NioSocketChannel.class);
             sb.handler(new ChannelHandler() { });
 
-            SocketChannel channel = (SocketChannel) sb.connect(socket.getLocalSocketAddress()).get();
+            SocketChannel channel = (SocketChannel) sb.connect(socket.getLocalSocketAddress()).asJdkFuture().get();
 
             accepted = socket.accept();
             channel.shutdown(ChannelShutdownDirection.Outbound).sync();


### PR DESCRIPTION
Motivation:
Blocking methods should not be called in the event loop, yet we still need to have them available outside of the event loop.
We can now hide them on the FutureCompletableStage interface, since converting a Future to an instance of FutureCompletableStage has been made effectively free.

Modification:
Move the blocking get methods to FutureCompletableStage, and remove them from Future.
Also remove the toJdkFuture method, and make FutureCompletableStage extend the JDK Future interface, making it very similar to the CompletableFuture from the JDK, except it's an interface rather than a class.

Result:
Fewer blocking methods on our Future interface.