### PR TITLE
Add escaping for stomp headers

### DIFF
--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeEncoder.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeEncoder.java
@@ -19,16 +19,77 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToMessageEncoder;
+import io.netty.util.concurrent.FastThreadLocal;
+import io.netty.util.internal.AppendableCharSequence;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map.Entry;
 
-import static io.netty.handler.codec.stomp.StompConstants.*;
+import static io.netty.handler.codec.stomp.StompConstants.NUL;
+import static io.netty.handler.codec.stomp.StompHeaders.ACCEPT_VERSION;
+import static io.netty.handler.codec.stomp.StompHeaders.ACK;
+import static io.netty.handler.codec.stomp.StompHeaders.CONTENT_LENGTH;
+import static io.netty.handler.codec.stomp.StompHeaders.CONTENT_TYPE;
+import static io.netty.handler.codec.stomp.StompHeaders.DESTINATION;
+import static io.netty.handler.codec.stomp.StompHeaders.HEART_BEAT;
+import static io.netty.handler.codec.stomp.StompHeaders.HOST;
+import static io.netty.handler.codec.stomp.StompHeaders.ID;
+import static io.netty.handler.codec.stomp.StompHeaders.LOGIN;
+import static io.netty.handler.codec.stomp.StompHeaders.MESSAGE;
+import static io.netty.handler.codec.stomp.StompHeaders.MESSAGE_ID;
+import static io.netty.handler.codec.stomp.StompHeaders.PASSCODE;
+import static io.netty.handler.codec.stomp.StompHeaders.RECEIPT;
+import static io.netty.handler.codec.stomp.StompHeaders.RECEIPT_ID;
+import static io.netty.handler.codec.stomp.StompHeaders.SERVER;
+import static io.netty.handler.codec.stomp.StompHeaders.SESSION;
+import static io.netty.handler.codec.stomp.StompHeaders.SUBSCRIPTION;
+import static io.netty.handler.codec.stomp.StompHeaders.TRANSACTION;
+import static io.netty.handler.codec.stomp.StompHeaders.VERSION;
 
 /**
  * Encodes a {@link StompFrame} or a {@link StompSubframe} into a {@link ByteBuf}.
  */
 public class StompSubframeEncoder extends MessageToMessageEncoder<StompSubframe> {
+
+    private static final int ESCAPE_HEADER_KEY_CACHE_LIMIT = 32;
+    private static final float DEFAULT_LOAD_FACTOR = 0.75f;
+    private static final FastThreadLocal<LinkedHashMap<CharSequence, CharSequence>> ESCAPE_HEADER_KEY_CACHE =
+            new FastThreadLocal<LinkedHashMap<CharSequence, CharSequence>>() {
+                @Override
+                protected LinkedHashMap<CharSequence, CharSequence> initialValue() throws Exception {
+                    LinkedHashMap<CharSequence, CharSequence> cache = new LinkedHashMap<CharSequence, CharSequence>(
+                            ESCAPE_HEADER_KEY_CACHE_LIMIT, DEFAULT_LOAD_FACTOR, true) {
+
+                        @Override
+                        protected boolean removeEldestEntry(Entry eldest) {
+                            return size() > ESCAPE_HEADER_KEY_CACHE_LIMIT;
+                        }
+                    };
+
+                    cache.put(ACCEPT_VERSION, ACCEPT_VERSION);
+                    cache.put(HOST, HOST);
+                    cache.put(LOGIN, LOGIN);
+                    cache.put(PASSCODE, PASSCODE);
+                    cache.put(HEART_BEAT, HEART_BEAT);
+                    cache.put(VERSION, VERSION);
+                    cache.put(SESSION, SESSION);
+                    cache.put(SERVER, SERVER);
+                    cache.put(DESTINATION, DESTINATION);
+                    cache.put(ID, ID);
+                    cache.put(ACK, ACK);
+                    cache.put(TRANSACTION, TRANSACTION);
+                    cache.put(RECEIPT, RECEIPT);
+                    cache.put(MESSAGE_ID, MESSAGE_ID);
+                    cache.put(SUBSCRIPTION, SUBSCRIPTION);
+                    cache.put(RECEIPT_ID, RECEIPT_ID);
+                    cache.put(MESSAGE, MESSAGE);
+                    cache.put(CONTENT_LENGTH, CONTENT_LENGTH);
+                    cache.put(CONTENT_TYPE, CONTENT_TYPE);
+
+                    return cache;
+                }
+            };
 
     @Override
     protected void encode(ChannelHandlerContext ctx, StompSubframe msg, List<Object> out) throws Exception {
@@ -89,11 +150,9 @@ public class StompSubframeEncoder extends MessageToMessageEncoder<StompSubframe>
         int estimatedSize = headersSubframe.headers().size() * 34 + 48;
         if (estimatedSize < 128) {
             return 128;
-        } else if (estimatedSize < 256) {
-            return 256;
         }
 
-        return estimatedSize;
+        return Math.max(estimatedSize, 256);
     }
 
     private ByteBuf encodeFullFrame(StompFrame frame, ChannelHandlerContext ctx) {
@@ -109,13 +168,28 @@ public class StompSubframeEncoder extends MessageToMessageEncoder<StompSubframe>
     }
 
     private static void encodeHeaders(StompHeadersSubframe frame, ByteBuf buf) {
-        ByteBufUtil.writeUtf8(buf, frame.command().toString());
+        StompCommand command = frame.command();
+        ByteBufUtil.writeUtf8(buf, command.toString());
         buf.writeByte(StompConstants.LF);
 
+        boolean shouldEscape = shouldEscape(command);
+        LinkedHashMap<CharSequence, CharSequence> cache = ESCAPE_HEADER_KEY_CACHE.get();
         for (Entry<CharSequence, CharSequence> entry : frame.headers()) {
-            ByteBufUtil.writeUtf8(buf, entry.getKey());
+            CharSequence headerKey = entry.getKey();
+            if (shouldEscape) {
+                CharSequence cachedHeaderKey = cache.get(headerKey);
+                if (cachedHeaderKey == null) {
+                    cachedHeaderKey = escape(headerKey);
+                    cache.put(headerKey, cachedHeaderKey);
+                }
+                headerKey = cachedHeaderKey;
+            }
+
+            ByteBufUtil.writeUtf8(buf, headerKey);
             buf.writeByte(StompConstants.COLON);
-            ByteBufUtil.writeUtf8(buf, entry.getValue());
+
+            CharSequence headerValue = shouldEscape? escape(entry.getValue()) : entry.getValue();
+            ByteBufUtil.writeUtf8(buf, headerValue);
             buf.writeByte(StompConstants.LF);
         }
 
@@ -131,5 +205,43 @@ public class StompSubframeEncoder extends MessageToMessageEncoder<StompSubframe>
         }
 
         return content.content().retain();
+    }
+
+    private static boolean shouldEscape(StompCommand command) {
+        return command != StompCommand.CONNECT && command != StompCommand.CONNECTED;
+    }
+
+    private static CharSequence escape(CharSequence input) {
+        AppendableCharSequence builder = null;
+        for (int i = 0; i < input.length(); i++) {
+            char chr = input.charAt(i);
+            if (chr == '\\') {
+                builder = escapeBuilder(builder, input, i);
+                builder.append("\\\\");
+            } else if (chr == ':') {
+                builder = escapeBuilder(builder, input, i);
+                builder.append("\\c");
+            } else if (chr == '\n') {
+                builder = escapeBuilder(builder, input, i);
+                builder.append("\\n");
+            } else if (chr == '\r') {
+                builder = escapeBuilder(builder, input, i);
+                builder.append("\\r");
+            } else if (builder != null) {
+                builder.append(chr);
+            }
+        }
+
+        return builder != null? builder : input;
+    }
+
+    private static AppendableCharSequence escapeBuilder(AppendableCharSequence builder, CharSequence input,
+                                                        int offset) {
+        if (builder != null) {
+            return builder;
+        }
+
+        // Add extra overhead to the input char sequence to avoid resizing during escaping.
+        return new AppendableCharSequence(input.length() + 8).append(input, 0, offset);
     }
 }

