### PR TITLE
Add profile to cross-compile for intel on m1 mac

### DIFF
--- a/resolver-dns-native-macos/pom.xml
+++ b/resolver-dns-native-macos/pom.xml
@@ -242,6 +242,115 @@
         </dependency>
       </dependencies>
     </profile>
+
+    <profile>
+      <id>mac-intel-cross-compile</id>
+      <properties>
+        <jni.compiler.args.ldflags>LDFLAGS=-arch x86_64 -Wl,-weak_library,${unix.common.lib.unpacked.dir}/lib${unix.common.lib.name}.a -Wl,-platform_version,macos,10.6,10.6</jni.compiler.args.ldflags>
+        <jni.compiler.args.cflags>CFLAGS=-target x86_64-apple-macos10.6 -O3 -Werror -fno-omit-frame-pointer -Wunused-variable -fvisibility=hidden -I${unix.common.include.unpacked.dir}</jni.compiler.args.cflags>
+
+        <!-- use aarch_64 as this is also what os.detected.arch will use on an aarch64 system -->
+        <jni.classifier>${os.detected.name}-x86_64</jni.classifier>
+        <javaModuleNameClassifier>${os.detected.name}.x86_64</javaModuleNameClassifier>
+        <skipTests>true</skipTests>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <!-- unpack the unix-common static library and include files -->
+              <execution>
+                <id>unpack</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>unpack-dependencies</goal>
+                </goals>
+                <configuration>
+                  <includeGroupIds>${project.groupId}</includeGroupIds>
+                  <includeArtifactIds>netty-transport-native-unix-common</includeArtifactIds>
+                  <classifier>${jni.classifier}</classifier>
+                  <outputDirectory>${unix.common.lib.dir}</outputDirectory>
+                  <includes>META-INF/native/**</includes>
+                  <overWriteReleases>false</overWriteReleases>
+                  <overWriteSnapshots>true</overWriteSnapshots>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>org.fusesource.hawtjni</groupId>
+            <artifactId>maven-hawtjni-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>build-native-lib</id>
+                <configuration>
+                  <name>netty_resolver_dns_native_macos_x86_64</name>
+                  <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
+                  <libDirectory>${project.build.outputDirectory}</libDirectory>
+                  <!-- We use Maven's artifact classifier instead.
+                       This hack will make the hawtjni plugin to put the native library
+                       under 'META-INF/native' rather than 'META-INF/native/${platform}'. -->
+                  <platform>.</platform>
+                  <configureArgs>
+                    <arg>${jni.compiler.args.ldflags}</arg>
+                    <arg>${jni.compiler.args.cflags}</arg>
+                    <configureArg>--host=x86_64-apple-darwin</configureArg>
+                    <arg>MACOSX_DEPLOYMENT_TARGET=10.6</arg>
+                  </configureArgs>
+                </configuration>
+                <goals>
+                  <goal>generate</goal>
+                  <goal>build</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <artifactId>maven-jar-plugin</artifactId>
+            <executions>
+              <!-- Generate the JAR that contains the native library in it. -->
+              <execution>
+                <id>native-jar</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+                <configuration>
+                  <archive>
+                    <manifest>
+                      <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                    </manifest>
+                    <manifestEntries>
+                      <Bundle-NativeCode>META-INF/native/libnetty_resolver_dns_native_macos_x86_64.jnilib; osname=MacOSX; processor=x86_64</Bundle-NativeCode>
+                      <Fragment-Host>io.netty.resolver-dns-classes-macos</Fragment-Host>
+                      <Automatic-Module-Name>${javaModuleName}</Automatic-Module-Name>
+                    </manifestEntries>
+                    <index>true</index>
+                    <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                  </archive>
+                  <classifier>${jni.classifier}</classifier>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+      <dependencies>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-unix-common</artifactId>
+          <version>${project.version}</version>
+          <classifier>${jni.classifier}</classifier>
+          <!--
+          The unix-common with classifier dependency is optional because it is not a runtime dependency, but a build time
+          dependency to get the static library which is built directly into the shared library generated by this project.
+          -->
+          <optional>true</optional>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 
   <properties>

--- a/scripts/finish_release.sh
+++ b/scripts/finish_release.sh
@@ -22,6 +22,8 @@ if [ "$#" -ne 2 ]; then
 fi
 
 OS=$(uname)
+ARCH=$(uname -p)
+
 
 if [ "$OS" != "Darwin" ]; then
     echo "Needs to be executed on macOS"
@@ -35,13 +37,18 @@ if git tag | grep -q "$2" ; then
     git tag -d "$2"
 fi
 
+CROSS_COMPILE_PROFILE="mac-m1-cross-compile"
+if [ "$ARCH" == "arm" ]; then
+    PROFILE="mac-intel-cross-compile"
+fi
+
 git fetch
 git checkout "$2"
 
 export JAVA_HOME="$JAVA8_HOME"
 
 ./mvnw -Psonatype-oss-release -am -pl resolver-dns-native-macos,transport-native-unix-common,transport-native-kqueue clean package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DstagingRepositoryId="$1" -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DskipTests=true
-./mvnw -Psonatype-oss-release,mac-m1-cross-compile -am -pl resolver-dns-native-macos,transport-native-unix-common,transport-native-kqueue clean package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DstagingRepositoryId="$1" -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DskipTests=true
+./mvnw -Psonatype-oss-release,"$CROSS_COMPILE_PROFILE" -am -pl resolver-dns-native-macos,transport-native-unix-common,transport-native-kqueue clean package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DstagingRepositoryId="$1" -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DskipTests=true
 
 ./mvnw -Psonatype-oss-release,full,native-dependencies,staging -pl all clean package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DstagingRepositoryId="$1" -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DskipTests=true
 

--- a/transport-native-kqueue/pom.xml
+++ b/transport-native-kqueue/pom.xml
@@ -246,6 +246,114 @@
       </dependencies>
     </profile>
     <profile>
+      <id>mac-intel-cross-compile</id>
+      <properties>
+        <!-- use aarch_64 as this is also what os.detected.arch will use on an aarch64 system -->
+        <jni.classifier>${os.detected.name}-x86_64</jni.classifier>
+        <javaModuleNameClassifier>${os.detected.name}.x86_64</javaModuleNameClassifier>
+        <jni.compiler.args.cflags>CFLAGS=-target x86_64-apple-macos10.6 -O3 -Werror -fno-omit-frame-pointer -Wunused-variable -fvisibility=hidden -I${unix.common.include.unpacked.dir}</jni.compiler.args.cflags>
+        <jni.compiler.args.ldflags>LDFLAGS=-arch x86_64 -Wl,-weak_library,${unix.common.lib.unpacked.dir}/lib${unix.common.lib.name}.a -Wl,-platform_version,macos,10.6,10.6</jni.compiler.args.ldflags>
+        <skipTests>true</skipTests>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <!-- unpack the unix-common static library and include files -->
+              <execution>
+                <id>unpack</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>unpack-dependencies</goal>
+                </goals>
+                <configuration>
+                  <includeGroupIds>${project.groupId}</includeGroupIds>
+                  <includeArtifactIds>netty-transport-native-unix-common</includeArtifactIds>
+                  <classifier>${jni.classifier}</classifier>
+                  <outputDirectory>${unix.common.lib.dir}</outputDirectory>
+                  <includes>META-INF/native/**</includes>
+                  <overWriteReleases>false</overWriteReleases>
+                  <overWriteSnapshots>true</overWriteSnapshots>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>org.fusesource.hawtjni</groupId>
+            <artifactId>maven-hawtjni-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>build-native-lib</id>
+                <configuration>
+                  <name>netty_transport_native_kqueue_aarch_64</name>
+                  <nativeSourceDirectory>${nativeSourceDirectory}</nativeSourceDirectory>
+                  <libDirectory>${project.build.outputDirectory}</libDirectory>
+                  <!-- We use Maven's artifact classifier instead.
+                       This hack will make the hawtjni plugin to put the native library
+                       under 'META-INF/native' rather than 'META-INF/native/${platform}'. -->
+                  <platform>.</platform>
+                  <configureArgs>
+                    <arg>${jni.compiler.args.ldflags}</arg>
+                    <arg>${jni.compiler.args.cflags}</arg>
+                    <arg>MACOSX_DEPLOYMENT_TARGET=10.6</arg>
+                    <configureArg>--host=x86_64-apple-darwin</configureArg>
+                    <configureArg>--libdir=${project.build.directory}/native-build/target/lib</configureArg>
+                  </configureArgs>
+                </configuration>
+                <goals>
+                  <goal>generate</goal>
+                  <goal>build</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <artifactId>maven-jar-plugin</artifactId>
+            <executions>
+              <!-- Generate the JAR that contains the native library in it. -->
+              <execution>
+                <id>native-jar</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+                <configuration>
+                  <archive>
+                    <manifest>
+                      <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                    </manifest>
+                    <manifestEntries>
+                      <Bundle-NativeCode>META-INF/native/libnetty_transport_native_kqueue_aarch_64.jnilib; osname=MacOSX; processor=aarch64</Bundle-NativeCode>
+                      <Fragment-Host>io.netty.transport-classes-kqueue</Fragment-Host>
+                      <Automatic-Module-Name>${javaModuleName}</Automatic-Module-Name>
+                    </manifestEntries>
+                    <index>true</index>
+                    <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                  </archive>
+                  <classifier>${jni.classifier}</classifier>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+      <dependencies>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-unix-common</artifactId>
+          <version>${project.version}</version>
+          <classifier>${jni.classifier}</classifier>
+          <!--
+          The unix-common with classifier dependency is optional because it is not a runtime dependency, but a build time
+          dependency to get the static library which is built directly into the shared library generated by this project.
+          -->
+          <optional>true</optional>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
       <id>openbsd</id>
       <activation>
         <os>

--- a/transport-native-unix-common/pom.xml
+++ b/transport-native-unix-common/pom.xml
@@ -240,6 +240,76 @@
       </build>
     </profile>
     <profile>
+      <id>mac-intel-cross-compile</id>
+      <properties>
+        <exe.compiler>clang</exe.compiler>
+        <jni.platform>darwin</jni.platform>
+        <!-- use aarch_64 as this is also what os.detected.arch will use on an aarch64 system -->
+        <jni.classifier>${os.detected.name}-x86_64</jni.classifier>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <!-- Build the additional JAR that contains the native library. -->
+              <execution>
+                <id>native-jar</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <copy todir="${nativeJarWorkdir}">
+                      <zipfileset src="${defaultJarFile}" />
+                    </copy>
+                    <copy todir="${nativeJarWorkdir}" includeEmptyDirs="false">
+                      <zipfileset dir="${nativeLibOnlyDir}" />
+                      <regexpmapper handledirsep="yes" from="^(?:[^/]+/)*([^/]+)$" to="META-INF/native/lib/\1" />
+                    </copy>
+                    <copy todir="${nativeJarWorkdir}" includeEmptyDirs="false">
+                      <zipfileset dir="${nativeIncludeDir}" />
+                      <regexpmapper handledirsep="yes" from="^(?:[^/]+/)*([^/]+).h$" to="META-INF/native/include/\1.h" />
+                    </copy>
+                    <copy todir="${nativeJarWorkdir}" includeEmptyDirs="false">
+                      <zipfileset dir="${jniUtilIncludeDir}" />
+                      <regexpmapper handledirsep="yes" from="^(?:[^/]+/)*([^/]+).h$" to="META-INF/native/include/\1.h" />
+                    </copy>
+                    <jar destfile="${nativeJarFile}" manifest="${nativeJarWorkdir}/META-INF/MANIFEST.MF" basedir="${nativeJarWorkdir}" index="true" excludes="META-INF/MANIFEST.MF,META-INF/INDEX.LIST" />
+                    <attachartifact file="${nativeJarFile}" classifier="${jni.classifier}" type="jar" />
+                  </target>
+                </configuration>
+              </execution>
+              <!-- invoke the make file to build a static library -->
+              <execution>
+                <id>build-native-lib</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <exec executable="${exe.make}" failonerror="true" resolveexecutable="true">
+                      <env key="CC" value="${exe.compiler}" />
+                      <env key="AR" value="${exe.archiver}" />
+                      <env key="LIB_DIR" value="${nativeLibOnlyDir}" />
+                      <env key="OBJ_DIR" value="${nativeObjsOnlyDir}" />
+                      <env key="JNI_PLATFORM" value="${jni.platform}" />
+                      <env key="CFLAGS" value="-target arm64-apple-macos11 -O3 -Werror -Wno-attributes -fPIC -fno-omit-frame-pointer -Wunused-variable -fvisibility=hidden" />
+                      <env key="LDFLAGS" value="-arch arm64 -Wl,--no-as-needed -lrt -Wl,-platform_version,macos,10.6,10.6" />
+                      <env key="LIB_NAME" value="${nativeLibName}" />
+                      <env key="MACOSX_DEPLOYMENT_TARGET" value="10.6" />
+                    </exec>
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <id>linux</id>
       <activation>
         <os>


### PR DESCRIPTION
Motivation:

As the new hw has a m1 / m2 chip we need to ensure we can also cross-compile for intel and do a release

Modifications:

- Add profile for cross-compile to intel
- Adjust finish_release.sh script to select the correct profile for cross compilation

Result:

Be able to cross compile on m1 and also do the release