### PR TITLE
Add API to be able if a Channel subtype is compatible with an EventLo…

### DIFF
--- a/testsuite/src/main/java/io/netty5/testsuite/transport/AbstractSingleThreadEventLoopTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/AbstractSingleThreadEventLoopTest.java
@@ -111,6 +111,26 @@ public abstract class AbstractSingleThreadEventLoopTest {
         }
     }
 
+    @Test
+    public void testDoesNotSupportChannelType() {
+        EventLoopGroup group = new MultithreadEventLoopGroup(newIoHandlerFactory());
+        try {
+            assertFalse(group.isCompatible(Channel.class));
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+
+    @Test
+    public void testDoesSupportChannelType() {
+        EventLoopGroup group = new MultithreadEventLoopGroup(newIoHandlerFactory());
+        try {
+            assertTrue(group.isCompatible(serverChannelClass()));
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+
     protected abstract IoHandlerFactory newIoHandlerFactory();
     protected abstract Class<? extends ServerChannel> serverChannelClass();
 }

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollServerChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollServerChannel.java
@@ -29,8 +29,6 @@ import io.netty5.util.concurrent.Promise;
 
 import java.net.SocketAddress;
 
-import static java.util.Objects.requireNonNull;
-
 public abstract class AbstractEpollServerChannel
         <P extends UnixChannel, L extends SocketAddress, R extends SocketAddress>
         extends AbstractEpollChannel<P, L, R> implements ServerChannel {
@@ -42,18 +40,20 @@ public abstract class AbstractEpollServerChannel
     // So use 26 bytes as it's a power of two.
     private final byte[] acceptedAddress = new byte[26];
 
-    AbstractEpollServerChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup, int fd) {
-        this(eventLoop, childEventLoopGroup, new LinuxSocket(fd), false);
-    }
-
-    AbstractEpollServerChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup, LinuxSocket fd) {
-        this(eventLoop, childEventLoopGroup, fd, isSoErrorZero(fd));
+    AbstractEpollServerChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup,
+                               Class<? extends Channel> childChannelType, int fd) {
+        this(eventLoop, childEventLoopGroup, childChannelType, new LinuxSocket(fd), false);
     }
 
     AbstractEpollServerChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup,
-                               LinuxSocket fd, boolean active) {
+                               Class<? extends Channel> childChannelType, LinuxSocket fd) {
+        this(eventLoop, childEventLoopGroup, childChannelType, fd, isSoErrorZero(fd));
+    }
+
+    AbstractEpollServerChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup,
+                               Class<? extends Channel> childChannelType, LinuxSocket fd, boolean active) {
         super(null, eventLoop, fd, active);
-        this.childEventLoopGroup = requireNonNull(childEventLoopGroup, "childEventLoopGroup");
+        this.childEventLoopGroup = validateEventLoopGroup(childEventLoopGroup, "childEventLoopGroup", childChannelType);
     }
 
     @Override

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollHandler.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollHandler.java
@@ -516,4 +516,9 @@ public class EpollHandler implements IoHandler {
             events.free();
         }
     }
+
+    @Override
+    public boolean isCompatible(Class<? extends Channel> channelType) {
+        return AbstractEpollChannel.class.isAssignableFrom(channelType);
+    }
 }

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollServerDomainSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollServerDomainSocketChannel.java
@@ -40,11 +40,11 @@ public final class EpollServerDomainSocketChannel
     private volatile DomainSocketAddress local;
 
     public EpollServerDomainSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup) {
-        super(eventLoop, childEventLoopGroup, newSocketDomain(), false);
+        super(eventLoop, childEventLoopGroup, EpollDomainSocketChannel.class,  newSocketDomain(), false);
     }
 
     public EpollServerDomainSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup, int fd) {
-        super(eventLoop, childEventLoopGroup, fd);
+        super(eventLoop, childEventLoopGroup, EpollDomainSocketChannel.class, fd);
     }
 
     @Override

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollServerSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollServerSocketChannel.java
@@ -51,14 +51,14 @@ public final class EpollServerSocketChannel
 
     public EpollServerSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup,
                                     InternetProtocolFamily protocolFamily) {
-        super(eventLoop, childEventLoopGroup, newSocketStream(protocolFamily), false);
+        super(eventLoop, childEventLoopGroup, EpollSocketChannel.class, newSocketStream(protocolFamily), false);
         config = new EpollServerSocketChannelConfig(this);
     }
 
     public EpollServerSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup, int fd) {
         // Must call this constructor to ensure this object's local address is configured correctly.
         // The local address can only be obtained from a Socket object.
-        super(eventLoop, childEventLoopGroup, new LinuxSocket(fd));
+        super(eventLoop, childEventLoopGroup, EpollSocketChannel.class, new LinuxSocket(fd));
         config = new EpollServerSocketChannelConfig(this);
     }
 

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueServerChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueServerChannel.java
@@ -29,8 +29,6 @@ import io.netty5.util.internal.UnstableApi;
 
 import java.net.SocketAddress;
 
