### PR TITLE
Don't restrict SocketChannel ServerSocketChannel to InetSocketAddress

### DIFF
--- a/transport/src/main/java/io/netty5/channel/socket/ServerSocketChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/ServerSocketChannel.java
@@ -17,16 +17,10 @@ package io.netty5.channel.socket;
 
 import io.netty5.channel.ServerChannel;
 
-import java.net.InetSocketAddress;
-
 /**
- * A TCP/IP {@link ServerChannel} which accepts incoming TCP/IP connections.
+ * A {@link ServerChannel} which accepts incoming TCP/IP connections.
  */
 public interface ServerSocketChannel extends ServerChannel {
     @Override
     ServerSocketChannelConfig config();
-    @Override
-    InetSocketAddress localAddress();
-    @Override
-    InetSocketAddress remoteAddress();
 }

--- a/transport/src/main/java/io/netty5/channel/socket/SocketChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/SocketChannel.java
@@ -17,10 +17,9 @@ package io.netty5.channel.socket;
 
 import io.netty5.channel.Channel;
 
-import java.net.InetSocketAddress;
 
 /**
- * A TCP/IP socket {@link Channel}.
+ * A socket {@link Channel}.
  */
 public interface SocketChannel extends Channel {
     @Override
@@ -28,8 +27,4 @@ public interface SocketChannel extends Channel {
 
     @Override
     SocketChannelConfig config();
-    @Override
-    InetSocketAddress localAddress();
-    @Override
-    InetSocketAddress remoteAddress();
 }

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioServerSocketChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioServerSocketChannel.java
@@ -33,7 +33,6 @@ import io.netty5.util.internal.logging.InternalLoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
-import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.SocketAddress;
 import java.nio.channels.SelectionKey;
@@ -47,7 +46,7 @@ import java.util.Map;
  * A {@link io.netty5.channel.socket.ServerSocketChannel} implementation which uses
  * NIO selector based implementation to accept new connections.
  */
-public class NioServerSocketChannel extends AbstractNioMessageChannel<Channel, InetSocketAddress, InetSocketAddress>
+public class NioServerSocketChannel extends AbstractNioMessageChannel<Channel, SocketAddress, SocketAddress>
                              implements io.netty5.channel.socket.ServerSocketChannel {
 
     private static final ChannelMetadata METADATA = new ChannelMetadata(false, 16);
@@ -132,8 +131,8 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel<Channel, I
     }
 
     @Override
-    protected InetSocketAddress localAddress0() {
-        return (InetSocketAddress) SocketUtils.localSocketAddress(javaChannel().socket());
+    protected SocketAddress localAddress0() {
+        return SocketUtils.localSocketAddress(javaChannel().socket());
     }
 
     @Override
@@ -181,12 +180,12 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel<Channel, I
     }
 
     @Override
-    protected boolean doFinishConnect(InetSocketAddress requestedRemoteAddress) {
+    protected boolean doFinishConnect(SocketAddress requestedRemoteAddress) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    protected InetSocketAddress remoteAddress0() {
+    protected SocketAddress remoteAddress0() {
         return null;
     }
 

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioSocketChannel.java
@@ -34,7 +34,6 @@ import io.netty5.util.internal.SocketUtils;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
-import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
@@ -50,7 +49,7 @@ import static io.netty5.channel.internal.ChannelUtils.MAX_BYTES_PER_GATHERING_WR
  * {@link io.netty5.channel.socket.SocketChannel} which uses NIO selector based implementation.
  */
 public class NioSocketChannel
-        extends AbstractNioByteChannel<NioServerSocketChannel, InetSocketAddress, InetSocketAddress>
+        extends AbstractNioByteChannel<NioServerSocketChannel, SocketAddress, SocketAddress>
         implements io.netty5.channel.socket.SocketChannel {
     private static final SelectorProvider DEFAULT_SELECTOR_PROVIDER = SelectorProvider.provider();
 
@@ -154,13 +153,13 @@ public class NioSocketChannel
     }
 
     @Override
-    protected InetSocketAddress localAddress0() {
-        return (InetSocketAddress) javaChannel().socket().getLocalSocketAddress();
+    protected SocketAddress localAddress0() {
+        return javaChannel().socket().getLocalSocketAddress();
     }
 
     @Override
-    protected InetSocketAddress remoteAddress0() {
-        return (InetSocketAddress) javaChannel().socket().getRemoteSocketAddress();
+    protected SocketAddress remoteAddress0() {
+        return javaChannel().socket().getRemoteSocketAddress();
     }
 
     @Override
@@ -194,7 +193,7 @@ public class NioSocketChannel
     }
 
     @Override
-    protected boolean doFinishConnect(InetSocketAddress requestedRemoteAddress) throws Exception {
+    protected boolean doFinishConnect(SocketAddress requestedRemoteAddress) throws Exception {
         return javaChannel().finishConnect();
     }
 


### PR DESCRIPTION
Motivation:

We shouldn't restrict to the usage of InetSocketAddress as this will disallow to wrap a java.nio.channels.SocketChannel that was created for a unix domain socket.

Modifications:

Just return SocketAddress

Result:

Be able to wrap java.nio.channels.SocketChannel implementations which not use InetSocketAddress at all
