### PR TITLE
Fix Http2ToHttp2ConnectionHandlerTest race

### DIFF
--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
@@ -70,6 +70,7 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyShort;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.never;
@@ -508,12 +509,16 @@ public class HttpToHttp2ConnectionHandlerTest {
         awaitRequests();
         verify(serverListener).onHeadersRead(any(ChannelHandlerContext.class), eq(3), eq(http2Headers), eq(0),
                 anyShort(), anyBoolean(), eq(0), eq(false));
-        verify(serverListener).onDataRead(any(ChannelHandlerContext.class), eq(3), any(Buffer.class), eq(0),
+        verify(serverListener, atLeastOnce()).onDataRead(any(ChannelHandlerContext.class), eq(3), any(Buffer.class), eq(0),
                 eq(false));
         verify(serverListener).onHeadersRead(any(ChannelHandlerContext.class), eq(3), eq(http2TrailingHeaders), eq(0),
                 anyShort(), anyBoolean(), eq(0), eq(true));
-        assertEquals(1, receivedBuffers.size());
-        assertEquals(text + text2, receivedBuffers.get(0));
+        assertFalse(receivedBuffers.isEmpty());
+        StringBuilder sb = new StringBuilder();
+        for (String received : receivedBuffers) {
+            sb.append(received);
+        }
+        assertEquals(text + text2, sb.toString());
     }
 
     private void bootstrapEnv(int requestCountDown, int serverSettingsAckCount, int trailersCount) throws Exception {

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
@@ -509,8 +509,8 @@ public class HttpToHttp2ConnectionHandlerTest {
         awaitRequests();
         verify(serverListener).onHeadersRead(any(ChannelHandlerContext.class), eq(3), eq(http2Headers), eq(0),
                 anyShort(), anyBoolean(), eq(0), eq(false));
-        verify(serverListener, atLeastOnce()).onDataRead(any(ChannelHandlerContext.class), eq(3), any(Buffer.class), eq(0),
-                eq(false));
+        verify(serverListener, atLeastOnce())
+                .onDataRead(any(ChannelHandlerContext.class), eq(3), any(Buffer.class), eq(0), eq(false));
         verify(serverListener).onHeadersRead(any(ChannelHandlerContext.class), eq(3), eq(http2TrailingHeaders), eq(0),
                 anyShort(), anyBoolean(), eq(0), eq(true));
         assertFalse(receivedBuffers.isEmpty());


### PR DESCRIPTION
Motivation:

There is nothing wrong with two buffers as long as long as the result is correct

Modifications:

Just ensure the end-result is correct and not depend on the number of Buffers received

Result:

Test has no races anymore
