### PR TITLE
Call RecvByteBufAllocator.Handle.readComplete() once read loop comple…

### DIFF
--- a/transport/src/main/java/io/netty/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalChannel.java
@@ -298,7 +298,7 @@ public class LocalChannel extends AbstractChannel {
             }
             pipeline.fireChannelRead(received);
         } while (handle.continueReading());
-
+        handle.readComplete();
         pipeline.fireChannelReadComplete();
     }
 

--- a/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
@@ -158,7 +158,7 @@ public class LocalServerChannel extends AbstractServerChannel {
             }
             pipeline.fireChannelRead(m);
         } while (handle.continueReading());
-
+        handle.readComplete();
         pipeline.fireChannelReadComplete();
     }
 


### PR DESCRIPTION
…tes in Local transport implementation

Motivation:

We need to call readComplete() once we are done reading.

Modifications:

- Add missing readComplete() calls
- Add unit test

Result:

Local*Channel uses Handle as expected
