### PR TITLE
Adding FuturePromiseFactory interface

### DIFF
--- a/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketProtocolHandlerTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketProtocolHandlerTest.java
@@ -158,7 +158,7 @@ public class WebSocketProtocolHandlerTest {
         EmbeddedChannel channel = new EmbeddedChannel(new ChannelHandler() {
             @Override
             public Future<Void> write(ChannelHandlerContext ctx, Object msg) {
-                Future<Void> future = ctx.newPromise().asFuture();
+                Future<Void> future = ctx.<Void>newPromise().asFuture();
                 ref.set(future);
                 Resource.dispose(msg);
                 return future;

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
@@ -125,8 +125,7 @@ public class DefaultHttp2ConnectionDecoderTest {
     public void setup() throws Exception {
         MockitoAnnotations.initMocks(this);
 
-        @SuppressWarnings("rawtypes")
-        Promise promise = ImmediateEventExecutor.INSTANCE.newPromise();
+        Promise<Void> promise = ImmediateEventExecutor.INSTANCE.newPromise();
 
         final AtomicInteger headersReceivedState = new AtomicInteger();
         when(channel.isActive()).thenReturn(true);
@@ -194,7 +193,7 @@ public class DefaultHttp2ConnectionDecoderTest {
         when(ctx.bufferAllocator()).thenReturn(onHeapAllocator());
         when(ctx.channel()).thenReturn(channel);
         when(ctx.newSucceededFuture()).thenReturn(future);
-        when(ctx.newPromise()).thenReturn(promise);
+        when(ctx.<Void>newPromise()).thenReturn(promise);
         when(ctx.write(any())).thenReturn(future);
 
         decoder = new DefaultHttp2ConnectionDecoder(connection, encoder, reader);

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
@@ -125,7 +125,8 @@ public class DefaultHttp2ConnectionDecoderTest {
     public void setup() throws Exception {
         MockitoAnnotations.initMocks(this);
 
-        Promise<Void> promise = ImmediateEventExecutor.INSTANCE.newPromise();
+        @SuppressWarnings("rawtypes")
+        Promise promise = ImmediateEventExecutor.INSTANCE.newPromise();
 
         final AtomicInteger headersReceivedState = new AtomicInteger();
         when(channel.isActive()).thenReturn(true);

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/DefaultHttp2LocalFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/DefaultHttp2LocalFlowControllerTest.java
@@ -63,7 +63,8 @@ public class DefaultHttp2LocalFlowControllerTest {
     private EventExecutor executor;
 
     @Mock
-    private Promise<Void> promise;
+    @SuppressWarnings("rawtypes")
+    private Promise promise;
 
     private DefaultHttp2Connection connection;
 
@@ -76,6 +77,7 @@ public class DefaultHttp2LocalFlowControllerTest {
         initController(false);
     }
 
+    @SuppressWarnings("unchecked")
     private void setupChannelHandlerContext(boolean allowFlush) {
         reset(ctx);
         when(ctx.newPromise()).thenReturn(promise);

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/DefaultHttp2LocalFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/DefaultHttp2LocalFlowControllerTest.java
@@ -63,8 +63,7 @@ public class DefaultHttp2LocalFlowControllerTest {
     private EventExecutor executor;
 
     @Mock
-    @SuppressWarnings("rawtypes")
-    private Promise promise;
+    private Promise<Void> promise;
 
     private DefaultHttp2Connection connection;
 
@@ -77,10 +76,9 @@ public class DefaultHttp2LocalFlowControllerTest {
         initController(false);
     }
 
-    @SuppressWarnings("unchecked")
     private void setupChannelHandlerContext(boolean allowFlush) {
         reset(ctx);
-        when(ctx.newPromise()).thenReturn(promise);
+        when(ctx.<Void>newPromise()).thenReturn(promise);
         if (allowFlush) {
             when(ctx.flush()).then((Answer<ChannelHandlerContext>) invocationOnMock -> ctx);
         } else {

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/DefaultHttp2RemoteFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/DefaultHttp2RemoteFlowControllerTest.java
@@ -79,8 +79,7 @@ public abstract class DefaultHttp2RemoteFlowControllerTest {
     private EventExecutor executor;
 
     @Mock
-    @SuppressWarnings("rawtypes")
-    private Promise promise;
+    private Promise<Void> promise;
 
     @Mock
     private Http2RemoteFlowController.Listener listener;
@@ -88,11 +87,10 @@ public abstract class DefaultHttp2RemoteFlowControllerTest {
     private DefaultHttp2Connection connection;
 
     @BeforeEach
-    @SuppressWarnings("unchecked")
     public void setup() throws Http2Exception {
         MockitoAnnotations.initMocks(this);
 
-        when(ctx.newPromise()).thenReturn(promise);
+        when(ctx.<Void>newPromise()).thenReturn(promise);
         when(ctx.flush()).thenThrow(new AssertionFailedError("forbidden"));
         setChannelWritability(true);
         when(channel.config()).thenReturn(config);

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/DefaultHttp2RemoteFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/DefaultHttp2RemoteFlowControllerTest.java
@@ -79,7 +79,8 @@ public abstract class DefaultHttp2RemoteFlowControllerTest {
     private EventExecutor executor;
 
     @Mock
-    private Promise<Void> promise;
+    @SuppressWarnings("rawtypes")
+    private Promise promise;
 
     @Mock
     private Http2RemoteFlowController.Listener listener;
@@ -87,6 +88,7 @@ public abstract class DefaultHttp2RemoteFlowControllerTest {
     private DefaultHttp2Connection connection;
 
     @BeforeEach
+    @SuppressWarnings("unchecked")
     public void setup() throws Http2Exception {
         MockitoAnnotations.initMocks(this);
 

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -83,7 +83,8 @@ public class Http2ConnectionHandlerTest {
     private static final int NON_EXISTANT_STREAM_ID = 13;
 
     private Http2ConnectionHandler handler;
-    private Promise<Void> promise;
+    @SuppressWarnings("rawtypes")
+    private Promise promise;
 
     @Mock
     private Http2Connection connection;

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -83,8 +83,7 @@ public class Http2ConnectionHandlerTest {
     private static final int NON_EXISTANT_STREAM_ID = 13;
 
     private Http2ConnectionHandler handler;
-    @SuppressWarnings("rawtypes")
-    private Promise promise;
+    private Promise<Void> promise;
 
     @Mock
     private Http2Connection connection;
@@ -195,7 +194,7 @@ public class Http2ConnectionHandlerTest {
                 .thenAnswer(invocationOnMock ->
                         ImmediateEventExecutor.INSTANCE.newFailedFuture(invocationOnMock.getArgument(0)));
         when(ctx.newSucceededFuture()).thenReturn(ImmediateEventExecutor.INSTANCE.newSucceededFuture(null));
-        when(ctx.newPromise()).thenReturn(promise);
+        when(ctx.<Void>newPromise()).thenReturn(promise);
         when(ctx.write(any())).thenReturn(future);
         when(ctx.executor()).thenReturn(executor);
         doAnswer(in -> {

--- a/common/src/main/java/io/netty5/util/concurrent/EventExecutor.java
+++ b/common/src/main/java/io/netty5/util/concurrent/EventExecutor.java
@@ -25,7 +25,7 @@ import java.util.Iterator;
  * way to access methods.
  *
  */
-public interface EventExecutor extends EventExecutorGroup {
+public interface EventExecutor extends EventExecutorGroup, FuturePromiseFactory {
 
     /**
      * Returns a reference to itself.

--- a/common/src/main/java/io/netty5/util/concurrent/FuturePromiseFactory.java
+++ b/common/src/main/java/io/netty5/util/concurrent/FuturePromiseFactory.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.util.concurrent;
+
+/**
+ * Provides a way to create {@link Future} and {@link Promise} instances.
+ */
+public interface FuturePromiseFactory {
+
+    /**
+     * Return a new {@link Promise}.
+     */
+    <V> Promise<V> newPromise();
+
+    /**
+     * Create a new {@link Future} which is marked as succeeded already. So {@link Future#isSuccess()}
+     * will return {@code true}. All {@link FutureListener} added to it will be notified directly. Also
+     * every call of blocking methods will just return without blocking.
+     */
+    default <V> Future<V> newSucceededFuture(V result) {
+        return this.<V>newPromise().setSuccess(result).asFuture();
+    }
+
+    /**
+     * Create a new {@link Future} which is marked as succeeded already. So {@link Future#isSuccess()}
+     * will return {@code true}. All {@link FutureListener} added to it will be notified directly. Also
+     * every call of blocking methods will just return without blocking.
+     */
+    default Future<Void> newSucceededFuture() {
+        return newSucceededFuture(null);
+    }
+
+    /**
+     * Create a new {@link Future} which is marked as failed already. So {@link Future#isSuccess()}
+     * will return {@code false}. All {@link FutureListener} added to it will be notified directly. Also
+     * every call of blocking methods will just return without blocking.
+     */
+    default <V> Future<V> newFailedFuture(Throwable cause) {
+        return this.<V>newPromise().setFailure(cause).asFuture();
+    }
+}

--- a/transport/src/main/java/io/netty5/channel/ChannelOutboundInvoker.java
+++ b/transport/src/main/java/io/netty5/channel/ChannelOutboundInvoker.java
@@ -17,13 +17,13 @@ package io.netty5.channel;
 
 import io.netty5.util.concurrent.EventExecutor;
 import io.netty5.util.concurrent.Future;
-import io.netty5.util.concurrent.FutureListener;
+import io.netty5.util.concurrent.FuturePromiseFactory;
 import io.netty5.util.concurrent.Promise;
 
 import java.net.ConnectException;
 import java.net.SocketAddress;
 
-public interface ChannelOutboundInvoker {
+public interface ChannelOutboundInvoker extends FuturePromiseFactory {
 
     /**
      * Request to bind to the given {@link SocketAddress} and notify the {@link Future} once the operation
@@ -174,28 +174,18 @@ public interface ChannelOutboundInvoker {
      */
     Future<Void> sendOutboundEvent(Object event);
 
-    /**
-     * Return a new {@link Promise}.
-     */
-    default Promise<Void> newPromise() {
+    @Override
+    default <V> Promise<V> newPromise() {
         return executor().newPromise();
     }
 
-    /**
-     * Create a new {@link Future} which is marked as succeeded already. So {@link Future#isSuccess()}
-     * will return {@code true}. All {@link FutureListener} added to it will be notified directly. Also
-     * every call of blocking methods will just return without blocking.
-     */
-    default Future<Void> newSucceededFuture() {
-        return executor().newSucceededFuture(null);
+    @Override
+    default <V> Future<V> newSucceededFuture(V value) {
+        return executor().newSucceededFuture(value);
     }
 
-    /**
-     * Create a new {@link Future} which is marked as failed already. So {@link Future#isSuccess()}
-     * will return {@code false}. All {@link FutureListener} added to it will be notified directly. Also
-     * every call of blocking methods will just return without blocking.
-     */
-    default Future<Void> newFailedFuture(Throwable cause) {
+    @Override
+    default <V> Future<V> newFailedFuture(Throwable cause) {
         return executor().newFailedFuture(cause);
     }
 

--- a/transport/src/main/java/io/netty5/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty5/channel/DefaultChannelPipeline.java
@@ -912,18 +912,22 @@ public abstract class DefaultChannelPipeline implements ChannelPipeline {
     }
 
     @Override
-    public final Promise<Void> newPromise() {
-        return executor().newPromise();
+    public final <V> Promise<V> newPromise() {
+        return ChannelPipeline.super.newPromise();
     }
 
     @Override
     public final Future<Void> newSucceededFuture() {
         return succeededFuture;
     }
+    @Override
+    public final <V> Future<V> newSucceededFuture(V value) {
+        return ChannelPipeline.super.newSucceededFuture(value);
+    }
 
     @Override
-    public final Future<Void> newFailedFuture(Throwable cause) {
-        return executor().newFailedFuture(cause);
+    public final  <V> Future<V> newFailedFuture(Throwable cause) {
+        return ChannelPipeline.super.newFailedFuture(cause);
     }
 
     /**

--- a/transport/src/main/java/io/netty5/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty5/channel/DefaultChannelPipeline.java
@@ -926,7 +926,7 @@ public abstract class DefaultChannelPipeline implements ChannelPipeline {
     }
 
     @Override
-    public final  <V> Future<V> newFailedFuture(Throwable cause) {
+    public final <V> Future<V> newFailedFuture(Throwable cause) {
         return ChannelPipeline.super.newFailedFuture(cause);
     }
 


### PR DESCRIPTION
Motivation:

We have multiple interfaces which have almost the same methods but dont share a super-interface.

Modifications:

- Add FuturePromiseFactory interface and extend it from EventExecutor and ChannelOutboundInvoker
- Add default methods

Result:

Share code and more clear API hierarchy
