### PR TITLE
SingleThreadedEventLoop: add read-only iterator of channels

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
@@ -34,6 +34,7 @@ import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.Queue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicLong;
@@ -277,6 +278,11 @@ class EpollEventLoop extends SingleThreadEventLoop {
     @Override
     public int registeredChannels() {
         return channels.size();
+    }
+
+    @Override
+    public Iterator<AbstractEpollChannel> registeredChannelsIterator() {
+        return channels.values().iterator();
     }
 
     private long epollWait(long deadlineNanos) throws IOException {

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoop.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoop.java
@@ -33,6 +33,7 @@ import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.Queue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
@@ -351,6 +352,11 @@ final class KQueueEventLoop extends SingleThreadEventLoop {
     @Override
     public int registeredChannels() {
         return channels.size();
+    }
+
+    @Override
+    public Iterator<AbstractKQueueChannel> registeredChannelsIterator() {
+        return channels.values().iterator();
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
@@ -22,6 +22,7 @@ import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.UnstableApi;
 
+import java.util.Iterator;
 import java.util.Queue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadFactory;
@@ -153,5 +154,12 @@ public abstract class SingleThreadEventLoop extends SingleThreadEventExecutor im
     @UnstableApi
     public int registeredChannels() {
         return -1;
+    }
+
+    /**
+     * Returns the read-only iterator of {@link Channel}s registered with this {@link EventLoop}.
+     */
+    public Iterator<? extends Channel> registeredChannelsIterator() {
+        throw new UnsupportedOperationException();
     }
 }

--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
@@ -44,6 +44,7 @@ import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.Executor;
@@ -370,6 +371,21 @@ public final class NioEventLoop extends SingleThreadEventLoop {
     @Override
     public int registeredChannels() {
         return selector.keys().size() - cancelledKeys;
+    }
+
+    @Override
+    public Iterator<AbstractNioChannel> registeredChannelsIterator() {
+        List<AbstractNioChannel> nioChannelList = new ArrayList<AbstractNioChannel>();
+        for (SelectionKey key: selector.keys()) {
+            if (!key.isValid()) {
+                continue;
+            }
+            Object o = key.attachment();
+            if (o instanceof AbstractNioChannel) {
+                nioChannelList.add((AbstractNioChannel) o);
+            }
+        }
+        return nioChannelList.iterator();
     }
 
     private void rebuildSelector0() {


### PR DESCRIPTION
Motivation:

For servers there is a need for per eventloop "watchdog" timer that ticks for all eventloop channels. For moderately high number of connections, It is cheaper cpu-wise than per channel scheduling.

Now this requires additional data structure to hold active channels - which is wasteful as It duplicates the one from SingleThreadedEventLoop (its practically useful impls - epoll, kqueue, nio).

It would be convenient to avoid this redundant additional data structure, and instead have read-only iterator of eventloop channels exposed on SingleThreadedEventLoop as Iterator<Channel> registeredChannelsIterator() (complementary to existing int registeredChannels() for channels count).

Modification:
add method to return the read-only iterator of channels registered with this EventLoop

Result:

Fixes #12595. 

If there is no issue then describe the changes introduced by this PR.
