### PR TITLE
Replace stdlib write/read with send/recv (Fixes #12673)

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
@@ -346,10 +346,10 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
         int localReadAmount;
         unsafe().recvBufAllocHandle().attemptedBytesRead(byteBuf.writableBytes());
         if (byteBuf.hasMemoryAddress()) {
-            localReadAmount = socket.readAddress(byteBuf.memoryAddress(), writerIndex, byteBuf.capacity());
+            localReadAmount = socket.recvAddress(byteBuf.memoryAddress(), writerIndex, byteBuf.capacity());
         } else {
             ByteBuffer buf = byteBuf.internalNioBuffer(writerIndex, byteBuf.writableBytes());
-            localReadAmount = socket.read(buf, buf.position(), buf.limit());
+            localReadAmount = socket.recv(buf, buf.position(), buf.limit());
         }
         if (localReadAmount > 0) {
             byteBuf.writerIndex(writerIndex + localReadAmount);
@@ -359,7 +359,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
 
     protected final int doWriteBytes(ChannelOutboundBuffer in, ByteBuf buf) throws Exception {
         if (buf.hasMemoryAddress()) {
-            int localFlushedAmount = socket.writeAddress(buf.memoryAddress(), buf.readerIndex(), buf.writerIndex());
+            int localFlushedAmount = socket.sendAddress(buf.memoryAddress(), buf.readerIndex(), buf.writerIndex());
             if (localFlushedAmount > 0) {
                 in.removeBytes(localFlushedAmount);
                 return 1;
@@ -367,7 +367,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
         } else {
             final ByteBuffer nioBuf = buf.nioBufferCount() == 1 ?
                     buf.internalNioBuffer(buf.readerIndex(), buf.readableBytes()) : buf.nioBuffer();
-            int localFlushedAmount = socket.write(nioBuf, nioBuf.position(), nioBuf.limit());
+            int localFlushedAmount = socket.send(nioBuf, nioBuf.position(), nioBuf.limit());
             if (localFlushedAmount > 0) {
                 nioBuf.position(nioBuf.position() + localFlushedAmount);
                 in.removeBytes(localFlushedAmount);
@@ -387,7 +387,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
         if (data.hasMemoryAddress()) {
             long memoryAddress = data.memoryAddress();
             if (remoteAddress == null) {
-                return socket.writeAddress(memoryAddress, data.readerIndex(), data.writerIndex());
+                return socket.sendAddress(memoryAddress, data.readerIndex(), data.writerIndex());
             }
             return socket.sendToAddress(memoryAddress, data.readerIndex(), data.writerIndex(),
                     remoteAddress.getAddress(), remoteAddress.getPort(), fastOpen);
@@ -408,7 +408,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
 
         ByteBuffer nioData = data.internalNioBuffer(data.readerIndex(), data.readableBytes());
         if (remoteAddress == null) {
-            return socket.write(nioData, nioData.position(), nioData.limit());
+            return socket.send(nioData, nioData.position(), nioData.limit());
         }
         return socket.sendTo(nioData, nioData.position(), nioData.limit(),
                 remoteAddress.getAddress(), remoteAddress.getPort(), fastOpen);

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
@@ -1043,6 +1043,12 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
     private final class EpollSocketWritableByteChannel extends SocketWritableByteChannel {
         EpollSocketWritableByteChannel() {
             super(socket);
+            assert fd == socket;
+        }
+
+        @Override
+        protected int write(final ByteBuffer buf, final int pos, final int limit) throws IOException {
+            return socket.send(buf, pos, limit);
         }
 
         @Override

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -537,10 +537,10 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
             int writerIndex = byteBuf.writerIndex();
             int localReadAmount;
             if (byteBuf.hasMemoryAddress()) {
-                localReadAmount = socket.readAddress(byteBuf.memoryAddress(), writerIndex, writerIndex + writable);
+                localReadAmount = socket.recvAddress(byteBuf.memoryAddress(), writerIndex, writerIndex + writable);
             } else {
                 ByteBuffer buf = byteBuf.internalNioBuffer(writerIndex, writable);
-                localReadAmount = socket.read(buf, buf.position(), buf.limit());
+                localReadAmount = socket.recv(buf, buf.position(), buf.limit());
             }
 
             if (localReadAmount <= 0) {

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainDatagramChannel.java
@@ -177,7 +177,7 @@ public final class EpollDomainDatagramChannel extends AbstractEpollChannel imple
         if (data.hasMemoryAddress()) {
             long memoryAddress = data.memoryAddress();
             if (remoteAddress == null) {
-                writtenBytes = socket.writeAddress(memoryAddress, data.readerIndex(), data.writerIndex());
+                writtenBytes = socket.sendAddress(memoryAddress, data.readerIndex(), data.writerIndex());
             } else {
                 writtenBytes = socket.sendToAddressDomainSocket(memoryAddress, data.readerIndex(), data.writerIndex(),
                         remoteAddress.path().getBytes(CharsetUtil.UTF_8));
@@ -197,7 +197,7 @@ public final class EpollDomainDatagramChannel extends AbstractEpollChannel imple
         } else {
             ByteBuffer nioData = data.internalNioBuffer(data.readerIndex(), data.readableBytes());
             if (remoteAddress == null) {
-                writtenBytes = socket.write(nioData, nioData.position(), nioData.limit());
+                writtenBytes = socket.send(nioData, nioData.position(), nioData.limit());
             } else {
                 writtenBytes = socket.sendToDomainSocket(nioData, nioData.position(), nioData.limit(),
                         remoteAddress.path().getBytes(CharsetUtil.UTF_8));

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketShutdownOutputByPeerTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketShutdownOutputByPeerTest.java
@@ -58,7 +58,7 @@ public class EpollDomainSocketShutdownOutputByPeerTest extends AbstractSocketShu
         final ByteBuffer buf = Buffer.allocateDirectWithNativeOrder(4);
         buf.putInt(data);
         buf.flip();
-        s.write(buf, buf.position(), buf.limit());
+        s.send(buf, buf.position(), buf.limit());
         Buffer.free(buf);
     }
 

--- a/transport-native-unix-common/src/main/c/netty_unix_socket.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_socket.c
@@ -435,6 +435,52 @@ static jobject _recvFromDomainSocket(JNIEnv* env, jint fd, void* buffer, jint po
     return createDomainDatagramSocketAddress(env, &addr, res, NULL);
 }
 
+static jint _send(JNIEnv* env, jclass clazz, jint fd, void* buffer, jint pos, jint limit) {
+    ssize_t res;
+    int err;
+    do {
+       res = send(fd, buffer + pos, (size_t) (limit - pos), 0);
+       // keep on writing if it was interrupted
+    } while (res == -1 && ((err = errno) == EINTR));
+
+    if (res < 0) {
+        return -err;
+    }
+    return (jint) res;
+}
+
+static jint netty_unix_socket_send(JNIEnv* env, jclass clazz, jint fd, jobject jbuffer, jint pos, jint limit) {
+    // We check that GetDirectBufferAddress will not return NULL in OnLoad
+    return _send(env, clazz, fd, (*env)->GetDirectBufferAddress(env, jbuffer), pos, limit);
+}
+
+static jint netty_unix_socket_sendAddress(JNIEnv* env, jclass clazz, jint fd, jlong address, jint pos, jint limit) {
+    return _send(env, clazz, fd, (void*) (intptr_t) address, pos, limit);
+}
+
+static jint _recv(JNIEnv* env, jclass clazz, jint fd, void* buffer, jint pos, jint limit) {
+    ssize_t res;
+    int err;
+    do {
+        res = recv(fd, buffer + pos, (size_t) (limit - pos), 0);
+        // Keep on reading if we was interrupted
+    } while (res == -1 && ((err = errno) == EINTR));
+
+    if (res < 0) {
+        return -err;
+    }
+    return (jint) res;
+}
+
+static jint netty_unix_socket_recv(JNIEnv* env, jclass clazz, jint fd, jobject jbuffer, jint pos, jint limit) {
+    // We check that GetDirectBufferAddress will not return NULL in OnLoad
+    return _recv(env, clazz, fd, (*env)->GetDirectBufferAddress(env, jbuffer), pos, limit);
+}
+
+static jint netty_unix_socket_recvAddress(JNIEnv* env, jclass clazz, jint fd, jlong address, jint pos, jint limit) {
+    return _recv(env, clazz, fd, (void*) (intptr_t) address, pos, limit);
+}
+
 void netty_unix_socket_getOptionHandleError(JNIEnv* env, int err) {
     netty_unix_socket_optionHandleError(env, err, "getsockopt() failed: ");
 }
@@ -1115,6 +1161,10 @@ static const JNINativeMethod fixed_method_table[] = {
   // "recvFromAddress" has a dynamic signature
   // "recvFromDomainSocket" has a dynamic signature
   // "recvFromAddressDomainSocket" has a dynamic signature
+  { "send", "(ILjava/nio/ByteBuffer;II)I", (void *) netty_unix_socket_send },
+  { "sendAddress", "(IJII)I", (void *) netty_unix_socket_sendAddress },
+  { "recv", "(ILjava/nio/ByteBuffer;II)I", (void *) netty_unix_socket_recv },
+  { "recvAddress", "(IJII)I", (void *) netty_unix_socket_recvAddress },
   { "recvFd", "(I)I", (void *) netty_unix_socket_recvFd },
   { "sendFd", "(II)I", (void *) netty_unix_socket_sendFd },
   { "bindDomainSocket", "(I[B)I", (void *) netty_unix_socket_bindDomainSocket },

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/Socket.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/Socket.java
@@ -268,6 +268,44 @@ public class Socket extends FileDescriptor {
         return recvFromAddressDomainSocket(fd, memoryAddress, pos, limit);
     }
 
+    public int recv(ByteBuffer buf, int pos, int limit) throws IOException {
+        int res = recv(intValue(), buf, pos, limit);
+        if (res > 0) {
+            return res;
+        }
+        if (res == 0) {
+            return -1;
+        }
+        return ioResult("recv", res);
+    }
+
+    public int recvAddress(long address, int pos, int limit) throws IOException {
+        int res = recvAddress(intValue(), address, pos, limit);
+        if (res > 0) {
+            return res;
+        }
+        if (res == 0) {
+            return -1;
+        }
+        return ioResult("recvAddress", res);
+    }
+
+    public int send(ByteBuffer buf, int pos, int limit) throws IOException {
+        int res = send(intValue(), buf, pos, limit);
+        if (res >= 0) {
+            return res;
+        }
+        return ioResult("send", res);
+    }
+
+    public int sendAddress(long address, int pos, int limit) throws IOException {
+        int res = sendAddress(intValue(), address, pos, limit);
+        if (res >= 0) {
+            return res;
+        }
+        return ioResult("sendAddress", res);
+    }
+
     public final int recvFd() throws IOException {
         int res = recvFd(fd);
         if (res > 0) {
@@ -596,6 +634,12 @@ public class Socket extends FileDescriptor {
 
     private static native byte[] remoteAddress(int fd);
     private static native byte[] localAddress(int fd);
+
+    private static native int send(int fd, ByteBuffer buf, int pos, int limit);
+    private static native int sendAddress(int fd, long address, int pos, int limit);
+    private static native int recv(int fd, ByteBuffer buf, int pos, int limit);
+
+    private static native int recvAddress(int fd, long address, int pos, int limit);
 
     private static native int sendTo(
             int fd, boolean ipv6, ByteBuffer buf, int pos, int limit, byte[] address, int scopeId, int port,


### PR DESCRIPTION
Motivation:

The performance Unix write/read paths is more involved (and slower) then the specialized socket send/rcv ones.

Modification:

Replace Unix write/read paths with send/recv

Result:

Better performance for single buffer send/recv