### PR TITLE
Rename EventLoop methods to use `Io` in name to be consistent with ot…

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollSocketChannel.java
@@ -131,7 +131,7 @@ public final class EpollSocketChannel
                 // because we try to read or write until the actual close happens which may be later due
                 // SO_LINGER handling.
                 // See https://github.com/netty/netty/issues/4449
-                executor().deregisterForIO(this).map(v -> GlobalEventExecutor.INSTANCE);
+                executor().deregisterForIo(this).map(v -> GlobalEventExecutor.INSTANCE);
             }
         } catch (Throwable ignore) {
             // Ignore the error as the underlying channel may be closed in the meantime and so

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueSocketChannel.java
@@ -99,7 +99,7 @@ public final class KQueueSocketChannel
                 // because we try to read or write until the actual close happens which may be later due
                 // SO_LINGER handling.
                 // See https://github.com/netty/netty/issues/4449
-                return executor().deregisterForIO(this).map(v -> GlobalEventExecutor.INSTANCE);
+                return executor().deregisterForIo(this).map(v -> GlobalEventExecutor.INSTANCE);
             }
         } catch (Throwable ignore) {
             // Ignore the error as the underlying channel may be closed in the meantime and so

--- a/transport/src/main/java/io/netty5/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty5/channel/AbstractChannel.java
@@ -320,7 +320,7 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
                 return;
             }
             boolean firstRegistration = neverRegistered;
