### PR TITLE
Rename AbstractChannel.doBeginRead() to doRead()

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
@@ -195,7 +195,7 @@ abstract class AbstractEpollChannel<P extends UnixChannel>
     }
 
     @Override
-    protected final void doBeginRead() throws Exception {
+    protected final void doRead() throws Exception {
         // Channel.read() or ChannelHandlerContext.read() was called
         readPending = true;
 

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueChannel.java
@@ -232,7 +232,7 @@ abstract class AbstractKQueueChannel<P extends UnixChannel>
     }
 
     @Override
-    protected final void doBeginRead() {
+    protected final void doRead() {
         // Channel.read() or ChannelHandlerContext.read() was called
         readPending = true;
 

--- a/transport/src/main/java/io/netty5/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty5/channel/AbstractChannel.java
@@ -46,7 +46,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 import static io.netty5.channel.ChannelOption.ALLOW_HALF_CLOSURE;
 import static io.netty5.channel.ChannelOption.AUTO_CLOSE;
@@ -97,11 +96,9 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
     private volatile R remoteAddress;
     private volatile boolean registered;
 
+    @SuppressWarnings("rawtypes")
     private static final AtomicIntegerFieldUpdater<AbstractChannel> AUTOREAD_UPDATER =
             AtomicIntegerFieldUpdater.newUpdater(AbstractChannel.class, "autoRead");
-    private static final AtomicReferenceFieldUpdater<AbstractChannel, WriteBufferWaterMark> WATERMARK_UPDATER =
-            AtomicReferenceFieldUpdater.newUpdater(
-                    AbstractChannel.class, WriteBufferWaterMark.class, "writeBufferWaterMark");
 
     private volatile BufferAllocator bufferAllocator = DefaultBufferAllocators.preferredAllocator();
     private volatile RecvBufferAllocator rcvBufAllocator;
@@ -843,7 +840,7 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
             return;
         }
         try {
-            doBeginRead();
+            doRead();
         } catch (final Exception e) {
             invokeLater(() -> pipeline.fireChannelExceptionCaught(e));
             closeTransport(newPromise());
@@ -1130,7 +1127,7 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
     /**
      * Schedule a read operation.
      */
-    protected abstract void doBeginRead() throws Exception;
+    protected abstract void doRead() throws Exception;
 
     /**
      * Flush the content of the given buffer to the remote peer.

--- a/transport/src/main/java/io/netty5/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty5/channel/embedded/EmbeddedChannel.java
@@ -736,7 +736,7 @@ public class EmbeddedChannel extends AbstractChannel<Channel, SocketAddress, Soc
     }
 
     @Override
-    protected void doBeginRead() throws Exception {
+    protected void doRead() throws Exception {
         // NOOP
     }
 

--- a/transport/src/main/java/io/netty5/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty5/channel/local/LocalChannel.java
@@ -260,7 +260,7 @@ public class LocalChannel extends AbstractChannel<LocalServerChannel, LocalAddre
     };
 
     @Override
-    protected void doBeginRead() throws Exception {
+    protected void doRead() throws Exception {
         if (readInProgress) {
             return;
         }

--- a/transport/src/main/java/io/netty5/channel/local/LocalServerChannel.java
+++ b/transport/src/main/java/io/netty5/channel/local/LocalServerChannel.java
@@ -80,7 +80,7 @@ public class LocalServerChannel extends AbstractServerChannel<LocalChannel, Loca
     }
 
     @Override
-    protected void doBeginRead() throws Exception {
+    protected void doRead() throws Exception {
         if (acceptInProgress) {
             return;
         }

--- a/transport/src/main/java/io/netty5/channel/nio/AbstractNioChannel.java
+++ b/transport/src/main/java/io/netty5/channel/nio/AbstractNioChannel.java
@@ -265,7 +265,7 @@ public abstract class AbstractNioChannel<P extends Channel, L extends SocketAddr
     }
 
     @Override
-    protected void doBeginRead() throws Exception {
+    protected void doRead() throws Exception {
         // Channel.read() or ChannelHandlerContext.read() was called
         final SelectionKey selectionKey = this.selectionKey;
         if (!selectionKey.isValid()) {

--- a/transport/src/main/java/io/netty5/channel/nio/AbstractNioMessageChannel.java
+++ b/transport/src/main/java/io/netty5/channel/nio/AbstractNioMessageChannel.java
@@ -51,11 +51,11 @@ public abstract class AbstractNioMessageChannel<P extends Channel, L extends Soc
     }
 
     @Override
-    protected void doBeginRead() throws Exception {
+    protected void doRead() throws Exception {
         if (inputShutdown) {
             return;
         }
-        super.doBeginRead();
+        super.doRead();
     }
 
     protected boolean continueReading(RecvBufferAllocator.Handle allocHandle) {

--- a/transport/src/test/java/io/netty5/channel/AbstractChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/AbstractChannelTest.java
@@ -245,7 +245,7 @@ public class AbstractChannelTest {
         protected void doClose() { }
 
         @Override
-        protected void doBeginRead() { }
+        protected void doRead() { }
 
         @Override
         protected void doWrite(ChannelOutboundBuffer in) throws Exception { }

--- a/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTailTest.java
+++ b/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTailTest.java
@@ -279,7 +279,7 @@ public class DefaultChannelPipelineTailTest {
         }
 
         @Override
-        protected void doBeginRead() throws Exception {
+        protected void doRead() throws Exception {
         }
 
         @Override


### PR DESCRIPTION
Motivation:

Let's be consistent in the naming of methods the user needs to implement

Modifications:

- Rename method
- Remove unused updater

Result:

Cleanup