### PR TITLE
Allow to influence how the Buffer is allocated per read operation.

### DIFF
--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpContentDecompressorTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpContentDecompressorTest.java
@@ -18,6 +18,7 @@ package io.netty5.handler.codec.http;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelOption;
+import io.netty5.channel.ReadBufferAllocator;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.api.Test;
 
@@ -35,9 +36,9 @@ public class HttpContentDecompressorTest {
         final AtomicInteger readCalled = new AtomicInteger();
         EmbeddedChannel channel = new EmbeddedChannel(new ChannelHandler() {
             @Override
-            public void read(ChannelHandlerContext ctx) {
+            public void read(ChannelHandlerContext ctx, ReadBufferAllocator readBufferAllocator) {
                 readCalled.incrementAndGet();
-                ctx.read();
+                ctx.read(readBufferAllocator);
             }
         }, new HttpContentDecompressor(), new ChannelHandler() {
             @Override

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2MultiplexHandler.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2MultiplexHandler.java
@@ -20,8 +20,10 @@ import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelOption;
+import io.netty5.channel.ChannelOutboundInvoker;
 import io.netty5.channel.ChannelPipeline;
 import io.netty5.channel.EventLoop;
+import io.netty5.channel.ReadBufferAllocator;
 import io.netty5.channel.ServerChannel;
 import io.netty5.handler.codec.http2.Http2FrameCodec.DefaultHttp2FrameStream;
 import io.netty5.util.Resource;
@@ -50,8 +52,8 @@ import static io.netty5.handler.codec.http2.Http2Exception.connectionError;
  * Http2GoAwayFrame} and {@link Http2ResetFrame}, as soon as they occur. Although {@code
  * Http2GoAwayFrame} and {@code Http2ResetFrame} signify that the remote is ignoring further
  * communication, closing of the channel is delayed until any inbound queue is drained with {@link
- * Channel#read()}, which follows the default behavior of channels in Netty. Applications are
- * free to close the channel in response to such events if they don't have use for any queued
+ * ChannelOutboundInvoker#read(ReadBufferAllocator)}, which follows the default behavior of channels in Netty.
+ * Applications are free to close the channel in response to such events if they don't have use for any queued
  * messages. Any connection level events like {@link Http2SettingsFrame} and {@link Http2GoAwayFrame}
  * will be processed internally and also propagated down the pipeline for other handlers to act on.
  *

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameInboundWriter.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameInboundWriter.java
@@ -22,6 +22,7 @@ import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
 import io.netty5.channel.ChannelShutdownDirection;
+import io.netty5.channel.ReadBufferAllocator;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.util.concurrent.EventExecutor;
 import io.netty5.util.concurrent.Future;
@@ -192,6 +193,12 @@ final class Http2FrameInboundWriter {
         @Override
         public ChannelHandlerContext fireChannelWritabilityChanged() {
             channel.pipeline().fireChannelWritabilityChanged();
+            return this;
+        }
+
+        @Override
+        public ChannelHandlerContext read(ReadBufferAllocator readBufferAllocator) {
+            channel.read(readBufferAllocator);
             return this;
         }
 

--- a/codec/src/main/java/io/netty5/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty5/handler/codec/ByteToMessageDecoder.java
@@ -21,8 +21,10 @@ import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerAdapter;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelOption;
+import io.netty5.channel.ChannelOutboundInvoker;
 import io.netty5.channel.ChannelPipeline;
 import io.netty5.channel.ChannelShutdownDirection;
+import io.netty5.channel.ReadBufferAllocator;
 import io.netty5.channel.internal.DelegatingChannelHandlerContext;
 import io.netty5.util.Send;
 import io.netty5.util.internal.StringUtil;
@@ -91,8 +93,8 @@ public abstract class ByteToMessageDecoder extends ChannelHandlerAdapter {
     private boolean singleDecode;
     private boolean first;
     /**
-     * This flag is used to determine if we need to call {@link ChannelHandlerContext#read()} to consume more data
-     * when {@link ChannelOption#AUTO_READ} is {@code false}.
+     * This flag is used to determine if we need to call {@link ChannelOutboundInvoker#read(ReadBufferAllocator)}
+     * to consume more data when {@link ChannelOption#AUTO_READ} is {@code false}.
      */
     private boolean firedChannelRead;
     private int numReads;

--- a/codec/src/main/java/io/netty5/handler/codec/DatagramPacketEncoder.java
+++ b/codec/src/main/java/io/netty5/handler/codec/DatagramPacketEncoder.java
@@ -19,6 +19,7 @@ import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.AddressedEnvelope;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
+import io.netty5.channel.ReadBufferAllocator;
 import io.netty5.channel.socket.DatagramPacket;
 import io.netty5.handler.codec.bytes.ByteArrayEncoder;
 import io.netty5.util.concurrent.Future;
@@ -118,8 +119,8 @@ public class DatagramPacketEncoder<M> extends MessageToMessageEncoder<AddressedE
     }
 
     @Override
-    public void read(ChannelHandlerContext ctx) {
-        encoder.read(ctx);
+    public void read(ChannelHandlerContext ctx, ReadBufferAllocator readBufferAllocator) {
+        encoder.read(ctx, readBufferAllocator);
     }
 
     @Override

--- a/codec/src/test/java/io/netty5/handler/codec/ByteToMessageDecoderTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/ByteToMessageDecoderTest.java
@@ -22,6 +22,7 @@ import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelOption;
 import io.netty5.channel.ChannelShutdownDirection;
+import io.netty5.channel.ReadBufferAllocator;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.handler.codec.ByteToMessageDecoder.Cumulator;
 import org.junit.jupiter.api.BeforeEach;
@@ -478,7 +479,7 @@ public class ByteToMessageDecoderTest {
             private int readsTriggered;
 
             @Override
-            public void read(ChannelHandlerContext ctx) {
+            public void read(ChannelHandlerContext ctx, ReadBufferAllocator readBufferAllocator) {
                 readsTriggered++;
                 ctx.read();
             }

--- a/codec/src/test/java/io/netty5/handler/codec/ByteToMessageDecoderTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/ByteToMessageDecoderTest.java
@@ -481,7 +481,7 @@ public class ByteToMessageDecoderTest {
             @Override
             public void read(ChannelHandlerContext ctx, ReadBufferAllocator readBufferAllocator) {
                 readsTriggered++;
-                ctx.read();
+                ctx.read(readBufferAllocator);
             }
         }
         ReadInterceptingHandler interceptor = new ReadInterceptingHandler();

--- a/codec/src/test/java/io/netty5/handler/codec/MessageAggregatorTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/MessageAggregatorTest.java
@@ -22,6 +22,7 @@ import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelOption;
 import io.netty5.channel.ChannelPipeline;
+import io.netty5.channel.ReadBufferAllocator;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.api.Test;
 
@@ -37,9 +38,9 @@ public class MessageAggregatorTest {
         int value;
 
         @Override
-        public void read(ChannelHandlerContext ctx) {
+        public void read(ChannelHandlerContext ctx, ReadBufferAllocator readBufferAllocator) {
             value++;
-            ctx.read();
+            ctx.read(readBufferAllocator);
         }
     }
 

--- a/handler/src/main/java/io/netty5/handler/flow/FlowControlHandler.java
+++ b/handler/src/main/java/io/netty5/handler/flow/FlowControlHandler.java
@@ -16,6 +16,7 @@
 package io.netty5.handler.flow;
 
 import io.netty5.channel.ChannelOption;
+import io.netty5.channel.ReadBufferAllocator;
 import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.handler.codec.MessageToByteEncoder;
 import io.netty5.util.Resource;
@@ -129,13 +130,13 @@ public class FlowControlHandler implements ChannelHandler {
     }
 
     @Override
-    public void read(ChannelHandlerContext ctx) {
+    public void read(ChannelHandlerContext ctx, ReadBufferAllocator readBufferAllocator) {
         if (dequeue(ctx, 1) == 0) {
             // It seems no messages were consumed. We need to read() some
             // messages from upstream and once one arrives it need to be
             // relayed to downstream to keep the flow going.
             shouldConsume = true;
-            ctx.read();
+            ctx.read(readBufferAllocator);
         }
     }
 
@@ -176,7 +177,7 @@ public class FlowControlHandler implements ChannelHandler {
      * consuming that number of messages regardless of the channel's auto
      * reading configuration.
      *
-     * @see #read(ChannelHandlerContext)
+     * @see ChannelHandler#read(ChannelHandlerContext, ReadBufferAllocator)
      * @see #channelRead(ChannelHandlerContext, Object)
      */
     private int dequeue(ChannelHandlerContext ctx, int minConsume) {

--- a/handler/src/main/java/io/netty5/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslHandler.java
@@ -20,6 +20,8 @@ import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.buffer.api.CompositeBuffer;
 import io.netty5.buffer.api.DefaultBufferAllocators;
+import io.netty5.channel.ChannelOutboundInvoker;
+import io.netty5.channel.ReadBufferAllocator;
 import io.netty5.util.Resource;
 import io.netty5.buffer.api.StandardAllocationTypes;
 import io.netty5.channel.AbstractCoalescingBufferQueue;
@@ -177,8 +179,8 @@ public class SslHandler extends ByteToMessageDecoder {
     private static final int STATE_CLOSE_NOTIFY = 1 << 6;
     private static final int STATE_PROCESS_TASK = 1 << 7;
     /**
-     * This flag is used to determine if we need to call {@link ChannelHandlerContext#read()} to consume more data
-     * when {@link ChannelOption#AUTO_READ} is {@code false}.
+     * This flag is used to determine if we need to call {@link ChannelOutboundInvoker#read(ReadBufferAllocator)} to
+     * consume more data when {@link ChannelOption#AUTO_READ} is {@code false}.
      */
     private static final int STATE_FIRE_CHANNEL_READ = 1 << 8;
     private static final int STATE_UNWRAP_REENTRY = 1 << 9;
@@ -608,12 +610,12 @@ public class SslHandler extends ByteToMessageDecoder {
     }
 
     @Override
-    public void read(ChannelHandlerContext ctx) {
+    public void read(ChannelHandlerContext ctx, ReadBufferAllocator readBufferAllocator) {
         if (!handshakePromise.isDone()) {
             setState(STATE_READ_DURING_HANDSHAKE);
         }
 
-        ctx.read();
+        ctx.read(readBufferAllocator);
     }
 
     private static IllegalStateException newPendingWritesNullException() {

--- a/handler/src/main/java/io/netty5/handler/traffic/AbstractTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty5/handler/traffic/AbstractTrafficShapingHandler.java
@@ -21,6 +21,7 @@ import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelOption;
 import io.netty5.channel.FileRegion;
+import io.netty5.channel.ReadBufferAllocator;
 import io.netty5.util.Attribute;
 import io.netty5.util.AttributeKey;
 import io.netty5.util.concurrent.Future;
@@ -537,10 +538,10 @@ public abstract class AbstractTrafficShapingHandler implements ChannelHandler {
     }
 
     @Override
-    public void read(ChannelHandlerContext ctx) {
+    public void read(ChannelHandlerContext ctx, ReadBufferAllocator readBufferAllocator) {
         if (isHandlerActive(ctx)) {
             // For Global Traffic (and Read when using EventLoop in pipeline) : check if READ_SUSPENDED is False
-            ctx.read();
+            ctx.read(readBufferAllocator);
         }
     }
 

--- a/handler/src/test/java/io/netty5/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SslHandlerTest.java
@@ -28,6 +28,7 @@ import io.netty5.channel.ChannelOption;
 import io.netty5.channel.DefaultChannelId;
 import io.netty5.channel.EventLoopGroup;
 import io.netty5.channel.MultithreadEventLoopGroup;
+import io.netty5.channel.ReadBufferAllocator;
 import io.netty5.channel.SimpleChannelInboundHandler;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.channel.local.LocalAddress;
@@ -424,9 +425,9 @@ public class SslHandlerTest {
         private volatile boolean readIssued;
 
         @Override
-        public void read(ChannelHandlerContext ctx) {
+        public void read(ChannelHandlerContext ctx, ReadBufferAllocator readBufferAllocator) {
             readIssued = true;
-            ctx.read();
+            ctx.read(readBufferAllocator);
         }
 
         public void test(final boolean dropChannelActive) throws Exception {

--- a/microbench/src/main/java/io/netty5/microbench/channel/EmbeddedChannelHandlerContext.java
+++ b/microbench/src/main/java/io/netty5/microbench/channel/EmbeddedChannelHandlerContext.java
@@ -21,6 +21,7 @@ import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
 import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.EventLoop;
+import io.netty5.channel.ReadBufferAllocator;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.util.Resource;
 import io.netty5.util.concurrent.EventExecutor;
@@ -211,6 +212,16 @@ public abstract class EmbeddedChannelHandlerContext implements ChannelHandlerCon
             handleException(e);
             return channel().newFailedFuture(e);
         }
+    }
+
+    @Override
+    public final ChannelHandlerContext read(ReadBufferAllocator readBufferAllocator) {
+        try {
+            channel().read(readBufferAllocator);
+        } catch (Exception e) {
+            handleException(e);
+        }
+        return this;
     }
 
     @Override

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DomainSocketReadAllocatorTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DomainSocketReadAllocatorTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.testsuite.transport.socket;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.testsuite.transport.TestsuitePermutation;
+import org.junit.jupiter.api.condition.EnabledIf;
+
+import java.net.SocketAddress;
+import java.util.List;
+
+@EnabledIf("isSupported")
+public class DomainSocketReadAllocatorTest extends SocketReadAllocatorTest {
+
+    static boolean isSupported() {
+        return NioDomainSocketTestUtil.isSocketSupported();
+    }
+
+    @Override
+    protected final SocketAddress newSocketAddress() {
+        return SocketTestPermutation.newDomainSocketAddress();
+    }
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return SocketTestPermutation.INSTANCE.domainSocket();
+    }
+}

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketReadAllocatorTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketReadAllocatorTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.testsuite.transport.socket;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.buffer.api.Buffer;
+import io.netty5.channel.Channel;
+import io.netty5.channel.ChannelHandler;
+import io.netty5.channel.ChannelHandlerContext;
+import io.netty5.channel.ChannelOption;
+import io.netty5.channel.FixedReadHandleFactory;
+import io.netty5.channel.ReadBufferAllocator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class SocketReadAllocatorTest extends AbstractSocketTest {
+    private static final int FIXED_CAPACITY = 1024;
+    private static final int CUSTOM_CAPACITY = 8;
+
+    @Test
+    public void testCustomReadAllocator(TestInfo testInfo) throws Throwable {
+        run(testInfo, (serverBootstrap, bootstrap) -> testReadAllocator(sb, cb, (allocator, estimatedCapacity) -> {
+            assertEquals(FIXED_CAPACITY, estimatedCapacity);
+            return allocator.allocate(CUSTOM_CAPACITY);
+        }));
+    }
+
+    @Test
+    public void testExactReadAllocator(TestInfo testInfo) throws Throwable {
+        run(testInfo, (serverBootstrap, bootstrap) ->
+                testReadAllocator(sb, cb, ReadBufferAllocator.exact(CUSTOM_CAPACITY)));
+    }
+
+    @Test
+    public void testDefaultReadAllocator(TestInfo testInfo) throws Throwable {
+        run(testInfo, (serverBootstrap, bootstrap) -> testReadAllocator(sb, cb, null));
+    }
+
+    private void testReadAllocator(ServerBootstrap sb, Bootstrap cb, ReadBufferAllocator allocator) throws Throwable {
+        Channel serverChannel = null;
+        Channel clientChannel = null;
+        try {
+            CountDownLatch latch = new CountDownLatch(1);
+            AtomicReference<Throwable> causeRef = new AtomicReference<>();
+            sb.option(ChannelOption.SO_BACKLOG, 1024)
+                    .option(ChannelOption.AUTO_READ, true)
+                    .childOption(ChannelOption.AUTO_READ, false)
+                    .childOption(ChannelOption.READ_HANDLE_FACTORY, new FixedReadHandleFactory(FIXED_CAPACITY))
+                    .childHandler(new ChannelHandler() {
+                        @Override
+                        public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                            try (Buffer buffer = (Buffer) msg) {
+                                if (allocator == null) {
+                                    assertEquals(FIXED_CAPACITY, buffer.capacity());
+                                } else {
+                                    assertEquals(CUSTOM_CAPACITY, buffer.capacity());
+                                }
+                                latch.countDown();
+                            }
+                        }
+
+                        @Override
+                        public void channelActive(ChannelHandlerContext ctx) {
+                            if (allocator == null) {
+                                ctx.read();
+                            } else {
+                                ctx.read(allocator);
+                            }
+                        }
+
+                        @Override
+                        public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                            if (!(cause instanceof IOException)) {
+                                causeRef.set(cause);
+                                latch.countDown();
+                            }
+                        }
+                    });
+
+            serverChannel = sb.bind().asStage().get();
+
+            cb.option(ChannelOption.AUTO_READ, true)
+                    .handler(new ChannelHandler() { });
+
+            clientChannel = cb.connect(serverChannel.localAddress()).asStage().get();
+            clientChannel.writeAndFlush(clientChannel.bufferAllocator().copyOf(new byte[3])).asStage().sync();
+
+            latch.await();
+            Throwable cause = causeRef.get();
+            if (cause != null) {
+                throw cause;
+            }
+        } finally {
+            if (clientChannel != null) {
+                clientChannel.close().asStage().sync();
+            }
+            if (serverChannel != null) {
+                serverChannel.close().asStage().sync();
+            }
+        }
+    }
+}

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDatagramChannel.java
@@ -642,6 +642,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel<UnixChannel
         } catch (Throwable t) {
             throw t;
         }
+        return false;
     }
 
     private ReadingState connectedRead(ReadHandleFactory.ReadHandle allocHandle, Buffer buf,

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollServerSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollServerSocketChannel.java
@@ -24,6 +24,7 @@ import io.netty5.channel.ChannelPipeline;
 import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.EventLoopGroup;
+import io.netty5.channel.ReadBufferAllocator;
 import io.netty5.channel.ReadHandleFactory;
 import io.netty5.channel.ServerChannelReadHandleFactory;
 import io.netty5.channel.socket.DomainSocketAddress;
@@ -353,7 +354,8 @@ public final class EpollServerSocketChannel
     }
 
     @Override
-    protected boolean epollInReady(ReadHandleFactory.ReadHandle readHandle, BufferAllocator recvBufferAllocator) {
+    protected boolean epollInReady(ReadHandleFactory.ReadHandle readHandle, ReadBufferAllocator readBufferAllocator,
+                                   BufferAllocator recvBufferAllocator) {
         final ChannelPipeline pipeline = pipeline();
         Throwable exception = null;
         boolean readAll = false;

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueServerSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueServerSocketChannel.java
@@ -24,6 +24,7 @@ import io.netty5.channel.ChannelPipeline;
 import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.EventLoopGroup;
+import io.netty5.channel.ReadBufferAllocator;
 import io.netty5.channel.ReadHandleFactory;
 import io.netty5.channel.ServerChannelReadHandleFactory;
 import io.netty5.channel.socket.DomainSocketAddress;
@@ -367,7 +368,8 @@ public final class KQueueServerSocketChannel extends
     }
 
     @Override
-    int readReady(ReadHandleFactory.ReadHandle readHandle, BufferAllocator recvBufferAllocator) {
+    int readReady(ReadHandleFactory.ReadHandle readHandle, ReadBufferAllocator readBufferAllocator,
+                  BufferAllocator recvBufferAllocator) {
         final ChannelPipeline pipeline = pipeline();
         Throwable exception = null;
         int totalBytesRead = 0;

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDomainSocketReadAllocatorTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDomainSocketReadAllocatorTest.java
@@ -26,6 +26,6 @@ public class EpollDomainSocketReadAllocatorTest extends DomainSocketReadAllocato
 
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
-        return EpollSocketTestPermutation.INSTANCE.socketWithFastOpen();
+        return EpollSocketTestPermutation.INSTANCE.domainSocket();
     }
 }

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDomainSocketReadAllocatorTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDomainSocketReadAllocatorTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.epoll;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.testsuite.transport.TestsuitePermutation;
+import io.netty5.testsuite.transport.socket.DomainSocketReadAllocatorTest;
+
+import java.util.List;
+
+public class EpollDomainSocketReadAllocatorTest extends DomainSocketReadAllocatorTest {
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return EpollSocketTestPermutation.INSTANCE.socketWithFastOpen();
+    }
+}

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollSocketReadAllocatorTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollSocketReadAllocatorTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.epoll;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.testsuite.transport.TestsuitePermutation;
+import io.netty5.testsuite.transport.socket.SocketReadAllocatorTest;
+
+import java.util.List;
+
+public class EpollSocketReadAllocatorTest extends SocketReadAllocatorTest {
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return EpollSocketTestPermutation.INSTANCE.socketWithFastOpen();
+    }
+}

--- a/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueDomainSocketReadAllocatorTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueDomainSocketReadAllocatorTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.kqueue;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.testsuite.transport.TestsuitePermutation;
+import io.netty5.testsuite.transport.socket.DomainSocketReadAllocatorTest;
+
+import java.util.List;
+
+public class KQueueDomainSocketReadAllocatorTest extends DomainSocketReadAllocatorTest {
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return KQueueSocketTestPermutation.INSTANCE.domainSocket();
+    }
+}

--- a/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueSocketReadAllocatorTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueSocketReadAllocatorTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.kqueue;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.testsuite.transport.TestsuitePermutation;
+import io.netty5.testsuite.transport.socket.SocketReadAllocatorTest;
+
+import java.util.List;
+
+public class KQueueSocketReadAllocatorTest extends SocketReadAllocatorTest {
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return KQueueSocketTestPermutation.INSTANCE.socket();
+    }
+}

--- a/transport/src/main/java/io/netty5/channel/Channel.java
+++ b/transport/src/main/java/io/netty5/channel/Channel.java
@@ -250,6 +250,12 @@ public interface Channel extends AttributeMap, ChannelOutboundInvoker, Comparabl
     BufferAllocator bufferAllocator();
 
     @Override
+    default Channel read(ReadBufferAllocator readBufferAllocator) {
+        pipeline().read(readBufferAllocator);
+        return this;
+    }
+
+    @Override
     default Channel read() {
         pipeline().read();
         return this;

--- a/transport/src/main/java/io/netty5/channel/ChannelHandler.java
+++ b/transport/src/main/java/io/netty5/channel/ChannelHandler.java
@@ -15,6 +15,7 @@
  */
 package io.netty5.channel;
 
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerMask.Skip;
 import io.netty5.util.Attribute;
 import io.netty5.util.AttributeKey;
@@ -238,7 +239,7 @@ public interface ChannelHandler {
      * Invoked when the last message read by the current read operation has been consumed by
      * {@link #channelRead(ChannelHandlerContext, Object)}.  If {@link ChannelOption#AUTO_READ} is off, no further
      * attempt to read an inbound data from the current {@link Channel} will be made until
-     * {@link ChannelHandlerContext#read()} is called.
+     * {@link ChannelOutboundInvoker#read(ReadBufferAllocator)} is called.
      */
     @Skip
     default void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
@@ -354,11 +355,17 @@ public interface ChannelHandler {
     }
 
     /**
-     * Intercepts {@link ChannelHandlerContext#read()}.
+     * Called once a read operation is made from the current registered {@link EventLoop}.
+     * If the {@link ChannelHandler} implementation queues the read and another read happens it is free to
+     * drop the first {@link ReadBufferAllocator} and just use the last one.
+     *
+     * @param ctx                   the {@link ChannelHandlerContext} for which the read operation is made
+     * @param readBufferAllocator   The {@link ReadBufferAllocator} that should be used to allocate a {@link Buffer}
+     *                              if needed (for reading the data).
      */
     @Skip
-    default void read(ChannelHandlerContext ctx) {
-        ctx.read();
+    default void read(ChannelHandlerContext ctx, ReadBufferAllocator readBufferAllocator) {
+        ctx.read(readBufferAllocator);
     }
 
     /**

--- a/transport/src/main/java/io/netty5/channel/ChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty5/channel/ChannelHandlerContext.java
@@ -129,6 +129,9 @@ public interface ChannelHandlerContext extends ChannelInboundInvoker, ChannelOut
     ChannelHandlerContext fireChannelWritabilityChanged();
 
     @Override
+    ChannelHandlerContext read(ReadBufferAllocator readBufferAllocator);
+
+    @Override
     ChannelHandlerContext read();
 
     @Override

--- a/transport/src/main/java/io/netty5/channel/ChannelHandlerMask.java
+++ b/transport/src/main/java/io/netty5/channel/ChannelHandlerMask.java
@@ -163,7 +163,7 @@ final class ChannelHandlerMask {
             if (isSkippable(handlerType, "deregister", ChannelHandlerContext.class)) {
                 mask &= ~MASK_DEREGISTER;
             }
-            if (isSkippable(handlerType, "read", ChannelHandlerContext.class)) {
+            if (isSkippable(handlerType, "read", ChannelHandlerContext.class, ReadBufferAllocator.class)) {
                 mask &= ~MASK_READ;
             }
             if (isSkippable(handlerType, "write", ChannelHandlerContext.class, Object.class)) {

--- a/transport/src/main/java/io/netty5/channel/ChannelOutboundInvoker.java
+++ b/transport/src/main/java/io/netty5/channel/ChannelOutboundInvoker.java
@@ -15,6 +15,7 @@
  */
 package io.netty5.channel;
 
+import io.netty5.buffer.api.Buffer;
 import io.netty5.util.concurrent.EventExecutor;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.FuturePromiseFactory;
@@ -133,16 +134,24 @@ public interface ChannelOutboundInvoker extends FuturePromiseFactory {
     Future<Void> deregister();
 
     /**
-     * Request to Read data from the {@link Channel} into the first inbound buffer, triggers an
+     * Request to read data from the {@link Channel}, triggers an
      * {@link ChannelHandler#channelRead(ChannelHandlerContext, Object)} event if data was
      * read, and triggers a
      * {@link ChannelHandler#channelReadComplete(ChannelHandlerContext) channelReadComplete} event so the
-     * handler can decide to continue reading.  If there's a pending read operation already, this method does nothing.
+     * handler can decide to continue reading. If there's a pending read operation already, this method does nothing.
      * <p>
      * This will result in having the
-     * {@link ChannelHandler#read(ChannelHandlerContext)}
+     * {@link ChannelHandler#read(ChannelHandlerContext, ReadBufferAllocator)}
      * method called of the next {@link ChannelHandler} contained in the {@link ChannelPipeline} of the
      * {@link Channel}.
+     *
+     * @param readBufferAllocator   The {@link ReadBufferAllocator} that should be used to allocate a {@link Buffer}
+     *                              if needed (for reading the data).
+     */
+    ChannelOutboundInvoker read(ReadBufferAllocator readBufferAllocator);
+
+    /**
+     * @see #read(ReadBufferAllocator) (using a default {@link ReadBufferAllocator}).
      */
     ChannelOutboundInvoker read();
 

--- a/transport/src/main/java/io/netty5/channel/ChannelPipeline.java
+++ b/transport/src/main/java/io/netty5/channel/ChannelPipeline.java
@@ -146,7 +146,7 @@ import java.util.NoSuchElementException;
  *     <li>{@link ChannelHandlerContext#connect(SocketAddress, SocketAddress)}</li>
  *     <li>{@link ChannelHandlerContext#write(Object)}</li>
  *     <li>{@link ChannelHandlerContext#flush()}</li>
- *     <li>{@link ChannelHandlerContext#read()}</li>
+ *     <li>{@link ChannelOutboundInvoker#read(ReadBufferAllocator)}</li>
  *     <li>{@link ChannelHandlerContext#disconnect()}</li>
  *     <li>{@link ChannelHandlerContext#close()}</li>
  *     <li>{@link ChannelHandlerContext#shutdown(ChannelShutdownDirection)}</li>
@@ -607,6 +607,12 @@ public interface ChannelPipeline
 
     @Override
     ChannelPipeline flush();
+
+    @Override
+    ChannelPipeline read(ReadBufferAllocator readBufferAllocator);
+
+    @Override
+    ChannelPipeline read();
 
     /**
      * The number of the outbound bytes that are buffered / queued in this {@link ChannelPipeline}. This number will

--- a/transport/src/main/java/io/netty5/channel/CombinedChannelDuplexHandler.java
+++ b/transport/src/main/java/io/netty5/channel/CombinedChannelDuplexHandler.java
@@ -328,12 +328,12 @@ public class CombinedChannelDuplexHandler<I extends ChannelHandler, O extends Ch
     }
 
     @Override
-    public void read(ChannelHandlerContext ctx) {
+    public void read(ChannelHandlerContext ctx, ReadBufferAllocator readBufferAllocator) {
         assert ctx == outboundCtx.delegatingCtx();
         if (!outboundCtx.removed) {
-            outboundHandler.read(outboundCtx);
+            outboundHandler.read(outboundCtx, readBufferAllocator);
         } else {
-            outboundCtx.read();
+            outboundCtx.read(readBufferAllocator);
         }
     }
 

--- a/transport/src/main/java/io/netty5/channel/ReadBufferAllocator.java
+++ b/transport/src/main/java/io/netty5/channel/ReadBufferAllocator.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel;
+
+import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.api.BufferAllocator;
+
+/**
+ * Implementations of this interface can influence how {@link Buffer}s are allocated that are used when reading from
+ * the transport.
+ */
+public interface ReadBufferAllocator {
+
+    /**
+     * Allocates a {@link Buffer} that is used for the next actual read to store the data in.
+     *
+     * @param allocator             The {@link BufferAllocator} that might be used for the allocation.
+     *                              While its fine to not use the {@link BufferAllocator} it is important that the
+     *                              returned {@link Buffer} matches the {@link BufferAllocator#getAllocationType()}
+     *                              of the allocator.
+     * @param estimatedCapacity     the estimated capacity for the buffer. This is just a best guess and users might
+     *                              decide to use their own capacity.
+     * @return                      the {@link Buffer} that will be used or {@code null} if the read should not happen
+     *                              until the next {@link ChannelOutboundInvoker#read(ReadBufferAllocator)} call is
+     *                              done.
+     */
+    Buffer allocate(BufferAllocator allocator, int estimatedCapacity);
+
+    /**
+     * Return a {@link ReadBufferAllocator} that will return a {@link Buffer} that has exact {@code numBytes} of
+     * writable bytes.
+     *
+     * @param numBytes  the number of bytes that can be written.
+     * @return          a {@link ReadBufferAllocator}.
+     */
+    static ReadBufferAllocator exact(int numBytes) {
+        return (allocator, estimatedCapacity) -> {
+            Buffer buffer = allocator.allocate(numBytes);
+            if (numBytes != buffer.writableBytes()) {
+                try (buffer) {
+                    return buffer.split(buffer.writerOffset() + numBytes);
+                }
+            }
+            return buffer;
+        };
+    }
+}

--- a/transport/src/main/java/io/netty5/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty5/channel/embedded/EmbeddedChannel.java
@@ -19,6 +19,7 @@ import io.netty5.buffer.api.internal.ResourceSupport;
 import io.netty5.buffer.api.internal.Statics;
 import io.netty5.channel.AdaptiveReadHandleFactory;
 import io.netty5.channel.ChannelShutdownDirection;
+import io.netty5.channel.ReadBufferAllocator;
 import io.netty5.util.Resource;
 import io.netty5.channel.AbstractChannel;
 import io.netty5.channel.Channel;
@@ -712,7 +713,7 @@ public class EmbeddedChannel extends AbstractChannel<Channel, SocketAddress, Soc
     }
 
     @Override
-    protected void doRead() throws Exception {
+    protected void doRead(ReadBufferAllocator readBufferAllocator) throws Exception {
         // NOOP
     }
 

--- a/transport/src/main/java/io/netty5/channel/internal/DelegatingChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty5/channel/internal/DelegatingChannelHandlerContext.java
@@ -21,6 +21,7 @@ import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
 import io.netty5.channel.ChannelShutdownDirection;
+import io.netty5.channel.ReadBufferAllocator;
 import io.netty5.util.concurrent.EventExecutor;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.Promise;
@@ -109,7 +110,6 @@ public abstract class DelegatingChannelHandlerContext implements ChannelHandlerC
 
     @Override
     public ChannelHandlerContext fireChannelRead(Object msg) {
-
         ctx.fireChannelRead(msg);
         return this;
     }
@@ -123,6 +123,12 @@ public abstract class DelegatingChannelHandlerContext implements ChannelHandlerC
     @Override
     public ChannelHandlerContext fireChannelWritabilityChanged() {
         ctx.fireChannelWritabilityChanged();
+        return this;
+    }
+
+    @Override
+    public ChannelHandlerContext read(ReadBufferAllocator readBufferAllocator) {
+        ctx.read(readBufferAllocator);
         return this;
     }
 

--- a/transport/src/main/java/io/netty5/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty5/channel/local/LocalChannel.java
@@ -18,6 +18,7 @@ package io.netty5.channel.local;
 import io.netty5.buffer.api.DefaultBufferAllocators;
 import io.netty5.channel.ChannelOption;
 import io.netty5.channel.ChannelShutdownDirection;
+import io.netty5.channel.ReadBufferAllocator;
 import io.netty5.util.ReferenceCounted;
 import io.netty5.util.Resource;
 import io.netty5.buffer.api.internal.ResourceSupport;
@@ -261,7 +262,7 @@ public class LocalChannel extends AbstractChannel<LocalServerChannel, LocalAddre
     };
 
     @Override
-    protected void doRead() throws Exception {
+    protected void doRead(ReadBufferAllocator readBufferAllocator) throws Exception {
         if (readInProgress) {
             return;
         }

--- a/transport/src/main/java/io/netty5/channel/local/LocalServerChannel.java
+++ b/transport/src/main/java/io/netty5/channel/local/LocalServerChannel.java
@@ -22,6 +22,7 @@ import io.netty5.channel.ChannelPipeline;
 import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.EventLoopGroup;
+import io.netty5.channel.ReadBufferAllocator;
 import io.netty5.channel.ReadHandleFactory;
 import io.netty5.channel.ServerChannel;
 
@@ -79,7 +80,7 @@ public class LocalServerChannel extends AbstractServerChannel<LocalChannel, Loca
     }
 
     @Override
-    protected void doRead() throws Exception {
+    protected void doRead(ReadBufferAllocator readBufferAllocator) throws Exception {
         if (acceptInProgress) {
             return;
         }

--- a/transport/src/main/java/io/netty5/channel/nio/AbstractNioChannel.java
+++ b/transport/src/main/java/io/netty5/channel/nio/AbstractNioChannel.java
@@ -18,6 +18,7 @@ package io.netty5.channel.nio;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.buffer.api.DefaultBufferAllocators;
+import io.netty5.channel.ReadBufferAllocator;
 import io.netty5.channel.ReadHandleFactory;
 import io.netty5.util.Resource;
 import io.netty5.channel.AbstractChannel;
@@ -45,10 +46,12 @@ public abstract class AbstractNioChannel<P extends Channel, L extends SocketAddr
             InternalLoggerFactory.getInstance(AbstractNioChannel.class);
 
     private final SelectableChannel ch;
+    private final Runnable clearReadPendingRunnable = this::clearReadPending0;
     protected final int readInterestOp;
     volatile SelectionKey selectionKey;
     boolean readPending;
-    private final Runnable clearReadPendingRunnable = this::clearReadPending0;
+
+    private ReadBufferAllocator readBufferAllocator;
 
     private final NioProcessor nioProcessor = new NioProcessor() {
         @Override
@@ -106,7 +109,7 @@ public abstract class AbstractNioChannel<P extends Channel, L extends SocketAddr
                 // Also check for readOps of 0 to workaround possible JDK bug which may otherwise lead
                 // to a spin loop
                 if ((readyOps & (SelectionKey.OP_READ | SelectionKey.OP_ACCEPT)) != 0 || readyOps == 0) {
-                    readNow();
+                    readNow(readBufferAllocator);
                 }
             } catch (CancelledKeyException ignored) {
                 closeTransportNow();
@@ -223,15 +226,16 @@ public abstract class AbstractNioChannel<P extends Channel, L extends SocketAddr
     }
 
     @Override
-    protected void doRead() throws Exception {
+    protected void doRead(ReadBufferAllocator readBufferAllocator) throws Exception {
         // Channel.read() or ChannelHandlerContext.read() was called
         final SelectionKey selectionKey = this.selectionKey;
         if (!selectionKey.isValid()) {
+            // No valid anymore
             return;
         }
 
         readPending = true;
-
+        this.readBufferAllocator = readBufferAllocator;
         final int interestOps = selectionKey.interestOps();
         if ((interestOps & readInterestOp) == 0) {
             selectionKey.interestOps(interestOps | readInterestOp);
@@ -290,7 +294,7 @@ public abstract class AbstractNioChannel<P extends Channel, L extends SocketAddr
         }
     }
 
-    protected abstract void readNow();
+    protected abstract void readNow(ReadBufferAllocator readBufferAllocator);
 
     private void closeTransportNow() {
         closeTransport(newPromise());

--- a/transport/src/main/java/io/netty5/channel/nio/AbstractNioMessageChannel.java
+++ b/transport/src/main/java/io/netty5/channel/nio/AbstractNioMessageChannel.java
@@ -20,6 +20,7 @@ import io.netty5.channel.ChannelOutboundBuffer;
 import io.netty5.channel.ChannelPipeline;
 import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.EventLoop;
+import io.netty5.channel.ReadBufferAllocator;
 import io.netty5.channel.ReadHandleFactory;
 import io.netty5.channel.ServerChannel;
 
@@ -50,15 +51,15 @@ public abstract class AbstractNioMessageChannel<P extends Channel, L extends Soc
     }
 
     @Override
-    protected void doRead() throws Exception {
+    protected void doRead(ReadBufferAllocator readBufferAllocator) throws Exception {
         if (inputShutdown) {
             return;
         }
-        super.doRead();
+        super.doRead(readBufferAllocator);
     }
 
     @Override
-    protected final void readNow() {
+    protected final void readNow(ReadBufferAllocator readBufferAllocator) {
         assert executor().inEventLoop();
         final ChannelPipeline pipeline = pipeline();
         final ReadHandleFactory.ReadHandle readHandle = readHandle();
@@ -68,7 +69,7 @@ public abstract class AbstractNioMessageChannel<P extends Channel, L extends Soc
         try {
             try {
                 do {
-                    int localRead = doReadMessages(readHandle, readBuf);
+                    int localRead = doReadMessages(readHandle, readBufferAllocator, readBuf);
                     if (localRead == 0) {
                         break;
                     }
@@ -194,7 +195,8 @@ public abstract class AbstractNioMessageChannel<P extends Channel, L extends Soc
     /**
      * Read messages into the given array and return the amount which was read.
      */
-    protected abstract int doReadMessages(ReadHandleFactory.ReadHandle readHandle, List<Object> buf) throws Exception;
+    protected abstract int doReadMessages(ReadHandleFactory.ReadHandle readHandle,
+                                          ReadBufferAllocator readBufferAllocator, List<Object> buf) throws Exception;
 
     /**
      * Write a message to the underlying {@link java.nio.channels.Channel}.

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioDatagramChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioDatagramChannel.java
@@ -18,6 +18,7 @@ package io.netty5.channel.socket.nio;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.FixedReadHandleFactory;
+import io.netty5.channel.ReadBufferAllocator;
 import io.netty5.util.Resource;
 import io.netty5.buffer.api.WritableComponent;
 import io.netty5.buffer.api.WritableComponentProcessor;
@@ -374,8 +375,13 @@ public final class NioDatagramChannel
     }
 
     @Override
-    protected int doReadMessages(ReadHandle readHandle, List<Object> buf) throws Exception {
-        Buffer data = bufferAllocator().allocate(readHandle.estimatedBufferCapacity());
+    protected int doReadMessages(ReadHandle readHandle, ReadBufferAllocator readBufferAllocator, List<Object> buf)
+            throws Exception {
+        Buffer data = readBufferAllocator.allocate(bufferAllocator(), readHandle.estimatedBufferCapacity());
+        if (data == null) {
+            readHandle.lastRead(0, 0, 0);
+            return 0;
+        }
         int attemptedBytesRead = data.writableBytes();
         boolean free = true;
         try {

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioServerSocketChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioServerSocketChannel.java
@@ -22,6 +22,7 @@ import io.netty5.channel.ChannelOutboundBuffer;
 import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.EventLoopGroup;
+import io.netty5.channel.ReadBufferAllocator;
 import io.netty5.channel.ReadHandleFactory;
 import io.netty5.channel.ServerChannelReadHandleFactory;
 import io.netty5.channel.nio.AbstractNioMessageChannel;
@@ -238,9 +239,9 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel<Channel, S
     }
 
     @Override
-    protected int doReadMessages(ReadHandleFactory.ReadHandle readHandle, List<Object> buf) throws Exception {
+    protected int doReadMessages(ReadHandleFactory.ReadHandle readHandle, ReadBufferAllocator readBufferAllocator,
+                                 List<Object> buf) throws Exception {
         SocketChannel ch = SocketUtils.accept(javaChannel());
-
         try {
             if (ch != null) {
                 buf.add(new NioSocketChannel(this, childEventLoopGroup().next(), ch, family));
@@ -248,6 +249,8 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel<Channel, S
                     return 1;
                 }
                 return 0;
+            } else {
+                readHandle.lastRead(0, 0, 0);
             }
         } catch (Throwable t) {
             logger.warn("Failed to create a new channel from an accepted socket.", t);

--- a/transport/src/test/java/io/netty5/channel/AbstractChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/AbstractChannelTest.java
@@ -244,7 +244,7 @@ public class AbstractChannelTest {
         protected void doClose() { }
 
         @Override
-        protected void doRead() { }
+        protected void doRead(ReadBufferAllocator readBufferAllocator) { }
 
         @Override
         protected void doWrite(ChannelOutboundBuffer in) throws Exception { }

--- a/transport/src/test/java/io/netty5/channel/CombinedChannelDuplexHandlerTest.java
+++ b/transport/src/test/java/io/netty5/channel/CombinedChannelDuplexHandlerTest.java
@@ -378,7 +378,7 @@ public class CombinedChannelDuplexHandlerTest {
         }
 
         @Override
-        public void read(ChannelHandlerContext ctx) {
+        public void read(ChannelHandlerContext ctx, ReadBufferAllocator readBufferAllocator) {
             queue.add(Event.READ);
         }
 

--- a/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTailTest.java
+++ b/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTailTest.java
@@ -277,7 +277,7 @@ public class DefaultChannelPipelineTailTest {
         }
 
         @Override
-        protected void doRead() throws Exception {
+        protected void doRead(ReadBufferAllocator readBufferAllocator) throws Exception {
         }
 
         @Override

--- a/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTest.java
+++ b/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTest.java
@@ -1272,9 +1272,9 @@ public class DefaultChannelPipelineTest {
 
             @Skip
             @Override
-            public void read(ChannelHandlerContext ctx) {
+            public void read(ChannelHandlerContext ctx, ReadBufferAllocator readBufferAllocator) {
                 fail();
-                ctx.read();
+                ctx.read(readBufferAllocator);
             }
 
             @Skip
@@ -1437,7 +1437,7 @@ public class DefaultChannelPipelineTest {
             }
 
             @Override
-            public void read(ChannelHandlerContext ctx) {
+            public void read(ChannelHandlerContext ctx, ReadBufferAllocator readBufferAllocator) {
                 executionMask |= MASK_READ;
             }
 

--- a/transport/src/test/java/io/netty5/channel/LoggingHandler.java
+++ b/transport/src/test/java/io/netty5/channel/LoggingHandler.java
@@ -80,9 +80,9 @@ final class LoggingHandler implements ChannelHandler {
     }
 
     @Override
-    public void read(ChannelHandlerContext ctx) {
+    public void read(ChannelHandlerContext ctx, ReadBufferAllocator readBufferAllocator) {
         log(Event.READ);
-        ctx.read();
+        ctx.read(readBufferAllocator);
     }
 
     @Override


### PR DESCRIPTION
Motivation:

To provide more flexibility we should allow to influence how the Buffer for read operations is allocated. This should be possible per read(...) call as people might want for example change how big the Buffer is for back-pressure reasons. Also it provides other possibilites like using the same Buffer for all reads etc.

Modifications:

- Add ReadBufferAllocator interface
- Add extra read(ReadBufferAllocator) method on ChannelOutboundInvoker interface and sub-types.
- Change ChannelHandler.read(...) method to use ReadBufferAllocator as argument as well.
- Make use of the provided ReadBufferAllocator in the read loop.

Result:

Much more flexibility in terms of reading