### PR TITLE
Add ChannelConfig methods that only existed in DefaultChannelConfig a…

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollChannelConfig.java
@@ -16,6 +16,7 @@
 package io.netty5.channel.epoll;
 
 import io.netty5.buffer.api.BufferAllocator;
+import io.netty5.channel.ChannelConfig;
 import io.netty5.channel.ChannelException;
 import io.netty5.channel.ChannelOption;
 import io.netty5.channel.DefaultChannelConfig;
@@ -141,6 +142,24 @@ public class EpollChannelConfig extends DefaultChannelConfig {
     @Override
     public EpollChannelConfig setMessageSizeEstimator(MessageSizeEstimator estimator) {
         super.setMessageSizeEstimator(estimator);
+        return this;
+    }
+
+    @Override
+    public EpollChannelConfig setMaxMessagesPerWrite(int maxMessagesPerWrite) {
+        super.setMaxMessagesPerWrite(maxMessagesPerWrite);
+        return this;
+    }
+
+    @Override
+    public EpollChannelConfig setAutoClose(boolean autoClose) {
+        super.setAutoClose(autoClose);
+        return this;
+    }
+
+    @Override
+    public EpollChannelConfig setAllowHalfClosure(boolean allowHalfClosure) {
+        super.setAllowHalfClosure(allowHalfClosure);
         return this;
     }
 

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDatagramChannel.java
@@ -315,7 +315,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel<UnixChannel
 
     @Override
     protected void doWrite(ChannelOutboundBuffer in) throws Exception {
-        int maxMessagesPerWrite = maxMessagesPerWrite();
+        int maxMessagesPerWrite = config().getMaxMessagesPerWrite();
         while (maxMessagesPerWrite > 0) {
             Object msg = in.current();
             if (msg == null) {

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDatagramChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDatagramChannelConfig.java
@@ -560,4 +560,10 @@ public final class EpollDatagramChannelConfig extends EpollChannelConfig impleme
         super.setMaxMessagesPerWrite(maxMessagesPerWrite);
         return this;
     }
+
+    @Override
+    public EpollDatagramChannelConfig setAllowHalfClosure(boolean allowHalfClosure) {
+        super.setAllowHalfClosure(allowHalfClosure);
+        return this;
+    }
 }

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDomainDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDomainDatagramChannel.java
@@ -152,7 +152,7 @@ public final class EpollDomainDatagramChannel
 
     @Override
     protected void doWrite(ChannelOutboundBuffer in) throws Exception {
-        int maxMessagesPerWrite = maxMessagesPerWrite();
+        int maxMessagesPerWrite = config().getMaxMessagesPerWrite();
         while (maxMessagesPerWrite > 0) {
             Object msg = in.current();
             if (msg == null) {

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDomainDatagramChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDomainDatagramChannelConfig.java
@@ -169,4 +169,22 @@ public final class EpollDomainDatagramChannelConfig extends EpollChannelConfig i
         super.setWriteSpinCount(writeSpinCount);
         return this;
     }
+
+    @Override
+    public EpollDomainDatagramChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
+        super.setWriteBufferHighWaterMark(writeBufferHighWaterMark);
+        return this;
+    }
+
+    @Override
+    public EpollDomainDatagramChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
+        super.setWriteBufferLowWaterMark(writeBufferLowWaterMark);
+        return this;
+    }
+
+    @Override
+    public EpollDomainDatagramChannelConfig setAllowHalfClosure(boolean allowHalfClosure) {
+        super.setAllowHalfClosure(allowHalfClosure);
+        return this;
+    }
 }

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollSocketChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollSocketChannelConfig.java
@@ -637,6 +637,12 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
         return this;
     }
 
