### PR TITLE
DatagramChannel should not restrict usage to InetSocketAddress

### DIFF
--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/DatagramDnsQuery.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/DatagramDnsQuery.java
@@ -26,10 +26,10 @@ import java.net.SocketAddress;
  */
 @UnstableApi
 public class DatagramDnsQuery extends DefaultDnsQuery
-        implements AddressedEnvelope<DatagramDnsQuery, InetSocketAddress> {
+        implements AddressedEnvelope<DatagramDnsQuery, SocketAddress> {
 
-    private final InetSocketAddress sender;
-    private final InetSocketAddress recipient;
+    private final SocketAddress sender;
+    private final SocketAddress recipient;
 
     /**
      * Creates a new instance with the {@link DnsOpCode#QUERY} {@code opCode}.
@@ -52,7 +52,7 @@ public class DatagramDnsQuery extends DefaultDnsQuery
      * @param opCode the {@code opCode} of the DNS query
      */
     public DatagramDnsQuery(
-            InetSocketAddress sender, InetSocketAddress recipient, int id, DnsOpCode opCode) {
+            SocketAddress sender, SocketAddress recipient, int id, DnsOpCode opCode) {
         super(id, opCode);
 
         if (recipient == null && sender == null) {
@@ -69,12 +69,12 @@ public class DatagramDnsQuery extends DefaultDnsQuery
     }
 
     @Override
-    public InetSocketAddress sender() {
+    public SocketAddress sender() {
         return sender;
     }
 
     @Override
-    public InetSocketAddress recipient() {
+    public SocketAddress recipient() {
         return recipient;
     }
 

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/DatagramDnsResponseDecoder.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/DatagramDnsResponseDecoder.java
@@ -68,6 +68,7 @@ public class DatagramDnsResponseDecoder extends MessageToMessageDecoder<Datagram
     }
 
     protected DnsResponse decodeResponse(ChannelHandlerContext ctx, DatagramPacket packet) throws Exception {
-        return responseDecoder.decode(packet.sender(), packet.recipient(), ctx.bufferAllocator(), packet.content());
+        return responseDecoder.decode((InetSocketAddress) packet.sender(), (InetSocketAddress) packet.recipient(),
+                ctx.bufferAllocator(), packet.content());
     }
 }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramUnicastInetTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramUnicastInetTest.java
@@ -74,7 +74,7 @@ public class DatagramUnicastInetTest extends DatagramUnicastTest {
 
                     InetSocketAddress localAddress = (InetSocketAddress) ctx.channel().localAddress();
                     if (localAddress.getAddress().isAnyLocalAddress()) {
-                        assertEquals(localAddress.getPort(), msg.recipient().getPort());
+                        assertEquals(localAddress.getPort(), ((InetSocketAddress) msg.recipient()).getPort());
                     } else {
                         // Test that the channel's localAddress is equal to the message's recipient
                         assertEquals(localAddress, msg.recipient());
@@ -110,7 +110,7 @@ public class DatagramUnicastInetTest extends DatagramUnicastTest {
                             } else {
                                 InetSocketAddress senderAddress = (InetSocketAddress) sender;
                                 if (senderAddress.getAddress().isAnyLocalAddress()) {
-                                    assertEquals(senderAddress.getPort(), msg.sender().getPort());
+                                    assertEquals(senderAddress.getPort(), ((InetSocketAddress) msg.sender()).getPort());
                                 } else {
                                     assertEquals(sender, msg.sender());
                                 }
@@ -150,6 +150,6 @@ public class DatagramUnicastInetTest extends DatagramUnicastTest {
 
     @Override
     protected Future<Void> write(Channel cc, Buffer buf, SocketAddress remote) {
-        return cc.write(new DatagramPacket(buf, (InetSocketAddress) remote));
+        return cc.write(new DatagramPacket(buf, remote));
     }
 }

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/NativeDatagramPacketArray.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/NativeDatagramPacketArray.java
@@ -160,7 +160,8 @@ final class NativeDatagramPacketArray {
                     }
                 }
                 boolean addedAny = false;
-                while (buf.readableBytes() > 0 && addReadable(buf, segmentSize, packet.recipient())) {
+                while (buf.readableBytes() > 0 &&
+                        addReadable(buf, segmentSize, (InetSocketAddress) packet.recipient())) {
                     addedAny = true;
                 }
                 added = addedAny;

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDatagramChannelTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDatagramChannelTest.java
@@ -62,7 +62,7 @@ public class EpollDatagramChannelTest {
         try {
             Socket socket = Socket.newSocketDgram();
             EpollDatagramChannel channel = new EpollDatagramChannel(group.next(), socket.intValue());
-            InetSocketAddress localAddress = channel.localAddress();
+            SocketAddress localAddress = channel.localAddress();
             assertTrue(channel.active);
             assertNotNull(localAddress);
             assertEquals(socket.localAddress(), localAddress);

--- a/transport-native-unix-common/src/main/java/io/netty5/channel/unix/SegmentedDatagramPacket.java
+++ b/transport-native-unix-common/src/main/java/io/netty5/channel/unix/SegmentedDatagramPacket.java
@@ -20,6 +20,7 @@ import io.netty5.channel.socket.DatagramPacket;
 import io.netty5.util.internal.ObjectUtil;
 
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 
 /**
  * Allows to use <a href="https://blog.cloudflare.com/accelerating-udp-packet-transmission-for-quic/">GSO</a>
@@ -38,8 +39,8 @@ public class SegmentedDatagramPacket extends DatagramPacket {
      * @param recipient The recipient address.
      * @param sender The sender address.
      */
-    public SegmentedDatagramPacket(Buffer message, int segmentSize, InetSocketAddress recipient,
-                                   InetSocketAddress sender) {
+    public SegmentedDatagramPacket(Buffer message, int segmentSize, SocketAddress recipient,
+                                   SocketAddress sender) {
         super(message, recipient, sender);
         this.segmentSize = ObjectUtil.checkPositive(segmentSize, "segmentSize");
     }

--- a/transport/src/main/java/io/netty5/channel/socket/DatagramChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/DatagramChannel.java
@@ -17,10 +17,8 @@ package io.netty5.channel.socket;
 
 import io.netty5.channel.Channel;
 import io.netty5.util.concurrent.Future;
-import io.netty5.util.concurrent.Promise;
 
 import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.net.NetworkInterface;
 
 /**
@@ -29,10 +27,6 @@ import java.net.NetworkInterface;
 public interface DatagramChannel extends Channel {
     @Override
     DatagramChannelConfig config();
-    @Override
-    InetSocketAddress localAddress();
-    @Override
-    InetSocketAddress remoteAddress();
 
     /**
      * Return {@code true} if the {@link DatagramChannel} is connected to the remote peer.
@@ -41,124 +35,83 @@ public interface DatagramChannel extends Channel {
 
     /**
      * Joins a multicast group and notifies the {@link Future} once the operation completes.
+     * <p>
+     * If the underlying implementation does not support this operation it will return a {@link Future} which
+     * is failed with an {@link UnsupportedOperationException}.
+     *
+     * @param multicastAddress  the multicast group address.
+     * @return                  a {@link Future} which is notified once the operation completes.
      */
     Future<Void> joinGroup(InetAddress multicastAddress);
 
     /**
-     * Joins a multicast group and notifies the {@link Future} once the operation completes.
-     *
-     * The given {@link Future} will be notified and also returned.
-     */
-    Future<Void> joinGroup(InetAddress multicastAddress, Promise<Void> future);
-
-    /**
-     * Joins the specified multicast group at the specified interface and notifies the {@link Future}
-     * once the operation completes.
-     */
-    Future<Void> joinGroup(InetSocketAddress multicastAddress, NetworkInterface networkInterface);
-
-    /**
      * Joins the specified multicast group at the specified interface and notifies the {@link Future}
      * once the operation completes.
      *
-     * The given {@link Future} will be notified and also returned.
-     */
-    Future<Void> joinGroup(
-            InetSocketAddress multicastAddress, NetworkInterface networkInterface, Promise<Void> future);
-
-    /**
-     * Joins the specified multicast group at the specified interface and notifies the {@link Future}
-     * once the operation completes.
+     * <p>
+     * If the underlying implementation does not support this operation it will return a {@link Future} which
+     * is failed with an {@link UnsupportedOperationException}.
+     *
+     * @param multicastAddress  the multicast group address.
+     * @param networkInterface  the interface to use.
+     * @param source            the source address (might be {@code null}).
+     * @return                  a {@link Future} which is notified once the operation completes.
      */
     Future<Void> joinGroup(InetAddress multicastAddress, NetworkInterface networkInterface, InetAddress source);
 
     /**
-     * Joins the specified multicast group at the specified interface and notifies the {@link Future}
-     * once the operation completes.
-     *
-     * The given {@link Future} will be notified and also returned.
-     */
-    Future<Void> joinGroup(
-            InetAddress multicastAddress, NetworkInterface networkInterface, InetAddress source, Promise<Void> future);
-
-    /**
      * Leaves a multicast group and notifies the {@link Future} once the operation completes.
+     *
+     * <p>
+     * If the underlying implementation does not support this operation it will return a {@link Future} which
+     * is failed with an {@link UnsupportedOperationException}.
+     *
+     * @param multicastAddress  the multicast group address.
+     * @return                  a {@link Future} which is notified once the operation completes.
      */
     Future<Void> leaveGroup(InetAddress multicastAddress);
 
     /**
-     * Leaves a multicast group and notifies the {@link Future} once the operation completes.
-     *
-     * The given {@link Future} will be notified and also returned.
-     */
-    Future<Void> leaveGroup(InetAddress multicastAddress, Promise<Void> future);
-
-    /**
-     * Leaves a multicast group on a specified local interface and notifies the {@link Future} once the
-     * operation completes.
-     */
-    Future<Void> leaveGroup(InetSocketAddress multicastAddress, NetworkInterface networkInterface);
-
-    /**
-     * Leaves a multicast group on a specified local interface and notifies the {@link Future} once the
-     * operation completes.
-     *
-     * The given {@link Future} will be notified and also returned.
-     */
-    Future<Void> leaveGroup(
-            InetSocketAddress multicastAddress, NetworkInterface networkInterface, Promise<Void> future);
-
-    /**
-     * Leave the specified multicast group at the specified interface using the specified source and notifies
-     * the {@link Future} once the operation completes.
-     */
-    Future<Void> leaveGroup(
-            InetAddress multicastAddress, NetworkInterface networkInterface, InetAddress source);
-
-    /**
      * Leave the specified multicast group at the specified interface using the specified source and notifies
      * the {@link Future} once the operation completes.
      *
-     * The given {@link Future} will be notified and also returned.
+     * <p>
+     * If the underlying implementation does not support this operation it will return a {@link Future} which
+     * is failed with an {@link UnsupportedOperationException}.
+     *
+     * @param multicastAddress  the multicast group address.
+     * @param networkInterface  the interface to use.
+     * @param source            the source address (might be {@code null}).
+     * @return                  a {@link Future} which is notified once the operation completes.
      */
-    Future<Void> leaveGroup(
-            InetAddress multicastAddress, NetworkInterface networkInterface, InetAddress source,
-            Promise<Void> future);
+    Future<Void> leaveGroup(InetAddress multicastAddress, NetworkInterface networkInterface, InetAddress source);
 
     /**
      * Block the given sourceToBlock address for the given multicastAddress on the given networkInterface and notifies
      * the {@link Future} once the operation completes.
      *
-     * The given {@link Future} will be notified and also returned.
-     */
-    Future<Void> block(
-            InetAddress multicastAddress, NetworkInterface networkInterface,
-            InetAddress sourceToBlock);
-
-    /**
-     * Block the given sourceToBlock address for the given multicastAddress on the given networkInterface and notifies
-     * the {@link Future} once the operation completes.
+     * <p>
+     * If the underlying implementation does not support this operation it will return a {@link Future} which
+     * is failed with an {@link UnsupportedOperationException}.
      *
-     * The given {@link Future} will be notified and also returned.
+     * @param multicastAddress  the multicast group address.
+     * @param networkInterface  the interface to use.
+     * @param sourceToBlock     the source address.
+     * @return                  a {@link Future} which is notified once the operation completes.
      */
-    Future<Void> block(
-            InetAddress multicastAddress, NetworkInterface networkInterface,
-            InetAddress sourceToBlock, Promise<Void> future);
+    Future<Void> block(InetAddress multicastAddress, NetworkInterface networkInterface, InetAddress sourceToBlock);
 
     /**
      * Block the given sourceToBlock address for the given multicastAddress and notifies the {@link Future} once
      * the operation completes.
      *
-     * The given {@link Future} will be notified and also returned.
+     * <p>
+     * If the underlying implementation does not support this operation it will return a {@link Future} which
+     * is failed with an {@link UnsupportedOperationException}.
+     *
+     * @param multicastAddress  the multicast group address.
+     * @param sourceToBlock     the source address.
+     * @return                  a {@link Future} which is notified once the operation completes.
      */
     Future<Void> block(InetAddress multicastAddress, InetAddress sourceToBlock);
-
-    /**
-     * Block the given sourceToBlock address for the given multicastAddress and notifies the {@link Future} once
-     * the operation completes.
-     *
-     * The given {@link Future} will be notified and also returned.
-     */
-    Future<Void> block(
-            InetAddress multicastAddress, InetAddress sourceToBlock, Promise<Void> future);
 }

--- a/transport/src/main/java/io/netty5/channel/socket/DatagramPacket.java
+++ b/transport/src/main/java/io/netty5/channel/socket/DatagramPacket.java
@@ -18,24 +18,24 @@ package io.netty5.channel.socket;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.BufferAddressedEnvelope;
 
-import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 
 /**
  * The message container that is used for {@link DatagramChannel} to communicate with the remote peer.
  */
-public class DatagramPacket extends BufferAddressedEnvelope<InetSocketAddress, DatagramPacket> {
+public class DatagramPacket extends BufferAddressedEnvelope<SocketAddress, DatagramPacket> {
     /**
      * Create a new instance with the specified packet {@code data}, {@code recipient} address, and {@code sender}
      * address.
      */
-    public DatagramPacket(Buffer message, InetSocketAddress recipient, InetSocketAddress sender) {
+    public DatagramPacket(Buffer message, SocketAddress recipient, SocketAddress sender) {
         super(message, recipient, sender);
     }
 
     /**
      * Create a new instance with the specified packet {@code data} and {@code recipient} address.
      */
-    public DatagramPacket(Buffer message, InetSocketAddress recipient) {
+    public DatagramPacket(Buffer message, SocketAddress recipient) {
         super(message, recipient);
     }
 


### PR DESCRIPTION
Motivation:

At the moment DatagramChannel and DatagramPacket requires InetSocketAdress which limits the flexibility as for example there could also be a DatagramChannel that uses unix domain sockets.
Beside this there are also still methods present in the public API that take a Promise as argument. These should be removed

Modifications:

- Make DatagramChannel & Datagram packet use SocketAddress
- Remove method overloads that take Promise
- Adjust code for the API changes

Result:

More flexible interface / cleanup