### PR TITLE
Share logic for asynchronous connect in AbstractChannel

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollServerChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollServerChannel.java
@@ -25,7 +25,6 @@ import io.netty5.channel.EventLoop;
 import io.netty5.channel.EventLoopGroup;
 import io.netty5.channel.ServerChannel;
 import io.netty5.channel.unix.UnixChannel;
-import io.netty5.util.concurrent.Promise;
 
 import java.net.SocketAddress;
 
@@ -87,13 +86,6 @@ public abstract class AbstractEpollServerChannel
     abstract Channel newChildChannel(int fd, byte[] remote, int offset, int len) throws Exception;
 
     @Override
-    protected final void connectTransport(
-            SocketAddress socketAddress, SocketAddress socketAddress2, Promise<Void> channelPromise) {
-        // Connect not supported by ServerChannel implementations
-        channelPromise.setFailure(new UnsupportedOperationException());
-    }
-
-    @Override
     final void epollInReady() {
         assert executor().inEventLoop();
         final ChannelConfig config = config();
@@ -149,6 +141,12 @@ public abstract class AbstractEpollServerChannel
     @Override
     public final boolean isShutdown(ChannelShutdownDirection direction) {
         return !isActive();
+    }
+
+    @Override
+    protected final boolean doFinishConnect(R requestedRemoteAddress) {
+        // Connect not supported by ServerChannel implementations
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueStreamChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueStreamChannel.java
@@ -479,7 +479,9 @@ public abstract class AbstractKQueueStreamChannel
         } else {
             buffer.close();
         }
-        if (!failConnectPromise(cause)) {
+        if (isConnectPending()) {
+            finishConnect();
+        } else {
             allocHandle.readComplete();
             pipeline.fireChannelReadComplete();
             pipeline.fireChannelExceptionCaught(cause);

--- a/transport/src/main/java/io/netty5/channel/AbstractServerChannel.java
+++ b/transport/src/main/java/io/netty5/channel/AbstractServerChannel.java
@@ -15,8 +15,6 @@
  */
 package io.netty5.channel;
 
-import io.netty5.util.concurrent.Promise;
-
 import java.net.SocketAddress;
 
 /**
@@ -67,7 +65,7 @@ public abstract class AbstractServerChannel<P extends Channel, L extends SocketA
     }
 
     @Override
-    protected final void doShutdown(ChannelShutdownDirection direction) throws Exception {
+    protected final void doShutdown(ChannelShutdownDirection direction) {
         throw new UnsupportedOperationException();
     }
 
@@ -77,7 +75,7 @@ public abstract class AbstractServerChannel<P extends Channel, L extends SocketA
     }
 
     @Override
-    protected final void doWrite(ChannelOutboundBuffer in) throws Exception {
+    protected final void doWrite(ChannelOutboundBuffer in) {
         throw new UnsupportedOperationException();
     }
 
@@ -87,7 +85,12 @@ public abstract class AbstractServerChannel<P extends Channel, L extends SocketA
     }
 
     @Override
-    public final void connectTransport(SocketAddress remoteAddress, SocketAddress localAddress, Promise<Void> promise) {
-        safeSetFailure(promise, new UnsupportedOperationException());
+    protected boolean doConnect(SocketAddress remoteAddress, SocketAddress localAddress) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected boolean doFinishConnect(R requestedRemoteAddress) {
+        throw new UnsupportedOperationException();
     }
 }

--- a/transport/src/main/java/io/netty5/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty5/channel/embedded/EmbeddedChannel.java
@@ -35,7 +35,6 @@ import io.netty5.channel.EventLoop;
 import io.netty5.util.ReferenceCountUtil;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.FutureListener;
-import io.netty5.util.concurrent.Promise;
 import io.netty5.util.internal.RecyclableArrayList;
 import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
@@ -824,8 +823,13 @@ public class EmbeddedChannel extends AbstractChannel<Channel, SocketAddress, Soc
     }
 
     @Override
-    protected void connectTransport(SocketAddress remoteAddress, SocketAddress localAddress, Promise<Void> promise) {
-        safeSetSuccess(promise);
+    protected boolean doConnect(SocketAddress remoteAddress, SocketAddress localAddress) {
+        return true;
+    }
+
+    @Override
+    protected boolean doFinishConnect(SocketAddress requestedRemoteAddress) {
+        return true;
     }
 
     private final class EmbeddedChannelPipeline extends DefaultAbstractChannelPipeline {

--- a/transport/src/main/java/io/netty5/channel/nio/NioHandler.java
+++ b/transport/src/main/java/io/netty5/channel/nio/NioHandler.java
@@ -568,7 +568,7 @@ public final class NioHandler implements IoHandler {
                 ops &= ~SelectionKey.OP_CONNECT;
                 k.interestOps(ops);
 
-                ch.finishConnect();
+                ch.finishConnectNow();
             }
 
             // Process OP_WRITE first as we may be able to write some queued buffers and so free memory.

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioDatagramChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioDatagramChannel.java
@@ -250,18 +250,13 @@ public final class NioDatagramChannel
     }
 
     @Override
-    protected void doFinishConnect() throws Exception {
-        throw new Error();
+    protected boolean doFinishConnect(InetSocketAddress requestedRemoteAddress) {
+        return true;
     }
 
     @Override
     protected void doDisconnect() throws Exception {
         javaChannel().disconnect();
-    }
-
-    @Override
-    protected void doClose() throws Exception {
-        javaChannel().close();
     }
 
     @Override

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioServerSocketChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioServerSocketChannel.java
@@ -152,11 +152,6 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel<Channel, I
     }
 
     @Override
-    protected void doClose() throws Exception {
-        javaChannel().close();
-    }
-
-    @Override
     protected int doReadMessages(List<Object> buf) throws Exception {
         SocketChannel ch = SocketUtils.accept(javaChannel());
 
@@ -181,12 +176,12 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel<Channel, I
     // Unnecessary stuff
     @Override
     protected boolean doConnect(
-            SocketAddress remoteAddress, SocketAddress localAddress) throws Exception {
+            SocketAddress remoteAddress, SocketAddress localAddress) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    protected void doFinishConnect() throws Exception {
+    protected boolean doFinishConnect(InetSocketAddress requestedRemoteAddress) {
         throw new UnsupportedOperationException();
     }
 
@@ -196,17 +191,17 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel<Channel, I
     }
 
     @Override
-    protected void doDisconnect() throws Exception {
+    protected void doDisconnect() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    protected boolean doWriteMessage(Object msg, ChannelOutboundBuffer in) throws Exception {
+    protected boolean doWriteMessage(Object msg, ChannelOutboundBuffer in) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    protected final Object filterOutboundMessage(Object msg) throws Exception {
+    protected final Object filterOutboundMessage(Object msg) {
         throw new UnsupportedOperationException();
     }
 

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioSocketChannel.java
@@ -194,21 +194,13 @@ public class NioSocketChannel
     }
 
     @Override
-    protected void doFinishConnect() throws Exception {
-        if (!javaChannel().finishConnect()) {
-            throw new Error();
-        }
+    protected boolean doFinishConnect(InetSocketAddress requestedRemoteAddress) throws Exception {
+        return javaChannel().finishConnect();
     }
 
     @Override
     protected void doDisconnect() throws Exception {
         doClose();
-    }
-
-    @Override
-    protected void doClose() throws Exception {
-        super.doClose();
-        javaChannel().close();
     }
 
     @Override

--- a/transport/src/test/java/io/netty5/channel/AbstractChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/AbstractChannelTest.java
@@ -17,7 +17,6 @@ package io.netty5.channel;
 
 import io.netty5.util.NetUtil;
 import io.netty5.util.concurrent.Future;
-import io.netty5.util.concurrent.Promise;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -146,10 +145,9 @@ public class AbstractChannelTest {
             private boolean active;
 
             @Override
-            protected void connectTransport(
-                    SocketAddress remoteAddress, SocketAddress localAddress, Promise<Void> promise) {
+            protected boolean doConnect(SocketAddress remoteAddress, SocketAddress localAddress) {
                 active = true;
-                promise.setSuccess(null);
+                return true;
             }
 
             @Override
@@ -230,9 +228,13 @@ public class AbstractChannelTest {
         }
 
         @Override
-        protected void connectTransport(
-                SocketAddress remoteAddress, SocketAddress localAddress, Promise<Void> promise) {
-            promise.setFailure(new UnsupportedOperationException());
+        protected boolean doConnect(SocketAddress remoteAddress, SocketAddress localAddress) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        protected boolean doFinishConnect(SocketAddress requestedRemoteAddress) {
+            throw new UnsupportedOperationException();
         }
 
         @Override

--- a/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTailTest.java
+++ b/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTailTest.java
@@ -15,7 +15,7 @@
  */
 package io.netty5.channel;
 
-import io.netty5.util.concurrent.Promise;
+
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -328,6 +328,17 @@ public class DefaultChannelPipelineTailTest {
             }
         }
 
+        @Override
+        protected boolean doConnect(SocketAddress remoteAddress, SocketAddress localAddress) {
+            active = true;
+            return true;
+        }
+
+        @Override
+        protected boolean doFinishConnect(SocketAddress requestedRemoteAddress) {
+            return true;
+        }
+
         protected void onUnhandledInboundChannelActive() {
         }
 
@@ -347,22 +358,6 @@ public class DefaultChannelPipelineTailTest {
         }
 
         protected void onUnhandledInboundWritabilityChanged() {
-        }
-
-        @Override
-        protected void connectTransport(
-                SocketAddress remoteAddress, SocketAddress localAddress, Promise<Void> promise) {
-            if (!ensureOpen(promise)) {
-                return;
-            }
-
-            if (!active) {
-                active = true;
-                pipeline().fireChannelActive();
-                readIfIsAutoRead();
-            }
-
-            promise.setSuccess(null);
         }
 
         private class MyChannelPipeline extends DefaultAbstractChannelPipeline {

--- a/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTest.java
+++ b/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTest.java
@@ -15,7 +15,6 @@
  */
 package io.netty5.channel;
 
-
 import io.netty5.bootstrap.Bootstrap;
 import io.netty5.bootstrap.ServerBootstrap;
 import io.netty5.channel.ChannelHandlerMask.Skip;

--- a/transport/src/test/java/io/netty5/channel/local/LocalTransportThreadModelTest2.java
+++ b/transport/src/test/java/io/netty5/channel/local/LocalTransportThreadModelTest2.java
@@ -78,7 +78,7 @@ public class LocalTransportThreadModelTest2 {
         if (localChannel.executor().inEventLoop()) {
             // Wait until all messages are flushed before closing the channel.
             if (localRegistrationHandler.lastWriteFuture != null) {
-                localRegistrationHandler.lastWriteFuture.asStage().await();
+                localRegistrationHandler.lastWriteFuture.asStage().sync();
             }
 
             localChannel.close();


### PR DESCRIPTION
Motivation:

We had a lot of duplication to handle asynchronous connect in multiple implementations. Let's share it and so remove a lot of duplication.

Modifications:

- Move logic into AbstractChannel
- Add abstract methods doConnect(...) and doFinishConnect(...)
- Add isConnectPending()

Result:

Share code / cleanup and better abstract base class
