### PR TITLE
Call read() when eof / rdhup was detected

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
@@ -395,10 +395,10 @@ abstract class AbstractEpollChannel<P extends UnixChannel>
         receivedRdHup = true;
 
         if (isActive()) {
-            // If it is still active, we need to call epollInReady as otherwise we may miss to
+            // If it is still active, we need to call read() as otherwise we may miss to
             // read pending data from the underlying file descriptor.
             // See https://github.com/netty/netty/issues/3709
-            epollInReady();
+            read();
         } else {
             // Just to be safe make sure the input marked as closed.
             shutdownInput(true);

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueChannel.java
@@ -493,10 +493,10 @@ abstract class AbstractKQueueChannel<P extends UnixChannel>
         eof = true;
 
         if (isActive()) {
-            // If it is still active, we need to call readReady as otherwise we may miss to
+            // If it is still active, we need to call read() as otherwise we may miss to
             // read pending data from the underlying file descriptor.
             // See https://github.com/netty/netty/issues/3709
-            readReady(allocHandle, ioBufferAllocator(), maybeMoreData);
+            read();
         } else {
             // Just to be safe make sure the input marked as closed.
             shutdownInput(true);


### PR DESCRIPTION
Motivation:

Let's call read() when eof / rdhup was detected instead of reading directly from the fd. This allows the user to delay if wanted while still ensure the user knows that there is something that should be read at some point.

Modifications:

Propagate read through the pipeline

Result:

Better handling of eof / rdhup