-import static java.util.Objects.requireNonNull;
-
 @UnstableApi
 public abstract class AbstractKQueueServerChannel
         <P extends UnixChannel, L extends SocketAddress, R extends SocketAddress>
@@ -43,13 +41,15 @@ public abstract class AbstractKQueueServerChannel
     // So use 26 bytes as it's a power of two.
     private final byte[] acceptedAddress = new byte[26];
 
-    AbstractKQueueServerChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup, BsdSocket fd) {
-        this(eventLoop, childEventLoopGroup, fd, isSoErrorZero(fd));
+    AbstractKQueueServerChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup,
+                                Class<? extends Channel> childChannelType, BsdSocket fd) {
+        this(eventLoop, childEventLoopGroup, childChannelType, fd, isSoErrorZero(fd));
     }
 
-    AbstractKQueueServerChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup, BsdSocket fd, boolean active) {
+    AbstractKQueueServerChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup,
+                                Class<? extends Channel> childChannelType, BsdSocket fd, boolean active) {
         super(null, eventLoop, fd, active);
-        this.childEventLoopGroup = requireNonNull(childEventLoopGroup, "childEventLoopGroup");
+        this.childEventLoopGroup = validateEventLoopGroup(childEventLoopGroup, "childEventLoopGroup", childChannelType);
     }
 
     @Override

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueHandler.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueHandler.java
@@ -343,6 +343,11 @@ public final class KQueueHandler implements IoHandler {
         }
     }
 
+    @Override
+    public boolean isCompatible(Class<? extends Channel> channelType) {
+        return AbstractKQueueChannel.class.isAssignableFrom(channelType);
+    }
+
     private static void handleLoopException(Throwable t) {
         logger.warn("Unexpected exception in the selector loop.", t);
 

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueServerDomainSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueServerDomainSocketChannel.java
@@ -41,7 +41,7 @@ public final class KQueueServerDomainSocketChannel
     private volatile DomainSocketAddress local;
 
     public KQueueServerDomainSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup) {
-        super(eventLoop, childEventLoopGroup, newSocketDomain(), false);
+        super(eventLoop, childEventLoopGroup, KQueueDomainSocketChannel.class, newSocketDomain(), false);
     }
 
     public KQueueServerDomainSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup, int fd) {
@@ -50,7 +50,7 @@ public final class KQueueServerDomainSocketChannel
 
     KQueueServerDomainSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup,
                                     BsdSocket socket, boolean active) {
-        super(eventLoop, childEventLoopGroup, socket, active);
+        super(eventLoop, childEventLoopGroup, KQueueDomainSocketChannel.class, socket, active);
     }
 
     @Override

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueServerSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueServerSocketChannel.java
@@ -34,7 +34,7 @@ public final class KQueueServerSocketChannel extends
     private final KQueueServerSocketChannelConfig config;
 
     public KQueueServerSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup) {
-        super(eventLoop, childEventLoopGroup, newSocketStream(), false);
+        super(eventLoop, childEventLoopGroup, KQueueSocketChannel.class, newSocketStream(), false);
         config = new KQueueServerSocketChannelConfig(this);
     }
 
@@ -45,12 +45,12 @@ public final class KQueueServerSocketChannel extends
     }
 
     KQueueServerSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup, BsdSocket fd) {
-        super(eventLoop, childEventLoopGroup, fd);
+        super(eventLoop, childEventLoopGroup, KQueueSocketChannel.class, fd);
         config = new KQueueServerSocketChannelConfig(this);
     }
 
     KQueueServerSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup, BsdSocket fd, boolean active) {
-        super(eventLoop, childEventLoopGroup, fd, active);
+        super(eventLoop, childEventLoopGroup, KQueueSocketChannel.class, fd, active);
         config = new KQueueServerSocketChannelConfig(this);
     }
 

