### PR TITLE
fix instant RST/FIN after SYN/SYN-ACK/ACK

### DIFF
--- a/example/src/main/java/io/netty/example/proxy/HexDumpProxyBackendHandler.java
+++ b/example/src/main/java/io/netty/example/proxy/HexDumpProxyBackendHandler.java
@@ -31,7 +31,11 @@ public class HexDumpProxyBackendHandler extends ChannelInboundHandlerAdapter {
 
     @Override
     public void channelActive(ChannelHandlerContext ctx) {
-        ctx.read();
+        if (!inboundChannel.isActive()) {
+            HexDumpProxyFrontendHandler.closeOnFlush(ctx.channel());
+        } else {
+            ctx.read();
+        }
     }
 
     @Override


### PR DESCRIPTION
Motivation:

If you close the connection before the backend connects, the backend will keep connected until timeout. If you add logging, you will have sth like that:
```
12:57:57.398 ProxyFrontendHandler channelActive
12:57:57.405 ProxyFrontendHandler channelInactive
12:57:57.431 ProxyBackendHandler channelActive
```
Ping between backend and frontend was about 50 ms, and the time difference between connecting and disconnecting was about 1 ms.
Example code in Java to test frontend/backend:
```
        while (true) {
            System.out.println("tick");
            try {
                Socket socket = new Socket();
                socket.connect(new InetSocketAddress("127.0.0.1", 8443), 3000);
                socket.close();
                Thread.sleep(100);
            } catch (IOException ex) {
                ex.printStackTrace();
            }
        }
```

PS. Why ChannelFuture from `new Bootstrap().connect` is not cancellable? In epoll you can simply close FD.

Modification:

Close backend connection if inbound is not active.
