### PR TITLE
Add ProtocolEvent and let SSL and websockets event implement it

### DIFF
--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientHandshakeCompletionEvent.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientHandshakeCompletionEvent.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.handler.codec.http.websocketx;
+
+public final class WebSocketClientHandshakeCompletionEvent
+        extends WebSocketHandshakeCompletionEvent<WebSocketVersion> {
+    public WebSocketClientHandshakeCompletionEvent(WebSocketVersion version) {
+        super(version);
+    }
+
+    public WebSocketClientHandshakeCompletionEvent(Throwable cause) {
+        super(cause);
+    }
+}
+

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientHandshakeCompletionEvent.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientHandshakeCompletionEvent.java
@@ -15,8 +15,12 @@
  */
 package io.netty5.handler.codec.http.websocketx;
 
+/**
+ * A websocket handshake was completed on the client-side.
+ */
 public final class WebSocketClientHandshakeCompletionEvent
-        extends WebSocketHandshakeCompletionEvent<WebSocketVersion> {
+        extends WebSocketHandshakeCompletionEvent {
+
     public WebSocketClientHandshakeCompletionEvent(WebSocketVersion version) {
         super(version);
     }

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientHandshakeCompletionEvent.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientHandshakeCompletionEvent.java
@@ -21,10 +21,20 @@ package io.netty5.handler.codec.http.websocketx;
 public final class WebSocketClientHandshakeCompletionEvent
         extends WebSocketHandshakeCompletionEvent {
 
+    /**
+     * Create a new event that indicate a successful websocket handshake.
+     *
+     * @param version   the {@link WebSocketVersion} that was used.
+     */
     public WebSocketClientHandshakeCompletionEvent(WebSocketVersion version) {
         super(version);
     }
 
+    /**
+     * Create a new event that indicate a failed websocket handshake.
+     *
+     * @param cause the cause of the failure.
+     */
     public WebSocketClientHandshakeCompletionEvent(Throwable cause) {
         super(cause);
     }

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientProtocolConfig.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientProtocolConfig.java
@@ -17,7 +17,6 @@ package io.netty5.handler.codec.http.websocketx;
 
 import io.netty5.handler.codec.http.EmptyHttpHeaders;
 import io.netty5.handler.codec.http.HttpHeaders;
-import io.netty5.handler.ssl.SslHandshakeCompletionEvent;
 
 import java.net.URI;
 import java.util.Objects;
@@ -343,8 +342,8 @@ public final class WebSocketClientProtocolConfig {
         }
 
         /**
-         * Handshake timeout in millis, when handshake timeout, will trigger channel
-         * event {@link SslHandshakeCompletionEvent} with a {@link WebSocketHandshakeException}.
+         * Handshake timeout in millis, when handshake timeout, will trigger and inbound channel
+         * event {@link WebSocketClientHandshakeCompletionEvent} with a {@link WebSocketHandshakeException}.
          */
         public Builder handshakeTimeoutMillis(long handshakeTimeoutMillis) {
             this.handshakeTimeoutMillis = handshakeTimeoutMillis;

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientProtocolConfig.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientProtocolConfig.java
@@ -342,7 +342,7 @@ public final class WebSocketClientProtocolConfig {
         }
 
         /**
-         * Handshake timeout in millis, when handshake timeout, will trigger and inbound channel
+         * Handshake timeout in millis, when handshake timeout, will trigger an inbound channel
          * event {@link WebSocketClientHandshakeCompletionEvent} with a {@link WebSocketHandshakeException}.
          */
         public Builder handshakeTimeoutMillis(long handshakeTimeoutMillis) {

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientProtocolConfig.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientProtocolConfig.java
@@ -344,7 +344,7 @@ public final class WebSocketClientProtocolConfig {
 
         /**
          * Handshake timeout in millis, when handshake timeout, will trigger channel
-         * event {@link SslHandshakeCompletionEvent} with an {@link WebSocketHandshakeException}.
+         * event {@link SslHandshakeCompletionEvent} with a {@link WebSocketHandshakeException}.
          */
         public Builder handshakeTimeoutMillis(long handshakeTimeoutMillis) {
             this.handshakeTimeoutMillis = handshakeTimeoutMillis;

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientProtocolConfig.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientProtocolConfig.java
@@ -17,7 +17,7 @@ package io.netty5.handler.codec.http.websocketx;
 
 import io.netty5.handler.codec.http.EmptyHttpHeaders;
 import io.netty5.handler.codec.http.HttpHeaders;
-import io.netty5.handler.codec.http.websocketx.WebSocketClientProtocolHandler.ClientHandshakeStateEvent;
+import io.netty5.handler.ssl.SslHandshakeCompletionEvent;
 
 import java.net.URI;
 import java.util.Objects;
@@ -343,8 +343,8 @@ public final class WebSocketClientProtocolConfig {
         }
 
         /**
-         * Handshake timeout in mills, when handshake timeout, will trigger user
-         * event {@link ClientHandshakeStateEvent#HANDSHAKE_TIMEOUT}
+         * Handshake timeout in millis, when handshake timeout, will trigger channel
+         * event {@link SslHandshakeCompletionEvent} with an {@link WebSocketHandshakeException}.
          */
         public Builder handshakeTimeoutMillis(long handshakeTimeoutMillis) {
             this.handshakeTimeoutMillis = handshakeTimeoutMillis;

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientProtocolHandler.java
@@ -19,7 +19,6 @@ import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
 import io.netty5.handler.codec.http.HttpHeaders;
-import io.netty5.handler.ssl.SslHandshakeCompletionEvent;
 import io.netty5.util.Resource;
 
 import java.net.URI;
@@ -136,8 +135,9 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
      *            When set to true, frames which are not masked properly according to the standard will still be
      *            accepted.
      * @param handshakeTimeoutMillis
-     *            Handshake timeout in mills, when handshake timeout, will trigger channel
-     *           event {@link SslHandshakeCompletionEvent} with a {@link WebSocketHandshakeTimeoutException}.
+     *            Handshake timeout in mills, when handshake timeout, will trigger an inbound channel
+     *            event {@link WebSocketClientHandshakeCompletionEvent} with a
+     *            {@link WebSocketHandshakeTimeoutException}.
      */
     public WebSocketClientProtocolHandler(URI webSocketURL, WebSocketVersion version, String subprotocol,
                                           boolean allowExtensions, HttpHeaders customHeaders,
@@ -190,8 +190,9 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
      * @param handleCloseFrames
      *            {@code true} if close frames should not be forwarded and just close the channel
      * @param handshakeTimeoutMillis
-     *            Handshake timeout in millis, when handshake timeout, will trigger channel
-     *            event {@link SslHandshakeCompletionEvent} with a {@link WebSocketHandshakeException}.
+     *            Handshake timeout in mills, when handshake timeout, will trigger an inbound channel
+     *            event {@link WebSocketClientHandshakeCompletionEvent} with a
+     *            {@link WebSocketHandshakeTimeoutException}.
      */
     public WebSocketClientProtocolHandler(URI webSocketURL, WebSocketVersion version, String subprotocol,
                                           boolean allowExtensions, HttpHeaders customHeaders, int maxFramePayloadLength,
@@ -237,8 +238,9 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
      * @param maxFramePayloadLength
      *            Maximum length of a frame's payload
      * @param handshakeTimeoutMillis
-     *            Handshake timeout in millis, when handshake timeout, will trigger channel
-     *            event {@link SslHandshakeCompletionEvent} with a {@link WebSocketHandshakeException}.
+     *            Handshake timeout in mills, when handshake timeout, will trigger an inbound channel
+     *            event {@link WebSocketClientHandshakeCompletionEvent} with a
+     *            {@link WebSocketHandshakeTimeoutException}.
      */
     public WebSocketClientProtocolHandler(URI webSocketURL, WebSocketVersion version, String subprotocol,
                                           boolean allowExtensions, HttpHeaders customHeaders,
@@ -269,8 +271,9 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
      * @param handleCloseFrames
      *            {@code true} if close frames should not be forwarded and just close the channel
      * @param handshakeTimeoutMillis
-     *            Handshake timeout in millis, when handshake timeout, will trigger channel
-     *            event {@link SslHandshakeCompletionEvent} with a {@link WebSocketHandshakeException}.
+     *            Handshake timeout in mills, when handshake timeout, will trigger an inbound channel
+     *            event {@link WebSocketClientHandshakeCompletionEvent} with a
+     *            {@link WebSocketHandshakeTimeoutException}.
      */
     public WebSocketClientProtocolHandler(WebSocketClientHandshaker handshaker, boolean handleCloseFrames,
                                           long handshakeTimeoutMillis) {
@@ -304,8 +307,9 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
      * @param dropPongFrames
      *            {@code true} if pong frames should not be forwarded
      * @param handshakeTimeoutMillis
-     *            Handshake timeout in millis, when handshake timeout, will trigger channel
-     *            event {@link SslHandshakeCompletionEvent} with a {@link WebSocketHandshakeException}.
+     *            Handshake timeout in mills, when handshake timeout, will trigger an inbound channel
+     *            event {@link WebSocketClientHandshakeCompletionEvent} with a
+     *            {@link WebSocketHandshakeTimeoutException}.
      */
     public WebSocketClientProtocolHandler(WebSocketClientHandshaker handshaker, boolean handleCloseFrames,
                                           boolean dropPongFrames, long handshakeTimeoutMillis) {
@@ -335,8 +339,9 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
      *            The {@link WebSocketClientHandshaker} which will be used to issue the handshake once the connection
      *            was established to the remote peer.
      * @param handshakeTimeoutMillis
-     *            Handshake timeout in millis, when handshake timeout, will trigger channel
-     *            event {@link SslHandshakeCompletionEvent} with a {@link WebSocketHandshakeException}.
+     *            Handshake timeout in mills, when handshake timeout, will trigger an inbound channel
+     *            event {@link WebSocketClientHandshakeCompletionEvent} with a
+     *            {@link WebSocketHandshakeTimeoutException}.
      */
     public WebSocketClientProtocolHandler(WebSocketClientHandshaker handshaker, long handshakeTimeoutMillis) {
         this(handshaker, DEFAULT_HANDLE_CLOSE_FRAMES, handshakeTimeoutMillis);

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientProtocolHandler.java
@@ -19,6 +19,7 @@ import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
 import io.netty5.handler.codec.http.HttpHeaders;
+import io.netty5.handler.ssl.SslHandshakeCompletionEvent;
 import io.netty5.util.Resource;
 
 import java.net.URI;
@@ -42,7 +43,7 @@ import static io.netty5.handler.codec.http.websocketx.WebSocketServerProtocolCon
  *
  * To know once a handshake was done you can intercept the
  * {@link ChannelHandler#channelInboundEvent(ChannelHandlerContext, Object)} and check if the event was of type
- * {@link ClientHandshakeStateEvent#HANDSHAKE_ISSUED} or {@link ClientHandshakeStateEvent#HANDSHAKE_COMPLETE}.
+ * {@link WebSocketHandshakeCompletionEvent}.
  */
 public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
     private final WebSocketClientHandshaker handshaker;
@@ -53,26 +54,6 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
      */
     public WebSocketClientHandshaker handshaker() {
         return handshaker;
-    }
-
-    /**
-     * Events that are fired to notify about handshake status
-     */
-    public enum ClientHandshakeStateEvent {
-        /**
-         * The Handshake was timed out
-         */
-        HANDSHAKE_TIMEOUT,
-
-        /**
-         * The Handshake was started but the server did not response yet to the request
-         */
-        HANDSHAKE_ISSUED,
-
-        /**
-         * The Handshake was complete succesful and so the channel was upgraded to websockets
-         */
-        HANDSHAKE_COMPLETE
     }
 
     /**
@@ -155,8 +136,8 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
      *            When set to true, frames which are not masked properly according to the standard will still be
      *            accepted.
      * @param handshakeTimeoutMillis
-     *            Handshake timeout in mills, when handshake timeout, will trigger user
-     *            event {@link ClientHandshakeStateEvent#HANDSHAKE_TIMEOUT}
+     *            Handshake timeout in mills, when handshake timeout, will trigger channel
+     *           event {@link SslHandshakeCompletionEvent} with an {@link WebSocketHandshakeTimeoutException}.
      */
     public WebSocketClientProtocolHandler(URI webSocketURL, WebSocketVersion version, String subprotocol,
                                           boolean allowExtensions, HttpHeaders customHeaders,
@@ -209,8 +190,8 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
      * @param handleCloseFrames
      *            {@code true} if close frames should not be forwarded and just close the channel
      * @param handshakeTimeoutMillis
-     *            Handshake timeout in mills, when handshake timeout, will trigger user
-     *            event {@link ClientHandshakeStateEvent#HANDSHAKE_TIMEOUT}
+     *            Handshake timeout in millis, when handshake timeout, will trigger channel
+     *            event {@link SslHandshakeCompletionEvent} with an {@link WebSocketHandshakeException}.
      */
     public WebSocketClientProtocolHandler(URI webSocketURL, WebSocketVersion version, String subprotocol,
                                           boolean allowExtensions, HttpHeaders customHeaders, int maxFramePayloadLength,
@@ -256,8 +237,8 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
      * @param maxFramePayloadLength
      *            Maximum length of a frame's payload
      * @param handshakeTimeoutMillis
-     *            Handshake timeout in mills, when handshake timeout, will trigger user
-     *            event {@link ClientHandshakeStateEvent#HANDSHAKE_TIMEOUT}
+     *            Handshake timeout in millis, when handshake timeout, will trigger channel
+     *            event {@link SslHandshakeCompletionEvent} with an {@link WebSocketHandshakeException}.
      */
     public WebSocketClientProtocolHandler(URI webSocketURL, WebSocketVersion version, String subprotocol,
                                           boolean allowExtensions, HttpHeaders customHeaders,
@@ -288,8 +269,8 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
      * @param handleCloseFrames
      *            {@code true} if close frames should not be forwarded and just close the channel
      * @param handshakeTimeoutMillis
-     *            Handshake timeout in mills, when handshake timeout, will trigger user
-     *            event {@link ClientHandshakeStateEvent#HANDSHAKE_TIMEOUT}
+     *            Handshake timeout in millis, when handshake timeout, will trigger channel
+     *            event {@link SslHandshakeCompletionEvent} with an {@link WebSocketHandshakeException}.
      */
     public WebSocketClientProtocolHandler(WebSocketClientHandshaker handshaker, boolean handleCloseFrames,
                                           long handshakeTimeoutMillis) {
@@ -323,8 +304,8 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
      * @param dropPongFrames
      *            {@code true} if pong frames should not be forwarded
      * @param handshakeTimeoutMillis
-     *            Handshake timeout in mills, when handshake timeout, will trigger user
-     *            event {@link ClientHandshakeStateEvent#HANDSHAKE_TIMEOUT}
+     *            Handshake timeout in millis, when handshake timeout, will trigger channel
+     *            event {@link SslHandshakeCompletionEvent} with an {@link WebSocketHandshakeException}.
      */
     public WebSocketClientProtocolHandler(WebSocketClientHandshaker handshaker, boolean handleCloseFrames,
                                           boolean dropPongFrames, long handshakeTimeoutMillis) {
@@ -354,8 +335,8 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
      *            The {@link WebSocketClientHandshaker} which will be used to issue the handshake once the connection
      *            was established to the remote peer.
      * @param handshakeTimeoutMillis
-     *            Handshake timeout in mills, when handshake timeout, will trigger user
-     *            event {@link ClientHandshakeStateEvent#HANDSHAKE_TIMEOUT}
+     *            Handshake timeout in millis, when handshake timeout, will trigger channel
+     *            event {@link SslHandshakeCompletionEvent} with an {@link WebSocketHandshakeException}.
      */
     public WebSocketClientProtocolHandler(WebSocketClientHandshaker handshaker, long handshakeTimeoutMillis) {
         this(handshaker, DEFAULT_HANDLE_CLOSE_FRAMES, handshakeTimeoutMillis);

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientProtocolHandler.java
@@ -137,7 +137,7 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
      *            accepted.
      * @param handshakeTimeoutMillis
      *            Handshake timeout in mills, when handshake timeout, will trigger channel
-     *           event {@link SslHandshakeCompletionEvent} with an {@link WebSocketHandshakeTimeoutException}.
+     *           event {@link SslHandshakeCompletionEvent} with a {@link WebSocketHandshakeTimeoutException}.
      */
     public WebSocketClientProtocolHandler(URI webSocketURL, WebSocketVersion version, String subprotocol,
                                           boolean allowExtensions, HttpHeaders customHeaders,
@@ -191,7 +191,7 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
      *            {@code true} if close frames should not be forwarded and just close the channel
      * @param handshakeTimeoutMillis
      *            Handshake timeout in millis, when handshake timeout, will trigger channel
-     *            event {@link SslHandshakeCompletionEvent} with an {@link WebSocketHandshakeException}.
+     *            event {@link SslHandshakeCompletionEvent} with a {@link WebSocketHandshakeException}.
      */
     public WebSocketClientProtocolHandler(URI webSocketURL, WebSocketVersion version, String subprotocol,
                                           boolean allowExtensions, HttpHeaders customHeaders, int maxFramePayloadLength,
@@ -238,7 +238,7 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
      *            Maximum length of a frame's payload
      * @param handshakeTimeoutMillis
      *            Handshake timeout in millis, when handshake timeout, will trigger channel
-     *            event {@link SslHandshakeCompletionEvent} with an {@link WebSocketHandshakeException}.
+     *            event {@link SslHandshakeCompletionEvent} with a {@link WebSocketHandshakeException}.
      */
     public WebSocketClientProtocolHandler(URI webSocketURL, WebSocketVersion version, String subprotocol,
                                           boolean allowExtensions, HttpHeaders customHeaders,
@@ -270,7 +270,7 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
      *            {@code true} if close frames should not be forwarded and just close the channel
      * @param handshakeTimeoutMillis
      *            Handshake timeout in millis, when handshake timeout, will trigger channel
-     *            event {@link SslHandshakeCompletionEvent} with an {@link WebSocketHandshakeException}.
+     *            event {@link SslHandshakeCompletionEvent} with a {@link WebSocketHandshakeException}.
      */
     public WebSocketClientProtocolHandler(WebSocketClientHandshaker handshaker, boolean handleCloseFrames,
                                           long handshakeTimeoutMillis) {
@@ -305,7 +305,7 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
      *            {@code true} if pong frames should not be forwarded
      * @param handshakeTimeoutMillis
      *            Handshake timeout in millis, when handshake timeout, will trigger channel
-     *            event {@link SslHandshakeCompletionEvent} with an {@link WebSocketHandshakeException}.
+     *            event {@link SslHandshakeCompletionEvent} with a {@link WebSocketHandshakeException}.
      */
     public WebSocketClientProtocolHandler(WebSocketClientHandshaker handshaker, boolean handleCloseFrames,
                                           boolean dropPongFrames, long handshakeTimeoutMillis) {
@@ -336,7 +336,7 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
      *            was established to the remote peer.
      * @param handshakeTimeoutMillis
      *            Handshake timeout in millis, when handshake timeout, will trigger channel
-     *            event {@link SslHandshakeCompletionEvent} with an {@link WebSocketHandshakeException}.
+     *            event {@link SslHandshakeCompletionEvent} with a {@link WebSocketHandshakeException}.
      */
     public WebSocketClientProtocolHandler(WebSocketClientHandshaker handshaker, long handshakeTimeoutMillis) {
         this(handshaker, DEFAULT_HANDLE_CLOSE_FRAMES, handshakeTimeoutMillis);

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientProtocolHandshakeHandler.java
@@ -18,7 +18,6 @@ package io.netty5.handler.codec.http.websocketx;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.http.FullHttpResponse;
-import io.netty5.handler.codec.http.websocketx.WebSocketClientProtocolHandler.ClientHandshakeStateEvent;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.Promise;
 
@@ -57,9 +56,6 @@ class WebSocketClientProtocolHandshakeHandler implements ChannelHandler {
             if (future.isFailed()) {
                 handshakePromise.tryFailure(future.cause());
                 ctx.fireChannelExceptionCaught(future.cause());
-            } else {
-                ctx.fireChannelInboundEvent(
-                        WebSocketClientProtocolHandler.ClientHandshakeStateEvent.HANDSHAKE_ISSUED);
             }
         });
         applyHandshakeTimeout();
@@ -86,8 +82,7 @@ class WebSocketClientProtocolHandshakeHandler implements ChannelHandler {
             if (!handshaker.isHandshakeComplete()) {
                 handshaker.finishHandshake(ctx.channel(), response);
                 handshakePromise.trySuccess(null);
-                ctx.fireChannelInboundEvent(
-                        ClientHandshakeStateEvent.HANDSHAKE_COMPLETE);
+                ctx.fireChannelInboundEvent(new WebSocketHandshakeCompletionEvent(handshaker.version()));
                 ctx.pipeline().remove(this);
                 return;
             }
@@ -106,9 +101,11 @@ class WebSocketClientProtocolHandshakeHandler implements ChannelHandler {
                 return;
             }
 
-            if (localHandshakePromise.tryFailure(new WebSocketClientHandshakeException("handshake timed out"))) {
+            WebSocketHandshakeException exception = new WebSocketHandshakeTimeoutException(
+                    "handshake timed out after " + handshakeTimeoutMillis + "ms");
+            if (localHandshakePromise.tryFailure(exception)) {
                 ctx.flush()
-                   .fireChannelInboundEvent(ClientHandshakeStateEvent.HANDSHAKE_TIMEOUT)
+                   .fireChannelInboundEvent(new WebSocketHandshakeCompletionEvent(exception))
                    .close();
             }
         }, handshakeTimeoutMillis, TimeUnit.MILLISECONDS);

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientProtocolHandshakeHandler.java
@@ -82,7 +82,7 @@ class WebSocketClientProtocolHandshakeHandler implements ChannelHandler {
             if (!handshaker.isHandshakeComplete()) {
                 handshaker.finishHandshake(ctx.channel(), response);
                 handshakePromise.trySuccess(null);
-                ctx.fireChannelInboundEvent(new WebSocketHandshakeCompletionEvent(handshaker.version()));
+                ctx.fireChannelInboundEvent(new WebSocketClientHandshakeCompletionEvent(handshaker.version()));
                 ctx.pipeline().remove(this);
                 return;
             }
@@ -105,7 +105,7 @@ class WebSocketClientProtocolHandshakeHandler implements ChannelHandler {
                     "handshake timed out after " + handshakeTimeoutMillis + "ms");
             if (localHandshakePromise.tryFailure(exception)) {
                 ctx.flush()
-                   .fireChannelInboundEvent(new WebSocketHandshakeCompletionEvent(exception))
+                   .fireChannelInboundEvent(new WebSocketClientHandshakeCompletionEvent(exception))
                    .close();
             }
         }, handshakeTimeoutMillis, TimeUnit.MILLISECONDS);

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketHandshakeCompletionEvent.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketHandshakeCompletionEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 The Netty Project
+ * Copyright 2022 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,38 +13,48 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package io.netty5.handler.ssl;
+package io.netty5.handler.codec.http.websocketx;
 
 import io.netty5.handler.codec.ProtocolEvent;
 
 import static java.util.Objects.requireNonNull;
 
-public abstract class SslCompletionEvent<V> implements ProtocolEvent<V> {
+/**
+ * {@link ProtocolEvent} that indicate the completion of a websocket handshake.
+ */
+public final class WebSocketHandshakeCompletionEvent implements ProtocolEvent<WebSocketVersion> {
 
-    private final V data;
+    private final WebSocketVersion version;
     private final Throwable cause;
 
-    SslCompletionEvent(V data) {
-        this.data = data;
-        cause = null;
+    /**
+     * Create a new event that indicate a successful websocket handshake.
+     *
+     * @param version the version.
+     */
+    public WebSocketHandshakeCompletionEvent(WebSocketVersion version) {
+        this.version = requireNonNull(version, "version");
+        this.cause = null;
     }
 
-    SslCompletionEvent(V data, Throwable cause) {
-        this.data = data;
+    /**
+     * Create a new event that indicate a failed websocket handshake.
+     *
+     * @param cause the cause of the failure
+     */
+    public WebSocketHandshakeCompletionEvent(Throwable cause) {
+        this.version = null;
         this.cause = requireNonNull(cause, "cause");
     }
 
     @Override
-    public V data() {
-        return data;
+    public Throwable cause() {
+        return cause;
     }
 
-    /**
-     * Return the {@link Throwable} if {@link #isSuccess()} returns {@code false}
-     * and so the completion failed.
-     */
-    public final Throwable cause() {
-        return cause;
+    @Override
+    public WebSocketVersion data() {
+        return version;
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketHandshakeCompletionEvent.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketHandshakeCompletionEvent.java
@@ -29,6 +29,8 @@ public abstract class WebSocketHandshakeCompletionEvent implements ProtocolEvent
 
     /**
      * Create a new event that indicate a successful websocket handshake.
+     *
+     * @param version   the {@link WebSocketVersion} that was used.
      */
     WebSocketHandshakeCompletionEvent(WebSocketVersion version) {
         this.version = requireNonNull(version, "version");

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketHandshakeCompletionEvent.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketHandshakeCompletionEvent.java
@@ -16,22 +16,22 @@
 package io.netty5.handler.codec.http.websocketx;
 
 import io.netty5.handler.codec.ProtocolEvent;
-import io.netty5.handler.codec.http.HttpHeaders;
 
 import static java.util.Objects.requireNonNull;
 
 /**
  * {@link ProtocolEvent} that indicate the completion of a websocket handshake.
  */
-public abstract class WebSocketHandshakeCompletionEvent<V> implements ProtocolEvent<V> {
+public abstract class WebSocketHandshakeCompletionEvent implements ProtocolEvent {
+
+    private final WebSocketVersion version;
     private final Throwable cause;
-    private final V data;
 
     /**
      * Create a new event that indicate a successful websocket handshake.
      */
-    protected WebSocketHandshakeCompletionEvent(V data) {
-        this.data = requireNonNull(data, "data");
+    WebSocketHandshakeCompletionEvent(WebSocketVersion version) {
+        this.version = requireNonNull(version, "version");
         this.cause = null;
     }
 
@@ -40,19 +40,23 @@ public abstract class WebSocketHandshakeCompletionEvent<V> implements ProtocolEv
      *
      * @param cause the cause of the failure
      */
-    protected WebSocketHandshakeCompletionEvent(Throwable cause) {
-        this.data = null;
+    WebSocketHandshakeCompletionEvent(Throwable cause) {
         this.cause = requireNonNull(cause, "cause");
+        version = null;
     }
 
     @Override
-    public V data() {
-        return data;
-    }
-
-    @Override
-    public Throwable cause() {
+    public final Throwable cause() {
         return cause;
+    }
+
+    /**
+     * Return the {@link WebSocketVersion} of the handshake or {@code null} in case of a failure.
+     *
+     * @return the version.
+     */
+    public final WebSocketVersion version() {
+        return version;
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketHandshakeCompletionEvent.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketHandshakeCompletionEvent.java
@@ -16,24 +16,22 @@
 package io.netty5.handler.codec.http.websocketx;
 
 import io.netty5.handler.codec.ProtocolEvent;
+import io.netty5.handler.codec.http.HttpHeaders;
 
 import static java.util.Objects.requireNonNull;
 
 /**
  * {@link ProtocolEvent} that indicate the completion of a websocket handshake.
  */
-public final class WebSocketHandshakeCompletionEvent implements ProtocolEvent<WebSocketVersion> {
-
-    private final WebSocketVersion version;
+public abstract class WebSocketHandshakeCompletionEvent<V> implements ProtocolEvent<V> {
     private final Throwable cause;
+    private final V data;
 
     /**
      * Create a new event that indicate a successful websocket handshake.
-     *
-     * @param version the version.
      */
-    public WebSocketHandshakeCompletionEvent(WebSocketVersion version) {
-        this.version = requireNonNull(version, "version");
+    protected WebSocketHandshakeCompletionEvent(V data) {
+        this.data = requireNonNull(data, "data");
         this.cause = null;
     }
 
@@ -42,19 +40,19 @@ public final class WebSocketHandshakeCompletionEvent implements ProtocolEvent<We
      *
      * @param cause the cause of the failure
      */
-    public WebSocketHandshakeCompletionEvent(Throwable cause) {
-        this.version = null;
+    protected WebSocketHandshakeCompletionEvent(Throwable cause) {
+        this.data = null;
         this.cause = requireNonNull(cause, "cause");
+    }
+
+    @Override
+    public V data() {
+        return data;
     }
 
     @Override
     public Throwable cause() {
         return cause;
-    }
-
-    @Override
-    public WebSocketVersion data() {
-        return version;
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketHandshakeTimeoutException.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketHandshakeTimeoutException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty5.handler.codec.http.websocketx;
+
+
+/**
+ * {@link WebSocketHandshakeException} that is used when a handshake failed due a configured timeout.
+ */
+public final class WebSocketHandshakeTimeoutException extends WebSocketHandshakeException {
+    public WebSocketHandshakeTimeoutException(String s) {
+        super(s);
+    }
+}

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketServerHandshakeCompletionEvent.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketServerHandshakeCompletionEvent.java
@@ -17,8 +17,6 @@ package io.netty5.handler.codec.http.websocketx;
 
 import io.netty5.handler.codec.http.HttpHeaders;
 
-import java.util.Objects;
-
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -29,6 +27,14 @@ public final class WebSocketServerHandshakeCompletionEvent extends WebSocketHand
     private final HttpHeaders requestHeaders;
     private final String selectedSubprotocol;
 
+    /**
+     * Create a new event that indicate a successful websocket handshake.
+     *
+     * @param version               the {@link WebSocketVersion} that was used.
+     * @param requestUri            the URI of the request.
+     * @param requestHeaders        the headers of the upgrade request.
+     * @param selectedSubprotocol   the selected sub-protocol, if any.
+     */
     public WebSocketServerHandshakeCompletionEvent(WebSocketVersion version,
             String requestUri, HttpHeaders requestHeaders, String selectedSubprotocol) {
         super(version);
@@ -37,6 +43,11 @@ public final class WebSocketServerHandshakeCompletionEvent extends WebSocketHand
         this.selectedSubprotocol = selectedSubprotocol;
     }
 
+    /**
+     * Create a new event that indicate a failed websocket handshake.
+     *
+     * @param cause the cause of the failure.
+     */
     public WebSocketServerHandshakeCompletionEvent(Throwable cause) {
         super(cause);
         requestUri = null;

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketServerHandshakeCompletionEvent.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketServerHandshakeCompletionEvent.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.handler.codec.http.websocketx;
+
+import io.netty5.handler.codec.http.HttpHeaders;
+
+public final class WebSocketServerHandshakeCompletionEvent
+        extends WebSocketHandshakeCompletionEvent<WebSocketServerHandshakeCompletionEvent.WebSocketHandshakeData> {
+
+    public WebSocketServerHandshakeCompletionEvent(
+            String requestUri, HttpHeaders requestHeaders, String selectedSubprotocol) {
+        super(new WebSocketHandshakeData(requestUri, requestHeaders, selectedSubprotocol));
+    }
+
+    public WebSocketServerHandshakeCompletionEvent(Throwable cause) {
+        super(cause);
+    }
+
+    public static final class WebSocketHandshakeData {
+        private final String requestUri;
+        private final HttpHeaders requestHeaders;
+        private final String selectedSubprotocol;
+
+        WebSocketHandshakeData(String requestUri, HttpHeaders requestHeaders, String selectedSubprotocol) {
+            this.requestUri = requestUri;
+            this.requestHeaders = requestHeaders;
+            this.selectedSubprotocol = selectedSubprotocol;
+        }
+
+        public String requestUri() {
+            return requestUri;
+        }
+
+        public HttpHeaders requestHeaders() {
+            return requestHeaders;
+        }
+
+        public String selectedSubprotocol() {
+            return selectedSubprotocol;
+        }
+    }
+}

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketServerHandshakeCompletionEvent.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketServerHandshakeCompletionEvent.java
@@ -17,39 +17,59 @@ package io.netty5.handler.codec.http.websocketx;
 
 import io.netty5.handler.codec.http.HttpHeaders;
 
-public final class WebSocketServerHandshakeCompletionEvent
-        extends WebSocketHandshakeCompletionEvent<WebSocketServerHandshakeCompletionEvent.WebSocketHandshakeData> {
+import java.util.Objects;
 
-    public WebSocketServerHandshakeCompletionEvent(
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A websocket handshake was completed on the server-side.
+ */
+public final class WebSocketServerHandshakeCompletionEvent extends WebSocketHandshakeCompletionEvent {
+    private final String requestUri;
+    private final HttpHeaders requestHeaders;
+    private final String selectedSubprotocol;
+
+    public WebSocketServerHandshakeCompletionEvent(WebSocketVersion version,
             String requestUri, HttpHeaders requestHeaders, String selectedSubprotocol) {
-        super(new WebSocketHandshakeData(requestUri, requestHeaders, selectedSubprotocol));
+        super(version);
+        this.requestUri = requireNonNull(requestUri, "requestUri");
+        this.requestHeaders = requireNonNull(requestHeaders, "requestHeaders");
+        this.selectedSubprotocol = selectedSubprotocol;
     }
 
     public WebSocketServerHandshakeCompletionEvent(Throwable cause) {
         super(cause);
+        requestUri = null;
+        requestHeaders = null;
+        selectedSubprotocol = null;
     }
 
-    public static final class WebSocketHandshakeData {
-        private final String requestUri;
-        private final HttpHeaders requestHeaders;
-        private final String selectedSubprotocol;
+    /**
+     * Return the request uri of the handshake if {@link #isSuccess()} returns {@code true}, {@code null} otherwise.
+     *
+     * @return the uri.
+     */
+    public String requestUri() {
+        return requestUri;
+    }
 
-        WebSocketHandshakeData(String requestUri, HttpHeaders requestHeaders, String selectedSubprotocol) {
-            this.requestUri = requestUri;
-            this.requestHeaders = requestHeaders;
-            this.selectedSubprotocol = selectedSubprotocol;
-        }
+    /**
+     * Return the request {@link HttpHeaders} of the handshake if {@link #isSuccess()} returns {@code true},
+     * {@code null} otherwise.
+     *
+     * @return the headers.
+     */
+    public HttpHeaders requestHeaders() {
+        return requestHeaders;
+    }
 
-        public String requestUri() {
-            return requestUri;
-        }
-
-        public HttpHeaders requestHeaders() {
-            return requestHeaders;
-        }
-
-        public String selectedSubprotocol() {
-            return selectedSubprotocol;
-        }
+    /**
+     * Return the selected sub-protocol of the handshake if {@link #isSuccess()} returns {@code true} and one was
+     * selected, {@code null} otherwise.
+     *
+     * @return the sub-protocol.
+     */
+    public String selectedSubprotocol() {
+        return selectedSubprotocol;
     }
 }

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketServerProtocolConfig.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketServerProtocolConfig.java
@@ -190,7 +190,7 @@ public final class WebSocketServerProtocolConfig {
 
         /**
          * Handshake timeout in millis, when handshake timeout, will trigger channel
-         * event {@link WebSocketHandshakeCompletionEvent} with an {@link WebSocketHandshakeException}.
+         * event {@link WebSocketHandshakeCompletionEvent} with a {@link WebSocketHandshakeException}.
          */
         public Builder handshakeTimeoutMillis(long handshakeTimeoutMillis) {
             this.handshakeTimeoutMillis = handshakeTimeoutMillis;

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketServerProtocolConfig.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketServerProtocolConfig.java
@@ -189,7 +189,7 @@ public final class WebSocketServerProtocolConfig {
         }
 
         /**
-         * Handshake timeout in millis, when handshake timeout, will trigger channel
+         * Handshake timeout in millis, when handshake timeout, will trigger an inbound channel
          * event {@link WebSocketHandshakeCompletionEvent} with a {@link WebSocketHandshakeException}.
          */
         public Builder handshakeTimeoutMillis(long handshakeTimeoutMillis) {

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketServerProtocolConfig.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketServerProtocolConfig.java
@@ -15,8 +15,6 @@
  */
 package io.netty5.handler.codec.http.websocketx;
 
-import io.netty5.handler.codec.http.websocketx.WebSocketClientProtocolHandler.ClientHandshakeStateEvent;
-
 import java.util.Objects;
 
 import static io.netty5.util.internal.ObjectUtil.checkPositive;
@@ -191,8 +189,8 @@ public final class WebSocketServerProtocolConfig {
         }
 
         /**
-         * Handshake timeout in mills, when handshake timeout, will trigger user
-         * event {@link ClientHandshakeStateEvent#HANDSHAKE_TIMEOUT}
+         * Handshake timeout in millis, when handshake timeout, will trigger channel
+         * event {@link WebSocketHandshakeCompletionEvent} with an {@link WebSocketHandshakeException}.
          */
         public Builder handshakeTimeoutMillis(long handshakeTimeoutMillis) {
             this.handshakeTimeoutMillis = handshakeTimeoutMillis;

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
@@ -22,7 +22,6 @@ import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
 import io.netty5.handler.codec.http.DefaultFullHttpResponse;
 import io.netty5.handler.codec.http.FullHttpResponse;
-import io.netty5.handler.codec.http.HttpHeaders;
 import io.netty5.handler.codec.http.HttpResponseStatus;
 import io.netty5.util.AttributeKey;
 import io.netty5.util.concurrent.Promise;
@@ -46,37 +45,10 @@ import static io.netty5.handler.codec.http.websocketx.WebSocketServerProtocolCon
  *
  * To know once a handshake was done you can intercept the
  * {@link ChannelHandler#channelInboundEvent(ChannelHandlerContext, Object)} and check if the event was instance
- * of {@link HandshakeComplete}, the event will contain extra information about the handshake such as the request and
- * selected subprotocol.
+ * of {@link WebSocketServerHandshakeCompletionEvent}, the event will contain extra information about the handshake
+ * such as the request and selected subprotocol.
  */
 public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
-
-    /**
-     * The Handshake was completed successfully and the channel was upgraded to websockets.
-     */
-    public static final class HandshakeComplete {
-        private final String requestUri;
-        private final HttpHeaders requestHeaders;
-        private final String selectedSubprotocol;
-
-        HandshakeComplete(String requestUri, HttpHeaders requestHeaders, String selectedSubprotocol) {
-            this.requestUri = requestUri;
-            this.requestHeaders = requestHeaders;
-            this.selectedSubprotocol = selectedSubprotocol;
-        }
-
-        public String requestUri() {
-            return requestUri;
-        }
-
-        public HttpHeaders requestHeaders() {
-            return requestHeaders;
-        }
-
-        public String selectedSubprotocol() {
-            return selectedSubprotocol;
-        }
-    }
 
     private static final AttributeKey<WebSocketServerHandshaker> HANDSHAKER_ATTR_KEY =
             AttributeKey.valueOf(WebSocketServerHandshaker.class, "HANDSHAKER");

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
@@ -52,16 +52,6 @@ import static io.netty5.handler.codec.http.websocketx.WebSocketServerProtocolCon
 public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
 
     /**
-     * Events that are fired to notify about handshake status
-     */
-    public enum ServerHandshakeStateEvent {
-        /**
-         * The Handshake was timed out
-         */
-        HANDSHAKE_TIMEOUT
-    }
-
-    /**
      * The Handshake was completed successfully and the channel was upgraded to websockets.
      */
     public static final class HandshakeComplete {

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
@@ -96,7 +96,7 @@ class WebSocketServerProtocolHandshakeHandler implements ChannelHandler {
                         } else {
                             localHandshakePromise.trySuccess(null);
                             ctx.fireChannelInboundEvent(
-                                    new WebSocketServerHandshakeCompletionEvent(
+                                    new WebSocketServerHandshakeCompletionEvent(handshaker.version(),
                                             req.uri(), req.headers(), handshaker.selectedSubprotocol()));
                         }
                         ctx.pipeline().remove(this);

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
@@ -96,7 +96,7 @@ class WebSocketServerProtocolHandshakeHandler implements ChannelHandler {
                         } else {
                             localHandshakePromise.trySuccess(null);
                             ctx.fireChannelInboundEvent(
-                                    new WebSocketServerProtocolHandler.HandshakeComplete(
+                                    new WebSocketServerHandshakeCompletionEvent(
                                             req.uri(), req.headers(), handshaker.selectedSubprotocol()));
                         }
                         ctx.pipeline().remove(this);
@@ -164,7 +164,7 @@ class WebSocketServerProtocolHandshakeHandler implements ChannelHandler {
                     "handshake timed out after " + handshakeTimeoutMillis + "ms");
             if (localHandshakePromise.tryFailure(exception)) {
                 ctx.flush()
-                   .fireChannelInboundEvent(new WebSocketHandshakeCompletionEvent(exception))
+                   .fireChannelInboundEvent(new WebSocketServerHandshakeCompletionEvent(exception))
                    .close();
             }
         }, handshakeTimeoutMillis, TimeUnit.MILLISECONDS);

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
@@ -24,7 +24,6 @@ import io.netty5.handler.codec.http.HttpHeaderNames;
 import io.netty5.handler.codec.http.HttpObject;
 import io.netty5.handler.codec.http.HttpRequest;
 import io.netty5.handler.codec.http.HttpResponse;
-import io.netty5.handler.codec.http.websocketx.WebSocketServerProtocolHandler.ServerHandshakeStateEvent;
 import io.netty5.handler.ssl.SslHandler;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.Promise;
@@ -158,10 +157,14 @@ class WebSocketServerProtocolHandshakeHandler implements ChannelHandler {
         }
 
         final Future<?> timeoutFuture = ctx.executor().schedule(() -> {
-            if (!localHandshakePromise.isDone() &&
-                    localHandshakePromise.tryFailure(new WebSocketServerHandshakeException("handshake timed out"))) {
+            if (localHandshakePromise.isDone()) {
+                return;
+            }
+            WebSocketHandshakeException exception = new WebSocketHandshakeTimeoutException(
+                    "handshake timed out after " + handshakeTimeoutMillis + "ms");
+            if (localHandshakePromise.tryFailure(exception)) {
                 ctx.flush()
-                   .fireChannelInboundEvent(ServerHandshakeStateEvent.HANDSHAKE_TIMEOUT)
+                   .fireChannelInboundEvent(new WebSocketHandshakeCompletionEvent(exception))
                    .close();
             }
         }, handshakeTimeoutMillis, TimeUnit.MILLISECONDS);

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketHandshakeHandOverTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketHandshakeHandOverTest.java
@@ -120,9 +120,9 @@ public class WebSocketHandshakeHandOverTest {
         transferAllDataWithMerge(clientChannel, serverChannel);
         assertTrue(serverReceivedHandshake);
         assertNotNull(serverHandshakeComplete);
-        assertEquals("/test", serverHandshakeComplete.data().requestUri());
-        assertEquals(7, serverHandshakeComplete.data().requestHeaders().size());
-        assertEquals("test-proto-2", serverHandshakeComplete.data().selectedSubprotocol());
+        assertEquals("/test", serverHandshakeComplete.requestUri());
+        assertEquals(7, serverHandshakeComplete.requestHeaders().size());
+        assertEquals("test-proto-2", serverHandshakeComplete.selectedSubprotocol());
 
         // Transfer the handshake response and the websocket message to the client
         transferAllDataWithMerge(serverChannel, clientChannel);

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketServerProtocolHandlerTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketServerProtocolHandlerTest.java
@@ -90,7 +90,7 @@ public class WebSocketServerProtocolHandlerTest {
         ch.pipeline().addLast(new ChannelHandler() {
             @Override
             public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
-                if (evt instanceof WebSocketServerProtocolHandler.HandshakeComplete) {
+                if (evt instanceof WebSocketServerHandshakeCompletionEvent) {
                     // We should have removed the handler already.
                     ctx.executor().execute(() -> ctx.pipeline().context(WebSocketServerProtocolHandshakeHandler.class));
                 }

--- a/codec/src/main/java/io/netty5/handler/codec/ProtocolEvent.java
+++ b/codec/src/main/java/io/netty5/handler/codec/ProtocolEvent.java
@@ -15,12 +15,12 @@
  */
 package io.netty5.handler.codec;
 
+import io.netty5.channel.ChannelPipeline;
+
 /**
- * An event for an application protocol that should be processed by the {@link io.netty5.channel.ChannelPipeline}.
- *
- * @param <T>   the type of the extra data that is passed with the event.
+ * An event for an application protocol that should be processed by the {@link ChannelPipeline}.
  */
-public interface ProtocolEvent<T> {
+public interface ProtocolEvent {
 
     /**
      * Returns {@code true} if the event was sent because of some successful protocol event.
@@ -46,11 +46,4 @@ public interface ProtocolEvent<T> {
      * @return the {@link Throwable} if {@link #isFailed()}  or {@code null} if {@link #isSuccess()}.
      */
     Throwable cause();
-
-    /**
-     * The extra data that is part of the event. Might be {@code null} if none.
-     *
-     * @return the data.
-     */
-    T data();
 }

--- a/codec/src/main/java/io/netty5/handler/codec/ProtocolEvent.java
+++ b/codec/src/main/java/io/netty5/handler/codec/ProtocolEvent.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty5.handler.codec;
+
+/**
+ * An event for an application protocol that should be processed by the {@link io.netty5.channel.ChannelPipeline}.
+ *
+ * @param <T>   the type of the extra data that is pasrt of the event.
+ */
+public interface ProtocolEvent<T> {
+
+    /**
+     * Returns {@code} true if the event was sent because of some successful protocol event.
+     *
+     * @return {@code true} when success, {@code false} otherwise.
+     */
+    default boolean isSuccess() {
+        return cause() == null;
+    }
+
+    /**
+     * Returns {@code} true if the event was sent because of some unsuccessful protocol event.
+     *
+     * @return {@code true} when unsuccessful, {@code false} otherwise.
+     */
+    default boolean isFailed() {
+        return cause() != null;
+    }
+
+    /**
+     * The error which was the cause for the event, or {@code null} if {@link #isSuccess()}.
+     *
+     * @return the {@link Throwable} if {@link #isFailed()}  or {@code null} if {@link #isSuccess()}.
+     */
+    Throwable cause();
+
+    /**
+     * The extra data that is part of the event. Might be {@code null} if none.
+     *
+     * @return the data.
+     */
+    T data();
+}

--- a/codec/src/main/java/io/netty5/handler/codec/ProtocolEvent.java
+++ b/codec/src/main/java/io/netty5/handler/codec/ProtocolEvent.java
@@ -18,7 +18,7 @@ package io.netty5.handler.codec;
 import io.netty5.channel.ChannelPipeline;
 
 /**
- * An event for an application protocol that should be processed by the {@link ChannelPipeline}.
+ * An application-level event propagated via an {@link ChannelPipeline}, such as a TLS or WebSocket handshake event.
  */
 public interface ProtocolEvent {
 
@@ -41,7 +41,7 @@ public interface ProtocolEvent {
     }
 
     /**
-     * The error which was the cause for the event, or {@code null} if {@link #isSuccess()}.
+     * Returns the cause of the failure, or {@code null} if {@link #isSuccess()}.
      *
      * @return the {@link Throwable} if {@link #isFailed()}  or {@code null} if {@link #isSuccess()}.
      */

--- a/codec/src/main/java/io/netty5/handler/codec/ProtocolEvent.java
+++ b/codec/src/main/java/io/netty5/handler/codec/ProtocolEvent.java
@@ -18,12 +18,12 @@ package io.netty5.handler.codec;
 /**
  * An event for an application protocol that should be processed by the {@link io.netty5.channel.ChannelPipeline}.
  *
- * @param <T>   the type of the extra data that is pasrt of the event.
+ * @param <T>   the type of the extra data that is passed with the event.
  */
 public interface ProtocolEvent<T> {
 
     /**
-     * Returns {@code} true if the event was sent because of some successful protocol event.
+     * Returns {@code true} if the event was sent because of some successful protocol event.
      *
      * @return {@code true} when success, {@code false} otherwise.
      */
@@ -32,7 +32,7 @@ public interface ProtocolEvent<T> {
     }
 
     /**
-     * Returns {@code} true if the event was sent because of some unsuccessful protocol event.
+     * Returns {@code true} if the event was sent because of some unsuccessful protocol event.
      *
      * @return {@code true} when unsuccessful, {@code false} otherwise.
      */

--- a/example/src/main/java/io/netty5/example/securechat/SecureChatServerHandler.java
+++ b/example/src/main/java/io/netty5/example/securechat/SecureChatServerHandler.java
@@ -20,7 +20,6 @@ import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.SimpleChannelInboundHandler;
 import io.netty5.channel.group.ChannelGroup;
 import io.netty5.channel.group.DefaultChannelGroup;
-import io.netty5.handler.ssl.SslHandler;
 import io.netty5.handler.ssl.SslHandshakeCompletionEvent;
 import io.netty5.util.concurrent.GlobalEventExecutor;
 
@@ -44,7 +43,7 @@ public class SecureChatServerHandler extends SimpleChannelInboundHandler<String>
                         "Welcome to " + InetAddress.getLocalHost().getHostName() + " secure chat service!\n");
                 ctx.writeAndFlush(
                         "Your session is protected by " +
-                                ctx.pipeline().get(SslHandler.class).engine().getSession().getCipherSuite() +
+                                completionEvent.session().getCipherSuite() +
                                 " cipher suite.\n");
                 channels.add(ctx.channel());
             } else {

--- a/handler/src/main/java/io/netty5/handler/ssl/ApplicationProtocolNegotiationHandler.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/ApplicationProtocolNegotiationHandler.java
@@ -132,12 +132,7 @@ public abstract class ApplicationProtocolNegotiationHandler implements ChannelHa
             SslHandshakeCompletionEvent handshakeEvent = (SslHandshakeCompletionEvent) evt;
             try {
                 if (handshakeEvent.isSuccess()) {
-                    SslHandler sslHandler = ctx.pipeline().get(SslHandler.class);
-                    if (sslHandler == null) {
-                        throw new IllegalStateException("cannot find an SslHandler in the pipeline (required for "
-                                + "application-level protocol negotiation)");
-                    }
-                    String protocol = sslHandler.applicationProtocol();
+                    String protocol = handshakeEvent.applicationProtocol();
                     configurePipeline(ctx, protocol != null ? protocol : fallbackProtocol);
                 } else {
                     // if the event is not produced because of an successful handshake we will receive the same

--- a/handler/src/main/java/io/netty5/handler/ssl/SniCompletionEvent.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SniCompletionEvent.java
@@ -23,16 +23,32 @@ package io.netty5.handler.ssl;
 public final class SniCompletionEvent extends SslCompletionEvent {
     private final String hostname;
 
+    /**
+     * Creates a new event that indicates a successful processing of the SNI extension.
+     *
+     * @param hostname      the hostname that was used for SNI.
+     */
     public SniCompletionEvent(String hostname) {
         super(null);
         this.hostname = hostname;
     }
 
+    /**
+     * Creates a new event that indicates a failed processing of the SNI extension.
+     *
+     * @param hostname      the hostname that was used for SNI.
+     * @param cause         the cause of the failure.
+     */
     public SniCompletionEvent(String hostname, Throwable cause) {
         super(null, cause);
         this.hostname = hostname;
     }
 
+    /**
+     * Creates a new event that indicates a failed processing of the SNI extension.
+     *
+     * @param cause         the cause of the failure.
+     */
     public SniCompletionEvent(Throwable cause) {
         this(null, cause);
     }

--- a/handler/src/main/java/io/netty5/handler/ssl/SniCompletionEvent.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SniCompletionEvent.java
@@ -15,20 +15,22 @@
  */
 package io.netty5.handler.ssl;
 
-import io.netty5.util.internal.UnstableApi;
 
 /**
  * Event that is fired once we did a selection of a {@link SslContext} based on the {@code SNI hostname},
  * which may be because it was successful or there was an error.
  */
-@UnstableApi
-public final class SniCompletionEvent extends SslCompletionEvent<String> {
+public final class SniCompletionEvent extends SslCompletionEvent {
+    private final String hostname;
+
     public SniCompletionEvent(String hostname) {
-        super(hostname);
+        super(null);
+        this.hostname = hostname;
     }
 
     public SniCompletionEvent(String hostname, Throwable cause) {
-        super(hostname, cause);
+        super(null, cause);
+        this.hostname = hostname;
     }
 
     public SniCompletionEvent(Throwable cause) {
@@ -38,15 +40,14 @@ public final class SniCompletionEvent extends SslCompletionEvent<String> {
     /**
      * Returns the SNI hostname send by the client if we were able to parse it, {@code null} otherwise.
      */
-    @Override
-    public String data() {
-        return super.data();
+    public String hostname() {
+        return hostname;
     }
 
     @Override
     public String toString() {
         final Throwable cause = cause();
-        return cause == null ? getClass().getSimpleName() + "(SUCCESS='"  + data() + "'\")":
+        return cause == null ? getClass().getSimpleName() + "(SUCCESS='"  + hostname() + "'\")":
                 getClass().getSimpleName() +  '(' + cause + ')';
     }
 }

--- a/handler/src/main/java/io/netty5/handler/ssl/SniCompletionEvent.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SniCompletionEvent.java
@@ -22,16 +22,13 @@ import io.netty5.util.internal.UnstableApi;
  * which may be because it was successful or there was an error.
  */
 @UnstableApi
-public final class SniCompletionEvent extends SslCompletionEvent {
-    private final String hostname;
-
+public final class SniCompletionEvent extends SslCompletionEvent<String> {
     public SniCompletionEvent(String hostname) {
-        this.hostname = hostname;
+        super(hostname);
     }
 
     public SniCompletionEvent(String hostname, Throwable cause) {
-        super(cause);
-        this.hostname = hostname;
+        super(hostname, cause);
     }
 
     public SniCompletionEvent(Throwable cause) {
@@ -41,14 +38,15 @@ public final class SniCompletionEvent extends SslCompletionEvent {
     /**
      * Returns the SNI hostname send by the client if we were able to parse it, {@code null} otherwise.
      */
-    public String hostname() {
-        return hostname;
+    @Override
+    public String data() {
+        return super.data();
     }
 
     @Override
     public String toString() {
         final Throwable cause = cause();
-        return cause == null ? getClass().getSimpleName() + "(SUCCESS='"  + hostname + "'\")":
+        return cause == null ? getClass().getSimpleName() + "(SUCCESS='"  + data() + "'\")":
                 getClass().getSimpleName() +  '(' + cause + ')';
     }
 }

--- a/handler/src/main/java/io/netty5/handler/ssl/SslClientHelloHandler.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslClientHelloHandler.java
@@ -65,7 +65,7 @@ public abstract class SslClientHelloHandler<T> extends ByteToMessageDecoder {
                                         "not an SSL/TLS record: " + BufferUtil.hexDump(in));
                                 in.skipReadableBytes(in.readableBytes());
                                 ctx.fireChannelInboundEvent(new SniCompletionEvent(e));
-                                ctx.fireChannelInboundEvent(new SslHandshakeCompletionEvent(e));
+                                ctx.fireChannelInboundEvent(new SslHandshakeCompletionEvent(null, null, e));
                                 throw e;
                             }
                             if (len == SslUtils.NOT_ENOUGH_DATA) {

--- a/handler/src/main/java/io/netty5/handler/ssl/SslClientHelloHandler.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslClientHelloHandler.java
@@ -65,7 +65,7 @@ public abstract class SslClientHelloHandler<T> extends ByteToMessageDecoder {
                                         "not an SSL/TLS record: " + BufferUtil.hexDump(in));
                                 in.skipReadableBytes(in.readableBytes());
                                 ctx.fireChannelInboundEvent(new SniCompletionEvent(e));
-                                ctx.fireChannelInboundEvent(new SslHandshakeCompletionEvent(null, null, e));
+                                ctx.fireChannelInboundEvent(new SslHandshakeCompletionEvent(e));
                                 throw e;
                             }
                             if (len == SslUtils.NOT_ENOUGH_DATA) {

--- a/handler/src/main/java/io/netty5/handler/ssl/SslCloseCompletionEvent.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslCloseCompletionEvent.java
@@ -18,9 +18,9 @@ package io.netty5.handler.ssl;
 import javax.net.ssl.SSLSession;
 
 /**
- * Event that is fired once the close_notify was received or if an failure happens before it was received.
+ * Event that is fired once the close_notify was received or if a failure happens before it was received.
  */
-public final class SslCloseCompletionEvent extends SslCompletionEvent<SSLSession> {
+public final class SslCloseCompletionEvent extends SslCompletionEvent {
 
     /**
      * Creates a new event that indicates a successful receiving of close_notify.
@@ -30,7 +30,7 @@ public final class SslCloseCompletionEvent extends SslCompletionEvent<SSLSession
     }
 
     /**
-     * Creates a new event that indicates an close_notify was not received because of an previous error.
+     * Creates a new event that indicates an close_notify was not received because of a previous error.
      */
     public SslCloseCompletionEvent(SSLSession session, Throwable cause) {
         super(session, cause);

--- a/handler/src/main/java/io/netty5/handler/ssl/SslCloseCompletionEvent.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslCloseCompletionEvent.java
@@ -15,23 +15,24 @@
  */
 package io.netty5.handler.ssl;
 
+import javax.net.ssl.SSLSession;
+
 /**
  * Event that is fired once the close_notify was received or if an failure happens before it was received.
  */
-public final class SslCloseCompletionEvent extends SslCompletionEvent {
-
-    public static final SslCloseCompletionEvent SUCCESS = new SslCloseCompletionEvent();
+public final class SslCloseCompletionEvent extends SslCompletionEvent<SSLSession> {
 
     /**
      * Creates a new event that indicates a successful receiving of close_notify.
      */
-    private SslCloseCompletionEvent() { }
+    public SslCloseCompletionEvent(SSLSession session) {
+        super(session);
+    }
 
     /**
      * Creates a new event that indicates an close_notify was not received because of an previous error.
-     * Use {@link #SUCCESS} to indicate a success.
      */
-    public SslCloseCompletionEvent(Throwable cause) {
-        super(cause);
+    public SslCloseCompletionEvent(SSLSession session, Throwable cause) {
+        super(session, cause);
     }
 }

--- a/handler/src/main/java/io/netty5/handler/ssl/SslCloseCompletionEvent.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslCloseCompletionEvent.java
@@ -18,19 +18,24 @@ package io.netty5.handler.ssl;
 import javax.net.ssl.SSLSession;
 
 /**
- * Event that is fired once the close_notify was received or if a failure happens before it was received.
+ * Event that is fired once the {@code close_notify} was received or if a failure happens before it was received.
  */
 public final class SslCloseCompletionEvent extends SslCompletionEvent {
 
     /**
-     * Creates a new event that indicates a successful receiving of close_notify.
+     * Creates a new event that indicates a successful receiving of {@code close_notify}.
+     *
+     * @param session               the {@link SSLSession} that is used.
      */
     public SslCloseCompletionEvent(SSLSession session) {
         super(session);
     }
 
     /**
-     * Creates a new event that indicates an close_notify was not received because of a previous error.
+     * Creates a new event that indicates a {@code close_notify} was not received because of a previous error.
+     *
+     * @param session               the {@link SSLSession} that is used.
+     * @param cause                 the cause of the failure.
      */
     public SslCloseCompletionEvent(SSLSession session, Throwable cause) {
         super(session, cause);

--- a/handler/src/main/java/io/netty5/handler/ssl/SslCompletionEvent.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslCompletionEvent.java
@@ -17,26 +17,25 @@ package io.netty5.handler.ssl;
 
 import io.netty5.handler.codec.ProtocolEvent;
 
+import javax.net.ssl.SSLSession;
+
 import static java.util.Objects.requireNonNull;
 
-public abstract class SslCompletionEvent<V> implements ProtocolEvent<V> {
-
-    private final V data;
+/**
+ * A {@link ProtocolEvent} for a completed SSL related event.
+ */
+public abstract class SslCompletionEvent implements ProtocolEvent {
+    private final SSLSession session;
     private final Throwable cause;
 
-    SslCompletionEvent(V data) {
-        this.data = data;
+    SslCompletionEvent(SSLSession session) {
+        this.session = session;
         cause = null;
     }
 
-    SslCompletionEvent(V data, Throwable cause) {
-        this.data = data;
+    SslCompletionEvent(SSLSession session, Throwable cause) {
+        this.session = session;
         this.cause = requireNonNull(cause, "cause");
-    }
-
-    @Override
-    public V data() {
-        return data;
     }
 
     /**
@@ -45,6 +44,15 @@ public abstract class SslCompletionEvent<V> implements ProtocolEvent<V> {
      */
     public final Throwable cause() {
         return cause;
+    }
+
+    /**
+     * Returns the {@link SSLSession} or {@code null} if none existed yet.
+     *
+     * @return the session.
+     */
+    public SSLSession session() {
+        return session;
     }
 
     @Override

--- a/handler/src/main/java/io/netty5/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslHandler.java
@@ -585,7 +585,8 @@ public class SslHandler extends ByteToMessageDecoder {
             if (!handshakePromise.isDone()) {
                 cause = new SSLHandshakeException("SslHandler removed before handshake completed");
                 if (handshakePromise.tryFailure(cause)) {
-                    ctx.fireChannelInboundEvent(new SslHandshakeCompletionEvent(cause));
+                    ctx.fireChannelInboundEvent(new SslHandshakeCompletionEvent(
+                            engine().getSession(), applicationProtocol(), cause));
                 }
             }
             if (!sslClosePromise.isDone()) {
@@ -1091,7 +1092,8 @@ public class SslHandler extends ByteToMessageDecoder {
             // listeners immediately close the Channel then we may end up firing the handshake event after the Channel
             // has been closed.
             if (handshakePromise.tryFailure(cause)) {
-                ctx.fireChannelInboundEvent(new SslHandshakeCompletionEvent(cause));
+                ctx.fireChannelInboundEvent(new SslHandshakeCompletionEvent(
+                        engine().getSession(), applicationProtocol(), cause));
             }
 
             // We need to flush one time as there may be an alert that we should send to the remote peer because
@@ -1638,7 +1640,8 @@ public class SslHandler extends ByteToMessageDecoder {
                         session.getProtocol(),
                         session.getCipherSuite());
             }
-            ctx.fireChannelInboundEvent(SslHandshakeCompletionEvent.SUCCESS);
+            ctx.fireChannelInboundEvent(
+                    new SslHandshakeCompletionEvent(engine().getSession(), applicationProtocol()));
         }
         if (isStateSet(STATE_READ_DURING_HANDSHAKE)) {
             clearState(STATE_READ_DURING_HANDSHAKE);
@@ -1684,7 +1687,8 @@ public class SslHandler extends ByteToMessageDecoder {
                 }
             }
             if (handshakePromise.tryFailure(cause) || alwaysFlushAndClose) {
-                SslUtils.handleHandshakeFailure(ctx, cause, notify);
+                SslUtils.handleHandshakeFailure(
+                        ctx, engine().getSession(), applicationProtocol(), cause, notify);
             }
         } finally {
             // Ensure we remove and fail all pending writes in all cases and so release memory quickly.
@@ -1700,7 +1704,8 @@ public class SslHandler extends ByteToMessageDecoder {
             SSLException transportFailure = new SSLException("failure when writing TLS control frames", cause);
             releaseAndFailAll(ctx, transportFailure);
             if (handshakePromise.tryFailure(transportFailure)) {
-                ctx.fireChannelInboundEvent(new SslHandshakeCompletionEvent(transportFailure));
+                ctx.fireChannelInboundEvent(new SslHandshakeCompletionEvent(
+                        engine().getSession(), applicationProtocol(), transportFailure));
             }
         } finally {
             ctx.close();
@@ -1716,11 +1721,11 @@ public class SslHandler extends ByteToMessageDecoder {
     private void notifyClosePromise(Throwable cause) {
         if (cause == null) {
             if (sslClosePromise.trySuccess(ctx.channel())) {
-                ctx.fireChannelInboundEvent(SslCloseCompletionEvent.SUCCESS);
+                ctx.fireChannelInboundEvent(new SslCloseCompletionEvent(engine().getSession()));
             }
         } else {
             if (sslClosePromise.tryFailure(cause)) {
-                ctx.fireChannelInboundEvent(new SslCloseCompletionEvent(cause));
+                ctx.fireChannelInboundEvent(new SslCloseCompletionEvent(engine().getSession(), cause));
             }
         }
     }
@@ -1908,7 +1913,8 @@ public class SslHandler extends ByteToMessageDecoder {
                     new SslHandshakeTimeoutException("handshake timed out after " + handshakeTimeoutMillis + "ms");
             try {
                 if (localHandshakePromise.tryFailure(exception)) {
-                    SslUtils.handleHandshakeFailure(ctx, exception, true);
+                    SslUtils.handleHandshakeFailure(
+                            ctx, engine().getSession(), applicationProtocol(), exception, true);
                 }
             } finally {
                 releaseAndFailAll(ctx, exception);

--- a/handler/src/main/java/io/netty5/handler/ssl/SslHandshakeCompletionEvent.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslHandshakeCompletionEvent.java
@@ -22,11 +22,13 @@ import javax.net.ssl.SSLSession;
  * was an error.
  */
 public final class SslHandshakeCompletionEvent extends SslCompletionEvent {
-
     private final String applicationProtocol;
 
     /**
      * Creates a new event that indicates a successful handshake.
+     *
+     * @param session               the {@link SSLSession} for the handshake.
+     * @param applicationProtocol   the application protocol that was selected (if any).
      */
     public SslHandshakeCompletionEvent(SSLSession session, String applicationProtocol) {
         super(session);
@@ -35,6 +37,10 @@ public final class SslHandshakeCompletionEvent extends SslCompletionEvent {
 
     /**
      * Creates a new event that indicates an unsuccessful handshake.
+     *
+     * @param session               the {@link SSLSession} for the handshake.
+     * @param applicationProtocol   the application protocol that was selected (if any).
+     * @param cause                 the cause of the failure.
      */
     public SslHandshakeCompletionEvent(SSLSession session, String applicationProtocol, Throwable cause) {
         super(session, cause);
@@ -43,6 +49,8 @@ public final class SslHandshakeCompletionEvent extends SslCompletionEvent {
 
     /**
      * Creates a new event that indicates an unsuccessful handshake.
+     *
+     * @param cause the cause of the failure.
      */
     public SslHandshakeCompletionEvent(Throwable cause) {
         this(null, null, cause);

--- a/handler/src/main/java/io/netty5/handler/ssl/SslHandshakeCompletionEvent.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslHandshakeCompletionEvent.java
@@ -16,28 +16,29 @@
 package io.netty5.handler.ssl;
 
 import javax.net.ssl.SSLSession;
-import java.util.Objects;
 
 /**
  * Event that is fired once the SSL handshake is complete, which may be because it was successful or there
  * was an error.
  */
-public final class SslHandshakeCompletionEvent
-        extends SslCompletionEvent<SslHandshakeCompletionEvent.SslHandshakeData> {
+public final class SslHandshakeCompletionEvent extends SslCompletionEvent {
+
+    private final String applicationProtocol;
 
     /**
      * Creates a new event that indicates a successful handshake.
      */
     public SslHandshakeCompletionEvent(SSLSession session, String applicationProtocol) {
-        super(new SslHandshakeData(Objects.requireNonNull(session, "session"), applicationProtocol));
+        super(session);
+        this.applicationProtocol = applicationProtocol;
     }
 
     /**
      * Creates a new event that indicates an unsuccessful handshake.
      */
     public SslHandshakeCompletionEvent(SSLSession session, String applicationProtocol, Throwable cause) {
-        super(session == null && applicationProtocol == null ? null :
-                new SslHandshakeData(session, applicationProtocol), cause);
+        super(session, cause);
+        this.applicationProtocol = applicationProtocol;
     }
 
     /**
@@ -47,21 +48,23 @@ public final class SslHandshakeCompletionEvent
         this(null, null, cause);
     }
 
-    public static final class SslHandshakeData {
-        private final SSLSession session;
-        private final String applicationProtocol;
+    /**
+     * Returns the {@link SSLSession} in case of {@link #isSuccess()} to be {@code true}, {@code null} in case of a
+     * failure.
+     *
+     * @return the session.
+     */
+    @Override
+    public SSLSession session() {
+        return super.session();
+    }
 
-        SslHandshakeData(SSLSession session, String applicationProtocol) {
-            this.session = session;
-            this.applicationProtocol = applicationProtocol;
-        }
-
-        public SSLSession session() {
-            return session;
-        }
-
-        public String applicationProtocol() {
-            return applicationProtocol;
-        }
+    /**
+     * Return the application protocol that was selected or {@code null} if none was selected.
+     *
+     * @return the application protocol.
+     */
+    public String applicationProtocol() {
+        return applicationProtocol;
     }
 }

--- a/handler/src/main/java/io/netty5/handler/ssl/SslHandshakeCompletionEvent.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslHandshakeCompletionEvent.java
@@ -15,24 +15,53 @@
  */
 package io.netty5.handler.ssl;
 
+import javax.net.ssl.SSLSession;
+import java.util.Objects;
+
 /**
  * Event that is fired once the SSL handshake is complete, which may be because it was successful or there
  * was an error.
  */
-public final class SslHandshakeCompletionEvent extends SslCompletionEvent {
-
-    public static final SslHandshakeCompletionEvent SUCCESS = new SslHandshakeCompletionEvent();
+public final class SslHandshakeCompletionEvent
+        extends SslCompletionEvent<SslHandshakeCompletionEvent.SslHandshakeData> {
 
     /**
      * Creates a new event that indicates a successful handshake.
      */
-    private SslHandshakeCompletionEvent() { }
+    public SslHandshakeCompletionEvent(SSLSession session, String applicationProtocol) {
+        super(new SslHandshakeData(Objects.requireNonNull(session, "session"), applicationProtocol));
+    }
 
     /**
      * Creates a new event that indicates an unsuccessful handshake.
-     * Use {@link #SUCCESS} to indicate a successful handshake.
+     */
+    public SslHandshakeCompletionEvent(SSLSession session, String applicationProtocol, Throwable cause) {
+        super(session == null && applicationProtocol == null ? null :
+                new SslHandshakeData(session, applicationProtocol), cause);
+    }
+
+    /**
+     * Creates a new event that indicates an unsuccessful handshake.
      */
     public SslHandshakeCompletionEvent(Throwable cause) {
-        super(cause);
+        this(null, null, cause);
+    }
+
+    public static final class SslHandshakeData {
+        private final SSLSession session;
+        private final String applicationProtocol;
+
+        SslHandshakeData(SSLSession session, String applicationProtocol) {
+            this.session = session;
+            this.applicationProtocol = applicationProtocol;
+        }
+
+        public SSLSession session() {
+            return session;
+        }
+
+        public String applicationProtocol() {
+            return applicationProtocol;
+        }
     }
 }

--- a/handler/src/main/java/io/netty5/handler/ssl/SslMasterKeyHandler.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslMasterKeyHandler.java
@@ -124,7 +124,8 @@ public abstract class SslMasterKeyHandler implements ChannelHandler {
     @Override
     public final void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
         //only try to log the session info if the ssl handshake has successfully completed.
-        if (evt == SslHandshakeCompletionEvent.SUCCESS && masterKeyHandlerEnabled()) {
+        if (evt instanceof SslHandshakeCompletionEvent &&
+                ((SslHandshakeCompletionEvent) evt).isSuccess() && masterKeyHandlerEnabled()) {
             final SslHandler handler = ctx.pipeline().get(SslHandler.class);
             final SSLEngine engine = handler.engine();
             final SSLSession sslSession = engine.getSession();

--- a/handler/src/main/java/io/netty5/handler/ssl/SslUtils.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslUtils.java
@@ -28,6 +28,7 @@ import io.netty5.util.internal.logging.InternalLoggerFactory;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLSession;
 import javax.net.ssl.TrustManager;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -414,12 +415,13 @@ final class SslUtils {
         return packetLength;
     }
 
-    static void handleHandshakeFailure(ChannelHandlerContext ctx, Throwable cause, boolean notify) {
+    static void handleHandshakeFailure(ChannelHandlerContext ctx, SSLSession session, String applicationProtocol,
+                                       Throwable cause, boolean notify) {
         // We have may haven written some parts of data before an exception was thrown so ensure we always flush.
         // See https://github.com/netty/netty/issues/3900#issuecomment-172481830
         ctx.flush();
         if (notify) {
-            ctx.fireChannelInboundEvent(new SslHandshakeCompletionEvent(cause));
+            ctx.fireChannelInboundEvent(new SslHandshakeCompletionEvent(session, applicationProtocol, cause));
         }
     }
 

--- a/handler/src/test/java/io/netty5/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SSLEngineTest.java
@@ -1139,13 +1139,15 @@ public abstract class SSLEngineTest {
                 p.addLast(new ChannelHandler() {
                     @Override
                     public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
-                        if (evt instanceof SslHandshakeCompletionEvent
-                                && ((SslHandshakeCompletionEvent) evt).isSuccess()) {
-                            try {
-                                verifySSLSessionForMutualAuth(
-                                        param, handler.engine().getSession(), clientCrtFile, PRINCIPAL_NAME);
-                            } catch (Throwable cause) {
-                                clientException = cause;
+                        if (evt instanceof SslHandshakeCompletionEvent) {
+                            SslHandshakeCompletionEvent handshakeCompletionEvent = (SslHandshakeCompletionEvent) evt;
+                            if (handshakeCompletionEvent.isSuccess()) {
+                                try {
+                                    verifySSLSessionForMutualAuth(param, handshakeCompletionEvent.data().session(),
+                                            clientCrtFile, PRINCIPAL_NAME);
+                                } catch (Throwable cause) {
+                                    clientException = cause;
+                                }
                             }
                         }
                     }

--- a/handler/src/test/java/io/netty5/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SSLEngineTest.java
@@ -1143,7 +1143,7 @@ public abstract class SSLEngineTest {
                             SslHandshakeCompletionEvent handshakeCompletionEvent = (SslHandshakeCompletionEvent) evt;
                             if (handshakeCompletionEvent.isSuccess()) {
                                 try {
-                                    verifySSLSessionForMutualAuth(param, handshakeCompletionEvent.data().session(),
+                                    verifySSLSessionForMutualAuth(param, handshakeCompletionEvent.session(),
                                             clientCrtFile, PRINCIPAL_NAME);
                                 } catch (Throwable cause) {
                                     clientException = cause;

--- a/handler/src/test/java/io/netty5/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SSLEngineTest.java
@@ -730,13 +730,15 @@ public abstract class SSLEngineTest {
                 p.addLast(new ChannelHandler() {
                     @Override
                     public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
-                        if (evt == SslHandshakeCompletionEvent.SUCCESS) {
-                            if (failureExpected) {
-                                serverException = new IllegalStateException("handshake complete. expected failure");
+                        if (evt instanceof SslHandshakeCompletionEvent) {
+                            SslHandshakeCompletionEvent event = (SslHandshakeCompletionEvent) evt;
+                            if (event.isSuccess()) {
+                                if (failureExpected) {
+                                    serverException = new IllegalStateException("handshake complete. expected failure");
+                                }
+                            } else {
+                                serverException = event.cause();
                             }
-                            serverLatch.countDown();
-                        } else if (evt instanceof SslHandshakeCompletionEvent) {
-                            serverException = ((SslHandshakeCompletionEvent) evt).cause();
                             serverLatch.countDown();
                         }
                         ctx.fireChannelInboundEvent(evt);
@@ -772,15 +774,18 @@ public abstract class SSLEngineTest {
                 p.addLast(new ChannelHandler() {
                     @Override
                     public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
-                        if (evt == SslHandshakeCompletionEvent.SUCCESS) {
-                            // With TLS1.3 a mutal auth error will not be propagated as a handshake error most of the
-                            // time as the handshake needs NO extra roundtrip.
-                            if (!failureExpected) {
+                        if (evt instanceof SslHandshakeCompletionEvent) {
+                            SslHandshakeCompletionEvent event = (SslHandshakeCompletionEvent) evt;
+                            if (event.isSuccess()) {
+                                // With TLS1.3 a mutal auth error will not be propagated as a handshake error most of
+                                // the time as the handshake needs NO extra roundtrip.
+                                if (!failureExpected) {
+                                    clientLatch.countDown();
+                                }
+                            } else {
+                                clientException = event.cause();
                                 clientLatch.countDown();
                             }
-                        } else if (evt instanceof SslHandshakeCompletionEvent) {
-                            clientException = ((SslHandshakeCompletionEvent) evt).cause();
-                            clientLatch.countDown();
                         }
                         ctx.fireChannelInboundEvent(evt);
                     }
@@ -897,13 +902,15 @@ public abstract class SSLEngineTest {
                 p.addLast(new ChannelHandler() {
                     @Override
                     public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
-                        if (evt == SslHandshakeCompletionEvent.SUCCESS) {
-                            if (failureExpected) {
-                                serverException = new IllegalStateException("handshake complete. expected failure");
+                        if (evt instanceof SslHandshakeCompletionEvent) {
+                            SslHandshakeCompletionEvent event = (SslHandshakeCompletionEvent) evt;
+                            if (event.isSuccess()) {
+                                if (failureExpected) {
+                                    serverException = new IllegalStateException("handshake complete. expected failure");
+                                }
+                            } else {
+                                serverException  = event.cause();
                             }
-                            serverLatch.countDown();
-                        } else if (evt instanceof SslHandshakeCompletionEvent) {
-                            serverException = ((SslHandshakeCompletionEvent) evt).cause();
                             serverLatch.countDown();
                         }
                         ctx.fireChannelInboundEvent(evt);
@@ -959,13 +966,15 @@ public abstract class SSLEngineTest {
 
                     @Override
                     public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
-                        if (evt == SslHandshakeCompletionEvent.SUCCESS) {
-                            if (failureExpected) {
-                                clientException = new IllegalStateException("handshake complete. expected failure");
+                        if (evt instanceof SslHandshakeCompletionEvent) {
+                            SslHandshakeCompletionEvent event = (SslHandshakeCompletionEvent) evt;
+                            if (event.isSuccess()) {
+                                if (failureExpected) {
+                                    clientException = new IllegalStateException("handshake complete. expected failure");
+                                }
+                            } else {
+                                clientException = event.cause();
                             }
-                            clientLatch.countDown();
-                        } else if (evt instanceof SslHandshakeCompletionEvent) {
-                            clientException = ((SslHandshakeCompletionEvent) evt).cause();
                             clientLatch.countDown();
                         }
                         ctx.fireChannelInboundEvent(evt);
@@ -1097,7 +1106,8 @@ public abstract class SSLEngineTest {
 
                     @Override
                     public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
-                        if (evt == SslHandshakeCompletionEvent.SUCCESS) {
+                        if (evt instanceof SslHandshakeCompletionEvent
+                                && ((SslHandshakeCompletionEvent) evt).isSuccess()) {
                             try {
                                 verifySSLSessionForMutualAuth(
                                         param, engine.getSession(), serverCrtFile, PRINCIPAL_NAME);
@@ -1129,7 +1139,8 @@ public abstract class SSLEngineTest {
                 p.addLast(new ChannelHandler() {
                     @Override
                     public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
-                        if (evt == SslHandshakeCompletionEvent.SUCCESS) {
+                        if (evt instanceof SslHandshakeCompletionEvent
+                                && ((SslHandshakeCompletionEvent) evt).isSuccess()) {
                             try {
                                 verifySSLSessionForMutualAuth(
                                         param, handler.engine().getSession(), clientCrtFile, PRINCIPAL_NAME);

--- a/handler/src/test/java/io/netty5/handler/ssl/SniHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SniHandlerTest.java
@@ -234,7 +234,7 @@ public class SniHandlerTest {
 
                 SniCompletionEvent evt = evtRef.get();
                 assertNotNull(evt);
-                assertEquals("chat4.leancloud.cn", evt.hostname());
+                assertEquals("chat4.leancloud.cn", evt.data());
                 assertTrue(evt.isSuccess());
                 assertNull(evt.cause());
             } finally {

--- a/handler/src/test/java/io/netty5/handler/ssl/SniHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SniHandlerTest.java
@@ -234,7 +234,7 @@ public class SniHandlerTest {
 
                 SniCompletionEvent evt = evtRef.get();
                 assertNotNull(evt);
-                assertEquals("chat4.leancloud.cn", evt.data());
+                assertEquals("chat4.leancloud.cn", evt.hostname());
                 assertTrue(evt.isSuccess());
                 assertNull(evt.cause());
             } finally {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
@@ -53,7 +53,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
@@ -253,7 +252,7 @@ public class SocketSslClientRenegotiateTest extends AbstractSocketTest {
                     if (handshakeEvt.cause() != null) {
                         logger.warn("Handshake failed:", handshakeEvt.cause());
                     }
-                    assertSame(SslHandshakeCompletionEvent.SUCCESS, evt);
+                    assertTrue(handshakeEvt.isSuccess());
                 } else {
                     if (ctx.channel().parent() == null) {
                         assertTrue(handshakeEvt.cause() instanceof ClosedChannelException);

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslEchoTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslEchoTest.java
@@ -66,7 +66,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SocketSslEchoTest extends AbstractSocketTest {
 
@@ -489,7 +489,7 @@ public class SocketSslEchoTest extends AbstractSocketTest {
                 if (handshakeEvt.cause() != null) {
                     logger.warn("Handshake failed:", handshakeEvt.cause());
                 }
-                assertSame(SslHandshakeCompletionEvent.SUCCESS, evt);
+                assertTrue(handshakeEvt.isSuccess());
                 negoCounter.incrementAndGet();
                 logStats("HANDSHAKEN");
             }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslGreetingTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslGreetingTest.java
@@ -234,7 +234,7 @@ public class SocketSslGreetingTest extends AbstractSocketTest {
             if (evt instanceof SslHandshakeCompletionEvent) {
                 final SslHandshakeCompletionEvent event = (SslHandshakeCompletionEvent) evt;
                 if (event.isSuccess()) {
-                    SSLSession session = ctx.pipeline().get(SslHandler.class).engine().getSession();
+                    SSLSession session = event.session();
                     try {
                         session.getPeerCertificates();
                         fail();


### PR DESCRIPTION
Motivation:

There are various protocols that will need to have a way to signal some sort of protocol event (like for example a protocol upgrade). We should have an interface for such events so its easier to "match" these.

Modifications:

- Add ProtocolEvent and implement it for SSL / websockets.
- Adjust code

Result:

Easier to and more consist way of re-acting on protocol events
