### PR TITLE
Ensure we try to read again if RDHUP / eof is detected

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
@@ -204,8 +204,9 @@ abstract class AbstractEpollChannel<P extends UnixChannel>
         setFlag(Native.EPOLLIN);
 
         // If EPOLL ET mode is enabled and auto read was toggled off on the last read loop then we may not be notified
-        // again if we didn't consume all the data. So we force a read operation here if there maybe more data.
-        if (maybeMoreDataToRead) {
+        // again if we didn't consume all the data. So we force a read operation here if there maybe more data or
+        // RDHUP was received
+        if (maybeMoreDataToRead || receivedRdHup) {
             executeEpollInReadyRunnable();
         }
     }

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueChannel.java
@@ -241,8 +241,9 @@ abstract class AbstractKQueueChannel<P extends UnixChannel>
         readFilter(true);
 
         // If auto read was toggled off on the last read loop then we may not be notified
-        // again if we didn't consume all the data. So we force a read operation here if there maybe more data.
-        if (maybeMoreDataToRead) {
+        // again if we didn't consume all the data. So we force a read operation here if there maybe more data or
+        // eof was received
+        if (maybeMoreDataToRead || eof) {
             executeReadReadyRunnable();
         }
     }


### PR DESCRIPTION
Motivation:

f9704477e85152c34cf894fee9ff6b4e16facb8e did introduce a change to just dispatch a read() when RDHUP / eof is detected. While this correct we also need to ensure we actually submit the read task later on.

Modifications:

Add check for RDHUP / eof

Result:

No more random stales
