### PR TITLE
Add ChannelPipeline.removeIfExists(...) methods and add some default …

### DIFF
--- a/transport/src/main/java/io/netty5/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty5/channel/DefaultChannelPipeline.java
@@ -421,15 +421,18 @@ public abstract class DefaultChannelPipeline implements ChannelPipeline {
         return (T) ctx.handler();
     }
 
+    @Override
     public final <T extends ChannelHandler> T removeIfExists(String name) {
         return removeIfExists(() -> findCtxIdx(context -> name.equals(context.name())));
     }
 
+    @Override
     public final <T extends ChannelHandler> T removeIfExists(Class<T> handlerType) {
         return removeIfExists(() -> findCtxIdx(
                 context -> handlerType.isAssignableFrom(context.handler().getClass())));
     }
 
+    @Override
     public final <T extends ChannelHandler> T removeIfExists(ChannelHandler handler) {
         return removeIfExists(() -> findCtxIdx(context -> handler == context.handler()));
     }

--- a/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTest.java
+++ b/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTest.java
@@ -220,7 +220,7 @@ public class DefaultChannelPipelineTest {
 
     @Test
     public void testRemoveIfExists() {
-        DefaultChannelPipeline pipeline = (DefaultChannelPipeline) newLocalChannel().pipeline();
+        ChannelPipeline pipeline = newLocalChannel().pipeline();
 
         ChannelHandler handler1 = newHandler();
         ChannelHandler handler2 = newHandler();
@@ -242,7 +242,7 @@ public class DefaultChannelPipelineTest {
 
     @Test
     public void testRemoveIfExistsDoesNotThrowException() {
-        DefaultChannelPipeline pipeline = (DefaultChannelPipeline) newLocalChannel().pipeline();
+        ChannelPipeline pipeline = newLocalChannel().pipeline();
 
         ChannelHandler handler1 = newHandler();
         ChannelHandler handler2 = newHandler();
@@ -259,7 +259,7 @@ public class DefaultChannelPipelineTest {
 
     @Test
     public void testRemoveThrowNoSuchElementException() {
-        DefaultChannelPipeline pipeline = (DefaultChannelPipeline) newLocalChannel().pipeline();
+        ChannelPipeline pipeline = newLocalChannel().pipeline();
 
         ChannelHandler handler1 = newHandler();
         pipeline.addLast("handler1", handler1);


### PR DESCRIPTION
…implementations

Motivation:

We added some extra methods to DefaultChannelPipeline in 4.1 but as we couldnt break APIs we didnt add these to the interface itself. We should do so now.

Modifications:

- Add methods to interface
- Add a few default implementations so its less work to write a custom ChannelPipeline

Result:

Enhance API