### PR TITLE
Handle content-type optional parameters other than charset (netty#12663)

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
@@ -776,7 +776,7 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
                             String values = StringUtil.substringAfter(contents[i], '=');
                             Attribute attribute;
                             try {
-                                attribute = factory.createAttribute(request, name, cleanString(values));
+                                attribute = factory.createAttribute(request, cleanString(name), values);
                             } catch (NullPointerException e) {
                                 throw new ErrorDataDecoderException(e);
                             } catch (IllegalArgumentException e) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
@@ -771,6 +771,18 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
                                 throw new ErrorDataDecoderException(e);
                             }
                             currentFieldAttributes.put(HttpHeaderValues.CHARSET, attribute);
+                        } else if (contents[i].contains("=")) {
+                            String name = StringUtil.substringBefore(contents[i], '=');
+                            String values = StringUtil.substringAfter(contents[i], '=');
+                            Attribute attribute;
+                            try {
+                                attribute = factory.createAttribute(request, name, cleanString(values));
+                            } catch (NullPointerException e) {
+                                throw new ErrorDataDecoderException(e);
+                            } catch (IllegalArgumentException e) {
+                                throw new ErrorDataDecoderException(e);
+                            }
+                            currentFieldAttributes.put(name, attribute);
                         } else {
                             Attribute attribute;
                             try {

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostMultiPartRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostMultiPartRequestDecoderTest.java
@@ -314,7 +314,7 @@ public class HttpPostMultiPartRequestDecoderTest {
         req.headers().set("content-length", content.length());
 
         HttpPostMultipartRequestDecoder test = new HttpPostMultipartRequestDecoder(req);
-        assertEquals("audio/ogg", ((MixedFileUpload)test.getBodyHttpDatas("file").get(0)).getContentType());
+        assertEquals("audio/ogg", ((FileUpload)test.getBodyHttpDatas("file").get(0)).getContentType());
     }
 
     private static void commonNotBadReleaseBuffersDuringDecoding(HttpDataFactory factory, boolean inMemory)

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostMultiPartRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostMultiPartRequestDecoderTest.java
@@ -316,6 +316,7 @@ public class HttpPostMultiPartRequestDecoderTest {
         HttpPostMultipartRequestDecoder test = new HttpPostMultipartRequestDecoder(req);
         FileUpload httpData = (FileUpload) test.getBodyHttpDatas("file").get(0);
         assertEquals("audio/ogg", httpData.getContentType());
+        test.destroy();
     }
 
     private static void commonNotBadReleaseBuffersDuringDecoding(HttpDataFactory factory, boolean inMemory)

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostMultiPartRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostMultiPartRequestDecoderTest.java
@@ -314,7 +314,7 @@ public class HttpPostMultiPartRequestDecoderTest {
         req.headers().set("content-length", content.length());
 
         HttpPostMultipartRequestDecoder test = new HttpPostMultipartRequestDecoder(req);
-        assertEquals("audio/ogg", ((FileUpload)test.getBodyHttpDatas("file").get(0)).getContentType());
+        assertEquals("audio/ogg", ((FileUpload) test.getBodyHttpDatas("file").get(0)).getContentType());
     }
 
     private static void commonNotBadReleaseBuffersDuringDecoding(HttpDataFactory factory, boolean inMemory)

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostMultiPartRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostMultiPartRequestDecoderTest.java
@@ -314,7 +314,8 @@ public class HttpPostMultiPartRequestDecoderTest {
         req.headers().set("content-length", content.length());
 
         HttpPostMultipartRequestDecoder test = new HttpPostMultipartRequestDecoder(req);
-        assertEquals("audio/ogg", ((FileUpload) test.getBodyHttpDatas("file").get(0)).getContentType());
+        FileUpload httpData = (FileUpload) test.getBodyHttpDatas("file").get(0);
+        assertEquals("audio/ogg", httpData.getContentType());
     }
 
     private static void commonNotBadReleaseBuffersDuringDecoding(HttpDataFactory factory, boolean inMemory)

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostMultiPartRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostMultiPartRequestDecoderTest.java
@@ -300,6 +300,23 @@ public class HttpPostMultiPartRequestDecoderTest {
         commonNotBadReleaseBuffersDuringDecoding(factory, false);
     }
 
+    @Test
+    public void testDecodeFullHttpRequestWithOptionalParameters() {
+        String content = "\n--861fbeab-cd20-470c-9609-d40a0f704466\r\n" +
+                "content-disposition: form-data; " +
+                "name=\"file\"; filename=\"myfile.ogg\"\r\n" +
+                "content-type: audio/ogg; codecs=opus; charset=UTF8\r\ncontent-transfer-encoding: binary\r\n" +
+                "\r\n\u0001\u0002\u0003\u0004\r\n--861fbeab-cd20-470c-9609-d40a0f704466--\r\n\",\n";
+
+        FullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/upload",
+                Unpooled.copiedBuffer(content, CharsetUtil.US_ASCII));
+        req.headers().set("content-type", "multipart/form-data; boundary=861fbeab-cd20-470c-9609-d40a0f704466");
+        req.headers().set("content-length", content.length());
+
+        HttpPostMultipartRequestDecoder test = new HttpPostMultipartRequestDecoder(req);
+        assertEquals("audio/ogg", ((MixedFileUpload)test.getBodyHttpDatas("file").get(0)).getContentType());
+    }
+
     private static void commonNotBadReleaseBuffersDuringDecoding(HttpDataFactory factory, boolean inMemory)
             throws IOException {
         int nbItems = 20;

--- a/common/src/main/java/io/netty/util/internal/StringUtil.java
+++ b/common/src/main/java/io/netty/util/internal/StringUtil.java
@@ -103,6 +103,19 @@ public final class StringUtil {
     }
 
     /**
+     * Get the item before one char delim if the delim is found (else null).
+     * This operation is a simplified and optimized
+     * version of {@link String#split(String, int)}.
+     */
+    public static String substringBefore(String value, char delim) {
+        int pos = value.indexOf(delim);
+        if (pos >= 0) {
+            return value.substring(0, pos);
+        }
+        return null;
+    }
+
+    /**
      * Checks if two strings have the same suffix of specified length
      *
      * @param s   string


### PR DESCRIPTION
Motivation:

When receiving multipart/form-data where the form-data includes a file with optional parameter, in my case a codec parameter, the content-type was incorrectly set to the parameter value. Currently this only behaves correctly if the optional parameter is a character set parameter.

Modification:

When processing the content-type header contents, after splitting the header into the String[], check each item to see if it is a name=value pair, indicating it is an optional parameter. Add an attribute using the split name and value.

Result:

When processing the content-type header, the code now correctly sets the content-type and adds additional attributes for the optional parameters.

Fixes #12663 


