### PR TITLE
Fix unit test failure on macOS

### DIFF
--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramUnicastTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramUnicastTest.java
@@ -194,9 +194,11 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
             assumeThat(e.getMessage()).doesNotContainIgnoringCase("unsupported address type");
             throw e;
         }
+        SocketAddress sendAddress = address instanceof InetSocketAddress ?
+                sendToAddress((InetSocketAddress) address) : address;
         for (int i = 0; i < 100; i++) {
             try {
-                client.send(new java.net.DatagramPacket(EmptyArrays.EMPTY_BYTES, 0, address));
+                client.send(new java.net.DatagramPacket(EmptyArrays.EMPTY_BYTES, 0, sendAddress));
             } catch (BindException e) {
                 throw new TestAbortedException("JDK sockets do not support binding to these addresses.", e);
             }


### PR DESCRIPTION
Motivation:

There needs to be special handling of any addresses as otherwise the test might fail with `NoRouteToHostException`.

```

java.net.NoRouteToHostException: No route to host

	at java.base/sun.nio.ch.DatagramChannelImpl.send0(Native Method)
	at java.base/sun.nio.ch.DatagramChannelImpl.sendFromNativeBuffer(DatagramChannelImpl.java:901)
	at java.base/sun.nio.ch.DatagramChannelImpl.send(DatagramChannelImpl.java:863)
	at java.base/sun.nio.ch.DatagramChannelImpl.send(DatagramChannelImpl.java:821)
	at java.base/sun.nio.ch.DatagramChannelImpl.blockingSend(DatagramChannelImpl.java:853)
	at java.base/sun.nio.ch.DatagramSocketAdaptor.send(DatagramSocketAdaptor.java:218)
	at java.base/java.net.DatagramSocket.send(DatagramSocket.java:669)
	at io.netty5.testsuite.transport.socket.DatagramUnicastTest.testReceiveEmptyDatagrams(DatagramUnicastTest.java:201)
	at io.netty5.testsuite.transport.socket.DatagramUnicastTest$1.run(DatagramUnicastTest.java:170)
	at io.netty5.testsuite.transport.socket.DatagramUnicastTest$1.run(DatagramUnicastTest.java:167)
	at io.netty5.testsuite.transport.AbstractComboTestsuiteTest.run(AbstractComboTestsuiteTest.java:54)
	at io.netty5.testsuite.transport.socket.DatagramUnicastTest.testReceiveEmptyDatagrams(DatagramUnicastTest.java:167)
        ...
```

Modifications:

Call sendToAddress(...)

Result:

No more test failures

