### PR TITLE
Expose new API EventLoop#supportsIoHandler

### DIFF
--- a/testsuite/src/main/java/io/netty5/testsuite/transport/AbstractSingleThreadEventLoopTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/AbstractSingleThreadEventLoopTest.java
@@ -20,6 +20,8 @@ import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.EventLoopGroup;
+import io.netty5.channel.IoExecutionContext;
+import io.netty5.channel.IoHandler;
 import io.netty5.channel.IoHandlerFactory;
 import io.netty5.channel.MultithreadEventLoopGroup;
 import io.netty5.channel.ServerChannel;
@@ -100,6 +102,16 @@ public abstract class AbstractSingleThreadEventLoopTest {
         assertRejection(loop);
     }
 
+    @Test
+    public void testDoesNotSupportIoHandler() {
+        EventLoopGroup group = new MultithreadEventLoopGroup(newIoHandlerFactory());
+        try {
+            assertFalse(group.next().supportsIoHandler(TestIoHandler.class));
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+
     private static final Runnable NOOP = () -> { };
 
     private static void assertRejection(EventExecutor loop) {
@@ -113,4 +125,32 @@ public abstract class AbstractSingleThreadEventLoopTest {
 
     protected abstract IoHandlerFactory newIoHandlerFactory();
     protected abstract Class<? extends ServerChannel> serverChannelClass();
+
+    private static class TestIoHandler implements IoHandler {
+
+        @Override
+        public int run(IoExecutionContext context) {
+            return 0;
+        }
+
+        @Override
+        public void wakeup(boolean inEventLoop) {
+        }
+
+        @Override
+        public void prepareToDestroy() {
+        }
+
+        @Override
+        public void destroy() {
+        }
+
+        @Override
+        public void register(Channel channel) {
+        }
+
+        @Override
+        public void deregister(Channel channel) {
+        }
+    }
 }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/NioSingleThreadEventLoopTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/NioSingleThreadEventLoopTest.java
@@ -15,12 +15,28 @@
  */
 package io.netty5.testsuite.transport;
 
+import io.netty5.channel.EventLoopGroup;
 import io.netty5.channel.IoHandlerFactory;
+import io.netty5.channel.MultithreadEventLoopGroup;
 import io.netty5.channel.ServerChannel;
 import io.netty5.channel.nio.NioHandler;
 import io.netty5.channel.socket.nio.NioServerSocketChannel;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class NioSingleThreadEventLoopTest extends AbstractSingleThreadEventLoopTest {
+
+    @Test
+    public void testSupportsIoHandler() {
+        EventLoopGroup group = new MultithreadEventLoopGroup(newIoHandlerFactory());
+        try {
+            assertTrue(group.next().supportsIoHandler(NioHandler.class));
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+
     @Override
     protected IoHandlerFactory newIoHandlerFactory() {
         return NioHandler.newFactory();

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollEventLoopTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollEventLoopTest.java
@@ -19,6 +19,7 @@ import io.netty5.channel.DefaultSelectStrategyFactory;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.EventLoopGroup;
 import io.netty5.channel.IoHandlerFactory;
+import io.netty5.channel.MultithreadEventLoopGroup;
 import io.netty5.channel.ServerChannel;
 import io.netty5.channel.SingleThreadEventLoop;
 import io.netty5.channel.unix.FileDescriptor;
@@ -157,6 +158,16 @@ public class EpollEventLoopTest extends AbstractSingleThreadEventLoopTest {
             epoll.close();
             eventFd.close();
             timerFd.close();
+        }
+    }
+
+    @Test
+    public void testSupportsIoHandler() {
+        EventLoopGroup group = new MultithreadEventLoopGroup(newIoHandlerFactory());
+        try {
+            assertTrue(group.next().supportsIoHandler(EpollHandler.class));
+        } finally {
+            group.shutdownGracefully();
         }
     }
 

--- a/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueEventLoopTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueEventLoopTest.java
@@ -45,6 +45,16 @@ public class KQueueEventLoopTest extends AbstractSingleThreadEventLoopTest {
         group.shutdownGracefully();
     }
 
+    @Test
+    public void testSupportsIoHandler() {
+        EventLoopGroup group = new MultithreadEventLoopGroup(newIoHandlerFactory());
+        try {
+            assertTrue(group.next().supportsIoHandler(KQueueHandler.class));
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+
     @Override
     protected IoHandlerFactory newIoHandlerFactory() {
         return KQueueHandler.newFactory();

--- a/transport/src/main/java/io/netty5/channel/EventLoop.java
+++ b/transport/src/main/java/io/netty5/channel/EventLoop.java
@@ -46,4 +46,8 @@ public interface EventLoop extends OrderedEventExecutor, EventLoopGroup {
      * @return          the {@link Future} that is notified once the operations completes.
      */
     Future<Void> deregisterForIo(Channel channel);
+
+    default boolean supportsIoHandler(Class<? extends IoHandler> ioHandlerClass) {
+        return false;
+    }
 }

--- a/transport/src/main/java/io/netty5/channel/SingleThreadEventLoop.java
+++ b/transport/src/main/java/io/netty5/channel/SingleThreadEventLoop.java
@@ -230,6 +230,11 @@ public class SingleThreadEventLoop extends SingleThreadEventExecutor implements 
        return promise.asFuture();
     }
 
+    @Override
+    public boolean supportsIoHandler(Class<? extends IoHandler> ioHandlerClass) {
+        return ioHandlerClass.isAssignableFrom(ioHandler.getClass());
+    }
+
     private void deregisterForIO(Channel channel, Promise<Void> promise) {
         try {
             if (!channel.isRegistered()) {


### PR DESCRIPTION
Motivation:

The `EventLoopGroup` can be
- `new MultithreadEventLoopGroup(NioHandler.newFactory())`
- `new MultithreadEventLoopGroup(EpollHandler.newFactory())`
- ...

A `Bootstrap` can be created like this
```
new Bootstrap().group(group)
               .channelFactory(eventLoop -> <new channel>)
```

The channel that will be returned by the channel factory may need to satisfy
- `NioHandler#cast`
- `EpollHandler#cast`
- ...

It will be helpful if one can check what `IoHandler` is supported by the event loop (if any is supported at all).

Modifications:

- Expose new API `EventLoop#supportsIoHandler`
- Add junit tests

Result:

It is possible to provide a channel based on the `IoHandler` supported by the event loop.
