### PR TITLE
Change EventLoop / IoHandler to take an IoHandle for registration / d…

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollHandler.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollHandler.java
@@ -15,9 +15,9 @@
  */
 package io.netty5.channel.epoll;
 
-import io.netty5.channel.Channel;
 import io.netty5.channel.DefaultSelectStrategyFactory;
 import io.netty5.channel.IoExecutionContext;
+import io.netty5.channel.IoHandle;
 import io.netty5.channel.IoHandler;
 import io.netty5.channel.IoHandlerFactory;
 import io.netty5.channel.SelectStrategy;
@@ -85,11 +85,11 @@ public class EpollHandler implements IoHandler {
     // See https://man7.org/linux/man-pages/man2/timerfd_create.2.html.
     private static final long MAX_SCHEDULED_TIMERFD_NS = 999999999;
 
-    private static AbstractEpollChannel<?, ?, ?> cast(Channel channel) {
-        if (channel instanceof AbstractEpollChannel) {
-            return (AbstractEpollChannel<?, ?, ?>) channel;
+    private static AbstractEpollChannel<?, ?, ?> cast(IoHandle handle) {
+        if (handle instanceof AbstractEpollChannel) {
+            return (AbstractEpollChannel<?, ?, ?>) handle;
         }
-        throw new IllegalArgumentException("Channel of type " + StringUtil.simpleClassName(channel) + " not supported");
+        throw new IllegalArgumentException("Channel of type " + StringUtil.simpleClassName(handle) + " not supported");
     }
 
     private EpollHandler() {
@@ -192,8 +192,8 @@ public class EpollHandler implements IoHandler {
     }
 
     @Override
-    public final void register(Channel channel) throws Exception {
-        final AbstractEpollChannel<?, ?, ?> epollChannel = cast(channel);
+    public final void register(IoHandle handle) throws Exception {
+        final AbstractEpollChannel<?, ?, ?> epollChannel = cast(handle);
         epollChannel.register0(new EpollRegistration() {
             @Override
             public void update() throws IOException {
@@ -219,8 +219,8 @@ public class EpollHandler implements IoHandler {
     }
 
     @Override
-    public final void deregister(Channel channel) throws Exception {
-        cast(channel).deregister0();
+    public final void deregister(IoHandle handle) throws Exception {
+        cast(handle).deregister0();
     }
 
     @Override
@@ -518,7 +518,7 @@ public class EpollHandler implements IoHandler {
     }
 
     @Override
-    public boolean isCompatible(Class<? extends Channel> channelType) {
-        return AbstractEpollChannel.class.isAssignableFrom(channelType);
+    public boolean isCompatible(Class<? extends IoHandle> handleType) {
+        return AbstractEpollChannel.class.isAssignableFrom(handleType);
     }
 }

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueHandler.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueHandler.java
@@ -15,9 +15,9 @@
  */
 package io.netty5.channel.kqueue;
 
-import io.netty5.channel.Channel;
 import io.netty5.channel.DefaultSelectStrategyFactory;
 import io.netty5.channel.IoExecutionContext;
+import io.netty5.channel.IoHandle;
 import io.netty5.channel.IoHandler;
 import io.netty5.channel.IoHandlerFactory;
 import io.netty5.channel.SelectStrategy;
@@ -66,11 +66,11 @@ public final class KQueueHandler implements IoHandler {
 
     private volatile int wakenUp;
 
-    private static AbstractKQueueChannel<?, ?, ?> cast(Channel channel) {
-        if (channel instanceof AbstractKQueueChannel) {
-            return (AbstractKQueueChannel<?, ?, ?>) channel;
+    private static AbstractKQueueChannel<?, ?, ?> cast(IoHandle handle) {
+        if (handle instanceof AbstractKQueueChannel) {
+            return (AbstractKQueueChannel<?, ?, ?>) handle;
         }
-        throw new IllegalArgumentException("Channel of type " + StringUtil.simpleClassName(channel) + " not supported");
+        throw new IllegalArgumentException("IoHandle of type " + StringUtil.simpleClassName(handle) + " not supported");
     }
 
     private KQueueHandler() {
@@ -113,8 +113,8 @@ public final class KQueueHandler implements IoHandler {
     }
 
     @Override
-    public void register(Channel channel) {
-        final AbstractKQueueChannel<?, ?, ?> kQueueChannel = cast(channel);
+    public void register(IoHandle handle) {
+        final AbstractKQueueChannel<?, ?, ?> kQueueChannel = cast(handle);
         final int id = kQueueChannel.fd().intValue();
         AbstractKQueueChannel<?, ?, ?> old = channels.put(id, kQueueChannel);
         // We either expect to have no Channel in the map with the same FD or that the FD of the old Channel is already
@@ -135,8 +135,8 @@ public final class KQueueHandler implements IoHandler {
     }
 
     @Override
-    public void deregister(Channel channel) throws Exception {
-        AbstractKQueueChannel<?, ?, ?> kQueueChannel = cast(channel);
+    public void deregister(IoHandle handle) throws Exception {
+        AbstractKQueueChannel<?, ?, ?> kQueueChannel = cast(handle);
         int fd = kQueueChannel.fd().intValue();
 
         AbstractKQueueChannel<?, ?, ?> old = channels.remove(fd);
@@ -344,8 +344,8 @@ public final class KQueueHandler implements IoHandler {
     }
 
     @Override
-    public boolean isCompatible(Class<? extends Channel> channelType) {
-        return AbstractKQueueChannel.class.isAssignableFrom(channelType);
+    public boolean isCompatible(Class<? extends IoHandle> handleType) {
+        return AbstractKQueueChannel.class.isAssignableFrom(handleType);
     }
 
     private static void handleLoopException(Throwable t) {

--- a/transport/src/main/java/io/netty5/channel/Channel.java
+++ b/transport/src/main/java/io/netty5/channel/Channel.java
@@ -117,7 +117,7 @@ import java.net.SocketAddress;
  * example, you can configure the parameters which are specific to a TCP/IP
  * socket as explained in {@link SocketChannel}.
  */
-public interface Channel extends AttributeMap, ChannelOutboundInvoker, Comparable<Channel> {
+public interface Channel extends AttributeMap, ChannelOutboundInvoker, Comparable<Channel>, IoHandle {
 
     /**
      * Returns the globally unique identifier of this {@link Channel}.
@@ -176,11 +176,6 @@ public interface Channel extends AttributeMap, ChannelOutboundInvoker, Comparabl
      * Returns {@code true} if the {@link Channel} is open and may get active later
      */
     boolean isOpen();
-
-    /**
-     * Returns {@code true} if the {@link Channel} is registered with an {@link EventLoop}.
-     */
-    boolean isRegistered();
 
     /**
      * Return {@code true} if the {@link Channel} is active and so connected.

--- a/transport/src/main/java/io/netty5/channel/EventLoop.java
+++ b/transport/src/main/java/io/netty5/channel/EventLoop.java
@@ -19,9 +19,9 @@ import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.OrderedEventExecutor;
 
 /**
- * Will handle all the I/O operations for a {@link Channel} once registered.
+ * Will handle all the I/O operations for a {@link IoHandle} once registered.
  *<p>
- * One {@link EventLoop} instance will usually handle more than one {@link Channel} but this may depend on
+ * One {@link EventLoop} instance will usually handle more than one {@link IoHandle} but this may depend on
  * implementation details and internals.
  */
 public interface EventLoop extends OrderedEventExecutor, EventLoopGroup {
@@ -32,24 +32,24 @@ public interface EventLoop extends OrderedEventExecutor, EventLoopGroup {
     }
 
     /**
-     * Register the {@link Channel} to the {@link EventLoop} for I/O processing.
+     * Register the {@link IoHandle} to the {@link EventLoop} for I/O processing.
      *
-     * @param channel   the {@link Channel} to register.
+     * @param handle   the {@link IoHandle} to register.
      * @return          the {@link Future} that is notified once the operations completes.
      */
-    Future<Void> registerForIo(Channel channel);
+    Future<Void> registerForIo(IoHandle handle);
 
     /**
      * Deregister the {@link Channel} from the {@link EventLoop} for I/O processing.
      *
-     * @param channel   the {@link Channel} to deregister.
+     * @param channel   the {@link IoHandle} to deregister.
      * @return          the {@link Future} that is notified once the operations completes.
      */
-    Future<Void> deregisterForIo(Channel channel);
+    Future<Void> deregisterForIo(IoHandle handle);
 
     // Force the implementing class to implement this method itself. This is needed as
     // EventLoopGroup provides default implementations that call next() which would lead to
     // and infinite loop if not implemented differently in the EventLoop itself.
     @Override
-    boolean isCompatible(Class<? extends Channel> channelType);
+    boolean isCompatible(Class<? extends IoHandle> handleType);
 }

--- a/transport/src/main/java/io/netty5/channel/EventLoopGroup.java
+++ b/transport/src/main/java/io/netty5/channel/EventLoopGroup.java
@@ -18,7 +18,7 @@ package io.netty5.channel;
 import io.netty5.util.concurrent.EventExecutorGroup;
 
 /**
- * Special {@link EventExecutorGroup} which allows registering {@link Channel}s that get
+ * Special {@link EventExecutorGroup} which allows registering {@link IoHandle}s that get
  * processed for later selection during the event loop.
  *
  */
@@ -33,10 +33,10 @@ public interface EventLoopGroup extends EventExecutorGroup {
      * Returns {@code true} if the given type is compatible with this {@link EventLoopGroup} and so can be registered
      * to the contained {@link EventLoop}s, {@code false} otherwise.
      *
-     * @param channelType   the type of the {@link Channel}.
+     * @param handleType    the type of the {@link IoHandle}.
      * @return              if compatible of not.
      */
-    default boolean isCompatible(Class<? extends Channel> channelType) {
-        return next().isCompatible(channelType);
+    default boolean isCompatible(Class<? extends IoHandle> handleType) {
+        return next().isCompatible(handleType);
     }
 }

--- a/transport/src/main/java/io/netty5/channel/IoHandle.java
+++ b/transport/src/main/java/io/netty5/channel/IoHandle.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel;
+
+/**
+ * A handle that will process I/O.
+ */
+public interface IoHandle {
+
+    /**
+     * Return true if registered already.
+     *
+     * @return {@code true} if registered, {@code false} otherwise
+     */
+    boolean isRegistered();
+}

--- a/transport/src/main/java/io/netty5/channel/IoHandler.java
+++ b/transport/src/main/java/io/netty5/channel/IoHandler.java
@@ -27,7 +27,7 @@ public interface IoHandler {
      * scheduled on the {@link EventLoop}. This is done by taking {@link IoExecutionContext#delayNanos(long)} or
      * {@link IoExecutionContext#deadlineNanos()} into account.
      *
-     * @return the number of {@link Channel} for which I/O was handled.
+     * @return the number of {@link IoHandle} for which I/O was handled.
      */
     int run(IoExecutionContext context);
 
@@ -48,15 +48,15 @@ public interface IoHandler {
      * @param channel       the {@link Channel} to register..
      * @throws Exception    thrown if an error happens during registration.
      */
-    void register(Channel channel) throws Exception;
+    void register(IoHandle channel) throws Exception;
 
     /**
-     * Deregister a {@link Channel} for IO.
+     * Deregister a {@link IoHandle} for IO.
      *
-     * @param channel       the {@link Channel} to deregister..
+     * @param handle        the {@link IoHandle} to deregister..
      * @throws Exception    thrown if an error happens during deregistration.
      */
-    void deregister(Channel channel) throws Exception;
+    void deregister(IoHandle handle) throws Exception;
 
     /**
      * Wakeup the {@link IoHandler}, which means if any operation blocks it should be unblocked and
@@ -68,8 +68,8 @@ public interface IoHandler {
      * Returns {@code true} if the given type is compatible with this {@link IoHandler} and so can be registered,
      * {@code false} otherwise.
      *
-     * @param channelType   the type of the {@link Channel}.
+     * @param handleType    the type of the {@link IoHandle}.
      * @return              if compatible of not.
      */
-    boolean isCompatible(Class<? extends Channel> channelType);
+    boolean isCompatible(Class<? extends IoHandle> handleType);
 }

--- a/transport/src/main/java/io/netty5/channel/embedded/EmbeddedEventLoop.java
+++ b/transport/src/main/java/io/netty5/channel/embedded/EmbeddedEventLoop.java
@@ -17,6 +17,7 @@ package io.netty5.channel.embedded;
 
 import io.netty5.channel.Channel;
 import io.netty5.channel.EventLoop;
+import io.netty5.channel.IoHandle;
 import io.netty5.util.concurrent.AbstractScheduledEventExecutor;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.Promise;
@@ -49,11 +50,11 @@ final class EmbeddedEventLoop extends AbstractScheduledEventExecutor implements 
     private final Queue<Runnable> tasks = new ArrayDeque<>(2);
     boolean running;
 
-    private static EmbeddedChannel cast(Channel channel) {
-        if (channel instanceof EmbeddedChannel) {
-            return (EmbeddedChannel) channel;
+    private static EmbeddedChannel cast(IoHandle handle) {
+        if (handle instanceof EmbeddedChannel) {
+            return (EmbeddedChannel) handle;
         }
-        throw new IllegalArgumentException("Channel of type " + StringUtil.simpleClassName(channel) + " not supported");
+        throw new IllegalArgumentException("Channel of type " + StringUtil.simpleClassName(handle) + " not supported");
     }
 
     @Override
@@ -62,8 +63,9 @@ final class EmbeddedEventLoop extends AbstractScheduledEventExecutor implements 
     }
 
     @Override
-    public Future<Void> registerForIo(Channel channel) {
+    public Future<Void> registerForIo(IoHandle handle) {
         Promise<Void> promise = newPromise();
+        EmbeddedChannel channel = cast(handle);
         if (inEventLoop()) {
             registerForIO0(channel, promise);
         } else {
@@ -72,7 +74,7 @@ final class EmbeddedEventLoop extends AbstractScheduledEventExecutor implements 
         return promise.asFuture();
     }
 
-    private void registerForIO0(Channel channel, Promise<Void> promise) {
+    private void registerForIO0(EmbeddedChannel channel, Promise<Void> promise) {
         assert inEventLoop();
         try {
             if (channel.isRegistered()) {
@@ -81,7 +83,7 @@ final class EmbeddedEventLoop extends AbstractScheduledEventExecutor implements 
             if (!channel.executor().inEventLoop()) {
                 throw new IllegalStateException("Channel.executor() is not using the same Thread as this EventLoop");
             }
-            cast(channel).setActive();
+            channel.setActive();
         } catch (Throwable cause) {
             promise.setFailure(cause);
             return;
@@ -89,8 +91,9 @@ final class EmbeddedEventLoop extends AbstractScheduledEventExecutor implements 
         promise.setSuccess(null);
     }
     @Override
-    public Future<Void> deregisterForIo(Channel channel) {
+    public Future<Void> deregisterForIo(IoHandle handle) {
         Promise<Void> promise = newPromise();
+        EmbeddedChannel channel = cast(handle);
         if (inEventLoop()) {
             deregisterForIO0(channel, promise);
         } else {
@@ -249,7 +252,7 @@ final class EmbeddedEventLoop extends AbstractScheduledEventExecutor implements 
     }
 
     @Override
-    public boolean isCompatible(Class<? extends Channel> channelType) {
-        return EmbeddedChannel.class.isAssignableFrom(channelType);
+    public boolean isCompatible(Class<? extends IoHandle> handleType) {
+        return EmbeddedChannel.class.isAssignableFrom(handleType);
     }
 }

--- a/transport/src/main/java/io/netty5/channel/local/LocalHandler.java
+++ b/transport/src/main/java/io/netty5/channel/local/LocalHandler.java
@@ -17,6 +17,7 @@ package io.netty5.channel.local;
 
 import io.netty5.channel.Channel;
 import io.netty5.channel.IoExecutionContext;
+import io.netty5.channel.IoHandle;
 import io.netty5.channel.IoHandler;
 import io.netty5.channel.IoHandlerFactory;
 import io.netty5.util.internal.StringUtil;
@@ -41,11 +42,11 @@ public final class LocalHandler implements IoHandler {
         return LocalHandler::new;
     }
 
-    private static LocalChannelUnsafe cast(Channel channel) {
-        if (channel instanceof LocalChannelUnsafe) {
-            return (LocalChannelUnsafe) channel;
+    private static LocalChannelUnsafe cast(IoHandle handle) {
+        if (handle instanceof LocalChannelUnsafe) {
+            return (LocalChannelUnsafe) handle;
         }
-        throw new IllegalArgumentException("Channel of type " + StringUtil.simpleClassName(channel) + " not supported");
+        throw new IllegalArgumentException("IoHandle of type " + StringUtil.simpleClassName(handle) + " not supported");
     }
 
     @Override
@@ -84,23 +85,23 @@ public final class LocalHandler implements IoHandler {
     }
 
     @Override
-    public void register(Channel channel) {
-        LocalChannelUnsafe unsafe = cast(channel);
+    public void register(IoHandle handle) {
+        LocalChannelUnsafe unsafe = cast(handle);
         if (registeredChannels.add(unsafe)) {
             unsafe.registerTransportNow();
         }
     }
 
     @Override
-    public void deregister(Channel channel) {
-        LocalChannelUnsafe unsafe = cast(channel);
+    public void deregister(IoHandle handle) {
+        LocalChannelUnsafe unsafe = cast(handle);
         if (registeredChannels.remove(unsafe)) {
             unsafe.deregisterTransportNow();
         }
     }
 
     @Override
-    public boolean isCompatible(Class<? extends Channel> channelType) {
-        return LocalChannelUnsafe.class.isAssignableFrom(channelType);
+    public boolean isCompatible(Class<? extends IoHandle> handleType) {
+        return LocalChannelUnsafe.class.isAssignableFrom(handleType);
     }
 }

--- a/transport/src/main/java/io/netty5/channel/nio/NioProcessor.java
+++ b/transport/src/main/java/io/netty5/channel/nio/NioProcessor.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.nio;
+
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
+
+
+/**
+ * Process IO.
+ */
+interface NioProcessor {
+
+    /**
+     * Register to a {@link Selector}.
+     *
+     * @param selector                  the {@link Selector} to register to.
+     * @throws ClosedChannelException   if already closed.
+     */
+    void register(Selector selector) throws ClosedChannelException;
+
+    /**
+     * Deregister from previous registered {@link Selector}.
+     */
+    void deregister();
+
+    /**
+     * Handle some IO for the given {@link SelectionKey}.
+     *
+     * @param key   the {@link SelectionKey} that needs to be handled.
+     */
+    void handle(SelectionKey key);
+
+    /**
+     * Close this processor.
+     */
+    void close();
+}

--- a/transport/src/main/java/io/netty5/channel/nio/NioSelectableChannelHandle.java
+++ b/transport/src/main/java/io/netty5/channel/nio/NioSelectableChannelHandle.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.nio;
+
+import io.netty5.channel.IoHandle;
+import io.netty5.util.internal.logging.InternalLogger;
+import io.netty5.util.internal.logging.InternalLoggerFactory;
+
+import java.io.IOException;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.SelectableChannel;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
+import java.util.function.BiConsumer;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Allows to create an {@link IoHandle} for a {@link SelectableChannel}, not necessarily created by Netty. This
+ * {@link IoHandle} can be used together with {@link NioHandler} and so have events dispatched for
+ * the {@link SelectableChannel}.
+ */
+public final class NioSelectableChannelHandle<S extends SelectableChannel> implements IoHandle {
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(NioSelectableChannelHandle.class);
+
+    private final S channel;
+    private final int interestOps;
+    private volatile SelectionKey selectionKey;
+
+    private final BiConsumer<S, SelectionKey> keyProcessor;
+
+    public NioSelectableChannelHandle(S channel, int interestOps, BiConsumer<S, SelectionKey> keyProcessor) {
+        if ((interestOps & ~channel.validOps()) != 0) {
+            throw new IllegalArgumentException(
+                    "invalid interestOps: " + interestOps + "(validOps: " + channel.validOps() + ')');
+        }
+        this.channel = requireNonNull(channel, "channel");
+        this.interestOps = interestOps;
+        this.keyProcessor = requireNonNull(keyProcessor, "keyProcessor");
+    }
+
+    @Override
+    public boolean isRegistered() {
+        return channel.isRegistered();
+    }
+
+    private final NioProcessor nioProcessor = new NioProcessor() {
+        @Override
+        public void register(Selector selector) throws ClosedChannelException {
+            int interestOps;
+            SelectionKey key = selectionKey;
+            if (key != null) {
+                interestOps = key.interestOps();
+                key.cancel();
+            } else {
+                interestOps = NioSelectableChannelHandle.this.interestOps;
+            }
+            selectionKey = channel.register(selector, interestOps, this);
+        }
+
+        @Override
+        public void deregister() {
+            SelectionKey key = selectionKey;
+            if (key != null) {
+                key.cancel();
+            }
+        }
+
+        @Override
+        public void handle(SelectionKey key) {
+            keyProcessor.accept(channel, key);
+        }
+
+        @Override
+        public void close() {
+            try {
+                channel.close();
+            } catch (IOException e) {
+                logger.warn("Unexpected exception while closing underlying channel", e);
+            }
+        }
+    };
+
+    NioProcessor nioProcessor() {
+        return nioProcessor;
+    }
+}

--- a/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTailTest.java
+++ b/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTailTest.java
@@ -62,12 +62,12 @@ public class DefaultChannelPipelineTailTest {
             }
 
             @Override
-            public void register(Channel channel) {
+            public void register(IoHandle handle) {
                 // NOOP
             }
 
             @Override
-            public void deregister(Channel channel) {
+            public void deregister(IoHandle handle) {
                 // NOOP
             }
 
@@ -81,8 +81,8 @@ public class DefaultChannelPipelineTailTest {
             }
 
             @Override
-            public boolean isCompatible(Class<? extends Channel> channelType) {
-                return MyChannel.class.isAssignableFrom(channelType);
+            public boolean isCompatible(Class<? extends IoHandle> handleType) {
+                return MyChannel.class.isAssignableFrom(handleType);
             }
         });
     }

--- a/transport/src/test/java/io/netty5/channel/SingleThreadEventLoopTest.java
+++ b/transport/src/test/java/io/netty5/channel/SingleThreadEventLoopTest.java
@@ -472,17 +472,17 @@ public class SingleThreadEventLoopTest {
         }
 
         @Override
-        public Future<Void> registerForIo(Channel channel) {
+        public Future<Void> registerForIo(IoHandle handle) {
             return newSucceededFuture(null);
         }
 
         @Override
-        public Future<Void> deregisterForIo(Channel channel) {
+        public Future<Void> deregisterForIo(IoHandle handle) {
             return newSucceededFuture(null);
         }
 
         @Override
-        public boolean isCompatible(Class<? extends Channel> channelType) {
+        public boolean isCompatible(Class<? extends IoHandle> handleType) {
             return true;
         }
     }
@@ -523,17 +523,17 @@ public class SingleThreadEventLoopTest {
         }
 
         @Override
-        public Future<Void> registerForIo(Channel channel) {
+        public Future<Void> registerForIo(IoHandle handleType) {
             return newSucceededFuture(null);
         }
 
         @Override
-        public Future<Void> deregisterForIo(Channel channel) {
+        public Future<Void> deregisterForIo(IoHandle handleType) {
             return newSucceededFuture(null);
         }
 
         @Override
-        public boolean isCompatible(Class<? extends Channel> channelType) {
+        public boolean isCompatible(Class<? extends IoHandle> handleType) {
             return true;
         }
     }

--- a/transport/src/test/java/io/netty5/channel/nio/NioEventLoopTest.java
+++ b/transport/src/test/java/io/netty5/channel/nio/NioEventLoopTest.java
@@ -148,17 +148,8 @@ public class NioEventLoopTest extends AbstractEventLoopTest {
 
             final CountDownLatch latch = new CountDownLatch(1);
 
-            loop.execute(() ->
-                    nioHandler.register(selectableChannel, SelectionKey.OP_CONNECT, new NioTask<SocketChannel>() {
-                        @Override
-                        public void channelReady(SocketChannel ch, SelectionKey key) {
-                            latch.countDown();
-                        }
-
-                        @Override
-                        public void channelUnregistered(SocketChannel ch, Throwable cause) {
-                        }
-                    }));
+            loop.registerForIo(new NioSelectableChannelHandle<>(selectableChannel,
+                    SelectionKey.OP_CONNECT, (ch, key) -> latch.countDown()));
 
             latch.await();
 

--- a/transport/src/test/java/io/netty5/channel/socket/nio/AbstractNioChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/socket/nio/AbstractNioChannelTest.java
@@ -19,6 +19,7 @@ import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelOption;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.EventLoopGroup;
+import io.netty5.channel.IoHandle;
 import io.netty5.channel.MultithreadEventLoopGroup;
 import io.netty5.channel.nio.AbstractNioChannel;
 import io.netty5.channel.nio.NioHandler;
@@ -163,18 +164,18 @@ public abstract class AbstractNioChannelTest<T extends AbstractNioChannel<?, ?, 
             }
 
             @Override
-            public Future<Void> registerForIo(Channel channel) {
-                return eventLoop.registerForIo(channel);
+            public Future<Void> registerForIo(IoHandle handle) {
+                return eventLoop.registerForIo(handle);
             }
 
             @Override
-            public Future<Void> deregisterForIo(Channel channel) {
-                return eventLoop.deregisterForIo(channel);
+            public Future<Void> deregisterForIo(IoHandle handle) {
+                return eventLoop.deregisterForIo(handle);
             }
 
             @Override
-            public boolean isCompatible(Class<? extends Channel> channelType) {
-                return eventLoop.isCompatible(channelType);
+            public boolean isCompatible(Class<? extends IoHandle> handleType) {
+                return eventLoop.isCompatible(handleType);
             }
         }
 


### PR DESCRIPTION
…eregistration

Motivation:

By changing the EventLoop / IoHandler to take an IoHandle (and not a Channel) as argument we can support handling of other things then netty channels via the EventLoop / IoHandler. For example we can use it to let people register their self managed SelectableChannel implementations. In the future we might also use this abstraction to support file IO via io_uring.

Modifications:

- Add IoHandle interface
- Change EventLoop / IoHandler methods to take IoHandle
- Let Channel extend IoHandle
- Remove NioTask and replace it by NioSelectableChannelHandle
- Share processing logic in NioHandler.

Result:

More flexible and future proof API when it comes to IO handling
