### PR TITLE
Fix epoll bug when receiving zero-sized datagrams

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastInetTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastInetTest.java
@@ -25,12 +25,15 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.DatagramPacket;
+import io.netty.util.internal.EmptyArrays;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
+import java.net.DatagramSocket;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -55,6 +58,38 @@ public class DatagramUnicastInetTest extends DatagramUnicastTest {
             channel = cb.bind(0).sync().channel();
         } finally {
             closeChannel(channel);
+        }
+    }
+
+    @Test
+    public void testReceiveEmptyDatagrams(TestInfo testInfo) throws Throwable {
+        run(testInfo, new Runner<Bootstrap, Bootstrap>() {
+            @Override
+            public void run(Bootstrap bootstrap, Bootstrap bootstrap2) throws Throwable {
+                testReceiveEmptyDatagrams(bootstrap, bootstrap2);
+            }
+        });
+    }
+
+    public void testReceiveEmptyDatagrams(Bootstrap sb, Bootstrap cb) throws Throwable {
+        final Semaphore semaphore = new Semaphore(0);
+        Channel server = sb.handler(new ChannelInitializer<Channel>() {
+            @Override
+            protected void initChannel(Channel ch) throws Exception {
+                ch.pipeline().addLast(new SimpleChannelInboundHandler<DatagramPacket>() {
+                    @Override
+                    protected void channelRead0(ChannelHandlerContext ctx, DatagramPacket msg) throws Exception {
+                        semaphore.release();
+                    }
+                });
+            }
+        }).bind(newSocketAddress()).sync().channel();
+
+        SocketAddress address = server.localAddress();
+        DatagramSocket client = new DatagramSocket();
+        for (int i = 0; i < 100; i++) {
+            client.send(new java.net.DatagramPacket(EmptyArrays.EMPTY_BYTES, 0, address));
+            semaphore.acquire();
         }
     }
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastInetTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastInetTest.java
@@ -25,15 +25,12 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.DatagramPacket;
-import io.netty.util.internal.EmptyArrays;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
-import java.net.DatagramSocket;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -58,38 +55,6 @@ public class DatagramUnicastInetTest extends DatagramUnicastTest {
             channel = cb.bind(0).sync().channel();
         } finally {
             closeChannel(channel);
-        }
-    }
-
-    @Test
-    public void testReceiveEmptyDatagrams(TestInfo testInfo) throws Throwable {
-        run(testInfo, new Runner<Bootstrap, Bootstrap>() {
-            @Override
-            public void run(Bootstrap bootstrap, Bootstrap bootstrap2) throws Throwable {
-                testReceiveEmptyDatagrams(bootstrap, bootstrap2);
-            }
-        });
-    }
-
-    public void testReceiveEmptyDatagrams(Bootstrap sb, Bootstrap cb) throws Throwable {
-        final Semaphore semaphore = new Semaphore(0);
-        Channel server = sb.handler(new ChannelInitializer<Channel>() {
-            @Override
-            protected void initChannel(Channel ch) throws Exception {
-                ch.pipeline().addLast(new SimpleChannelInboundHandler<DatagramPacket>() {
-                    @Override
-                    protected void channelRead0(ChannelHandlerContext ctx, DatagramPacket msg) throws Exception {
-                        semaphore.release();
-                    }
-                });
-            }
-        }).bind(newSocketAddress()).sync().channel();
-
-        SocketAddress address = server.localAddress();
-        DatagramSocket client = new DatagramSocket();
-        for (int i = 0; i < 100; i++) {
-            client.send(new java.net.DatagramPacket(EmptyArrays.EMPTY_BYTES, 0, address));
-            semaphore.acquire();
         }
     }
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
@@ -219,18 +219,17 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
         }).bind(newSocketAddress()).sync().channel();
 
         SocketAddress address = server.localAddress();