-            executor().registerForIO(this).addListener(f -> {
+            executor().registerForIo(this).addListener(f -> {
                 if (f.isSuccess()) {
 
                     neverRegistered = false;
@@ -650,7 +650,7 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
         // https://github.com/netty/netty/issues/4435
         invokeLater(() -> {
             try {
-                eventLoop.deregisterForIO(this).addListener(f -> {
+                eventLoop.deregisterForIo(this).addListener(f -> {
                     if (f.isFailed()) {
                         logger.warn("Unexpected exception occurred while deregistering a channel.", f.cause());
                     }

--- a/transport/src/main/java/io/netty5/channel/EventLoop.java
+++ b/transport/src/main/java/io/netty5/channel/EventLoop.java
@@ -37,7 +37,7 @@ public interface EventLoop extends OrderedEventExecutor, EventLoopGroup {
      * @param channel   the {@link Channel} to register.
      * @return          the {@link Future} that is notified once the operations completes.
      */
-    Future<Void> registerForIO(Channel channel);
+    Future<Void> registerForIo(Channel channel);
 
     /**
      * Deregister the {@link Channel} from the {@link EventLoop} for I/O processing.
@@ -45,5 +45,5 @@ public interface EventLoop extends OrderedEventExecutor, EventLoopGroup {
      * @param channel   the {@link Channel} to deregister.
      * @return          the {@link Future} that is notified once the operations completes.
      */
-    Future<Void> deregisterForIO(Channel channel);
+    Future<Void> deregisterForIo(Channel channel);
 }

--- a/transport/src/main/java/io/netty5/channel/SingleThreadEventLoop.java
+++ b/transport/src/main/java/io/netty5/channel/SingleThreadEventLoop.java
@@ -193,7 +193,7 @@ public class SingleThreadEventLoop extends SingleThreadEventExecutor implements 
     }
 
     @Override
-    public final Future<Void> registerForIO(Channel channel) {
+    public final Future<Void> registerForIo(Channel channel) {
         Promise<Void> promise = newPromise();
         if (inEventLoop()) {
             registerForIO0(channel, promise);
@@ -220,7 +220,7 @@ public class SingleThreadEventLoop extends SingleThreadEventExecutor implements 
     }
 
     @Override
-    public final Future<Void> deregisterForIO(Channel channel) {
+    public final Future<Void> deregisterForIo(Channel channel) {
        Promise<Void> promise = newPromise();
        if (inEventLoop()) {
            deregisterForIO(channel, promise);

--- a/transport/src/main/java/io/netty5/channel/embedded/EmbeddedEventLoop.java
+++ b/transport/src/main/java/io/netty5/channel/embedded/EmbeddedEventLoop.java
@@ -62,7 +62,7 @@ final class EmbeddedEventLoop extends AbstractScheduledEventExecutor implements 
     }
 
     @Override
-    public Future<Void> registerForIO(Channel channel) {
+    public Future<Void> registerForIo(Channel channel) {
         Promise<Void> promise = newPromise();
         if (inEventLoop()) {
             registerForIO0(channel, promise);
@@ -89,7 +89,7 @@ final class EmbeddedEventLoop extends AbstractScheduledEventExecutor implements 
         promise.setSuccess(null);
     }
     @Override
-    public Future<Void> deregisterForIO(Channel channel) {
+    public Future<Void> deregisterForIo(Channel channel) {
         Promise<Void> promise = newPromise();
         if (inEventLoop()) {
             deregisterForIO0(channel, promise);

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioSocketChannel.java
@@ -314,7 +314,7 @@ public class NioSocketChannel
                 // because we try to read or write until the actual close happens which may be later due
                 // SO_LINGER handling.
                 // See https://github.com/netty/netty/issues/4449
-                return executor().deregisterForIO(this).map(v -> GlobalEventExecutor.INSTANCE);
+                return executor().deregisterForIo(this).map(v -> GlobalEventExecutor.INSTANCE);
             }
         } catch (Throwable ignore) {
             // Ignore the error as the underlying channel may be closed in the meantime and so

--- a/transport/src/test/java/io/netty5/channel/AbstractChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/AbstractChannelTest.java
@@ -192,8 +192,8 @@ public class AbstractChannelTest {
     }
 
     private static void registerChannel(Channel channel) throws Exception {
-        when(channel.executor().registerForIO(channel)).thenReturn(INSTANCE.newSucceededFuture(null));
-        when(channel.executor().deregisterForIO(channel)).thenReturn(INSTANCE.newSucceededFuture(null));
+        when(channel.executor().registerForIo(channel)).thenReturn(INSTANCE.newSucceededFuture(null));
+        when(channel.executor().deregisterForIo(channel)).thenReturn(INSTANCE.newSucceededFuture(null));
         channel.register().sync(); // Cause any exceptions to be thrown
     }
 

--- a/transport/src/test/java/io/netty5/channel/SingleThreadEventLoopTest.java
+++ b/transport/src/test/java/io/netty5/channel/SingleThreadEventLoopTest.java
@@ -472,12 +472,12 @@ public class SingleThreadEventLoopTest {
         }
 
         @Override
-        public Future<Void> registerForIO(Channel channel) {
+        public Future<Void> registerForIo(Channel channel) {
             return newSucceededFuture(null);
         }
 
         @Override
-        public Future<Void> deregisterForIO(Channel channel) {
+        public Future<Void> deregisterForIo(Channel channel) {
             return newSucceededFuture(null);
         }
     }
@@ -518,12 +518,12 @@ public class SingleThreadEventLoopTest {
         }
 
         @Override
-        public Future<Void> registerForIO(Channel channel) {
+        public Future<Void> registerForIo(Channel channel) {
             return newSucceededFuture(null);
         }
 
         @Override
-        public Future<Void> deregisterForIO(Channel channel) {
+        public Future<Void> deregisterForIo(Channel channel) {
             return newSucceededFuture(null);
         }
     }

--- a/transport/src/test/java/io/netty5/channel/socket/nio/AbstractNioChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/socket/nio/AbstractNioChannelTest.java
@@ -176,13 +176,13 @@ public abstract class AbstractNioChannelTest<T extends AbstractNioChannel> {
             }
 
             @Override
-            public Future<Void> registerForIO(Channel channel) {
-                return eventLoop.registerForIO(channel);
+            public Future<Void> registerForIo(Channel channel) {
+                return eventLoop.registerForIo(channel);
             }
 
             @Override
-            public Future<Void> deregisterForIO(Channel channel) {
-                return eventLoop.deregisterForIO(channel);
+            public Future<Void> deregisterForIo(Channel channel) {
+                return eventLoop.deregisterForIo(channel);
             }
         }
 


### PR DESCRIPTION
…her interfaces

Motivation:

We should try to be as consistent as possible in naming. We already have interfaces / classes that are called `Io*` so let us also use the same naming in methods.

Modifications:

Rename methods from `*IO` to `*Io`.

Result:

Consistent naming