### PR TITLE
Fix isOriginForm and isAsteriskForm

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
@@ -31,6 +31,7 @@ import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.UnstableApi;
 
 import static io.netty.util.internal.StringUtil.COMMA;
+import static io.netty.util.internal.StringUtil.isNullOrEmpty;
 import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 
 /**
@@ -49,8 +50,7 @@ public final class HttpUtil {
      * <a href="https://tools.ietf.org/html/rfc7230#section-5.3">rfc7230, 5.3</a>.
      */
     public static boolean isOriginForm(URI uri) {
-        return uri.getScheme() == null && uri.getSchemeSpecificPart() == null &&
-               uri.getHost() == null && uri.getAuthority() == null;
+        return isNullOrEmpty(uri.getScheme()) && isNullOrEmpty(uri.getAuthority()) && uri.toString().startsWith("/");
     }
 
     /**
@@ -58,10 +58,7 @@ public final class HttpUtil {
      * <a href="https://tools.ietf.org/html/rfc7230#section-5.3">rfc7230, 5.3</a>.
      */
     public static boolean isAsteriskForm(URI uri) {
-        return "*".equals(uri.getPath()) &&
-                uri.getScheme() == null && uri.getSchemeSpecificPart() == null &&
-                uri.getHost() == null && uri.getAuthority() == null && uri.getQuery() == null &&
-                uri.getFragment() == null;
+        return "*".equals(uri.toString());
     }
 
     /**

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpUtilTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpUtilTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.function.Executable;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -37,6 +38,29 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class HttpUtilTest {
+
+    @Test
+    public void testRecognizesOriginForm() {
+        // Origin form: https://tools.ietf.org/html/rfc7230#section-5.3.1
+        assertTrue(HttpUtil.isOriginForm(URI.create("/where?q=now")));
+        // Absolute form: https://tools.ietf.org/html/rfc7230#section-5.3.2
+        assertFalse(HttpUtil.isOriginForm(URI.create("http://www.example.org/pub/WWW/TheProject.html")));
+        // Authority form: https://tools.ietf.org/html/rfc7230#section-5.3.3
+        assertFalse(HttpUtil.isOriginForm(URI.create("www.example.com:80")));
+        // Asterisk form: https://tools.ietf.org/html/rfc7230#section-5.3.4
+        assertFalse(HttpUtil.isOriginForm(URI.create("*")));
+    }
+
+    @Test public void testRecognizesAsteriskForm() {
+        // Asterisk form: https://tools.ietf.org/html/rfc7230#section-5.3.4
+        assertTrue(HttpUtil.isAsteriskForm(URI.create("*")));
+        // Origin form: https://tools.ietf.org/html/rfc7230#section-5.3.1
+        assertFalse(HttpUtil.isAsteriskForm(URI.create("/where?q=now")));
+        // Absolute form: https://tools.ietf.org/html/rfc7230#section-5.3.2
+        assertFalse(HttpUtil.isAsteriskForm(URI.create("http://www.example.org/pub/WWW/TheProject.html")));
+        // Authority form: https://tools.ietf.org/html/rfc7230#section-5.3.3
+        assertFalse(HttpUtil.isAsteriskForm(URI.create("www.example.com:80")));
+    }
 
     @Test
     public void testRemoveTransferEncodingIgnoreCase() {


### PR DESCRIPTION
Motivation:

These methods would always return false using the previously implementation (URI#getSchemeSpecificPart is [documented](https://docs.oracle.com/javase/8/docs/api/java/net/URI.html#getSchemeSpecificPart--) to *never* return `null`). They also had other implementation errors.

Modification:

Edit methods to conform with RFC 7230.

Result:

Methods handle the basic examples provided in RFC 7230. More test cases can be added as needed.
