### PR TITLE
Keep completed flag for retained/duplicated HttpData

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractHttpData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractHttpData.java
@@ -83,7 +83,11 @@ public abstract class AbstractHttpData extends AbstractReferenceCounted implemen
     }
 
     protected void setCompleted() {
-        completed = true;
+        setCompleted(true);
+    }
+
+    protected void setCompleted(boolean completed) {
+        this.completed = completed;
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/DiskAttribute.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/DiskAttribute.java
@@ -242,6 +242,7 @@ public class DiskAttribute extends AbstractDiskHttpData implements Attribute {
                 throw new ChannelException(e);
             }
         }
+        attr.setCompleted(isCompleted());
         return attr;
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/DiskFileUpload.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/DiskFileUpload.java
@@ -210,6 +210,7 @@ public class DiskFileUpload extends AbstractDiskHttpData implements FileUpload {
                 throw new ChannelException(e);
             }
         }
+        upload.setCompleted(isCompleted());
         return upload;
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/MemoryAttribute.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/MemoryAttribute.java
@@ -167,6 +167,7 @@ public class MemoryAttribute extends AbstractMemoryHttpData implements Attribute
                 throw new ChannelException(e);
             }
         }
+        attr.setCompleted(isCompleted());
         return attr;
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/MemoryFileUpload.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/MemoryFileUpload.java
@@ -154,11 +154,11 @@ public class MemoryFileUpload extends AbstractMemoryHttpData implements FileUplo
         if (content != null) {
             try {
                 upload.setContent(content);
-                return upload;
             } catch (IOException e) {
                 throw new ChannelException(e);
             }
         }
+        upload.setCompleted(isCompleted());
         return upload;
     }
 


### PR DESCRIPTION
Motivation:

When you retain and duplicate a multipart HttpData, then the "isCompleted" flag is not preserved.

Example:
Using the following code:

```
        HttpData data = new MemoryAttribute("test", 0),
        data.addContent(Unpooled.wrappedBuffer("foo".getBytes(CharsetUtil.UTF_8)), false);
        HttpData duplicate = httpDatadata.retainedDuplicate();
```
then data.isCompleted() returns false, but duplicate.isCompleted() will return true

Modification:

_retainDuplicate_ actually calls **_replace_** method, and when the various _**replace**_ methods are calling _setContent_(), then after the call to _setContent_, the _isCompleted_ flag will be reset to true.

The propose patch adds a new _setCompleted_(boolean) method in AbstractHttpData class, and then all the _replace_ methods ensure that the _setCompleted_ method is called after having called _setContent_.

Example for the _replace_ method implemented by the MemoryFileUpload class:

```
    @Override
    public FileUpload replace(ByteBuf content) {
        MemoryFileUpload upload = new MemoryFileUpload(
                getName(), getFilename(), getContentType(), getContentTransferEncoding(), getCharset(), size);
        if (content != null) {
            try {
                upload.setContent(content);
            } catch (IOException e) {
                throw new ChannelException(e);
            }
        }
        upload.setCompleted(isCompleted());
        return upload;
    }
```

Result:

The _isCompleted_ flag is preserved in the HttpData returned by the retainedDuplicate() method, so users can check if the HttpData is partial or not.

thanks.
