### PR TITLE
Add missing synchronized when using setTcpMd5Sig(...) for epoll

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannel.java
@@ -107,6 +107,9 @@ public final class EpollServerSocketChannel extends AbstractEpollServerChannel i
     }
 
     void setTcpMd5Sig(Map<InetAddress, byte[]> keys) throws IOException {
-        tcpMd5SigAddresses = TcpMd5Util.newTcpMd5Sigs(this, tcpMd5SigAddresses, keys);
+        // Add synchronized as newTcpMp5Sigs might do multiple operations on the socket itself.
+        synchronized (this) {
+            tcpMd5SigAddresses = TcpMd5Util.newTcpMd5Sigs(this, tcpMd5SigAddresses, keys);
+        }
     }
 }

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannel.java
@@ -168,6 +168,9 @@ public final class EpollSocketChannel extends AbstractEpollStreamChannel impleme
     }
 
     void setTcpMd5Sig(Map<InetAddress, byte[]> keys) throws IOException {
-        tcpMd5SigAddresses = TcpMd5Util.newTcpMd5Sigs(this, tcpMd5SigAddresses, keys);
+        // Add synchronized as newTcpMp5Sigs might do multiple operations on the socket itself.
+        synchronized (this) {
+            tcpMd5SigAddresses = TcpMd5Util.newTcpMd5Sigs(this, tcpMd5SigAddresses, keys);
+        }
     }
 }


### PR DESCRIPTION
Motivation:

As we should guard with a synchronized block as setTcpMd5Sig(...) might do multiple operations on the socket

Modifications:

Add synchronized

Result:

Correctly guard

