### PR TITLE
Correctly check the argument whe EpollServerSocketChannelConfig.setTc…

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerChannelConfig.java
@@ -153,8 +153,8 @@ public class EpollServerChannelConfig extends EpollChannelConfig implements Serv
      * @see <a href="https://tools.ietf.org/html/rfc7413#appendix-A.2">RFC 7413 Passive Open</a>
      */
     public EpollServerChannelConfig setTcpFastopen(int pendingFastOpenRequestsThreshold) {
-        checkPositiveOrZero(this.pendingFastOpenRequestsThreshold, "pendingFastOpenRequestsThreshold");
-        this.pendingFastOpenRequestsThreshold = pendingFastOpenRequestsThreshold;
+        this.pendingFastOpenRequestsThreshold = checkPositiveOrZero(pendingFastOpenRequestsThreshold,
+                "pendingFastOpenRequestsThreshold");
         return this;
     }
 

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollServerSocketChannelConfigTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollServerSocketChannelConfigTest.java
@@ -23,12 +23,14 @@ import io.netty.channel.EventLoopGroup;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import java.net.InetSocketAddress;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class EpollServerSocketChannelConfigTest {
@@ -85,5 +87,17 @@ public class EpollServerSocketChannelConfigTest {
     public void getGetOptions() {
         Map<ChannelOption<?>, Object> map = ch.config().getOptions();
         assertFalse(map.isEmpty());
+    }
+
+    @Test
+    public void testFastOpen() {
+        assertThrows(IllegalArgumentException.class, new Executable() {
+            @Override
+            public void execute() {
+                ch.config().setTcpFastopen(-1);
+            }
+        });
+        ch.config().setTcpFastopen(10);
+        assertEquals(10, ch.config().getTcpFastopen());
     }
 }


### PR DESCRIPTION
…pFastOpen(...) is called

Motivation:

Due a bug we didnt check the argument but the already set value when calling setTcpFastOpen(...)

Modifications:

- Correctly check argument
- Add unit test

Result:

Throw if incorrect argument is used