--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeDecoderTest.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeDecoderTest.java
@@ -244,4 +244,91 @@ public class StompSubframeDecoderTest {
         assertEquals("unexpected byte in buffer 1 while expecting NULL byte",
                      lastContentFrame.decoderResult().cause().getMessage());
     }
+
+    @Test
+    void testUnescapeHeaders() {
+        channel = new EmbeddedChannel(new StompSubframeDecoder(true));
+
+        ByteBuf incoming = Unpooled.wrappedBuffer(StompTestConstants.ESCAPED_MESSAGE_FRAME.getBytes(UTF_8));
+        assertTrue(channel.writeInbound(incoming));
+
+        StompHeadersSubframe headersSubFrame = channel.readInbound();
+        assertNotNull(headersSubFrame);
+        assertFalse(headersSubFrame.decoderResult().isFailure());
+        assertEquals(6, headersSubFrame.headers().size());
+        assertEquals("/queue/a:", headersSubFrame.headers().get(StompHeaders.DESTINATION));
+        assertEquals("header\\\r\n:Value", headersSubFrame.headers().get("header\\\r\n:Name"));
+        assertEquals("header_\\_\r_\n_:_Value", headersSubFrame.headers().get("header_\\_\r_\n_:_Name"));
+        assertEquals(":headerValue", headersSubFrame.headers().get("headerName:"));
+
+        StompContentSubframe content = channel.readInbound();
+        assertSame(LastStompContentSubframe.EMPTY_LAST_CONTENT, content);
+        content.release();
+
+        Object obj = channel.readInbound();
+        assertNull(obj);
+    }
+
+    @Test
+    void testNotUnescapeHeadersForConnectCommand() {
+        String expectedStompFrame = "CONNECT\n"
+                + "headerName-\\\\:headerValue-\\\\\n"
+                + "\n" + '\0';
+        channel = new EmbeddedChannel(new StompSubframeDecoder(true));
+
+        ByteBuf incoming = Unpooled.wrappedBuffer(expectedStompFrame.getBytes(UTF_8));
+        assertTrue(channel.writeInbound(incoming));
+
+        StompHeadersSubframe headersSubFrame = channel.readInbound();
+        assertNotNull(headersSubFrame);
+        assertFalse(headersSubFrame.decoderResult().isFailure());
+        assertEquals(1, headersSubFrame.headers().size());
+        assertEquals("headerValue-\\\\", headersSubFrame.headers().get("headerName-\\\\"));
+
+        StompContentSubframe content = channel.readInbound();
+        assertSame(LastStompContentSubframe.EMPTY_LAST_CONTENT, content);
+        content.release();
+
+        Object obj = channel.readInbound();
+        assertNull(obj);
+    }
+
+    @Test
+    void testNotUnescapeHeadersForConnectedCommand() {
+        String expectedStompFrame = "CONNECTED\n"
+                + "headerName-\\\\:headerValue-\\\\\n"
+                + "\n" + '\0';
+        channel = new EmbeddedChannel(new StompSubframeDecoder(true));
+
+        ByteBuf incoming = Unpooled.wrappedBuffer(expectedStompFrame.getBytes(UTF_8));
+        assertTrue(channel.writeInbound(incoming));
+
+        StompHeadersSubframe headersSubFrame = channel.readInbound();
+        assertNotNull(headersSubFrame);
+        assertFalse(headersSubFrame.decoderResult().isFailure());
+        assertEquals(1, headersSubFrame.headers().size());
+        assertEquals("headerValue-\\\\", headersSubFrame.headers().get("headerName-\\\\"));
+
+        StompContentSubframe content = channel.readInbound();
+        assertSame(LastStompContentSubframe.EMPTY_LAST_CONTENT, content);
+        content.release();
+
+        Object obj = channel.readInbound();
+        assertNull(obj);
+    }
+
+    @Test
+    void testInvalidEscapeHeadersSequence() {
+        channel = new EmbeddedChannel(new StompSubframeDecoder(true));
+
+        ByteBuf incoming = Unpooled.wrappedBuffer(INVALID_ESCAPED_MESSAGE_FRAME.getBytes(UTF_8));
+        assertTrue(channel.writeInbound(incoming));
+
+        StompHeadersSubframe headersSubFrame = channel.readInbound();
+        assertNotNull(headersSubFrame);
+        assertTrue(headersSubFrame.decoderResult().isFailure());
+
+        assertEquals("received an invalid escape header sequence 'custom_invalid\\t'",
+                     headersSubFrame.decoderResult().cause().getMessage());
+    }
 }

