### PR TITLE
Remove ChannelOption.MAX_MESSAGES_PER_READ

### DIFF
--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2MultiplexHandler.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2MultiplexHandler.java
@@ -57,7 +57,7 @@ import static io.netty5.handler.codec.http2.Http2Exception.connectionError;
  *
  * <p>Outbound streams are supported via the {@link Http2StreamChannelBootstrap}.
  *
- * <p>{@link ChannelOption#MAX_MESSAGES_PER_READ} and {@link ChannelOption#AUTO_READ} are supported.
+ * <p>{@link ChannelOption#AUTO_READ} is supported.
  *
  * <h3>Resources</h3>
  *

--- a/transport-native-unix-common-tests/src/main/java/io/netty5/channel/unix/tests/DetectPeerCloseWithoutReadTest.java
+++ b/transport-native-unix-common-tests/src/main/java/io/netty5/channel/unix/tests/DetectPeerCloseWithoutReadTest.java
@@ -71,8 +71,8 @@ public abstract class DetectPeerCloseWithoutReadTest {
             // Ensure we read only one message per read() call and that we need multiple read()
             // calls to consume everything.
             sb.childOption(ChannelOption.AUTO_READ, false);
-            sb.childOption(ChannelOption.MAX_MESSAGES_PER_READ, 1);
-            sb.childOption(ChannelOption.RCVBUFFER_ALLOCATOR, new FixedRecvBufferAllocator(expectedBytes / 10));
+            sb.childOption(ChannelOption.RCVBUFFER_ALLOCATOR,
+                    new FixedRecvBufferAllocator(expectedBytes / 10).maxMessagesPerRead(1));
             sb.childHandler(new ChannelInitializer<>() {
                 @Override
                 protected void initChannel(Channel ch) {
@@ -155,8 +155,8 @@ public abstract class DetectPeerCloseWithoutReadTest {
             // Ensure we read only one message per read() call and that we need multiple read()
             // calls to consume everything.
             cb.option(ChannelOption.AUTO_READ, false);
-            cb.option(ChannelOption.MAX_MESSAGES_PER_READ, 1);
-            cb.option(ChannelOption.RCVBUFFER_ALLOCATOR, new FixedRecvBufferAllocator(expectedBytes / 10));
+            cb.option(ChannelOption.RCVBUFFER_ALLOCATOR,
+                    new FixedRecvBufferAllocator(expectedBytes / 10).maxMessagesPerRead(1));
             cb.handler(new ChannelInitializer<>() {
                 @Override
                 protected void initChannel(Channel ch) throws Exception {

--- a/transport/src/main/java/io/netty5/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty5/channel/AbstractChannel.java
@@ -52,7 +52,6 @@ import static io.netty5.channel.ChannelOption.AUTO_CLOSE;
 import static io.netty5.channel.ChannelOption.AUTO_READ;
 import static io.netty5.channel.ChannelOption.BUFFER_ALLOCATOR;
 import static io.netty5.channel.ChannelOption.CONNECT_TIMEOUT_MILLIS;
-import static io.netty5.channel.ChannelOption.MAX_MESSAGES_PER_READ;
 import static io.netty5.channel.ChannelOption.MAX_MESSAGES_PER_WRITE;
 import static io.netty5.channel.ChannelOption.MESSAGE_SIZE_ESTIMATOR;
 import static io.netty5.channel.ChannelOption.RCVBUFFER_ALLOCATOR;
@@ -1314,9 +1313,6 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
         if (option == CONNECT_TIMEOUT_MILLIS) {
             return (T) Integer.valueOf(getConnectTimeoutMillis());
         }
-        if (option == MAX_MESSAGES_PER_READ) {
-            return (T) Integer.valueOf(getMaxMessagesPerRead());
-        }
         if (option == WRITE_SPIN_COUNT) {
             return (T) Integer.valueOf(getWriteSpinCount());
         }
@@ -1366,8 +1362,6 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
             setWriteBufferWaterMark((WriteBufferWaterMark) value);
         } else if (option == CONNECT_TIMEOUT_MILLIS) {
             setConnectTimeoutMillis((Integer) value);
-        } else if (option == MAX_MESSAGES_PER_READ) {
-            setMaxMessagesPerRead((Integer) value);
         } else if (option == WRITE_SPIN_COUNT) {
             setWriteSpinCount((Integer) value);
         } else if (option == BUFFER_ALLOCATOR) {
@@ -1422,7 +1416,7 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
 
     private static Set<ChannelOption<?>> supportedOptions() {
         return newSupportedIdentityOptionsSet(
-                AUTO_READ, WRITE_BUFFER_WATER_MARK, CONNECT_TIMEOUT_MILLIS, MAX_MESSAGES_PER_READ,
+                AUTO_READ, WRITE_BUFFER_WATER_MARK, CONNECT_TIMEOUT_MILLIS,
                 WRITE_SPIN_COUNT, BUFFER_ALLOCATOR, RCVBUFFER_ALLOCATOR, AUTO_CLOSE, MESSAGE_SIZE_ESTIMATOR,
                 MAX_MESSAGES_PER_WRITE, ALLOW_HALF_CLOSURE);
     }
@@ -1445,38 +1439,6 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
     private void setConnectTimeoutMillis(int connectTimeoutMillis) {
         checkPositiveOrZero(connectTimeoutMillis, "connectTimeoutMillis");
         this.connectTimeoutMillis = connectTimeoutMillis;
-    }
-
-    /**
-     * <p>
-     * @throws IllegalStateException if {@link #getRecvBufferAllocator()} does not return an object of type
-     * {@link MaxMessagesRecvBufferAllocator}.
-     */
-    @Deprecated
-    private int getMaxMessagesPerRead() {
-        try {
-            MaxMessagesRecvBufferAllocator allocator = getRecvBufferAllocator();
-            return allocator.maxMessagesPerRead();
-        } catch (ClassCastException e) {
-            throw new IllegalStateException("getRecvBufferAllocator() must return an object of type " +
-                    "MaxMessagesRecvBufferAllocator", e);
-        }
-    }
-
-    /**
-     * <p>
-     * @throws IllegalStateException if {@link #getRecvBufferAllocator()} does not return an object of type
-     * {@link MaxMessagesRecvBufferAllocator}.
-     */
-    @Deprecated
-    private void setMaxMessagesPerRead(int maxMessagesPerRead) {
-        try {
-            MaxMessagesRecvBufferAllocator allocator = getRecvBufferAllocator();
-            allocator.maxMessagesPerRead(maxMessagesPerRead);
-        } catch (ClassCastException e) {
-            throw new IllegalStateException("getRecvBufferAllocator() must return an object of type " +
-                    "MaxMessagesRecvBufferAllocator", e);
-        }
     }
 
     /**

--- a/transport/src/main/java/io/netty5/channel/ChannelOption.java
+++ b/transport/src/main/java/io/netty5/channel/ChannelOption.java
@@ -19,7 +19,6 @@ import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.util.AbstractConstant;
 import io.netty5.util.ConstantPool;
 
-import java.net.InetAddress;
 import java.net.NetworkInterface;
 
 import static java.util.Objects.requireNonNull;
@@ -81,12 +80,7 @@ public class ChannelOption<T> extends AbstractConstant<ChannelOption<T>> {
     public static final ChannelOption<MessageSizeEstimator> MESSAGE_SIZE_ESTIMATOR = valueOf("MESSAGE_SIZE_ESTIMATOR");
 
     public static final ChannelOption<Integer> CONNECT_TIMEOUT_MILLIS = valueOf("CONNECT_TIMEOUT_MILLIS");
-    /**
-     * @deprecated Use {@link MaxMessagesRecvBufferAllocator}
-     * and {@link MaxMessagesRecvBufferAllocator#maxMessagesPerRead(int)}.
-     */
-    @Deprecated
-    public static final ChannelOption<Integer> MAX_MESSAGES_PER_READ = valueOf("MAX_MESSAGES_PER_READ");
+
     public static final ChannelOption<Integer> MAX_MESSAGES_PER_WRITE = valueOf("MAX_MESSAGES_PER_WRITE");
 
     public static final ChannelOption<Integer> WRITE_SPIN_COUNT = valueOf("WRITE_SPIN_COUNT");

--- a/transport/src/main/java/io/netty5/channel/DefaultMaxMessagesRecvBufferAllocator.java
+++ b/transport/src/main/java/io/netty5/channel/DefaultMaxMessagesRecvBufferAllocator.java
@@ -68,9 +68,6 @@ public abstract class DefaultMaxMessagesRecvBufferAllocator implements MaxMessag
 
         private final Predicate<Handle> defaultMaybeMoreSupplier = h -> attemptedBytesRead == lastBytesRead;
 
-        /**
-         * Only {@link ChannelOption#MAX_MESSAGES_PER_READ} is used.
-         */
         @Override
         public void reset() {
             maxMessagePerRead = maxMessagesPerRead();

--- a/transport/src/test/java/io/netty5/channel/local/LocalChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/local/LocalChannelTest.java
@@ -19,6 +19,7 @@ import io.netty5.bootstrap.Bootstrap;
 import io.netty5.bootstrap.ServerBootstrap;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
+import io.netty5.channel.AdaptiveRecvBufferAllocator;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
@@ -28,6 +29,7 @@ import io.netty5.channel.EventLoop;
 import io.netty5.channel.EventLoopGroup;
 import io.netty5.channel.IoHandler;
 import io.netty5.channel.MultithreadEventLoopGroup;
+import io.netty5.channel.ServerChannelRecvBufferAllocator;
 import io.netty5.channel.SimpleChannelInboundHandler;
 import io.netty5.channel.SingleThreadEventLoop;
 import io.netty5.util.concurrent.Future;
@@ -1039,7 +1041,7 @@ public class LocalChannelTest {
         cb.group(serverGroup)
                 .channel(LocalChannel.class)
                 .option(ChannelOption.AUTO_READ, autoRead)
-                .option(ChannelOption.MAX_MESSAGES_PER_READ, 1)
+                .option(ChannelOption.RCVBUFFER_ALLOCATOR, new AdaptiveRecvBufferAllocator().maxMessagesPerRead(1))
                 .handler(new ChannelReadHandler(countDownLatch, autoRead));
         sb.group(clientGroup)
                 .channel(LocalServerChannel.class)
@@ -1109,7 +1111,7 @@ public class LocalChannelTest {
         sb.group(clientGroup)
                 .channel(LocalServerChannel.class)
                 .option(ChannelOption.AUTO_READ, autoRead)
-                .option(ChannelOption.MAX_MESSAGES_PER_READ, 1)
+                .option(ChannelOption.RCVBUFFER_ALLOCATOR, new ServerChannelRecvBufferAllocator().maxMessagesPerRead(1))
                 .handler(new ChannelReadHandler(countDownLatch, autoRead))
                 .childHandler(new ChannelInitializer<Channel>() {
                     @Override


### PR DESCRIPTION
Motivation:

The ChannelOption was deprecated in 4.1, lets remove it now

Modifications:

Remove previously deprecated ChannelOption

Result:

Cleanup
