### PR TITLE
Fix epoll bug when receiving zero-sized datagrams

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/NativeDatagramPacketArray.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/NativeDatagramPacketArray.java
@@ -248,6 +248,10 @@ final class NativeDatagramPacketArray {
             }
         }
 
+        boolean hasSender() {
+            return senderPort > 0;
+        }
+
         DatagramPacket newDatagramPacket(Buffer buffer, InetSocketAddress recipient) throws UnknownHostException {
             InetSocketAddress sender = newAddress(senderAddr, senderAddrLen, senderPort, senderScopeId, ipv4Bytes);
             if (recipientAddrLen != 0) {


### PR DESCRIPTION
This is a forward port of #12644.

Motivation:
Datagrams are allowed to be empty when sent over UNIX or INET sockets.
In such cases, we cannot use "received zero bytes" as a signal that no packets were received.

Modification:
When we receive a zero-sized datagram, tell the EpollRecvByteAllocatorHandle that we really received one byte, because the allocation handles use zero as an end-of-data signal.
Such signals will put the event loop to rest, which is wrong because we don't know at this point if there are more packets to process.
Use the absence of a sender-point as signal that no packets were read from recvmsg(2), and then continue to use -1 as the end-of-data signal to allocation handle.
Add a DatagramUnicastTest to verify that we can receive multiple empty datagrams in a row without the eventloop mistakenly going to sleep.
The JDK DatagramSocket and DatagramPacket do not currently support UNIX sockets, so the test catches those specific exceptions and bails out in those cases.

Result:
Robust handling of zero-sized datagrams in the epoll transport.