### PR TITLE
Improve websocket masking, use long datatype for XOR operation.

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameDecoder.java
@@ -271,8 +271,10 @@ public class WebSocket08FrameDecoder extends ByteToMessageDecoder
                     return;
                 }
                 framePayloadLength = in.readLong();
-                // TODO: check if it's bigger than 0x7FFFFFFFFFFFFFFF, Maybe
-                // just check if it's negative?
+                if (framePayloadLength < 0) {
+                    protocolViolation(ctx, in, "invalid data frame length (negative length)");
+                    return;
+                }
 
                 if (framePayloadLength < 65536) {
                     protocolViolation(ctx, in, "invalid data frame length (not using minimal length encoding)");
@@ -396,23 +398,34 @@ public class WebSocket08FrameDecoder extends ByteToMessageDecoder
 
         // Remark: & 0xFF is necessary because Java will do signed expansion from
         // byte to int which we don't want.
-        int intMask = ((maskingKey[0] & 0xFF) << 24)
-                    | ((maskingKey[1] & 0xFF) << 16)
-                    | ((maskingKey[2] & 0xFF) << 8)
-                    | (maskingKey[3] & 0xFF);
+        long longMask = ((long) maskingKey[0] & 0xff) << 56 |
+                        ((long) maskingKey[1] & 0xff) << 48 |
+                        ((long) maskingKey[2] & 0xff) << 40 |
+                        ((long) maskingKey[3] & 0xff) << 32 |
+                        ((long) maskingKey[0] & 0xff) << 24 |
+                        ((long) maskingKey[1] & 0xff) << 16 |
+                        ((long) maskingKey[2] & 0xff) <<  8 |
+                        (long)  maskingKey[3] & 0xff;
 
         // If the byte order of our buffers it little endian we have to bring our mask
         // into the same format, because getInt() and writeInt() will use a reversed byte order
         if (order == ByteOrder.LITTLE_ENDIAN) {
-            intMask = Integer.reverseBytes(intMask);
+            longMask = Long.reverseBytes(longMask);
         }
 
-        for (; i + 3 < end; i += 4) {
-            int unmasked = frame.getInt(i) ^ intMask;
-            frame.setInt(i, unmasked);
+        for (int lim = end - 7; i < lim; i += 8) {
+            long unmasked = frame.getLong(i) ^ longMask;
+            frame.setLong(i, unmasked);
         }
+
+        if (i < end - 3) {
+            frame.setInt(i, frame.getInt(i) ^ (int) (longMask >> 32));
+            i += 4;
+        }
+
+        int maskOffset = 0;
         for (; i < end; i++) {
-            frame.setByte(i, frame.getByte(i) ^ maskingKey[i % 4]);
+            frame.setByte(i, frame.getByte(i) ^ maskingKey[maskOffset++ & 3]);
         }
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameEncoder.java
@@ -83,7 +83,7 @@ public class WebSocket08FrameEncoder extends MessageToMessageEncoder<WebSocketFr
     private static final byte OPCODE_PONG = 0xA;
 
     /**
-     * The size threshold for gathering writes. Non-Masked messages bigger than this size will be be sent fragmented as
+     * The size threshold for gathering writes. Non-Masked messages bigger than this size will be sent fragmented as
      * a header and a content ByteBuf whereas messages smaller than the size will be merged into a single buffer and
      * sent at once.<br>
      * Masked messages will always be sent at once.
@@ -139,8 +139,7 @@ public class WebSocket08FrameEncoder extends MessageToMessageEncoder<WebSocketFr
         b0 |= opcode % 128;
 
         if (opcode == OPCODE_PING && length > 125) {
-            throw new TooLongFrameException("invalid payload for PING (payload length must be <= 125, was "
-                    + length);
+            throw new TooLongFrameException("invalid payload for PING (payload length must be <= 125, was " + length);
         }
 
         boolean release = true;
@@ -148,10 +147,7 @@ public class WebSocket08FrameEncoder extends MessageToMessageEncoder<WebSocketFr
         try {
             int maskLength = maskPayload ? 4 : 0;
             if (length <= 125) {
-                int size = 2 + maskLength;
-                if (maskPayload || length <= GATHERING_WRITE_THRESHOLD) {
-                    size += length;
-                }
+                int size = 2 + maskLength + length;
                 buf = ctx.alloc().buffer(size);
                 buf.writeByte(b0);
                 byte b = (byte) (maskPayload ? 0x80 | (byte) length : (byte) length);
@@ -168,7 +164,7 @@ public class WebSocket08FrameEncoder extends MessageToMessageEncoder<WebSocketFr
                 buf.writeByte(length & 0xFF);
             } else {
                 int size = 10 + maskLength;
-                if (maskPayload || length <= GATHERING_WRITE_THRESHOLD) {
+                if (maskPayload) {
                     size += length;
                 }
                 buf = ctx.alloc().buffer(size);
@@ -186,7 +182,6 @@ public class WebSocket08FrameEncoder extends MessageToMessageEncoder<WebSocketFr
                 ByteOrder srcOrder = data.order();
                 ByteOrder dstOrder = buf.order();
 
-                int counter = 0;
                 int i = data.readerIndex();
                 int end = data.writerIndex();
 
@@ -194,25 +189,35 @@ public class WebSocket08FrameEncoder extends MessageToMessageEncoder<WebSocketFr
                     // Use the optimized path only when byte orders match
                     // Remark: & 0xFF is necessary because Java will do signed expansion from
                     // byte to int which we don't want.
-                    int intMask = ((mask[0] & 0xFF) << 24)
-                                | ((mask[1] & 0xFF) << 16)
-                                | ((mask[2] & 0xFF) << 8)
-                                | (mask[3] & 0xFF);
+                    long longMask = ((long) mask[0] & 0xff) << 56
+                                    | ((long) mask[1] & 0xff) << 48
+                                    | ((long) mask[2] & 0xff) << 40
+                                    | ((long) mask[3] & 0xff) << 32
+                                    | ((long) mask[0] & 0xff) << 24
+                                    | ((long) mask[1] & 0xff) << 16
+                                    | ((long) mask[2] & 0xff) << 8
+                                    | (long) mask[3] & 0xff;
 
                     // If the byte order of our buffers it little endian we have to bring our mask
                     // into the same format, because getInt() and writeInt() will use a reversed byte order
                     if (srcOrder == ByteOrder.LITTLE_ENDIAN) {
-                        intMask = Integer.reverseBytes(intMask);
+                        longMask = Long.reverseBytes(longMask);
                     }
 
-                    for (; i + 3 < end; i += 4) {
-                        int intData = data.getInt(i);
-                        buf.writeInt(intData ^ intMask);
+                    for (int lim = end - 7; i < lim; i += 8) {
+                        long longData = data.getLong(i);
+                        buf.writeLong(longData ^ longMask);
+                    }
+
+                    if (i < end - 3) {
+                        buf.writeInt(data.getInt(i) ^ (int) (longMask >> 32));
+                        i += 4;
                     }
                 }
+                int maskOffset = 0;
                 for (; i < end; i++) {
                     byte byteData = data.getByte(i);
-                    buf.writeByte(byteData ^ mask[counter++ % 4]);
+                    buf.writeByte(byteData ^ mask[maskOffset++ & 3]);
                 }
                 out.add(buf);
             } else {

--- a/microbench/src/main/java/io/netty/microbench/websocket/WebSocketFrame08DecoderBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/websocket/WebSocketFrame08DecoderBenchmark.java
@@ -54,7 +54,7 @@ public class WebSocketFrame08DecoderBenchmark extends AbstractMicrobenchmark {
     private ChannelHandlerContext context;
 
     private ByteBuf websocketFrame;
-    @Param({ "0", "4", "8", "32", "100", "1000", "3000" })
+    @Param({ "0", "2", "4", "8", "32", "100", "1000", "3000" })
     public int contentLength;
 
     @Param({ "true", "false" })
@@ -89,6 +89,7 @@ public class WebSocketFrame08DecoderBenchmark extends AbstractMicrobenchmark {
         websocketFrame.release();
         websocketFrame = null;
     }
+
     @Benchmark
     public void readWebSocketFrame() throws Exception {
         websocketDecoder.channelRead(context, websocketFrame.retainedDuplicate());

--- a/microbench/src/main/java/io/netty/microbench/websocket/WebSocketFrame08DecoderBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/websocket/WebSocketFrame08DecoderBenchmark.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.microbench.websocket;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.buffer.Unpooled;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.WebSocket08FrameDecoder;
+import io.netty.handler.codec.http.websocketx.WebSocket08FrameEncoder;
+import io.netty.microbench.channel.EmbeddedChannelHandlerContext;
+import io.netty.microbench.util.AbstractMicrobenchmark;
+import io.netty.util.internal.ThreadLocalRandom;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
+
+@State(Scope.Benchmark)
+@Fork(value = 2)
+@Threads(1)
+@Warmup(iterations = 5)
+@Measurement(iterations = 10)
+public class WebSocketFrame08DecoderBenchmark extends AbstractMicrobenchmark {
+
+    private WebSocket08FrameDecoder websocketDecoder;
+
+    private ChannelHandlerContext context;
+
+    private ByteBuf websocketFrame;
+    @Param({ "0", "4", "8", "32", "100", "1000", "3000" })
+    public int contentLength;
+
+    @Param({ "true", "false" })
+    public boolean pooledAllocator;
+
+    @Param({ "true" })
+    public boolean masking;
+
+    @Setup(Level.Trial)
+    public void setUp() {
+        byte[] bytes = new byte[contentLength];
+        ThreadLocalRandom.current().nextBytes(bytes);
+        ByteBufAllocator allocator = pooledAllocator? PooledByteBufAllocator.DEFAULT : UnpooledByteBufAllocator.DEFAULT;
+        ByteBuf testContent = allocator.buffer(contentLength).writeBytes(bytes);
+
+        EmbeddedChannel channel = new EmbeddedChannel(new WebSocket08FrameEncoder(masking));
+        channel.writeOutbound(new BinaryWebSocketFrame(testContent));
+        websocketFrame = Unpooled.unreleasableBuffer(((ByteBuf) channel.readOutbound()).asReadOnly());
+        channel.pipeline().remove(WebSocket08FrameEncoder.class);
+
+        websocketDecoder = new WebSocket08FrameDecoder(masking, false, 65536);
+        context = new EmbeddedChannelHandlerContext(allocator, websocketDecoder, channel) {
+            @Override
+            protected void handleException(Throwable t) {
+                handleUnexpectedException(t);
+            }
+        };
+    }
+
+    @TearDown(Level.Trial)
+    public void teardown() {
+        websocketFrame.release();
+        websocketFrame = null;
+    }
+    @Benchmark
+    public void readWebSocketFrame() throws Exception {
+        websocketDecoder.channelRead(context, websocketFrame.retainedDuplicate());
+    }
+
+    @Override
+    protected ChainedOptionsBuilder newOptionsBuilder() throws Exception {
+        return super.newOptionsBuilder().addProfiler(GCProfiler.class);
+    }
+}

--- a/microbench/src/main/java/io/netty/microbench/websocket/WebSocketFrame08EncoderBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/websocket/WebSocketFrame08EncoderBenchmark.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.microbench.websocket;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.buffer.Unpooled;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.WebSocket08FrameEncoder;
+import io.netty.microbench.channel.EmbeddedChannelWriteReleaseHandlerContext;
+import io.netty.microbench.util.AbstractMicrobenchmark;
+import io.netty.util.internal.ThreadLocalRandom;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
+
+@State(Scope.Benchmark)
+@Fork(value = 2)
+@Threads(1)
+@Warmup(iterations = 5)
+@Measurement(iterations = 10)
+public class WebSocketFrame08EncoderBenchmark extends AbstractMicrobenchmark {
+
+    private WebSocket08FrameEncoder websocketEncoder;
+
+    private ChannelHandlerContext context;
+
+    private ByteBuf content;
+
+    private BinaryWebSocketFrame webSocketFrame;
+    @Param({ "0", "4", "8", "32", "100", "1000", "3000" })
+    public int contentLength;
+
+    @Param({ "true", "false" })
+    public boolean pooledAllocator;
+
+    @Param({ "true" })
+    public boolean masking;
+
+    @Setup(Level.Trial)
+    public void setUp() {
+        byte[] bytes = new byte[contentLength];
+        ThreadLocalRandom.current().nextBytes(bytes);
+        ByteBufAllocator allocator = pooledAllocator? PooledByteBufAllocator.DEFAULT : UnpooledByteBufAllocator.DEFAULT;
+        content = allocator.buffer(contentLength).writeBytes(bytes);
+        ByteBuf testContent = Unpooled.unreleasableBuffer(content.asReadOnly());
+
+        webSocketFrame = new BinaryWebSocketFrame(testContent);
+        websocketEncoder = new WebSocket08FrameEncoder(masking);
+        context = new EmbeddedChannelWriteReleaseHandlerContext(allocator, websocketEncoder) {
+            @Override
+            protected void handleException(Throwable t) {
+                handleUnexpectedException(t);
+            }
+        };
+    }
+
+    @TearDown(Level.Trial)
+    public void teardown() {
+        content.release();
+        content = null;
+    }
+
+    @Benchmark
+    public void writeWebSocketFrame() throws Exception {
+        websocketEncoder.write(context, webSocketFrame, context.voidPromise());
+    }
+
+    @Override
+    protected ChainedOptionsBuilder newOptionsBuilder() throws Exception {
+        return super.newOptionsBuilder().addProfiler(GCProfiler.class);
+    }
+}

--- a/microbench/src/main/java/io/netty/microbench/websocket/package-info.java
+++ b/microbench/src/main/java/io/netty/microbench/websocket/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * Benchmarks for {@link io.netty.handler.codec.http.websocketx.WebSocket08FrameDecoder}
+ * and {@link io.netty.handler.codec.http.websocketx.WebSocket08FrameEncoder}.
+ */
+package io.netty.microbench.websocket;


### PR DESCRIPTION
Motivation:

The performance of a websocket depends a lot on frame masking and unmasking, we can improve this by using a long data type for the XOR operation. 

Modification:

Use long datatype for XOR operation. This reduces the number of reads and writes required when masking a data buffer.
Provide benchmarks to check result.

Result:

Websocket performance is better.
