### PR TITLE
Length field based frame decoder can be optimized

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/LengthFieldBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/LengthFieldBasedFrameDecoder.java
@@ -396,7 +396,7 @@ public class LengthFieldBasedFrameDecoder extends ByteToMessageDecoder {
      */
     protected Object decode(ChannelHandlerContext ctx, ByteBuf in) throws Exception {
         long frameLength = 0;
-        if(frameLengthInt == -1) { // new frame
+        if (frameLengthInt == -1) { // new frame
 
             if (discardingTooLongFrame) {
                 discardingTooLongFrame(in);

--- a/codec/src/main/java/io/netty/handler/codec/LengthFieldBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/LengthFieldBasedFrameDecoder.java
@@ -15,15 +15,13 @@
  */
 package io.netty.handler.codec;
 
-import static io.netty.util.internal.ObjectUtil.checkNotNull;
-import static io.netty.util.internal.ObjectUtil.checkPositive;
-import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
 
 import java.nio.ByteOrder;
 import java.util.List;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelHandlerContext;
+import static io.netty.util.internal.ObjectUtil.*;
 
 /**
  * A decoder that splits the received {@link ByteBuf}s dynamically by the
@@ -197,6 +195,8 @@ public class LengthFieldBasedFrameDecoder extends ByteToMessageDecoder {
     private boolean discardingTooLongFrame;
     private long tooLongFrameLength;
     private long bytesToDiscard;
+
+    private int frameLengthInt = -1;
 
     /**
      * Creates a new instance.
@@ -394,38 +394,40 @@ public class LengthFieldBasedFrameDecoder extends ByteToMessageDecoder {
      *                          be created.
      */
     protected Object decode(ChannelHandlerContext ctx, ByteBuf in) throws Exception {
-        if (discardingTooLongFrame) {
-            discardingTooLongFrame(in);
-        }
+        long frameLength = 0;
+        if(frameLengthInt == -1) { // new frame
 
-        if (in.readableBytes() < lengthFieldEndOffset) {
+            if (discardingTooLongFrame) {
+                discardingTooLongFrame(in);
+            }
+
+            if (in.readableBytes() < lengthFieldEndOffset) {
+                return null;
+            }
+
+            int actualLengthFieldOffset = in.readerIndex() + lengthFieldOffset;
+            frameLength = getUnadjustedFrameLength(in, actualLengthFieldOffset, lengthFieldLength, byteOrder);
+
+            if (frameLength < 0) {
+                failOnNegativeLengthField(in, frameLength, lengthFieldEndOffset);
+            }
+
+            frameLength += lengthAdjustment + lengthFieldEndOffset;
+
+            if (frameLength < lengthFieldEndOffset) {
+                failOnFrameLengthLessThanLengthFieldEndOffset(in, frameLength, lengthFieldEndOffset);
+            }
+
+            if (frameLength > maxFrameLength) {
+                exceededFrameLength(in, frameLength);
+                return null;
+            }
+            // never overflows because it's less than maxFrameLength
+            frameLengthInt = (int) frameLength;
+        }
+        if (in.readableBytes() < frameLengthInt) { // frameLengthInt exist , just check buf
             return null;
         }
-
-        int actualLengthFieldOffset = in.readerIndex() + lengthFieldOffset;
-        long frameLength = getUnadjustedFrameLength(in, actualLengthFieldOffset, lengthFieldLength, byteOrder);
-
-        if (frameLength < 0) {
-            failOnNegativeLengthField(in, frameLength, lengthFieldEndOffset);
-        }
-
-        frameLength += lengthAdjustment + lengthFieldEndOffset;
-
-        if (frameLength < lengthFieldEndOffset) {
-            failOnFrameLengthLessThanLengthFieldEndOffset(in, frameLength, lengthFieldEndOffset);
-        }
-
-        if (frameLength > maxFrameLength) {
-            exceededFrameLength(in, frameLength);
-            return null;
-        }
-
-        // never overflows because it's less than maxFrameLength
-        int frameLengthInt = (int) frameLength;
-        if (in.readableBytes() < frameLengthInt) {
-            return null;
-        }
-
         if (initialBytesToStrip > frameLengthInt) {
             failOnFrameLengthLessThanInitialBytesToStrip(in, frameLength, initialBytesToStrip);
         }
@@ -436,6 +438,7 @@ public class LengthFieldBasedFrameDecoder extends ByteToMessageDecoder {
         int actualFrameLength = frameLengthInt - initialBytesToStrip;
         ByteBuf frame = extractFrame(ctx, in, readerIndex, actualFrameLength);
         in.readerIndex(readerIndex + actualFrameLength);
+        frameLengthInt = -1; // start processing the next frame
         return frame;
     }
 

--- a/codec/src/main/java/io/netty/handler/codec/LengthFieldBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/LengthFieldBasedFrameDecoder.java
@@ -197,7 +197,6 @@ public class LengthFieldBasedFrameDecoder extends ByteToMessageDecoder {
     private boolean discardingTooLongFrame;
     private long tooLongFrameLength;
     private long bytesToDiscard;
-
     private int frameLengthInt = -1;
 
     /**

--- a/codec/src/main/java/io/netty/handler/codec/LengthFieldBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/LengthFieldBasedFrameDecoder.java
@@ -15,13 +15,15 @@
  */
 package io.netty.handler.codec;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelHandlerContext;
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import static io.netty.util.internal.ObjectUtil.checkPositive;
+import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 
 import java.nio.ByteOrder;
 import java.util.List;
 
-import static io.netty.util.internal.ObjectUtil.*;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
 
 /**
  * A decoder that splits the received {@link ByteBuf}s dynamically by the

--- a/codec/src/main/java/io/netty/handler/codec/LengthFieldBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/LengthFieldBasedFrameDecoder.java
@@ -182,6 +182,9 @@ import io.netty.channel.ChannelHandlerContext;
  * | 0xCA | 0x0010 | 0xFE | "HELLO, WORLD" |      | 0xFE | "HELLO, WORLD" |
  * +------+--------+------+----------------+      +------+----------------+
  * </pre>
+ *
+ * NOTE: we use frameLengthInt variable to avoid repeated parsing frame, but sometimes we could need it.
+ * so you can call resetFrameLengthInt do it.
  * @see LengthFieldPrepender
  */
 public class LengthFieldBasedFrameDecoder extends ByteToMessageDecoder {
@@ -441,6 +444,13 @@ public class LengthFieldBasedFrameDecoder extends ByteToMessageDecoder {
         in.readerIndex(readerIndex + actualFrameLength);
         frameLengthInt = -1; // start processing the next frame
         return frame;
+    }
+
+    /**
+     * allow repeat read frame
+     */
+    public void resetFrameLengthInt(){
+        this.frameLengthInt = -1;
     }
 
     /**


### PR DESCRIPTION
Motivation:

Not long ago, I have modified the LengthFieldBasedFrameDecoder class to skip frames of parsed, however, we should be allowed to repeat reading frame, to meet their business expansion

Modification:

allow repeat read frame

Result:

Fixes #12171. 
