### PR TITLE
Add check for |Connection| and |Upgrade| headers inside WebSocketServerrHandshaker13

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker13.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker13.java
@@ -134,7 +134,19 @@ public class WebSocketServerHandshaker13 extends WebSocketServerHandshaker {
      */
     @Override
     protected FullHttpResponse newHandshakeResponse(FullHttpRequest req, HttpHeaders headers) {
-        CharSequence key = req.headers().get(HttpHeaderNames.SEC_WEBSOCKET_KEY);
+        HttpHeaders reqHeaders = req.headers();
+        if (!reqHeaders.contains(HttpHeaderNames.CONNECTION) ||
+            !reqHeaders.containsValue(HttpHeaderNames.CONNECTION, HttpHeaderValues.UPGRADE, true)) {
+            throw new WebSocketServerHandshakeException(
+                    "not a WebSocket request: a |Connection| header must includes a token 'Upgrade'", req);
+        }
+
+        if (!reqHeaders.contains(HttpHeaderNames.UPGRADE, HttpHeaderValues.WEBSOCKET, true)) {
+            throw new WebSocketServerHandshakeException(
+                    "not a WebSocket request: a |Upgrade| header must containing the value 'websocket'", req);
+        }
+
+        CharSequence key = reqHeaders.get(HttpHeaderNames.SEC_WEBSOCKET_KEY);
         if (key == null) {
             throw new WebSocketServerHandshakeException("not a WebSocket request: missing key", req);
         }
@@ -157,7 +169,7 @@ public class WebSocketServerHandshaker13 extends WebSocketServerHandshaker {
                      .set(HttpHeaderNames.CONNECTION, HttpHeaderValues.UPGRADE)
                      .set(HttpHeaderNames.SEC_WEBSOCKET_ACCEPT, accept);
 
-        String subprotocols = req.headers().get(HttpHeaderNames.SEC_WEBSOCKET_PROTOCOL);
+        String subprotocols = reqHeaders.get(HttpHeaderNames.SEC_WEBSOCKET_PROTOCOL);
         if (subprotocols != null) {
             String selectedSubprotocol = selectSubprotocol(subprotocols);
             if (selectedSubprotocol == null) {

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketRequestBuilder.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketRequestBuilder.java
@@ -156,6 +156,7 @@ public class WebSocketRequestBuilder {
                 .uri("/test")
                 .host("server.example.com")
                 .upgrade(HttpHeaderValues.WEBSOCKET)
+                .connection(HttpHeaderValues.UPGRADE)
                 .key("dGhlIHNhbXBsZSBub25jZQ==")
                 .origin("http://example.com")
                 .version13()

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker13Test.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker13Test.java
@@ -30,18 +30,22 @@ import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseDecoder;
 import io.netty.handler.codec.http.HttpResponseEncoder;
 import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.handler.codec.http.HttpVersion;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.ReferenceCounted;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import java.util.Iterator;
 
-import static io.netty.handler.codec.http.HttpVersion.*;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class WebSocketServerHandshaker13Test extends WebSocketServerHandshakerTest {
@@ -89,6 +93,83 @@ public class WebSocketServerHandshaker13Test extends WebSocketServerHandshakerTe
     @Test
     public void testCloseReasonWithCodec() {
         testCloseReason0(new HttpServerCodec());
+    }
+
+    @Test
+    public void testHandshakeExceptionWhenConnectionHeaderIsAbsent() {
+        final WebSocketServerHandshaker serverHandshaker = newHandshaker("ws://example.com/chat",
+                                                                         "chat", WebSocketDecoderConfig.DEFAULT);
+        final FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET,
+                                                                   "ws://example.com/chat");
+        request.headers()
+               .set(HttpHeaderNames.HOST, "server.example.com")
+               .set(HttpHeaderNames.UPGRADE, HttpHeaderValues.WEBSOCKET)
+               .set(HttpHeaderNames.SEC_WEBSOCKET_KEY, "dGhlIHNhbXBsZSBub25jZQ==")
+               .set(HttpHeaderNames.SEC_WEBSOCKET_ORIGIN, "http://example.com")
+               .set(HttpHeaderNames.SEC_WEBSOCKET_PROTOCOL, "chat, superchat")
+               .set(HttpHeaderNames.SEC_WEBSOCKET_VERSION, "13");
+        Throwable exception = assertThrows(WebSocketServerHandshakeException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                serverHandshaker.handshake(null, request, null, null);
+            }
+        });
+
+        assertEquals("not a WebSocket request: a |Connection| header must includes a token 'Upgrade'",
+                     exception.getMessage());
+        assertTrue(request.release());
+    }
+
+    @Test
+    public void testHandshakeExceptionWhenInvalidConnectionHeader() {
+        final WebSocketServerHandshaker serverHandshaker = newHandshaker("ws://example.com/chat",
+                                                                         "chat", WebSocketDecoderConfig.DEFAULT);
+        final FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET,
+                                                                   "ws://example.com/chat");
+        request.headers()
+               .set(HttpHeaderNames.HOST, "server.example.com")
+               .set(HttpHeaderNames.CONNECTION, "close")
+               .set(HttpHeaderNames.UPGRADE, HttpHeaderValues.WEBSOCKET)
+               .set(HttpHeaderNames.SEC_WEBSOCKET_KEY, "dGhlIHNhbXBsZSBub25jZQ==")
+               .set(HttpHeaderNames.SEC_WEBSOCKET_ORIGIN, "http://example.com")
+               .set(HttpHeaderNames.SEC_WEBSOCKET_PROTOCOL, "chat, superchat")
+               .set(HttpHeaderNames.SEC_WEBSOCKET_VERSION, "13");
+        Throwable exception = assertThrows(WebSocketServerHandshakeException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                serverHandshaker.handshake(null, request, null, null);
+            }
+        });
+
+        assertEquals("not a WebSocket request: a |Connection| header must includes a token 'Upgrade'",
+                     exception.getMessage());
+        assertTrue(request.release());
+    }
+
+    @Test
+    public void testHandshakeExceptionWhenInvalidUpgradeHeader() {
+        final WebSocketServerHandshaker serverHandshaker = newHandshaker("ws://example.com/chat",
+                                                                         "chat", WebSocketDecoderConfig.DEFAULT);
+        final FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET,
+                                                                   "ws://example.com/chat");
+        request.headers()
+               .set(HttpHeaderNames.HOST, "server.example.com")
+               .set(HttpHeaderNames.CONNECTION, HttpHeaderValues.UPGRADE)
+               .set(HttpHeaderNames.UPGRADE, "my_websocket")
+               .set(HttpHeaderNames.SEC_WEBSOCKET_KEY, "dGhlIHNhbXBsZSBub25jZQ==")
+               .set(HttpHeaderNames.SEC_WEBSOCKET_ORIGIN, "http://example.com")
+               .set(HttpHeaderNames.SEC_WEBSOCKET_PROTOCOL, "chat, superchat")
+               .set(HttpHeaderNames.SEC_WEBSOCKET_VERSION, "13");
+        Throwable exception = assertThrows(WebSocketServerHandshakeException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                serverHandshaker.handshake(null, request, null, null);
+            }
+        });
+
+        assertEquals("not a WebSocket request: a |Upgrade| header must containing the value 'websocket'",
+                     exception.getMessage());
+        assertTrue(request.release());
     }
 
     private static void testCloseReason0(ChannelHandler... handlers) {


### PR DESCRIPTION
Motivation:

We faced with problem between proxies and Netty backend server. If we received a handshake request which doesn't contain a |Connection| or |Upgrade| headers with proper value the Netty accept this request and upgrade pipeline to handle websocket frames. But proxy thinks that is not upgrade request and can reuse this connection to any others http requests which we don't expect.

Modification:

Add check for |Connection| and |Upgrade| headers inside `WebSocketServerrHandshaker13` according spec
https://datatracker.ietf.org/doc/html/rfc6455#section-4.2.1. 

Result:

Proper handshake request handling for websocket version 13.
