### PR TITLE
Update version to 5.0.0.Alpha5-SNAPSHOT

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty5-parent</artifactId>
-    <version>5.0.1.Alpha4-SNAPSHOT</version>
+    <version>5.0.0.Alpha5-SNAPSHOT</version>
   </parent>
 
   <artifactId>netty5-all</artifactId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -25,7 +25,7 @@
 
   <groupId>io.netty</groupId>
   <artifactId>netty5-bom</artifactId>
-  <version>5.0.1.Alpha4-SNAPSHOT</version>
+  <version>5.0.0.Alpha5-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Netty5/BOM</name>

--- a/buffer/pom.xml
+++ b/buffer/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty5-parent</artifactId>
-    <version>5.0.1.Alpha4-SNAPSHOT</version>
+    <version>5.0.0.Alpha5-SNAPSHOT</version>
   </parent>
 
   <artifactId>netty5-buffer</artifactId>

--- a/codec-dns/pom.xml
+++ b/codec-dns/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty5-parent</artifactId>
-    <version>5.0.1.Alpha4-SNAPSHOT</version>
+    <version>5.0.0.Alpha5-SNAPSHOT</version>
   </parent>
 
   <artifactId>netty5-codec-dns</artifactId>

--- a/codec-http/pom.xml
+++ b/codec-http/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty5-parent</artifactId>
-    <version>5.0.1.Alpha4-SNAPSHOT</version>
+    <version>5.0.0.Alpha5-SNAPSHOT</version>
   </parent>
 
   <artifactId>netty5-codec-http</artifactId>

--- a/codec-http2/pom.xml
+++ b/codec-http2/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty5-parent</artifactId>
-    <version>5.0.1.Alpha4-SNAPSHOT</version>
+    <version>5.0.0.Alpha5-SNAPSHOT</version>
   </parent>
 
   <artifactId>netty5-codec-http2</artifactId>

--- a/codec/pom.xml
+++ b/codec/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty5-parent</artifactId>
-    <version>5.0.1.Alpha4-SNAPSHOT</version>
+    <version>5.0.0.Alpha5-SNAPSHOT</version>
   </parent>
 
   <artifactId>netty5-codec</artifactId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty5-parent</artifactId>
-    <version>5.0.1.Alpha4-SNAPSHOT</version>
+    <version>5.0.0.Alpha5-SNAPSHOT</version>
   </parent>
 
   <artifactId>netty5-common</artifactId>

--- a/dev-tools/pom.xml
+++ b/dev-tools/pom.xml
@@ -25,7 +25,7 @@
 
   <groupId>io.netty</groupId>
   <artifactId>netty5-dev-tools</artifactId>
-  <version>5.0.1.Alpha4-SNAPSHOT</version>
+  <version>5.0.0.Alpha5-SNAPSHOT</version>
 
   <name>Netty5/Dev-Tools</name>
 

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty5-parent</artifactId>
-    <version>5.0.1.Alpha4-SNAPSHOT</version>
+    <version>5.0.0.Alpha5-SNAPSHOT</version>
   </parent>
 
   <artifactId>netty5-example</artifactId>

--- a/handler/pom.xml
+++ b/handler/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty5-parent</artifactId>
-    <version>5.0.1.Alpha4-SNAPSHOT</version>
+    <version>5.0.0.Alpha5-SNAPSHOT</version>
   </parent>
 
   <artifactId>netty5-handler</artifactId>

--- a/microbench/pom.xml
+++ b/microbench/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty5-parent</artifactId>
-    <version>5.0.1.Alpha4-SNAPSHOT</version>
+    <version>5.0.0.Alpha5-SNAPSHOT</version>
   </parent>
 
   <artifactId>netty5-microbench</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   <groupId>io.netty</groupId>
   <artifactId>netty5-parent</artifactId>
   <packaging>pom</packaging>
-  <version>5.0.1.Alpha4-SNAPSHOT</version>
+  <version>5.0.0.Alpha5-SNAPSHOT</version>
 
   <name>Netty 5 Parent</name>
   <url>https://netty.io/</url>

--- a/resolver-dns-classes-macos/pom.xml
+++ b/resolver-dns-classes-macos/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty5-parent</artifactId>
-    <version>5.0.1.Alpha4-SNAPSHOT</version>
+    <version>5.0.0.Alpha5-SNAPSHOT</version>
   </parent>
   <artifactId>netty5-resolver-dns-classes-macos</artifactId>
 

--- a/resolver-dns-native-macos/pom.xml
+++ b/resolver-dns-native-macos/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty5-parent</artifactId>
-    <version>5.0.1.Alpha4-SNAPSHOT</version>
+    <version>5.0.0.Alpha5-SNAPSHOT</version>
   </parent>
   <artifactId>netty5-resolver-dns-native-macos</artifactId>
 

--- a/resolver-dns/pom.xml
+++ b/resolver-dns/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty5-parent</artifactId>
-    <version>5.0.1.Alpha4-SNAPSHOT</version>
+    <version>5.0.0.Alpha5-SNAPSHOT</version>
   </parent>
 
   <artifactId>netty5-resolver-dns</artifactId>

--- a/resolver/pom.xml
+++ b/resolver/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty5-parent</artifactId>
-    <version>5.0.1.Alpha4-SNAPSHOT</version>
+    <version>5.0.0.Alpha5-SNAPSHOT</version>
   </parent>
 
   <artifactId>netty5-resolver</artifactId>

--- a/testsuite-autobahn/pom.xml
+++ b/testsuite-autobahn/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty5-parent</artifactId>
-    <version>5.0.1.Alpha4-SNAPSHOT</version>
+    <version>5.0.0.Alpha5-SNAPSHOT</version>
   </parent>
 
   <artifactId>netty5-testsuite-autobahn</artifactId>

