### PR TITLE
Updates to basic build instructions for Netty 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 # Netty Project
 
-Netty is an asynchronous event-driven network application framework for rapid development of maintainable high performance protocol servers & clients.
+Netty is an asynchronous event-driven network application framework for rapid development of maintainable high 
+performance protocol servers & clients.
 
 ## Links
 
@@ -16,17 +17,22 @@ Netty is an asynchronous event-driven network application framework for rapid de
 
 For the detailed information about building and developing Netty, please visit [the developer guide](https://netty.io/wiki/developer-guide.html).  This page only gives very basic information.
 
-You require the following to build Netty:
+You will require the following to build Netty:
 
-* Latest stable [OpenJDK 8](https://adoptium.net/)
+* Latest stable [OpenJDK 11](https://adoptium.net/) for Netty 5, [OpenJDK 8](https://adoptium.net/) for older releases.
 * Latest stable [Apache Maven](https://maven.apache.org/)
-* If you are on Linux or MacOS, you need [additional development packages](https://netty.io/wiki/native-transports.html) installed on your system, because you'll build the native transport.
+* If you are on Linux or MacOS, you need [additional development packages](https://netty.io/wiki/native-transports.html)
+installed on your system, because you'll build the native transport.
 
-Note that this is build-time requirement.  JDK 5 (for 3.x) or 6 (for 4.0+ / 4.1+) is enough to run your Netty-based application.
+Note that this is build-time requirement. JDK 5 (for 3.x) or 6 (for 4.0+ / 4.1+) are enough to run your Netty-based 
+application.
 
 ## Branches to look
 
-Development of all versions takes place in each branch whose name is identical to `<majorVersion>.<minorVersion>`.  For example, the development of 3.9 and 4.1 resides in [the branch '3.9'](https://github.com/netty/netty/tree/3.9) and [the branch '4.1'](https://github.com/netty/netty/tree/4.1) respectively.
+Development of released versions takes place in each branch whose name is identical to `<majorVersion>.<minorVersion>`. 
+For example, the development of 3.9 and 4.1 resides in [the branch '3.9'](https://github.com/netty/netty/tree/3.9) and 
+[the branch '4.1'](https://github.com/netty/netty/tree/4.1) respectively. Development for Netty 5 resides on the 
+[main branch](https://github.com/netty/netty/tree/main).
 
 ## Usage with JDK 9+
 
@@ -54,5 +60,5 @@ are listed below:
 
 
 
-Automatic modules do not provide any means to declare dependencies, so you need to list each used module separately
+Automatic modules do not provide any means to declare dependencies, so you need to list each used module separately 
 in your `module-info` file.


### PR DESCRIPTION
Motivation:
The requirements for building Netty 5 are different than for earlier releases and the source is located on the `main` branch.
Modifications:
Updates to describe required versions of tools needed for building and location of Netty 5 source.
Result:
Up-to-date build instructions.