### PR TITLE
Native Image Support: Set IS_EXPLICIT_TRY_REFLECTION_SET_ACCESSIBLE to true by default for native images

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -53,12 +53,13 @@ final class PlatformDependent0 {
 
     private static final Throwable UNSAFE_UNAVAILABILITY_CAUSE;
     private static final Object INTERNAL_UNSAFE;
-    private static final boolean IS_EXPLICIT_TRY_REFLECTION_SET_ACCESSIBLE = explicitTryReflectionSetAccessible0();
 
     // See https://github.com/oracle/graal/blob/master/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/
     // ImageInfo.java
     private static final boolean RUNNING_IN_NATIVE_IMAGE = SystemPropertyUtil.contains(
             "org.graalvm.nativeimage.imagecode");
+
+    private static final boolean IS_EXPLICIT_TRY_REFLECTION_SET_ACCESSIBLE = explicitTryReflectionSetAccessible0();
 
     static final Unsafe UNSAFE;
 
@@ -975,7 +976,8 @@ final class PlatformDependent0 {
 
     private static boolean explicitTryReflectionSetAccessible0() {
         // we disable reflective access
-        return SystemPropertyUtil.getBoolean("io.netty.tryReflectionSetAccessible", javaVersion() < 9);
+        return SystemPropertyUtil.getBoolean("io.netty.tryReflectionSetAccessible",
+                javaVersion() < 9 || RUNNING_IN_NATIVE_IMAGE);
     }
 
     static boolean isExplicitTryReflectionSetAccessible() {


### PR DESCRIPTION
Motivation:
To prevent memory leaks when running as a native-image, users explicitly set the `io.netty.tryReflectionSetAccessible` property to true. If Netty is initialized at image build time, this property can be set during the image build and is not required when running the image.
However, if Netty is initialized at image runtime, users would need to supply this system property every time they run their image.

Modification:
To improve support for runtime initialization of Netty 4, this PR sets the `io.netty.tryReflectionSetAccessible` property to default to true if running in a native-image.
This ensures that even in the case of runtime initialization, users do not need to supply extra flags to their image.