### PR TITLE
Add BufferAllocatorMetric#pinnedMemory

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/pool/BufferAllocatorMetric.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/pool/BufferAllocatorMetric.java
@@ -55,4 +55,10 @@ public interface BufferAllocatorMetric {
      * Returns the number of bytes of heap memory used by a {@link BufferAllocator} or {@code -1} if unknown.
      */
     long usedMemory();
+
+    /**
+     * Returns the number of bytes of memory that is currently pinned to the buffers allocated by a
+     * {@link BufferAllocator}, or {@code -1} if unknown.
+     */
+    long pinnedMemory();
 }

--- a/buffer/src/main/java/io/netty5/buffer/api/pool/PoolArena.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/pool/PoolArena.java
@@ -389,6 +389,19 @@ class PoolArena extends SizeClasses implements PoolArenaMetric {
         return max(0, val);
     }
 
+    @Override
+    public long numPinnedBytes() {
+        long val = activeBytesHuge.longValue();
+        synchronized (this) {
+            for (int i = 0; i < chunkListMetrics.size(); i++) {
+                for (PoolChunkMetric m: chunkListMetrics.get(i)) {
+                    val += m.pinnedBytes();
+                }
+            }
+        }
+        return max(0, val);
+    }
+
     protected final PoolChunk newChunk(int pageSize, int maxPageIdx, int pageShifts, int chunkSize) {
         return new PoolChunk(this, pageSize, pageShifts, chunkSize, maxPageIdx);
     }

--- a/buffer/src/main/java/io/netty5/buffer/api/pool/PoolArenaMetric.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/pool/PoolArenaMetric.java
@@ -111,4 +111,9 @@ public interface PoolArenaMetric extends SizeClassesMetric {
      * Return the number of active bytes that are currently allocated by the arena.
      */
     long numActiveBytes();
+
+    /**
+     * Return the number of bytes that are currently pinned to buffer instances, by the arena.
+     */
+    long numPinnedBytes();
 }

--- a/buffer/src/main/java/io/netty5/buffer/api/pool/PoolChunkMetric.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/pool/PoolChunkMetric.java
@@ -34,4 +34,9 @@ public interface PoolChunkMetric {
      * Return the number of free bytes in the chunk.
      */
     int freeBytes();
+
+    /**
+     * Return the number of pinned bytes in the chunk.
+     */
+    int pinnedBytes();
 }

--- a/buffer/src/main/java/io/netty5/buffer/api/pool/PooledBufferAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/pool/PooledBufferAllocator.java
@@ -558,6 +558,24 @@ public class PooledBufferAllocator implements BufferAllocator, BufferAllocatorMe
         return used;
     }
 
