### PR TITLE
Fix test-failure on macOS with JDK versions < 20

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastIPv6MappedTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastIPv6MappedTest.java
@@ -15,7 +15,10 @@
  */
 package io.netty.testsuite.transport.socket;
 
+import io.netty.channel.socket.DatagramChannel;
+import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.util.NetUtil;
+import io.netty.util.internal.PlatformDependent;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -35,5 +38,14 @@ public class DatagramUnicastIPv6MappedTest extends DatagramUnicastIPv6Test {
             return new InetSocketAddress(NetUtil.LOCALHOST4, serverAddress.getPort());
         }
         return serverAddress;
+    }
+
+    @Override
+    protected boolean disconnectMightFail(DatagramChannel channel) {
+        // See https://bugs.openjdk.org/browse/JDK-8285515
+        if (channel instanceof NioDatagramChannel && PlatformDependent.javaVersion() < 20) {
+            return true;
+        }
+        return super.disconnectMightFail(channel);
     }
 }


### PR DESCRIPTION
Motivation:

Calling DatagramChannel.disconnect() on JDK versions < 20 with mapped ipv6 addresses throw an exception, we should workaround this bug.

Modifications:

Only try to call disconnect() when the DatagramChannel is not using NIO when using mapped ipv6 addresses

Result:

No more build failures on macOS
