### PR TITLE
Rename ChannelOption.RECVBUF_ALLOCATOR to RECBUFFER_ALLOCATOR and und…

### DIFF
--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/DefaultHttp2StreamChannel.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/DefaultHttp2StreamChannel.java
@@ -62,7 +62,7 @@ import static io.netty5.channel.ChannelOption.CONNECT_TIMEOUT_MILLIS;
 import static io.netty5.channel.ChannelOption.MAX_MESSAGES_PER_READ;
 import static io.netty5.channel.ChannelOption.MAX_MESSAGES_PER_WRITE;
 import static io.netty5.channel.ChannelOption.MESSAGE_SIZE_ESTIMATOR;
-import static io.netty5.channel.ChannelOption.RCVBUF_ALLOCATOR;
+import static io.netty5.channel.ChannelOption.RCVBUFFER_ALLOCATOR;
 import static io.netty5.channel.ChannelOption.WRITE_BUFFER_WATER_MARK;
 import static io.netty5.channel.ChannelOption.WRITE_SPIN_COUNT;
 import static io.netty5.handler.codec.http2.Http2CodecUtil.isStreamIdValid;
@@ -1013,7 +1013,7 @@ final class DefaultHttp2StreamChannel extends DefaultAttributeMap implements Htt
         if (option == BUFFER_ALLOCATOR) {
             return (T) getBufferAllocator();
         }
-        if (option == RCVBUF_ALLOCATOR) {
+        if (option == RCVBUFFER_ALLOCATOR) {
             return getRecvBufferAllocator();
         }
         if (option == AUTO_CLOSE) {
@@ -1049,7 +1049,7 @@ final class DefaultHttp2StreamChannel extends DefaultAttributeMap implements Htt
             setWriteSpinCount((Integer) value);
         } else if (option == BUFFER_ALLOCATOR) {
             setBufferAllocator((BufferAllocator) value);
-        } else if (option == RCVBUF_ALLOCATOR) {
+        } else if (option == RCVBUFFER_ALLOCATOR) {
             setRecvBufferAllocator((RecvBufferAllocator) value);
         } else if (option == AUTO_CLOSE) {
             setAutoClose((Boolean) value);
@@ -1067,7 +1067,7 @@ final class DefaultHttp2StreamChannel extends DefaultAttributeMap implements Htt
     public boolean isOptionSupported(ChannelOption<?> option) {
         return option == AUTO_READ || option == WRITE_BUFFER_WATER_MARK || option == CONNECT_TIMEOUT_MILLIS ||
                 option == MAX_MESSAGES_PER_READ || option == WRITE_SPIN_COUNT || option == BUFFER_ALLOCATOR ||
-                option == RCVBUF_ALLOCATOR || option == AUTO_CLOSE || option == MESSAGE_SIZE_ESTIMATOR ||
+                option == RCVBUFFER_ALLOCATOR || option == AUTO_CLOSE || option == MESSAGE_SIZE_ESTIMATOR ||
                 option == MAX_MESSAGES_PER_WRITE || option == ALLOW_HALF_CLOSURE;
     }
 

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/TestChannelInitializer.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/TestChannelInitializer.java
@@ -45,7 +45,7 @@ public class TestChannelInitializer extends ChannelInitializer<Channel> {
             handler = null;
         }
         if (maxReads != null) {
-            channel.setOption(ChannelOption.RCVBUF_ALLOCATOR, new TestNumReadsRecvBufferAllocator(maxReads));
+            channel.setOption(ChannelOption.RCVBUFFER_ALLOCATOR, new TestNumReadsRecvBufferAllocator(maxReads));
         }
     }
 

--- a/resolver-dns/src/main/java/io/netty5/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty5/resolver/dns/DnsNameResolver.java
@@ -473,7 +473,7 @@ public class DnsNameResolver extends InetNameResolver {
                 });
             }
         });
