### PR TITLE
Correctly exclude NIO Datagram for Unix Domain Socket if not supported

### DIFF
--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketTestPermutation.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketTestPermutation.java
@@ -223,6 +223,6 @@ public class SocketTestPermutation {
     }
 
     public static boolean isJdkDomainDatagramSupported() {
-        return NioDomainSocketTestUtil.isSocketSupported();
+        return NioDomainSocketTestUtil.isDatagramSupported();
     }
 }


### PR DESCRIPTION
Motivation:

We need to exclude NIO Datagram Unix Domain Socket when running our tests if its not supported

Modifications:

Call the correct method

Result:

Testsuite pass on macOS
