### PR TITLE
timeout: expose remaining time of timeout

### DIFF
--- a/common/src/main/java/io/netty/util/HashedWheelTimer.java
+++ b/common/src/main/java/io/netty/util/HashedWheelTimer.java
@@ -645,6 +645,11 @@ public class HashedWheelTimer implements Timer {
         }
 
         @Override
+        public long remaining(TimeUnit unit) {
+            return unit.convert(deadline - System.nanoTime() + timer.startTime, TimeUnit.NANOSECONDS);
+        }
+
+        @Override
         public Timer timer() {
             return timer;
         }
@@ -723,7 +728,7 @@ public class HashedWheelTimer implements Timer {
         @Override
         public String toString() {
             final long currentTime = System.nanoTime();
-            long remaining = deadline - currentTime + timer.startTime;
+            long remaining = remaining(TimeUnit.NANOSECONDS);
 
             StringBuilder buf = new StringBuilder(192)
                .append(simpleClassName(this))

--- a/common/src/main/java/io/netty/util/Timeout.java
+++ b/common/src/main/java/io/netty/util/Timeout.java
@@ -15,6 +15,8 @@
  */
 package io.netty.util;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * A handle associated with a {@link TimerTask} that is returned by a
  * {@link Timer}.
@@ -30,6 +32,17 @@ public interface Timeout {
      * Returns the {@link TimerTask} which is associated with this handle.
      */
     TimerTask task();
+
+    /**
+     * The remaining time until the timeout expires.
+     *
+     * <p>Given <code>unit</code>, produce the time remaining until this
+     * timeout will expire represented as the given time unit.</p>
+     *
+     * @param unit time unit resolution of result.
+     * @return Number of remaining time units.
+     */
+    long remaining(TimeUnit unit);
 
     /**
      * Returns {@code true} if and only if the {@link TimerTask} associated

--- a/common/src/test/java/io/netty/util/HashedWheelTimerTest.java
+++ b/common/src/test/java/io/netty/util/HashedWheelTimerTest.java
@@ -45,6 +45,7 @@ public class HashedWheelTimerTest {
         }, 10, TimeUnit.SECONDS);
         assertFalse(barrier.await(3, TimeUnit.SECONDS));
         assertFalse(timeout.isExpired(), "timer should not expire");
+        assertTrue(timeout.remaining(TimeUnit.NANOSECONDS) > 0, "has time remaining");
         timer.stop();
     }
 
@@ -60,6 +61,7 @@ public class HashedWheelTimerTest {
         }, 2, TimeUnit.SECONDS);
         assertTrue(barrier.await(3, TimeUnit.SECONDS));
         assertTrue(timeout.isExpired(), "timer should expire");
+        assertTrue(timeout.remaining(TimeUnit.NANOSECONDS) < 0, "has negative time remaining");
         timer.stop();
     }
 


### PR DESCRIPTION
To allow timeouts to be a little more useful, expose the deadline of the
timeout via a method `remaining(TimeUnit)` which returns the remaining
time until the deadline in `TimeUnit`. Would possibly be useful to
instead of the `java.time.Instant` instead, but there's both a
difference in the underlying clock in most platforms (monotonic vs
realtime) and for some reason `java.time.Instant` doesn't pass the
animalsniffer check.

Motivation:

It is common when dealing with high resolution timeouts to
communicate the time available to downstream systems. Today
this requires tracking a time measurement as well as tracking
the `Timeout` object, yet the `HashedWheelTimer.HashedWheelTimeout`
contains the deadline as a member value.

Modification:

Expose the deadline in units remaining. It would possibly be useful
in a future iteration to include the deadline as a future Instant relative
to the realtime clock on Linux systems. Included a simple test for the
API.