+    @Override
+    public EpollSocketChannelConfig setMaxMessagesPerWrite(int maxMessagesPerWrite) {
+        super.setMaxMessagesPerWrite(maxMessagesPerWrite);
+        return this;
+    }
+
     private void calculateMaxBytesPerGatheringWrite() {
         // Multiply by 2 to give some extra space in case the OS can process write data faster than we can provide.
         int newSendBufferSize = getSendBufferSize() << 1;

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueDatagramChannel.java
@@ -43,7 +43,7 @@ abstract class AbstractKQueueDatagramChannel<P extends UnixChannel, L extends So
 
     @Override
     protected void doWrite(ChannelOutboundBuffer in) throws Exception {
-        int maxMessagesPerWrite = maxMessagesPerWrite();
+        int maxMessagesPerWrite = config().getMaxMessagesPerWrite();
         while (maxMessagesPerWrite > 0) {
             Object msg = in.current();
             if (msg == null) {

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueChannelConfig.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueChannelConfig.java
@@ -196,4 +196,22 @@ public class KQueueChannelConfig extends DefaultChannelConfig {
     final long getMaxBytesPerGatheringWrite() {
         return maxBytesPerGatheringWrite;
     }
+
+    @Override
+    public KQueueChannelConfig setMaxMessagesPerWrite(int maxMessagesPerWrite) {
+        super.setMaxMessagesPerWrite(maxMessagesPerWrite);
+        return this;
+    }
+
+    @Override
+    public KQueueChannelConfig setAutoClose(boolean autoClose) {
+        super.setAutoClose(autoClose);
+        return this;
+    }
+
+    @Override
+    public KQueueChannelConfig setAllowHalfClosure(boolean allowHalfClosure) {
+        super.setAllowHalfClosure(allowHalfClosure);
+        return this;
+    }
 }

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDatagramChannelConfig.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDatagramChannelConfig.java
@@ -388,4 +388,10 @@ public final class KQueueDatagramChannelConfig extends KQueueChannelConfig imple
         super.setMaxMessagesPerWrite(maxMessagesPerWrite);
         return this;
     }
+
+    @Override
+    public KQueueDatagramChannelConfig setAllowHalfClosure(boolean allowHalfClosure) {
+        super.setAllowHalfClosure(allowHalfClosure);
+        return this;
+    }
 }

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueSocketChannelConfig.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueSocketChannelConfig.java
@@ -393,6 +393,12 @@ public final class KQueueSocketChannelConfig extends KQueueChannelConfig impleme
         return this;
     }
 
+    @Override
+    public KQueueSocketChannelConfig setMaxMessagesPerWrite(int maxMessagesPerWrite) {
+        super.setMaxMessagesPerWrite(maxMessagesPerWrite);
+        return this;
+    }
+
     private void calculateMaxBytesPerGatheringWrite() {
         // Multiply by 2 to give some extra space in case the OS can process write data faster than we can provide.
         int newSendBufferSize = getSendBufferSize() << 1;

--- a/transport/src/main/java/io/netty5/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty5/channel/AbstractChannel.java
@@ -116,18 +116,6 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
         return group;
     }
 
-    protected final int maxMessagesPerWrite() {
-        ChannelConfig config = config();
-        if (config instanceof DefaultChannelConfig) {
-            return ((DefaultChannelConfig) config).getMaxMessagesPerWrite();
-        }
-        Integer value = config.getOption(ChannelOption.MAX_MESSAGES_PER_WRITE);
-        if (value == null) {
-            return Integer.MAX_VALUE;
-        }
-        return value;
-    }
-
     @Override
     public final ChannelId id() {
         return id;

--- a/transport/src/main/java/io/netty5/channel/ChannelConfig.java
+++ b/transport/src/main/java/io/netty5/channel/ChannelConfig.java
@@ -57,6 +57,8 @@ import java.util.Map;
  * <td>{@link ChannelOption#AUTO_READ}</td><td>{@link #setAutoRead(boolean)}</td>
  * </tr><tr>
  * <td>{@link ChannelOption#ALLOW_HALF_CLOSURE}</td><td>{@link #setAllowHalfClosure(boolean)}</td>
+ * </tr><tr>
+ * <td>{@link ChannelOption#MAX_MESSAGES_PER_WRITE}</td><td>{@link #setMaxMessagesPerWrite(int)}</td>
  * </tr>
  * </table>
  * <p>
@@ -283,4 +285,16 @@ public interface ChannelConfig {
      * If {@code false}, the connection is closed automatically.
      */
     ChannelConfig setAllowHalfClosure(boolean allowHalfClosure);
+
+    /**
+     * Get the maximum number of message to write per eventloop run. Once this limit is
+     * reached we will continue to process other events before trying to write the remaining messages.
+     */
+    int getMaxMessagesPerWrite();
+
+    /**
+     * Set the maximum number of message to write per eventloop run. Once this limit is
+     * reached we will continue to process other events before trying to write the remaining messages.
+     */
+    ChannelConfig setMaxMessagesPerWrite(int maxMessagesPerWrite);
 }

--- a/transport/src/main/java/io/netty5/channel/nio/AbstractNioMessageChannel.java
+++ b/transport/src/main/java/io/netty5/channel/nio/AbstractNioMessageChannel.java
@@ -131,7 +131,7 @@ public abstract class AbstractNioMessageChannel<P extends Channel, L extends Soc
         }
         final int interestOps = key.interestOps();
 
-        int maxMessagesPerWrite = maxMessagesPerWrite();
+        int maxMessagesPerWrite = config().getMaxMessagesPerWrite();
         while (maxMessagesPerWrite > 0) {
             Object msg = in.current();
             if (msg == null) {

--- a/transport/src/main/java/io/netty5/channel/socket/DatagramChannelConfig.java
+++ b/transport/src/main/java/io/netty5/channel/socket/DatagramChannelConfig.java
@@ -15,6 +15,7 @@
  */
 package io.netty5.channel.socket;
 
+import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.channel.ChannelConfig;
 import io.netty5.channel.ChannelOption;
 import io.netty5.channel.MessageSizeEstimator;
@@ -181,4 +182,18 @@ public interface DatagramChannelConfig extends ChannelConfig {
     @Override
     DatagramChannelConfig setWriteBufferWaterMark(WriteBufferWaterMark writeBufferWaterMark);
 
+    @Override
+    DatagramChannelConfig setBufferAllocator(BufferAllocator allocator);
+
+    @Override
+    DatagramChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark);
+
+    @Override
+    DatagramChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark);
+
+    @Override
+    DatagramChannelConfig setAllowHalfClosure(boolean allowHalfClosure);
+
+    @Override
+    DatagramChannelConfig setMaxMessagesPerWrite(int maxMessagesPerWrite);
 }

--- a/transport/src/main/java/io/netty5/channel/socket/DefaultDatagramChannelConfig.java
+++ b/transport/src/main/java/io/netty5/channel/socket/DefaultDatagramChannelConfig.java
@@ -442,4 +442,10 @@ public class DefaultDatagramChannelConfig extends DefaultChannelConfig implement
         super.setMaxMessagesPerWrite(maxMessagesPerWrite);
         return this;
     }
+
+    @Override
+    public DatagramChannelConfig setAllowHalfClosure(boolean allowHalfClosure) {
+        super.setAllowHalfClosure(allowHalfClosure);
+        return this;
+    }
 }

--- a/transport/src/main/java/io/netty5/channel/socket/DefaultSocketChannelConfig.java
+++ b/transport/src/main/java/io/netty5/channel/socket/DefaultSocketChannelConfig.java
@@ -16,6 +16,7 @@
 package io.netty5.channel.socket;
 
 import io.netty5.buffer.api.BufferAllocator;
+import io.netty5.channel.ChannelConfig;
 import io.netty5.channel.ChannelException;
 import io.netty5.channel.ChannelOption;
 import io.netty5.channel.DefaultChannelConfig;
@@ -319,7 +320,7 @@ public class DefaultSocketChannelConfig extends DefaultChannelConfig
 
     @Override
     public SocketChannelConfig setAutoRead(boolean autoRead) {
-         super.setAutoRead(autoRead);
+        super.setAutoRead(autoRead);
         return this;
     }
 
@@ -350,6 +351,12 @@ public class DefaultSocketChannelConfig extends DefaultChannelConfig
     @Override
     public SocketChannelConfig setMessageSizeEstimator(MessageSizeEstimator estimator) {
         super.setMessageSizeEstimator(estimator);
+        return this;
+    }
+
+    @Override
+    public SocketChannelConfig setMaxMessagesPerWrite(int maxMessagesPerWrite) {
+        super.setMaxMessagesPerWrite(maxMessagesPerWrite);
         return this;
     }
 }

--- a/transport/src/main/java/io/netty5/channel/socket/SocketChannelConfig.java
+++ b/transport/src/main/java/io/netty5/channel/socket/SocketChannelConfig.java
@@ -15,6 +15,7 @@
  */
 package io.netty5.channel.socket;
 
+import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.channel.ChannelConfig;
 import io.netty5.channel.ChannelOption;
 import io.netty5.channel.MessageSizeEstimator;
@@ -165,4 +166,16 @@ public interface SocketChannelConfig extends ChannelConfig {
 
     @Override
     SocketChannelConfig setWriteBufferWaterMark(WriteBufferWaterMark writeBufferWaterMark);
+
+    @Override
+    SocketChannelConfig setBufferAllocator(BufferAllocator allocator);
+
+    @Override
+    SocketChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark);
+
+    @Override
+    SocketChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark);
+
+    @Override
+    SocketChannelConfig setMaxMessagesPerWrite(int maxMessagesPerWrite);
 }


### PR DESCRIPTION
…nd add overrides

Motivation:

In netty 4.1 we added some methods to DefaultChannelConfig only as we could not change the interface. We should now add these to the interface. Beside this we also missed a few overrides that broke method chaining

Modifications:

- Add ChannelConfig.setMaxMessagesPerWrite(...) and getMaxMessagesPerWrite()
- Add missing overrides

Result:

Cleanup