### PR TITLE
Remove deprecated watermark methods from ChannelConfig and sub-classes

### DIFF
--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/DefaultHttp2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/DefaultHttp2RemoteFlowController.java
@@ -242,7 +242,7 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
         // an "adequate" amount of connection window before allocation is attempted. This is not foolproof as if the
         // number of streams is >= this minimal number then we may still have the issue, but the idea is to narrow the
         // circumstances in which this can happen without rewriting the allocation algorithm.
-        return max(ctx.channel().config().getWriteBufferLowWaterMark(), MIN_WRITABLE_CHUNK);
+        return max(ctx.channel().config().getWriteBufferWaterMark().low(), MIN_WRITABLE_CHUNK);
     }
 
     private int maxUsableChannelBytes() {

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/DefaultHttp2StreamChannel.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/DefaultHttp2StreamChannel.java
@@ -190,7 +190,7 @@ final class DefaultHttp2StreamChannel extends DefaultAttributeMap implements Htt
         }
 
         long newWriteBufferSize = TOTAL_PENDING_SIZE_UPDATER.addAndGet(this, size);
-        if (newWriteBufferSize > config().getWriteBufferHighWaterMark()) {
+        if (newWriteBufferSize > config().getWriteBufferWaterMark().high()) {
             setUnwritable(invokeLater);
         }
     }
@@ -206,7 +206,7 @@ final class DefaultHttp2StreamChannel extends DefaultAttributeMap implements Htt
         // prevent excessive buffering in the parent outbound buffer. If the parent is not writable
         // we will mark the child channel as writable once the parent becomes writable by calling
         // trySetWritable() later.
-        if (newWriteBufferSize < config().getWriteBufferLowWaterMark() && parent().isWritable()) {
+        if (newWriteBufferSize < config().getWriteBufferWaterMark().low() && parent().isWritable()) {
             setWritable(invokeLater);
         }
     }
@@ -216,7 +216,7 @@ final class DefaultHttp2StreamChannel extends DefaultAttributeMap implements Htt
         // Lets try to set the child channel writable to match the state of the parent channel
         // if (and only if) the totalPendingSize is smaller then the low water-mark.
         // If this is not the case we will try again later once we drop under it.
-        if (totalPendingSize < config().getWriteBufferLowWaterMark()) {
+        if (totalPendingSize < config().getWriteBufferWaterMark().low()) {
             setWritable(false);
         }
     }
