### PR TITLE
Move await() and sync() methods to the FutureCompletionStage interface

### DIFF
--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpClientCodecTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpClientCodecTest.java
@@ -192,7 +192,7 @@ public class HttpClientCodecTest {
             int port = ((InetSocketAddress) serverChannel.localAddress()).getPort();
 
             Future<Channel> ccf = cb.connect(new InetSocketAddress(NetUtil.LOCALHOST, port));
-            assertTrue(ccf.await().isSuccess());
+            assertTrue(ccf.asStage().await().future().isSuccess());
             Channel clientChannel = ccf.asStage().get();
             assertTrue(serverChannelLatch.await(5, SECONDS));
             clientChannel.writeAndFlush(new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/"));

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketClientHandshakerTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketClientHandshakerTest.java
@@ -235,7 +235,7 @@ public abstract class WebSocketClientHandshakerTest {
         }
         // We need to first write the request as HttpClientCodec will fail if we receive a response before a request
         // was written.
-        shaker.handshake(ch).sync();
+        shaker.handshake(ch).asStage().sync();
         for (;;) {
             // Just consume the bytes, we are not interested in these.
             try (Buffer buf = ch.readOutbound()) {

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketHandshakeHandOverTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketHandshakeHandOverTest.java
@@ -34,6 +34,7 @@ import java.net.URI;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -183,9 +184,9 @@ public class WebSocketHandshakeHandOverTest {
         assertFalse(clientReceivedMessage);
         // Should throw WebSocketHandshakeException
         try {
-            assertTrue(assertThrows(CompletionException.class,
-                () -> handshakeHandler.getHandshakeFuture().sync())
-                    .getCause() instanceof WebSocketHandshakeException);
+            var exception = assertThrows(CompletionException.class,
+                                         () -> handshakeHandler.getHandshakeFuture().asStage().sync());
+            assertThat(exception).hasCauseInstanceOf(WebSocketHandshakeException.class);
         } finally {
             serverChannel.finishAndReleaseAll();
         }

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/DataCompressionHttp2Test.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/DataCompressionHttp2Test.java
@@ -111,24 +111,24 @@ public class DataCompressionHttp2Test {
     @AfterEach
     public void teardown() throws InterruptedException {
         if (clientChannel != null) {
-            clientChannel.close().sync();
+            clientChannel.close().asStage().sync();
             clientChannel = null;
         }
         if (serverChannel != null) {
-            serverChannel.close().sync();
+            serverChannel.close().asStage().sync();
             serverChannel = null;
         }
         final Channel serverConnectedChannel = this.serverConnectedChannel;
         if (serverConnectedChannel != null) {
-            serverConnectedChannel.close().sync();
+            serverConnectedChannel.close().asStage().sync();
             this.serverConnectedChannel = null;
         }
         Future<?> serverGroup = sb.config().group().shutdownGracefully(0, 0, MILLISECONDS);
         Future<?> serverChildGroup = sb.config().childGroup().shutdownGracefully(0, 0, MILLISECONDS);
         Future<?> clientGroup = cb.config().group().shutdownGracefully(0, 0, MILLISECONDS);
-        serverGroup.sync();
-        serverChildGroup.sync();
-        clientGroup.sync();
+        serverGroup.asStage().sync();
+        serverChildGroup.asStage().sync();
+        clientGroup.asStage().sync();
     }
 
     @Test

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ClientUpgradeCodecTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ClientUpgradeCodecTest.java
@@ -72,7 +72,7 @@ public class Http2ClientUpgradeCodecTest {
             codec.upgradeTo(ctx,
                     new DefaultFullHttpResponse(HTTP_1_1, OK, channel.bufferAllocator().allocate(0)).send());
             return null;
-        }).sync();
+        }).asStage().sync();
         assertNotNull(channel.pipeline().get("connectionHandler"));
 
         if (multiplexer != null) {

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -122,9 +122,9 @@ public class Http2ConnectionRoundtripTest {
     }
 
     @AfterEach
-    public void teardown() throws Exception {
+    public void tearDown() throws Exception {
         if (clientChannel != null) {
-            clientChannel.close().await();
+            clientChannel.close().asStage().await();
             clientChannel = null;
         }
         if (serverChannel != null) {

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -128,20 +128,20 @@ public class Http2ConnectionRoundtripTest {
             clientChannel = null;
         }
         if (serverChannel != null) {
-            serverChannel.close().sync();
+            serverChannel.close().asStage().sync();
             serverChannel = null;
         }
         final Channel serverConnectedChannel = this.serverConnectedChannel;
         if (serverConnectedChannel != null) {
-            serverConnectedChannel.close().sync();
+            serverConnectedChannel.close().asStage().sync();
             this.serverConnectedChannel = null;
         }
         Future<?> serverGroup = sb.config().group().shutdownGracefully(0, 5, SECONDS);
         Future<?> serverChildGroup = sb.config().childGroup().shutdownGracefully(0, 5, SECONDS);
         Future<?> clientGroup = cb.config().group().shutdownGracefully(0, 5, SECONDS);
-        serverGroup.sync();
-        serverChildGroup.sync();
-        clientGroup.sync();
+        serverGroup.asStage().sync();
+        serverChildGroup.asStage().sync();
+        clientGroup.asStage().sync();
     }
 
     @Test
@@ -682,7 +682,7 @@ public class Http2ConnectionRoundtripTest {
             }
         });
         assertThat(e).hasCauseInstanceOf(IllegalStateException.class);
-        assertPromise.asFuture().sync();
+        assertPromise.asFuture().asStage().sync();
     }
 
     @Test

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameCodecTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameCodecTest.java
@@ -620,7 +620,7 @@ public class Http2FrameCodecTest {
         Future<Void> f = channel.writeAndFlush(new DefaultHttp2DataFrame(bb(100).send()).stream(stream));
         assertTrue(f.isSuccess());
 
-        listenerExecuted.asFuture().sync();
+        listenerExecuted.asFuture().asStage().sync();
         assertTrue(listenerExecuted.isSuccess());
     }
 
@@ -641,7 +641,7 @@ public class Http2FrameCodecTest {
         channel.runPendingTasks();
         assertTrue(isStreamIdValid(stream2.id()));
 
-        assertTrue(future1.sync().isSuccess());
+        assertTrue(future1.asStage().sync().isSuccess());
         assertFalse(future2.isDone());
 
         // Increase concurrent streams limit to 2
@@ -649,7 +649,7 @@ public class Http2FrameCodecTest {
 
         channel.flush();
 
-        assertTrue(future2.sync().isSuccess());
+        assertTrue(future2.asStage().sync().isSuccess());
     }
 
     @Test
@@ -673,7 +673,7 @@ public class Http2FrameCodecTest {
         channel.runPendingTasks();
         assertTrue(isStreamIdValid(stream2.id()));
 
-        assertTrue(future1.sync().isSuccess());
+        assertTrue(future1.asStage().sync().isSuccess());
         assertFalse(future2.isDone());
         assertFalse(future3.isDone());
 
@@ -682,14 +682,14 @@ public class Http2FrameCodecTest {
         channel.flush();
 
         // As we increased the limit to 2 we should have also succeed the second frame.
-        assertTrue(future2.sync().isSuccess());
+        assertTrue(future2.asStage().sync().isSuccess());
         assertFalse(future3.isDone());
 
         frameInboundWriter.writeInboundSettings(new Http2Settings().maxConcurrentStreams(3));
         channel.flush();
 
         // With the max streams of 3 all streams should be succeed now.
-        assertTrue(future3.sync().isSuccess());
+        assertTrue(future3.asStage().sync().isSuccess());
 
         assertFalse(channel.finishAndReleaseAll());
     }
@@ -709,7 +709,7 @@ public class Http2FrameCodecTest {
                 new DefaultHttp2HeadersFrame(new DefaultHttp2Headers()).stream(stream2));
         channel.runPendingTasks();
 
-        assertTrue(stream1HeaderFuture.sync().isSuccess());
+        assertTrue(stream1HeaderFuture.asStage().sync().isSuccess());
         assertTrue(stream2HeaderFuture.isDone());
 
         assertEquals(0, frameCodec.numInitializingStreams());
@@ -723,7 +723,7 @@ public class Http2FrameCodecTest {
         channel.executor().submit(() -> {
             assertNotNull(frameCodec.connection().local().createStream(maxServerStreamId, false));
             return null;
-        }).sync();
+        }).asStage().sync();
 
         Http2FrameStream stream = frameCodec.newStream();
         assertNotNull(stream);

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameCodecTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameCodecTest.java
@@ -381,7 +381,7 @@ public class Http2FrameCodecTest {
         assertEquals(1, frame.refCnt());
 
         Future<Void> f = channel.write(frame);
-        f.await();
+        f.asStage().await();
         assertTrue(f.isDone());
         assertFalse(f.isSuccess());
         assertThat(f.cause(), instanceOf(UnsupportedMessageTypeException.class));

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameInboundWriter.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameInboundWriter.java
@@ -47,60 +47,59 @@ final class Http2FrameInboundWriter {
     }
 
     void writeInboundData(int streamId, Buffer data, int padding, boolean endStream) throws Exception {
-        writer.writeData(ctx, streamId, data, padding, endStream).sync();
+        writer.writeData(ctx, streamId, data, padding, endStream).asStage().sync();
     }
 
     void writeInboundHeaders(int streamId, Http2Headers headers,
                          int padding, boolean endStream) throws Exception {
-        writer.writeHeaders(ctx, streamId, headers, padding, endStream).sync();
+        writer.writeHeaders(ctx, streamId, headers, padding, endStream).asStage().sync();
     }
 
     void writeInboundHeaders(
             int streamId, Http2Headers headers, int streamDependency, short weight, boolean exclusive,
             int padding, boolean endStream) throws Exception {
         writer.writeHeaders(ctx, streamId, headers, streamDependency,
-                weight, exclusive, padding, endStream).sync();
+                weight, exclusive, padding, endStream).asStage().sync();
     }
 
     void writeInboundPriority(int streamId, int streamDependency,
                                 short weight, boolean exclusive) throws Exception {
-        writer.writePriority(ctx, streamId, streamDependency, weight,
-                exclusive).sync();
+        writer.writePriority(ctx, streamId, streamDependency, weight, exclusive).asStage().sync();
     }
 
     void writeInboundRstStream(int streamId, long errorCode) throws Exception {
-        writer.writeRstStream(ctx, streamId, errorCode).sync();
+        writer.writeRstStream(ctx, streamId, errorCode).asStage().sync();
     }
 
     void writeInboundSettings(Http2Settings settings) throws Exception {
-        writer.writeSettings(ctx, settings).sync();
+        writer.writeSettings(ctx, settings).asStage().sync();
     }
 
     void writeInboundSettingsAck() throws Exception {
-        writer.writeSettingsAck(ctx).sync();
+        writer.writeSettingsAck(ctx).asStage().sync();
     }
 
     void writeInboundPing(boolean ack, long data) throws Exception {
-        writer.writePing(ctx, ack, data).sync();
+        writer.writePing(ctx, ack, data).asStage().sync();
     }
 
     void writePushPromise(int streamId, int promisedStreamId,
                                    Http2Headers headers, int padding) throws Exception {
-           writer.writePushPromise(ctx, streamId, promisedStreamId,
-                   headers, padding).sync();
+        writer.writePushPromise(ctx, streamId, promisedStreamId,
+                   headers, padding).asStage().sync();
     }
 
     void writeInboundGoAway(int lastStreamId, long errorCode, Buffer debugData) throws Exception {
-        writer.writeGoAway(ctx, lastStreamId, errorCode, debugData).sync();
+        writer.writeGoAway(ctx, lastStreamId, errorCode, debugData).asStage().sync();
     }
 
     void writeInboundWindowUpdate(int streamId, int windowSizeIncrement) throws Exception {
-        writer.writeWindowUpdate(ctx, streamId, windowSizeIncrement).sync();
+        writer.writeWindowUpdate(ctx, streamId, windowSizeIncrement).asStage().sync();
     }
 
     void writeInboundFrame(
             byte frameType, int streamId, Http2Flags flags, Buffer payload) throws Exception {
-        writer.writeFrame(ctx, frameType, streamId, flags, payload).sync();
+        writer.writeFrame(ctx, frameType, streamId, flags, payload).asStage().sync();
     }
 
     private static final class WriteInboundChannelHandlerContext

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexClientUpgradeTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexClientUpgradeTest.java
@@ -78,7 +78,7 @@ public class Http2MultiplexClientUpgradeTest {
         ch.executor().submit(() -> {
             codec.onHttpClientUpgrade();
             return null;
-        }).sync();
+        }).asStage().sync();
 
         assertFalse(upgradeHandler.stateOnActive.localSideOpen());
         assertTrue(upgradeHandler.stateOnActive.remoteSideOpen());
@@ -104,7 +104,7 @@ public class Http2MultiplexClientUpgradeTest {
         ch.executor().submit(() -> {
             codec.onHttpClientUpgrade();
             return null;
-        }).sync();
+        }).asStage().sync();
         latch.await();
         ch.finishAndReleaseAll();
     }

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexTest.java
@@ -359,7 +359,7 @@ public class Http2MultiplexTest {
         assertTrue(channel.isActive());
 
         if (closeLocal) {
-            channel.writeAndFlush(new DefaultHttp2HeadersFrame(new DefaultHttp2Headers(), true)).sync();
+            channel.writeAndFlush(new DefaultHttp2HeadersFrame(new DefaultHttp2Headers(), true)).asStage().sync();
             assertEquals(Http2Stream.State.HALF_CLOSED_LOCAL, channel.stream().state());
         } else {
             assertEquals(Http2Stream.State.OPEN, channel.stream().state());
@@ -550,9 +550,8 @@ public class Http2MultiplexTest {
     }
 
     private Http2StreamChannel newOutboundStream(ChannelHandler handler) throws Exception {
-        Future<Http2StreamChannel> future = new Http2StreamChannelBootstrap(parentChannel).handler(handler)
-                .open();
-        return future.sync().getNow();
+        Future<Http2StreamChannel> future = new Http2StreamChannelBootstrap(parentChannel).handler(handler).open();
+        return future.asStage().get();
     }
 
     /**
@@ -684,7 +683,7 @@ public class Http2MultiplexTest {
         CompletionException e = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() throws Exception {
-                future.sync();
+                future.asStage().sync();
             }
         });
         assertThat(e.getCause(), CoreMatchers.instanceOf(ClosedChannelException.class));
@@ -745,7 +744,7 @@ public class Http2MultiplexTest {
         CompletionException e = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() throws Exception {
-                future.sync();
+                future.asStage().sync();
             }
         });
         assertThat(e.getCause(), CoreMatchers.instanceOf(Http2NoMoreStreamIdsException.class));
@@ -769,7 +768,7 @@ public class Http2MultiplexTest {
             channelOpen.set(channel.isOpen());
             channelActive.set(channel.isActive());
         });
-        childChannel.close().cascadeTo(p).sync();
+        childChannel.close().cascadeTo(p).asStage().sync();
 
         assertFalse(channelOpen.get());
         assertFalse(channelActive.get());
@@ -791,9 +790,9 @@ public class Http2MultiplexTest {
              channelOpen.set(channel.isOpen());
              channelActive.set(channel.isActive());
          });
-         childChannel.close().sync();
+        childChannel.close().asStage().sync();
 
-         assertFalse(channelOpen.get());
+        assertFalse(channelOpen.get());
          assertFalse(channelActive.get());
          assertFalse(childChannel.isActive());
     }
@@ -842,8 +841,8 @@ public class Http2MultiplexTest {
 
         assertTrue(childChannel.isOpen());
         assertTrue(childChannel.isActive());
-        childChannel.close().sync();
-        childChannel.close().sync();
+        childChannel.close().asStage().sync();
+        childChannel.close().asStage().sync();
 
         assertFalse(childChannel.isOpen());
         assertFalse(childChannel.isActive());
@@ -952,7 +951,7 @@ public class Http2MultiplexTest {
             }
         });
 
-        childChannel.close().sync();
+        childChannel.close().asStage().sync();
         assertFalse(channelOpen.get());
         assertFalse(channelActive.get());
     }
@@ -1067,7 +1066,7 @@ public class Http2MultiplexTest {
         parentChannel.pipeline().remove(readCompleteSupressHandler);
         parentChannel.flushInbound();
 
-        childChannel.closeFuture().sync();
+        childChannel.closeFuture().asStage().sync();
     }
 
     private boolean useUserEventForResetFrame() {
@@ -1098,7 +1097,7 @@ public class Http2MultiplexTest {
         frameInboundWriter.writeInboundWindowUpdate(Http2CodecUtil.CONNECTION_STREAM_ID, 6);
 
         assertNull(parentChannel.readInbound());
-        childChannel.close().sync();
+        childChannel.close().asStage().sync();
     }
 
     @Test

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexTest.java
@@ -828,7 +828,7 @@ public class Http2MultiplexTest {
 
         Promise<Void> first = writePromises.poll();
         first.setFailure(new ClosedChannelException());
-        f.await();
+        f.asStage().await();
 
         assertFalse(channelOpen.get());
         assertFalse(channelActive.get());

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexTransportTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexTransportTest.java
@@ -181,7 +181,7 @@ public class Http2MultiplexTransportTest {
         serverConnectedChannel = serverConnectedChannelRef.get();
 
         serverConnectedChannel.writeAndFlush(new DefaultHttp2SettingsFrame(new Http2Settings()
-                .maxConcurrentStreams(10))).sync();
+                .maxConcurrentStreams(10))).asStage().sync();
 
         clientSettingsLatch.await();
 
@@ -190,8 +190,8 @@ public class Http2MultiplexTransportTest {
 
         // We expect 2 settings frames, the initial settings frame during connection establishment and the setting frame
         // written in this test. We should ack both of these settings frames.
-        clientChannel.writeAndFlush(Http2SettingsAckFrame.INSTANCE).sync();
-        clientChannel.writeAndFlush(Http2SettingsAckFrame.INSTANCE).sync();
+        clientChannel.writeAndFlush(Http2SettingsAckFrame.INSTANCE).asStage().sync();
+        clientChannel.writeAndFlush(Http2SettingsAckFrame.INSTANCE).asStage().sync();
 
         serverAckAllLatch.await();
     }
@@ -251,9 +251,8 @@ public class Http2MultiplexTransportTest {
                     Resource.dispose(msg);
                 }
             });
-            Http2StreamChannel streamChannel = h2Bootstrap.open().sync().getNow();
-            streamChannel.writeAndFlush(new DefaultHttp2HeadersFrame(new DefaultHttp2Headers(), true))
-                    .sync();
+            Http2StreamChannel streamChannel = h2Bootstrap.open().asStage().get();
+            streamChannel.writeAndFlush(new DefaultHttp2HeadersFrame(new DefaultHttp2Headers(), true)).asStage().sync();
 
             latch.await();
         } finally {

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2StreamChannelBootstrapTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2StreamChannelBootstrapTest.java
@@ -94,7 +94,7 @@ public class Http2StreamChannelBootstrapTest {
 
             Http2StreamChannelBootstrap bootstrap = new Http2StreamChannelBootstrap(clientChannel);
             final Promise<Http2StreamChannel> promise = clientChannel.executor().newPromise();
-            clientChannel.close().sync();
+            clientChannel.close().asStage().sync();
 
             bootstrap.open(promise);
 
@@ -127,7 +127,7 @@ public class Http2StreamChannelBootstrapTest {
     private static void safeClose(Channel channel) {
         if (channel != null) {
             try {
-                channel.close().sync();
+                channel.close().asStage().sync();
             } catch (Exception e) {
                 logger.error(e);
             }

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2TestUtil.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2TestUtil.java
@@ -63,7 +63,7 @@ public final class Http2TestUtil {
         channel.executor().submit(() -> {
             runnable.run();
             return null;
-        }).sync();
+        }).asStage().sync();
     }
 
     /**

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
@@ -347,7 +347,7 @@ public class HttpToHttp2ConnectionHandlerTest {
 
         Future<Void> writeFuture = clientChannel.writeAndFlush(request);
 
-        assertTrue(writeFuture.await(WAIT_TIME_SECONDS, SECONDS));
+        assertTrue(writeFuture.asStage().await(WAIT_TIME_SECONDS, SECONDS));
         assertTrue(writeFuture.isDone());
         assertFalse(writeFuture.isSuccess());
     }
@@ -364,7 +364,7 @@ public class HttpToHttp2ConnectionHandlerTest {
 
         Future<Void> writeFuture = clientChannel.writeAndFlush(request);
 
-        assertTrue(writeFuture.await(WAIT_TIME_SECONDS, SECONDS));
+        assertTrue(writeFuture.asStage().await(WAIT_TIME_SECONDS, SECONDS));
         assertTrue(writeFuture.isDone());
         assertFalse(writeFuture.isSuccess());
         Throwable cause = writeFuture.cause();
@@ -398,7 +398,7 @@ public class HttpToHttp2ConnectionHandlerTest {
 
         Future<Void> writeFuture = clientChannel.writeAndFlush(request);
 
-        assertTrue(writeFuture.await(WAIT_TIME_SECONDS, SECONDS));
+        assertTrue(writeFuture.asStage().await(WAIT_TIME_SECONDS, SECONDS));
         assertTrue(writeFuture.isSuccess());
         awaitRequests();
         verify(serverListener).onHeadersRead(any(ChannelHandlerContext.class), eq(3), eq(http2Headers), eq(0),
@@ -441,7 +441,7 @@ public class HttpToHttp2ConnectionHandlerTest {
 
         Future<Void> writeFuture = clientChannel.writeAndFlush(request);
 
-        assertTrue(writeFuture.await(WAIT_TIME_SECONDS, SECONDS));
+        assertTrue(writeFuture.asStage().await(WAIT_TIME_SECONDS, SECONDS));
         assertTrue(writeFuture.isSuccess());
         awaitRequests();
         verify(serverListener).onHeadersRead(any(ChannelHandlerContext.class), eq(3), eq(http2Headers), eq(0),
@@ -496,13 +496,13 @@ public class HttpToHttp2ConnectionHandlerTest {
 
         clientChannel.flush();
 
-        assertTrue(writeFuture.await(WAIT_TIME_SECONDS, SECONDS));
+        assertTrue(writeFuture.asStage().await(WAIT_TIME_SECONDS, SECONDS));
         assertTrue(writeFuture.isSuccess());
 
-        assertTrue(contentFuture.await(WAIT_TIME_SECONDS, SECONDS));
+        assertTrue(contentFuture.asStage().await(WAIT_TIME_SECONDS, SECONDS));
         assertTrue(contentFuture.isSuccess());
 
-        assertTrue(lastContentFuture.await(WAIT_TIME_SECONDS, SECONDS));
+        assertTrue(lastContentFuture.asStage().await(WAIT_TIME_SECONDS, SECONDS));
         assertTrue(lastContentFuture.isSuccess());
 
         awaitRequests();
@@ -577,7 +577,7 @@ public class HttpToHttp2ConnectionHandlerTest {
 
     private void verifyHeadersOnly(Http2Headers expected, Future<Void> writeFuture)
             throws Exception {
-        assertTrue(writeFuture.await(WAIT_TIME_SECONDS, SECONDS));
+        assertTrue(writeFuture.asStage().await(WAIT_TIME_SECONDS, SECONDS));
         assertTrue(writeFuture.isSuccess());
         awaitRequests();
         verify(serverListener).onHeadersRead(any(ChannelHandlerContext.class), eq(5),

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
@@ -105,24 +105,24 @@ public class HttpToHttp2ConnectionHandlerTest {
     @AfterEach
     public void tearDown() throws Exception {
         if (clientChannel != null) {
-            clientChannel.close().sync();
+            clientChannel.close().asStage().sync();
             clientChannel = null;
         }
         if (serverChannel != null) {
-            serverChannel.close().sync();
+            serverChannel.close().asStage().sync();
             serverChannel = null;
         }
         final Channel serverConnectedChannel = this.serverConnectedChannel;
         if (serverConnectedChannel != null) {
-            serverConnectedChannel.close().sync();
+            serverConnectedChannel.close().asStage().sync();
             this.serverConnectedChannel = null;
         }
         Future<?> serverGroup = sb.config().group().shutdownGracefully(0, 5, SECONDS);
         Future<?> serverChildGroup = sb.config().childGroup().shutdownGracefully(0, 5, SECONDS);
         Future<?> clientGroup = cb.config().group().shutdownGracefully(0, 5, SECONDS);
-        serverGroup.sync();
-        serverChildGroup.sync();
-        clientGroup.sync();
+        serverGroup.asStage().sync();
+        serverChildGroup.asStage().sync();
+        clientGroup.asStage().sync();
     }
 
     @Test

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
@@ -114,24 +114,24 @@ public class InboundHttp2ToHttpAdapterTest {
         cleanupCapturedRequests();
         cleanupCapturedResponses();
         if (clientChannel != null) {
-            clientChannel.close().sync();
+            clientChannel.close().asStage().sync();
             clientChannel = null;
         }
         if (serverChannel != null) {
-            serverChannel.close().sync();
+            serverChannel.close().asStage().sync();
             serverChannel = null;
         }
         final Channel serverConnectedChannel = this.serverConnectedChannel;
         if (serverConnectedChannel != null) {
-            serverConnectedChannel.close().sync();
+            serverConnectedChannel.close().asStage().sync();
             this.serverConnectedChannel = null;
         }
         Future<?> serverGroup = sb.config().group().shutdownGracefully(0, 5, SECONDS);
         Future<?> serverChildGroup = sb.config().childGroup().shutdownGracefully(0, 5, SECONDS);
         Future<?> clientGroup = cb.config().group().shutdownGracefully(0, 5, SECONDS);
-        serverGroup.sync();
-        serverChildGroup.sync();
-        clientGroup.sync();
+        serverGroup.asStage().sync();
+        serverChildGroup.asStage().sync();
+        clientGroup.asStage().sync();
     }
 
     @Test

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/StreamBufferingEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/StreamBufferingEncoderTest.java
@@ -48,6 +48,7 @@ import static io.netty5.handler.codec.http2.Http2CodecUtil.SMALLEST_MAX_CONCURRE
 import static io.netty5.handler.codec.http2.Http2Error.CANCEL;
 import static io.netty5.handler.codec.http2.Http2Stream.State.HALF_CLOSED_LOCAL;
 import static io.netty5.handler.codec.http2.Http2TestUtil.empty;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -278,7 +279,8 @@ public class StreamBufferingEncoderTest {
         connection.goAwayReceived(11, 8, empty());
         Future<Void> f = encoderWriteHeaders(5);
 
-        assertTrue(f.await().cause() instanceof Http2GoAwayException);
+        Throwable result = f.asStage().join((r, e) -> e);
+        assertThat(result).isInstanceOf(Http2GoAwayException.class);
         assertEquals(0, encoder.numBufferedStreams());
     }
 
@@ -466,7 +468,7 @@ public class StreamBufferingEncoderTest {
         Future<Void> f = encoderWriteHeaders(-1);
 
         // Verify that the write fails.
-        assertNotNull(f.await().cause());
+        assertNotNull(f.asStage().join((r, e) -> e));
     }
 
     @Test
@@ -497,9 +499,9 @@ public class StreamBufferingEncoderTest {
         Future<Void> f3 = encoderWriteHeaders(7);
 
         encoder.close();
-        assertNotNull(f1.await().cause());
-        assertNotNull(f2.await().cause());
-        assertNotNull(f3.await().cause());
+        assertNotNull(f1.asStage().join((r, e) -> e));
+        assertNotNull(f2.asStage().join((r, e) -> e));
+        assertNotNull(f3.asStage().join((r, e) -> e));
     }
 
     @Test

--- a/common/src/main/java/io/netty5/util/concurrent/AbstractScheduledEventExecutor.java
+++ b/common/src/main/java/io/netty5/util/concurrent/AbstractScheduledEventExecutor.java
@@ -384,12 +384,6 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
         }
 
         @Override
-        public RunnableFuture<V> sync() throws InterruptedException {
-            future.sync();
-            return this;
-        }
-
-        @Override
         public boolean isSuccess() {
             return future.isSuccess();
         }

--- a/common/src/main/java/io/netty5/util/concurrent/AbstractScheduledEventExecutor.java
+++ b/common/src/main/java/io/netty5/util/concurrent/AbstractScheduledEventExecutor.java
@@ -416,11 +416,6 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
         }
 
         @Override
-        public boolean await(long timeout, TimeUnit unit) throws InterruptedException {
-            return future.await(timeout, unit);
-        }
-
-        @Override
         public V getNow() {
             return future.getNow();
         }

--- a/common/src/main/java/io/netty5/util/concurrent/AbstractScheduledEventExecutor.java
+++ b/common/src/main/java/io/netty5/util/concurrent/AbstractScheduledEventExecutor.java
@@ -390,12 +390,6 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
         }
 
         @Override
-        public RunnableFuture<V> await() throws InterruptedException {
-            future.await();
-            return this;
-        }
-
-        @Override
         public boolean isSuccess() {
             return future.isSuccess();
         }

--- a/common/src/main/java/io/netty5/util/concurrent/DefaultPromise.java
+++ b/common/src/main/java/io/netty5/util/concurrent/DefaultPromise.java
@@ -36,7 +36,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public class DefaultPromise<V> implements Promise<V>, Future<V>,
                                           FutureCompletionStage<V>, java.util.concurrent.Future<V> {

--- a/common/src/main/java/io/netty5/util/concurrent/DefaultPromise.java
+++ b/common/src/main/java/io/netty5/util/concurrent/DefaultPromise.java
@@ -238,7 +238,7 @@ public class DefaultPromise<V> implements Promise<V>, Future<V>,
     }
 
     @Override
-    public Future<V> await() throws InterruptedException {
+    public FutureCompletionStage<V> await() throws InterruptedException {
         if (isDone()) {
             return this;
         }

--- a/common/src/main/java/io/netty5/util/concurrent/EventExecutorGroup.java
+++ b/common/src/main/java/io/netty5/util/concurrent/EventExecutorGroup.java
@@ -76,7 +76,7 @@ public interface EventExecutorGroup extends Iterable<EventExecutor>, Executor {
      * executor group to terminate.
      */
     default boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
-        return terminationFuture().await(timeout, unit);
+        return terminationFuture().asStage().await(timeout, unit);
     }
 
     /**

--- a/common/src/main/java/io/netty5/util/concurrent/Future.java
+++ b/common/src/main/java/io/netty5/util/concurrent/Future.java
@@ -15,8 +15,6 @@
  */
 package io.netty5.util.concurrent;
 
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
@@ -171,15 +169,6 @@ public interface Future<V> extends AsynchronousResult<V> {
      * @return this future object.
      */
     <C> Future<V> addListener(C context, FutureContextListener<? super C, ? super V> listener);
-
-    /**
-     * Waits for this future until it is done, and rethrows the cause of the failure if this future failed.
-     *
-     * @throws CancellationException if the computation was cancelled
-     * @throws CompletionException   if the computation threw an exception.
-     * @throws InterruptedException  if the current thread was interrupted while waiting
-     */
-    Future<V> sync() throws InterruptedException;
 
     /**
      * Returns a {@link FutureCompletionStage} that reflects the state of this {@link Future} and so will receive all

--- a/common/src/main/java/io/netty5/util/concurrent/Future.java
+++ b/common/src/main/java/io/netty5/util/concurrent/Future.java
@@ -58,11 +58,11 @@ import java.util.function.Function;
  * retrieve the result of the I/O operation. It also allows you to add {@link FutureListener}s so you can get notified
  * when the I/O operation is completed.
  *
- * <h3>Prefer {@link #addListener(FutureListener)} to {@link #await()}</h3>
+ * <h3>Prefer {@link #addListener(FutureListener)} to {@link FutureCompletionStage#await()}</h3>
  * <p>
  * It is recommended to prefer {@link #addListener(FutureListener)}, or {@link #addListener(Object,
- * FutureContextListener)}, to {@link #await()} wherever possible to get notified when an I/O operation is done and to
- * do any follow-up tasks.
+ * FutureContextListener)}, to {@link FutureCompletionStage#await()} wherever possible to get notified when an I/O
+ * operation is done and to do any follow-up tasks.
  * <p>
  * The {@link #addListener(FutureListener)} method is non-blocking. It simply adds the specified {@link FutureListener}
  * to the {@link Future}, and the I/O thread will notify the listeners when the I/O operation associated with the future
@@ -70,17 +70,18 @@ import java.util.function.Function;
  * resource utilization because it does not block at all, but it could be tricky to implement a sequential logic if you
  * are not used to event-driven programming.
  * <p>
- * By contrast, {@link #await()} is a blocking operation. Once called, the caller thread blocks until the operation is
- * done. It is easier to implement a sequential logic with {@link #await()}, but the caller thread blocks unnecessarily
- * until the I/O operation is done and there's relatively expensive cost of inter-thread notification. Moreover, there's
- * a chance of dead-lock in a particular circumstance, which is described below.
+ * By contrast, {@link FutureCompletionStage#await()} is a blocking operation. Once called, the caller thread blocks
+ * until the operation is done. It is easier to implement a sequential logic with {@link FutureCompletionStage#await()},
+ * but the caller thread blocks unnecessarily until the I/O operation is done and there's relatively expensive cost of
+ * inter-thread notification. Moreover, there's a chance of deadlock in a particular circumstance, which is
+ * described below.
  *
- * <h3>Do not call {@link #await()} inside a {@link io.netty5.channel.ChannelHandler}</h3>
+ * <h3>Do not call {@link FutureCompletionStage#await()} inside a {@link io.netty5.channel.ChannelHandler}</h3>
  * <p>
- * The event handler methods in {@link io.netty5.channel.ChannelHandler} are usually called by an I/O thread. If {@link
- * #await()} is called by an event handler method, which is called by the I/O thread, the I/O operation it is waiting
- * for might never complete because {@link #await()} can block the I/O operation it is waiting for, which is a
- * dead-lock.
+ * The event handler methods in {@link io.netty5.channel.ChannelHandler} are usually called by an I/O thread.
+ * If {@link FutureCompletionStage#await()} is called by an event handler method, which is called by the I/O thread,
+ * the I/O operation it is waiting for might never complete because {@link FutureCompletionStage#await()} can block
+ * the I/O operation it is waiting for, which is a deadlock.
  * <pre>
  * // BAD - NEVER DO THIS
  * {@code @Override}
@@ -105,8 +106,9 @@ import java.util.function.Function;
  * </pre>
  * <p>
  * In spite of the disadvantages mentioned above, there are certainly the cases where it is more convenient to call
- * {@link #await()}. In such a case, please make sure you do not call {@link #await()} in an I/O thread. Otherwise,
- * {@link BlockingOperationException} will be raised to prevent a dead-lock.
+ * {@link FutureCompletionStage#await()}. In such a case, please make sure you do not call
+ * {@link FutureCompletionStage#await()} in an I/O thread. Otherwise, {@link BlockingOperationException} will be
+ * raised to prevent a deadlock.
  *
  * <h3>Do not confuse I/O timeout and await timeout</h3>
  * <p>
@@ -178,13 +180,6 @@ public interface Future<V> extends AsynchronousResult<V> {
      * @throws InterruptedException  if the current thread was interrupted while waiting
      */
     Future<V> sync() throws InterruptedException;
-
-    /**
-     * Waits for this future to be completed.
-     *
-     * @throws InterruptedException if the current thread was interrupted
-     */
-    Future<V> await() throws InterruptedException;
 
     /**
      * Returns a {@link FutureCompletionStage} that reflects the state of this {@link Future} and so will receive all

--- a/common/src/main/java/io/netty5/util/concurrent/Future.java
+++ b/common/src/main/java/io/netty5/util/concurrent/Future.java
@@ -86,7 +86,7 @@ import java.util.function.Function;
  * {@code @Override}
  * public void channelRead({@link io.netty5.channel.ChannelHandlerContext} ctx, Object msg) {
  *     {@link Future} future = ctx.channel().close();
- *     future.await();
+ *     future.asStage().await();
  *     // Perform post-closure operation
  *     // ...
  * }
@@ -110,7 +110,7 @@ import java.util.function.Function;
  *
  * <h3>Do not confuse I/O timeout and await timeout</h3>
  * <p>
- * The timeout value you specify with {@link #await(long, TimeUnit)} are not related with
+ * The timeout value you specify with {@link FutureCompletionStage#await(long, TimeUnit)} is not related to the
  * I/O timeout at all.
  * If an I/O operation times out, the future will be marked as 'completed with failure,' as depicted in the
  * diagram above.  For example, connect timeout should be configured via a transport-specific option:
@@ -118,7 +118,7 @@ import java.util.function.Function;
  * // BAD - NEVER DO THIS
  * {@link io.netty5.bootstrap.Bootstrap} b = ...;
  * {@link Future} f = b.connect(...);
- * f.await(10, TimeUnit.SECONDS);
+ * f.asStage().await(10, TimeUnit.SECONDS);
  * if (f.isCancelled()) {
  *     // Connection attempt cancelled by user
  * } else if (!f.isSuccess()) {
@@ -134,7 +134,7 @@ import java.util.function.Function;
  * // Configure the connect timeout option.
  * <b>b.option({@link io.netty5.channel.ChannelOption}.CONNECT_TIMEOUT_MILLIS, 10000);</b>
  * {@link Future} f = b.connect(...);
- * f.await();
+ * f.asStage().await();
  *
  * // Now we are sure the future is completed.
  * assert f.isDone();
@@ -185,14 +185,6 @@ public interface Future<V> extends AsynchronousResult<V> {
      * @throws InterruptedException if the current thread was interrupted
      */
     Future<V> await() throws InterruptedException;
-
-    /**
-     * Waits for this future to be completed within the specified time limit.
-     *
-     * @return {@code true} if and only if the future was completed within the specified time limit
-     * @throws InterruptedException if the current thread was interrupted
-     */
-    boolean await(long timeout, TimeUnit unit) throws InterruptedException;
 
     /**
      * Returns a {@link FutureCompletionStage} that reflects the state of this {@link Future} and so will receive all

--- a/common/src/main/java/io/netty5/util/concurrent/FutureCompletionStage.java
+++ b/common/src/main/java/io/netty5/util/concurrent/FutureCompletionStage.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -41,6 +42,14 @@ import java.util.function.Function;
  * @param <V> the value type.
  */
 public interface FutureCompletionStage<V> extends CompletionStage<V>, java.util.concurrent.Future<V> {
+
+    /**
+     * Waits for this future to be completed within the specified time limit.
+     *
+     * @return {@code true} if and only if the future was completed within the specified time limit
+     * @throws InterruptedException if the current thread was interrupted
+     */
+    boolean await(long timeout, TimeUnit unit) throws InterruptedException;
 
     /**
      * Returns the underlying {@link Future} of this {@link FutureCompletionStage}.

--- a/common/src/main/java/io/netty5/util/concurrent/FutureCompletionStage.java
+++ b/common/src/main/java/io/netty5/util/concurrent/FutureCompletionStage.java
@@ -18,7 +18,9 @@ package io.netty5.util.concurrent;
 import io.netty5.util.internal.StringUtil;
 
 import java.util.Objects;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -42,6 +44,15 @@ import java.util.function.Function;
  * @param <V> the value type.
  */
 public interface FutureCompletionStage<V> extends CompletionStage<V>, java.util.concurrent.Future<V> {
+
+    /**
+     * Waits for this future until it is done, and rethrows the cause of the failure if this future failed.
+     *
+     * @throws CancellationException if the computation was cancelled
+     * @throws CompletionException   if the computation threw an exception.
+     * @throws InterruptedException  if the current thread was interrupted while waiting
+     */
+    Future<V> sync() throws InterruptedException;
 
     /**
      * Waits for the future to complete, then calls the given result handler with the outcome.

--- a/common/src/main/java/io/netty5/util/concurrent/RunnableFuture.java
+++ b/common/src/main/java/io/netty5/util/concurrent/RunnableFuture.java
@@ -25,7 +25,4 @@ public interface RunnableFuture<V> extends Runnable, Future<V> {
 
     @Override
     <C> RunnableFuture<V> addListener(C context, FutureContextListener<? super C, ? super V> listener);
-
-    @Override
-    RunnableFuture<V> sync() throws InterruptedException;
 }

--- a/common/src/main/java/io/netty5/util/concurrent/RunnableFuture.java
+++ b/common/src/main/java/io/netty5/util/concurrent/RunnableFuture.java
@@ -28,7 +28,4 @@ public interface RunnableFuture<V> extends Runnable, Future<V> {
 
     @Override
     RunnableFuture<V> sync() throws InterruptedException;
-
-    @Override
-    RunnableFuture<V> await() throws InterruptedException;
 }

--- a/common/src/main/java/io/netty5/util/concurrent/RunnableFutureAdapter.java
+++ b/common/src/main/java/io/netty5/util/concurrent/RunnableFutureAdapter.java
@@ -71,12 +71,6 @@ final class RunnableFutureAdapter<V> implements RunnableFuture<V> {
     }
 
     @Override
-    public RunnableFuture<V> sync() throws InterruptedException {
-        future.sync();
-        return this;
-    }
-
-    @Override
     public V getNow() {
         return promise.getNow();
     }

--- a/common/src/main/java/io/netty5/util/concurrent/RunnableFutureAdapter.java
+++ b/common/src/main/java/io/netty5/util/concurrent/RunnableFutureAdapter.java
@@ -84,11 +84,6 @@ final class RunnableFutureAdapter<V> implements RunnableFuture<V> {
     }
 
     @Override
-    public boolean await(long timeout, TimeUnit unit) throws InterruptedException {
-        return future.await(timeout, unit);
-    }
-
-    @Override
     public V getNow() {
         return promise.getNow();
     }

--- a/common/src/main/java/io/netty5/util/concurrent/RunnableFutureAdapter.java
+++ b/common/src/main/java/io/netty5/util/concurrent/RunnableFutureAdapter.java
@@ -18,7 +18,6 @@ package io.netty5.util.concurrent;
 import io.netty5.util.internal.StringUtil;
 
 import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
 
 import static java.util.Objects.requireNonNull;
 
@@ -74,12 +73,6 @@ final class RunnableFutureAdapter<V> implements RunnableFuture<V> {
     @Override
     public RunnableFuture<V> sync() throws InterruptedException {
         future.sync();
-        return this;
-    }
-
-    @Override
-    public RunnableFuture<V> await() throws InterruptedException {
-        future.await();
         return this;
     }
 

--- a/common/src/main/java/io/netty5/util/concurrent/RunnableScheduledFutureAdapter.java
+++ b/common/src/main/java/io/netty5/util/concurrent/RunnableScheduledFutureAdapter.java
@@ -20,7 +20,6 @@ import io.netty5.util.internal.DefaultPriorityQueue;
 import io.netty5.util.internal.StringUtil;
 
 import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static java.util.Objects.requireNonNull;
@@ -186,12 +185,6 @@ final class RunnableScheduledFutureAdapter<V> implements AbstractScheduledEventE
     @Override
     public RunnableScheduledFuture<V> sync() throws InterruptedException {
         future.sync();
-        return this;
-    }
-
-    @Override
-    public RunnableScheduledFuture<V> await() throws InterruptedException {
-        future.await();
         return this;
     }
 

--- a/common/src/main/java/io/netty5/util/concurrent/RunnableScheduledFutureAdapter.java
+++ b/common/src/main/java/io/netty5/util/concurrent/RunnableScheduledFutureAdapter.java
@@ -196,11 +196,6 @@ final class RunnableScheduledFutureAdapter<V> implements AbstractScheduledEventE
     }
 
     @Override
-    public boolean await(long timeout, TimeUnit unit) throws InterruptedException {
-        return future.await(timeout, unit);
-    }
-
-    @Override
     public V getNow() {
         return promise.getNow();
     }

--- a/common/src/main/java/io/netty5/util/concurrent/RunnableScheduledFutureAdapter.java
+++ b/common/src/main/java/io/netty5/util/concurrent/RunnableScheduledFutureAdapter.java
@@ -183,12 +183,6 @@ final class RunnableScheduledFutureAdapter<V> implements AbstractScheduledEventE
     }
 
     @Override
-    public RunnableScheduledFuture<V> sync() throws InterruptedException {
-        future.sync();
-        return this;
-    }
-
-    @Override
     public V getNow() {
         return promise.getNow();
     }

--- a/common/src/main/java/io/netty5/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty5/util/concurrent/SingleThreadEventExecutor.java
@@ -696,7 +696,7 @@ public class SingleThreadEventExecutor extends AbstractScheduledEventExecutor im
             Thread thread = this.thread;
             if (thread == null) {
                 assert !inEventLoop();
-                submit(NOOP_TASK).sync();
+                submit(NOOP_TASK).asStage().sync();
                 thread = this.thread;
                 assert thread != null;
             }

--- a/common/src/test/java/io/netty5/util/concurrent/DefaultPromiseTest.java
+++ b/common/src/test/java/io/netty5/util/concurrent/DefaultPromiseTest.java
@@ -308,7 +308,7 @@ public class DefaultPromiseTest {
                 assertTrue(listeners.isEmpty(), "Fail during run " + i + " / " + runs);
             }
         } finally {
-            executor.shutdownGracefully(0, 0, TimeUnit.SECONDS).sync();
+            executor.shutdownGracefully(0, 0, TimeUnit.SECONDS).asStage().sync();
         }
     }
 
@@ -321,7 +321,7 @@ public class DefaultPromiseTest {
         // Testing second execution path in DefaultPromise
         testListenerNotifyLater(2, executor);
 
-        executor.shutdownGracefully().sync();
+        executor.shutdownGracefully().asStage().sync();
     }
 
     @Test
@@ -437,7 +437,7 @@ public class DefaultPromiseTest {
         assertTrue(promise.isFailed());
 
         try {
-            promise.sync();
+            promise.asStage().sync();
         } catch (CompletionException e) {
             assertSame(exception, e.getCause());
         }
@@ -447,7 +447,7 @@ public class DefaultPromiseTest {
     public void throwCancelled() throws InterruptedException {
         DefaultPromise<String> promise = new DefaultPromise<>(INSTANCE);
         promise.cancel();
-        assertThrows(CancellationException.class, promise::sync);
+        assertThrows(CancellationException.class, () -> promise.asStage().sync());
     }
 
     @Test
@@ -621,7 +621,7 @@ public class DefaultPromiseTest {
 
             latch3.await();
         } finally {
-            executor.shutdownGracefully(0, 0, TimeUnit.SECONDS).sync();
+            executor.shutdownGracefully(0, 0, TimeUnit.SECONDS).asStage().sync();
         }
     }
 

--- a/common/src/test/java/io/netty5/util/concurrent/DefaultPromiseTest.java
+++ b/common/src/test/java/io/netty5/util/concurrent/DefaultPromiseTest.java
@@ -366,7 +366,7 @@ public class DefaultPromiseTest {
             for (final Map.Entry<Thread, DefaultPromise<Void>> promise : promises.entrySet()) {
                 promise.getKey().start();
                 final long start = System.nanoTime();
-                promise.getValue().await(wait, TimeUnit.NANOSECONDS);
+                promise.getValue().asStage().await(wait, TimeUnit.NANOSECONDS);
                 assertThat(System.nanoTime() - start).isLessThan(wait);
             }
         } finally {

--- a/common/src/test/java/io/netty5/util/concurrent/FutureCompletionStageTest.java
+++ b/common/src/test/java/io/netty5/util/concurrent/FutureCompletionStageTest.java
@@ -176,7 +176,7 @@ public class FutureCompletionStageTest {
                                     boolean exception) throws Exception {
         FutureCompletionStage<Boolean> stage = future.asStage();
 
-        Future<Boolean> f = fn.apply(stage).future().await();
+        Future<Boolean> f = fn.apply(stage).future().asStage().await().future();
         if (exception) {
             assertSame(EXPECTED_EXCEPTION, f.cause());
         } else {
@@ -282,7 +282,7 @@ public class FutureCompletionStageTest {
                                         boolean exception)
             throws Exception {
         FutureCompletionStage<Boolean> stage = future.asStage();
-        Future<Void> f = fn.apply(stage).future().await();
+        Future<Void> f = fn.apply(stage).future().asStage().await().future();
         if (exception) {
             assertSame(EXPECTED_EXCEPTION, f.cause());
         } else {
@@ -812,7 +812,7 @@ public class FutureCompletionStageTest {
                 }
             }
 
-            f.await();
+            f.asStage().await().future();
 
             switch (testMode) {
                 case COMPLETE_EXCEPTIONAL:
@@ -1103,7 +1103,7 @@ public class FutureCompletionStageTest {
         FutureCompletionStage<Boolean> stage = FutureCompletionStage.toFutureCompletionStage(
                 future, ImmediateEventExecutor.INSTANCE);
         assertSame(ImmediateEventExecutor.INSTANCE, stage.executor());
-        assertSame(exception, stage.future().await().cause());
+        assertSame(exception, stage.future().asStage().await().future().cause());
     }
 
     @Test

--- a/common/src/test/java/io/netty5/util/concurrent/FutureCompletionStageTest.java
+++ b/common/src/test/java/io/netty5/util/concurrent/FutureCompletionStageTest.java
@@ -180,7 +180,7 @@ public class FutureCompletionStageTest {
         if (exception) {
             assertSame(EXPECTED_EXCEPTION, f.cause());
         } else {
-            assertSame(EXPECTED_BOOLEAN, f.sync().getNow());
+            assertSame(EXPECTED_BOOLEAN, f.asStage().get());
         }
     }
 
@@ -286,7 +286,7 @@ public class FutureCompletionStageTest {
         if (exception) {
             assertSame(EXPECTED_EXCEPTION, f.cause());
         } else {
-            assertNull(f.sync().getNow());
+            assertNull(f.asStage().get());
         }
     }
 
@@ -820,7 +820,7 @@ public class FutureCompletionStageTest {
                     assertSame(EXPECTED_EXCEPTION, f.cause());
                     break;
                 case COMPLETE:
-                    assertEquals(EXPECTED_INTEGER, f.sync().getNow());
+                    assertEquals(EXPECTED_INTEGER, f.asStage().get());
                     break;
                 default:
                     fail();
@@ -1091,7 +1091,7 @@ public class FutureCompletionStageTest {
         FutureCompletionStage<Boolean> stage = FutureCompletionStage.toFutureCompletionStage(
                 CompletableFuture.completedFuture(Boolean.TRUE), ImmediateEventExecutor.INSTANCE);
         assertSame(ImmediateEventExecutor.INSTANCE, stage.executor());
-        assertSame(Boolean.TRUE, stage.future().sync().getNow());
+        assertSame(Boolean.TRUE, stage.future().asStage().get());
     }
 
     @Test
@@ -1121,7 +1121,7 @@ public class FutureCompletionStageTest {
             FutureCompletionStage<Boolean> stage2 = FutureCompletionStage.toFutureCompletionStage(
                     stage, ImmediateEventExecutor.INSTANCE);
             assertNotSame(stage, stage2);
-            assertSame(stage.future().sync().getNow(), stage2.future().sync().getNow());
+            assertSame(stage.future().asStage().get(), stage2.future().asStage().get());
         } finally {
             group.shutdownGracefully();
         }

--- a/common/src/test/java/io/netty5/util/concurrent/FuturesTest.java
+++ b/common/src/test/java/io/netty5/util/concurrent/FuturesTest.java
@@ -190,7 +190,7 @@ class FuturesTest {
         });
 
         promise.setSuccess(42);
-        assertTrue(strFut.await(5, SECONDS));
+        assertTrue(strFut.asStage().await(5, SECONDS));
         assertTrue(strFut.isCancelled());
     }
 
@@ -210,7 +210,7 @@ class FuturesTest {
 
         executor.submit(() -> promise.setSuccess(42));
         mappingLatchEnter.await();
-        assertFalse(strFut.await(100, TimeUnit.MILLISECONDS));
+        assertFalse(strFut.asStage().await(100, TimeUnit.MILLISECONDS));
         mappingLatchExit.countDown();
         assertThat(strFut.asStage().get(5, SECONDS)).isEqualTo("42");
     }
@@ -243,7 +243,7 @@ class FuturesTest {
         Exception ex = new Exception();
         promise.setFailure(ex);
         assertTrue(promise.isFailed());
-        assertTrue(promise2.await(1, SECONDS));
+        assertTrue(promise2.asStage().await(1, SECONDS));
         assertTrue(promise2.isFailed());
         assertSame(promise.cause(), promise2.cause());
     }
@@ -257,7 +257,7 @@ class FuturesTest {
 
         assertTrue(promise.cancel());
         assertTrue(promise.isCancelled());
-        assertTrue(promise2.await(1, SECONDS));
+        assertTrue(promise2.asStage().await(1, SECONDS));
         assertTrue(promise2.isCancelled());
     }
 
@@ -272,7 +272,7 @@ class FuturesTest {
         assertTrue(promise2.isCancelled());
 
         //
-        assertTrue(promise.await(1, SECONDS));
+        assertTrue(promise.asStage().await(1, SECONDS));
         assertTrue(promise2.isCancelled());
     }
 }

--- a/common/src/test/java/io/netty5/util/concurrent/GlobalEventExecutorTest.java
+++ b/common/src/test/java/io/netty5/util/concurrent/GlobalEventExecutorTest.java
@@ -73,7 +73,7 @@ public class GlobalEventExecutorTest {
     public void testScheduledTasks() throws Exception {
         TestRunnable task = new TestRunnable(0);
         Future<?> f = e.schedule(task, 1500, TimeUnit.MILLISECONDS);
-        f.sync();
+        f.asStage().sync();
         assertThat(task.ran.get(), is(true));
 
         // Ensure the thread is still running.
@@ -117,7 +117,7 @@ public class GlobalEventExecutorTest {
         TestRunnable afterTask = new TestRunnable(0);
         e.execute(afterTask);
 
-        f.sync();
+        f.asStage().sync();
 
         assertThat(beforeTask.ran.get(), is(true));
         assertThat(scheduledTask.ran.get(), is(true));
@@ -143,7 +143,7 @@ public class GlobalEventExecutorTest {
             }
         });
 
-        f.sync();
+        f.asStage().sync();
 
         assertThat(t.ran.get(), is(true));
     }

--- a/common/src/test/java/io/netty5/util/concurrent/NonStickyEventExecutorGroupTest.java
+++ b/common/src/test/java/io/netty5/util/concurrent/NonStickyEventExecutorGroupTest.java
@@ -147,7 +147,7 @@ public class NonStickyEventExecutorGroupTest {
         }
         latch.await();
         for (Future<?> future: futures) {
-            future.sync();
+            future.asStage().sync();
         }
         Throwable error = cause.get();
         if (error != null) {

--- a/common/src/test/java/io/netty5/util/concurrent/SingleThreadEventExecutorTest.java
+++ b/common/src/test/java/io/netty5/util/concurrent/SingleThreadEventExecutorTest.java
@@ -60,7 +60,7 @@ public class SingleThreadEventExecutorTest {
         executeShouldFail(executor);
         executeShouldFail(executor);
         var exception = assertThrows(
-                CompletionException.class, () -> executor.shutdownGracefully().sync());
+                CompletionException.class, () -> executor.shutdownGracefully().asStage().sync());
         assertThat(exception).hasCauseInstanceOf(RejectedExecutionException.class);
         assertTrue(executor.isShutdown());
     }
@@ -148,10 +148,10 @@ public class SingleThreadEventExecutorTest {
         };
 
         // Start the loop
-        executor.submit(DUMMY_TASK).sync();
+        executor.submit(DUMMY_TASK).asStage().sync();
 
         // Shutdown without any quiet period
-        executor.shutdownGracefully(0, 100, TimeUnit.MILLISECONDS).sync();
+        executor.shutdownGracefully(0, 100, TimeUnit.MILLISECONDS).asStage().sync();
 
         // Ensure there are no user-tasks left.
         assertEquals(0, executor.drainTasks());
@@ -193,7 +193,7 @@ public class SingleThreadEventExecutorTest {
             TestRunnable afterTask = new TestRunnable();
             executor.execute(afterTask);
 
-            f.sync();
+            f.asStage().sync();
 
             assertThat(beforeTask.ran.get()).isTrue();
             assertThat(scheduledTask.ran.get()).isTrue();
@@ -234,7 +234,7 @@ public class SingleThreadEventExecutorTest {
                 }
             });
 
-            f.sync();
+            f.asStage().sync();
 
             assertThat(t.ran.get()).isTrue();
         });

--- a/common/src/test/java/io/netty5/util/concurrent/UnorderedThreadPoolEventExecutorTest.java
+++ b/common/src/test/java/io/netty5/util/concurrent/UnorderedThreadPoolEventExecutorTest.java
@@ -100,7 +100,7 @@ public class UnorderedThreadPoolEventExecutorTest {
                 }
             });
 
-            assertSame(cause, f.await().cause());
+            assertSame(cause, f.asStage().join((r, e) -> e));
         } finally {
             executor.shutdownGracefully();
         }

--- a/common/src/test/java/io/netty5/util/concurrent/UnorderedThreadPoolEventExecutorTest.java
+++ b/common/src/test/java/io/netty5/util/concurrent/UnorderedThreadPoolEventExecutorTest.java
@@ -39,7 +39,7 @@ public class UnorderedThreadPoolEventExecutorTest {
             executor.execute(task);
             Future<?> future = executor.submit(task).addListener((FutureListener<Object>) future1 -> latch.countDown());
             latch.await();
-            future.sync();
+            future.asStage().sync();
 
             // Now just check if the queue stays empty multiple times. This is needed as the submit to execute(...)
             // by DefaultPromise may happen in an async fashion

--- a/example/src/main/java/io/netty5/example/discard/DiscardClient.java
+++ b/example/src/main/java/io/netty5/example/discard/DiscardClient.java
@@ -68,7 +68,7 @@ public final class DiscardClient {
             Channel channel = b.connect(HOST, PORT).asStage().get();
 
             // Wait until the connection is closed.
-            channel.closeFuture().sync();
+            channel.closeFuture().asStage().sync();
         } finally {
             group.shutdownGracefully();
         }

--- a/example/src/main/java/io/netty5/example/discard/DiscardServer.java
+++ b/example/src/main/java/io/netty5/example/discard/DiscardServer.java
@@ -72,7 +72,7 @@ public final class DiscardServer {
             // Wait until the server socket is closed.
             // In this example, this does not happen, but you can do that to gracefully
             // shut down your server.
-            channel.closeFuture().sync();
+            channel.closeFuture().asStage().sync();
         } finally {
             workerGroup.shutdownGracefully();
             bossGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty5/example/dns/dot/DoTClient.java
+++ b/example/src/main/java/io/netty5/example/dns/dot/DoTClient.java
@@ -104,11 +104,11 @@ public final class DoTClient {
             int randomID = new Random().nextInt(60000 - 1000) + 1000;
             DnsQuery query = new DefaultDnsQuery(randomID, DnsOpCode.QUERY)
                     .setRecord(DnsSection.QUESTION, new DefaultDnsQuestion(QUERY_DOMAIN, DnsRecordType.A));
-            ch.writeAndFlush(query).sync();
+            ch.writeAndFlush(query).asStage().sync();
             boolean success = ch.closeFuture().asStage().await(10, TimeUnit.SECONDS);
             if (!success) {
                 System.err.println("dns query timeout!");
-                ch.close().sync();
+                ch.close().asStage().sync();
             }
         } finally {
             group.shutdownGracefully();

--- a/example/src/main/java/io/netty5/example/dns/dot/DoTClient.java
+++ b/example/src/main/java/io/netty5/example/dns/dot/DoTClient.java
@@ -105,7 +105,7 @@ public final class DoTClient {
             DnsQuery query = new DefaultDnsQuery(randomID, DnsOpCode.QUERY)
                     .setRecord(DnsSection.QUESTION, new DefaultDnsQuestion(QUERY_DOMAIN, DnsRecordType.A));
             ch.writeAndFlush(query).sync();
-            boolean success = ch.closeFuture().await(10, TimeUnit.SECONDS);
+            boolean success = ch.closeFuture().asStage().await(10, TimeUnit.SECONDS);
             if (!success) {
                 System.err.println("dns query timeout!");
                 ch.close().sync();

--- a/example/src/main/java/io/netty5/example/dns/tcp/TcpDnsClient.java
+++ b/example/src/main/java/io/netty5/example/dns/tcp/TcpDnsClient.java
@@ -99,7 +99,7 @@ public final class TcpDnsClient {
             DnsQuery query = new DefaultDnsQuery(randomID, DnsOpCode.QUERY)
                     .setRecord(DnsSection.QUESTION, new DefaultDnsQuestion(QUERY_DOMAIN, DnsRecordType.A));
             ch.writeAndFlush(query).sync();
-            boolean success = ch.closeFuture().await(10, TimeUnit.SECONDS);
+            boolean success = ch.closeFuture().asStage().await(10, TimeUnit.SECONDS);
             if (!success) {
                 System.err.println("dns query timeout!");
                 ch.close().sync();

--- a/example/src/main/java/io/netty5/example/dns/tcp/TcpDnsClient.java
+++ b/example/src/main/java/io/netty5/example/dns/tcp/TcpDnsClient.java
@@ -98,11 +98,11 @@ public final class TcpDnsClient {
             int randomID = new Random().nextInt(60000 - 1000) + 1000;
             DnsQuery query = new DefaultDnsQuery(randomID, DnsOpCode.QUERY)
                     .setRecord(DnsSection.QUESTION, new DefaultDnsQuestion(QUERY_DOMAIN, DnsRecordType.A));
-            ch.writeAndFlush(query).sync();
+            ch.writeAndFlush(query).asStage().sync();
             boolean success = ch.closeFuture().asStage().await(10, TimeUnit.SECONDS);
             if (!success) {
                 System.err.println("dns query timeout!");
-                ch.close().sync();
+                ch.close().asStage().sync();
             }
         } finally {
             group.shutdownGracefully();

--- a/example/src/main/java/io/netty5/example/dns/tcp/TcpDnsServer.java
+++ b/example/src/main/java/io/netty5/example/dns/tcp/TcpDnsServer.java
@@ -106,7 +106,7 @@ public final class TcpDnsServer {
                 e.printStackTrace();
             }
         }, 1000, TimeUnit.MILLISECONDS);
-        channel.closeFuture().sync();
+        channel.closeFuture().asStage().sync();
     }
 
     // copy from TcpDnsClient.java
@@ -140,11 +140,11 @@ public final class TcpDnsServer {
             int randomID = new Random().nextInt(60000 - 1000) + 1000;
             DnsQuery query = new DefaultDnsQuery(randomID, DnsOpCode.QUERY)
                     .setRecord(DnsSection.QUESTION, new DefaultDnsQuestion(QUERY_DOMAIN, DnsRecordType.A));
-            ch.writeAndFlush(query).sync();
+            ch.writeAndFlush(query).asStage().sync();
             boolean success = ch.closeFuture().asStage().await(10, TimeUnit.SECONDS);
             if (!success) {
                 System.err.println("dns query timeout!");
-                ch.close().sync();
+                ch.close().asStage().sync();
             }
         } finally {
             group.shutdownGracefully();

--- a/example/src/main/java/io/netty5/example/dns/tcp/TcpDnsServer.java
+++ b/example/src/main/java/io/netty5/example/dns/tcp/TcpDnsServer.java
@@ -141,7 +141,7 @@ public final class TcpDnsServer {
             DnsQuery query = new DefaultDnsQuery(randomID, DnsOpCode.QUERY)
                     .setRecord(DnsSection.QUESTION, new DefaultDnsQuestion(QUERY_DOMAIN, DnsRecordType.A));
             ch.writeAndFlush(query).sync();
-            boolean success = ch.closeFuture().await(10, TimeUnit.SECONDS);
+            boolean success = ch.closeFuture().asStage().await(10, TimeUnit.SECONDS);
             if (!success) {
                 System.err.println("dns query timeout!");
                 ch.close().sync();

--- a/example/src/main/java/io/netty5/example/dns/udp/DnsClient.java
+++ b/example/src/main/java/io/netty5/example/dns/udp/DnsClient.java
@@ -96,7 +96,7 @@ public final class DnsClient {
                     DnsSection.QUESTION,
                     new DefaultDnsQuestion(QUERY_DOMAIN, DnsRecordType.A));
             ch.writeAndFlush(query).sync();
-            boolean success = ch.closeFuture().await(10, TimeUnit.SECONDS);
+            boolean success = ch.closeFuture().asStage().await(10, TimeUnit.SECONDS);
             if (!success) {
                 System.err.println("dns query timeout!");
                 ch.close().sync();

--- a/example/src/main/java/io/netty5/example/dns/udp/DnsClient.java
+++ b/example/src/main/java/io/netty5/example/dns/udp/DnsClient.java
@@ -95,11 +95,11 @@ public final class DnsClient {
             DnsQuery query = new DatagramDnsQuery(null, addr, 1).setRecord(
                     DnsSection.QUESTION,
                     new DefaultDnsQuestion(QUERY_DOMAIN, DnsRecordType.A));
-            ch.writeAndFlush(query).sync();
+            ch.writeAndFlush(query).asStage().sync();
             boolean success = ch.closeFuture().asStage().await(10, TimeUnit.SECONDS);
             if (!success) {
                 System.err.println("dns query timeout!");
-                ch.close().sync();
+                ch.close().asStage().sync();
             }
         } finally {
             group.shutdownGracefully();

--- a/example/src/main/java/io/netty5/example/echo/EchoClient.java
+++ b/example/src/main/java/io/netty5/example/echo/EchoClient.java
@@ -75,7 +75,7 @@ public final class EchoClient {
             Channel channel = b.connect(HOST, PORT).asStage().get();
 
             // Wait until the connection is closed.
-            channel.closeFuture().sync();
+            channel.closeFuture().asStage().sync();
         } finally {
             // Shut down the event loop to terminate all threads.
             group.shutdownGracefully();

--- a/example/src/main/java/io/netty5/example/echo/EchoServer.java
+++ b/example/src/main/java/io/netty5/example/echo/EchoServer.java
@@ -75,7 +75,7 @@ public final class EchoServer {
             Channel channel = b.bind(PORT).asStage().get();
 
             // Wait until the server socket is closed.
-            channel.closeFuture().sync();
+            channel.closeFuture().asStage().sync();
         } finally {
             // Shut down all event loops to terminate all threads.
             bossGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty5/example/factorial/FactorialServer.java
+++ b/example/src/main/java/io/netty5/example/factorial/FactorialServer.java
@@ -54,7 +54,7 @@ public final class FactorialServer {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new FactorialServerInitializer(sslCtx));
 
-            b.bind(PORT).asStage().get().closeFuture().sync();
+            b.bind(PORT).asStage().get().closeFuture().asStage().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty5/example/file/FileServer.java
+++ b/example/src/main/java/io/netty5/example/file/FileServer.java
@@ -84,7 +84,7 @@ public final class FileServer {
             Channel channel = b.bind(PORT).asStage().get();
 
             // Wait until the server socket is closed.
-            channel.closeFuture().sync();
+            channel.closeFuture().asStage().sync();
         } finally {
             // Shut down all event loops to terminate all threads.
             bossGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty5/example/http/cors/HttpCorsServer.java
+++ b/example/src/main/java/io/netty5/example/http/cors/HttpCorsServer.java
@@ -96,7 +96,7 @@ public final class HttpCorsServer {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new HttpCorsServerInitializer(sslCtx));
 
-            b.bind(PORT).asStage().get().closeFuture().sync();
+            b.bind(PORT).asStage().get().closeFuture().asStage().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty5/example/http/file/HttpStaticFileServer.java
+++ b/example/src/main/java/io/netty5/example/http/file/HttpStaticFileServer.java
@@ -58,7 +58,7 @@ public final class HttpStaticFileServer {
             System.err.println("Open your web browser and navigate to " +
                     (SSL? "https" : "http") + "://127.0.0.1:" + PORT + '/');
 
-            ch.closeFuture().sync();
+            ch.closeFuture().asStage().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty5/example/http/helloworld/HttpHelloWorldServer.java
+++ b/example/src/main/java/io/netty5/example/http/helloworld/HttpHelloWorldServer.java
@@ -63,7 +63,7 @@ public final class HttpHelloWorldServer {
             System.err.println("Open your web browser and navigate to " +
                     (SSL? "https" : "http") + "://127.0.0.1:" + PORT + '/');
 
-            ch.closeFuture().sync();
+            ch.closeFuture().asStage().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty5/example/http/snoop/HttpSnoopClient.java
+++ b/example/src/main/java/io/netty5/example/http/snoop/HttpSnoopClient.java
@@ -100,7 +100,7 @@ public final class HttpSnoopClient {
             ch.writeAndFlush(request);
 
             // Wait for the server to close the connection.
-            ch.closeFuture().sync();
+            ch.closeFuture().asStage().sync();
         } finally {
             // Shut down executor threads to exit.
             group.shutdownGracefully();

--- a/example/src/main/java/io/netty5/example/http/snoop/HttpSnoopServer.java
+++ b/example/src/main/java/io/netty5/example/http/snoop/HttpSnoopServer.java
@@ -61,7 +61,7 @@ public final class HttpSnoopServer {
             System.err.println("Open your web browser and navigate to " +
                     (SSL? "https" : "http") + "://127.0.0.1:" + PORT + '/');
 
-            ch.closeFuture().sync();
+            ch.closeFuture().asStage().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty5/example/http/websocketx/benchmarkserver/WebSocketServer.java
+++ b/example/src/main/java/io/netty5/example/http/websocketx/benchmarkserver/WebSocketServer.java
@@ -61,7 +61,7 @@ public final class WebSocketServer {
             System.out.println("Open your web browser and navigate to " +
                     (SSL? "https" : "http") + "://127.0.0.1:" + PORT + '/');
 
-            ch.closeFuture().sync();
+            ch.closeFuture().asStage().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty5/example/http/websocketx/client/WebSocketClient.java
+++ b/example/src/main/java/io/netty5/example/http/websocketx/client/WebSocketClient.java
@@ -120,7 +120,7 @@ public final class WebSocketClient {
              });
 
             Channel ch = b.connect(uri.getHost(), port).asStage().get();
-            handler.handshakeFuture().sync();
+            handler.handshakeFuture().asStage().sync();
 
             BufferedReader console = new BufferedReader(new InputStreamReader(System.in));
             while (true) {
@@ -129,7 +129,7 @@ public final class WebSocketClient {
                     break;
                 } else if ("bye".equalsIgnoreCase(msg)) {
                     ch.writeAndFlush(new CloseWebSocketFrame(true, 0, ch.bufferAllocator().allocate(0)));
-                    ch.closeFuture().sync();
+                    ch.closeFuture().asStage().sync();
                     break;
                 } else if ("ping".equalsIgnoreCase(msg)) {
                     WebSocketFrame frame =

--- a/example/src/main/java/io/netty5/example/http/websocketx/server/WebSocketServer.java
+++ b/example/src/main/java/io/netty5/example/http/websocketx/server/WebSocketServer.java
@@ -75,7 +75,7 @@ public final class WebSocketServer {
             System.out.println("Open your web browser and navigate to " +
                     (SSL? "https" : "http") + "://127.0.0.1:" + PORT + '/');
 
-            ch.closeFuture().sync();
+            ch.closeFuture().asStage().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty5/example/http2/file/Http2StaticFileServer.java
+++ b/example/src/main/java/io/netty5/example/http2/file/Http2StaticFileServer.java
@@ -60,11 +60,11 @@ public final class Http2StaticFileServer {
                     .handler(new LoggingHandler(LogLevel.INFO))
                     .childHandler(new Http2StaticFileServerInitializer(sslCtx));
 
-            Channel ch = b.bind(PORT).sync().getNow();
+            Channel ch = b.bind(PORT).asStage().get();
 
             System.out.println("Open your web browser and navigate to https://127.0.0.1:" + PORT + '/');
 
-            ch.closeFuture().sync();
+            ch.closeFuture().asStage().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty5/example/http2/helloworld/client/Http2Client.java
+++ b/example/src/main/java/io/netty5/example/http2/helloworld/client/Http2Client.java
@@ -144,7 +144,7 @@ public final class Http2Client {
             System.out.println("Finished HTTP/2 request(s)");
 
             // Wait until the connection is closed.
-            channel.close().sync();
+            channel.close().asStage().sync();
         } finally {
             workerGroup.shutdownGracefully();
         }

--- a/example/src/main/java/io/netty5/example/http2/helloworld/client/Http2SettingsHandler.java
+++ b/example/src/main/java/io/netty5/example/http2/helloworld/client/Http2SettingsHandler.java
@@ -45,7 +45,7 @@ public class Http2SettingsHandler extends SimpleChannelInboundHandler<Http2Setti
      * @throws Exception if timeout or other failure occurs
      */
     public void awaitSettings(long timeout, TimeUnit unit) throws Exception {
-        if (!promise.asFuture().await(timeout, unit)) {
+        if (!promise.asFuture().asStage().await(timeout, unit)) {
             throw new IllegalStateException("Timed out waiting for settings");
         }
         if (promise.isFailed()) {

--- a/example/src/main/java/io/netty5/example/http2/helloworld/client/HttpResponseHandler.java
+++ b/example/src/main/java/io/netty5/example/http2/helloworld/client/HttpResponseHandler.java
@@ -68,14 +68,14 @@ public class HttpResponseHandler extends SimpleChannelInboundHandler<FullHttpRes
         while (itr.hasNext()) {
             Entry<Integer, Entry<Future<Void>, Promise<Void>>> entry = itr.next();
             Future<Void> writeFuture = entry.getValue().getKey();
-            if (!writeFuture.await(timeout, unit)) {
+            if (!writeFuture.asStage().await(timeout, unit)) {
                 throw new IllegalStateException("Timed out waiting to write for stream id " + entry.getKey());
             }
             if (writeFuture.isFailed()) {
                 throw new RuntimeException(writeFuture.cause());
             }
             Promise<Void> promise = entry.getValue().getValue();
-            if (!promise.asFuture().await(timeout, unit)) {
+            if (!promise.asFuture().asStage().await(timeout, unit)) {
                 throw new IllegalStateException("Timed out waiting for response on stream id " + entry.getKey());
             }
             if (promise.isFailed()) {

--- a/example/src/main/java/io/netty5/example/http2/helloworld/frame/client/Http2FrameClient.java
+++ b/example/src/main/java/io/netty5/example/http2/helloworld/frame/client/Http2FrameClient.java
@@ -96,7 +96,7 @@ public final class Http2FrameClient {
                     new Http2ClientStreamFrameResponseHandler();
 
             final Http2StreamChannelBootstrap streamChannelBootstrap = new Http2StreamChannelBootstrap(channel);
-            final Http2StreamChannel streamChannel = streamChannelBootstrap.open().sync().getNow();
+            final Http2StreamChannel streamChannel = streamChannelBootstrap.open().asStage().get();
             streamChannel.pipeline().addLast(streamFrameResponseHandler);
 
             // Send request (a HTTP/2 HEADERS frame - with ':method = GET' in this case)
@@ -116,7 +116,7 @@ public final class Http2FrameClient {
             System.out.println("Finished HTTP/2 request, will close the connection.");
 
             // Wait until the connection is closed.
-            channel.close().sync();
+            channel.close().asStage().sync();
         } finally {
             clientWorkerGroup.shutdownGracefully();
         }

--- a/example/src/main/java/io/netty5/example/http2/helloworld/frame/server/Http2Server.java
+++ b/example/src/main/java/io/netty5/example/http2/helloworld/frame/server/Http2Server.java
@@ -90,7 +90,7 @@ public final class Http2Server {
             System.err.println("Open your HTTP/2-enabled web browser and navigate to " +
                     (SSL? "https" : "http") + "://127.0.0.1:" + PORT + '/');
 
-            ch.closeFuture().sync();
+            ch.closeFuture().asStage().sync();
         } finally {
             group.shutdownGracefully();
         }

--- a/example/src/main/java/io/netty5/example/http2/helloworld/multiplex/server/Http2Server.java
+++ b/example/src/main/java/io/netty5/example/http2/helloworld/multiplex/server/Http2Server.java
@@ -92,7 +92,7 @@ public final class Http2Server {
             System.err.println("Open your HTTP/2-enabled web browser and navigate to " +
                     (SSL? "https" : "http") + "://127.0.0.1:" + PORT + '/');
 
-            ch.closeFuture().sync();
+            ch.closeFuture().asStage().sync();
         } finally {
             group.shutdownGracefully();
         }

--- a/example/src/main/java/io/netty5/example/http2/helloworld/server/Http2Server.java
+++ b/example/src/main/java/io/netty5/example/http2/helloworld/server/Http2Server.java
@@ -87,7 +87,7 @@ public final class Http2Server {
             System.err.println("Open your HTTP/2-enabled web browser and navigate to " +
                     (SSL? "https" : "http") + "://127.0.0.1:" + PORT + '/');
 
-            ch.closeFuture().sync();
+            ch.closeFuture().asStage().sync();
         } finally {
             group.shutdownGracefully();
         }

--- a/example/src/main/java/io/netty5/example/http2/tiles/Launcher.java
+++ b/example/src/main/java/io/netty5/example/http2/tiles/Launcher.java
@@ -45,7 +45,7 @@ public final class Launcher {
         try {
             http2.start();
             System.err.println("Open your web browser and navigate to " + "http://" + Html.IP + ":" + HttpServer.PORT);
-            http.start().sync();
+            http.start().asStage().sync();
         } catch (Exception e) {
             e.printStackTrace();
         } finally {

--- a/example/src/main/java/io/netty5/example/localecho/LocalEcho.java
+++ b/example/src/main/java/io/netty5/example/localecho/LocalEcho.java
@@ -98,7 +98,7 @@ public final class LocalEcho {
 
             // Wait until all messages are flushed before closing the channel.
             if (lastWriteFuture != null) {
-                lastWriteFuture.await();
+                lastWriteFuture.asStage().await();
             }
         } finally {
             serverGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty5/example/localecho/LocalEcho.java
+++ b/example/src/main/java/io/netty5/example/localecho/LocalEcho.java
@@ -77,7 +77,7 @@ public final class LocalEcho {
               });
 
             // Start the server.
-            sb.bind(addr).sync();
+            sb.bind(addr).asStage().sync();
 
             // Start the client.
             Channel ch = cb.connect(addr).asStage().get();

--- a/example/src/main/java/io/netty5/example/portunification/PortUnificationServer.java
+++ b/example/src/main/java/io/netty5/example/portunification/PortUnificationServer.java
@@ -60,7 +60,7 @@ public final class PortUnificationServer {
             });
 
             // Bind and start to accept incoming connections.
-            b.bind(PORT).asStage().get().closeFuture().sync();
+            b.bind(PORT).asStage().get().closeFuture().asStage().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty5/example/proxy/HexDumpProxy.java
+++ b/example/src/main/java/io/netty5/example/proxy/HexDumpProxy.java
@@ -43,7 +43,7 @@ public final class HexDumpProxy {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new HexDumpProxyInitializer(REMOTE_HOST, REMOTE_PORT))
              .childOption(ChannelOption.AUTO_READ, false)
-             .bind(LOCAL_PORT).asStage().get().closeFuture().sync();
+             .bind(LOCAL_PORT).asStage().get().closeFuture().asStage().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty5/example/qotm/QuoteOfTheMomentClient.java
+++ b/example/src/main/java/io/netty5/example/qotm/QuoteOfTheMomentClient.java
@@ -60,7 +60,7 @@ public final class QuoteOfTheMomentClient {
             // QuoteOfTheMomentClientHandler will close the DatagramChannel when a
             // response is received.  If the channel is not closed within 5 seconds,
             // print an error message and quit.
-            if (!ch.closeFuture().await(5000, TimeUnit.MILLISECONDS)) {
+            if (!ch.closeFuture().asStage().await(5000, TimeUnit.MILLISECONDS)) {
                 System.err.println("QOTM request timed out.");
             }
         } finally {

--- a/example/src/main/java/io/netty5/example/qotm/QuoteOfTheMomentClient.java
+++ b/example/src/main/java/io/netty5/example/qotm/QuoteOfTheMomentClient.java
@@ -55,7 +55,8 @@ public final class QuoteOfTheMomentClient {
 
             // Broadcast the QOTM request to port 8080.
             Buffer message = DefaultBufferAllocators.preferredAllocator().copyOf("QOTM?", UTF_8);
-            ch.writeAndFlush(new DatagramPacket(message, SocketUtils.socketAddress("255.255.255.255", PORT))).sync();
+            ch.writeAndFlush(new DatagramPacket(message, SocketUtils.socketAddress("255.255.255.255", PORT)))
+              .asStage().sync();
 
             // QuoteOfTheMomentClientHandler will close the DatagramChannel when a
             // response is received.  If the channel is not closed within 5 seconds,

--- a/example/src/main/java/io/netty5/example/qotm/QuoteOfTheMomentServer.java
+++ b/example/src/main/java/io/netty5/example/qotm/QuoteOfTheMomentServer.java
@@ -41,7 +41,7 @@ public final class QuoteOfTheMomentServer {
              .option(ChannelOption.SO_BROADCAST, true)
              .handler(new QuoteOfTheMomentServerHandler());
 
-            b.bind(PORT).asStage().get().closeFuture().await();
+            b.bind(PORT).asStage().get().closeFuture().asStage().await();
         } finally {
             group.shutdownGracefully();
         }

--- a/example/src/main/java/io/netty5/example/securechat/SecureChatClient.java
+++ b/example/src/main/java/io/netty5/example/securechat/SecureChatClient.java
@@ -68,14 +68,14 @@ public final class SecureChatClient {
                 // If user typed the 'bye' command, wait until the server closes
                 // the connection.
                 if ("bye".equalsIgnoreCase(line)) {
-                    ch.closeFuture().sync();
+                    ch.closeFuture().asStage().sync();
                     break;
                 }
             }
 
             // Wait until all messages are flushed before closing the channel.
             if (lastWriteFuture != null) {
-                lastWriteFuture.sync();
+                lastWriteFuture.asStage().sync();
             }
         } finally {
             // The connection is closed automatically on shutdown.

--- a/example/src/main/java/io/netty5/example/securechat/SecureChatServer.java
+++ b/example/src/main/java/io/netty5/example/securechat/SecureChatServer.java
@@ -48,7 +48,7 @@ public final class SecureChatServer {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new SecureChatServerInitializer(sslCtx));
 
-            b.bind(PORT).asStage().get().closeFuture().sync();
+            b.bind(PORT).asStage().get().closeFuture().asStage().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty5/example/telnet/TelnetClient.java
+++ b/example/src/main/java/io/netty5/example/telnet/TelnetClient.java
@@ -73,14 +73,14 @@ public final class TelnetClient {
                 // If user typed the 'bye' command, wait until the server closes
                 // the connection.
                 if ("bye".equalsIgnoreCase(line)) {
-                    ch.closeFuture().sync();
+                    ch.closeFuture().asStage().sync();
                     break;
                 }
             }
 
             // Wait until all messages are flushed before closing the channel.
             if (lastWriteFuture != null) {
-                lastWriteFuture.sync();
+                lastWriteFuture.asStage().sync();
             }
         } finally {
             group.shutdownGracefully();

--- a/example/src/main/java/io/netty5/example/telnet/TelnetServer.java
+++ b/example/src/main/java/io/netty5/example/telnet/TelnetServer.java
@@ -53,7 +53,7 @@ public final class TelnetServer {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new TelnetServerInitializer(sslCtx));
 
-            b.bind(PORT).asStage().get().closeFuture().sync();
+            b.bind(PORT).asStage().get().closeFuture().asStage().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty5/example/uptime/UptimeServer.java
+++ b/example/src/main/java/io/netty5/example/uptime/UptimeServer.java
@@ -59,7 +59,7 @@ public final class UptimeServer {
             // Wait until the server socket is closed.
             // In this example, this does not happen, but you can do that to gracefully
             // shut down your server.
-            channel.closeFuture().sync();
+            channel.closeFuture().asStage().sync();
         } finally {
             workerGroup.shutdownGracefully();
             bossGroup.shutdownGracefully();

--- a/handler/src/test/java/io/netty5/handler/address/DynamicAddressConnectHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/address/DynamicAddressConnectHandlerTest.java
@@ -63,7 +63,7 @@ public class DynamicAddressConnectHandlerTest {
                 return REMOTE_NEW;
             }
         });
-        channel.connect(REMOTE, LOCAL).sync();
+        channel.connect(REMOTE, LOCAL).asStage().sync();
         assertNull(channel.pipeline().get(DynamicAddressConnectHandler.class));
         assertFalse(channel.finish());
     }

--- a/handler/src/test/java/io/netty5/handler/address/ResolveAddressHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/address/ResolveAddressHandlerTest.java
@@ -92,7 +92,7 @@ public class ResolveAddressHandlerTest {
 
         // Start server
         Channel sc = sb.bind(RESOLVED).asStage().get();
-        Future<Channel> future = cb.connect(UNRESOLVED).await();
+        Future<Channel> future = cb.connect(UNRESOLVED).asStage().await().future();
         try {
             if (fail) {
                 assertSame(ERROR, future.cause());

--- a/handler/src/test/java/io/netty5/handler/address/ResolveAddressHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/address/ResolveAddressHandlerTest.java
@@ -98,10 +98,10 @@ public class ResolveAddressHandlerTest {
                 assertSame(ERROR, future.cause());
             } else {
                 assertTrue(future.isSuccess());
-                future.asStage().get().close().sync();
+                future.asStage().get().close().asStage().sync();
             }
         } finally {
-            sc.close().sync();
+            sc.close().asStage().sync();
             resolverGroup.close();
         }
     }

--- a/handler/src/test/java/io/netty5/handler/flow/FlowControlHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/flow/FlowControlHandlerTest.java
@@ -140,8 +140,7 @@ public class FlowControlHandlerTest {
         Channel client = newClient(server.localAddress());
 
         try {
-            client.writeAndFlush(newOneMessage())
-                .sync();
+            client.writeAndFlush(newOneMessage()).asStage().sync();
 
             // We received three messages even through auto reading
             // was turned off after we received the first message.
@@ -188,8 +187,7 @@ public class FlowControlHandlerTest {
             Channel peer = peerRef.exchange(null, 1L, SECONDS);
 
             // Write the message
-            client.writeAndFlush(newOneMessage())
-                .sync();
+            client.writeAndFlush(newOneMessage()).asStage().sync();
 
             // Read the message
             peer.read();
@@ -235,8 +233,7 @@ public class FlowControlHandlerTest {
             Channel peer = peerRef.exchange(null, 1L, SECONDS);
 
             // Write the message
-            client.writeAndFlush(newOneMessage())
-                .sync();
+            client.writeAndFlush(newOneMessage()).asStage().sync();
 
             // We should receive 3 messages
             assertTrue(latch.await(1L, SECONDS));
@@ -307,8 +304,7 @@ public class FlowControlHandlerTest {
             // The client connection on the server side
             Channel peer = peerRef.exchange(null, 1L, SECONDS);
 
-            client.writeAndFlush(newOneMessage())
-                .sync();
+            client.writeAndFlush(newOneMessage()).asStage().sync();
 
             // channelRead(1)
             assertTrue(msgRcvLatch1.await(1L, SECONDS));
@@ -365,8 +361,7 @@ public class FlowControlHandlerTest {
             Channel peer = peerRef.exchange(null, 1L, SECONDS);
 
             // Write the message
-            client.writeAndFlush(newOneMessage())
-                .sync();
+            client.writeAndFlush(newOneMessage()).asStage().sync();
 
             // channelRead(1)
             peer.read();
@@ -419,8 +414,7 @@ public class FlowControlHandlerTest {
             Channel peer = peerRef.exchange(null, 1L, SECONDS);
 
             // Write the message
-            client.writeAndFlush(newOneMessage())
-                    .sync();
+            client.writeAndFlush(newOneMessage()).asStage().sync();
 
             // channelRead(1)
             peer.read();
@@ -551,7 +545,7 @@ public class FlowControlHandlerTest {
             Channel peer = peerRef.exchange(null, 1L, SECONDS);
 
             // Write one message
-            client.writeAndFlush(newOneMessage()).sync();
+            client.writeAndFlush(newOneMessage()).asStage().sync();
 
             // We should receive 3 messages
             assertTrue(latch.await(1L, SECONDS));

--- a/handler/src/test/java/io/netty5/handler/ipfilter/UniqueIpFilterTest.java
+++ b/handler/src/test/java/io/netty5/handler/ipfilter/UniqueIpFilterTest.java
@@ -46,8 +46,8 @@ public class UniqueIpFilterTest {
                 assertFalse(ch1.isActive() && ch2.isActive());
 
                 barrier.reset();
-                ch1.close().await();
-                ch2.close().await();
+                ch1.close().asStage().await();
+                ch2.close().asStage().await();
             }
         } finally {
             executorService.shutdown();

--- a/handler/src/test/java/io/netty5/handler/logging/LoggingHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/logging/LoggingHandlerTest.java
@@ -146,21 +146,21 @@ public class LoggingHandlerTest {
     @Test
     public void shouldLogChannelClose() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new LoggingHandler());
-        channel.close().await();
+        channel.close().asStage().await();
         verify(appender).doAppend(argThat(new RegexLogMatcher(".+CLOSE$")));
     }
 
     @Test
     public void shouldLogChannelConnect() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new LoggingHandler());
-        channel.connect(new InetSocketAddress(80)).await();
+        channel.connect(new InetSocketAddress(80)).asStage().await();
         verify(appender).doAppend(argThat(new RegexLogMatcher(".+CONNECT: 0.0.0.0/0.0.0.0:80$")));
     }
 
     @Test
     public void shouldLogChannelConnectWithLocalAddress() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new LoggingHandler());
-        channel.connect(new InetSocketAddress(80), new InetSocketAddress(81)).await();
+        channel.connect(new InetSocketAddress(80), new InetSocketAddress(81)).asStage().await();
         verify(appender).doAppend(argThat(new RegexLogMatcher(
                 "^\\[id: 0xembedded, L:embedded - R:embedded\\] CONNECT: 0.0.0.0/0.0.0.0:80, 0.0.0.0/0.0.0.0:81$")));
     }
@@ -168,8 +168,8 @@ public class LoggingHandlerTest {
     @Test
     public void shouldLogChannelDisconnect() throws Exception {
         EmbeddedChannel channel = new DisconnectingEmbeddedChannel(new LoggingHandler());
-        channel.connect(new InetSocketAddress(80)).await();
-        channel.disconnect().await();
+        channel.connect(new InetSocketAddress(80)).asStage().await();
+        channel.disconnect().asStage().await();
         verify(appender).doAppend(argThat(new RegexLogMatcher(".+DISCONNECT$")));
     }
 

--- a/handler/src/test/java/io/netty5/handler/ssl/CipherSuiteCanaryTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/CipherSuiteCanaryTest.java
@@ -214,7 +214,7 @@ public class CipherSuiteCanaryTest {
                     Channel client = client(server, clientHandler);
                     try {
                         client.writeAndFlush(preferredAllocator().copyOf(new byte[] {'P', 'I', 'N', 'G'}))
-                              .sync();
+                              .asStage().sync();
 
                         Future<Object> clientFuture = clientPromise.asFuture();
                         Future<Object> serverFuture = serverPromise.asFuture();
@@ -222,13 +222,13 @@ public class CipherSuiteCanaryTest {
                         assertTrue(clientFuture.asStage().await(5L, TimeUnit.SECONDS), "client timeout");
                         assertTrue(serverFuture.asStage().await(5L, TimeUnit.SECONDS), "server timeout");
 
-                        clientFuture.sync();
-                        serverFuture.sync();
+                        clientFuture.asStage().sync();
+                        serverFuture.asStage().sync();
                     } finally {
-                        client.close().sync();
+                        client.close().asStage().sync();
                     }
                 } finally {
-                    server.close().sync();
+                    server.close().asStage().sync();
                 }
             } finally {
                 Resource.dispose(sslClientContext);

--- a/handler/src/test/java/io/netty5/handler/ssl/CipherSuiteCanaryTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/CipherSuiteCanaryTest.java
@@ -219,8 +219,8 @@ public class CipherSuiteCanaryTest {
                         Future<Object> clientFuture = clientPromise.asFuture();
                         Future<Object> serverFuture = serverPromise.asFuture();
 
-                        assertTrue(clientFuture.await(5L, TimeUnit.SECONDS), "client timeout");
-                        assertTrue(serverFuture.await(5L, TimeUnit.SECONDS), "server timeout");
+                        assertTrue(clientFuture.asStage().await(5L, TimeUnit.SECONDS), "client timeout");
+                        assertTrue(serverFuture.asStage().await(5L, TimeUnit.SECONDS), "server timeout");
 
                         clientFuture.sync();
                         serverFuture.sync();

--- a/handler/src/test/java/io/netty5/handler/ssl/OpenSslCertificateCompressionTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/OpenSslCertificateCompressionTest.java
@@ -322,21 +322,20 @@ public class OpenSslCertificateCompressionTest {
             ServerBootstrap sb = new ServerBootstrap();
             sb.group(group).channel(LocalServerChannel.class)
                     .childHandler(new CertCompressionTestChannelInitializer(serverPromise, serverSslContext));
-            Channel serverChannel = sb.bind(new LocalAddress(getClass()))
-                    .sync().getNow();
+            Channel serverChannel = sb.bind(new LocalAddress(getClass())).asStage().get();
 
             Bootstrap bootstrap = new Bootstrap();
             bootstrap.group(group).channel(LocalChannel.class)
                     .handler(new CertCompressionTestChannelInitializer(clientPromise, clientSslContext));
 
-            Channel clientChannel = bootstrap.connect(serverChannel.localAddress()).sync().getNow();
+            Channel clientChannel = bootstrap.connect(serverChannel.localAddress()).asStage().get();
 
             assertTrue(clientPromise.asFuture().asStage().await(5L, TimeUnit.SECONDS), "client timeout");
             assertTrue(serverPromise.asFuture().asStage().await(5L, TimeUnit.SECONDS), "server timeout");
-            clientPromise.asFuture().sync();
-            serverPromise.asFuture().sync();
-            clientChannel.close().sync();
-            serverChannel.close().sync();
+            clientPromise.asFuture().asStage().sync();
+            serverPromise.asFuture().asStage().sync();
+            clientChannel.close().asStage().sync();
+            serverChannel.close().asStage().sync();
         } finally  {
             group.shutdownGracefully();
         }

--- a/handler/src/test/java/io/netty5/handler/ssl/OpenSslCertificateCompressionTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/OpenSslCertificateCompressionTest.java
@@ -331,8 +331,8 @@ public class OpenSslCertificateCompressionTest {
 
             Channel clientChannel = bootstrap.connect(serverChannel.localAddress()).sync().getNow();
 
-            assertTrue(clientPromise.asFuture().await(5L, TimeUnit.SECONDS), "client timeout");
-            assertTrue(serverPromise.asFuture().await(5L, TimeUnit.SECONDS), "server timeout");
+            assertTrue(clientPromise.asFuture().asStage().await(5L, TimeUnit.SECONDS), "client timeout");
+            assertTrue(serverPromise.asFuture().asStage().await(5L, TimeUnit.SECONDS), "server timeout");
             clientPromise.asFuture().sync();
             serverPromise.asFuture().sync();
             clientChannel.close().sync();

--- a/handler/src/test/java/io/netty5/handler/ssl/OpenSslPrivateKeyMethodTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/OpenSslPrivateKeyMethodTest.java
@@ -305,8 +305,8 @@ public class OpenSslPrivateKeyMethodTest {
 
                     Future<Object> clientFuture = clientPromise.asFuture();
                     Future<Object> serverFuture = serverPromise.asFuture();
-                    assertTrue(clientFuture.await(5L, TimeUnit.SECONDS), "client timeout");
-                    assertTrue(serverFuture.await(5L, TimeUnit.SECONDS), "server timeout");
+                    assertTrue(clientFuture.asStage().await(5L, TimeUnit.SECONDS), "client timeout");
+                    assertTrue(serverFuture.asStage().await(5L, TimeUnit.SECONDS), "server timeout");
 
                     clientFuture.sync();
                     serverFuture.sync();

--- a/handler/src/test/java/io/netty5/handler/ssl/OpenSslPrivateKeyMethodTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/OpenSslPrivateKeyMethodTest.java
@@ -300,22 +300,21 @@ public class OpenSslPrivateKeyMethodTest {
 
                 Channel client = client(server, clientHandler);
                 try {
-                    client.writeAndFlush(offHeapAllocator().copyOf(new byte[] {'P', 'I', 'N', 'G'}))
-                          .sync();
+                    client.writeAndFlush(offHeapAllocator().copyOf(new byte[] {'P', 'I', 'N', 'G'})).asStage().sync();
 
                     Future<Object> clientFuture = clientPromise.asFuture();
                     Future<Object> serverFuture = serverPromise.asFuture();
                     assertTrue(clientFuture.asStage().await(5L, TimeUnit.SECONDS), "client timeout");
                     assertTrue(serverFuture.asStage().await(5L, TimeUnit.SECONDS), "server timeout");
 
-                    clientFuture.sync();
-                    serverFuture.sync();
+                    clientFuture.asStage().sync();
+                    serverFuture.asStage().sync();
                     assertTrue(signCalled.get());
                 } finally {
-                    client.close().sync();
+                    client.close().asStage().sync();
                 }
             } finally {
-                server.close().sync();
+                server.close().asStage().sync();
             }
         }
     }
@@ -370,10 +369,10 @@ public class OpenSslPrivateKeyMethodTest {
                     assertNotNull(clientCause);
                     assertThat(serverCause, Matchers.instanceOf(SSLHandshakeException.class));
                 } finally {
-                    client.close().sync();
+                    client.close().asStage().sync();
                 }
             } finally {
-                server.close().sync();
+                server.close().asStage().sync();
             }
         }
     }

--- a/handler/src/test/java/io/netty5/handler/ssl/OpenSslPrivateKeyMethodTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/OpenSslPrivateKeyMethodTest.java
@@ -365,8 +365,8 @@ public class OpenSslPrivateKeyMethodTest {
             try {
                 Channel client = client(server, clientSslHandler);
                 try {
-                    Throwable clientCause = clientSslHandler.handshakeFuture().await().cause();
-                    Throwable serverCause = serverSslHandler.handshakeFuture().await().cause();
+                    Throwable clientCause = clientSslHandler.handshakeFuture().asStage().join((r, e) -> e);
+                    Throwable serverCause = serverSslHandler.handshakeFuture().asStage().join((r, e) -> e);
                     assertNotNull(clientCause);
                     assertThat(serverCause, Matchers.instanceOf(SSLHandshakeException.class));
                 } finally {

--- a/handler/src/test/java/io/netty5/handler/ssl/ParameterizedSslHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/ParameterizedSslHandlerTest.java
@@ -259,13 +259,13 @@ public class ParameterizedSslHandlerTest {
                         }
                     }).connect(sc.localAddress()).asStage().get();
 
-            donePromise.asFuture().sync();
+            donePromise.asFuture().asStage().sync();
         } finally {
             if (cc != null) {
-                cc.close().sync();
+                cc.close().asStage().sync();
             }
             if (sc != null) {
-                sc.close().sync();
+                sc.close().asStage().sync();
             }
             group.shutdownGracefully();
 
@@ -360,13 +360,13 @@ public class ParameterizedSslHandlerTest {
                         }
                     }).connect(sc.localAddress()).asStage().get();
 
-            promise.asFuture().sync();
+            promise.asFuture().asStage().sync();
         } finally {
             if (cc != null) {
-                cc.close().sync();
+                cc.close().asStage().sync();
             }
             if (sc != null) {
-                sc.close().sync();
+                sc.close().asStage().sync();
             }
             group.shutdownGracefully();
 
@@ -498,10 +498,10 @@ public class ParameterizedSslHandlerTest {
             }
         } finally {
             if (cc != null) {
-                cc.close().sync();
+                cc.close().asStage().sync();
             }
             if (sc != null) {
-                sc.close().sync();
+                sc.close().asStage().sync();
             }
             group.shutdownGracefully();
 
@@ -614,10 +614,10 @@ public class ParameterizedSslHandlerTest {
             assertEquals(expectedContent, clientQueue.toString());
         } finally {
             if (cc != null) {
-                cc.close().sync();
+                cc.close().asStage().sync();
             }
             if (sc != null) {
-                sc.close().sync();
+                sc.close().asStage().sync();
             }
 
             Resource.dispose(sslServerCtx);

--- a/handler/src/test/java/io/netty5/handler/ssl/ParameterizedSslHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/ParameterizedSslHandlerTest.java
@@ -484,8 +484,8 @@ public class ParameterizedSslHandlerTest {
                         }
                     }).connect(sc.localAddress()).asStage().get();
 
-            serverPromise.asFuture().await();
-            clientPromise.asFuture().await();
+            serverPromise.asFuture().asStage().await();
+            clientPromise.asFuture().asStage().await();
 
             // Server always received the close_notify as the client triggers the close sequence.
             assertTrue(serverPromise.isSuccess());

--- a/handler/src/test/java/io/netty5/handler/ssl/RenegotiateTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/RenegotiateTest.java
@@ -132,8 +132,8 @@ public abstract class RenegotiateTest {
 
             Channel clientChannel = bootstrap.connect(channel.localAddress()).asStage().get();
             latch.await();
-            clientChannel.close().sync();
-            channel.close().sync();
+            clientChannel.close().asStage().sync();
+            channel.close().asStage().sync();
             verifyResult(error);
         } finally  {
             group.shutdownGracefully();

--- a/handler/src/test/java/io/netty5/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SSLEngineTest.java
@@ -1204,7 +1204,7 @@ public abstract class SSLEngineTest {
         List<Buffer> dataCapture = null;
         try {
             Future<Void> writeAndFlush = sendChannel.writeAndFlush(message.copy());
-            assertTrue(writeAndFlush.await(10, TimeUnit.SECONDS));
+            assertTrue(writeAndFlush.asStage().await(10, TimeUnit.SECONDS));
             if (!writeAndFlush.isSuccess()) {
                 throw new Exception("Write and flush failed", writeAndFlush.cause());
             }
@@ -3955,7 +3955,7 @@ public abstract class SSLEngineTest {
             out.flush();
 
             Future<SecretKey> future = promise.asFuture();
-            assertTrue(future.await(10, TimeUnit.SECONDS));
+            assertTrue(future.asStage().await(10, TimeUnit.SECONDS));
             SecretKey key = future.asStage().get();
             assertEquals(48, key.getEncoded().length, "AES secret key must be 48 bytes");
         } finally {

--- a/handler/src/test/java/io/netty5/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SSLEngineTest.java
@@ -378,13 +378,13 @@ public abstract class SSLEngineTest {
         //
         // See https://github.com/netty/netty/issues/5692
         if (clientCloseFuture != null) {
-            clientCloseFuture.sync();
+            clientCloseFuture.asStage().sync();
         }
         if (serverConnectedCloseFuture != null) {
-            serverConnectedCloseFuture.sync();
+            serverConnectedCloseFuture.asStage().sync();
         }
         if (serverCloseFuture != null) {
-            serverCloseFuture.sync();
+            serverCloseFuture.asStage().sync();
         }
         if (serverSslCtx != null) {
             cleanupServerSslContext(serverSslCtx);
@@ -405,11 +405,11 @@ public abstract class SSLEngineTest {
             clientGroupShutdownFuture = cb.config().group().shutdownGracefully(0, 0, TimeUnit.MILLISECONDS);
         }
         if (serverGroupShutdownFuture != null) {
-            serverGroupShutdownFuture.sync();
-            serverChildGroupShutdownFuture.sync();
+            serverGroupShutdownFuture.asStage().sync();
+            serverChildGroupShutdownFuture.asStage().sync();
         }
         if (clientGroupShutdownFuture != null) {
-            clientGroupShutdownFuture.sync();
+            clientGroupShutdownFuture.asStage().sync();
         }
         delegatingExecutor.shutdown();
         serverException = null;
@@ -1474,7 +1474,7 @@ public abstract class SSLEngineTest {
                 });
 
         Future<Channel> ccf = cb.connect(serverChannel.localAddress());
-        assertTrue(ccf.sync().isSuccess());
+        assertTrue(ccf.asStage().sync().isSuccess());
         clientChannel = ccf.asStage().get();
 
         serverLatch.await();
@@ -1795,7 +1795,7 @@ public abstract class SSLEngineTest {
         serverChannel = sb.bind(new InetSocketAddress(0)).asStage().get();
 
         Future<Channel> ccf = cb.connect(serverChannel.localAddress());
-        assertTrue(ccf.sync().isSuccess());
+        assertTrue(ccf.asStage().sync().isSuccess());
         clientChannel = ccf.asStage().get();
     }
 
@@ -1906,7 +1906,7 @@ public abstract class SSLEngineTest {
 
         }).connect(serverChannel.localAddress()).asStage().get();
 
-        promise.asFuture().sync();
+        promise.asFuture().asStage().sync();
 
         serverCert.delete();
         clientCert.delete();

--- a/handler/src/test/java/io/netty5/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SSLEngineTest.java
@@ -807,7 +807,7 @@ public abstract class SSLEngineTest {
         int port = ((InetSocketAddress) serverChannel.localAddress()).getPort();
 
         Future<Channel> ccf = cb.connect(new InetSocketAddress(NetUtil.LOCALHOST, port));
-        assertTrue(ccf.await().isSuccess());
+        assertTrue(ccf.asStage().await().future().isSuccess());
         clientChannel = ccf.asStage().get();
     }
 
@@ -847,7 +847,7 @@ public abstract class SSLEngineTest {
                 "unexpected exception: " + serverException);
 
         // Verify that any pending writes are failed with the cached handshake exception and not a general SSLException.
-        clientWriteFuture.await();
+        clientWriteFuture.asStage().await();
         Throwable actualCause = clientWriteFuture.cause();
         assertTrue(clientWriteFuture.isDone());
         assertTrue(clientWriteFuture.isFailed());
@@ -997,7 +997,7 @@ public abstract class SSLEngineTest {
         final int port = ((InetSocketAddress) serverChannel.localAddress()).getPort();
 
         Future<Channel> ccf = cb.connect(new InetSocketAddress(expectedHost, port));
-        assertTrue(ccf.await().isSuccess());
+        assertTrue(ccf.asStage().await().future().isSuccess());
         clientChannel = ccf.asStage().get();
         return clientWritePromise.asFuture();
     }
@@ -1169,7 +1169,7 @@ public abstract class SSLEngineTest {
         int port = ((InetSocketAddress) serverChannel.localAddress()).getPort();
 
         Future<Channel> ccf = cb.connect(new InetSocketAddress(NetUtil.LOCALHOST, port));
-        assertTrue(ccf.await().isSuccess());
+        assertTrue(ccf.asStage().await().future().isSuccess());
         clientChannel = ccf.asStage().get();
     }
 

--- a/handler/src/test/java/io/netty5/handler/ssl/SniClientTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SniClientTest.java
@@ -194,16 +194,16 @@ public class SniClientTest {
             Bootstrap cb = new Bootstrap();
             cc = cb.group(group).channel(LocalChannel.class).handler(sslHandler).connect(address).asStage().get();
 
-            promise.asFuture().sync();
-            sslHandler.handshakeFuture().sync();
+            promise.asFuture().asStage().sync();
+            sslHandler.handshakeFuture().asStage().sync();
         } catch (CompletionException e) {
             throw e.getCause();
         } finally {
             if (cc != null) {
-                cc.close().sync();
+                cc.close().asStage().sync();
             }
             if (sc != null) {
-                sc.close().sync();
+                sc.close().asStage().sync();
             }
 
             Resource.dispose(sslServerContext);
@@ -440,20 +440,20 @@ public class SniClientTest {
             SslHandler handler = new SslHandler(
                     sslClientContext.newEngine(offHeapAllocator(), sniHostName, -1));
             cc = cb.group(group).channel(LocalChannel.class).handler(handler).connect(address).asStage().get();
-            assertEquals(sniHostName, promise.asFuture().sync().getNow());
+            assertEquals(sniHostName, promise.asFuture().asStage().get());
 
             // After we are done with handshaking getHandshakeSession() should return null.
-            handler.handshakeFuture().sync();
+            handler.handshakeFuture().asStage().sync();
             assertNull(handler.engine().getHandshakeSession());
 
             assertSSLSession(
                     handler.engine().getUseClientMode(), handler.engine().getSession(), sniHostName);
         } finally {
             if (cc != null) {
-                cc.close().sync();
+                cc.close().asStage().sync();
             }
             if (sc != null) {
-                sc.close().sync();
+                sc.close().asStage().sync();
             }
             Resource.dispose(sslServerContext);
             Resource.dispose(sslClientContext);

--- a/handler/src/test/java/io/netty5/handler/ssl/SniHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SniHandlerTest.java
@@ -566,7 +566,7 @@ public class SniHandlerTest {
 
                     // The client disconnects
                     cc.close().sync();
-                    if (!releasePromise.asFuture().await(10L, TimeUnit.SECONDS)) {
+                    if (!releasePromise.asFuture().asStage().await(10L, TimeUnit.SECONDS)) {
                         throw new IllegalStateException("It doesn't seem #replaceHandler() got called.");
                     }
 

--- a/handler/src/test/java/io/netty5/handler/ssl/SniHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SniHandlerTest.java
@@ -458,10 +458,10 @@ public class SniHandlerTest {
                 assertThat(handler.sslContext(), is(sniContext));
             } finally {
                 if (serverChannel != null) {
-                    serverChannel.close().sync();
+                    serverChannel.close().asStage().sync();
                 }
                 if (clientChannel != null) {
-                    clientChannel.close().sync();
+                    clientChannel.close().asStage().sync();
                 }
                 group.shutdownGracefully(0, 0, TimeUnit.MICROSECONDS);
             }
@@ -557,15 +557,14 @@ public class SniHandlerTest {
                                    sslContext.newEngine(offHeapAllocator(), sniHost, -1)))
                            .connect(address).asStage().get();
 
-                    cc.writeAndFlush(cc.bufferAllocator().copyOf("Hello, World!", UTF_8))
-                            .sync();
+                    cc.writeAndFlush(cc.bufferAllocator().copyOf("Hello, World!", UTF_8)).asStage().sync();
 
                     // Notice how the server's SslContext refCnt is 2 as it is incremented when the SSLEngine is created
                     // and only decremented once it is destroyed.
                     assertEquals(2, ((ReferenceCounted) sslServerContext).refCnt());
 
                     // The client disconnects
-                    cc.close().sync();
+                    cc.close().asStage().sync();
                     if (!releasePromise.asFuture().asStage().await(10L, TimeUnit.SECONDS)) {
                         throw new IllegalStateException("It doesn't seem #replaceHandler() got called.");
                     }
@@ -574,10 +573,10 @@ public class SniHandlerTest {
                     assertEquals(0, ((ReferenceCounted) sslServerContext).refCnt());
                 } finally {
                     if (cc != null) {
-                        cc.close().sync();
+                        cc.close().asStage().sync();
                     }
                     if (sc != null) {
-                        sc.close().sync();
+                        sc.close().asStage().sync();
                     }
                     if (sslContext != null) {
                         Resource.dispose(sslContext);

--- a/handler/src/test/java/io/netty5/handler/ssl/SslErrorTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SslErrorTest.java
@@ -189,13 +189,13 @@ public class SslErrorTest {
                         }
                     }).connect(serverChannel.localAddress()).asStage().get();
             // Block until we received the correct exception
-            promise.asFuture().sync();
+            promise.asFuture().asStage().sync();
         } finally {
             if (clientChannel != null) {
-                clientChannel.close().sync();
+                clientChannel.close().asStage().sync();
             }
             if (serverChannel != null) {
-                serverChannel.close().sync();
+                serverChannel.close().asStage().sync();
             }
             group.shutdownGracefully();
         }

--- a/handler/src/test/java/io/netty5/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SslHandlerTest.java
@@ -264,7 +264,7 @@ public class SslHandlerTest {
                 ch.runPendingTasks();
             }
 
-            handler.handshakeFuture().sync();
+            handler.handshakeFuture().asStage().sync();
         } catch (CompletionException e) {
             throw e.getCause();
         } finally {
@@ -409,7 +409,7 @@ public class SslHandlerTest {
                 assertEquals(1, ((ReferenceCounted) sslEngine).refCnt());
 
                 assertTrue(ch.finishAndReleaseAll());
-                ch.close().sync();
+                ch.close().asStage().sync();
 
                 assertEquals(1, ((ReferenceCounted) sslContext).refCnt());
                 assertEquals(0, ((ReferenceCounted) sslEngine).refCnt());
@@ -494,14 +494,14 @@ public class SslHandlerTest {
             sc = serverBootstrap.bind(new InetSocketAddress(0)).asStage().get();
             cc = bootstrap.connect(sc.localAddress()).asStage().get();
 
-            serverPromise.asFuture().sync();
-            clientPromise.asFuture().sync();
+            serverPromise.asFuture().asStage().sync();
+            clientPromise.asFuture().asStage().sync();
         } finally {
             if (cc != null) {
-                cc.close().sync();
+                cc.close().asStage().sync();
             }
             if (sc != null) {
-                sc.close().sync();
+                sc.close().asStage().sync();
             }
             group.shutdownGracefully();
         }
@@ -679,9 +679,9 @@ public class SslHandlerTest {
             Future<Void> future = (Future<Void>) events.take();
             assertThat(future.cause(), is(instanceOf(SSLException.class)));
 
-            serverChannel.close().sync();
+            serverChannel.close().asStage().sync();
             serverChannel = null;
-            clientChannel.close().sync();
+            clientChannel.close().asStage().sync();
             clientChannel = null;
 
             latch2.await();
@@ -755,14 +755,14 @@ public class SslHandlerTest {
                 Buffer secondBuffer = offHeapAllocator().allocate(10);
                 secondBuffer.skipWritableBytes(secondBuffer.capacity());
                 cc.write(firstBuffer);
-                cc.writeAndFlush(secondBuffer).sync();
+                cc.writeAndFlush(secondBuffer).asStage().sync();
                 serverReceiveLatch.countDown();
             } finally {
                 if (cc != null) {
-                    cc.close().sync();
+                    cc.close().asStage().sync();
                 }
                 if (sc != null) {
-                    sc.close().sync();
+                    sc.close().asStage().sync();
                 }
                 group.shutdownGracefully();
             }
@@ -818,13 +818,13 @@ public class SslHandlerTest {
                 handler.handshakeFuture().asStage().await();
                 assertFalse(handler.handshakeFuture().isSuccess());
 
-                cc.closeFuture().sync();
+                cc.closeFuture().asStage().sync();
             } finally {
                 if (cc != null) {
-                    cc.close().sync();
+                    cc.close().asStage().sync();
                 }
                 if (sc != null) {
-                    sc.close().sync();
+                    sc.close().asStage().sync();
                 }
                 group.shutdownGracefully();
             }
@@ -840,7 +840,7 @@ public class SslHandlerTest {
         assertFalse(channel.finish());
         channel.pipeline().addLast(new SslHandler(engine));
         assertFalse(engine.isOutboundDone());
-        channel.close().sync();
+        channel.close().asStage().sync();
 
         assertTrue(engine.isOutboundDone());
     }
@@ -907,10 +907,10 @@ public class SslHandlerTest {
                 assertThat(sslHandler.handshakeFuture().asStage().join((r, e) -> e), instanceOf(SSLException.class));
             } finally {
                 if (cc != null) {
-                    cc.close().sync();
+                    cc.close().asStage().sync();
                 }
                 if (sc != null) {
-                    sc.close().sync();
+                    sc.close().asStage().sync();
                 }
                 group.shutdownGracefully();
             }
@@ -980,10 +980,10 @@ public class SslHandlerTest {
                 assertThat(cause.getMessage(), containsString("timed out"));
             } finally {
                 if (cc != null) {
-                    cc.close().sync();
+                    cc.close().asStage().sync();
                 }
                 if (sc != null) {
-                    sc.close().sync();
+                    sc.close().asStage().sync();
                 }
                 group.shutdownGracefully();
             }
@@ -1173,10 +1173,10 @@ public class SslHandlerTest {
                 }
             } finally {
                 if (cc != null) {
-                    cc.close().sync();
+                    cc.close().asStage().sync();
                 }
                 if (sc != null) {
-                    sc.close().sync();
+                    sc.close().asStage().sync();
                 }
                 group.shutdownGracefully();
             }
@@ -1253,10 +1253,10 @@ public class SslHandlerTest {
                 }
             } finally {
                 if (cc != null) {
-                    cc.close().sync();
+                    cc.close().asStage().sync();
                 }
                 if (sc != null) {
-                    sc.close().sync();
+                    sc.close().asStage().sync();
                 }
                 group.shutdownGracefully();
             }
@@ -1371,7 +1371,7 @@ public class SslHandlerTest {
                 }
             } finally {
                 if (sc != null) {
-                    sc.close().sync();
+                    sc.close().asStage().sync();
                 }
                 group.shutdownGracefully();
             }
@@ -1412,7 +1412,7 @@ public class SslHandlerTest {
                     }).connect(serverAddress);
             cc = future.asStage().get();
 
-            assertTrue(clientSslHandler.handshakeFuture().sync().isSuccess());
+            assertTrue(clientSslHandler.handshakeFuture().asStage().sync().isSuccess());
 
             ReferenceCountedOpenSslEngine engine = (ReferenceCountedOpenSslEngine) clientSslHandler.engine();
             // This test only works for non TLSv1.3 as TLSv1.3 will establish sessions after
@@ -1432,7 +1432,7 @@ public class SslHandlerTest {
             }
         } finally {
             if (cc != null) {
-                cc.close().sync();
+                cc.close().asStage().sync();
             }
         }
     }
@@ -1544,7 +1544,7 @@ public class SslHandlerTest {
             assertNull(errorQueue.poll(1, TimeUnit.MILLISECONDS));
         } finally {
             if (sc != null) {
-                sc.close().sync();
+                sc.close().asStage().sync();
             }
             group.shutdownGracefully();
         }
@@ -1658,8 +1658,8 @@ public class SslHandlerTest {
                 Throwable serverCause = serverSslHandler.handshakeFuture().asStage().join((r, e) -> e);
                 assertThat(serverCause, instanceOf(SSLException.class));
                 assertThat(serverCause.getCause(), not(instanceOf(ClosedChannelException.class)));
-                cc.close().sync();
-                sc.close().sync();
+                cc.close().asStage().sync();
+                sc.close().asStage().sync();
 
                 Throwable eventClientCause = clientEvent.get().cause();
                 assertThat(eventClientCause, instanceOf(SSLException.class));
@@ -1760,9 +1760,9 @@ public class SslHandlerTest {
                     assertTrue(event.isSuccess());
                 }
 
-                cc1.close().sync();
-                cc2.close().sync();
-                sc.close().sync();
+                cc1.close().asStage().sync();
+                cc2.close().asStage().sync();
+                sc.close().asStage().sync();
                 assertEquals(0, clientCompletionEvents.size());
                 assertEquals(0, serverCompletionEvents.size());
             } finally {

--- a/handler/src/test/java/io/netty5/handler/ssl/ocsp/OcspTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/ocsp/OcspTest.java
@@ -373,8 +373,8 @@ public class OcspTest {
                         try {
                             assertTrue(latch.await(10L, TimeUnit.SECONDS));
                         } finally {
-                            client.close().sync();
-                            server.close().sync();
+                            client.close().asStage().sync();
+                            server.close().asStage().sync();
                         }
                     } finally {
                         group.shutdownGracefully(1L, 1L, TimeUnit.SECONDS);

--- a/handler/src/test/java/io/netty5/handler/stream/ChunkedWriteHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/stream/ChunkedWriteHandlerTest.java
@@ -435,7 +435,7 @@ public class ChunkedWriteHandlerTest {
         };
 
         EmbeddedChannel ch = new EmbeddedChannel(noOpWrites, new ChunkedWriteHandler());
-        ch.writeAndFlush(nonClosableInput).await();
+        ch.writeAndFlush(nonClosableInput).asStage().await();
         // Should be `false` as we do not expect any messages to be written
         assertFalse(ch.finish());
         buffer.close();
@@ -676,7 +676,7 @@ public class ChunkedWriteHandlerTest {
 
         EmbeddedChannel ch = new EmbeddedChannel(failFirst, new ChunkedWriteHandler());
         Future<Void> r1 = ch.write(input1);
-        Future<Void> r2 = ch.writeAndFlush(input2).await();
+        Future<Void> r2 = ch.writeAndFlush(input2).asStage().await().future();
         assertTrue(ch.finish());
 
         assertTrue(r1.cause() instanceof RuntimeException);

--- a/handler/src/test/java/io/netty5/handler/stream/ChunkedWriteHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/stream/ChunkedWriteHandlerTest.java
@@ -195,7 +195,7 @@ public class ChunkedWriteHandlerTest {
         final FutureListener<Void> listener = future -> listenerNotified.set(true);
 
         EmbeddedChannel ch = new EmbeddedChannel(new ChunkedWriteHandler());
-        ch.writeAndFlush(input).addListener(listener).sync();
+        ch.writeAndFlush(input).addListener(listener).asStage().sync();
         assertTrue(ch.finish());
 
         // the listener should have been notified
@@ -246,7 +246,7 @@ public class ChunkedWriteHandlerTest {
         };
 
         EmbeddedChannel ch = new EmbeddedChannel(new ChunkedWriteHandler());
-        ch.writeAndFlush(input).sync();
+        ch.writeAndFlush(input).asStage().sync();
         assertTrue(ch.finish());
 
         assertEquals(0, (Integer) ch.readOutbound());
@@ -586,7 +586,7 @@ public class ChunkedWriteHandlerTest {
             }
         }, new ChunkedWriteHandler());
 
-        ch.writeAndFlush(input).sync();
+        ch.writeAndFlush(input).asStage().sync();
         assertFalse(ch.finishAndReleaseAll());
     }
 

--- a/handler/src/test/java/io/netty5/handler/traffic/FileRegionThrottleTest.java
+++ b/handler/src/test/java/io/netty5/handler/traffic/FileRegionThrottleTest.java
@@ -102,12 +102,12 @@ public class FileRegionThrottleTest {
         Channel cc = clientConnect(sc.localAddress(), new ReadHandler(latch));
 
         long start = TrafficCounter.milliSecondFromNano();
-        cc.writeAndFlush(preferredAllocator().copyOf("send-file\n", CharsetUtil.US_ASCII)).sync();
+        cc.writeAndFlush(preferredAllocator().copyOf("send-file\n", CharsetUtil.US_ASCII)).asStage().sync();
         latch.await();
         long timeTaken = TrafficCounter.milliSecondFromNano() - start;
         assertTrue(timeTaken > 3000, "Data streamed faster than expected");
-        sc.close().sync();
-        cc.close().sync();
+        sc.close().asStage().sync();
+        cc.close().asStage().sync();
     }
 
     private Channel clientConnect(final SocketAddress server, final ReadHandler readHandler) throws Exception {

--- a/handler/src/test/java/io/netty5/handler/traffic/TrafficShapingHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/traffic/TrafficShapingHandlerTest.java
@@ -116,10 +116,10 @@ public class TrafficShapingHandlerTest {
             assertNull(attr.get());
         } finally {
             if (ch != null) {
-                ch.close().sync();
+                ch.close().asStage().sync();
             }
             if (svrChannel != null) {
-                svrChannel.close().sync();
+                svrChannel.close().asStage().sync();
             }
         }
     }

--- a/handler/src/test/java/io/netty5/handler/traffic/TrafficShapingHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/traffic/TrafficShapingHandlerTest.java
@@ -106,12 +106,12 @@ public class TrafficShapingHandlerTest {
             Attribute<Runnable> attr = ch.attr(AbstractTrafficShapingHandler.REOPEN_TASK);
             assertNull(attr.get());
             ch.writeAndFlush(preferredAllocator().copyOf("foo".getBytes(CharsetUtil.UTF_8)));
-            ch.writeAndFlush(preferredAllocator().copyOf("bar".getBytes(CharsetUtil.UTF_8))).await();
+            ch.writeAndFlush(preferredAllocator().copyOf("bar".getBytes(CharsetUtil.UTF_8))).asStage().await();
             assertNotNull(attr.get());
             final Channel clientChannel = ch;
             ch.executor().submit(() -> {
                 clientChannel.pipeline().remove("traffic-shaping");
-            }).await();
+            }).asStage().await();
             //the attribute--reopen task must be released.
             assertNull(attr.get());
         } finally {

--- a/microbench/src/main/java/io/netty5/microbench/channel/epoll/EpollSocketChannelBenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/channel/epoll/EpollSocketChannelBenchmark.java
@@ -118,16 +118,16 @@ public class EpollSocketChannelBenchmark extends AbstractMicrobenchmark {
 
     @TearDown
     public void tearDown() throws Exception {
-        chan.close().sync();
-        serverChan.close().sync();
+        chan.close().asStage().sync();
+        serverChan.close().asStage().sync();
         future.cancel();
-        group.shutdownGracefully(0, 0, TimeUnit.SECONDS).sync();
+        group.shutdownGracefully(0, 0, TimeUnit.SECONDS).asStage().sync();
         abyte.close();
     }
 
     @Benchmark
     public Object pingPong() throws Exception {
-        return chan.pipeline().writeAndFlush(abyte.copy(true)).sync();
+        return chan.pipeline().writeAndFlush(abyte.copy(true)).asStage().sync();
     }
 
     @Benchmark

--- a/microbench/src/main/java/io/netty5/microbench/concurrent/RunnableScheduledFutureAdapterBenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/concurrent/RunnableScheduledFutureAdapterBenchmark.java
@@ -52,16 +52,16 @@ public class RunnableScheduledFutureAdapterBenchmark extends AbstractMicrobenchm
         public void reset() throws Exception {
             futures.clear();
             executor.submit(() -> {
-                for (int i = 1; i <= num; i++) {
-                    futures.add(executor.schedule(NO_OP, i, TimeUnit.HOURS));
-                }
-            }).sync();
+                    for (int i = 1; i <= num; i++) {
+                        futures.add(executor.schedule(NO_OP, i, TimeUnit.HOURS));
+                    }
+                }).asStage().sync();
         }
     }
 
     @TearDown(Level.Trial)
     public void stop() throws Exception {
-        executor.shutdownGracefully().sync();
+        executor.shutdownGracefully().asStage().sync();
     }
 
     @Benchmark
@@ -70,7 +70,7 @@ public class RunnableScheduledFutureAdapterBenchmark extends AbstractMicrobenchm
             for (int i = 0; i < futuresHolder.num; i++) {
                 futuresHolder.futures.get(i).cancel();
             }
-        }).sync();
+        }).asStage().sync();
     }
 
     @Benchmark
@@ -79,6 +79,6 @@ public class RunnableScheduledFutureAdapterBenchmark extends AbstractMicrobenchm
             for (int i = futuresHolder.num - 1; i >= 0; i--) {
                 futuresHolder.futures.get(i).cancel();
             }
-        }).sync();
+        }).asStage().sync();
     }
 }

--- a/resolver-dns/src/main/java/io/netty5/resolver/dns/Cache.java
+++ b/resolver-dns/src/main/java/io/netty5/resolver/dns/Cache.java
@@ -97,11 +97,6 @@ abstract class Cache<E> {
         }
 
         @Override
-        public boolean await(long timeout, TimeUnit unit) throws InterruptedException {
-            return true;
-        }
-
-        @Override
         public Object getNow() {
             return null;
         }

--- a/resolver-dns/src/main/java/io/netty5/resolver/dns/Cache.java
+++ b/resolver-dns/src/main/java/io/netty5/resolver/dns/Cache.java
@@ -92,11 +92,6 @@ abstract class Cache<E> {
         }
 
         @Override
-        public Future<Object> await() throws InterruptedException {
-            return this;
-        }
-
-        @Override
         public Object getNow() {
             return null;
         }

--- a/resolver-dns/src/main/java/io/netty5/resolver/dns/Cache.java
+++ b/resolver-dns/src/main/java/io/netty5/resolver/dns/Cache.java
@@ -87,11 +87,6 @@ abstract class Cache<E> {
         }
 
         @Override
-        public Future<Object> sync() throws InterruptedException {
-            return this;
-        }
-
-        @Override
         public Object getNow() {
             return null;
         }

--- a/resolver-dns/src/test/java/io/netty5/resolver/dns/DnsAddressResolverGroupTest.java
+++ b/resolver-dns/src/test/java/io/netty5/resolver/dns/DnsAddressResolverGroupTest.java
@@ -55,7 +55,7 @@ public class DnsAddressResolverGroupTest {
                 } catch (Throwable cause) {
                     promise.setFailure(cause);
                 }
-            }).await();
+            }).asStage().await();
             promise.asFuture().sync();
         } finally {
             resolverGroup.close();

--- a/resolver-dns/src/test/java/io/netty5/resolver/dns/DnsAddressResolverGroupTest.java
+++ b/resolver-dns/src/test/java/io/netty5/resolver/dns/DnsAddressResolverGroupTest.java
@@ -56,7 +56,7 @@ public class DnsAddressResolverGroupTest {
                     promise.setFailure(cause);
                 }
             }).asStage().await();