--- a/testsuite-http2/pom.xml
+++ b/testsuite-http2/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty5-parent</artifactId>
-    <version>5.0.1.Alpha4-SNAPSHOT</version>
+    <version>5.0.0.Alpha5-SNAPSHOT</version>
   </parent>
 
   <artifactId>netty5-testsuite-http2</artifactId>

--- a/testsuite-native-image-client-runtime-init/pom.xml
+++ b/testsuite-native-image-client-runtime-init/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty5-parent</artifactId>
-    <version>5.0.1.Alpha4-SNAPSHOT</version>
+    <version>5.0.0.Alpha5-SNAPSHOT</version>
   </parent>
 
   <artifactId>netty5-testsuite-native-image-client-runtime-init</artifactId>

--- a/testsuite-native-image-client/pom.xml
+++ b/testsuite-native-image-client/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty5-parent</artifactId>
-    <version>5.0.1.Alpha4-SNAPSHOT</version>
+    <version>5.0.0.Alpha5-SNAPSHOT</version>
   </parent>
 
   <artifactId>netty5-testsuite-native-image-client</artifactId>

--- a/testsuite-native-image/pom.xml
+++ b/testsuite-native-image/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty5-parent</artifactId>
-    <version>5.0.1.Alpha4-SNAPSHOT</version>
+    <version>5.0.0.Alpha5-SNAPSHOT</version>
   </parent>
 
   <artifactId>netty5-testsuite-native-image</artifactId>

--- a/testsuite-native/pom.xml
+++ b/testsuite-native/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty5-parent</artifactId>
-    <version>5.0.1.Alpha4-SNAPSHOT</version>
+    <version>5.0.0.Alpha5-SNAPSHOT</version>
   </parent>
 
   <artifactId>netty5-testsuite-native</artifactId>

--- a/testsuite-osgi/pom.xml
+++ b/testsuite-osgi/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty5-parent</artifactId>
-    <version>5.0.1.Alpha4-SNAPSHOT</version>
+    <version>5.0.0.Alpha5-SNAPSHOT</version>
   </parent>
 
   <artifactId>netty5-testsuite-osgi</artifactId>

--- a/testsuite-shading/pom.xml
+++ b/testsuite-shading/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty5-parent</artifactId>
-    <version>5.0.1.Alpha4-SNAPSHOT</version>
+    <version>5.0.0.Alpha5-SNAPSHOT</version>
   </parent>
 
   <artifactId>netty5-testsuite-shading</artifactId>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty5-parent</artifactId>
-    <version>5.0.1.Alpha4-SNAPSHOT</version>
+    <version>5.0.0.Alpha5-SNAPSHOT</version>
   </parent>
 
   <artifactId>netty5-testsuite</artifactId>

--- a/transport-blockhound-tests/pom.xml
+++ b/transport-blockhound-tests/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty5-parent</artifactId>
-    <version>5.0.1.Alpha4-SNAPSHOT</version>
+    <version>5.0.0.Alpha5-SNAPSHOT</version>
   </parent>
 
   <artifactId>netty5-transport-blockhound-tests</artifactId>

--- a/transport-classes-epoll/pom.xml
+++ b/transport-classes-epoll/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty5-parent</artifactId>
-    <version>5.0.1.Alpha4-SNAPSHOT</version>
+    <version>5.0.0.Alpha5-SNAPSHOT</version>
   </parent>
   <artifactId>netty5-transport-classes-epoll</artifactId>
 

--- a/transport-classes-kqueue/pom.xml
+++ b/transport-classes-kqueue/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty5-parent</artifactId>
-    <version>5.0.1.Alpha4-SNAPSHOT</version>
+    <version>5.0.0.Alpha5-SNAPSHOT</version>
   </parent>
   <artifactId>netty5-transport-classes-kqueue</artifactId>
 

--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty5-parent</artifactId>
-    <version>5.0.1.Alpha4-SNAPSHOT</version>
+    <version>5.0.0.Alpha5-SNAPSHOT</version>
   </parent>
   <artifactId>netty5-transport-native-epoll</artifactId>
 

--- a/transport-native-kqueue/pom.xml
+++ b/transport-native-kqueue/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty5-parent</artifactId>
-    <version>5.0.1.Alpha4-SNAPSHOT</version>
+    <version>5.0.0.Alpha5-SNAPSHOT</version>
   </parent>
   <artifactId>netty5-transport-native-kqueue</artifactId>
 

--- a/transport-native-unix-common-tests/pom.xml
+++ b/transport-native-unix-common-tests/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty5-parent</artifactId>
-    <version>5.0.1.Alpha4-SNAPSHOT</version>
+    <version>5.0.0.Alpha5-SNAPSHOT</version>
   </parent>
   <artifactId>netty5-transport-native-unix-common-tests</artifactId>
 

--- a/transport-native-unix-common/pom.xml
+++ b/transport-native-unix-common/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty5-parent</artifactId>
-    <version>5.0.1.Alpha4-SNAPSHOT</version>
+    <version>5.0.0.Alpha5-SNAPSHOT</version>
   </parent>
   <artifactId>netty5-transport-native-unix-common</artifactId>
 

--- a/transport/pom.xml
+++ b/transport/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty5-parent</artifactId>
-    <version>5.0.1.Alpha4-SNAPSHOT</version>
+    <version>5.0.0.Alpha5-SNAPSHOT</version>
   </parent>
 
   <artifactId>netty5-transport</artifactId>


### PR DESCRIPTION
Motivation:

Next version should be 5.0.0.Alpha5

Modifications:

Update snapshot version

Result:

Correct version used
