### PR TITLE
Don't use static instances of FixedRecvByteBufAllocator

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannelConfig.java
@@ -32,13 +32,12 @@ import java.net.NetworkInterface;
 import java.util.Map;
 
 public final class EpollDatagramChannelConfig extends EpollChannelConfig implements DatagramChannelConfig {
-    private static final RecvByteBufAllocator DEFAULT_RCVBUF_ALLOCATOR = new FixedRecvByteBufAllocator(2048);
     private boolean activeOnOpen;
     private volatile int maxDatagramSize;
 
     EpollDatagramChannelConfig(EpollDatagramChannel channel) {
         super(channel);
-        setRecvByteBufAllocator(DEFAULT_RCVBUF_ALLOCATOR);
+        setRecvByteBufAllocator(new FixedRecvByteBufAllocator(2048));
     }
 
     @Override

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainDatagramChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainDatagramChannelConfig.java
@@ -34,13 +34,11 @@ import static io.netty.channel.ChannelOption.SO_SNDBUF;
 @UnstableApi
 public final class EpollDomainDatagramChannelConfig extends EpollChannelConfig implements DomainDatagramChannelConfig {
 
-    private static final RecvByteBufAllocator DEFAULT_RCVBUF_ALLOCATOR = new FixedRecvByteBufAllocator(2048);
-
     private boolean activeOnOpen;
 
     EpollDomainDatagramChannelConfig(EpollDomainDatagramChannel channel) {
         super(channel);
-        setRecvByteBufAllocator(DEFAULT_RCVBUF_ALLOCATOR);
+        setRecvByteBufAllocator(new FixedRecvByteBufAllocator(2048));
     }
 
     @Override

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannelConfig.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannelConfig.java
@@ -44,12 +44,11 @@ import static io.netty.channel.unix.UnixChannelOption.SO_REUSEPORT;
 
 @UnstableApi
 public final class KQueueDatagramChannelConfig extends KQueueChannelConfig implements DatagramChannelConfig {
-    private static final RecvByteBufAllocator DEFAULT_RCVBUF_ALLOCATOR = new FixedRecvByteBufAllocator(2048);
     private boolean activeOnOpen;
 
     KQueueDatagramChannelConfig(KQueueDatagramChannel channel) {
         super(channel);
-        setRecvByteBufAllocator(DEFAULT_RCVBUF_ALLOCATOR);
+        setRecvByteBufAllocator(new FixedRecvByteBufAllocator(2048));
     }
 
     @Override

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainDatagramChannelConfig.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainDatagramChannelConfig.java
@@ -35,13 +35,11 @@ import static io.netty.channel.ChannelOption.SO_SNDBUF;
 public final class KQueueDomainDatagramChannelConfig
         extends KQueueChannelConfig implements DomainDatagramChannelConfig {
 
-    private static final RecvByteBufAllocator DEFAULT_RCVBUF_ALLOCATOR = new FixedRecvByteBufAllocator(2048);
-
     private boolean activeOnOpen;
 
     KQueueDomainDatagramChannelConfig(KQueueDomainDatagramChannel channel) {
         super(channel);
-        setRecvByteBufAllocator(DEFAULT_RCVBUF_ALLOCATOR);
+        setRecvByteBufAllocator(new FixedRecvByteBufAllocator(2048));
     }
 
     @Override


### PR DESCRIPTION
Motivation:

FixedRecvByteBufAllocator has state internally so we cant use a static instance across different ChannelConfig instances. This was noticed while working on https://github.com/netty/netty/pull/12593.

Modifications:

Create a new instance of FixedRecvByteBufAllocator when creating the ChannelConfig

Result:

Correctly handling internal state
