### PR TITLE
Cleanup FuturePromiseFactory sub-types

### DIFF
--- a/transport/src/main/java/io/netty5/channel/ChannelOutboundInvoker.java
+++ b/transport/src/main/java/io/netty5/channel/ChannelOutboundInvoker.java
@@ -189,6 +189,11 @@ public interface ChannelOutboundInvoker extends FuturePromiseFactory {
         return executor().newFailedFuture(cause);
     }
 
+    @Override
+    default Future<Void> newSucceededFuture() {
+        return executor().newSucceededFuture();
+    }
+
     /**
      * Returns the {@link EventExecutor} that is used to execute the operations of this {@link ChannelOutboundInvoker}.
      *

--- a/transport/src/main/java/io/netty5/channel/DefaultChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty5/channel/DefaultChannelHandlerContext.java
@@ -906,21 +906,6 @@ final class DefaultChannelHandlerContext implements ChannelHandlerContext, Resou
         return newFailedFuture(new IllegalStateException(msg, cause));
     }
 
-    @Override
-    public Promise<Void> newPromise() {
-        return executor().newPromise();
-    }
-
-    @Override
-    public Future<Void> newSucceededFuture() {
-        return executor().newSucceededFuture(null);
-    }
-
-    @Override
-    public Future<Void> newFailedFuture(Throwable cause) {
-        return executor().newFailedFuture(cause);
-    }
-
     private DefaultChannelHandlerContext findContextInbound(int mask) {
         DefaultChannelHandlerContext ctx = this;
         if (ctx.next == null) {

--- a/transport/src/main/java/io/netty5/channel/internal/DelegatingChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty5/channel/internal/DelegatingChannelHandlerContext.java
@@ -204,7 +204,7 @@ public abstract class DelegatingChannelHandlerContext implements ChannelHandlerC
     }
 
     @Override
-    public Promise<Void> newPromise() {
+    public <V> Promise<V> newPromise() {
         return ctx.newPromise();
     }
 
@@ -214,7 +214,12 @@ public abstract class DelegatingChannelHandlerContext implements ChannelHandlerC
     }
 
     @Override
-    public Future<Void> newFailedFuture(Throwable cause) {
+    public <V> Future<V> newFailedFuture(Throwable cause) {
         return ctx.newFailedFuture(cause);
+    }
+
+    @Override
+    public <V> Future<V> newSucceededFuture(V value) {
+        return ctx.newSucceededFuture(value);
     }
 }


### PR DESCRIPTION
Motivation:

We recently added FuturePromiseFactory but did not correctly adjust generics in some implementations whcih lead to warnings. Beside this we could also remove some overrides and just use the default implementation.

Modifications:

- Fix generics
- Make use of default methods

Result:

Cleanup
