### PR TITLE
Use netty-tcnative-boringssl-static when on linux aarch64

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -376,6 +376,23 @@
       </properties>
     </profile>
     <profile>
+      <id>boringssl-linux-aarch64</id>
+      <activation>
+        <os>
+          <!--
+           Automatically active on linux with aarch64 as we only release static boringssl version of
+           netty-tcnative for it.
+         -->
+          <family>linux</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <tcnative.artifactId>netty-tcnative-boringssl-static</tcnative.artifactId>
+        <tcnative.classifier />
+      </properties>
+    </profile>
+    <profile>
       <id>boringssl</id>
       <activation>
         <!--


### PR DESCRIPTION
Motivation:

We only publish netty-tcnative-boringssl-static foor linux aarch64.

Modifications:

Use boringssl version

Result:

Build works on linux aarch64