-        DatagramSocket client = new DatagramSocket(newSocketAddress());
-        for (int i = 0; i < 100; i++) {
-            java.net.DatagramPacket packet;
-            try {
-                packet = new java.net.DatagramPacket(EmptyArrays.EMPTY_BYTES, 0, address);
-            } catch (IllegalArgumentException e) {
-                if ("unsupported address type".equals(e.getMessage())) {
-                    throw new TestAbortedException("The JDK DatagramPacket does not support this address type.", e);
-                }
-                throw e;
+        DatagramSocket client;
+        try {
+            client = new DatagramSocket(newSocketAddress());
+        } catch (IllegalArgumentException e) {
+            if ("unsupported address type".equals(e.getMessage())) {
+                throw new TestAbortedException("The JDK DatagramPacket does not support this address type.", e);
             }
-            client.send(packet);
+            throw e;
+        }
+        for (int i = 0; i < 100; i++) {
+            client.send(new java.net.DatagramPacket(EmptyArrays.EMPTY_BYTES, 0, address));
             semaphore.acquire();
         }
     }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
@@ -31,7 +31,6 @@ import io.netty.util.NetUtil;
 import io.netty.util.internal.EmptyArrays;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
-import org.opentest4j.TestAbortedException;
 
 import java.net.DatagramSocket;
 import java.net.Inet6Address;
@@ -47,6 +46,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -223,9 +223,7 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
         try {
             client = new DatagramSocket(newSocketAddress());
         } catch (IllegalArgumentException e) {
-            if ("unsupported address type".equals(e.getMessage())) {
-                throw new TestAbortedException("The JDK DatagramPacket does not support this address type.", e);
-            }
+            assumeThat(e.getMessage()).doesNotContainIgnoringCase("unsupported address type");
             throw e;
         }
         for (int i = 0; i < 100; i++) {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
@@ -31,7 +31,10 @@ import io.netty.util.NetUtil;
 import io.netty.util.internal.EmptyArrays;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.opentest4j.TestAbortedException;
 
+import java.io.IOException;
+import java.net.BindException;
 import java.net.DatagramSocket;
 import java.net.Inet6Address;
 import java.net.InetAddress;
@@ -227,7 +230,11 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
             throw e;
         }
         for (int i = 0; i < 100; i++) {
-            client.send(new java.net.DatagramPacket(EmptyArrays.EMPTY_BYTES, 0, address));
+            try {
+                client.send(new java.net.DatagramPacket(EmptyArrays.EMPTY_BYTES, 0, address));
+            } catch (BindException e) {
+                throw new TestAbortedException("JDK sockets do not support binding to these addresses.", e);
+            }
             semaphore.acquire();
         }
     }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
@@ -219,7 +219,7 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
         }).bind(newSocketAddress()).sync().channel();
 
         SocketAddress address = server.localAddress();
