### PR TITLE
Avoid allocating large buffers in ZlibCompressor

### DIFF
--- a/codec/src/main/java/io/netty5/handler/codec/compression/ZlibCompressor.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/ZlibCompressor.java
@@ -17,6 +17,7 @@ package io.netty5.handler.codec.compression;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
+import io.netty5.util.internal.EmptyArrays;
 import io.netty5.util.internal.SystemPropertyUtil;
 import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
@@ -254,6 +255,8 @@ public final class ZlibCompressor implements Compressor {
                     break;
                 }
             }
+            // clear input so that we don't keep an unnecessary reference to the input array
+            deflater.setInput(EmptyArrays.EMPTY_BYTES);
         } catch (Throwable cause) {
             out.close();
             throw cause;


### PR DESCRIPTION
Motivation:

Before this patch, ZlibCompressor allocates a buffer of roughly the same size as the input buffer for the output.This is sometimes unnecessary, if the input data compresses well. This behavior can lead to large heap buffer allocation that bypass pooling and lead to unnecessary heap pressure.

Modification:

This patch introduces a limit to the initial allocation. The limit is arbitrarily set to 64K to stay within standard pool thresholds, and can be configured with the `io.netty.jdkzlib.encoder.maxInitialOutputBufferSize` system property.

The output buffer code was already capable of expanding a too small buffer. If the output is larger than the limit, we could instead write it incrementally as small chunks downstream, however I don't know if this is worthwhile, since we don't really have any way of handling backpressure.

Additionally, this patch fixes three bugs I found during development:

- It is possible for the deflater to return needsInput even when there is still data to write, because the output buffer is full. I changed the code to check whether output is full first. This could potentially lead to a pointless resize if we estimated the output size exactly right, but this seems unlikely.
- the size estimate could overflow if the input buffer is almost 2G. The capacity limit fixes this issue.
- The deflater kept a reference to the input array even after the encode call had completed. I set the input to `new byte[0]` to avoid this.

Result:

ZlibCompressor does not allocate unnecessarily large temporary arrays. However, it may have to resize the output array more often if data can't be compressed well.