--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompTestConstants.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompTestConstants.java
@@ -84,5 +84,22 @@ public final class StompTestConstants {
              '\n' +
              "body\1";
 
+    public static final String ESCAPED_MESSAGE_FRAME = "MESSAGE\n" +
+             "message-id:100\n" +
+             "subscription:1\n" +
+             "destination:/queue/a\\c\n" +
+             "header\\\\\\r\\n\\cName:header\\\\\\r\\n\\cValue\n" +
+             "header_\\\\_\\r_\\n_\\c_Name:header_\\\\_\\r_\\n_\\c_Value\n" +
+             "headerName\\c:\\cheaderValue\n" +
+             '\n' + '\0';
+
+    public static final String INVALID_ESCAPED_MESSAGE_FRAME = "MESSAGE\n" +
+             "message-id:100\n" +
+             "subscription:0\n" +
+             "destination:/queue/a\n" +
+             "custom_colon\\c_header_\\ckey:custom_colon\\c_header_\\cvalue\n" +
+             "custom_invalid\\t_header_\\tkey:custom_invalid\\t_header_\\tvalue\n" +
+             '\n' + '\0';
+
     private StompTestConstants() { }
 }

--- a/microbench/src/main/java/io/netty/microbench/stomp/ExampleStompHeadersSubframe.java
+++ b/microbench/src/main/java/io/netty/microbench/stomp/ExampleStompHeadersSubframe.java
@@ -59,8 +59,8 @@ public final class ExampleStompHeadersSubframe {
                        .set(StompHeaders.DESTINATION, "/queue/chat")
                        .set(StompHeaders.CONTENT_TYPE, "application/octet-stream")
                        .set(StompHeaders.ACK, UUID.randomUUID().toString())
-                       .setLong("timestamp", System.currentTimeMillis())
-                       .set("Message-Type: 007");
+                       .setLong("_:timestamp:_", System.currentTimeMillis())
+                       .set("Message-Type: 007_:\\\r\n:_");
         EXAMPLES.put(HeadersType.SEVEN, headersSubframe);
 
         headersSubframe = new DefaultStompHeadersSubframe(StompCommand.MESSAGE);
@@ -70,10 +70,10 @@ public final class ExampleStompHeadersSubframe {
                        .set(StompHeaders.DESTINATION, "/queue/chat")
                        .set(StompHeaders.CONTENT_TYPE, "application/octet-stream")
                        .set(StompHeaders.ACK, UUID.randomUUID().toString())
-                       .setLong("timestamp", System.currentTimeMillis())
+                       .setLong("_:timestamp:_", System.currentTimeMillis())
                        .set("Message-Type: 0011")
                        .set("Strict-Transport-Security", "max-age=31536000; includeSubdomains; preload")
-                       .set("Server", "GitHub.com")
+                       .set("\\Server\\", "\\GitHub.com\\")
                        .set("Expires", "Sat, 01 Jan 2000 00:00:00 GMT")
                        .set("Content-Language", "en");
         EXAMPLES.put(HeadersType.ELEVEN, headersSubframe);
@@ -85,17 +85,17 @@ public final class ExampleStompHeadersSubframe {
                        .set(StompHeaders.DESTINATION, "/queue/chat")
                        .set(StompHeaders.CONTENT_TYPE, "application/octet-stream")
                        .set(StompHeaders.ACK, UUID.randomUUID().toString())
-                       .setLong("timestamp", System.currentTimeMillis())
+                       .setLong("_:timestamp:_", System.currentTimeMillis())
                        .set("Message-Type: 0020")
                        .set("date", "Wed, 22 Apr 2015 00:40:28 GMT")
                        .set("expires", "Tue, 31 Mar 1981 05:00:00 GMT")
                        .set("last-modified", "Wed, 22 Apr 2015 00:40:28 GMT")
                        .set("ms", "ms")
-                       .set("pragma", "no-cache")
-                       .set("server", "tsa_b")
-                       .set("set-cookie", "noneofyourbusiness")
+                       .set("\\\\pragma\\\\", "no-cache")
+                       .set("\\Server\\", "\\GitHub.com\\")
+                       .set("set-cookie", "\nnoneofyourbusiness\n")
                        .set("strict-transport-security", "max-age=631138519")
-                       .set("version", "STOMP_v1.2")
+                       .set("\rversion\r", "STOMP_v1.2")
                        .set("x-connection-hash", "e176fe40accc1e2c613a34bc1941aa98")
                        .set("x-content-type-options", "nosniff")
                        .set("x-frame-options", "SAMEORIGIN")


### PR DESCRIPTION
Motivation:

Currently we compatible with STOMP 1.2 but one important thing like escaping has not been implemented, see 
https://stomp.github.io/stomp-specification-1.2.html#Value_Encoding

Modification:

Add escaping to stomp encoder/decoder according specification.

Result:

Fixes #4448 

Stomp codec comply with STOMP 1.2 and in most case backward compatible with 1.1 and 1.0.