@@ -347,7 +347,7 @@ final class DefaultHttp2StreamChannel extends DefaultAttributeMap implements Htt
 
     @Override
     public long writableBytes() {
-        long bytes = config().getWriteBufferHighWaterMark() - totalPendingSize - pipeline.pendingOutboundBytes();
+        long bytes = config().getWriteBufferWaterMark().high() - totalPendingSize - pipeline.pendingOutboundBytes();
         // If bytes is negative we know we are not writable.
         if (bytes > 0) {
             return unwritable == 0 ? bytes : 0;

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/DefaultHttp2RemoteFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/DefaultHttp2RemoteFlowControllerTest.java
@@ -18,6 +18,7 @@ package io.netty5.handler.codec.http2;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelConfig;
 import io.netty5.channel.ChannelHandlerContext;
+import io.netty5.channel.WriteBufferWaterMark;
 import io.netty5.util.concurrent.EventExecutor;
 import io.netty5.util.concurrent.Promise;
 import org.junit.jupiter.api.BeforeEach;
@@ -93,6 +94,7 @@ public abstract class DefaultHttp2RemoteFlowControllerTest {
         when(ctx.<Void>newPromise()).thenReturn(promise);
         when(ctx.flush()).thenThrow(new AssertionFailedError("forbidden"));
         setChannelWritability(true);
+        when(config.getWriteBufferWaterMark()).thenReturn(new WriteBufferWaterMark(0, 0));
         when(channel.config()).thenReturn(config);
         when(executor.inEventLoop()).thenReturn(true);
 

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ControlFrameLimitEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ControlFrameLimitEncoderTest.java
@@ -16,6 +16,7 @@
 package io.netty5.handler.codec.http2;
 
 import io.netty5.buffer.api.Buffer;
+import io.netty5.channel.WriteBufferWaterMark;
 import io.netty5.util.Resource;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelConfig;
@@ -143,7 +144,7 @@ public class Http2ControlFrameLimitEncoderTest {
         when(channel.config()).thenReturn(config);
         when(channel.writableBytes()).thenReturn(Long.MAX_VALUE);
         when(channel.isWritable()).thenReturn(true);
-        when(config.getWriteBufferHighWaterMark()).thenReturn(Integer.MAX_VALUE);
+        when(config.getWriteBufferWaterMark()).thenReturn(new WriteBufferWaterMark(1024, Integer.MAX_VALUE));
         when(config.getMessageSizeEstimator()).thenReturn(DefaultMessageSizeEstimator.DEFAULT);
         ChannelMetadata metadata = new ChannelMetadata(false, 16);
         when(channel.metadata()).thenReturn(metadata);

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexTest.java
@@ -870,7 +870,7 @@ public class Http2MultiplexTest {
         parentChannel.flush();
 
         // Test for initial window size
-        assertTrue(initialRemoteStreamWindow < childChannel.config().getWriteBufferHighWaterMark());
+        assertTrue(initialRemoteStreamWindow < childChannel.config().getWriteBufferWaterMark().high());
 
         assertTrue(childChannel.isWritable());
         int size = 16 * 1024 * 1024;

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/StreamBufferingEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/StreamBufferingEncoderTest.java
@@ -20,6 +20,7 @@ import io.netty5.channel.ChannelConfig;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelMetadata;
 import io.netty5.channel.DefaultMessageSizeEstimator;
+import io.netty5.channel.WriteBufferWaterMark;
 import io.netty5.handler.codec.http2.StreamBufferingEncoder.Http2GoAwayException;
 import io.netty5.util.concurrent.EventExecutor;
 import io.netty5.util.concurrent.Future;
@@ -147,7 +148,7 @@ public class StreamBufferingEncoderTest {
         when(channel.config()).thenReturn(config);
         when(channel.isWritable()).thenReturn(true);
         when(channel.writableBytes()).thenReturn(Long.MAX_VALUE);
-        when(config.getWriteBufferHighWaterMark()).thenReturn(Integer.MAX_VALUE);
+        when(config.getWriteBufferWaterMark()).thenReturn(new WriteBufferWaterMark(1024, Integer.MAX_VALUE));
         when(config.getMessageSizeEstimator()).thenReturn(DefaultMessageSizeEstimator.DEFAULT);
         ChannelMetadata metadata = new ChannelMetadata(false, 16);
         when(channel.metadata()).thenReturn(metadata);

--- a/handler/src/test/java/io/netty5/handler/logging/LoggingHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/logging/LoggingHandlerTest.java
@@ -21,6 +21,7 @@ import ch.qos.logback.core.Appender;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelMetadata;
+import io.netty5.channel.WriteBufferWaterMark;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.util.CharsetUtil;
 import org.junit.jupiter.api.AfterAll;
@@ -126,8 +127,7 @@ public class LoggingHandlerTest {
     public void shouldLogChannelWritabilityChanged() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new LoggingHandler());
         // this is used to switch the channel to become unwritable
-        channel.config().setWriteBufferLowWaterMark(5);
-        channel.config().setWriteBufferHighWaterMark(10);
+        channel.config().setWriteBufferWaterMark(new WriteBufferWaterMark(5, 10));
         channel.write("hello");
 
         // This is expected to be called 3 times:

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollChannelConfig.java
@@ -16,7 +16,6 @@
 package io.netty5.channel.epoll;
 
 import io.netty5.buffer.api.BufferAllocator;
-import io.netty5.channel.ChannelConfig;
 import io.netty5.channel.ChannelException;
 import io.netty5.channel.ChannelOption;
 import io.netty5.channel.DefaultChannelConfig;
@@ -116,20 +115,6 @@ public class EpollChannelConfig extends DefaultChannelConfig {
     @Override
     public EpollChannelConfig setAutoRead(boolean autoRead) {
         super.setAutoRead(autoRead);
-        return this;
-    }
-
-    @Override
-    @Deprecated
-    public EpollChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
-        super.setWriteBufferHighWaterMark(writeBufferHighWaterMark);
-        return this;
-    }
-
-    @Override
-    @Deprecated
-    public EpollChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
-        super.setWriteBufferLowWaterMark(writeBufferLowWaterMark);
         return this;
     }
 

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDatagramChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDatagramChannelConfig.java
@@ -172,20 +172,6 @@ public final class EpollDatagramChannelConfig extends EpollChannelConfig impleme
     }
 
     @Override
-    @Deprecated
-    public EpollDatagramChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
-        super.setWriteBufferLowWaterMark(writeBufferLowWaterMark);
-        return this;
-    }
-
-    @Override
-    @Deprecated
-    public EpollDatagramChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
-        super.setWriteBufferHighWaterMark(writeBufferHighWaterMark);
-        return this;
-    }
-
-    @Override
     public EpollDatagramChannelConfig setWriteBufferWaterMark(WriteBufferWaterMark writeBufferWaterMark) {
         super.setWriteBufferWaterMark(writeBufferWaterMark);
         return this;

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDomainDatagramChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDomainDatagramChannelConfig.java
@@ -171,18 +171,6 @@ public final class EpollDomainDatagramChannelConfig extends EpollChannelConfig i
     }
 
     @Override
-    public EpollDomainDatagramChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
-        super.setWriteBufferHighWaterMark(writeBufferHighWaterMark);
-        return this;
-    }
-
-    @Override
-    public EpollDomainDatagramChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
-        super.setWriteBufferLowWaterMark(writeBufferLowWaterMark);
-        return this;
-    }
-
-    @Override
     public EpollDomainDatagramChannelConfig setAllowHalfClosure(boolean allowHalfClosure) {
         super.setAllowHalfClosure(allowHalfClosure);
         return this;

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDomainSocketChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDomainSocketChannelConfig.java
@@ -125,20 +125,6 @@ public final class EpollDomainSocketChannelConfig extends EpollChannelConfig
     }
 
     @Override
