### PR TITLE
Add nativeAddress() method to Buffer.

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/Buffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/Buffer.java
@@ -208,6 +208,25 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
     }
 
     /**
+     * Queries if this buffer is backed by native memory and has single component, or not.
+     *
+     * @return {@code true} if this buffer is backed by native, off-heap, single component, memory. Otherwise, {@code false}, if this
+     * buffer is backed by on-heap memory or has more than one components.
+     */
+    public boolean hasNativeAddress();
+
+    /**
+     * Give the native memory address backing this buffer in unsafe way.
+     * <p>
+     * <strong>Note</strong> that the address should not be used for reading from or writing to the buffer memory, and doing so may
+     * produce undefined behaviour.
+     *
+     * @return The native memory address, if Buffer has {@linkplain #countComponents() single} component and is {@linkplain #isDirect direct}.
+     * @throws UnsupportedOperationException if this buffer do not have {@linkplain #hasNativeAddress() native address}.
+     */
+    long nativeAddress();
+
+    /**
      * Fills the buffer with the given byte value. This method does not respect the {@link #readerOffset()} or {@link
      * #writerOffset()}, but copies the full capacity of the buffer. The {@link #readerOffset()} and {@link
      * #writerOffset()} are not modified.

--- a/buffer/src/main/java/io/netty5/buffer/api/BufferStub.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/BufferStub.java
@@ -94,6 +94,16 @@ public class BufferStub implements Buffer {
     }
 
     @Override
+    public boolean hasNativeAddress() {
+        return delegate.hasNativeAddress();
+    }
+
+    @Override
+    public long nativeAddress() {
+        return delegate.nativeAddress();
+    }
+
+    @Override
     public Buffer fill(byte value) {
         delegate.fill(value);
         return this;

--- a/buffer/src/main/java/io/netty5/buffer/api/DefaultCompositeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/DefaultCompositeBuffer.java
@@ -455,6 +455,24 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
     }
 
     @Override
+    public boolean hasNativeAddress() {
+        if (bufs.length == 1) {
+            return bufs[0].hasNativeAddress();
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public long nativeAddress() {
+        if (bufs.length == 1) {
+            return bufs[0].nativeAddress();
+        } else {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @Override
     public CompositeBuffer fill(byte value) {
         if (closed) {
             throw bufferIsClosed(this);

--- a/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
@@ -162,7 +162,13 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
         return this;
     }
 
-    private long nativeAddress() {
+    @Override
+    public boolean hasNativeAddress() {
+        return isDirect();
+    }
+
+    @Override
+    public long nativeAddress() {
         return Statics.nativeAddressOfDirectByteBuffer(rmem);
     }
 

--- a/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
@@ -176,8 +176,18 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
         return this;
     }
 
-    private long nativeAddress() {
-        return base == null? address : 0;
+    @Override
+    public boolean hasNativeAddress() {
+        return isDirect();
+    }
+
+    @Override
+    public long nativeAddress() {
+        if (base == null) {
+          return address;
+        } else {
+          throw new UnsupportedOperationException();
+        }
     }
 
     @Override

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferBulkAccessTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferBulkAccessTest.java
@@ -874,6 +874,7 @@ public class BufferBulkAccessTest extends BufferTestSupport {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             assertTrue(buf.isDirect());
+            assertTrue(buf.hasNativeAddress());
         }
     }
 
@@ -883,6 +884,7 @@ public class BufferBulkAccessTest extends BufferTestSupport {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             assertFalse(buf.isDirect());
+            assertFalse(buf.hasNativeAddress());
         }
     }
 }


### PR DESCRIPTION
Motiviation:

We should be able to support of getting the raw memory address of single and direct Buffer.

Modifications:

- Add hasNativeAddress() method to Buffer.
- Make nativeAddress() method public.

Result:

Be able to get memory address of a Buffer like in netty 4.

Fixes #12609.