--- a/transport/src/main/java/io/netty5/channel/AbstractServerChannel.java
+++ b/transport/src/main/java/io/netty5/channel/AbstractServerChannel.java
@@ -42,9 +42,10 @@ public abstract class AbstractServerChannel<P extends Channel, L extends SocketA
     /**
      * Creates a new instance.
      */
-    protected AbstractServerChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup) {
+    protected AbstractServerChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup,
+                                    Class<? extends Channel> childChannelType) {
         super(null, eventLoop);
-        this.childEventLoopGroup = requireNonNull(childEventLoopGroup, "childEventLoopGroup");
+        this.childEventLoopGroup = validateEventLoopGroup(childEventLoopGroup, "childEventLoopGroup", childChannelType);
     }
 
     @Override

--- a/transport/src/main/java/io/netty5/channel/AbstractServerChannel.java
+++ b/transport/src/main/java/io/netty5/channel/AbstractServerChannel.java
@@ -19,8 +19,6 @@ import io.netty5.util.concurrent.Promise;
 
 import java.net.SocketAddress;
 
-import static java.util.Objects.requireNonNull;
-
 /**
  * A skeletal server-side {@link Channel} implementation.  A server-side
  * {@link Channel} does not allow the following operations:

--- a/transport/src/main/java/io/netty5/channel/EventLoop.java
+++ b/transport/src/main/java/io/netty5/channel/EventLoop.java
@@ -46,4 +46,10 @@ public interface EventLoop extends OrderedEventExecutor, EventLoopGroup {
      * @return          the {@link Future} that is notified once the operations completes.
      */
     Future<Void> deregisterForIo(Channel channel);
+
+    // Force the implementing class to implement this method itself. This is needed as
+    // EventLoopGroup provides default implementations that call next() which would lead to
+    // and infinite loop if not implemented differently in the EventLoop itself.
+    @Override
+    boolean isCompatible(Class<? extends Channel> channelType);
 }

--- a/transport/src/main/java/io/netty5/channel/EventLoopGroup.java
+++ b/transport/src/main/java/io/netty5/channel/EventLoopGroup.java
@@ -28,4 +28,15 @@ public interface EventLoopGroup extends EventExecutorGroup {
      */
     @Override
     EventLoop next();
+
+    /**
+     * Returns {@code true} if the given type is compatible with this {@link EventLoopGroup} and so can be registered
+     * to the contained {@link EventLoop}s, {@code false} otherwise.
+     *
+     * @param channelType   the type of the {@link Channel}.
+     * @return              if compatible of not.
+     */
+    default boolean isCompatible(Class<? extends Channel> channelType) {
+        return next().isCompatible(channelType);
+    }
 }

--- a/transport/src/main/java/io/netty5/channel/IoHandler.java
+++ b/transport/src/main/java/io/netty5/channel/IoHandler.java
@@ -17,7 +17,7 @@ package io.netty5.channel;
 
 /**
  * Handles IO dispatching for an {@link EventLoop}
- * All operations except {@link #wakeup(boolean)} <strong>MUST</strong> be executed
+ * All operations except {@link #wakeup(boolean)} and {@link #isCompatible(Class)} <strong>MUST</strong> be executed
  * on the {@link EventLoop} thread and should never be called from the user-directly.
  */
 public interface IoHandler {
@@ -30,12 +30,6 @@ public interface IoHandler {
      * @return the number of {@link Channel} for which I/O was handled.
      */
     int run(IoExecutionContext context);
-
-    /**
-     * Wakeup the {@link IoHandler}, which means if any operation blocks it should be unblocked and
-     * return as soon as possible.
-     */
-    void wakeup(boolean inEventLoop);
 
     /**
      * Prepare to destroy this {@link IoHandler}. This method will be called before {@link #destroy()} and may be
@@ -63,4 +57,19 @@ public interface IoHandler {
      * @throws Exception    thrown if an error happens during deregistration.
      */
     void deregister(Channel channel) throws Exception;
+
+    /**
+     * Wakeup the {@link IoHandler}, which means if any operation blocks it should be unblocked and
+     * return as soon as possible.
+     */
+    void wakeup(boolean inEventLoop);
+
+    /**
+     * Returns {@code true} if the given type is compatible with this {@link IoHandler} and so can be registered,
+     * {@code false} otherwise.
+     *
+     * @param channelType   the type of the {@link Channel}.
+     * @return              if compatible of not.
+     */
+    boolean isCompatible(Class<? extends Channel> channelType);
 }

--- a/transport/src/main/java/io/netty5/channel/SingleThreadEventLoop.java
+++ b/transport/src/main/java/io/netty5/channel/SingleThreadEventLoop.java
@@ -256,4 +256,9 @@ public class SingleThreadEventLoop extends SingleThreadEventExecutor implements 
         assert inEventLoop();
         ioHandler.destroy();
     }