-    @Deprecated
-    public EpollDomainSocketChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
-        super.setWriteBufferLowWaterMark(writeBufferLowWaterMark);
-        return this;
-    }
-
-    @Override
-    @Deprecated
-    public EpollDomainSocketChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
-        super.setWriteBufferHighWaterMark(writeBufferHighWaterMark);
-        return this;
-    }
-
-    @Override
     public EpollDomainSocketChannelConfig setWriteBufferWaterMark(WriteBufferWaterMark writeBufferWaterMark) {
         super.setWriteBufferWaterMark(writeBufferWaterMark);
         return this;

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollServerChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollServerChannelConfig.java
@@ -201,20 +201,6 @@ public class EpollServerChannelConfig extends EpollChannelConfig implements Serv
     }
 
     @Override
-    @Deprecated
-    public EpollServerChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
-        super.setWriteBufferHighWaterMark(writeBufferHighWaterMark);
-        return this;
-    }
-
-    @Override
-    @Deprecated
-    public EpollServerChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
-        super.setWriteBufferLowWaterMark(writeBufferLowWaterMark);
-        return this;
-    }
-
-    @Override
     public EpollServerChannelConfig setWriteBufferWaterMark(WriteBufferWaterMark writeBufferWaterMark) {
         super.setWriteBufferWaterMark(writeBufferWaterMark);
         return this;

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollServerSocketChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollServerSocketChannelConfig.java
@@ -147,20 +147,6 @@ public final class EpollServerSocketChannelConfig extends EpollServerChannelConf
     }
 
     @Override
-    @Deprecated
-    public EpollServerSocketChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
-        super.setWriteBufferHighWaterMark(writeBufferHighWaterMark);
-        return this;
-    }
-
-    @Override
-    @Deprecated
-    public EpollServerSocketChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
-        super.setWriteBufferLowWaterMark(writeBufferLowWaterMark);
-        return this;
-    }
-
-    @Override
     public EpollServerSocketChannelConfig setWriteBufferWaterMark(WriteBufferWaterMark writeBufferWaterMark) {
         super.setWriteBufferWaterMark(writeBufferWaterMark);
         return this;

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollSocketChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollSocketChannelConfig.java
@@ -612,20 +612,6 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
     }
 
     @Override
-    @Deprecated
-    public EpollSocketChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
-        super.setWriteBufferHighWaterMark(writeBufferHighWaterMark);
-        return this;
-    }
-
-    @Override
-    @Deprecated
-    public EpollSocketChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
-        super.setWriteBufferLowWaterMark(writeBufferLowWaterMark);
-        return this;
-    }
-
-    @Override
     public EpollSocketChannelConfig setWriteBufferWaterMark(WriteBufferWaterMark writeBufferWaterMark) {
         super.setWriteBufferWaterMark(writeBufferWaterMark);
         return this;

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueChannelConfig.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueChannelConfig.java
@@ -159,20 +159,6 @@ public class KQueueChannelConfig extends DefaultChannelConfig {
     }
 
     @Override
-    @Deprecated
-    public KQueueChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
-        super.setWriteBufferHighWaterMark(writeBufferHighWaterMark);
-        return this;
-    }
-
-    @Override
-    @Deprecated
-    public KQueueChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
-        super.setWriteBufferLowWaterMark(writeBufferLowWaterMark);
-        return this;
-    }
-
-    @Override
     public KQueueChannelConfig setWriteBufferWaterMark(WriteBufferWaterMark writeBufferWaterMark) {
         super.setWriteBufferWaterMark(writeBufferWaterMark);
         return this;

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDatagramChannelConfig.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDatagramChannelConfig.java
@@ -186,20 +186,6 @@ public final class KQueueDatagramChannelConfig extends KQueueChannelConfig imple
     }
 
     @Override
