### PR TITLE
Allow KQueueServerSocketChannel construction with ProtocolFamily

### DIFF
--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueServerSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueServerSocketChannel.java
@@ -111,7 +111,7 @@ public final class KQueueServerSocketChannel extends
     }
 
     public KQueueServerSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup,
-                                     SocketProtocolFamily protocolFamily) {
+                                     ProtocolFamily protocolFamily) {
         super(null, eventLoop, METADATA, new ServerChannelRecvBufferAllocator(),
                 BsdSocket.newSocket(protocolFamily), false);
         this.childEventLoopGroup = validateEventLoopGroup(childEventLoopGroup, "childEventLoopGroup",


### PR DESCRIPTION
Motivation:

The current implementation limits `KQueueServerSocketChannel` construction to `SocketProtocolFamily`,
the rest of the `ServerSocketChannel` and `SocketChannel` implementations use `ProtocolFamily`.

Modification:

- Allow `KQueueServerSocketChannel` construction with `ProtocolFamily`

Result:

Allow `KQueueServerSocketChannel` construction with `ProtocolFamily`