### PR TITLE
Add Blockhound exceptions for the PooledByteBufAllocator

### DIFF
--- a/common/src/main/java/io/netty/util/internal/Hidden.java
+++ b/common/src/main/java/io/netty/util/internal/Hidden.java
@@ -76,6 +76,26 @@ class Hidden {
             );
 
             builder.allowBlockingCallsInside(
+                    "io.netty.buffer.PoolArena",
+                    "lock"
+            );
+
+            builder.allowBlockingCallsInside(
+                    "io.netty.buffer.PoolSubpage",
+                    "lock"
+            );
+
+            builder.allowBlockingCallsInside(
+                    "io.netty.buffer.PoolChunk",
+                    "allocateRun"
+            );
+
+            builder.allowBlockingCallsInside(
+                    "io.netty.buffer.PoolChunk",
+                    "free"
+            );
+
+            builder.allowBlockingCallsInside(
                     "io.netty.handler.ssl.SslHandler",
                     "handshake"
             );


### PR DESCRIPTION
Motivation:
In #12622 we replaced a number of synchronised blocks with explicit locks.
It turns out that blockhound ignores synchronised blocks for some reason, and now complain about the explicit locks.

Modification:
Add exceptions and allow blocking calls in select methods in the PooledByteBufAllocator.

Result:
No more blockhound complaints.