### PR TITLE
Replace synchronized with Java Locks on the allocator (Fixes #12621)

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolChunkList.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunkList.java
@@ -209,7 +209,8 @@ final class PoolChunkList<T> implements PoolChunkListMetric {
 
     @Override
     public Iterator<PoolChunkMetric> iterator() {
-        synchronized (arena) {
+        arena.lock();
+        try {
             if (head == null) {
                 return EMPTY_METRICS;
             }
@@ -222,13 +223,16 @@ final class PoolChunkList<T> implements PoolChunkListMetric {
                 }
             }
             return metrics.iterator();
+        } finally {
+            arena.unlock();
         }
     }
 
     @Override
     public String toString() {
         StringBuilder buf = new StringBuilder();
-        synchronized (arena) {
+        arena.lock();
+        try {
             if (head == null) {
                 return "none";
             }
@@ -241,6 +245,8 @@ final class PoolChunkList<T> implements PoolChunkListMetric {
                 }
                 buf.append(StringUtil.NEWLINE);
             }
+        } finally {
+            arena.unlock();
         }
         return buf.toString();
     }


### PR DESCRIPTION
Motivation:
JDK 19 Virtual Thread preview is not compatible with synchronized blocks and Netty pooled allocator code is making uses of it to protect arenas/chunk/subpages accesses

Modification:
Replacing existing synchronized usages to make the existing core more Virtual threads friendly: no evident effects should exist on performance, but an increased allocation rate under contention.

Result:
Virtual Threads compliant pooled allocator