-    @Deprecated
-    public KQueueDatagramChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
-        super.setWriteBufferLowWaterMark(writeBufferLowWaterMark);
-        return this;
-    }
-
-    @Override
-    @Deprecated
-    public KQueueDatagramChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
-        super.setWriteBufferHighWaterMark(writeBufferHighWaterMark);
-        return this;
-    }
-
-    @Override
     public KQueueDatagramChannelConfig setWriteBufferWaterMark(WriteBufferWaterMark writeBufferWaterMark) {
         super.setWriteBufferWaterMark(writeBufferWaterMark);
         return this;

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDomainSocketChannelConfig.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDomainSocketChannelConfig.java
@@ -128,20 +128,6 @@ public final class KQueueDomainSocketChannelConfig extends KQueueChannelConfig
     }
 
     @Override
-    @Deprecated
-    public KQueueDomainSocketChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
-        super.setWriteBufferLowWaterMark(writeBufferLowWaterMark);
-        return this;
-    }
-
-    @Override
-    @Deprecated
-    public KQueueDomainSocketChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
-        super.setWriteBufferHighWaterMark(writeBufferHighWaterMark);
-        return this;
-    }
-
-    @Override
     public KQueueDomainSocketChannelConfig setWriteBufferWaterMark(WriteBufferWaterMark writeBufferWaterMark) {
         super.setWriteBufferWaterMark(writeBufferWaterMark);
         return this;

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueServerChannelConfig.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueServerChannelConfig.java
@@ -207,20 +207,6 @@ public class KQueueServerChannelConfig extends KQueueChannelConfig implements Se
     }
 
     @Override
-    @Deprecated
-    public KQueueServerChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
-        super.setWriteBufferHighWaterMark(writeBufferHighWaterMark);
-        return this;
-    }
-
-    @Override
-    @Deprecated
-    public KQueueServerChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
-        super.setWriteBufferLowWaterMark(writeBufferLowWaterMark);
-        return this;
-    }
-
-    @Override
     public KQueueServerChannelConfig setWriteBufferWaterMark(WriteBufferWaterMark writeBufferWaterMark) {
         super.setWriteBufferWaterMark(writeBufferWaterMark);
         return this;

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueServerSocketChannelConfig.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueServerSocketChannelConfig.java
@@ -179,20 +179,6 @@ public class KQueueServerSocketChannelConfig extends KQueueServerChannelConfig {
     }
 
     @Override
-    @Deprecated
-    public KQueueServerSocketChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
-        super.setWriteBufferHighWaterMark(writeBufferHighWaterMark);
-        return this;
-    }
-
-    @Override
-    @Deprecated
-    public KQueueServerSocketChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
-        super.setWriteBufferLowWaterMark(writeBufferLowWaterMark);
-        return this;
-    }
-
-    @Override
     public KQueueServerSocketChannelConfig setWriteBufferWaterMark(WriteBufferWaterMark writeBufferWaterMark) {
         super.setWriteBufferWaterMark(writeBufferWaterMark);
         return this;

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueSocketChannelConfig.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueSocketChannelConfig.java
@@ -368,20 +368,6 @@ public final class KQueueSocketChannelConfig extends KQueueChannelConfig impleme
     }
 
     @Override
-    @Deprecated
-    public KQueueSocketChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
-        super.setWriteBufferHighWaterMark(writeBufferHighWaterMark);
-        return this;
-    }
-
-    @Override
-    @Deprecated
-    public KQueueSocketChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
-        super.setWriteBufferLowWaterMark(writeBufferLowWaterMark);
-        return this;
-    }
-
-    @Override
     public KQueueSocketChannelConfig setWriteBufferWaterMark(WriteBufferWaterMark writeBufferWaterMark) {
         super.setWriteBufferWaterMark(writeBufferWaterMark);
         return this;

--- a/transport-native-unix-common/src/main/java/io/netty5/channel/unix/DomainSocketChannelConfig.java
+++ b/transport-native-unix-common/src/main/java/io/netty5/channel/unix/DomainSocketChannelConfig.java
@@ -47,14 +47,6 @@ public interface DomainSocketChannelConfig extends ChannelConfig {
     DomainSocketChannelConfig setAutoClose(boolean autoClose);
 
     @Override
-    @Deprecated
-    DomainSocketChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark);
-
-    @Override
-    @Deprecated
-    DomainSocketChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark);
-
-    @Override
     DomainSocketChannelConfig setWriteBufferWaterMark(WriteBufferWaterMark writeBufferWaterMark);
 
     @Override

