### PR TITLE
Replace synchronized with Java Locks on the allocator (Fixes #12621)

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/pool/PoolChunkList.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/pool/PoolChunkList.java
@@ -202,7 +202,8 @@ final class PoolChunkList implements PoolChunkListMetric {
 
     @Override
     public Iterator<PoolChunkMetric> iterator() {
-        synchronized (arena) {
+        arena.lock();
+        try {
             if (head == null) {
                 return EMPTY_METRICS;
             }
@@ -215,13 +216,16 @@ final class PoolChunkList implements PoolChunkListMetric {
                 }
             }
             return metrics.iterator();
+        } finally {
+            arena.unlock();
         }
     }
 
     @Override
     public String toString() {
         StringBuilder buf = new StringBuilder();
-        synchronized (arena) {
+        arena.lock();
+        try {
             if (head == null) {
                 return "none";
             }
@@ -234,6 +238,8 @@ final class PoolChunkList implements PoolChunkListMetric {
                 }
                 buf.append(StringUtil.NEWLINE);
             }
+        } finally {
+            arena.unlock();
         }
         return buf.toString();
     }


### PR DESCRIPTION
Motivation:
JDK 19 Virtual Thread preview is not compatible with synchronized blocks and Netty pooled allocator code is making uses of it to protect arenas/chunk/subpages accesses

Modification:
Replacing existing synchronized usages to make the existing core more Virtual threads friendly: no evident effects should exist on performance, but an increased allocation rate under contention.

Result:
Virtual Threads compliant pooled allocator