### PR TITLE
Improve error message when ByteToMessageDecoder subclasses release their input buffers

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
@@ -23,6 +23,7 @@ import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.socket.ChannelInputShutdownEvent;
+import io.netty.util.IllegalReferenceCountException;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
 
@@ -285,7 +286,15 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
                 try {
                     if (cumulation != null && !cumulation.isReadable()) {
                         numReads = 0;
-                        cumulation.release();
+                        try {
+                            cumulation.release();
+                        } catch (IllegalReferenceCountException e) {
+                            //noinspection ThrowFromFinallyBlock
+                            throw new IllegalReferenceCountException(
+                                    getClass().getSimpleName() + "#decode() might have released its input buffer, " +
+                                            "or passed it down the pipeline without a retain() call, " +
+                                            "which is not allowed.", e);
+                        }
                         cumulation = null;
                     } else if (++numReads >= discardAfterReads) {
                         // We did enough reads already try to discard some bytes, so we not risk to see a OOME.


### PR DESCRIPTION
Motivation:
Releasing the buffer in the decode() method is a violation of the API, but this is not obvious without reading the javadocs carefully.
The error message people get, are difficult to act on and debug.

Modification:
Capture the precise class name of the ByteToMessageDecoder subclass that released the buffer, in the error message.
This will tell people what code to investigate, when they get this error.

Result:
It is now easier for people to debug issues that arise when they mess up the reference counting of buffers.

Fixes #12360