### PR TITLE
allow LengthFieldBasedFrameDecoder repeat read frame 

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/LengthFieldBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/LengthFieldBasedFrameDecoder.java
@@ -182,6 +182,9 @@ import io.netty.channel.ChannelHandlerContext;
  * | 0xCA | 0x0010 | 0xFE | "HELLO, WORLD" |      | 0xFE | "HELLO, WORLD" |
  * +------+--------+------+----------------+      +------+----------------+
  * </pre>
+ *
+ * NOTE: we use frameLengthInt variable to avoid repeated parsing frame, but sometimes we could need it.
+ * so you can call resetFrameLengthInt do it.
  * @see LengthFieldPrepender
  */
 public class LengthFieldBasedFrameDecoder extends ByteToMessageDecoder {
@@ -443,6 +446,13 @@ public class LengthFieldBasedFrameDecoder extends ByteToMessageDecoder {
         return frame;
     }
 
+    /**
+     * allow repeat read frame
+     */
+    public void resetFrameLengthInt(){
+        this.frameLengthInt = -1;
+    }
+    
     /**
      * Decodes the specified region of the buffer into an unadjusted frame length.  The default implementation is
      * capable of decoding the specified region into an unsigned 8/16/24/32/64 bit integer.  Override this method to

--- a/codec/src/main/java/io/netty/handler/codec/LengthFieldBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/LengthFieldBasedFrameDecoder.java
@@ -442,7 +442,7 @@ public class LengthFieldBasedFrameDecoder extends ByteToMessageDecoder {
         int actualFrameLength = frameLengthInt - initialBytesToStrip;
         ByteBuf frame = extractFrame(ctx, in, readerIndex, actualFrameLength);
         in.readerIndex(readerIndex + actualFrameLength);
-        frameLengthInt = -1; // start processing the next frame
+        resetFrameLengthInt(); // start processing the next frame
         return frame;
     }
 

--- a/codec/src/main/java/io/netty/handler/codec/LengthFieldBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/LengthFieldBasedFrameDecoder.java
@@ -449,7 +449,7 @@ public class LengthFieldBasedFrameDecoder extends ByteToMessageDecoder {
     /**
      * allow repeat read frame
      */
-    public void resetFrameLengthInt() {
+    protected void resetFrameLengthInt() {
         this.frameLengthInt = -1;
     }
 

--- a/codec/src/main/java/io/netty/handler/codec/LengthFieldBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/LengthFieldBasedFrameDecoder.java
@@ -449,10 +449,10 @@ public class LengthFieldBasedFrameDecoder extends ByteToMessageDecoder {
     /**
      * allow repeat read frame
      */
-    public void resetFrameLengthInt(){
+    public void resetFrameLengthInt() {
         this.frameLengthInt = -1;
     }
-    
+
     /**
      * Decodes the specified region of the buffer into an unadjusted frame length.  The default implementation is
      * capable of decoding the specified region into an unsigned 8/16/24/32/64 bit integer.  Override this method to


### PR DESCRIPTION
Motivation:

Not long ago, I have modified the LengthFieldBasedFrameDecoder class to skip frames of parsed, however, we should be allowed to repeat reading frame, to meet their business expansion

Modification:

allow repeat read frame

Result:

Fixes #12171.