-        DatagramSocket client = new DatagramSocket();
+        DatagramSocket client = new DatagramSocket(newSocketAddress());
         for (int i = 0; i < 100; i++) {
             java.net.DatagramPacket packet;
             try {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
@@ -22,17 +22,13 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.socket.DatagramChannel;
-import io.netty.channel.socket.DatagramPacket;
 import io.netty.util.NetUtil;
-import io.netty.util.internal.EmptyArrays;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
-import java.net.DatagramSocket;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -42,7 +38,6 @@ import java.nio.channels.NotYetConnectedException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -191,38 +186,6 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
     public void testSimpleSendWithConnect(Bootstrap sb, Bootstrap cb) throws Throwable {
         testSimpleSendWithConnect(sb, cb, Unpooled.directBuffer().writeBytes(BYTES), BYTES, 1);
         testSimpleSendWithConnect(sb, cb, Unpooled.directBuffer().writeBytes(BYTES), BYTES, 4);
-    }
-
-    @Test
-    public void testReceiveEmptyDatagrams(TestInfo testInfo) throws Throwable {
-        run(testInfo, new Runner<Bootstrap, Bootstrap>() {
-            @Override
-            public void run(Bootstrap bootstrap, Bootstrap bootstrap2) throws Throwable {
-                testReceiveEmptyDatagrams(bootstrap, bootstrap2);
-            }
-        });
-    }
-
-    public void testReceiveEmptyDatagrams(Bootstrap sb, Bootstrap cb) throws Throwable {
-        final Semaphore semaphore = new Semaphore(0);
-        Channel server = sb.handler(new ChannelInitializer<Channel>() {
-            @Override
-            protected void initChannel(Channel ch) throws Exception {
-                ch.pipeline().addLast(new SimpleChannelInboundHandler<DatagramPacket>() {
-                    @Override
-                    protected void channelRead0(ChannelHandlerContext ctx, DatagramPacket msg) throws Exception {
-                        semaphore.release();
-                    }
-                });
-            }
-        }).bind(newSocketAddress()).sync().channel();
-
-        SocketAddress address = server.localAddress();
-        DatagramSocket client = new DatagramSocket();
-        for (int i = 0; i < 100; i++) {
-            client.send(new java.net.DatagramPacket(EmptyArrays.EMPTY_BYTES, 0, address));
-            semaphore.acquire();
-        }
     }
 
     @SuppressWarnings("deprecation")

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
@@ -22,13 +22,17 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.socket.DatagramChannel;
+import io.netty.channel.socket.DatagramPacket;
 import io.netty.util.NetUtil;
+import io.netty.util.internal.EmptyArrays;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
+import java.net.DatagramSocket;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -38,6 +42,7 @@ import java.nio.channels.NotYetConnectedException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -186,6 +191,38 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
     public void testSimpleSendWithConnect(Bootstrap sb, Bootstrap cb) throws Throwable {
         testSimpleSendWithConnect(sb, cb, Unpooled.directBuffer().writeBytes(BYTES), BYTES, 1);
         testSimpleSendWithConnect(sb, cb, Unpooled.directBuffer().writeBytes(BYTES), BYTES, 4);
+    }
+
+    @Test
+    public void testReceiveEmptyDatagrams(TestInfo testInfo) throws Throwable {
+        run(testInfo, new Runner<Bootstrap, Bootstrap>() {
+            @Override
+            public void run(Bootstrap bootstrap, Bootstrap bootstrap2) throws Throwable {
+                testReceiveEmptyDatagrams(bootstrap, bootstrap2);
+            }
+        });
+    }
+
+    public void testReceiveEmptyDatagrams(Bootstrap sb, Bootstrap cb) throws Throwable {
+        final Semaphore semaphore = new Semaphore(0);
+        Channel server = sb.handler(new ChannelInitializer<Channel>() {
+            @Override
+            protected void initChannel(Channel ch) throws Exception {
+                ch.pipeline().addLast(new SimpleChannelInboundHandler<DatagramPacket>() {
+                    @Override
+                    protected void channelRead0(ChannelHandlerContext ctx, DatagramPacket msg) throws Exception {
+                        semaphore.release();
+                    }
+                });
+            }
+        }).bind(newSocketAddress()).sync().channel();
+
+        SocketAddress address = server.localAddress();
+        DatagramSocket client = new DatagramSocket();
+        for (int i = 0; i < 100; i++) {
+            client.send(new java.net.DatagramPacket(EmptyArrays.EMPTY_BYTES, 0, address));
+            semaphore.acquire();
+        }
     }
 
     @SuppressWarnings("deprecation")

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/NativeDatagramPacketArray.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/NativeDatagramPacketArray.java
@@ -209,6 +209,10 @@ final class NativeDatagramPacketArray {
             }
         }
 
+        boolean hasSender() {
+            return senderPort > 0;
+        }
+
         DatagramPacket newDatagramPacket(ByteBuf buffer, InetSocketAddress recipient) throws UnknownHostException {
             InetSocketAddress sender = newAddress(senderAddr, senderAddrLen, senderPort, senderScopeId, ipv4Bytes);
             if (recipientAddrLen != 0) {


### PR DESCRIPTION
Motivation:
Datagrams are allowed to be empty when sent over UNIX or INET sockets.
In such cases, we cannot use "received zero bytes" as a signal that no packets were received.

Modification:
When we receive a zero-sized datagram, tell the EpollRecvByteAllocatorHandle that we really received one byte, because the allocation handles use zero as an end-of-data signal.
Such signals will put the event loop to rest, which is wrong because we don't know at this point if there are more packets to process.
Use the absence of a sender-point as signal that no packets were read from recvmsg(2), and then continue to use -1 as the end-of-data signal to allocation handle.
Add a DatagramUnicastTest to verify that we can receive multiple empty datagrams in a row without the eventloop mistakenly going to sleep.

Result:
Robust handling of zero-sized datagrams in the epoll transport.