### PR TITLE
Remove shutdown hooks for default buffer allocators

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/DefaultBufferAllocators.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/DefaultBufferAllocators.java
@@ -61,12 +61,6 @@ public final class DefaultBufferAllocators {
             offHeap = BufferAllocator.offHeapPooled();
             logger.debug("-Dio.netty5.allocator.type: pooled (unknown: {})", allocType);
         }
-        getRuntime().addShutdownHook(new Thread(() -> {
-            //noinspection EmptyTryBlock
-            try (onHeap; offHeap) {
-                // Left blank.
-            }
-        }));
         UncloseableBufferAllocator onHeapUnclosable = new UncloseableBufferAllocator(onHeap);
         UncloseableBufferAllocator offHeapUnclosable = new UncloseableBufferAllocator(offHeap);
         DEFAULT_PREFERRED_ALLOCATOR = directBufferPreferred? offHeapUnclosable : onHeapUnclosable;


### PR DESCRIPTION
Motivation:
Shutdown hooks can race with application threads, and this can cause problems since the allocators may still be in use during the shutdown process.

It is also not necessary to shut the allocators down, since the process is about to terminate anyway, at which point all memory will be returned to the OS regardlesss of what we do.

Modification:
Avoid installing any shutdown hooks for closing the DefaultBufferAllocators.

Result:
We should no longer see any "closed allocator exceptions" when shutting the JVM down - at least not any that are caused by these shared allocators.

Fixes #12671