### PR TITLE
Avoid allocating large buffers in JdkZlibEncoder

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibEncoder.java
@@ -45,11 +45,11 @@ public class JdkZlibEncoder extends ZlibEncoder {
      * Maximum initial size for temporary heap buffers used for the compressed output. Buffer may still grow beyond
      * this if necessary.
      */
-    static final int MAX_INITIAL_OUTPUT_BUFFER_SIZE;
+    private static final int MAX_INITIAL_OUTPUT_BUFFER_SIZE;
     /**
      * Max size for temporary heap buffers used to copy input data to heap.
      */
-    static final int MAX_INPUT_BUFFER_SIZE;
+    private static final int MAX_INPUT_BUFFER_SIZE;
 
     private final ZlibWrapper wrapper;
     private final Deflater deflater;

--- a/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibEncoder.java
@@ -267,7 +267,7 @@ public class JdkZlibEncoder extends ZlibEncoder {
             deflate(out);
             if (!out.isWritable()) {
                 // The buffer is not writable anymore. Increase the capacity to make more room.
-                // Can't rely on needsInput here, it might return false even if there's still data to be written.
+                // Can't rely on needsInput here, it might return true even if there's still data to be written.
                 out.ensureWritable(out.writerIndex());
             } else if (deflater.needsInput()) {
                 // Consumed everything

--- a/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibEncoder.java
@@ -244,9 +244,11 @@ public class JdkZlibEncoder extends ZlibEncoder {
         deflater.setInput(EmptyArrays.EMPTY_BYTES);
     }
 
-    private void encodeSome(ByteBuf heapBuf, ByteBuf out) {
-        byte[] inAry = heapBuf.array();
-        int offset = heapBuf.arrayOffset() + heapBuf.readerIndex();
+    private void encodeSome(ByteBuf in, ByteBuf out) {
+        // both in and out are heap buffers, here
+
+        byte[] inAry = in.array();
+        int offset = in.arrayOffset() + in.readerIndex();
 
         if (writeHeader) {
             writeHeader = false;
@@ -255,7 +257,7 @@ public class JdkZlibEncoder extends ZlibEncoder {
             }
         }
 
-        int len = heapBuf.readableBytes();
+        int len = in.readableBytes();
         if (wrapper == ZlibWrapper.GZIP) {
             crc.update(inAry, offset, len);
         }
@@ -272,7 +274,7 @@ public class JdkZlibEncoder extends ZlibEncoder {
                 break;
             }
         }
-        heapBuf.skipBytes(len);
+        in.skipBytes(len);
     }
 
     @Override


### PR DESCRIPTION
Hi, not sure if it should be done this way at all, or whether it should be configurable, open for suggestions.

---

Motivation:

Before this patch, JdkZlibEncoder allocates two buffers of roughly the same size as the input buffer: one for copying data to heap, one for output. The former is always unnecessary, since inflate calls can take smaller buffers, and the latter is sometimes unnecessary, if the input data compresses well. This behavior can lead to large heap buffer allocation that bypass pooling and lead to unnecessary heap pressure.

Modification:

This patch introduces a limit to both allocations. The limit is arbitrarily set to 64K (should it be configurable?) to stay within standard pool thresholds.

The copy-to-heap code is modified so that if the input is larger than this limit, it is gradually passed to the deflater with multiple setInput/deflate calls.

The output buffer code was already capable of expanding a too small buffer. If the output is larger than the limit, we could instead write it incrementally as small chunks downstream, however I don't know if this is worthwhile, since we don't really have any way of handling backpressure.

Additionally, this patch fixes three bugs I found during development:
- It is possible for the deflater to return `needsInput` even when there is still data to write, because the output buffer is full. I changed the code to check whether output is full first. This could potentially lead to a pointless resize if we estimated the output size exactly right, but this seems unlikely.
- the size estimate in `allocateBuffer` could overflow if the input buffer is almost 2G. The capacity limit fixes this issue.
- The deflater kept a reference to the input array even after the encode call had completed. I set the input to `new byte[0]` to avoid this.

Result:

JdkZlibEncoder does not allocate unnecessarily large temporary arrays. However, it may have to resize the output array more often if data can't be compressed well.

Motivation:

Explain here the context, and why you're making that change.
What is the problem you're trying to solve.

Modification:

Describe the modifications you've done.

Result:

Fixes #<GitHub issue number>. 

If there is no issue then describe the changes introduced by this PR.