+    final long pinnedMemory() {
+        return pinnedMemory(arenas);
+    }
+
+    private static long pinnedMemory(PoolArena[] arenas) {
+        if (arenas == null) {
+            return -1;
+        }
+        long used = 0;
+        for (PoolArena arena : arenas) {
+            used += arena.numPinnedBytes();
+            if (used < 0) {
+                return Long.MAX_VALUE;
+            }
+        }
+        return used;
+    }
+
     final PoolThreadCache threadCache() {
         PoolThreadCache cache =  threadCache.get();
         assert cache != null;

--- a/buffer/src/main/java/io/netty5/buffer/api/pool/PooledBufferAllocatorMetric.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/pool/PooledBufferAllocatorMetric.java
@@ -66,10 +66,16 @@ final class PooledBufferAllocatorMetric implements BufferAllocatorMetric {
     }
 
     @Override
+    public long pinnedMemory() {
+        return allocator.pinnedMemory();
+    }
+
+    @Override
     public String toString() {
         StringBuilder sb = new StringBuilder(256);
         sb.append(StringUtil.simpleClassName(this))
                 .append("(usedMemory: ").append(usedMemory())
+                .append("; pinnedMemory: ").append(pinnedMemory())
                 .append("; numArenas: ").append(numArenas())
                 .append("; smallCacheSize: ").append(smallCacheSize())
                 .append("; normalCacheSize: ").append(normalCacheSize())

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferAllocatorMetricTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferAllocatorMetricTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.buffer.api.tests;
+
+import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.api.BufferAllocator;
+import io.netty5.buffer.api.pool.BufferAllocatorMetric;
+import io.netty5.buffer.api.pool.PooledBufferAllocator;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BufferAllocatorMetricTest extends BufferTestSupport {
+
+    @ParameterizedTest
+    @MethodSource("pooledAllocators")
+    void testUsedMemory(Fixture fixture) {
+        for (int power = 0; power < 8; power++) {
+            int initialCapacity = 1024 << power;
+            testUsedMemory(fixture, initialCapacity);
+        }
+    }
+
+    private static void testUsedMemory(Fixture fixture, int initialCapacity) {
+        try (BufferAllocator allocator = fixture.createAllocator()) {
+            if (allocator instanceof PooledBufferAllocator) {
+                PooledBufferAllocator pooledBufferAllocator = (PooledBufferAllocator) allocator;
+                BufferAllocatorMetric metric = pooledBufferAllocator.metric();
+                assertEquals(0, metric.usedMemory());
+                assertEquals(0, metric.pinnedMemory());
+                try (Buffer buffer = allocator.allocate(initialCapacity)) {
+                    int capacity = buffer.capacity();
+                    assertThat(metric.usedMemory()).isEqualTo(metric.chunkSize());
+                    assertThat(metric.pinnedMemory())
+                            .isGreaterThanOrEqualTo(capacity)
+                            .isLessThanOrEqualTo(metric.usedMemory());
+
+                    buffer.ensureWritable(capacity << 1);
+                    capacity = buffer.capacity();
+                    assertThat(metric.usedMemory()).isEqualTo(metric.chunkSize());
+                    assertThat(metric.pinnedMemory())
+                            .isGreaterThanOrEqualTo(capacity)
+                            .isLessThanOrEqualTo(metric.usedMemory());
+                }
+
+                assertThat(metric.usedMemory()).isEqualTo(metric.chunkSize());
+                assertThat(metric.pinnedMemory())
+                        .isGreaterThanOrEqualTo(0)
+                        .isLessThanOrEqualTo(metric.usedMemory());
+                pooledBufferAllocator.trimCurrentThreadCache();
+                assertEquals(0, metric.pinnedMemory());
+
+                int[] capacities = new int[30];
+                Random rng = new Random();
+                for (int i = 0; i < capacities.length; i++) {
+                    capacities[i] = initialCapacity / 4 + rng.nextInt(8 * initialCapacity);
+                }
+                Buffer[] buffers = new Buffer[capacities.length];
+                for (int i = 0; i < 20; i++) {
+                    buffers[i] = allocator.allocate(capacities[i]);
+                }
+                for (int i = 0; i < 10; i++) {
+                    buffers[i].close();
+                }
+                for (int i = 20; i < 30; i++) {
+                    buffers[i] = allocator.allocate(capacities[i]);
+                }
+                for (int i = 0; i < 10; i++) {
+                    buffers[i] = allocator.allocate(capacities[i]);
+                }
+                for (int i = 0; i < 30; i++) {
+                    buffers[i].close();
+                }
+                pooledBufferAllocator.trimCurrentThreadCache();
+                assertEquals(0, metric.pinnedMemory());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Motivation:
The `used memory` is the amount of memory that a pooled allocator has currently allocated and committed for itself.
The `pinned memory` is the memory currently in use by buffers in circulation.
This is porting PR #11667 from `4.1` to `main`.

Modification:
- Add pinned memory accounting to `PoolChunk`.
- Add junit test

Result:
It is now possible to obtain the memory currently in use by buffers in circulation.