-            promise.asFuture().sync();
+            promise.asFuture().asStage().sync();
         } finally {
             resolverGroup.close();
             group.shutdownGracefully();

--- a/resolver-dns/src/test/java/io/netty5/resolver/dns/DnsNameResolverClientSubnetTest.java
+++ b/resolver-dns/src/test/java/io/netty5/resolver/dns/DnsNameResolverClientSubnetTest.java
@@ -48,7 +48,7 @@ public class DnsNameResolverClientSubnetTest {
                             // 157.88.0.0 / 24
                             new DefaultDnsOptEcsRecord(1024, 24,
                                                        SocketUtils.addressByName("157.88.0.0").getAddress())));
-            for (InetAddress address: future.sync().getNow()) {
+            for (InetAddress address: future.asStage().get()) {
                 System.out.println(address);
             }
         } finally {

--- a/resolver-dns/src/test/java/io/netty5/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty5/resolver/dns/DnsNameResolverTest.java
@@ -569,7 +569,7 @@ public class DnsNameResolverTest {
     private static void testNonCachedResolveEmptyHostName(String inetHost) throws Exception {
         DnsNameResolver resolver = newNonCachedResolver(ResolvedAddressTypes.IPV4_ONLY).build();
         try {
-            InetAddress addr = resolver.resolve(inetHost).sync().getNow();
+            InetAddress addr = resolver.resolve(inetHost).asStage().get();
             assertEquals(SocketUtils.addressByName(inetHost), addr);
         } finally {
             resolver.close();
@@ -591,7 +591,7 @@ public class DnsNameResolverTest {
     private static void testNonCachedResolveAllEmptyHostName(String inetHost) throws Exception {
         DnsNameResolver resolver = newNonCachedResolver(ResolvedAddressTypes.IPV4_ONLY).build();
         try {
-            List<InetAddress> addrs = resolver.resolveAll(inetHost).sync().getNow();
+            List<InetAddress> addrs = resolver.resolveAll(inetHost).asStage().get();
             assertEquals(asList(
                     SocketUtils.allAddressesByName(inetHost)), addrs);
         } finally {
@@ -599,10 +599,9 @@ public class DnsNameResolverTest {
         }
     }
 
-    private static Map<String, InetAddress> testResolve0(DnsNameResolver resolver, Set<String> excludedDomains,
-                                                         DnsRecordType cancelledType)
-            throws InterruptedException {
-
+    private static Map<String, InetAddress> testResolve0(
+            DnsNameResolver resolver, Set<String> excludedDomains, DnsRecordType cancelledType)
+            throws Exception {
         assertThat(resolver.isRecursionDesired(), is(true));
 
         final Map<String, InetAddress> results = new HashMap<>();
@@ -619,7 +618,7 @@ public class DnsNameResolverTest {
 
         for (Entry<String, Future<InetAddress>> e : futures.entrySet()) {
             String unresolved = e.getKey();
-            InetAddress resolved = e.getValue().sync().getNow();
+            InetAddress resolved = e.getValue().asStage().get();
 
             logger.info("{}: {}", unresolved, resolved.getHostAddress());
 
@@ -736,7 +735,7 @@ public class DnsNameResolverTest {
 
     private static UnknownHostException resolveNonExistentDomain(DnsNameResolver resolver) throws Exception {
         try {
-            resolver.resolve("non-existent.netty.io").sync();
+            resolver.resolve("non-existent.netty.io").asStage().sync();
             fail();
             return null;
         } catch (CompletionException cause) {
@@ -765,7 +764,7 @@ public class DnsNameResolverTest {
     @Test
     public void testResolveIp() throws Exception {
         try (DnsNameResolver resolver = newResolver().build()) {
-            InetAddress address = resolver.resolve("10.0.0.1").sync().getNow();
+            InetAddress address = resolver.resolve("10.0.0.1").asStage().get();
 
             assertEquals("10.0.0.1", address.getHostAddress());
 
@@ -829,7 +828,7 @@ public class DnsNameResolverTest {
     private static void testResolve0(ResolvedAddressTypes addressTypes, InetAddress expectedAddr, String name)
             throws Exception {
         try (DnsNameResolver resolver = newResolver(addressTypes).build()) {
-            InetAddress address = resolver.resolve(name).sync().getNow();
+            InetAddress address = resolver.resolve(name).asStage().get();
             assertEquals(expectedAddr, address);
 
             // We are resolving the local address, so we shouldn't make any queries.
@@ -936,7 +935,7 @@ public class DnsNameResolverTest {
                 builder.resolvedAddressTypes(ResolvedAddressTypes.IPV6_PREFERRED);
             }
             resolver = builder.build();
-            InetAddress resolvedAddress = resolver.resolve(firstName).sync().getNow();
+            InetAddress resolvedAddress = resolver.resolve(firstName).asStage().get();
             if (ipv4Preferred) {
                 assertEquals(ipv4Addr, resolvedAddress.getHostAddress());
             } else {
@@ -1033,7 +1032,7 @@ public class DnsNameResolverTest {
                     return new InetSocketAddress(server, port);
                 }
             };
-            InetAddress resolvedAddress = resolver.resolve(firstName).sync().getNow();
+            InetAddress resolvedAddress = resolver.resolve(firstName).asStage().get();
             if (ipv4Preferred) {
                 assertEquals(ipv4Addr, resolvedAddress.getHostAddress());
             } else {
@@ -1062,7 +1061,7 @@ public class DnsNameResolverTest {
     private static void testResolveAll0(ResolvedAddressTypes addressTypes, InetAddress expectedAddr, String name)
             throws Exception {
         try (DnsNameResolver resolver = newResolver(addressTypes).build()) {
-            List<InetAddress> addresses = resolver.resolveAll(name).sync().getNow();
+            List<InetAddress> addresses = resolver.resolveAll(name).asStage().get();
             assertEquals(1, addresses.size());
             assertEquals(expectedAddr, addresses.get(0));
 
@@ -1128,7 +1127,7 @@ public class DnsNameResolverTest {
                     return null;
                 }).build();
 
-        final List<DnsRecord> records = resolver.resolveAll(new DefaultDnsQuestion("foo.com.", A)).sync().getNow();
+        final List<DnsRecord> records = resolver.resolveAll(new DefaultDnsQuestion("foo.com.", A)).asStage().get();
         assertThat(records, hasSize(1));
         assertThat(records.get(0), instanceOf(DnsRawRecord.class));
 
@@ -1155,7 +1154,7 @@ public class DnsNameResolverTest {
     private static void testResolveUnicode(boolean decode) throws Exception {
         try (DnsNameResolver resolver = newResolver(decode).build()) {
             for (Entry<String, String> entries : DOMAINS_PUNYCODE.entrySet()) {
-                InetAddress address = resolver.resolve(entries.getKey()).sync().getNow();
+                InetAddress address = resolver.resolve(entries.getKey()).asStage().get();
                 assertEquals(decode? entries.getKey() : entries.getValue(), address.getHostName());
             }
 
@@ -1205,7 +1204,7 @@ public class DnsNameResolverTest {
             builder.nameServerProvider(new SequentialDnsServerAddressStreamProvider(dnsServer1Address,
                     dnsServer2.localAddress()));
             resolver = builder.build();
-            assertNotNull(resolver.resolve(knownHostName).sync().getNow());
+            assertNotNull(resolver.resolve(knownHostName).asStage().get());
 
             TestDnsQueryLifecycleObserver observer = lifecycleObserverFactory.observers.poll();
             assertNotNull(observer);
@@ -1253,7 +1252,7 @@ public class DnsNameResolverTest {
             builder.nameServerProvider(new SequentialDnsServerAddressStreamProvider(dnsServer1.localAddress(),
                     dnsServer2.localAddress()));
             resolver = builder.build();
-            assertNotNull(resolver.resolve(knownHostName).sync().getNow());
+            assertNotNull(resolver.resolve(knownHostName).asStage().get());
 
             TestDnsQueryLifecycleObserver observer = lifecycleObserverFactory.observers.poll();
             assertNotNull(observer);
@@ -1322,7 +1321,7 @@ public class DnsNameResolverTest {
                     .nameServerProvider(new SingletonDnsServerAddressStreamProvider(
                             nonCompliantDnsServer.localAddress()))
                     .build();
-            InetAddress resolved = resolver.resolve("netty.com").sync().getNow();
+            InetAddress resolved = resolver.resolve("netty.com").asStage().get();
             if (types == ResolvedAddressTypes.IPV4_PREFERRED) {
                 assertEquals(ipv4Address, resolved.getHostAddress());
             } else {
@@ -1333,7 +1332,7 @@ public class DnsNameResolverTest {
             InetAddress ipv6InetAddress = InetAddress.getByAddress("netty.com",
                     InetAddress.getByName(ipv6Address).getAddress());
 
-            List<InetAddress> resolvedAll = resolver.resolveAll("netty.com").sync().getNow();
+            List<InetAddress> resolvedAll = resolver.resolveAll("netty.com").asStage().get();
             List<InetAddress> expected = types == ResolvedAddressTypes.IPV4_PREFERRED ?
                     asList(ipv4InetAddress, ipv6InetAddress) :  asList(ipv6InetAddress, ipv4InetAddress);
             assertEquals(expected, resolvedAll);
@@ -1380,7 +1379,7 @@ public class DnsNameResolverTest {
         String expectedDnsName = "dns4.some.record.netty.io.";
 
         try {
-            resolver.resolveAll(hostname).sync();
+            resolver.resolveAll(hostname).asStage().sync();
 
             TestDnsQueryLifecycleObserver observer = lifecycleObserverFactory.observers.poll();
             assertNotNull(observer);
@@ -1409,7 +1408,7 @@ public class DnsNameResolverTest {
                 assertNull(nsCache.cache.get(hostname));
 
                 // Test again via cache.
-                resolver.resolveAll(hostname).sync();
+                resolver.resolveAll(hostname).asStage().sync();
 
                 observer = lifecycleObserverFactory.observers.poll();
                 assertNotNull(observer);
@@ -1420,7 +1419,7 @@ public class DnsNameResolverTest {
                 assertEquals(dnsServerAuthority.localAddress(), writtenEvent1.dnsServerAddress);
                 succeededEvent = (QuerySucceededEvent) observer.events.poll();
 
-                resolver.resolveAll(hostname2).sync();
+                resolver.resolveAll(hostname2).asStage().sync();
 
                 observer = lifecycleObserverFactory.observers.poll();
                 assertNotNull(observer);
@@ -1548,11 +1547,11 @@ public class DnsNameResolverTest {
         };
 
         try {
-            List<InetAddress> resolved = resolver.resolveAll(expected.getHostName()).sync().getNow();
+            List<InetAddress> resolved = resolver.resolveAll(expected.getHostName()).asStage().get();
             assertEquals(1, resolved.size());
             assertEquals(expected, resolved.get(0));
 
-            List<InetAddress> resolved2 = resolver.resolveAll(expected.getHostName()).sync().getNow();
+            List<InetAddress> resolved2 = resolver.resolveAll(expected.getHostName()).asStage().get();
             assertEquals(1, resolved2.size());
             assertEquals(expected, resolved2.get(0));
 
@@ -1930,7 +1929,7 @@ public class DnsNameResolverTest {
                 .build();
 
         try {
-            final List<InetAddress> addresses = resolver.resolveAll(unresolved).sync().asStage().get();
+            final List<InetAddress> addresses = resolver.resolveAll(unresolved).asStage().get();
             assertThat(addresses, hasSize(greaterThan(0)));
             for (InetAddress address : addresses) {
                 assertThat(address.getHostName(), startsWith(unresolved));
@@ -2338,7 +2337,7 @@ public class DnsNameResolverTest {
 
             resolver = builder.build();
             List<InetAddress> resolvedAddresses =
-                    resolver.resolveAll("somehost.netty.io").sync().getNow();
+                    resolver.resolveAll("somehost.netty.io").asStage().get();
             assertEquals(2, resolvedAddresses.size());
             assertTrue(resolvedAddresses.contains(InetAddress.getByAddress(new byte[] { 10, 0, 0, 99 })));
             assertTrue(resolvedAddresses.contains(InetAddress.getByAddress(new byte[] { 10, 0, 0, 2 })));
@@ -2383,7 +2382,7 @@ public class DnsNameResolverTest {
 
             resolver[0] = builder.build();
             final CompletionException completion = assertThrows(CompletionException.class,
-                () -> resolver[0].resolveAll("somehost.netty.io").sync().getNow());
+                () -> resolver[0].resolveAll("somehost.netty.io").asStage().get());
             assertTrue(completion.getCause() instanceof UnknownHostException);
         } catch (CompletionException e) {
             throw e.getCause();
@@ -2413,7 +2412,7 @@ public class DnsNameResolverTest {
             resolver[0].cnameCache().cache(name, name2, Long.MAX_VALUE, resolver[0].executor());
             resolver[0].cnameCache().cache(name2, name, Long.MAX_VALUE, resolver[0].executor());
             final CompletionException completion = assertThrows(CompletionException.class,
-                () -> resolver[0].resolve(name).sync().getNow());
+                () -> resolver[0].resolve(name).asStage().get());
             assertTrue(completion.getCause() instanceof UnknownHostException);
         } finally {
             if (resolver[0] != null) {
@@ -2440,7 +2439,7 @@ public class DnsNameResolverTest {
                 .ndots(1)
                 .searchDomains(singletonList(".")).build();
         try {
-            resolver.resolve("invalid.com").sync();
+            resolver.resolve("invalid.com").asStage().sync();
         } catch (CompletionException cause) {
             throw cause.getCause();
         } finally {
@@ -2522,7 +2521,7 @@ public class DnsNameResolverTest {
             String domain = DOMAINS.iterator().next();
             String domainWithDot = domain + '.';
 
-            resolver.resolve(domain).sync();
+            resolver.resolve(domain).asStage().sync();
             List<? extends DnsCacheEntry> cached = cache.get(domain, null);
             List<? extends DnsCacheEntry> cached2 = cache.get(domainWithDot, null);
 
@@ -2540,7 +2539,7 @@ public class DnsNameResolverTest {
                 .searchDomains(singletonList("netty.io"))
                 .nameServerProvider(new SingletonDnsServerAddressStreamProvider(server.localAddress()))
                 .resolveCache(cache).build()) {
-            resolver.resolve("test").sync();
+            resolver.resolve("test").asStage().sync();
 
             assertNull(cache.cacheHits.get("test.netty.io"));
 
@@ -2549,7 +2548,7 @@ public class DnsNameResolverTest {
             assertEquals(1, cached.size());
             assertSame(cached, cached2);
 
-            resolver.resolve("test").sync();
+            resolver.resolve("test").asStage().sync();
             List<? extends DnsCacheEntry> entries = cache.cacheHits.get("test.netty.io");
             assertFalse(entries.isEmpty());
         } finally {
@@ -2637,7 +2636,7 @@ public class DnsNameResolverTest {
                     });
             resolver = builder.build();
             List<InetAddress> resolvedAddresses =
-                    resolver.resolveAll("x.netty.io").sync().getNow();
+                    resolver.resolveAll("x.netty.io").asStage().get();
             assertEquals(1, resolvedAddresses.size());
             assertTrue(resolvedAddresses.contains(InetAddress.getByAddress(new byte[] { 10, 0, 0, 99 })));
 
@@ -2646,7 +2645,7 @@ public class DnsNameResolverTest {
             assertEquals(1, aQueries.get());
 
             resolvedAddresses =
-                    resolver.resolveAll("x.netty.io").sync().getNow();
+                    resolver.resolveAll("x.netty.io").asStage().get();
             assertEquals(1, resolvedAddresses.size());
             assertTrue(resolvedAddresses.contains(InetAddress.getByAddress(new byte[] { 10, 0, 0, 99 })));
 
@@ -2655,7 +2654,7 @@ public class DnsNameResolverTest {
             assertEquals(2, aQueries.get());
 
             resolvedAddresses =
-                    resolver.resolveAll("y.netty.io").sync().getNow();
+                    resolver.resolveAll("y.netty.io").asStage().get();
             assertEquals(1, resolvedAddresses.size());
             assertTrue(resolvedAddresses.contains(InetAddress.getByAddress(new byte[] { 10, 0, 0, 99 })));
 
@@ -2666,7 +2665,7 @@ public class DnsNameResolverTest {
             assertEquals(3, aQueries.get());
 
             resolvedAddresses =
-                    resolver.resolveAll("y.netty.io").sync().getNow();
+                    resolver.resolveAll("y.netty.io").asStage().get();
             assertEquals(1, resolvedAddresses.size());
             assertTrue(resolvedAddresses.contains(InetAddress.getByAddress(new byte[] { 10, 0, 0, 99 })));
 
@@ -2730,7 +2729,7 @@ public class DnsNameResolverTest {
                 .build();
         try {
             AddressedEnvelope<DnsResponse, InetSocketAddress> envelope = resolver.query(
-                    new DefaultDnsQuestion(hostname, DnsRecordType.TXT)).sync().getNow();
+                    new DefaultDnsQuestion(hostname, DnsRecordType.TXT)).asStage().get();
             assertNotNull(envelope.sender());
 
             DnsResponse response = envelope.content();
@@ -2800,7 +2799,7 @@ public class DnsNameResolverTest {
             builder.resolvedAddressTypes(ResolvedAddressTypes.IPV4_ONLY);
 
             resolver = builder.build();
-            List<InetAddress> resolvedAddresses = resolver.resolveAll(name).sync().getNow();
+            List<InetAddress> resolvedAddresses = resolver.resolveAll(name).asStage().get();
             assertEquals(singletonList(InetAddress.getByAddress(name, new byte[] { 1, 2, 3, 4 })),
                          resolvedAddresses);
         } finally {
@@ -2836,7 +2835,7 @@ public class DnsNameResolverTest {
             builder.resolvedAddressTypes(ResolvedAddressTypes.IPV4_ONLY);
 
             resolver = builder.build();
-            List<DnsRecord> resolvedAddresses = resolver.resolveAll(new DefaultDnsQuestion(name, A)).sync().getNow();
+            List<DnsRecord> resolvedAddresses = resolver.resolveAll(new DefaultDnsQuestion(name, A)).asStage().get();
             assertEquals(2, resolvedAddresses.size());
             for (DnsRecord record: resolvedAddresses) {
                 Resource.dispose(record);
@@ -2864,7 +2863,7 @@ public class DnsNameResolverTest {
                     .nameServerProvider(new SingletonDnsServerAddressStreamProvider(dnsServer2.localAddress()));
 
             resolver = builder.build();
-            List<InetAddress> addressList = resolver.resolveAll(host).sync().getNow();
+            List<InetAddress> addressList = resolver.resolveAll(host).asStage().get();
             assertEquals(1, addressList.size());
             assertEquals(host, addressList.get(0).getHostName());
         } finally {
@@ -2891,7 +2890,7 @@ public class DnsNameResolverTest {
                     .nameServerProvider(new SingletonDnsServerAddressStreamProvider(dnsServer2.localAddress()));
 
             resolver = builder.build();
-            InetAddress address = resolver.resolve(host).sync().getNow();
+            InetAddress address = resolver.resolve(host).asStage().get();
             assertEquals(host, address.getHostName());
         } finally {
             dnsServer2.stop();
@@ -2931,7 +2930,7 @@ public class DnsNameResolverTest {
                     .nameServerProvider(new SingletonDnsServerAddressStreamProvider(dnsServer2.localAddress()));
 
             resolver = builder.build();
-            List<InetAddress> addresses = resolver.resolveAll(host).sync().getNow();
+            List<InetAddress> addresses = resolver.resolveAll(host).asStage().get();
             assertEquals(2, addresses.size());
             for (InetAddress address: addresses) {
                 assertThat(address, instanceOf(Inet4Address.class));
@@ -3074,13 +3073,13 @@ public class DnsNameResolverTest {
                 }
                 socket.getOutputStream().flush();
                 // Let's wait until we received the envelope before closing the socket.
-                envelopeFuture.sync();
+                envelopeFuture.asStage().sync();
 
                 socket.close();
                 serverSocket.close();
             }
 
-            AddressedEnvelope<DnsResponse, InetSocketAddress> envelope = envelopeFuture.sync().getNow();
+            AddressedEnvelope<DnsResponse, InetSocketAddress> envelope = envelopeFuture.asStage().get();
             assertNotNull(envelope.sender());
 
             DnsResponse response = envelope.content();
@@ -3141,7 +3140,7 @@ public class DnsNameResolverTest {
                 .build();
 
         try {
-            resolver.resolve("non-existent.netty.io", promise).sync();
+            resolver.resolve("non-existent.netty.io", promise).asStage().sync();
             fail();
         } catch (Exception e) {
             assertThat(e, is(instanceOf(CancellationException.class)));
@@ -3208,7 +3207,7 @@ public class DnsNameResolverTest {
                 })
                 .resolvedAddressTypes(ResolvedAddressTypes.IPV4_PREFERRED).build()) {
 
-            assertResolvedAddress(resolver.resolve(firstName).sync().getNow(), ipv4Addr, firstName);
+            assertResolvedAddress(resolver.resolve(firstName).asStage().get(), ipv4Addr, firstName);
         } finally {
             dnsServer2.stop();
             dnsServer3.stop();
@@ -3273,16 +3272,16 @@ public class DnsNameResolverTest {
                 })
                 .resolvedAddressTypes(ResolvedAddressTypes.IPV4_ONLY).build()) {
 
-            assertResolvedAddress(resolver.resolve(domain).sync().getNow(), ipv4Addr, domain);
+            assertResolvedAddress(resolver.resolve(domain).asStage().get(), ipv4Addr, domain);
             assertEquals(1, server2Counter.get());
             assertEquals(0, server3Counter.get());
-            assertResolvedAddress(resolver.resolve(domain).sync().getNow(), ipv4Addr, domain);
+            assertResolvedAddress(resolver.resolve(domain).asStage().get(), ipv4Addr, domain);
             assertEquals(1, server2Counter.get());
             assertEquals(1, server3Counter.get());
-            assertResolvedAddress(resolver.resolve(domain).sync().getNow(), ipv4Addr, domain);
+            assertResolvedAddress(resolver.resolve(domain).asStage().get(), ipv4Addr, domain);
             assertEquals(2, server2Counter.get());
             assertEquals(1, server3Counter.get());
-            assertResolvedAddress(resolver.resolve(domain).sync().getNow(), ipv4Addr, domain);
+            assertResolvedAddress(resolver.resolve(domain).asStage().get(), ipv4Addr, domain);
             assertEquals(2, server2Counter.get());
             assertEquals(2, server3Counter.get());
         } finally {
@@ -3543,7 +3542,7 @@ public class DnsNameResolverTest {
                 try (DnsNameResolver resolver = newResolver()
                         .localAddress(datagramSocket.getLocalSocketAddress()).build()) {
                     Throwable cause = assertThrows(CompletionException.class,
-                            () -> resolver.resolve("netty.io").sync());
+                                                   () -> resolver.resolve("netty.io").asStage().sync());
                     assertThat(cause.getCause(), instanceOf(UnknownHostException.class));
                     assertThat(cause.getCause().getCause(), instanceOf(BindException.class));
                 }

--- a/resolver-dns/src/test/java/io/netty5/resolver/dns/SearchDomainTest.java
+++ b/resolver-dns/src/test/java/io/netty5/resolver/dns/SearchDomainTest.java
@@ -253,26 +253,26 @@ public class SearchDomainTest {
 
     private static void assertNotResolve(DnsNameResolver resolver, String inetHost) throws InterruptedException {
         Future<InetAddress> fut = resolver.resolve(inetHost);
-        assertTrue(fut.await(10, TimeUnit.SECONDS));
+        assertTrue(fut.asStage().await(10, TimeUnit.SECONDS));
         assertFalse(fut.isSuccess());
     }
 
     private static void assertNotResolveAll(DnsNameResolver resolver, String inetHost) throws InterruptedException {
         Future<List<InetAddress>> fut = resolver.resolveAll(inetHost);
-        assertTrue(fut.await(10, TimeUnit.SECONDS));
+        assertTrue(fut.asStage().await(10, TimeUnit.SECONDS));
         assertFalse(fut.isSuccess());
     }
 
     private static String assertResolve(DnsNameResolver resolver, String inetHost) throws InterruptedException {
         Future<InetAddress> fut = resolver.resolve(inetHost);
-        assertTrue(fut.await(10, TimeUnit.SECONDS));
+        assertTrue(fut.asStage().await(10, TimeUnit.SECONDS));
         return fut.getNow().getHostAddress();
     }
 
     private static List<String> assertResolveAll(DnsNameResolver resolver,
                                                  String inetHost) throws InterruptedException {
         Future<List<InetAddress>> fut = resolver.resolveAll(inetHost);
-        assertTrue(fut.await(10, TimeUnit.SECONDS));
+        assertTrue(fut.asStage().await(10, TimeUnit.SECONDS));
         List<String> list = new ArrayList<>();
         for (InetAddress addr : fut.getNow()) {
             list.add(addr.getHostAddress());
@@ -289,7 +289,7 @@ public class SearchDomainTest {
         resolver = newResolver().searchDomains(Collections.singletonList("foo.com")).ndots(1).build();
 
         Future<InetAddress> fut = resolver.resolve("unknown.hostname");
-        assertTrue(fut.await(10, TimeUnit.SECONDS));
+        assertTrue(fut.asStage().await(10, TimeUnit.SECONDS));
         assertFalse(fut.isSuccess());
         final Throwable cause = fut.cause();
         assertThat(cause, instanceOf(UnknownHostException.class));
@@ -306,7 +306,7 @@ public class SearchDomainTest {
         resolver = newResolver().searchDomains(Collections.singletonList("foo.com")).ndots(2).build();
 
         Future<InetAddress> fut = resolver.resolve("unknown.hostname");
-        assertTrue(fut.await(10, TimeUnit.SECONDS));
+        assertTrue(fut.asStage().await(10, TimeUnit.SECONDS));
         assertFalse(fut.isSuccess());
         final Throwable cause = fut.cause();
         assertThat(cause, instanceOf(UnknownHostException.class));

--- a/testsuite-autobahn/src/main/java/io/netty5/testsuite/autobahn/AutobahnServer.java
+++ b/testsuite-autobahn/src/main/java/io/netty5/testsuite/autobahn/AutobahnServer.java
@@ -48,7 +48,7 @@ public class AutobahnServer {
 
             Channel channel = b.bind(port).asStage().get();
             System.out.println("Web Socket Server started at port " + port);
-            channel.closeFuture().sync();
+            channel.closeFuture().asStage().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();

--- a/testsuite-http2/src/main/java/io/netty5/testsuite/http2/Http2Server.java
+++ b/testsuite-http2/src/main/java/io/netty5/testsuite/http2/Http2Server.java
@@ -51,7 +51,7 @@ public final class Http2Server {
 
             Channel ch = b.bind(port).asStage().get();
 
-            ch.closeFuture().sync();
+            ch.closeFuture().asStage().sync();
         } finally {
             group.shutdownGracefully();
         }

--- a/testsuite-native-image/src/main/java/io/netty5/testsuite/svm/HttpNativeServer.java
+++ b/testsuite-native-image/src/main/java/io/netty5/testsuite/svm/HttpNativeServer.java
@@ -53,7 +53,7 @@ public final class HttpNativeServer {
 
             Channel channel = b.bind(0).asStage().get();
             System.err.println("Server started, will shutdown now.");
-            channel.close().sync();
+            channel.close().asStage().sync();
             serverStartSucess = true;
         } finally {
             bossGroup.shutdownGracefully();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/AbstractSingleThreadEventLoopTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/AbstractSingleThreadEventLoopTest.java
@@ -67,11 +67,11 @@ public abstract class AbstractSingleThreadEventLoopTest {
         // Not close the Channel to ensure the EventLoop is still shutdown in time.
         Future<Channel> cf = serverChannelClass() == LocalServerChannel.class
                 ? b.bind(new LocalAddress(getClass())) : b.bind(0);
-        cf.sync();
+        cf.asStage().sync();
 
         Future<?> f = loop.shutdownGracefully(0, 1, TimeUnit.MINUTES);
         assertTrue(loop.awaitTermination(600, TimeUnit.MILLISECONDS));
-        assertTrue(f.sync().isSuccess());
+        assertTrue(f.asStage().sync().isSuccess());
         assertTrue(loop.isShutdown());
         assertTrue(loop.isTerminated());
     }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/AbstractSingleThreadEventLoopTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/AbstractSingleThreadEventLoopTest.java
@@ -51,7 +51,7 @@ public abstract class AbstractSingleThreadEventLoopTest {
     @Test
     public void shutdownGracefullyZeroQuietBeforeStart() throws Exception {
         EventLoopGroup group =  new MultithreadEventLoopGroup(newIoHandlerFactory());
-        assertTrue(group.shutdownGracefully(0L, 2L, TimeUnit.SECONDS).await(200, TimeUnit.MILLISECONDS));
+        assertTrue(group.shutdownGracefully(0L, 2L, TimeUnit.SECONDS).asStage().await(200, TimeUnit.MILLISECONDS));
     }
 
     // Copied from AbstractEventLoopTest
@@ -79,7 +79,8 @@ public abstract class AbstractSingleThreadEventLoopTest {
     @Test
     public void shutdownGracefullyBeforeStart() throws Exception {
         EventLoopGroup group = new MultithreadEventLoopGroup(newIoHandlerFactory());
-        assertTrue(group.shutdownGracefully(200L, 1000L, TimeUnit.MILLISECONDS).await(500, TimeUnit.MILLISECONDS));
+        assertTrue(group.shutdownGracefully(200L, 1000L, TimeUnit.MILLISECONDS).asStage()
+                        .await(500, TimeUnit.MILLISECONDS));
     }
 
     @Test

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/AbstractSocketReuseFdTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/AbstractSocketReuseFdTest.java
@@ -102,9 +102,9 @@ public abstract class AbstractSocketReuseFdTest extends AbstractSocketTest {
             cb.connect(sc.localAddress()).addListener(listener);
         }
 
-        clientDonePromise.asFuture().sync();
-        serverDonePromise.asFuture().sync();
-        sc.close().sync();
+        clientDonePromise.asFuture().asStage().sync();
+        serverDonePromise.asFuture().asStage().sync();
+        sc.close().asStage().sync();
 
         if (globalException.get() != null && !(globalException.get() instanceof IOException)) {
             throw globalException.get();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/CompositeBufferGatheringWriteTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/CompositeBufferGatheringWriteTest.java
@@ -138,10 +138,10 @@ public class CompositeBufferGatheringWriteTest extends AbstractSocketTest {
             }
         } finally {
             if (clientChannel != null) {
-                clientChannel.close().sync();
+                clientChannel.close().asStage().sync();
             }
             if (serverChannel != null) {
-                serverChannel.close().sync();
+                serverChannel.close().asStage().sync();
             }
         }
     }
@@ -275,10 +275,10 @@ public class CompositeBufferGatheringWriteTest extends AbstractSocketTest {
             }
         } finally {
             if (clientChannel != null) {
-                clientChannel.close().sync();
+                clientChannel.close().asStage().sync();
             }
             if (serverChannel != null) {
-                serverChannel.close().sync();
+                serverChannel.close().asStage().sync();
             }
         }
     }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramConnectNotExistsTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramConnectNotExistsTest.java
@@ -69,8 +69,8 @@ public class DatagramConnectNotExistsTest extends AbstractClientSocketTest {
             assertTrue(datagramChannel.isActive());
             BufferAllocator allocator = datagramChannel.bufferAllocator();
             datagramChannel.writeAndFlush(
-                    allocator.copyOf("test".getBytes(CharsetUtil.US_ASCII))).sync();
-            assertTrue(promise.asFuture().sync().getNow() instanceof PortUnreachableException);
+                        allocator.copyOf("test".getBytes(CharsetUtil.US_ASCII))).asStage().sync();
+            assertTrue(promise.asFuture().asStage().sync().getNow() instanceof PortUnreachableException);
         } finally {
             if (datagramChannel != null) {
                 datagramChannel.close();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramMulticastTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramMulticastTest.java
@@ -86,20 +86,20 @@ public class DatagramMulticastTest extends AbstractDatagramTest {
 
         InetSocketAddress groupAddress = SocketUtils.socketAddress(groupAddress(), addr.getPort());
 
-        cc.joinGroup(groupAddress, iface).sync();
+        cc.joinGroup(groupAddress, iface).asStage().sync();
 
         BufferAllocator allocator = sc.bufferAllocator();
-        sc.writeAndFlush(new DatagramPacket(allocator.allocate(4).writeInt(1), groupAddress)).sync();
+        sc.writeAndFlush(new DatagramPacket(allocator.allocate(4).writeInt(1), groupAddress)).asStage().sync();
         assertTrue(mhandler.await());
 
         // leave the group
-        cc.leaveGroup(groupAddress, iface).sync();
+        cc.leaveGroup(groupAddress, iface).asStage().sync();
 
         // sleep a second to make sure we left the group
         Thread.sleep(1000);
 
         // we should not receive a message anymore as we left the group before
-        sc.writeAndFlush(new DatagramPacket(allocator.allocate(4).writeInt(1), groupAddress)).sync();
+        sc.writeAndFlush(new DatagramPacket(allocator.allocate(4).writeInt(1), groupAddress)).asStage().sync();
         mhandler.await();
 
         cc.config().setLoopbackModeDisabled(false);

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramMulticastTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramMulticastTest.java
@@ -114,8 +114,8 @@ public class DatagramMulticastTest extends AbstractDatagramTest {
         assertTrue(cc.config().isLoopbackModeDisabled());
         assertTrue(sc.config().isLoopbackModeDisabled());
 
-        sc.close().await();
-        cc.close().await();
+        sc.close().asStage().await();
+        cc.close().asStage().await();
     }
 
     private static void assertInterfaceAddress(NetworkInterface networkInterface, InetAddress expected) {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramUnicastTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramUnicastTest.java
@@ -267,7 +267,7 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
                 assertNotNull(cc.localAddress());
                 assertNull(cc.remoteAddress());
 
-                Future<Void> future = cc.writeAndFlush(buf.copy()).await();
+                Future<Void> future = cc.writeAndFlush(buf.copy()).asStage().await().future();
                 assertThat(future.cause()).isInstanceOf(NotYetConnectedException.class);
             }
         } finally {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramUnicastTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramUnicastTest.java
@@ -190,7 +190,7 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
             cc.flush();
 
             for (Future<Void> future: futures) {
-                future.sync();
+                future.asStage().sync();
             }
             if (!latch.await(10, TimeUnit.SECONDS)) {
                 Throwable error = errorRef.get();
@@ -226,7 +226,7 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
             SocketAddress localAddr = sc.localAddress();
             SocketAddress addr = localAddr instanceof InetSocketAddress ?
                     sendToAddress((InetSocketAddress) localAddr) : localAddr;
-            cc.connect(addr).sync();
+            cc.connect(addr).asStage().sync();
 
             List<Future<Void>> futures = new ArrayList<>();
             for (int i = 0; i < count; i++) {
@@ -235,7 +235,7 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
             cc.flush();
 
             for (Future<Void> future: futures) {
-                future.sync();
+                future.asStage().sync();
             }
 
             if (!latch.await(10, TimeUnit.SECONDS)) {
@@ -262,7 +262,7 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
 
             if (supportDisconnect()) {
                 // Test what happens when we call disconnect()
-                cc.disconnect().sync();
+                cc.disconnect().asStage().sync();
                 assertFalse(isConnected(cc));
                 assertNotNull(cc.localAddress());
                 assertNull(cc.remoteAddress());
@@ -291,7 +291,7 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
 
     protected static void closeChannel(Channel channel) throws Exception {
         if (channel != null) {
-            channel.close().sync();
+            channel.close().asStage().sync();
         }
     }
 

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketAutoReadTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketAutoReadTest.java
@@ -95,10 +95,10 @@ public class SocketAutoReadTest extends AbstractSocketTest {
             clientInitializer.autoReadHandler.assertSingleReadSecondTry();
         } finally {
             if (clientChannel != null) {
-                clientChannel.close().sync();
+                clientChannel.close().asStage().sync();
             }
             if (serverChannel != null) {
-                serverChannel.close().sync();
+                serverChannel.close().asStage().sync();
             }
         }
     }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketBufReleaseTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketBufReleaseTest.java
@@ -61,8 +61,8 @@ public class SocketBufReleaseTest extends AbstractSocketTest {
         serverHandler.awaitPipelineInit();
 
         // and then close all sockets.
-        sc.close().sync();
-        cc.close().sync();
+        sc.close().asStage().sync();
+        cc.close().asStage().sync();
 
         serverHandler.check();
         clientHandler.check();
@@ -104,7 +104,7 @@ public class SocketBufReleaseTest extends AbstractSocketTest {
 
         @Override
         void awaitPipelineInit() throws InterruptedException {
-            channelFuture.asFuture().sync();
+            channelFuture.asFuture().asStage().sync();
         }
 
         @Override

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketCancelWriteTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketCancelWriteTest.java
@@ -80,9 +80,9 @@ public class SocketCancelWriteTest extends AbstractSocketTest {
                 // Ignore.
             }
         }
-        sh.channel.close().sync();
-        ch.channel.close().sync();
-        sc.close().sync();
+        sh.channel.close().asStage().sync();
+        ch.channel.close().asStage().sync();
+        sc.close().asStage().sync();
 
         if (sh.exception.get() != null && !(sh.exception.get() instanceof IOException)) {
             throw sh.exception.get();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketChannelNotYetConnectedTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketChannelNotYetConnectedTest.java
@@ -106,7 +106,7 @@ public class SocketChannelNotYetConnectedTest extends AbstractClientSocketTest {
                 bootstrap.connect(serverChannel.localAddress()).sync();
 
                 readLatch.await();
-                group.shutdownGracefully().await();
+                group.shutdownGracefully().asStage().await();
             }
         });
     }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketChannelNotYetConnectedTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketChannelNotYetConnectedTest.java
@@ -53,20 +53,20 @@ public class SocketChannelNotYetConnectedTest extends AbstractClientSocketTest {
                                              .bind(newSocketAddress()).asStage().get();
         try {
             try {
-                ch.shutdown(ChannelShutdownDirection.Inbound).sync();
+                ch.shutdown(ChannelShutdownDirection.Inbound).asStage().sync();
                 fail();
             } catch (Throwable cause) {
                 assertThat(cause).hasCauseInstanceOf(NotYetConnectedException.class);
             }
 
             try {
-                ch.shutdown(ChannelShutdownDirection.Outbound).sync();
+                ch.shutdown(ChannelShutdownDirection.Outbound).asStage().sync();
                 fail();
             } catch (Throwable cause) {
                 assertThat(cause).hasCauseInstanceOf(NotYetConnectedException.class);
             }
         } finally {
-            ch.close().sync();
+            ch.close().asStage().sync();
         }
     }
 
@@ -103,7 +103,7 @@ public class SocketChannelNotYetConnectedTest extends AbstractClientSocketTest {
                         }
                     }
                 });
-                bootstrap.connect(serverChannel.localAddress()).sync();
+                bootstrap.connect(serverChannel.localAddress()).asStage().sync();
 
                 readLatch.await();
                 group.shutdownGracefully().asStage().await();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConnectTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConnectTest.java
@@ -80,10 +80,10 @@ public class SocketConnectTest extends AbstractSocketTest {
             assertLocalAddress(localAddressPromise.asFuture().asStage().get());
         } finally {
             if (clientChannel != null) {
-                clientChannel.close().sync();
+                clientChannel.close().asStage().sync();
             }
             if (serverChannel != null) {
-                serverChannel.close().sync();
+                serverChannel.close().asStage().sync();
             }
         }
     }
@@ -160,12 +160,12 @@ public class SocketConnectTest extends AbstractSocketTest {
         Future<Void> write = channel.write(writeAsciiBuffer(sc, "[fastopen]"));
         SocketAddress remoteAddress = sc.localAddress();
         Future<Void> connectFuture = channel.connect(remoteAddress);
-        connectFuture.sync();
-        channel.writeAndFlush(writeAsciiBuffer(sc, "[normal data]")).sync();
-        write.sync();
+        connectFuture.asStage().sync();
+        channel.writeAndFlush(writeAsciiBuffer(sc, "[normal data]")).asStage().sync();
+        write.asStage().sync();
         String expectedString = "[fastopen][normal data]";
         String result = handler.collectBuffer(expectedString.getBytes(US_ASCII).length);
-        channel.disconnect().sync();
+        channel.disconnect().asStage().sync();
         assertEquals(expectedString, result);
     }
 

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConnectionAttemptTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConnectionAttemptTest.java
@@ -94,7 +94,7 @@ public class SocketConnectionAttemptTest extends AbstractClientSocketTest {
 
         cb.handler(handler);
         cb.option(ChannelOption.ALLOW_HALF_CLOSURE, halfClosure);
-        Future<Channel> future = cb.connect(NetUtil.LOCALHOST, UNASSIGNED_PORT).await();
+        Future<Channel> future = cb.connect(NetUtil.LOCALHOST, UNASSIGNED_PORT).asStage().await().future();
         assertThat(future.cause()).isInstanceOf(ConnectException.class);
         assertFalse(errorPromise.isFailed());
     }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConnectionAttemptTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConnectionAttemptTest.java
@@ -58,7 +58,7 @@ public class SocketConnectionAttemptTest extends AbstractClientSocketTest {
     public void testConnectTimeout(Bootstrap cb) throws Throwable {
         cb.handler(new TestHandler()).option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 2000);
         Future<Channel> future = cb.connect(BAD_HOST, BAD_PORT);
-        assertThat(future.await(3000, TimeUnit.MILLISECONDS)).isTrue();
+        assertThat(future.asStage().await(3000, TimeUnit.MILLISECONDS)).isTrue();
         ExecutionException e = assertThrows(ExecutionException.class, future.asStage()::get);
         assertThat(e).hasCauseInstanceOf(ConnectTimeoutException.class);
     }
@@ -122,7 +122,7 @@ public class SocketConnectionAttemptTest extends AbstractClientSocketTest {
     public void testConnectCancellation(Bootstrap cb) throws Throwable {
         cb.handler(new TestHandler()).option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 4000);
         Future<Channel> future = cb.connect(BAD_HOST, BAD_PORT);
-        if (future.await(1000, TimeUnit.MILLISECONDS)) {
+        if (future.asStage().await(1000, TimeUnit.MILLISECONDS)) {
             if (future.isSuccess()) {
                 fail("A connection attempt to " + BAD_HOST + " must not succeed.");
             } else {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketDataReadInitialStateTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketDataReadInitialStateTest.java
@@ -98,7 +98,7 @@ public class SocketDataReadInitialStateTest extends AbstractSocketTest {
 
             serverChannel = sb.bind().asStage().get();
             clientChannel = cb.connect(serverChannel.localAddress()).asStage().get();
-            clientChannel.writeAndFlush(clientChannel.bufferAllocator().copyOf(new byte[] {0})).sync();
+            clientChannel.writeAndFlush(clientChannel.bufferAllocator().copyOf(new byte[] {0})).asStage().sync();
 
             // The acceptor shouldn't read any data until we call read() below, but give it some time to see if it will.
             Thread.sleep(sleepMs);
@@ -123,10 +123,10 @@ public class SocketDataReadInitialStateTest extends AbstractSocketTest {
             clientReadLatch.await();
         } finally {
             if (serverChannel != null) {
-                serverChannel.close().sync();
+                serverChannel.close().asStage().sync();
             }
             if (clientChannel != null) {
-                clientChannel.close().sync();
+                clientChannel.close().asStage().sync();
             }
         }
     }
@@ -174,15 +174,15 @@ public class SocketDataReadInitialStateTest extends AbstractSocketTest {
 
             serverChannel = sb.bind().asStage().get();
             clientChannel = cb.connect(serverChannel.localAddress()).asStage().get();
-            clientChannel.writeAndFlush(clientChannel.bufferAllocator().copyOf(new byte[] {0})).sync();
+            clientChannel.writeAndFlush(clientChannel.bufferAllocator().copyOf(new byte[] {0})).asStage().sync();
             serverReadLatch.await();
             clientReadLatch.await();
         } finally {
             if (serverChannel != null) {
-                serverChannel.close().sync();
+                serverChannel.close().asStage().sync();
             }
             if (clientChannel != null) {
-                clientChannel.close().sync();
+                clientChannel.close().asStage().sync();
             }
         }
     }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketEchoTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketEchoTest.java
@@ -122,9 +122,9 @@ public class SocketEchoTest extends AbstractSocketTest {
             }
         }
 
-        sh.channel.close().sync();
-        ch.channel.close().sync();
-        sc.close().sync();
+        sh.channel.close().asStage().sync();
+        ch.channel.close().asStage().sync();
+        sc.close().asStage().sync();
 
         if (sh.exception.get() != null && !(sh.exception.get() instanceof IOException)) {
             throw sh.exception.get();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketExceptionHandlingTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketExceptionHandlingTest.java
@@ -65,10 +65,10 @@ public class SocketExceptionHandlingTest extends AbstractSocketTest {
                                         " exceptions when 1 was expected");
         } finally {
             if (serverChannel != null) {
-                serverChannel.close().sync();
+                serverChannel.close().asStage().sync();
             }
             if (clientChannel != null) {
-                clientChannel.close().sync();
+                clientChannel.close().asStage().sync();
             }
         }
     }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketFileRegionTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketFileRegionTest.java
@@ -105,7 +105,8 @@ public class SocketFileRegionTest extends AbstractSocketTest {
         FileRegion region = new DefaultFileRegion(
                 new RandomAccessFile(file, "r").getChannel(), 0, data.length + 1024);
 
-        assertThat(cc.writeAndFlush(region).await().cause()).isInstanceOf(IOException.class);
+        Throwable result = cc.writeAndFlush(region).asStage().join((r, e) -> e);
+        assertThat(result).isInstanceOf(IOException.class);
         cc.close().sync();
         sc.close().sync();
     }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketFileRegionTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketFileRegionTest.java
@@ -107,8 +107,8 @@ public class SocketFileRegionTest extends AbstractSocketTest {
 
         Throwable result = cc.writeAndFlush(region).asStage().join((r, e) -> e);
         assertThat(result).isInstanceOf(IOException.class);
-        cc.close().sync();
-        sc.close().sync();
+        cc.close().asStage().sync();
+        sc.close().asStage().sync();
     }
 
     private static void testFileRegion0(
@@ -196,9 +196,9 @@ public class SocketFileRegionTest extends AbstractSocketTest {
             }
         }
 
-        sh.channel.close().sync();
-        cc.close().sync();
-        sc.close().sync();
+        sh.channel.close().asStage().sync();
+        cc.close().asStage().sync();
+        sc.close().asStage().sync();
 
         if (sh.exception.get() != null && !(sh.exception.get() instanceof IOException)) {
             throw sh.exception.get();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketFixedLengthEchoTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketFixedLengthEchoTest.java
@@ -115,9 +115,9 @@ public class SocketFixedLengthEchoTest extends AbstractSocketTest {
             Thread.sleep(50);
         }
 
-        sh.channel.close().sync();
-        ch.channel.close().sync();
-        sc.close().sync();
+        sh.channel.close().asStage().sync();
+        ch.channel.close().asStage().sync();
+        sc.close().asStage().sync();
 
         if (sh.exception.get() != null && !(sh.exception.get() instanceof IOException)) {
             throw sh.exception.get();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketGatheringWriteTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketGatheringWriteTest.java
@@ -151,17 +151,17 @@ public class SocketGatheringWriteTest extends AbstractSocketTest {
         Future<Void> cf = cc.writeAndFlush(preferredAllocator().allocate(0));
         try {
             assertTrue(cf.asStage().await(60000, TimeUnit.MILLISECONDS));
-            cf.sync();
+            cf.asStage().sync();
         } catch (Throwable t) {
             // TODO: Remove this once we fix this test.
             TestUtils.dump(StringUtil.simpleClassName(this));
             throw t;
         }
 
-        serverDonePromise.asFuture().sync();
-        sh.channel.close().sync();
-        ch.channel.close().sync();
-        sc.close().sync();
+        serverDonePromise.asFuture().asStage().sync();
+        sh.channel.close().asStage().sync();
+        ch.channel.close().asStage().sync();
+        sc.close().asStage().sync();
 
         if (sh.exception.get() != null && !(sh.exception.get() instanceof IOException)) {
             throw sh.exception.get();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketGatheringWriteTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketGatheringWriteTest.java
@@ -150,7 +150,7 @@ public class SocketGatheringWriteTest extends AbstractSocketTest {
 
         Future<Void> cf = cc.writeAndFlush(preferredAllocator().allocate(0));
         try {
-            assertTrue(cf.await(60000, TimeUnit.MILLISECONDS));
+            assertTrue(cf.asStage().await(60000, TimeUnit.MILLISECONDS));
             cf.sync();
         } catch (Throwable t) {
             // TODO: Remove this once we fix this test.

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -104,11 +104,11 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
             waitHalfClosureDone.await();
         } finally {
             if (clientChannel != null) {
-                clientChannel.close().sync();
+                clientChannel.close().asStage().sync();
             }
 
             if (serverChannel != null) {
-                serverChannel.close().sync();
+                serverChannel.close().asStage().sync();
             }
         }
     }
@@ -170,7 +170,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
             assertEquals(1, shutdownEventReceivedCounter.get());
         } finally {
             if (serverChannel != null) {
-                serverChannel.close().sync();
+                serverChannel.close().asStage().sync();
             }
         }
     }
@@ -272,10 +272,10 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                 "too many read complete events: " + clientReadCompletes.get());
         } finally {
             if (clientChannel != null) {
-                clientChannel.close().sync();
+                clientChannel.close().asStage().sync();
             }
             if (serverChannel != null) {
-                serverChannel.close().sync();
+                serverChannel.close().asStage().sync();
             }
         }
     }
@@ -337,10 +337,10 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
             assertNull(causeRef.get());
         } finally {
             if (clientChannel != null) {
-                clientChannel.close().sync();
+                clientChannel.close().asStage().sync();
             }
             if (serverChannel != null) {
-                serverChannel.close().sync();
+                serverChannel.close().asStage().sync();
             }
         }
     }
@@ -579,10 +579,10 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                 "too many read complete events: " + clientReadCompletes.get());
         } finally {
             if (clientChannel != null) {
-                clientChannel.close().sync();
+                clientChannel.close().asStage().sync();
             }
             if (serverChannel != null) {
-                serverChannel.close().sync();
+                serverChannel.close().asStage().sync();
             }
         }
     }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -166,7 +166,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
 
             serverChannel = sb.bind().asStage().get();
             Channel clientChannel = cb.connect(serverChannel.localAddress()).asStage().get();
-            clientChannel.closeFuture().await();
+            clientChannel.closeFuture().asStage().await();
             assertEquals(1, shutdownEventReceivedCounter.get());
         } finally {
             if (serverChannel != null) {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketMultipleConnectTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketMultipleConnectTest.java
@@ -50,7 +50,7 @@ public class SocketMultipleConnectTest extends AbstractSocketTest {
 
             cb.handler(new ChannelHandler() { });
             cc = cb.register().asStage().get();
-            cc.connect(sc.localAddress()).sync();
+            cc.connect(sc.localAddress()).asStage().sync();
             Future<Void> connectFuture2 = cc.connect(sc.localAddress()).asStage().await().future();
             assertTrue(connectFuture2.cause() instanceof AlreadyConnectedException);
         } finally {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketMultipleConnectTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketMultipleConnectTest.java
@@ -51,7 +51,7 @@ public class SocketMultipleConnectTest extends AbstractSocketTest {
             cb.handler(new ChannelHandler() { });
             cc = cb.register().asStage().get();
             cc.connect(sc.localAddress()).sync();
-            Future<Void> connectFuture2 = cc.connect(sc.localAddress()).await();
+            Future<Void> connectFuture2 = cc.connect(sc.localAddress()).asStage().await().future();
             assertTrue(connectFuture2.cause() instanceof AlreadyConnectedException);
         } finally {
             if (cc != null) {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketReadPendingTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketReadPendingTest.java
@@ -84,10 +84,10 @@ public class SocketReadPendingTest extends AbstractSocketTest {
             clientInitializer.readPendingHandler.assertAllRead();
         } finally {
             if (serverChannel != null) {
-                serverChannel.close().sync();
+                serverChannel.close().asStage().sync();
             }
             if (clientChannel != null) {
-                clientChannel.close().sync();
+                clientChannel.close().asStage().sync();
             }
         }
     }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketRstTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketRstTest.java
@@ -134,7 +134,7 @@ public class SocketRstTest extends AbstractSocketTest {
             }
         });
         Channel sc = sb.bind().asStage().get();
-        cb.connect(sc.localAddress()).sync();
+        cb.connect(sc.localAddress()).asStage().sync();
 
         // Wait for the server to get setup.
         latch.await();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketShutdownOutputBySelfTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketShutdownOutputBySelfTest.java
@@ -68,7 +68,7 @@ public class SocketShutdownOutputBySelfTest extends AbstractClientSocketTest {
             assertFalse(ch.isShutdown(ChannelShutdownDirection.Outbound));
 
             s = ss.accept();
-            ch.writeAndFlush(onHeapAllocator().copyOf(new byte[] { 1 })).sync();
+            ch.writeAndFlush(onHeapAllocator().copyOf(new byte[] { 1 })).asStage().sync();
             assertEquals(1, s.getInputStream().read());
 
             assertTrue(h.ch.isOpen());
@@ -77,7 +77,7 @@ public class SocketShutdownOutputBySelfTest extends AbstractClientSocketTest {
             assertFalse(h.ch.isShutdown(ChannelShutdownDirection.Outbound));
 
             // Make the connection half-closed and ensure read() returns -1.
-            ch.shutdown(ChannelShutdownDirection.Outbound).sync();
+            ch.shutdown(ChannelShutdownDirection.Outbound).asStage().sync();
             assertEquals(-1, s.getInputStream().read());
 
             assertTrue(h.ch.isOpen());
@@ -115,15 +115,15 @@ public class SocketShutdownOutputBySelfTest extends AbstractClientSocketTest {
             assertTrue(ch.isActive());
             s = ss.accept();
 
-            ch.close().sync();
+            ch.close().asStage().sync();
             try {
-                ch.shutdown(ChannelShutdownDirection.Inbound).sync();
+                ch.shutdown(ChannelShutdownDirection.Inbound).asStage().sync();
                 fail();
             } catch (Throwable cause) {
                 checkThrowable(cause.getCause());
             }
             try {
-                ch.shutdown(ChannelShutdownDirection.Outbound).sync();
+                ch.shutdown(ChannelShutdownDirection.Outbound).asStage().sync();
                 fail();
             } catch (Throwable cause) {
                 checkThrowable(cause.getCause());
@@ -161,7 +161,7 @@ public class SocketShutdownOutputBySelfTest extends AbstractClientSocketTest {
             Future<Void> writeFuture = ch.write(onHeapAllocator().copyOf(expectedBytes));
             h.assertWritability(false);
             ch.flush();
-            writeFuture.sync();
+            writeFuture.asStage().sync();
             h.assertWritability(true);
             for (byte expectedByte : expectedBytes) {
                 assertEquals(expectedByte, s.getInputStream().read());
@@ -173,7 +173,7 @@ public class SocketShutdownOutputBySelfTest extends AbstractClientSocketTest {
             assertFalse(h.ch.isShutdown(ChannelShutdownDirection.Outbound));
 
             // Make the connection half-closed and ensure read() returns -1.
-            ch.shutdown(ChannelShutdownDirection.Outbound).sync();
+            ch.shutdown(ChannelShutdownDirection.Outbound).asStage().sync();
             assertEquals(-1, s.getInputStream().read());
 
             assertTrue(h.ch.isOpen());
@@ -183,7 +183,7 @@ public class SocketShutdownOutputBySelfTest extends AbstractClientSocketTest {
 
             try {
                 // If half-closed, the local endpoint shouldn't be able to write
-                ch.writeAndFlush(onHeapAllocator().copyOf(new byte[]{ 2 })).sync();
+                ch.writeAndFlush(onHeapAllocator().copyOf(new byte[]{ 2 })).asStage().sync();
                 fail();
             } catch (Throwable cause) {
                 checkThrowable(cause.getCause());
@@ -231,9 +231,9 @@ public class SocketShutdownOutputBySelfTest extends AbstractClientSocketTest {
                        .connect(ss.getLocalSocketAddress()).asStage().get();
             s = ss.accept();
 
-            client.shutdown(ChannelShutdownDirection.Outbound).sync();
+            client.shutdown(ChannelShutdownDirection.Outbound).asStage().sync();
             if (shutdownInputAsWell) {
-                client.shutdown(ChannelShutdownDirection.Inbound).sync();
+                client.shutdown(ChannelShutdownDirection.Inbound).asStage().sync();
             }
         } finally {
             if (s != null) {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
@@ -184,10 +184,10 @@ public class SocketSslClientRenegotiateTest extends AbstractSocketTest {
             String renegotiation = clientSslHandler.engine().getEnabledCipherSuites()[0];
             // Use the first previous enabled ciphersuite and try to renegotiate.
             clientSslHandler.engine().setEnabledCipherSuites(new String[]{renegotiation});
-            clientSslHandler.renegotiate().await();
-            serverChannel.close().await();
-            clientChannel.close().await();
-            sc.close().await();
+            clientSslHandler.renegotiate().asStage().await();
+            serverChannel.close().asStage().await();
+            clientChannel.close().asStage().await();
+            sc.close().asStage().await();
             try {
                 if (serverException.get() != null) {
                     throw serverException.get();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
@@ -176,10 +176,10 @@ public class SocketSslClientRenegotiateTest extends AbstractSocketTest {
             });
 
             Channel sc = sb.bind().asStage().get();
-            cb.connect(sc.localAddress()).sync();
+            cb.connect(sc.localAddress()).asStage().sync();
 
             Future<Channel> clientHandshakeFuture = clientSslHandler.handshakeFuture();
-            clientHandshakeFuture.sync();
+            clientHandshakeFuture.asStage().sync();
 
             String renegotiation = clientSslHandler.engine().getEnabledCipherSuites()[0];
             // Use the first previous enabled ciphersuite and try to renegotiate.

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslEchoTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslEchoTest.java
@@ -382,9 +382,9 @@ public class SocketSslEchoTest extends AbstractSocketTest {
             serverHandler.renegoFuture.sync();
         }
 
-        serverChannel.close().await();
-        clientChannel.close().await();
-        sc.close().await();
+        serverChannel.close().asStage().await();
+        clientChannel.close().asStage().await();
+        sc.close().asStage().await();
         delegatedTaskExecutor.shutdown();
 
         if (serverException.get() != null && !(serverException.get() instanceof IOException)) {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslEchoTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslEchoTest.java
@@ -308,12 +308,12 @@ public class SocketSslEchoTest extends AbstractSocketTest {
         });
 
         final Channel sc = sb.bind().asStage().get();
-        cb.connect(sc.localAddress()).sync();
+        cb.connect(sc.localAddress()).asStage().sync();
 
         final Future<Channel> clientHandshakeFuture = clientSslHandler.handshakeFuture();
 
         // Wait for the handshake to complete before we flush anything. SslHandler should flush non-application data.
-        clientHandshakeFuture.sync();
+        clientHandshakeFuture.asStage().sync();
         clientHandshakeEventLatch.await();
         Buffer dataBuffer = bufferAllocator.copyOf(data);
 
@@ -332,7 +332,7 @@ public class SocketSslEchoTest extends AbstractSocketTest {
 
             Future<Void> future = clientChannel.writeAndFlush(buf);
             clientSendCounter.set(clientSendCounterVal += length);
-            future.sync();
+            future.asStage().sync();
 
             if (needsRenegotiation && clientSendCounterVal >= data.length / 2) {
                 needsRenegotiation = false;
@@ -376,10 +376,10 @@ public class SocketSslEchoTest extends AbstractSocketTest {
 
         // Wait until renegotiation is done.
         if (renegoFuture != null) {
-            renegoFuture.sync();
+            renegoFuture.asStage().sync();
         }
         if (serverHandler.renegoFuture != null) {
-            serverHandler.renegoFuture.sync();
+            serverHandler.renegoFuture.asStage().sync();
         }
 
         serverChannel.close().asStage().await();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslGreetingTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslGreetingTest.java
@@ -154,9 +154,9 @@ public class SocketSslGreetingTest extends AbstractSocketTest {
 
             ch.latch.await();
 
-            sh.channel.close().await();
-            cc.close().await();
-            sc.close().await();
+            sh.channel.close().asStage().await();
+            cc.close().asStage().await();
+            sc.close().asStage().await();
 
             if (sh.exception.get() != null && !(sh.exception.get() instanceof IOException)) {
                 throw sh.exception.get();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslSessionReuseTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslSessionReuseTest.java
@@ -122,15 +122,15 @@ public class SocketSslSessionReuseTest extends AbstractSocketTest {
             SSLSessionContext clientSessionCtx = clientCtx.sessionContext();
             Buffer msg = DefaultBufferAllocators.preferredAllocator().copyOf(new byte[] { 0xa, 0xb, 0xc, 0xd });
             Channel cc = cb.connect(sc.localAddress()).asStage().get();
-            cc.writeAndFlush(msg).sync();
-            cc.closeFuture().sync();
+            cc.writeAndFlush(msg).asStage().sync();
+            cc.closeFuture().asStage().sync();
             rethrowHandlerExceptions(sh, ch);
             Set<String> sessions = sessionIdSet(clientSessionCtx.getIds());
 
             msg = DefaultBufferAllocators.preferredAllocator().copyOf(new byte[] { 0xa, 0xb, 0xc, 0xd });
             cc = cb.connect(sc.localAddress()).asStage().get();
-            cc.writeAndFlush(msg).sync();
-            cc.closeFuture().sync();
+            cc.writeAndFlush(msg).asStage().sync();
+            cc.closeFuture().asStage().sync();
             assertEquals(sessions, sessionIdSet(clientSessionCtx.getIds()), "Expected no new sessions");
             rethrowHandlerExceptions(sh, ch);
         } finally {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslSessionReuseTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslSessionReuseTest.java
@@ -134,7 +134,7 @@ public class SocketSslSessionReuseTest extends AbstractSocketTest {
             assertEquals(sessions, sessionIdSet(clientSessionCtx.getIds()), "Expected no new sessions");
             rethrowHandlerExceptions(sh, ch);
         } finally {
-            sc.close().await();
+            sc.close().asStage().await();
         }
     }
 

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketStartTlsTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketStartTlsTest.java
@@ -194,9 +194,9 @@ public class SocketStartTlsTest extends AbstractSocketTest {
             }
         }
 
-        sh.channel.close().await();
-        cc.close().await();
-        sc.close().await();
+        sh.channel.close().asStage().await();
+        cc.close().asStage().await();
+        sc.close().asStage().await();
 
         if (sh.exception.get() != null && !(sh.exception.get() instanceof IOException)) {
             throw sh.exception.get();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketStringEchoTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketStringEchoTest.java
@@ -111,11 +111,11 @@ public class SocketStringEchoTest extends AbstractSocketTest {
             cc.writeAndFlush(element + delimiter);
         }
 
-        ch.donePromise.asFuture().sync();
-        sh.donePromise.asFuture().sync();
-        sh.channel.close().sync();
-        ch.channel.close().sync();
-        sc.close().sync();
+        ch.donePromise.asFuture().asStage().sync();
+        sh.donePromise.asFuture().asStage().sync();
+        sh.channel.close().asStage().sync();
+        ch.channel.close().asStage().sync();
+        sc.close().asStage().sync();
 
         if (sh.exception.get() != null && !(sh.exception.get() instanceof IOException)) {
             throw sh.exception.get();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/TrafficShapingHandlerTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/TrafficShapingHandlerTest.java
@@ -347,7 +347,7 @@ public class TrafficShapingHandlerTest extends AbstractSocketTest {
         }
         cc.flush();
 
-        promise.asFuture().await();
+        promise.asFuture().asStage().await();
         Long stop = TrafficCounter.milliSecondFromNano();
         assertTrue(promise.isSuccess(), "Error during execution of TrafficShapping: " + promise.cause());
 

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/TrafficShapingHandlerTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/TrafficShapingHandlerTest.java
@@ -81,8 +81,8 @@ public class TrafficShapingHandlerTest extends AbstractSocketTest {
 
     @AfterAll
     public static void destroyGroup() throws Exception {
-        group.shutdownGracefully().sync();
-        groupForGlobal.shutdownGracefully().sync();
+        group.shutdownGracefully().asStage().sync();
+        groupForGlobal.shutdownGracefully().asStage().sync();
         executor.shutdown();
     }
 
@@ -354,9 +354,9 @@ public class TrafficShapingHandlerTest extends AbstractSocketTest {
         float average = (totalNb * messageSize) / (float) (stop - start);
         logger.info("TEST: " + currentTestName + " RUN: " + currentTestRun +
                     " Average of traffic: " + average + " compare to " + bandwidthFactor);
-        sh.channel.close().sync();
-        ch.channel.close().sync();
-        sc.close().sync();
+        sh.channel.close().asStage().sync();
+        ch.channel.close().asStage().sync();
+        sc.close().asStage().sync();
         if (autoRead != null) {
             // for extra release call in AutoRead
             Thread.sleep(minimalms);

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/WriteBeforeRegisteredTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/WriteBeforeRegisteredTest.java
@@ -40,7 +40,7 @@ public class WriteBeforeRegisteredTest extends AbstractClientSocketTest {
             cb.handler(h);
             ch = (SocketChannel) cb.createUnregistered();
             ch.writeAndFlush(DefaultBufferAllocators.preferredAllocator().copyOf(new byte[] { 1 }));
-            ch.register().sync();
+            ch.register().asStage().sync();
             ch.connect(newSocketAddress());
         } finally {
             if (ch != null) {

--- a/transport-blockhound-tests/src/test/java/io/netty5/util/internal/NettyBlockHoundIntegrationTest.java
+++ b/transport-blockhound-tests/src/test/java/io/netty5/util/internal/NettyBlockHoundIntegrationTest.java
@@ -475,8 +475,8 @@ public class NettyBlockHoundIntegrationTest {
                         }).connect(sc.localAddress());
                 cc = future.asStage().get();
 
-                clientSslHandler.handshakeFuture().await().sync();
-                serverSslHandler.handshakeFuture().await().sync();
+                clientSslHandler.handshakeFuture().sync();
+                serverSslHandler.handshakeFuture().sync();
             } finally {
                 if (cc != null) {
                     cc.close().sync();

--- a/transport-blockhound-tests/src/test/java/io/netty5/util/internal/NettyBlockHoundIntegrationTest.java
+++ b/transport-blockhound-tests/src/test/java/io/netty5/util/internal/NettyBlockHoundIntegrationTest.java
@@ -147,7 +147,7 @@ public class NettyBlockHoundIntegrationTest {
     private static void testEventExecutorTakeTask(EventExecutor eventExecutor) throws InterruptedException {
         CountDownLatch latch = new CountDownLatch(1);
         Future<?> f = eventExecutor.schedule(latch::countDown, 10, TimeUnit.MILLISECONDS);
-        f.sync();
+        f.asStage().sync();
         latch.await();
     }
 
@@ -329,10 +329,10 @@ public class NettyBlockHoundIntegrationTest {
                 assertNull(error.get());
             } finally {
                 if (cc != null) {
-                    cc.close().sync();
+                    cc.close().asStage().sync();
                 }
                 if (sc != null) {
-                    sc.close().sync();
+                    sc.close().asStage().sync();
                 }
                 group.shutdownGracefully();
             }
@@ -475,14 +475,14 @@ public class NettyBlockHoundIntegrationTest {
                         }).connect(sc.localAddress());
                 cc = future.asStage().get();
 
-                clientSslHandler.handshakeFuture().sync();
-                serverSslHandler.handshakeFuture().sync();
+                clientSslHandler.handshakeFuture().asStage().sync();
+                serverSslHandler.handshakeFuture().asStage().sync();
             } finally {
                 if (cc != null) {
-                    cc.close().sync();
+                    cc.close().asStage().sync();
                 }
                 if (sc != null) {
-                    sc.close().sync();
+                    sc.close().asStage().sync();
                 }
                 group.shutdownGracefully();
             }

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDatagramChannelTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDatagramChannelTest.java
@@ -94,7 +94,7 @@ public class EpollDatagramChannelTest {
             assertTrue(localAddressAfterBind instanceof InetSocketAddress);
             assertTrue(((InetSocketAddress) localAddressAfterBind).getPort() != 0);
 
-            channel.close().sync();
+            channel.close().asStage().sync();
         } finally {
             group.shutdownGracefully();
         }

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDatagramScatteringReadTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDatagramScatteringReadTest.java
@@ -150,7 +150,7 @@ public class EpollDatagramScatteringReadTest extends AbstractDatagramTest  {
             sc = sb.bind(newSocketAddress()).asStage().get();
 
             if (connected) {
-                sc.connect(cc.localAddress()).sync();
+                sc.connect(cc.localAddress()).asStage().sync();
             }
 
             InetSocketAddress addr = (InetSocketAddress) sc.localAddress();
@@ -163,7 +163,7 @@ public class EpollDatagramScatteringReadTest extends AbstractDatagramTest  {
             cc.flush();
 
             for (Future<Void> f: futures) {
-                f.sync();
+                f.asStage().sync();
             }
 
             // Enable autoread now which also triggers a read, this should cause scattering reads (recvmmsg) to happen.
@@ -178,10 +178,10 @@ public class EpollDatagramScatteringReadTest extends AbstractDatagramTest  {
             }
         } finally {
             if (cc != null) {
-                cc.close().sync();
+                cc.close().asStage().sync();
             }
             if (sc != null) {
-                sc.close().sync();
+                sc.close().asStage().sync();
             }
         }
     }
@@ -251,12 +251,12 @@ public class EpollDatagramScatteringReadTest extends AbstractDatagramTest  {
             sc = sb.bind(newSocketAddress()).asStage().get();
 
             if (connected) {
-                sc.connect(cc.localAddress()).sync();
+                sc.connect(cc.localAddress()).asStage().sync();
             }
 
             InetSocketAddress addr = (InetSocketAddress) sc.localAddress();
 
-            cc.writeAndFlush(new DatagramPacket(cc.bufferAllocator().copyOf(bytes), addr)).sync();
+            cc.writeAndFlush(new DatagramPacket(cc.bufferAllocator().copyOf(bytes), addr)).asStage().sync();
 
             if (!latch.await(10, TimeUnit.SECONDS)) {
                 Throwable error = errorRef.get();
@@ -267,10 +267,10 @@ public class EpollDatagramScatteringReadTest extends AbstractDatagramTest  {
             }
         } finally {
             if (cc != null) {
-                cc.close().sync();
+                cc.close().asStage().sync();
             }
             if (sc != null) {
-                sc.close().sync();
+                sc.close().asStage().sync();
             }
         }
     }

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDatagramUnicastTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDatagramUnicastTest.java
@@ -173,7 +173,7 @@ public class EpollDatagramUnicastTest extends DatagramUnicastInetTest {
                 buffer.fill((byte) 0);
                 buffer.skipWritableBytes(bufferCapacity);
             }
-            cc.writeAndFlush(new SegmentedDatagramPacket(buffer, segmentSize, addr)).sync();
+            cc.writeAndFlush(new SegmentedDatagramPacket(buffer, segmentSize, addr)).asStage().sync();
 
             if (!latch.await(10, TimeUnit.SECONDS)) {
                 Throwable error = errorRef.get();
@@ -184,10 +184,10 @@ public class EpollDatagramUnicastTest extends DatagramUnicastInetTest {
             }
         } finally {
             if (cc != null) {
-                cc.close().sync();
+                cc.close().asStage().sync();
             }
             if (sc != null) {
-                sc.close().sync();
+                sc.close().asStage().sync();
             }
         }
     }

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDomainDatagramPathTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDomainDatagramPathTest.java
@@ -53,8 +53,8 @@ class EpollDomainDatagramPathTest extends AbstractClientSocketTest {
                 Channel ch = bootstrap.handler(new ChannelHandlerAdapter() { })
                                       .bind(EpollSocketTestPermutation.newDomainSocketAddress()).asStage().get();
                 ch.writeAndFlush(new DomainDatagramPacket(
-                        ch.bufferAllocator().copyOf("test", CharsetUtil.US_ASCII),
-                        EpollSocketTestPermutation.newDomainSocketAddress())).sync();
+                                ch.bufferAllocator().copyOf("test", CharsetUtil.US_ASCII),
+                                EpollSocketTestPermutation.newDomainSocketAddress())).asStage().sync();
                 fail("Expected FileNotFoundException");
             } catch (Exception e) {
                 assertTrue(e.getCause() instanceof FileNotFoundException);

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDomainSocketFdTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDomainSocketFdTest.java
@@ -91,8 +91,8 @@ public class EpollDomainSocketFdTest extends AbstractSocketTest {
         Channel cc = cb.connect(sc.localAddress()).asStage().get();
 
         Object received = queue.take();
-        cc.close().sync();
-        sc.close().sync();
+        cc.close().asStage().sync();
+        sc.close().asStage().sync();
 
         if (received instanceof FileDescriptor) {
             FileDescriptor fd = (FileDescriptor) received;

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollEventLoopTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollEventLoopTest.java
@@ -60,7 +60,7 @@ public class EpollEventLoopTest extends AbstractSingleThreadEventLoopTest {
                 // NOOP
             }, Long.MAX_VALUE, TimeUnit.MILLISECONDS);
 
-            assertFalse(future.await(1000, TimeUnit.MILLISECONDS));
+            assertFalse(future.asStage().await(1000, TimeUnit.MILLISECONDS));
             assertTrue(future.cancel());
             assertNull(capture.get());
         } finally {

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollReuseAddrTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollReuseAddrTest.java
@@ -105,12 +105,12 @@ public class EpollReuseAddrTest {
         bootstrap.handler(new LoggingHandler(LogLevel.ERROR));
         Channel channel = bootstrap.bind().asStage().get();
         try {
-            bootstrap.bind(channel.localAddress()).sync();
+            bootstrap.bind(channel.localAddress()).asStage().sync();
             fail();
         } catch (Exception e) {
             assertTrue(e.getCause() instanceof IOException);
         }
-        channel.close().sync();
+        channel.close().asStage().sync();
     }
 
     @Test
@@ -135,8 +135,8 @@ public class EpollReuseAddrTest {
             socket.setReuseAddress(true);
             socket.close();
         }
-        firstChannel.close().sync();
-        secondChannel.close().sync();
+        firstChannel.close().asStage().sync();
+        secondChannel.close().asStage().sync();
     }
 
     @Test
@@ -184,8 +184,8 @@ public class EpollReuseAddrTest {
         }
         latch.await();
         executor.shutdown();
-        firstChannel.close().sync();
-        secondChannel.close().sync();
+        firstChannel.close().asStage().sync();
+        secondChannel.close().asStage().sync();
         assertTrue(received1.get());
         assertTrue(received2.get());
     }

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollServerSocketChannelConfigTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollServerSocketChannelConfigTest.java
@@ -49,7 +49,7 @@ public class EpollServerSocketChannelConfigTest {
     @AfterAll
     public static void after() throws Exception {
         try {
-            ch.close().sync();
+            ch.close().asStage().sync();
         } finally {
             group.shutdownGracefully();
         }

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollSocketChannelConfigTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollSocketChannelConfigTest.java
@@ -70,7 +70,7 @@ public class EpollSocketChannelConfigTest {
 
     @AfterEach
     public void tearDown() throws Exception {
-        ch.close().sync();
+        ch.close().asStage().sync();
     }
 
     private static long randLong(long min, long max) {
@@ -146,7 +146,7 @@ public class EpollSocketChannelConfigTest {
     // want to see a ClosedChannelException for the test to pass.
     @RepeatedIfExceptionsTest(repeats = 4)
     public void testSetOptionWhenClosed() throws Exception {
-        ch.close().sync();
+        ch.close().asStage().sync();
         ChannelException e = assertThrows(ChannelException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
@@ -161,7 +161,7 @@ public class EpollSocketChannelConfigTest {
     // want to see a ClosedChannelException for the test to pass.
     @RepeatedIfExceptionsTest(repeats = 4)
     public void testGetOptionWhenClosed() throws Exception {
-        ch.close().sync();
+        ch.close().asStage().sync();
         ChannelException e = assertThrows(ChannelException.class, new Executable() {
             @Override
             public void execute() throws Throwable {

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollSocketChannelTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollSocketChannelTest.java
@@ -41,7 +41,7 @@ public class EpollSocketChannelTest {
                                                                   .bind(new InetSocketAddress(0)).asStage().get();
             EpollTcpInfo info = ch.tcpInfo();
             assertTcpInfo0(info);
-            ch.close().sync();
+            ch.close().asStage().sync();
         } finally {
             group.shutdownGracefully();
         }
@@ -60,7 +60,7 @@ public class EpollSocketChannelTest {
             EpollTcpInfo info = new EpollTcpInfo();
             ch.tcpInfo(info);
             assertTcpInfo0(info);
-            ch.close().sync();
+            ch.close().asStage().sync();
         } finally {
             group.shutdownGracefully();
         }
@@ -115,7 +115,7 @@ public class EpollSocketChannelTest {
                                                                   .option(ChannelOption.SO_LINGER, 10)
                                                                   .handler(new ChannelHandler() { })
                                                                   .bind(new InetSocketAddress(0)).asStage().get();
-            ch.close().sync();
+            ch.close().asStage().sync();
         } finally {
             group.shutdownGracefully();
         }

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollSocketTcpMd5Test.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollSocketTcpMd5Test.java
@@ -65,7 +65,7 @@ public class EpollSocketTcpMd5Test {
 
     @AfterEach
     public void tearDown() throws Exception {
-        server.close().sync();
+        server.close().asStage().sync();
     }
 
     @Test
@@ -89,7 +89,7 @@ public class EpollSocketTcpMd5Test {
                 Collections.singletonMap(NetUtil.LOCALHOST4, SERVER_KEY));
         ch.config().setOption(EpollChannelOption.TCP_MD5SIG, Collections.emptyMap());
 
-        ch.close().sync();
+        ch.close().asStage().sync();
     }
 
     @Test
@@ -107,7 +107,7 @@ public class EpollSocketTcpMd5Test {
                             Collections.singletonMap(NetUtil.LOCALHOST4, BAD_KEY))
                     .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 1000)
                     .connect(server.localAddress()).asStage().get();
-            client.close().sync();
+            client.close().asStage().sync();
         });
         assertThat(completion.getCause())
                 .isInstanceOf(ConnectTimeoutException.class);
@@ -124,6 +124,6 @@ public class EpollSocketTcpMd5Test {
                 .handler(new ChannelHandler() { })
                 .option(EpollChannelOption.TCP_MD5SIG, Collections.singletonMap(NetUtil.LOCALHOST4, SERVER_KEY))
                 .connect(server.localAddress()).asStage().get();
-        client.close().sync();
+        client.close().asStage().sync();
     }
 }

--- a/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueChannelConfigTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueChannelConfigTest.java
@@ -89,7 +89,7 @@ public class KQueueChannelConfigTest {
                     .option(ChannelOption.SO_LINGER, 10)
                     .handler(new ChannelHandler() { })
                     .bind(new InetSocketAddress(0)).asStage().get();
-            ch.close().sync();
+            ch.close().asStage().sync();
         } finally {
             group.shutdownGracefully();
         }

--- a/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueDomainDatagramPathTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueDomainDatagramPathTest.java
@@ -53,8 +53,8 @@ class KQueueDomainDatagramPathTest extends AbstractClientSocketTest {
                 Channel ch = bootstrap.handler(new ChannelHandlerAdapter() { })
                                       .bind(KQueueSocketTestPermutation.newSocketAddress()).asStage().get();
                 ch.writeAndFlush(new DomainDatagramPacket(
-                        ch.bufferAllocator().copyOf("test", US_ASCII),
-                        KQueueSocketTestPermutation.newSocketAddress())).sync();
+                                ch.bufferAllocator().copyOf("test", US_ASCII),
+                                KQueueSocketTestPermutation.newSocketAddress())).asStage().sync();
                 fail("Expected FileNotFoundException");
             } catch (Exception e) {
                 assertTrue(e.getCause() instanceof FileNotFoundException);

--- a/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueDomainSocketFdTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueDomainSocketFdTest.java
@@ -91,8 +91,8 @@ public class KQueueDomainSocketFdTest extends AbstractSocketTest {
         Channel cc = cb.connect(sc.localAddress()).asStage().get();
 
         Object received = queue.take();
-        cc.close().sync();
-        sc.close().sync();
+        cc.close().asStage().sync();
+        sc.close().asStage().sync();
 
         if (received instanceof FileDescriptor) {
             FileDescriptor fd = (FileDescriptor) received;

--- a/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueEventLoopTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueEventLoopTest.java
@@ -40,7 +40,7 @@ public class KQueueEventLoopTest extends AbstractSingleThreadEventLoopTest {
             // NOOP
         }, Long.MAX_VALUE, TimeUnit.MILLISECONDS);
 
-        assertFalse(future.await(1000, TimeUnit.MILLISECONDS));
+        assertFalse(future.asStage().await(1000, TimeUnit.MILLISECONDS));
         assertTrue(future.cancel());
         group.shutdownGracefully();
     }

--- a/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueServerSocketChannelConfigTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueServerSocketChannelConfigTest.java
@@ -48,7 +48,7 @@ public class KQueueServerSocketChannelConfigTest {
     @AfterAll
     public static void after() throws Exception {
         try {
-            ch.close().sync();
+            ch.close().asStage().sync();
         } finally {
             group.shutdownGracefully();
         }

--- a/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueSocketChannelConfigTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueSocketChannelConfigTest.java
@@ -65,7 +65,7 @@ public class KQueueSocketChannelConfigTest {
 
     @AfterEach
     public void tearDown() throws Exception {
-        ch.close().sync();
+        ch.close().asStage().sync();
     }
 
     @Test
@@ -103,7 +103,7 @@ public class KQueueSocketChannelConfigTest {
 
     @Test
     public void testSetOptionWhenClosed() throws Exception {
-        ch.close().sync();
+        ch.close().asStage().sync();
         try {
             ch.config().setSoLinger(0);
             fail();
@@ -114,7 +114,7 @@ public class KQueueSocketChannelConfigTest {
 
     @Test
     public void testGetOptionWhenClosed() throws Exception {
-        ch.close().sync();
+        ch.close().asStage().sync();
         try {
         ch.config().getSoLinger();
             fail();

--- a/transport-native-unix-common-tests/src/main/java/io/netty5/channel/unix/tests/DetectPeerCloseWithoutReadTest.java
+++ b/transport-native-unix-common-tests/src/main/java/io/netty5/channel/unix/tests/DetectPeerCloseWithoutReadTest.java
@@ -95,7 +95,7 @@ public abstract class DetectPeerCloseWithoutReadTest {
             assertEquals(expectedBytes, bytesRead.get());
         } finally {
             if (serverChannel != null) {
-                serverChannel.close().sync();
+                serverChannel.close().asStage().sync();
             }
             if (serverGroup != null) {
                 serverGroup.shutdownGracefully();
@@ -169,10 +169,10 @@ public abstract class DetectPeerCloseWithoutReadTest {
             assertEquals(expectedBytes, bytesRead.get());
         } finally {
             if (serverChannel != null) {
-                serverChannel.close().sync();
+                serverChannel.close().asStage().sync();
             }
             if (clientChannel != null) {
-                clientChannel.close().sync();
+                clientChannel.close().asStage().sync();
             }
             if (serverGroup != null) {
                 serverGroup.shutdownGracefully();

--- a/transport/src/main/java/io/netty5/channel/group/ChannelGroupFuture.java
+++ b/transport/src/main/java/io/netty5/channel/group/ChannelGroupFuture.java
@@ -143,9 +143,6 @@ public interface ChannelGroupFuture extends Future<Void>, Iterable<Future<Void>>
     @Override
     ChannelGroupFuture addListener(FutureListener<? super Void> listener);
 
-    @Override
-    ChannelGroupFuture sync() throws InterruptedException;
-
     /**
      * Returns the {@link Iterator} that enumerates all {@link Future}s
      * which are associated with this future.  Please note that the returned

--- a/transport/src/main/java/io/netty5/channel/group/DefaultChannelGroupFuture.java
+++ b/transport/src/main/java/io/netty5/channel/group/DefaultChannelGroupFuture.java
@@ -120,7 +120,7 @@ final class DefaultChannelGroupFuture extends DefaultPromise<Void> implements Ch
 
     @Override
     public DefaultChannelGroupFuture await() throws InterruptedException {
-        super.await();
+        asStage().await();
         return this;
     }
 

--- a/transport/src/main/java/io/netty5/channel/group/DefaultChannelGroupFuture.java
+++ b/transport/src/main/java/io/netty5/channel/group/DefaultChannelGroupFuture.java
@@ -125,12 +125,6 @@ final class DefaultChannelGroupFuture extends DefaultPromise<Void> implements Ch
     }
 
     @Override
-    public DefaultChannelGroupFuture sync() throws InterruptedException {
-        super.sync();
-        return this;
-    }
-
-    @Override
     public ChannelGroupException cause() {
         return (ChannelGroupException) super.cause();
     }

--- a/transport/src/test/java/io/netty5/bootstrap/BootstrapTest.java
+++ b/transport/src/test/java/io/netty5/bootstrap/BootstrapTest.java
@@ -75,8 +75,8 @@ public class BootstrapTest {
     public static void destroy() throws Exception {
         groupA.shutdownGracefully();
         groupB.shutdownGracefully();
-        groupA.terminationFuture().sync();
-        groupB.terminationFuture().sync();
+        groupA.terminationFuture().asStage().sync();
+        groupB.terminationFuture().asStage().sync();
     }
 
     @Test
@@ -117,7 +117,7 @@ public class BootstrapTest {
                         assertEquals("value", ch.attr(key).get());
                     }
                 })
-                .bind(LocalAddress.ANY).sync();
+                .bind(LocalAddress.ANY).asStage().sync();
     }
 
     @Test
@@ -147,7 +147,7 @@ public class BootstrapTest {
         }
 
         for (Future<?> f: bindFutures) {
-            f.sync();
+            f.asStage().sync();
         }
     }
 
@@ -178,7 +178,7 @@ public class BootstrapTest {
         }
 
         for (Future<?> f: bindFutures) {
-            f.sync();
+            f.asStage().sync();
         }
     }
 
@@ -205,7 +205,7 @@ public class BootstrapTest {
             assertTrue(queue.take());
         } finally {
             group.shutdownGracefully();
-            group.terminationFuture().sync();
+            group.terminationFuture().asStage().sync();
         }
     }
 
@@ -241,7 +241,7 @@ public class BootstrapTest {
             assertFalse(queue.take());
         } finally {
             group.shutdownGracefully();
-            group.terminationFuture().sync();
+            group.terminationFuture().asStage().sync();
         }
     }
 
@@ -258,7 +258,7 @@ public class BootstrapTest {
             Future<Channel> future = bootstrapA.connect(LocalAddress.ANY);
             assertFalse(future.isDone());
             registerHandler.registerPromise().setSuccess(null);
-            CompletionException cause = assertThrows(CompletionException.class, future::sync);
+            CompletionException cause = assertThrows(CompletionException.class, future.asStage()::sync);
             assertThat(cause.getCause(), instanceOf(ConnectException.class));
         } finally {
             group.shutdownGracefully();
@@ -280,7 +280,7 @@ public class BootstrapTest {
         SocketAddress localAddress = bootstrapB.bind(LocalAddress.ANY).asStage().get().localAddress();
 
         // Connect to the server using the asynchronous resolver.
-        bootstrapA.connect(localAddress).sync();
+        bootstrapA.connect(localAddress).asStage().sync();
     }
 
     @Test
@@ -297,9 +297,9 @@ public class BootstrapTest {
             Future<Void> registerFuture = channel.register();
             Future<Void> connectFuture = channel.connect(LocalAddress.ANY);
             registerHandler.registerPromise().setSuccess(null);
-            registerFuture.sync();
+            registerFuture.asStage().sync();
             CompletionException exception =
-                    assertThrows(CompletionException.class, connectFuture::sync);
+                    assertThrows(CompletionException.class, connectFuture.asStage()::sync);
             assertTrue(exception.getCause() instanceof ConnectException);
         } finally {
             group.shutdownGracefully();
@@ -387,7 +387,7 @@ public class BootstrapTest {
                 .option(ChannelOption.WRITE_BUFFER_LOW_WATER_MARK, 1)
                 .option(ChannelOption.WRITE_BUFFER_HIGH_WATER_MARK, 2);
 
-        bootstrap.register().sync();
+        bootstrap.register().asStage().sync();
 
         latch.await();
 

--- a/transport/src/test/java/io/netty5/bootstrap/BootstrapTest.java
+++ b/transport/src/test/java/io/netty5/bootstrap/BootstrapTest.java
@@ -324,7 +324,7 @@ public class BootstrapTest {
         Future<Channel> connectFuture = bootstrapA.connect(localAddress);
 
         // Should fail with the UnknownHostException.
-        assertTrue(connectFuture.await(10000, TimeUnit.MILLISECONDS));
+        assertTrue(connectFuture.asStage().await(10000, TimeUnit.MILLISECONDS));
         assertThat(connectFuture.cause(), instanceOf(UnknownHostException.class));
     }
 
@@ -342,7 +342,7 @@ public class BootstrapTest {
         Future<Channel> connectFuture = bootstrap.connect(LocalAddress.ANY);
 
         // Should fail with the RuntimeException.
-        assertTrue(connectFuture.await(10000, TimeUnit.MILLISECONDS));
+        assertTrue(connectFuture.asStage().await(10000, TimeUnit.MILLISECONDS));
         assertSame(connectFuture.cause(), exception);
     }
 

--- a/transport/src/test/java/io/netty5/bootstrap/ServerBootstrapTest.java
+++ b/transport/src/test/java/io/netty5/bootstrap/ServerBootstrapTest.java
@@ -65,7 +65,7 @@ public class ServerBootstrapTest {
                       }
                   }
               });
-            sb.register().sync();
+            sb.register().asStage().sync();
             latch.await();
             assertNull(error.get());
         } finally {
@@ -136,10 +136,10 @@ public class ServerBootstrapTest {
             readLatch.await();
         } finally {
             if (sch != null) {
-                sch.close().sync();
+                sch.close().asStage().sync();
             }
             if (cch != null) {
-                cch.close().sync();
+                cch.close().asStage().sync();
             }
             group.shutdownGracefully();
         }
@@ -172,8 +172,8 @@ public class ServerBootstrapTest {
                 .channel(LocalChannel.class)
                 .handler(new ChannelHandler() { });
         Channel clientChannel = cb.connect(addr).asStage().get();
-        serverChannel.close().sync();
-        clientChannel.close().sync();
+        serverChannel.close().asStage().sync();
+        clientChannel.close().asStage().sync();
         group.shutdownGracefully();
         assertTrue(requestServed.get());
     }

--- a/transport/src/test/java/io/netty5/channel/AbstractChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/AbstractChannelTest.java
@@ -174,7 +174,7 @@ public class AbstractChannelTest {
         try {
             registerChannel(channel);
             channel.connect(new InetSocketAddress(NetUtil.LOCALHOST, 8888)).sync();
-            assertSame(ioException, channel.writeAndFlush("").await().cause());
+            assertSame(ioException, channel.writeAndFlush("").asStage().await().future().cause());
 
             assertClosedChannelException(channel.writeAndFlush(""), ioException);
             assertClosedChannelException(channel.write(""), ioException);
@@ -186,7 +186,7 @@ public class AbstractChannelTest {
 
     private static void assertClosedChannelException(Future<Void> future, IOException expected)
             throws InterruptedException {
-        Throwable cause = future.await().cause();
+        Throwable cause = future.asStage().await().future().cause();
         assertTrue(cause instanceof ClosedChannelException);
         assertSame(expected, cause.getCause());
     }

--- a/transport/src/test/java/io/netty5/channel/AbstractChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/AbstractChannelTest.java
@@ -173,7 +173,7 @@ public class AbstractChannelTest {
 
         try {
             registerChannel(channel);
-            channel.connect(new InetSocketAddress(NetUtil.LOCALHOST, 8888)).sync();
+            channel.connect(new InetSocketAddress(NetUtil.LOCALHOST, 8888)).asStage().sync();
             assertSame(ioException, channel.writeAndFlush("").asStage().await().future().cause());
 
             assertClosedChannelException(channel.writeAndFlush(""), ioException);
@@ -194,7 +194,7 @@ public class AbstractChannelTest {
     private static void registerChannel(Channel channel) throws Exception {
         when(channel.executor().registerForIo(channel)).thenReturn(INSTANCE.newSucceededFuture(null));
         when(channel.executor().deregisterForIo(channel)).thenReturn(INSTANCE.newSucceededFuture(null));
-        channel.register().sync(); // Cause any exceptions to be thrown
+        channel.register().asStage().sync(); // Cause any exceptions to be thrown
     }
 
     private static class TestChannel extends AbstractChannel<Channel, SocketAddress, SocketAddress> {

--- a/transport/src/test/java/io/netty5/channel/AbstractEventLoopTest.java
+++ b/transport/src/test/java/io/netty5/channel/AbstractEventLoopTest.java
@@ -37,11 +37,11 @@ public abstract class AbstractEventLoopTest {
                 .childHandler(new ChannelHandler() { });
 
         // Not close the Channel to ensure the EventLoop is still shutdown in time.
-        b.bind(0).sync();
+        b.bind(0).asStage().sync();
 
         Future<?> f = loop.shutdownGracefully(0, 1, TimeUnit.MINUTES);
         assertTrue(loop.awaitTermination(600, TimeUnit.MILLISECONDS));
-        assertTrue(f.sync().isSuccess());
+        assertTrue(f.asStage().sync().isSuccess());
         assertTrue(loop.isShutdown());
         assertTrue(loop.isTerminated());
     }

--- a/transport/src/test/java/io/netty5/channel/ChannelInitializerTest.java
+++ b/transport/src/test/java/io/netty5/channel/ChannelInitializerTest.java
@@ -100,7 +100,7 @@ public class ChannelInitializerTest {
         });
 
         if (!registerFirst) {
-            assertTrue(pipeline.channel().register().await().cause() instanceof ClosedChannelException);
+            assertTrue(pipeline.channel().register().asStage().await().future().cause() instanceof ClosedChannelException);
         }
         pipeline.channel().close().sync();
         pipeline.channel().closeFuture().sync();

--- a/transport/src/test/java/io/netty5/channel/ChannelOutboundBufferTest.java
+++ b/transport/src/test/java/io/netty5/channel/ChannelOutboundBufferTest.java
@@ -46,12 +46,12 @@ public class ChannelOutboundBufferTest {
         try {
             ChannelOutboundBuffer buffer = new ChannelOutboundBuffer(executor);
             executor.submit(() -> {
-                try {
-                    testConsumer.accept(buffer, executor);
-                } finally {
-                    release(buffer);
-                }
-            }).sync();
+                    try {
+                        testConsumer.accept(buffer, executor);
+                    } finally {
+                        release(buffer);
+                    }
+                }).asStage().sync();
         } finally {
             executor.shutdownGracefully();
         }

--- a/transport/src/test/java/io/netty5/channel/CombinedChannelDuplexHandlerTest.java
+++ b/transport/src/test/java/io/netty5/channel/CombinedChannelDuplexHandlerTest.java
@@ -208,15 +208,15 @@ public class CombinedChannelDuplexHandlerTest {
     }
 
     private static void doOutboundOperations(Channel channel) throws Exception {
-        channel.pipeline().bind(LOCAL_ADDRESS).sync();
-        channel.pipeline().connect(REMOTE_ADDRESS, LOCAL_ADDRESS).sync();
-        channel.pipeline().write(MSG).sync();
+        channel.pipeline().bind(LOCAL_ADDRESS).asStage().sync();
+        channel.pipeline().connect(REMOTE_ADDRESS, LOCAL_ADDRESS).asStage().sync();
+        channel.pipeline().write(MSG).asStage().sync();
         channel.pipeline().flush();
         channel.pipeline().read();
         channel.pipeline().sendOutboundEvent(USER_EVENT);
-        channel.pipeline().disconnect().sync();
-        channel.pipeline().close().sync();
-        channel.pipeline().deregister().sync();
+        channel.pipeline().disconnect().asStage().sync();
+        channel.pipeline().close().asStage().sync();
+        channel.pipeline().deregister().asStage().sync();
     }
 
     private static void assertOutboundOperations(OutboundEventHandler outboundHandler) {

--- a/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTailTest.java
+++ b/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTailTest.java
@@ -76,7 +76,7 @@ public class DefaultChannelPipelineTailTest {
         };
 
         myChannel.pipeline().fireChannelInactive();
-        myChannel.close().sync();
+        myChannel.close().asStage().sync();
 
         assertTrue(latch.await(1L, TimeUnit.SECONDS));
     }

--- a/transport/src/test/java/io/netty5/channel/PendingWriteQueueTest.java
+++ b/transport/src/test/java/io/netty5/channel/PendingWriteQueueTest.java
@@ -97,7 +97,7 @@ public class PendingWriteQueueTest {
             }
             assertTrue(channel.writeOutbound(buffers));
             assertTrue(channel.finish());
-            channel.closeFuture().sync();
+            channel.closeFuture().asStage().sync();
 
             for (int i = 0; i < buffers.length; i++) {
                 assertBuffer(channel, buffer);
@@ -133,7 +133,7 @@ public class PendingWriteQueueTest {
                 assertTrue(e instanceof TestException);
             }
             assertFalse(channel.finish());
-            channel.closeFuture().sync();
+            channel.closeFuture().asStage().sync();
 
             assertNull(channel.readOutbound());
         }
@@ -282,7 +282,7 @@ public class PendingWriteQueueTest {
     public void testCloseChannelOnCreation() throws Exception {
         EmbeddedChannel channel = newChannel();
         ChannelHandlerContext context = channel.pipeline().firstContext();
-        channel.close().sync();
+        channel.close().asStage().sync();
 
         final PendingWriteQueue queue = new PendingWriteQueue(context.executor(),
                 channel.config().getMessageSizeEstimator().newHandle());

--- a/transport/src/test/java/io/netty5/channel/ReentrantChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/ReentrantChannelTest.java
@@ -37,7 +37,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
         LocalAddress addr = new LocalAddress(getClass());
 
         ServerBootstrap sb = getLocalServerBootstrap();
-        sb.bind(addr).sync();
+        sb.bind(addr).asStage().sync();
 
         Bootstrap cb = getLocalClientBootstrap();
 
@@ -79,9 +79,9 @@ public class ReentrantChannelTest extends BaseChannelTest {
         Future<Void> future = clientChannel.write(createTestBuffer(2000));
 
         clientChannel.flush();
-        future.sync();
+        future.asStage().sync();
 
-        clientChannel.close().sync();
+        clientChannel.close().asStage().sync();
 
         assertLog(
                 "WRITABILITY: writable=true\n" +
@@ -104,7 +104,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
         LocalAddress addr = new LocalAddress(getClass());
 
         ServerBootstrap sb = getLocalServerBootstrap();
-        sb.bind(addr).sync();
+        sb.bind(addr).asStage().sync();
 
         Bootstrap cb = getLocalClientBootstrap();
 
@@ -146,9 +146,9 @@ public class ReentrantChannelTest extends BaseChannelTest {
         Future<Void> future = clientChannel.write(createTestBuffer(2000));
 
         clientChannel.flush();
-        future.sync();
+        future.asStage().sync();
 
-        clientChannel.close().sync();
+        clientChannel.close().asStage().sync();
 
         assertLog("WRITABILITY: writable=true\n" +
                         "WRITE\n" +
@@ -173,7 +173,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
         LocalAddress addr = new LocalAddress(getClass());
 
         ServerBootstrap sb = getLocalServerBootstrap();
-        sb.bind(addr).sync();
+        sb.bind(addr).asStage().sync();
 
         Bootstrap cb = getLocalClientBootstrap();
 
@@ -195,8 +195,8 @@ public class ReentrantChannelTest extends BaseChannelTest {
 
         assertTrue(clientChannel.isWritable());
 
-        clientChannel.write(createTestBuffer(2000)).sync();
-        clientChannel.close().sync();
+        clientChannel.write(createTestBuffer(2000)).asStage().sync();
+        clientChannel.close().asStage().sync();
 
         assertLog("WRITABILITY: writable=true\n" +
                         "WRITE\n" +
@@ -222,7 +222,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
         LocalAddress addr = new LocalAddress(getClass());
 
         ServerBootstrap sb = getLocalServerBootstrap();
-        sb.bind(addr).sync();
+        sb.bind(addr).asStage().sync();
 
         Bootstrap cb = getLocalClientBootstrap();
 
@@ -244,8 +244,8 @@ public class ReentrantChannelTest extends BaseChannelTest {
 
         assertTrue(clientChannel.isWritable());
 
-        clientChannel.write(createTestBuffer(2000)).sync();
-        clientChannel.close().sync();
+        clientChannel.write(createTestBuffer(2000)).asStage().sync();
+        clientChannel.close().asStage().sync();
 
         assertLog("WRITABILITY: writable=true\n" +
                         "WRITE\n" +
@@ -268,7 +268,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
         LocalAddress addr = new LocalAddress(getClass());
 
         ServerBootstrap sb = getLocalServerBootstrap();
-        sb.bind(addr).sync();
+        sb.bind(addr).asStage().sync();
 
         Bootstrap cb = getLocalClientBootstrap();
 
@@ -301,7 +301,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
         });
 
         clientChannel.writeAndFlush(createTestBuffer(2000));
-        clientChannel.close().sync();
+        clientChannel.close().asStage().sync();
 
         assertLog("WRITE\n" +
                 "FLUSH\n" +
@@ -324,7 +324,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
         LocalAddress addr = new LocalAddress(getClass());
 
         ServerBootstrap sb = getLocalServerBootstrap();
-        sb.bind(addr).sync();
+        sb.bind(addr).asStage().sync();
 
         Bootstrap cb = getLocalClientBootstrap();
 
@@ -357,7 +357,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
         });
 
         clientChannel.writeAndFlush(createTestBuffer(2000));
-        clientChannel.close().sync();
+        clientChannel.close().asStage().sync();
 
         assertLog("WRITE\n" +
                 "FLUSH\n" +
@@ -380,7 +380,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
         LocalAddress addr = new LocalAddress(getClass());
 
         ServerBootstrap sb = getLocalServerBootstrap();
-        sb.bind(addr).sync();
+        sb.bind(addr).asStage().sync();
 
         Bootstrap cb = getLocalClientBootstrap();
 
@@ -398,8 +398,8 @@ public class ReentrantChannelTest extends BaseChannelTest {
             }
         });
 
-        clientChannel.write(createTestBuffer(2000)).sync();
-        clientChannel.closeFuture().sync();
+        clientChannel.write(createTestBuffer(2000)).asStage().sync();
+        clientChannel.closeFuture().asStage().sync();
 
         assertLog("WRITE\nFLUSH\nCLOSE\n");
     }
@@ -410,7 +410,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
         LocalAddress addr = new LocalAddress(getClass());
 
         ServerBootstrap sb = getLocalServerBootstrap();
-        sb.bind(addr).sync();
+        sb.bind(addr).asStage().sync();
 
         Bootstrap cb = getLocalClientBootstrap();
 
@@ -428,8 +428,8 @@ public class ReentrantChannelTest extends BaseChannelTest {
             }
         });
 
-        clientChannel.write(createTestBuffer(2000)).sync();
-        clientChannel.closeFuture().sync();
+        clientChannel.write(createTestBuffer(2000)).asStage().sync();
+        clientChannel.closeFuture().asStage().sync();
 
         assertLog("WRITE\nFLUSH\nCLOSE\n");
     }
@@ -440,7 +440,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
         LocalAddress addr = new LocalAddress(getClass());
 
         ServerBootstrap sb = getLocalServerBootstrap();
-        sb.bind(addr).sync();
+        sb.bind(addr).asStage().sync();
 
         Bootstrap cb = getLocalClientBootstrap();
 
@@ -463,14 +463,14 @@ public class ReentrantChannelTest extends BaseChannelTest {
         });
 
         try {
-            clientChannel.writeAndFlush(createTestBuffer(2000)).sync();
+            clientChannel.writeAndFlush(createTestBuffer(2000)).asStage().sync();
             fail();
         } catch (Throwable cce) {
             // FIXME:  shouldn't this contain the "intentional failure" exception?
             assertThat(cce.getCause(), Matchers.instanceOf(ClosedChannelException.class));
         }
 
-        clientChannel.closeFuture().sync();
+        clientChannel.closeFuture().asStage().sync();
 
         assertLog("WRITE\nCLOSE\n");
     }
@@ -481,7 +481,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
         LocalAddress addr = new LocalAddress(getClass());
 
         ServerBootstrap sb = getLocalServerBootstrap();
-        sb.bind(addr).sync();
+        sb.bind(addr).asStage().sync();
 
         Bootstrap cb = getLocalClientBootstrap();
 
@@ -504,14 +504,14 @@ public class ReentrantChannelTest extends BaseChannelTest {
         });
 
         try {
-            clientChannel.writeAndFlush(createTestBuffer(2000)).sync();
+            clientChannel.writeAndFlush(createTestBuffer(2000)).asStage().sync();
             fail();
         } catch (Throwable cce) {
             // FIXME:  shouldn't this contain the "intentional failure" exception?
             assertThat(cce.getCause(), Matchers.instanceOf(ClosedChannelException.class));
         }
 
-        clientChannel.closeFuture().sync();
+        clientChannel.closeFuture().asStage().sync();
 
         assertLog("WRITE\nCLOSE\n");
     }

--- a/transport/src/test/java/io/netty5/channel/SingleThreadEventLoopTest.java
+++ b/transport/src/test/java/io/netty5/channel/SingleThreadEventLoopTest.java
@@ -95,7 +95,7 @@ public class SingleThreadEventLoopTest {
 
     @Test
     public void shutdownBeforeStart() throws Exception {
-        loopA.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS).await();
+        loopA.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS).asStage().await();
         assertRejection(loopA);
     }
 
@@ -108,7 +108,7 @@ public class SingleThreadEventLoopTest {
         latch.await();
 
         // Request the event loop thread to stop.
-        loopA.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS).await();
+        loopA.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS).asStage().await();
         assertRejection(loopA);
 
         assertTrue(loopA.isShutdown());
@@ -334,7 +334,7 @@ public class SingleThreadEventLoopTest {
     @Test
     @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
     public void testRegistrationAfterShutdown() throws Exception {
-        loopA.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS).await();
+        loopA.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS).asStage().await();
 
         // Disable logging temporarily.
         Logger root = (Logger) LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
@@ -348,7 +348,7 @@ public class SingleThreadEventLoopTest {
         try {
             Channel channel = new LocalChannel(loopA);
             Future<Void> f = channel.register();
-            f.await();
+            f.asStage().await();
             assertFalse(f.isSuccess());
             assertThat(f.cause(), is(instanceOf(RejectedExecutionException.class)));
             // TODO: What to do in this case ?
@@ -363,7 +363,7 @@ public class SingleThreadEventLoopTest {
     @Test
     @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
     public void testRegistrationAfterShutdown2() throws Exception {
-        loopA.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS).await();
+        loopA.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS).asStage().await();
         final CountDownLatch latch = new CountDownLatch(1);
         Channel ch = new LocalChannel(loopA);
 
@@ -378,7 +378,7 @@ public class SingleThreadEventLoopTest {
 
         try {
             Future<Void> f = ch.register().addListener(future -> latch.countDown());
-            f.await();
+            f.asStage().await();
             assertFalse(f.isSuccess());
             assertThat(f.cause(), is(instanceOf(RejectedExecutionException.class)));
 

--- a/transport/src/test/java/io/netty5/channel/embedded/EmbeddedChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/embedded/EmbeddedChannelTest.java
@@ -91,7 +91,7 @@ public class EmbeddedChannelTest {
         EmbeddedChannel channel = new EmbeddedChannel();
         channel.closeFuture().addListener(channel, (c, f) -> c.close());
 
-        channel.close().sync();
+        channel.close().asStage().sync();
     }
 
     @Test
@@ -218,7 +218,7 @@ public class EmbeddedChannelTest {
                 latch.countDown();
             }
         });
-        action.doRun(channel).sync();
+        action.doRun(channel).asStage().sync();
         latch.await();
     }
 
@@ -410,9 +410,9 @@ public class EmbeddedChannelTest {
           fail("Nobody called #channelRead() in time.");
       }
 
-      channel.close().sync();
+        channel.close().asStage().sync();
 
-      // There was no #flushInbound() call so nobody should have called
+        // There was no #flushInbound() call so nobody should have called
       // #channelReadComplete()
       assertEquals(0, flushCount.get());
     }
@@ -460,7 +460,7 @@ public class EmbeddedChannelTest {
             fail("Nobody called #write() in time.");
         }
 
-        channel.close().sync();
+        channel.close().asStage().sync();
 
         // There was no #flushOutbound() call so nobody should have called #flush()
         assertEquals(0, flushCount.get());
@@ -469,7 +469,7 @@ public class EmbeddedChannelTest {
     @Test
     public void testEnsureOpen() throws InterruptedException {
         EmbeddedChannel channel = new EmbeddedChannel();
-        channel.close().sync();
+        channel.close().asStage().sync();
 
         try {
             channel.writeOutbound("Hello, Netty!");

--- a/transport/src/test/java/io/netty5/channel/group/DefaultChannelGroupTest.java
+++ b/transport/src/test/java/io/netty5/channel/group/DefaultChannelGroupTest.java
@@ -47,7 +47,7 @@ public class DefaultChannelGroupTest {
         });
         b.channel(NioServerSocketChannel.class);
 
-        Future<Channel> f = b.bind(0).sync();
+        Future<Channel> f = b.bind(0).asStage().sync();
 
         if (f.isSuccess()) {
             allChannels.add(f.getNow());
@@ -56,7 +56,7 @@ public class DefaultChannelGroupTest {
 
         bossGroup.shutdownGracefully();
         workerGroup.shutdownGracefully();
-        bossGroup.terminationFuture().sync();
-        workerGroup.terminationFuture().sync();
+        bossGroup.terminationFuture().asStage().sync();
+        workerGroup.terminationFuture().asStage().sync();
     }
 }

--- a/transport/src/test/java/io/netty5/channel/group/DefaultChannelGroupTest.java
+++ b/transport/src/test/java/io/netty5/channel/group/DefaultChannelGroupTest.java
@@ -51,7 +51,7 @@ public class DefaultChannelGroupTest {
 
         if (f.isSuccess()) {
             allChannels.add(f.getNow());
-            allChannels.close().await();
+            allChannels.close().asStage().await();
         }
 
         bossGroup.shutdownGracefully();

--- a/transport/src/test/java/io/netty5/channel/local/LocalChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/local/LocalChannelTest.java
@@ -318,7 +318,7 @@ public class LocalChannelTest {
                         }
                     });
             Future<Channel> future = bootstrap.connect(sc.localAddress());
-            assertTrue(future.await(2000, TimeUnit.MILLISECONDS), "Connection should finish, not time out");
+            assertTrue(future.asStage().await(2000, TimeUnit.MILLISECONDS), "Connection should finish, not time out");
             cc = future.await().isSuccess() ? future.asStage().get() : null;
         } finally {
             closeChannel(cc);

--- a/transport/src/test/java/io/netty5/channel/local/LocalChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/local/LocalChannelTest.java
@@ -88,9 +88,9 @@ public class LocalChannelTest {
         Future<?> group1Future = group1.shutdownGracefully(0, 0, SECONDS);
         Future<?> group2Future = group2.shutdownGracefully(0, 0, SECONDS);
         Future<?> sharedGroupFuture = sharedGroup.shutdownGracefully(0, 0, SECONDS);
-        group1Future.await();
-        group2Future.await();
-        sharedGroupFuture.await();
+        group1Future.asStage().await();
+        group2Future.asStage().await();
+        sharedGroupFuture.asStage().await();
     }
 
     static Stream<IntFunction<Buffer>> allocators() {
@@ -319,11 +319,11 @@ public class LocalChannelTest {
                     });
             Future<Channel> future = bootstrap.connect(sc.localAddress());
             assertTrue(future.asStage().await(2000, TimeUnit.MILLISECONDS), "Connection should finish, not time out");
-            cc = future.await().isSuccess() ? future.asStage().get() : null;
+            cc = future.asStage().join((r, e) -> r);
         } finally {
             closeChannel(cc);
             closeChannel(sc);
-            clientGroup.shutdownGracefully(0, 0, SECONDS).await();
+            clientGroup.shutdownGracefully(0, 0, SECONDS).asStage().await();
         }
     }
 

--- a/transport/src/test/java/io/netty5/channel/local/LocalTransportThreadModelTest2.java
+++ b/transport/src/test/java/io/netty5/channel/local/LocalTransportThreadModelTest2.java
@@ -78,7 +78,7 @@ public class LocalTransportThreadModelTest2 {
         if (localChannel.executor().inEventLoop()) {
             // Wait until all messages are flushed before closing the channel.
             if (localRegistrationHandler.lastWriteFuture != null) {
-                localRegistrationHandler.lastWriteFuture.await();
+                localRegistrationHandler.lastWriteFuture.asStage().await();
             }
 
             localChannel.close();
@@ -91,7 +91,7 @@ public class LocalTransportThreadModelTest2 {
         });
 
         // Wait until the connection is closed or the connection attempt fails.
-        localChannel.closeFuture().await();
+        localChannel.closeFuture().asStage().await();
     }
 
     static class LocalHandler implements ChannelHandler {

--- a/transport/src/test/java/io/netty5/channel/local/LocalTransportThreadModelTest2.java
+++ b/transport/src/test/java/io/netty5/channel/local/LocalTransportThreadModelTest2.java
@@ -55,7 +55,7 @@ public class LocalTransportThreadModelTest2 {
                 .channel(LocalChannel.class)
                 .remoteAddress(new LocalAddress(LOCAL_CHANNEL)).handler(clientHandler);
 
-        serverBootstrap.bind(new LocalAddress(LOCAL_CHANNEL)).sync();
+        serverBootstrap.bind(new LocalAddress(LOCAL_CHANNEL)).asStage().sync();
 
         int count = 100;
         for (int i = 1; i < count + 1; i ++) {

--- a/transport/src/test/java/io/netty5/channel/nio/NioEventLoopTest.java
+++ b/transport/src/test/java/io/netty5/channel/nio/NioEventLoopTest.java
@@ -67,22 +67,22 @@ public class NioEventLoopTest extends AbstractEventLoopTest {
         EventLoop loop = new SingleThreadEventLoop(new DefaultThreadFactory("ioPool"), nioHandler);
         try {
             Channel channel = new NioServerSocketChannel(loop, loop);
-            channel.register().sync();
+            channel.register().asStage().sync();
 
-            Selector selector = loop.submit(nioHandler::unwrappedSelector).sync().getNow();
+            Selector selector = loop.submit(nioHandler::unwrappedSelector).asStage().get();
 
-            assertSame(selector, loop.submit(nioHandler::unwrappedSelector).sync().getNow());
+            assertSame(selector, loop.submit(nioHandler::unwrappedSelector).asStage().get());
             assertTrue(selector.isOpen());
 
-            // Submit to the EventLoop so we are sure its really executed in a non-async manner.
-            loop.submit(nioHandler::rebuildSelector).sync();
+            // Submit to the EventLoop, so we are sure its really executed in a non-async manner.
+            loop.submit(nioHandler::rebuildSelector).asStage().sync();
 
-            Selector newSelector = loop.submit(nioHandler::unwrappedSelector).sync().getNow();
+            Selector newSelector = loop.submit(nioHandler::unwrappedSelector).asStage().get();
             assertTrue(newSelector.isOpen());
             assertNotSame(selector, newSelector);
             assertFalse(selector.isOpen());
 
-            channel.close().sync();
+            channel.close().asStage().sync();
         } finally {
             loop.shutdownGracefully();
         }
@@ -107,25 +107,25 @@ public class NioEventLoopTest extends AbstractEventLoopTest {
         final NioHandler nioHandler = (NioHandler) NioHandler.newFactory().newHandler();
         EventLoop loop = new SingleThreadEventLoop(new DefaultThreadFactory("ioPool"), nioHandler);
         try {
-            Selector selector = loop.submit(nioHandler::unwrappedSelector).sync().getNow();
+            Selector selector = loop.submit(nioHandler::unwrappedSelector).asStage().get();
             assertTrue(selector.isOpen());
 
             loop.submit(() -> {
-                // Interrupt the thread which should not end-up in a busy spin and
-                // so the selector should not have been rebuild.
-                Thread.currentThread().interrupt();
-            }).sync();
+                    // Interrupt the thread which should not end-up in a busy spin and
+                    // so the selector should not have been rebuild.
+                    Thread.currentThread().interrupt();
+                }).asStage().sync();
 
             assertTrue(selector.isOpen());
 
             final CountDownLatch latch = new CountDownLatch(2);
-            loop.submit(latch::countDown).sync();
+            loop.submit(latch::countDown).asStage().sync();
 
-            loop.schedule(latch::countDown, 2, TimeUnit.SECONDS).sync();
+            loop.schedule(latch::countDown, 2, TimeUnit.SECONDS).asStage().sync();
 
             latch.await();
 
-            assertSame(selector, loop.submit(nioHandler::unwrappedSelector).sync().getNow());
+            assertSame(selector, loop.submit(nioHandler::unwrappedSelector).asStage().get());
             assertTrue(selector.isOpen());
         } finally {
             loop.shutdownGracefully();
@@ -139,8 +139,8 @@ public class NioEventLoopTest extends AbstractEventLoopTest {
         EventLoop loop = new SingleThreadEventLoop(new DefaultThreadFactory("ioPool"), nioHandler);
         try {
             Channel channel = new NioServerSocketChannel(loop, loop);
-            channel.register().sync();
-            channel.bind(new InetSocketAddress(0)).sync();
+            channel.register().asStage().sync();
+            channel.bind(new InetSocketAddress(0)).asStage().sync();
 
             final SocketChannel selectableChannel = SocketChannel.open();
             selectableChannel.configureBlocking(false);
@@ -163,7 +163,7 @@ public class NioEventLoopTest extends AbstractEventLoopTest {
             latch.await();
 
             selectableChannel.close();
-            channel.close().sync();
+            channel.close().asStage().sync();
         } finally {
             loop.shutdownGracefully();
         }
@@ -192,14 +192,14 @@ public class NioEventLoopTest extends AbstractEventLoopTest {
             t.start();
             Future<?> termination = group.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS);
             t.join();
-            termination.sync();
+            termination.asStage().sync();
             assertThat(error.get(), instanceOf(RejectedExecutionException.class));
             error.set(null);
         }
     }
 
     @Test
-    public void testRebuildSelectorOnIOException() throws InterruptedException {
+    public void testRebuildSelectorOnIOException() throws Exception {
         final CountDownLatch latch = new CountDownLatch(1);
         final CountDownLatch strategyLatch = new CountDownLatch(1);
         SelectStrategyFactory selectStrategyFactory = () -> new SelectStrategy() {
@@ -227,16 +227,16 @@ public class NioEventLoopTest extends AbstractEventLoopTest {
             Selector selector = nioHandler.unwrappedSelector();
             strategyLatch.countDown();
 
-            channel.register().sync();
+            channel.register().asStage().sync();
 
             latch.await();
 
-            Selector newSelector = loop.submit(nioHandler::unwrappedSelector).sync().getNow();
+            Selector newSelector = loop.submit(nioHandler::unwrappedSelector).asStage().get();
             assertTrue(newSelector.isOpen());
             assertNotSame(selector, newSelector);
             assertFalse(selector.isOpen());
 
-            channel.close().sync();
+            channel.close().asStage().sync();
         } finally {
             loop.shutdownGracefully();
         }

--- a/transport/src/test/java/io/netty5/channel/nio/NioEventLoopTest.java
+++ b/transport/src/test/java/io/netty5/channel/nio/NioEventLoopTest.java
@@ -97,7 +97,7 @@ public class NioEventLoopTest extends AbstractEventLoopTest {
             // NOOP
         }, Long.MAX_VALUE, TimeUnit.MILLISECONDS);
 
-        assertFalse(future.await(1000, TimeUnit.MILLISECONDS));
+        assertFalse(future.asStage().await(1000, TimeUnit.MILLISECONDS));
         assertTrue(future.cancel());
         group.shutdownGracefully();
     }

--- a/transport/src/test/java/io/netty5/channel/socket/nio/AbstractNioChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/socket/nio/AbstractNioChannelTest.java
@@ -64,7 +64,7 @@ public abstract class AbstractNioChannelTest<T extends AbstractNioChannel> {
             assertEquals(value3, value4);
             assertNotEquals(value1, value4);
         } finally {
-            channel.close().sync();
+            channel.close().asStage().sync();
             eventLoopGroup.shutdownGracefully();
         }
     }
@@ -78,7 +78,7 @@ public abstract class AbstractNioChannelTest<T extends AbstractNioChannel> {
             assertFalse(channel.config().setOption(option, null));
             assertNull(channel.config().getOption(option));
         } finally {
-            channel.close().sync();
+            channel.close().asStage().sync();
             eventLoopGroup.shutdownGracefully();
         }
     }
@@ -90,7 +90,7 @@ public abstract class AbstractNioChannelTest<T extends AbstractNioChannel> {
         try {
             channel.config().getOptions();
         } finally {
-            channel.close().sync();
+            channel.close().asStage().sync();
             eventLoopGroup.shutdownGracefully();
         }
     }
@@ -188,10 +188,10 @@ public abstract class AbstractNioChannelTest<T extends AbstractNioChannel> {
 
         EventLoop wrapped = new WrappedEventLoop(eventLoop);
         T channel = newNioChannel(wrapped);
-        channel.register().sync();
+        channel.register().asStage().sync();
 
         assertSame(wrapped, channel.executor());
-        channel.close().sync();
+        channel.close().asStage().sync();
         eventLoopGroup.shutdownGracefully();
     }
 }

--- a/transport/src/test/java/io/netty5/channel/socket/nio/NioDatagramChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/socket/nio/NioDatagramChannelTest.java
@@ -62,8 +62,8 @@ public class NioDatagramChannelTest extends AbstractNioChannelTest<NioDatagramCh
             }
             assertEquals(100, channelGroup.size());
         } finally {
-            channelGroup.close().sync();
-            group.shutdownGracefully().sync();
+            channelGroup.close().asStage().sync();
+            group.shutdownGracefully().asStage().sync();
         }
     }
 

--- a/transport/src/test/java/io/netty5/channel/socket/nio/NioServerSocketChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/socket/nio/NioServerSocketChannelTest.java
@@ -39,11 +39,11 @@ public class NioServerSocketChannelTest extends AbstractNioChannelTest<NioServer
 
         NioServerSocketChannel serverSocketChannel = new NioServerSocketChannel(group.next(), group, jdkChannel);
         try {
-            serverSocketChannel.register().sync();
-            serverSocketChannel.bind(new InetSocketAddress(0)).sync();
+            serverSocketChannel.register().asStage().sync();
+            serverSocketChannel.bind(new InetSocketAddress(0)).asStage().sync();
             assertFalse(serverSocketChannel.closeOnReadError(new IOException()));
             assertTrue(serverSocketChannel.closeOnReadError(new IllegalArgumentException()));
-            serverSocketChannel.close().sync();
+            serverSocketChannel.close().asStage().sync();
         } finally {
             group.shutdownGracefully();
         }
@@ -54,11 +54,11 @@ public class NioServerSocketChannelTest extends AbstractNioChannelTest<NioServer
         EventLoopGroup group = new MultithreadEventLoopGroup(1, NioHandler.newFactory());
         NioServerSocketChannel channel = new NioServerSocketChannel(group.next(), group);
         try {
-            channel.register().sync();
-            channel.bind(new InetSocketAddress(0)).sync();
+            channel.register().asStage().sync();
+            channel.bind(new InetSocketAddress(0)).asStage().sync();
             assertTrue(channel.isActive());
             assertTrue(channel.isOpen());
-            channel.close().sync();
+            channel.close().asStage().sync();
             assertFalse(channel.isOpen());
             assertFalse(channel.isActive());
         } finally {

--- a/transport/src/test/java/io/netty5/channel/socket/nio/NioSocketChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/socket/nio/NioSocketChannelTest.java
@@ -118,7 +118,7 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
             assertThat(f3.isSuccess(), is(false));
             assertThat(f3.cause(), is(instanceOf(ClosedChannelException.class)));
         } finally {
-            group.shutdownGracefully().sync();
+            group.shutdownGracefully().asStage().sync();
         }
     }
 
@@ -157,7 +157,7 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
 
             s.close();
         } finally {
-            group.shutdownGracefully().sync();
+            group.shutdownGracefully().asStage().sync();
         }
     }
 
@@ -212,7 +212,7 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
             bootstrap.group(group).channel(NioSocketChannel.class);
             bootstrap.handler(new ChannelHandler() { });
             cc = bootstrap.connect(sc.localAddress()).asStage().get();
-            cc.writeAndFlush(onHeapAllocator().copyOf(bytes)).sync();
+            cc.writeAndFlush(onHeapAllocator().copyOf(bytes)).asStage().sync();
             latch.await();
         } finally {
             if (cc != null) {
@@ -240,9 +240,9 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
             SocketChannel channel = (SocketChannel) sb.connect(socket.getLocalSocketAddress()).asStage().get();
 
             accepted = socket.accept();
-            channel.shutdown(ChannelShutdownDirection.Outbound).sync();
+            channel.shutdown(ChannelShutdownDirection.Outbound).asStage().sync();
 
-            channel.close().sync();
+            channel.close().asStage().sync();
         } finally {
             if (accepted != null) {
                 try {


### PR DESCRIPTION
Motivation:

We want to keep the Future interface free of blocking methods, so they're not called by mistake in an event loop thread.
We also want the blocking methods to still be available, somehow, because they are very useful outside of the event loop.

Modification:

The `await()` (with and without timeout) and `sync()` methods have been removed from the `Future` interface and added to the `FutureCompletionStage` interface.
All usage sites have been updated accordingly.

Result:
No more blocking methods on the `Future` interface.