### PR TITLE
Fix rawtypes warnings

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollChannelConfig.java
@@ -33,11 +33,11 @@ import static io.netty5.channel.unix.Limits.SSIZE_MAX;
 public class EpollChannelConfig extends DefaultChannelConfig {
     private volatile long maxBytesPerGatheringWrite = SSIZE_MAX;
 
-    EpollChannelConfig(AbstractEpollChannel channel) {
+    EpollChannelConfig(AbstractEpollChannel<?, ?, ?> channel) {
         super(channel);
     }
 
-    EpollChannelConfig(AbstractEpollChannel channel, RecvBufferAllocator recvBufferAllocator) {
+    EpollChannelConfig(AbstractEpollChannel<?, ?, ?> channel, RecvBufferAllocator recvBufferAllocator) {
         super(channel, recvBufferAllocator);
     }
     @SuppressWarnings("unchecked")
@@ -46,13 +46,13 @@ public class EpollChannelConfig extends DefaultChannelConfig {
         try {
             if (option instanceof IntegerUnixChannelOption) {
                 IntegerUnixChannelOption opt = (IntegerUnixChannelOption) option;
-                return (T) Integer.valueOf(((AbstractEpollChannel) channel).socket.getIntOpt(
+                return (T) Integer.valueOf(((AbstractEpollChannel<?, ?, ?>) channel).socket.getIntOpt(
                         opt.level(), opt.optname()));
             }
             if (option instanceof RawUnixChannelOption) {
                 RawUnixChannelOption opt = (RawUnixChannelOption) option;
                 ByteBuffer out = ByteBuffer.allocate(opt.length());
-                ((AbstractEpollChannel) channel).socket.getRawOpt(opt.level(), opt.optname(), out);
+                ((AbstractEpollChannel<?, ?, ?>) channel).socket.getRawOpt(opt.level(), opt.optname(), out);
                 return (T) out.flip();
             }
         } catch (IOException e) {
@@ -67,11 +67,12 @@ public class EpollChannelConfig extends DefaultChannelConfig {
         try {
             if (option instanceof IntegerUnixChannelOption) {
                 IntegerUnixChannelOption opt = (IntegerUnixChannelOption) option;
-                ((AbstractEpollChannel) channel).socket.setIntOpt(opt.level(), opt.optname(), (Integer) value);
+                ((AbstractEpollChannel<?, ?, ?>) channel).socket.setIntOpt(opt.level(), opt.optname(), (Integer) value);
                 return true;
             } else if (option instanceof RawUnixChannelOption) {
                 RawUnixChannelOption opt = (RawUnixChannelOption) option;
-                ((AbstractEpollChannel) channel).socket.setRawOpt(opt.level(), opt.optname(), (ByteBuffer) value);
+                ((AbstractEpollChannel<?, ?, ?>) channel).socket.setRawOpt(
+                        opt.level(), opt.optname(), (ByteBuffer) value);
                 return true;
             }
         } catch (IOException e) {
@@ -145,7 +146,7 @@ public class EpollChannelConfig extends DefaultChannelConfig {
 
     @Override
     protected final void autoReadCleared() {
-        ((AbstractEpollChannel) channel).clearEpollIn();
+        ((AbstractEpollChannel<?, ?, ?>) channel).clearEpollIn();
     }
 
     final void setMaxBytesPerGatheringWrite(long maxBytesPerGatheringWrite) {

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueChannelConfig.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueChannelConfig.java
@@ -39,11 +39,11 @@ public class KQueueChannelConfig extends DefaultChannelConfig {
     private volatile boolean transportProvidesGuess;
     private volatile long maxBytesPerGatheringWrite = SSIZE_MAX;
 
-    KQueueChannelConfig(AbstractKQueueChannel channel) {
+    KQueueChannelConfig(AbstractKQueueChannel<?, ?, ?> channel) {
         super(channel);
     }
 
-    KQueueChannelConfig(AbstractKQueueChannel channel, RecvBufferAllocator recvBufferAllocator) {
+    KQueueChannelConfig(AbstractKQueueChannel<?, ?, ?> channel, RecvBufferAllocator recvBufferAllocator) {
         super(channel, recvBufferAllocator);
     }
 
@@ -61,13 +61,13 @@ public class KQueueChannelConfig extends DefaultChannelConfig {
         try {
             if (option instanceof IntegerUnixChannelOption) {
                 IntegerUnixChannelOption opt = (IntegerUnixChannelOption) option;
-                return (T) Integer.valueOf(((AbstractKQueueChannel) channel).socket.getIntOpt(
+                return (T) Integer.valueOf(((AbstractKQueueChannel<?, ?, ?>) channel).socket.getIntOpt(
                         opt.level(), opt.optname()));
             }
             if (option instanceof RawUnixChannelOption) {
                 RawUnixChannelOption opt = (RawUnixChannelOption) option;
                 ByteBuffer out = ByteBuffer.allocate(opt.length());
-                ((AbstractKQueueChannel) channel).socket.getRawOpt(opt.level(), opt.optname(), out);
+                ((AbstractKQueueChannel<?, ?, ?>) channel).socket.getRawOpt(opt.level(), opt.optname(), out);
                 return (T) out.flip();
             }
         } catch (IOException e) {
@@ -86,11 +86,13 @@ public class KQueueChannelConfig extends DefaultChannelConfig {
             try {
                 if (option instanceof IntegerUnixChannelOption) {
                     IntegerUnixChannelOption opt = (IntegerUnixChannelOption) option;
-                    ((AbstractKQueueChannel) channel).socket.setIntOpt(opt.level(), opt.optname(), (Integer) value);
+                    ((AbstractKQueueChannel<?, ?, ?>) channel).socket.setIntOpt(
+                            opt.level(), opt.optname(), (Integer) value);
                     return true;
                 } else if (option instanceof RawUnixChannelOption) {
                     RawUnixChannelOption opt = (RawUnixChannelOption) option;
-                    ((AbstractKQueueChannel) channel).socket.setRawOpt(opt.level(), opt.optname(), (ByteBuffer) value);
+                    ((AbstractKQueueChannel<?, ?, ?>) channel).socket.setRawOpt(
+                            opt.level(), opt.optname(), (ByteBuffer) value);
                     return true;
                 }
             } catch (IOException e) {
@@ -184,7 +186,7 @@ public class KQueueChannelConfig extends DefaultChannelConfig {
 
     @Override
     protected final void autoReadCleared() {
-        ((AbstractKQueueChannel) channel).clearReadFilter();
+        ((AbstractKQueueChannel<?, ?, ?>) channel).clearReadFilter();
     }
 
     final void setMaxBytesPerGatheringWrite(long maxBytesPerGatheringWrite) {

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueHandler.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueHandler.java
@@ -62,13 +62,13 @@ public final class KQueueHandler implements IoHandler {
     private final SelectStrategy selectStrategy;
     private final IovArray iovArray = new IovArray();
     private final IntSupplier selectNowSupplier = this::kqueueWaitNow;
-    private final IntObjectMap<AbstractKQueueChannel> channels = new IntObjectHashMap<AbstractKQueueChannel>(4096);
+    private final IntObjectMap<AbstractKQueueChannel<?, ?, ?>> channels = new IntObjectHashMap<>(4096);
 
     private volatile int wakenUp;
 
-    private static AbstractKQueueChannel cast(Channel channel) {
+    private static AbstractKQueueChannel<?, ?, ?> cast(Channel channel) {
         if (channel instanceof AbstractKQueueChannel) {
-            return (AbstractKQueueChannel) channel;
+            return (AbstractKQueueChannel<?, ?, ?>) channel;
         }
         throw new IllegalArgumentException("Channel of type " + StringUtil.simpleClassName(channel) + " not supported");
     }
@@ -114,9 +114,9 @@ public final class KQueueHandler implements IoHandler {
 
     @Override
     public void register(Channel channel) {
-        final AbstractKQueueChannel kQueueChannel = cast(channel);
+        final AbstractKQueueChannel<?, ?, ?> kQueueChannel = cast(channel);
         final int id = kQueueChannel.fd().intValue();
-        AbstractKQueueChannel old = channels.put(id, kQueueChannel);
+        AbstractKQueueChannel<?, ?, ?> old = channels.put(id, kQueueChannel);
         // We either expect to have no Channel in the map with the same FD or that the FD of the old Channel is already
         // closed.
         assert old == null || !old.isOpen();
@@ -136,10 +136,10 @@ public final class KQueueHandler implements IoHandler {
 
     @Override
     public void deregister(Channel channel) throws Exception {
-        AbstractKQueueChannel kQueueChannel = cast(channel);
+        AbstractKQueueChannel<?, ?, ?> kQueueChannel = cast(channel);
         int fd = kQueueChannel.fd().intValue();
 
-        AbstractKQueueChannel old = channels.remove(fd);
+        AbstractKQueueChannel<?, ?, ?> old = channels.remove(fd);
         if (old != null && old != kQueueChannel) {
             // The Channel mapping was already replaced due FD reuse, put back the stored Channel.
             channels.put(fd, old);
@@ -157,7 +157,7 @@ public final class KQueueHandler implements IoHandler {
         kQueueChannel.deregister0();
     }
 
-    private void evSet(AbstractKQueueChannel ch, short filter, short flags, int fflags) {
+    private void evSet(AbstractKQueueChannel<?, ?, ?> ch, short filter, short flags, int fflags) {
         changeList.evSet(ch, filter, flags, fflags);
     }
 
@@ -216,7 +216,7 @@ public final class KQueueHandler implements IoHandler {
                 continue;
             }
 
-            AbstractKQueueChannel channel = channels.get(fd);
+            AbstractKQueueChannel<?, ?, ?> channel = channels.get(fd);
             if (channel == null) {
                 // This may happen if the channel has already been closed, and it will be removed from kqueue anyways.
                 // We also handle EV_ERROR above to skip this even early if it is a result of a referencing a closed and
@@ -336,9 +336,9 @@ public final class KQueueHandler implements IoHandler {
 
         // Using the intermediate collection to prevent ConcurrentModificationException.
         // In the `close()` method, the channel is deleted from `channels` map.
-        AbstractKQueueChannel[] localChannels = channels.values().toArray(new AbstractKQueueChannel[0]);
+        AbstractKQueueChannel<?, ?, ?>[] localChannels = channels.values().toArray(new AbstractKQueueChannel[0]);
 
-        for (AbstractKQueueChannel ch: localChannels) {
+        for (AbstractKQueueChannel<?, ?, ?> ch: localChannels) {
             ch.closeTransportNow();
         }
     }

--- a/transport/src/main/java/io/netty5/channel/nio/NioHandler.java
+++ b/transport/src/main/java/io/netty5/channel/nio/NioHandler.java
@@ -303,13 +303,13 @@ public final class NioHandler implements IoHandler {
                 SelectionKey newKey = key.channel().register(newSelectorTuple.unwrappedSelector, interestOps, a);
                 if (a instanceof AbstractNioChannel) {
                     // Update SelectionKey
-                    ((AbstractNioChannel) a).selectionKey = newKey;
+                    ((AbstractNioChannel<?, ?, ?>) a).selectionKey = newKey;
                 }
                 nChannels ++;
             } catch (Exception e) {
                 logger.warn("Failed to re-register a Channel to the new Selector.", e);
                 if (a instanceof AbstractNioChannel) {
-                    AbstractNioChannel ch = (AbstractNioChannel) a;
+                    AbstractNioChannel<?, ?, ?> ch = (AbstractNioChannel<?, ?, ?>) a;
                     ch.closeTransportNow();
                 } else {
                     @SuppressWarnings("unchecked")
@@ -336,16 +336,16 @@ public final class NioHandler implements IoHandler {
         }
     }
 
-    private static AbstractNioChannel cast(Channel channel) {
+    private static AbstractNioChannel<?, ?, ?> cast(Channel channel) {
         if (channel instanceof AbstractNioChannel) {
-            return (AbstractNioChannel) channel;
+            return (AbstractNioChannel<?, ?, ?>) channel;
         }
         throw new IllegalArgumentException("Channel of type " + StringUtil.simpleClassName(channel) + " not supported");
     }
 
     @Override
     public void register(Channel channel) throws Exception {
-        AbstractNioChannel nioChannel = cast(channel);
+        AbstractNioChannel<?, ?, ?> nioChannel = cast(channel);
         boolean selected = false;
         for (;;) {
             try {
@@ -368,7 +368,7 @@ public final class NioHandler implements IoHandler {
 
     @Override
     public void deregister(Channel channel) {
-        AbstractNioChannel nioChannel = cast(channel);
+        AbstractNioChannel<?, ?, ?> nioChannel = cast(channel);
         cancel(nioChannel.selectionKey());
     }
 
@@ -541,7 +541,7 @@ public final class NioHandler implements IoHandler {
         final Object a = k.attachment();
 
         if (a instanceof AbstractNioChannel) {
-            processSelectedKey(k, (AbstractNioChannel) a);
+            processSelectedKey(k, (AbstractNioChannel<?, ?, ?>) a);
         } else {
             @SuppressWarnings("unchecked")
             NioTask<SelectableChannel> task = (NioTask<SelectableChannel>) a;
@@ -549,7 +549,7 @@ public final class NioHandler implements IoHandler {
         }
     }
 
-    private void processSelectedKey(SelectionKey k, AbstractNioChannel ch) {
+    private void processSelectedKey(SelectionKey k, AbstractNioChannel<?, ?, ?> ch) {
         if (!k.isValid()) {
 
             // close the channel if the key is not valid anymore
@@ -617,11 +617,11 @@ public final class NioHandler implements IoHandler {
     public void prepareToDestroy() {
         selectAgain();
         Set<SelectionKey> keys = selector.keys();
-        Collection<AbstractNioChannel> channels = new ArrayList<>(keys.size());
+        Collection<AbstractNioChannel<?, ?, ?>> channels = new ArrayList<>(keys.size());
         for (SelectionKey k: keys) {
             Object a = k.attachment();
             if (a instanceof AbstractNioChannel) {
-                channels.add((AbstractNioChannel) a);
+                channels.add((AbstractNioChannel<?, ?, ?>) a);
             } else {
                 k.cancel();
                 @SuppressWarnings("unchecked")
@@ -630,7 +630,7 @@ public final class NioHandler implements IoHandler {
             }
         }
 
-        for (AbstractNioChannel ch: channels) {
+        for (AbstractNioChannel<?, ?, ?> ch: channels) {
             ch.closeTransportNow();
         }
     }


### PR DESCRIPTION
Motivation:

AbstractChannel now uses Generics so we should also ensure we use define these when using AbstractChannel.

Modifications:

Add <?, ?, ?> to fix warnings

Result:

Cleanup