### PR TITLE
Rename AbstractChannel.flush0() to writeFlushed() and also add asserts

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
@@ -465,12 +465,12 @@ abstract class AbstractEpollChannel<P extends UnixChannel, L extends SocketAddre
     }
 
     @Override
-    protected final void flush0() {
+    protected final void writeFlushed() {
         // Flush immediately only when there's no pending flush.
         // If there's a pending flush operation, event loop will call forceFlush() later,
         // and thus there's no need to call it now.
         if (!isFlagSet(Native.EPOLLOUT)) {
-            super.flush0();
+            super.writeFlushed();
         }
     }
 
@@ -483,7 +483,7 @@ abstract class AbstractEpollChannel<P extends UnixChannel, L extends SocketAddre
             finishConnect();
         } else if (!socket.isOutputShutdown()) {
             // directly call super.flush0() to force a flush now
-            super.flush0();
+            super.writeFlushed();
         }
     }
 

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollStreamChannel.java
@@ -52,7 +52,7 @@ public abstract class AbstractEpollStreamChannel
                     StringUtil.simpleClassName(DefaultFileRegion.class) + ')';
     // Calling flush0 directly to ensure we not try to flush messages that were added via write(...) in the
     // meantime.
-    private final Runnable flushTask = this::flush0;
+    private final Runnable flushTask = this::writeFlushed;
 
     private WritableByteChannel byteChannel;
 

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueChannel.java
@@ -405,7 +405,7 @@ abstract class AbstractKQueueChannel<P extends UnixChannel, L extends SocketAddr
             finishConnect();
         } else if (!socket.isOutputShutdown()) {
             // directly call super.flush0() to force a flush now
-            super.flush0();
+            super.writeFlushed();
         }
     }
 
@@ -457,12 +457,12 @@ abstract class AbstractKQueueChannel<P extends UnixChannel, L extends SocketAddr
     }
 
     @Override
-    protected final void flush0() {
+    protected final void writeFlushed() {
         // Flush immediately only when there's no pending flush.
         // If there's a pending flush operation, event loop will call forceFlush() later,
         // and thus there's no need to call it now.
         if (!writeFilterEnabled) {
-            super.flush0();
+            super.writeFlushed();
         }
     }
 

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueStreamChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueStreamChannel.java
@@ -55,7 +55,7 @@ public abstract class AbstractKQueueStreamChannel
 
     // Calling flush0 directly to ensure we not try to flush messages that were added via write(...) in the
     // meantime.
-    private final Runnable flushTask = this::flush0;
+    private final Runnable flushTask = this::writeFlushed;
 
     AbstractKQueueStreamChannel(P parent, EventLoop eventLoop, BsdSocket fd, boolean active) {
         super(parent, eventLoop, fd, active);

--- a/transport/src/main/java/io/netty5/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty5/channel/AbstractChannel.java
@@ -725,7 +725,7 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
             } finally {
                 // If the outboundBuffer is null we know the channel was closed or the outbound was shutdown, so
                 // need to fail the future right away. If it is not null the handling of the rest
-                // will be done in flush0()
+                // will be done in writeFlushed()
                 // See https://github.com/netty/netty/issues/2362
                 final Throwable cause;
                 if (!isActive()) {
@@ -804,7 +804,7 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
                         updateWritabilityIfNeeded(true, true);
                     } else {
                         // Do not trigger channelWritabilityChanged because the channel is closed already.
-                        outboundBuffer.failFlushed(newClosedChannelException(initialCloseCause, "flush0()"));
+                        outboundBuffer.failFlushed(newClosedChannelException(initialCloseCause, "writeFlushed()"));
                     }
                 }
             } finally {
@@ -837,7 +837,7 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
              * the exception.
              */
             initialCloseCause = t;
-            close(newPromise(), t, newClosedChannelException(t, "flush0()"));
+            close(newPromise(), t, newClosedChannelException(t, "writeFlushed()"));
         } else {
             try {
                 if (shutdownOutput(newPromise(), t)) {
@@ -845,7 +845,7 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
                 }
             } catch (Throwable t2) {
                 initialCloseCause = t;
-                close(newPromise(), t2, newClosedChannelException(t, "flush0()"));
+                close(newPromise(), t2, newClosedChannelException(t, "writeFlushed()"));
             }
         }
     }

--- a/transport/src/main/java/io/netty5/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty5/channel/embedded/EmbeddedChannel.java
@@ -373,7 +373,7 @@ public class EmbeddedChannel extends AbstractChannel<Channel, SocketAddress, Soc
     private void flushInbound(boolean recordException) {
       if (checkOpen(recordException)) {
           pipeline().fireChannelReadComplete();
-          readIfIsAutoRead();
+          embeddedEventLoop().execute(this::readIfIsAutoRead);
           runPendingTasks();
       }
       checkException();

--- a/transport/src/main/java/io/netty5/channel/nio/AbstractNioByteChannel.java
+++ b/transport/src/main/java/io/netty5/channel/nio/AbstractNioByteChannel.java
@@ -50,7 +50,7 @@ public abstract class AbstractNioByteChannel<P extends Channel, L extends Socket
 
     // Calling flush0 directly to ensure we not try to flush messages that were added via write(...) in the
     // meantime.
-    private final Runnable flushTask = this::flush0;
+    private final Runnable flushTask = this::writeFlushed;
     private boolean inputClosedSeenErrorOnRead;
 
     /**

--- a/transport/src/main/java/io/netty5/channel/nio/AbstractNioChannel.java
+++ b/transport/src/main/java/io/netty5/channel/nio/AbstractNioChannel.java
@@ -292,18 +292,18 @@ public abstract class AbstractNioChannel<P extends Channel, L extends SocketAddr
     }
 
     @Override
-    protected final void flush0() {
+    protected final void writeFlushed() {
         // Flush immediately only when there's no pending flush.
         // If there's a pending flush operation, event loop will call forceFlush() later,
         // and thus there's no need to call it now.
         if (!isFlushPending()) {
-            super.flush0();
+            super.writeFlushed();
         }
     }
 
     final void forceFlush() {
         // directly call super.flush0() to force a flush now
-        super.flush0();
+        super.writeFlushed();
     }
 
     private boolean isFlushPending() {


### PR DESCRIPTION
Motivation:

We should rename flush0() so its clear what exactly this methods does. This is especially true as its called by sub-classes as well.
Beside this we should also add asserts on all the methods which must only be called from the EventLoop thread.

Modifications:

- Rename method
- Add asserts

Result:

Cleanup