+
+    @Override
+    public boolean isCompatible(Class<? extends Channel> channelType) {
+        return ioHandler.isCompatible(channelType);
+    }
 }

--- a/transport/src/main/java/io/netty5/channel/embedded/EmbeddedEventLoop.java
+++ b/transport/src/main/java/io/netty5/channel/embedded/EmbeddedEventLoop.java
@@ -247,4 +247,9 @@ final class EmbeddedEventLoop extends AbstractScheduledEventExecutor implements 
     public boolean inEventLoop(Thread thread) {
         return running;
     }
+
+    @Override
+    public boolean isCompatible(Class<? extends Channel> channelType) {
+        return EmbeddedChannel.class.isAssignableFrom(channelType);
+    }
 }

--- a/transport/src/main/java/io/netty5/channel/local/LocalHandler.java
+++ b/transport/src/main/java/io/netty5/channel/local/LocalHandler.java
@@ -98,4 +98,9 @@ public final class LocalHandler implements IoHandler {
             unsafe.deregisterTransportNow();
         }
     }
+
+    @Override
+    public boolean isCompatible(Class<? extends Channel> channelType) {
+        return LocalChannelUnsafe.class.isAssignableFrom(channelType);
+    }
 }

--- a/transport/src/main/java/io/netty5/channel/local/LocalServerChannel.java
+++ b/transport/src/main/java/io/netty5/channel/local/LocalServerChannel.java
@@ -45,7 +45,7 @@ public class LocalServerChannel extends AbstractServerChannel<LocalChannel, Loca
     private volatile boolean acceptInProgress;
 
     public LocalServerChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup) {
-        super(eventLoop, childEventLoopGroup);
+        super(eventLoop, childEventLoopGroup, LocalChannel.class);
         config().setBufferAllocator(DefaultBufferAllocators.onHeapAllocator());
     }
 

--- a/transport/src/main/java/io/netty5/channel/nio/NioHandler.java
+++ b/transport/src/main/java/io/netty5/channel/nio/NioHandler.java
@@ -650,6 +650,11 @@ public final class NioHandler implements IoHandler {
         }
     }
 
+    @Override
+    public boolean isCompatible(Class<? extends Channel> channelType) {
+        return AbstractNioChannel.class.isAssignableFrom(channelType);
+    }
+
     Selector unwrappedSelector() {
         return unwrappedSelector;
     }

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioServerSocketChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioServerSocketChannel.java
@@ -43,8 +43,6 @@ import java.nio.channels.spi.SelectorProvider;
 import java.util.List;
 import java.util.Map;
 
