### PR TITLE
Correctly update pendingOutboundBytes() when handler is removed and a…

### DIFF
--- a/transport/src/main/java/io/netty5/channel/DefaultChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty5/channel/DefaultChannelHandlerContext.java
@@ -945,6 +945,7 @@ final class DefaultChannelHandlerContext implements ChannelHandlerContext, Resou
     private Future<Void> invokeSendOutboundEvent(Object event) {
         Future<Void> failed = saveCurrentPendingBytesIfNeededOutbound();
         if (failed != null) {
+            Resource.dispose(event);
             return failed;
         }
 

--- a/transport/src/main/java/io/netty5/channel/DefaultChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty5/channel/DefaultChannelHandlerContext.java
@@ -1279,7 +1279,7 @@ final class DefaultChannelHandlerContext implements ChannelHandlerContext, Resou
     private long pendingOutboundBytes() {
         long pending = handler().pendingOutboundBytes(this);
         if (pending < 0) {
-            pipeline.closeTransport(newPromise());
+            pipeline.forceCloseTransport();
             String message = StringUtil.simpleClassName(handler.getClass()) +
                     ".pendingOutboundBytes(ChannelHandlerContext) returned a negative value: " +
                     pending + ". Force closed transport.";

--- a/transport/src/main/java/io/netty5/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty5/channel/DefaultChannelPipeline.java
@@ -1254,6 +1254,16 @@ public abstract class DefaultChannelPipeline implements ChannelPipeline {
         }
     }
 
+    final void forceCloseTransport() {
+        EventExecutor executor = transportExecutor();
+        Promise<Void> promise = executor.newPromise();
+        if (executor.inEventLoop()) {
+            closeTransport(promise);
+        } else {
+            safeExecute(executor, () -> closeTransport(promise), promise, null);
+        }
+    }
+
     /**
      * Returns the {@link EventExecutor} that is used for all the abstract transport operations.
      *

--- a/transport/src/main/java/io/netty5/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty5/channel/DefaultChannelPipeline.java
@@ -1029,7 +1029,7 @@ public abstract class DefaultChannelPipeline implements ChannelPipeline {
         assert delta > 0;
         long pending = TOTAL_PENDING_OUTBOUND_BYTES_UPDATER.addAndGet(this, delta);
         if (pending < 0) {
-            closeTransport(newPromise());
+            forceCloseTransport();
             throw new IllegalStateException("pendingOutboundBytes overflowed, force closed transport.");
         }
         pendingOutboundBytesUpdated(pending);
@@ -1044,7 +1044,7 @@ public abstract class DefaultChannelPipeline implements ChannelPipeline {
         assert delta > 0;
         long pending = TOTAL_PENDING_OUTBOUND_BYTES_UPDATER.addAndGet(this, -delta);
         if (pending < 0) {
-            closeTransport(newPromise());
+            forceCloseTransport();
             throw new IllegalStateException("pendingOutboundBytes underflowed, force closed transport.");
         }
         pendingOutboundBytesUpdated(pending);


### PR DESCRIPTION
…lso guard against invalid state when updating pendingOutboundBytes()

Motivation:

We didnt update the pendingOutboundBytes() of the pipeline when a handler was removed so we could get out of sync. Also we didnt guard against invalid return values of `ChannelHandler.pendingOutboundBytes(...)` when update which could lead to side-effects.

Beside this we also should not try to call `channelExceptionCaught` when an IllegalStateException was thrown due of `pendingOutboundBytes(...)` as it would just throw another one as well

Modifications:

- Correctly update pending bytes on handler remoal
- Better handling of invalid return values
- Add unit tests

Result:

pendingOutboundBytes() are correctly updated in all cases.