--- a/transport/src/main/java/io/netty5/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty5/channel/AbstractChannel.java
@@ -212,7 +212,7 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
             return 0;
         }
 
-        long bytes = config().getWriteBufferHighWaterMark() -
+        long bytes = config().getWriteBufferWaterMark().high() -
                 totalPending;
         // If bytes is negative we know we are not writable.
         if (bytes > 0) {
@@ -458,11 +458,11 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
 
     private void updateWritabilityIfNeeded(boolean notify, boolean notifyLater) {
         long totalPending = totalPending();
-        if (totalPending > config().getWriteBufferHighWaterMark()) {
+        if (totalPending >  config().getWriteBufferWaterMark().high()) {
             if (WRITABLE_UPDATER.compareAndSet(this, 1, 0)) {
                 fireChannelWritabilityChangedIfNeeded(notify, notifyLater);
             }
-        } else if (totalPending < config().getWriteBufferLowWaterMark()) {
+        } else if (totalPending <  config().getWriteBufferWaterMark().low()) {
             if (WRITABLE_UPDATER.compareAndSet(this, 0, 1)) {
                 fireChannelWritabilityChangedIfNeeded(notify, notifyLater);
             }

--- a/transport/src/main/java/io/netty5/channel/ChannelConfig.java
+++ b/transport/src/main/java/io/netty5/channel/ChannelConfig.java
@@ -213,40 +213,6 @@ public interface ChannelConfig {
     ChannelConfig setAutoClose(boolean autoClose);
 
     /**
-     * Returns the high water mark of the write buffer.  If the number of bytes
-     * queued in the write buffer exceeds this value, {@link Channel#writableBytes()}
-     * will start to return {@code 0}.
-     */
-    int getWriteBufferHighWaterMark();
-
-    /**
-     * <p>
-     * Sets the high water mark of the write buffer.  If the number of bytes
-     * queued in the write buffer exceeds this value, {@link Channel#writableBytes()}
-     * will start to return {@code 0}.
-     */
-    ChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark);
-
-    /**
-     * Returns the low water mark of the write buffer.  Once the number of bytes
-     * queued in the write buffer exceeded the
-     * {@linkplain #setWriteBufferHighWaterMark(int) high water mark} and then
-     * dropped down below this value, {@link Channel#writableBytes()} ()} will start to return
-     * a positive value again.
-     */
-    int getWriteBufferLowWaterMark();
-
-    /**
-     * <p>
-     * Sets the low water mark of the write buffer.  Once the number of bytes
-     * queued in the write buffer exceeded the
-     * {@linkplain #setWriteBufferHighWaterMark(int) high water mark} and then
-     * dropped down below this value, {@link Channel#writableBytes()} ()} will start to return
-     * a positive value again.
-     */
-    ChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark);
-
-    /**
      * Returns {@link MessageSizeEstimator} which is used for the channel
      * to detect the size of a message.
      */

--- a/transport/src/main/java/io/netty5/channel/ChannelOption.java
+++ b/transport/src/main/java/io/netty5/channel/ChannelOption.java
@@ -90,16 +90,7 @@ public class ChannelOption<T> extends AbstractConstant<ChannelOption<T>> {
     public static final ChannelOption<Integer> MAX_MESSAGES_PER_WRITE = valueOf("MAX_MESSAGES_PER_WRITE");
 
     public static final ChannelOption<Integer> WRITE_SPIN_COUNT = valueOf("WRITE_SPIN_COUNT");
-    /**
-     * @deprecated Use {@link #WRITE_BUFFER_WATER_MARK}
-     */
-    @Deprecated
-    public static final ChannelOption<Integer> WRITE_BUFFER_HIGH_WATER_MARK = valueOf("WRITE_BUFFER_HIGH_WATER_MARK");
-    /**
-     * @deprecated Use {@link #WRITE_BUFFER_WATER_MARK}
-     */
-    @Deprecated
-    public static final ChannelOption<Integer> WRITE_BUFFER_LOW_WATER_MARK = valueOf("WRITE_BUFFER_LOW_WATER_MARK");
+
     public static final ChannelOption<WriteBufferWaterMark> WRITE_BUFFER_WATER_MARK =
             valueOf("WRITE_BUFFER_WATER_MARK");
 

--- a/transport/src/main/java/io/netty5/channel/DefaultChannelConfig.java
+++ b/transport/src/main/java/io/netty5/channel/DefaultChannelConfig.java
@@ -33,8 +33,6 @@ import static io.netty5.channel.ChannelOption.MAX_MESSAGES_PER_READ;
 import static io.netty5.channel.ChannelOption.MAX_MESSAGES_PER_WRITE;
 import static io.netty5.channel.ChannelOption.MESSAGE_SIZE_ESTIMATOR;
 import static io.netty5.channel.ChannelOption.RCVBUF_ALLOCATOR;
-import static io.netty5.channel.ChannelOption.WRITE_BUFFER_HIGH_WATER_MARK;
-import static io.netty5.channel.ChannelOption.WRITE_BUFFER_LOW_WATER_MARK;
 import static io.netty5.channel.ChannelOption.WRITE_BUFFER_WATER_MARK;
 import static io.netty5.channel.ChannelOption.WRITE_SPIN_COUNT;
 import static io.netty5.util.internal.ObjectUtil.checkPositive;
@@ -86,8 +84,7 @@ public class DefaultChannelConfig implements ChannelConfig {
         return getOptions(
                 null,
                 CONNECT_TIMEOUT_MILLIS, MAX_MESSAGES_PER_READ, WRITE_SPIN_COUNT,
-                BUFFER_ALLOCATOR, AUTO_READ, AUTO_CLOSE, RCVBUF_ALLOCATOR,
-                WRITE_BUFFER_HIGH_WATER_MARK, WRITE_BUFFER_LOW_WATER_MARK, WRITE_BUFFER_WATER_MARK,
+                BUFFER_ALLOCATOR, AUTO_READ, AUTO_CLOSE, RCVBUF_ALLOCATOR, WRITE_BUFFER_WATER_MARK,
                 MESSAGE_SIZE_ESTIMATOR, MAX_MESSAGES_PER_WRITE, ALLOW_HALF_CLOSURE);
     }
 
@@ -143,12 +140,6 @@ public class DefaultChannelConfig implements ChannelConfig {
         if (option == AUTO_CLOSE) {
             return (T) Boolean.valueOf(isAutoClose());
         }
-        if (option == WRITE_BUFFER_HIGH_WATER_MARK) {
-            return (T) Integer.valueOf(getWriteBufferHighWaterMark());
-        }
-        if (option == WRITE_BUFFER_LOW_WATER_MARK) {
-            return (T) Integer.valueOf(getWriteBufferLowWaterMark());
-        }
         if (option == WRITE_BUFFER_WATER_MARK) {
             return (T) getWriteBufferWaterMark();
         }
@@ -184,10 +175,6 @@ public class DefaultChannelConfig implements ChannelConfig {
             setAutoRead((Boolean) value);
         } else if (option == AUTO_CLOSE) {
             setAutoClose((Boolean) value);
-        } else if (option == WRITE_BUFFER_HIGH_WATER_MARK) {
-            setWriteBufferHighWaterMark((Integer) value);
-        } else if (option == WRITE_BUFFER_LOW_WATER_MARK) {
-            setWriteBufferLowWaterMark((Integer) value);
         } else if (option == WRITE_BUFFER_WATER_MARK) {
             setWriteBufferWaterMark((WriteBufferWaterMark) value);
         } else if (option == MESSAGE_SIZE_ESTIMATOR) {
@@ -363,52 +350,6 @@ public class DefaultChannelConfig implements ChannelConfig {
     public ChannelConfig setAutoClose(boolean autoClose) {
         this.autoClose = autoClose;
         return this;
-    }
-
-    @Override
-    public int getWriteBufferHighWaterMark() {
-        return writeBufferWaterMark.high();
-    }
-
-    @Override
-    public ChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
-        checkPositiveOrZero(writeBufferHighWaterMark, "writeBufferHighWaterMark");
-        for (;;) {
-            WriteBufferWaterMark waterMark = writeBufferWaterMark;
-            if (writeBufferHighWaterMark < waterMark.low()) {
-                throw new IllegalArgumentException(
-                        "writeBufferHighWaterMark cannot be less than " +
-                                "writeBufferLowWaterMark (" + waterMark.low() + "): " +
-                                writeBufferHighWaterMark);
-            }
-            if (WATERMARK_UPDATER.compareAndSet(this, waterMark,
-                    new WriteBufferWaterMark(waterMark.low(), writeBufferHighWaterMark, false))) {
-                return this;
-            }
-        }
-    }
-
-    @Override
-    public int getWriteBufferLowWaterMark() {
-        return writeBufferWaterMark.low();
-    }
-
-    @Override
-    public ChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
-        checkPositiveOrZero(writeBufferLowWaterMark, "writeBufferLowWaterMark");
-        for (;;) {
-            WriteBufferWaterMark waterMark = writeBufferWaterMark;
-            if (writeBufferLowWaterMark > waterMark.high()) {
-                throw new IllegalArgumentException(
-                        "writeBufferLowWaterMark cannot be greater than " +
-                                "writeBufferHighWaterMark (" + waterMark.high() + "): " +
-                                writeBufferLowWaterMark);
-            }
-            if (WATERMARK_UPDATER.compareAndSet(this, waterMark,
-                    new WriteBufferWaterMark(writeBufferLowWaterMark, waterMark.high(), false))) {
-                return this;
-            }
-        }
     }
 
     @Override

--- a/transport/src/main/java/io/netty5/channel/socket/DatagramChannelConfig.java
+++ b/transport/src/main/java/io/netty5/channel/socket/DatagramChannelConfig.java
@@ -186,12 +186,6 @@ public interface DatagramChannelConfig extends ChannelConfig {
     DatagramChannelConfig setBufferAllocator(BufferAllocator allocator);
 
     @Override
-    DatagramChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark);
-
-    @Override
-    DatagramChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark);
-
-    @Override
     DatagramChannelConfig setAllowHalfClosure(boolean allowHalfClosure);
 
     @Override

--- a/transport/src/main/java/io/netty5/channel/socket/DefaultDatagramChannelConfig.java
+++ b/transport/src/main/java/io/netty5/channel/socket/DefaultDatagramChannelConfig.java
@@ -414,18 +414,6 @@ public class DefaultDatagramChannelConfig extends DefaultChannelConfig implement
     }
 
     @Override
-    public DatagramChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
-        super.setWriteBufferHighWaterMark(writeBufferHighWaterMark);
-        return this;
-    }
-
-    @Override
-    public DatagramChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
-        super.setWriteBufferLowWaterMark(writeBufferLowWaterMark);
-        return this;
-    }
-
-    @Override
     public DatagramChannelConfig setWriteBufferWaterMark(WriteBufferWaterMark writeBufferWaterMark) {
         super.setWriteBufferWaterMark(writeBufferWaterMark);
         return this;

--- a/transport/src/main/java/io/netty5/channel/socket/DefaultServerSocketChannelConfig.java
+++ b/transport/src/main/java/io/netty5/channel/socket/DefaultServerSocketChannelConfig.java
@@ -184,18 +184,6 @@ public class DefaultServerSocketChannelConfig extends DefaultChannelConfig
     }
 
     @Override
-    public ServerSocketChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
-        super.setWriteBufferHighWaterMark(writeBufferHighWaterMark);
-        return this;
-    }
-
-    @Override
-    public ServerSocketChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
-        super.setWriteBufferLowWaterMark(writeBufferLowWaterMark);
-        return this;
-    }
-
-    @Override
     public ServerSocketChannelConfig setWriteBufferWaterMark(WriteBufferWaterMark writeBufferWaterMark) {
         super.setWriteBufferWaterMark(writeBufferWaterMark);
         return this;

--- a/transport/src/main/java/io/netty5/channel/socket/DefaultSocketChannelConfig.java
+++ b/transport/src/main/java/io/netty5/channel/socket/DefaultSocketChannelConfig.java
@@ -331,18 +331,6 @@ public class DefaultSocketChannelConfig extends DefaultChannelConfig
     }
 
     @Override