-import static java.util.Objects.requireNonNull;
-
 /**
  * A {@link io.netty5.channel.socket.ServerSocketChannel} implementation which uses
  * NIO selector based implementation to accept new connections.
@@ -101,7 +99,8 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel<Channel, I
     public NioServerSocketChannel(
             EventLoop eventLoop, EventLoopGroup childEventLoopGroup, ServerSocketChannel channel) {
         super(null, eventLoop, channel, SelectionKey.OP_ACCEPT);
-        this.childEventLoopGroup = requireNonNull(childEventLoopGroup, "childEventLoopGroup");
+        this.childEventLoopGroup = validateEventLoopGroup(
+                childEventLoopGroup, "childEventLoopGroup", NioSocketChannel.class);
         config = new NioServerSocketChannelConfig(this, javaChannel().socket());
     }
 

--- a/transport/src/test/java/io/netty5/channel/AbstractChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/AbstractChannelTest.java
@@ -44,7 +44,7 @@ public class AbstractChannelTest {
         // This allows us to have a single-threaded test
         when(eventLoop.inEventLoop()).thenReturn(true);
         when(eventLoop.newPromise()).thenReturn(INSTANCE.newPromise());
-
+        when(eventLoop.isCompatible(any())).thenReturn(true);
         TestChannel channel = new TestChannel(eventLoop);
         // Using spy as otherwise intelliJ will not be able to understand that we dont want to skip the handler
         ChannelHandler handler = spy(new ChannelHandler() {
@@ -78,6 +78,7 @@ public class AbstractChannelTest {
         // This allows us to have a single-threaded test
         when(eventLoop.inEventLoop()).thenReturn(true);
         when(eventLoop.newPromise()).thenAnswer(inv -> INSTANCE.newPromise());
+        when(eventLoop.isCompatible(any())).thenReturn(true);
 
         doAnswer(invocationOnMock -> {
             ((Runnable) invocationOnMock.getArgument(0)).run();
@@ -121,6 +122,7 @@ public class AbstractChannelTest {
     @Test
     public void ensureDefaultChannelId() {
         final EventLoop eventLoop = mock(EventLoop.class);
+        when(eventLoop.isCompatible(any())).thenReturn(true);
         TestChannel channel = new TestChannel(eventLoop);
         final ChannelId channelId = channel.id();
         assertTrue(channelId instanceof DefaultChannelId);
@@ -137,6 +139,7 @@ public class AbstractChannelTest {
             ((Runnable) invocationOnMock.getArgument(0)).run();
             return null;
         }).when(eventLoop).execute(any(Runnable.class));
+        when(eventLoop.isCompatible(any())).thenReturn(true);
 
         final Channel channel = new TestChannel(eventLoop) {
             private boolean open = true;

--- a/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTailTest.java
+++ b/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTailTest.java
@@ -15,7 +15,6 @@
  */
 package io.netty5.channel;
 
-import io.netty5.channel.local.LocalHandler;
 import io.netty5.util.concurrent.Promise;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -54,22 +53,22 @@ public class DefaultChannelPipelineTailTest {
 
             @Override
             public void prepareToDestroy() {
-
+                // NOOP
             }
 
             @Override
             public void destroy() {
-
+                // NOOP
             }
 
             @Override
-            public void register(Channel channel) throws Exception {
-
+            public void register(Channel channel) {
+                // NOOP
             }
 
             @Override
-            public void deregister(Channel channel) throws Exception {
-
+            public void deregister(Channel channel) {
+                // NOOP
             }
 
             @Override

--- a/transport/src/test/java/io/netty5/channel/SingleThreadEventLoopTest.java
+++ b/transport/src/test/java/io/netty5/channel/SingleThreadEventLoopTest.java
@@ -480,6 +480,11 @@ public class SingleThreadEventLoopTest {
         public Future<Void> deregisterForIo(Channel channel) {
             return newSucceededFuture(null);
         }
+
+        @Override
+        public boolean isCompatible(Class<? extends Channel> channelType) {
+            return true;
+        }
     }
 
     private static class SingleThreadEventLoopB extends SingleThreadEventExecutor implements EventLoop {
@@ -525,6 +530,11 @@ public class SingleThreadEventLoopTest {
         @Override
         public Future<Void> deregisterForIo(Channel channel) {
             return newSucceededFuture(null);
+        }
+
+        @Override
+        public boolean isCompatible(Class<? extends Channel> channelType) {
+            return true;
         }
     }
 }

--- a/transport/src/test/java/io/netty5/channel/socket/nio/AbstractNioChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/socket/nio/AbstractNioChannelTest.java
@@ -184,6 +184,11 @@ public abstract class AbstractNioChannelTest<T extends AbstractNioChannel> {
             public Future<Void> deregisterForIo(Channel channel) {
                 return eventLoop.deregisterForIo(channel);
             }
+
+            @Override
+            public boolean isCompatible(Class<? extends Channel> channelType) {
+                return eventLoop.isCompatible(channelType);
+            }
         }
 
         EventLoop wrapped = new WrappedEventLoop(eventLoop);


### PR DESCRIPTION
…opGroup instance

Motivation:

We should expose some API that allows us the check if a Channel subtype is compatible with an EventLoopGroup.

This serve multiple purposes:
 - The user can check if its possible to use an existing EventLoopGroup with a Channel type before register it.
 - We can fail fast if a user tries to instance an AbstractChannel subtype with an uncompatible group

Modifications:

- Add EventLoopGroup.isCompatible(...) and IoHandler.isCompatible(...)
- Add implementations
- Fast fail
- Add unit tests

Result:

Be able to know if a EventLoopGroup can be used for a specific Channel type or not.