-        b.option(ChannelOption.RCVBUF_ALLOCATOR, new FixedRecvBufferAllocator(maxPayloadSize));
+        b.option(ChannelOption.RCVBUFFER_ALLOCATOR, new FixedRecvBufferAllocator(maxPayloadSize));
 
         try {
             Future<Void> future;

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketAutoReadTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketAutoReadTest.java
@@ -61,7 +61,7 @@ public class SocketAutoReadTest extends AbstractSocketTest {
                     .childOption(ChannelOption.AUTO_READ, true)
                     // We want to ensure that we attempt multiple individual read operations per read loop so we can
                     // test the auto read feature being turned off when data is first read.
-                    .childOption(ChannelOption.RCVBUF_ALLOCATOR, new TestRecvBufferAllocator())
+                    .childOption(ChannelOption.RCVBUFFER_ALLOCATOR, new TestRecvBufferAllocator())
                     .childHandler(serverInitializer);
 
             serverChannel = sb.bind().asStage().get();
@@ -69,7 +69,7 @@ public class SocketAutoReadTest extends AbstractSocketTest {
             cb.option(ChannelOption.AUTO_READ, true)
                     // We want to ensure that we attempt multiple individual read operations per read loop so we can
                     // test the auto read feature being turned off when data is first read.
-                    .option(ChannelOption.RCVBUF_ALLOCATOR, new TestRecvBufferAllocator())
+                    .option(ChannelOption.RCVBUFFER_ALLOCATOR, new TestRecvBufferAllocator())
                     .handler(clientInitializer);
 
             clientChannel = cb.connect(serverChannel.localAddress()).asStage().get();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -197,7 +197,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
         try {
             cb.option(ChannelOption.ALLOW_HALF_CLOSURE, true)
               .option(ChannelOption.AUTO_READ, autoRead)
-              .option(ChannelOption.RCVBUF_ALLOCATOR, new TestNumReadsRecvBufferAllocator(numReadsPerReadLoop));
+              .option(ChannelOption.RCVBUFFER_ALLOCATOR, new TestNumReadsRecvBufferAllocator(numReadsPerReadLoop));
 
             sb.childHandler(new ChannelInitializer<>() {
                 @Override
@@ -498,7 +498,8 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
         try {
             cb.option(ChannelOption.ALLOW_HALF_CLOSURE, allowHalfClosed)
                     .option(ChannelOption.AUTO_READ, autoRead)
-                    .option(ChannelOption.RCVBUF_ALLOCATOR, new TestNumReadsRecvBufferAllocator(numReadsPerReadLoop));
+                    .option(ChannelOption.RCVBUFFER_ALLOCATOR,
+                            new TestNumReadsRecvBufferAllocator(numReadsPerReadLoop));
 
             sb.childHandler(new ChannelInitializer<>() {
                 @Override

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketReadPendingTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketReadPendingTest.java
@@ -58,14 +58,14 @@ public class SocketReadPendingTest extends AbstractSocketTest {
               .option(ChannelOption.AUTO_READ, true)
               .childOption(ChannelOption.AUTO_READ, false)
               // We intend to do 2 reads per read loop wakeup
-              .childOption(ChannelOption.RCVBUF_ALLOCATOR, new TestNumReadsRecvBufferAllocator(2))
+              .childOption(ChannelOption.RCVBUFFER_ALLOCATOR, new TestNumReadsRecvBufferAllocator(2))
               .childHandler(serverInitializer);
 
             serverChannel = sb.bind().asStage().get();
 
             cb.option(ChannelOption.AUTO_READ, false)
               // We intend to do 2 reads per read loop wakeup
-              .option(ChannelOption.RCVBUF_ALLOCATOR, new TestNumReadsRecvBufferAllocator(2))
+              .option(ChannelOption.RCVBUFFER_ALLOCATOR, new TestNumReadsRecvBufferAllocator(2))
               .handler(clientInitializer);
             clientChannel = cb.connect(serverChannel.localAddress()).asStage().get();
 

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDatagramScatteringReadTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDatagramScatteringReadTest.java
@@ -96,7 +96,7 @@ public class EpollDatagramScatteringReadTest extends AbstractDatagramTest  {
         int packetSize = 512;
         int numPackets = 4;
 
-        sb.option(ChannelOption.RCVBUF_ALLOCATOR, new AdaptiveRecvBufferAllocator(
+        sb.option(ChannelOption.RCVBUFFER_ALLOCATOR, new AdaptiveRecvBufferAllocator(
                 packetSize, packetSize * (partial ? numPackets / 2 : numPackets), 64 * 1024));
         sb.option(EpollChannelOption.MAX_DATAGRAM_PAYLOAD_SIZE, packetSize);
 
@@ -207,7 +207,7 @@ public class EpollDatagramScatteringReadTest extends AbstractDatagramTest  {
     private void testScatteringReadWithSmallBuffer0(Bootstrap sb, Bootstrap cb, boolean connected) throws Throwable {
         int packetSize = 16;
 
-        sb.option(ChannelOption.RCVBUF_ALLOCATOR, new AdaptiveRecvBufferAllocator(1400, 1400, 64 * 1024));
+        sb.option(ChannelOption.RCVBUFFER_ALLOCATOR, new AdaptiveRecvBufferAllocator(1400, 1400, 64 * 1024));
         sb.option(EpollChannelOption.MAX_DATAGRAM_PAYLOAD_SIZE, 1400);
 
         Channel sc = null;

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDatagramUnicastTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDatagramUnicastTest.java
@@ -121,7 +121,7 @@ public class EpollDatagramUnicastTest extends DatagramUnicastInetTest {
                 // Enable GRO and also ensure we can read everything with one read as otherwise
                 // we will drop things on the floor.
                 sb.option(EpollChannelOption.UDP_GRO, true);
-                sb.option(ChannelOption.RCVBUF_ALLOCATOR, new FixedRecvBufferAllocator(bufferCapacity));
+                sb.option(ChannelOption.RCVBUFFER_ALLOCATOR, new FixedRecvBufferAllocator(bufferCapacity));
             }
             sc = sb.handler(new SimpleChannelInboundHandler<Object>() {
                 @Override

--- a/transport-native-unix-common-tests/src/main/java/io/netty5/channel/unix/tests/DetectPeerCloseWithoutReadTest.java
+++ b/transport-native-unix-common-tests/src/main/java/io/netty5/channel/unix/tests/DetectPeerCloseWithoutReadTest.java
@@ -72,7 +72,7 @@ public abstract class DetectPeerCloseWithoutReadTest {
             // calls to consume everything.
             sb.childOption(ChannelOption.AUTO_READ, false);
             sb.childOption(ChannelOption.MAX_MESSAGES_PER_READ, 1);
-            sb.childOption(ChannelOption.RCVBUF_ALLOCATOR, new FixedRecvBufferAllocator(expectedBytes / 10));
+            sb.childOption(ChannelOption.RCVBUFFER_ALLOCATOR, new FixedRecvBufferAllocator(expectedBytes / 10));
             sb.childHandler(new ChannelInitializer<>() {
                 @Override
                 protected void initChannel(Channel ch) {
@@ -156,7 +156,7 @@ public abstract class DetectPeerCloseWithoutReadTest {
             // calls to consume everything.
             cb.option(ChannelOption.AUTO_READ, false);
             cb.option(ChannelOption.MAX_MESSAGES_PER_READ, 1);
-            cb.option(ChannelOption.RCVBUF_ALLOCATOR, new FixedRecvBufferAllocator(expectedBytes / 10));
+            cb.option(ChannelOption.RCVBUFFER_ALLOCATOR, new FixedRecvBufferAllocator(expectedBytes / 10));
             cb.handler(new ChannelInitializer<>() {
                 @Override
                 protected void initChannel(Channel ch) throws Exception {

--- a/transport/src/main/java/io/netty5/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty5/channel/AbstractChannel.java
@@ -55,7 +55,7 @@ import static io.netty5.channel.ChannelOption.CONNECT_TIMEOUT_MILLIS;
 import static io.netty5.channel.ChannelOption.MAX_MESSAGES_PER_READ;
 import static io.netty5.channel.ChannelOption.MAX_MESSAGES_PER_WRITE;
 import static io.netty5.channel.ChannelOption.MESSAGE_SIZE_ESTIMATOR;
-import static io.netty5.channel.ChannelOption.RCVBUF_ALLOCATOR;
+import static io.netty5.channel.ChannelOption.RCVBUFFER_ALLOCATOR;
 import static io.netty5.channel.ChannelOption.WRITE_BUFFER_WATER_MARK;
 import static io.netty5.channel.ChannelOption.WRITE_SPIN_COUNT;
 import static io.netty5.util.internal.ObjectUtil.checkPositive;
@@ -1315,7 +1315,7 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
         if (option == BUFFER_ALLOCATOR) {
             return (T) getBufferAllocator();
         }
-        if (option == RCVBUF_ALLOCATOR) {
+        if (option == RCVBUFFER_ALLOCATOR) {
             return getRecvBufferAllocator();
         }
         if (option == AUTO_CLOSE) {
@@ -1364,7 +1364,7 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
             setWriteSpinCount((Integer) value);
         } else if (option == BUFFER_ALLOCATOR) {
             setBufferAllocator((BufferAllocator) value);
-        } else if (option == RCVBUF_ALLOCATOR) {
+        } else if (option == RCVBUFFER_ALLOCATOR) {
             setRecvBufferAllocator((RecvBufferAllocator) value);
         } else if (option == AUTO_CLOSE) {
             setAutoClose((Boolean) value);
@@ -1415,7 +1415,7 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
     private static Set<ChannelOption<?>> supportedOptions() {
         return newSupportedIdentityOptionsSet(
                 AUTO_READ, WRITE_BUFFER_WATER_MARK, CONNECT_TIMEOUT_MILLIS, MAX_MESSAGES_PER_READ,
-                WRITE_SPIN_COUNT, BUFFER_ALLOCATOR, RCVBUF_ALLOCATOR, AUTO_CLOSE, MESSAGE_SIZE_ESTIMATOR,
+                WRITE_SPIN_COUNT, BUFFER_ALLOCATOR, RCVBUFFER_ALLOCATOR, AUTO_CLOSE, MESSAGE_SIZE_ESTIMATOR,
                 MAX_MESSAGES_PER_WRITE, ALLOW_HALF_CLOSURE);
     }
 

--- a/transport/src/main/java/io/netty5/channel/ChannelOption.java
+++ b/transport/src/main/java/io/netty5/channel/ChannelOption.java
@@ -77,7 +77,7 @@ public class ChannelOption<T> extends AbstractConstant<ChannelOption<T>> {
     }
 
     public static final ChannelOption<BufferAllocator> BUFFER_ALLOCATOR = valueOf("BUFFER_ALLOCATOR");
-    public static final ChannelOption<RecvBufferAllocator> RCVBUF_ALLOCATOR = valueOf("RCVBUF_ALLOCATOR");
+    public static final ChannelOption<RecvBufferAllocator> RCVBUFFER_ALLOCATOR = valueOf("RCVBUFFER_ALLOCATOR");
     public static final ChannelOption<MessageSizeEstimator> MESSAGE_SIZE_ESTIMATOR = valueOf("MESSAGE_SIZE_ESTIMATOR");
 
     public static final ChannelOption<Integer> CONNECT_TIMEOUT_MILLIS = valueOf("CONNECT_TIMEOUT_MILLIS");
@@ -129,7 +129,6 @@ public class ChannelOption<T> extends AbstractConstant<ChannelOption<T>> {
      */
     public static final ChannelOption<Integer> TCP_FASTOPEN = valueOf(ChannelOption.class, "TCP_FASTOPEN");
 
-    @Deprecated
     public static final ChannelOption<Boolean> DATAGRAM_CHANNEL_ACTIVE_ON_REGISTRATION =
             valueOf("DATAGRAM_CHANNEL_ACTIVE_ON_REGISTRATION");
 


### PR DESCRIPTION
…eprecate DATAGRAM_ACTIVE_ON_REGISTRATION.

Motivation:

We replace ByteBuf with Buffer so we should also be consistent in naming. Beside this DATAGRAM_ACTIVE_ON_REGISTRATION will not be removed as it is useful

Modifications:

- Rename ChannelOption
- Un-deprecate DATAGRAM_ACTIVE_ON_REGISTRATION.

Result:

Cleanup