-    public SocketChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
-        super.setWriteBufferHighWaterMark(writeBufferHighWaterMark);
-        return this;
-    }
-
-    @Override
-    public SocketChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
-        super.setWriteBufferLowWaterMark(writeBufferLowWaterMark);
-        return this;
-    }
-
-    @Override
     public SocketChannelConfig setWriteBufferWaterMark(WriteBufferWaterMark writeBufferWaterMark) {
         super.setWriteBufferWaterMark(writeBufferWaterMark);
         return this;

--- a/transport/src/main/java/io/netty5/channel/socket/ServerSocketChannelConfig.java
+++ b/transport/src/main/java/io/netty5/channel/socket/ServerSocketChannelConfig.java
@@ -104,12 +104,6 @@ public interface ServerSocketChannelConfig extends ChannelConfig {
     ServerSocketChannelConfig setMessageSizeEstimator(MessageSizeEstimator estimator);
 
     @Override
-    ServerSocketChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark);
-
-    @Override
-    ServerSocketChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark);
-
-    @Override
     ServerSocketChannelConfig setWriteBufferWaterMark(WriteBufferWaterMark writeBufferWaterMark);
 
 }

--- a/transport/src/main/java/io/netty5/channel/socket/SocketChannelConfig.java
+++ b/transport/src/main/java/io/netty5/channel/socket/SocketChannelConfig.java
@@ -171,11 +171,5 @@ public interface SocketChannelConfig extends ChannelConfig {
     SocketChannelConfig setBufferAllocator(BufferAllocator allocator);
 
     @Override
-    SocketChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark);
-
-    @Override
-    SocketChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark);
-
-    @Override
     SocketChannelConfig setMaxMessagesPerWrite(int maxMessagesPerWrite);
 }

--- a/transport/src/test/java/io/netty5/bootstrap/BootstrapTest.java
+++ b/transport/src/test/java/io/netty5/bootstrap/BootstrapTest.java
@@ -384,16 +384,16 @@ public class BootstrapTest {
                         };
                     }
                 })
-                .option(ChannelOption.WRITE_BUFFER_LOW_WATER_MARK, 1)
-                .option(ChannelOption.WRITE_BUFFER_HIGH_WATER_MARK, 2);
+                .option(ChannelOption.MAX_MESSAGES_PER_WRITE, 1)
+                .option(ChannelOption.WRITE_SPIN_COUNT, 2);
 
         bootstrap.register().asStage().sync();
 
         latch.await();
 
         // Check the order is the same as what we defined before.
-        assertSame(ChannelOption.WRITE_BUFFER_LOW_WATER_MARK, options.take());
-        assertSame(ChannelOption.WRITE_BUFFER_HIGH_WATER_MARK, options.take());
+        assertSame(ChannelOption.MAX_MESSAGES_PER_WRITE, options.take());
+        assertSame(ChannelOption.WRITE_SPIN_COUNT, options.take());
     }
 
     private static final class LateRegisterHandler implements ChannelHandler {

--- a/transport/src/test/java/io/netty5/channel/PendingWriteQueueTest.java
+++ b/transport/src/test/java/io/netty5/channel/PendingWriteQueueTest.java
@@ -88,8 +88,7 @@ public class PendingWriteQueueTest {
     private static void assertWrite(ChannelHandler handler, int count) throws Exception {
         try (Buffer buffer = preferredAllocator().copyOf("Test", CharsetUtil.US_ASCII)) {
             final EmbeddedChannel channel = new EmbeddedChannel(handler);
-            channel.config().setWriteBufferLowWaterMark(1);
-            channel.config().setWriteBufferHighWaterMark(3);
+            channel.config().setWriteBufferWaterMark(new WriteBufferWaterMark(1, 3));
 
             Buffer[] buffers = new Buffer[count];
             for (int i = 0; i < buffers.length; i++) {

--- a/transport/src/test/java/io/netty5/channel/ReentrantChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/ReentrantChannelTest.java
@@ -44,8 +44,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
         setInterest(Event.WRITE, Event.FLUSH, Event.WRITABILITY);
 
         Channel clientChannel = cb.connect(addr).asStage().get();
-        clientChannel.config().setWriteBufferLowWaterMark(512);
-        clientChannel.config().setWriteBufferHighWaterMark(1024);
+        clientChannel.config().setWriteBufferWaterMark(new WriteBufferWaterMark(512, 1024));
 
         // What is supposed to happen from this point:
         //
@@ -111,8 +110,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
         setInterest(Event.WRITE, Event.FLUSH, Event.WRITABILITY);
 
         Channel clientChannel = cb.connect(addr).asStage().get();
-        clientChannel.config().setWriteBufferLowWaterMark(512);
-        clientChannel.config().setWriteBufferHighWaterMark(1024);
+        clientChannel.config().setWriteBufferWaterMark(new WriteBufferWaterMark(512, 1024));
 
         // What is supposed to happen from this point:
         //
@@ -180,8 +178,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
         setInterest(Event.WRITE, Event.FLUSH, Event.WRITABILITY);
 
         Channel clientChannel = cb.connect(addr).asStage().get();
-        clientChannel.config().setWriteBufferLowWaterMark(512);
-        clientChannel.config().setWriteBufferHighWaterMark(1024);
+        clientChannel.config().setWriteBufferWaterMark(new WriteBufferWaterMark(512, 1024));
 
         clientChannel.pipeline().addLast(new ChannelHandler() {
             @Override
@@ -229,8 +226,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
         setInterest(Event.WRITE, Event.FLUSH, Event.WRITABILITY);
 
         Channel clientChannel = cb.connect(addr).asStage().get();
-        clientChannel.config().setWriteBufferLowWaterMark(512);
-        clientChannel.config().setWriteBufferHighWaterMark(1024);
+        clientChannel.config().setWriteBufferWaterMark(new WriteBufferWaterMark(512, 1024));
 
         clientChannel.pipeline().addLast(new ChannelHandler() {
             @Override


### PR DESCRIPTION
Motivation:

Now that we can break the API we should remove the deprecated watermark methods in ChannelConfig. These could lead to errors when used in the wrong order.

Modifications:

Remove methods

Result:

API cleanup
