### PR TITLE
AUTO_READ should not affect ReadHandle.continueReading()

### DIFF
--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/DefaultHttp2StreamChannel.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/DefaultHttp2StreamChannel.java
@@ -423,7 +423,7 @@ final class DefaultHttp2StreamChannel extends DefaultAttributeMap implements Htt
             // to the same EventLoop thread. There are a limited number of frame types that may come after EOS is
             // read (unknown, reset) and the trade off is less conditionals for the hot path (headers/data) at the
             // cost of additional readComplete notifications on the rare path.
-            if (readHandle.continueReading(isAutoRead()) && !isShutdown(ChannelShutdownDirection.Inbound)) {
+            if (readHandle.continueReading() && !isShutdown(ChannelShutdownDirection.Inbound)) {
                 maybeAddChannelToReadCompletePendingQueue();
             } else {
                 notifyReadComplete(readHandle, true);
@@ -704,7 +704,7 @@ final class DefaultHttp2StreamChannel extends DefaultAttributeMap implements Htt
             boolean continueReading = false;
             do {
                 doRead0((Http2Frame) message, allocHandle);
-            } while ((readEOS || (continueReading = allocHandle.continueReading(isAutoRead())))
+            } while ((readEOS || (continueReading = allocHandle.continueReading()))
                     && (message = pollQueuedMessage()) != null);
 
             if (continueReading && handler.isParentReadInProgress() && !readEOS) {

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/TestChannelInitializer.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/TestChannelInitializer.java
@@ -71,7 +71,7 @@ public class TestChannelInitializer extends ChannelInitializer<Channel> {
                 }
 
                 @Override
-                public boolean continueReading(boolean autoRead) {
+                public boolean continueReading() {
                     return numMessagesRead < numReads.get();
                 }
 

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketAutoReadTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketAutoReadTest.java
@@ -38,17 +38,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SocketAutoReadTest extends AbstractSocketTest {
     @Test
-    public void testAutoReadOffDuringReadOnlyReadsOne(TestInfo testInfo) throws Throwable {
-        run(testInfo, this::testAutoReadOffDuringReadOnlyReadsOne);
+    public void testAutoReadOffDuringRead(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testAutoReadOffDuringRead);
     }
 
-    public void testAutoReadOffDuringReadOnlyReadsOne(ServerBootstrap sb, Bootstrap cb) throws Throwable {
-        testAutoReadOffDuringReadOnlyReadsOne(true, sb, cb);
-        testAutoReadOffDuringReadOnlyReadsOne(false, sb, cb);
+    public void testAutoReadOffDuringRead(ServerBootstrap sb, Bootstrap cb) throws Throwable {
+        testAutoReadOffDuringRead(true, sb, cb);
+        testAutoReadOffDuringRead(false, sb, cb);
     }
 
-    private static void testAutoReadOffDuringReadOnlyReadsOne(boolean readOutsideEventLoopThread,
-                                                           ServerBootstrap sb, Bootstrap cb) throws Throwable {
+    private static void testAutoReadOffDuringRead(boolean readOutsideEventLoopThread,
+                                                  ServerBootstrap sb, Bootstrap cb) throws Throwable {
         Channel serverChannel = null;
         Channel clientChannel = null;
         try {
@@ -123,7 +123,7 @@ public class SocketAutoReadTest extends AbstractSocketTest {
 
         AutoReadHandler(boolean callRead) {
             this.callRead = callRead;
-            latch2 = new CountDownLatch(callRead ? 3 : 2);
+            latch2 = new CountDownLatch(1);
         }
 
         @Override
@@ -155,7 +155,7 @@ public class SocketAutoReadTest extends AbstractSocketTest {
 
         void assertSingleReadSecondTry() throws InterruptedException {
             assertTrue(latch2.await(5, TimeUnit.SECONDS));
-            assertEquals(callRead ? 3 : 2, count.get());
+            assertEquals(3, count.get());
         }
     }
 
@@ -178,8 +178,9 @@ public class SocketAutoReadTest extends AbstractSocketTest {
                 }
 
                 @Override
-                public boolean continueReading(boolean autoRead) {
-                    return autoRead;
+                public boolean continueReading() {
+                    // Reading until there is nothing left to read.
+                    return true;
                 }
 
                 @Override

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -610,7 +610,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                 }
 
                 @Override
-                public boolean continueReading(boolean autoRead) {
+                public boolean continueReading() {
                     return numMessagesRead < numReads;
                 }
 

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketReadPendingTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketReadPendingTest.java
@@ -154,7 +154,7 @@ public class SocketReadPendingTest extends AbstractSocketTest {
                 }
 
                 @Override
-                public boolean continueReading(boolean autoRead) {
+                public boolean continueReading() {
                     return numMessagesRead < numReads;
                 }
 

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDatagramChannel.java
@@ -565,7 +565,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel<UnixChannel
                 buf = null;
 
                 // Continue reading
-            } while (readHandle.continueReading(isAutoRead()));
+            } while (readHandle.continueReading());
             return false;
         } catch (Throwable t) {
             if (buf != null) {
@@ -612,7 +612,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel<UnixChannel
                     return true;
                 }
             // Continue reading
-            } while (readHandle.continueReading(isAutoRead()));
+            } while (readHandle.continueReading());
             return false;
         } catch (Throwable t) {
             throw t;

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollServerSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollServerSocketChannel.java
@@ -370,8 +370,7 @@ public final class EpollServerSocketChannel
                 readPending = false;
                 pipeline.fireChannelRead(newChildChannel(acceptedFd, acceptedAddress, 1,
                         acceptedAddress[0]));
-            } while (readHandle.continueReading(isAutoRead())
-                    && !isShutdown(ChannelShutdownDirection.Inbound));
+            } while (readHandle.continueReading() && !isShutdown(ChannelShutdownDirection.Inbound));
         } catch (Throwable t) {
             exception = t;
         }

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollSocketChannel.java
@@ -588,7 +588,7 @@ public final class EpollSocketChannel
                     //   was "wrapped" by this Channel implementation.
                     break;
                 }
-            } while (readHandle.continueReading(isAutoRead()) && readMore &&
+            } while (readHandle.continueReading() && readMore &&
                     !isShutdown(ChannelShutdownDirection.Inbound));
 
             readHandle.readComplete();
@@ -1219,7 +1219,7 @@ public final class EpollSocketChannel
                         pipeline.fireChannelRead(new FileDescriptor(readFd));
                         break;
                 }
-            } while (readHandle.continueReading(isAutoRead())
+            } while (readHandle.continueReading()
                     && !isShutdown(ChannelShutdownDirection.Inbound));
 
             readHandle.readComplete();

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDatagramChannel.java
@@ -570,7 +570,7 @@ public final class KQueueDatagramChannel
                 pipeline.fireChannelRead(packet);
 
                 buffer = null;
-            } while (readHandle.continueReading(isAutoRead()));
+            } while (readHandle.continueReading());
         } catch (Throwable t) {
             if (buffer != null) {
                 buffer.close();

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueServerSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueServerSocketChannel.java
@@ -384,7 +384,7 @@ public final class KQueueServerSocketChannel extends
                 readPending = false;
                 pipeline.fireChannelRead(newChildChannel(acceptFd, acceptedAddress, 1,
                         acceptedAddress[0]));
-            } while (readHandle.continueReading(isAutoRead()) &&
+            } while (readHandle.continueReading() &&
                     !isShutdown(ChannelShutdownDirection.Inbound));
         } catch (Throwable t) {
             exception = t;

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueSocketChannel.java
@@ -528,7 +528,7 @@ public final class KQueueSocketChannel
                         pipeline.fireChannelRead(new FileDescriptor(recvFd));
                         break;
                 }
-            } while (readHandle.continueReading(isAutoRead()) && !isShutdown(ChannelShutdownDirection.Inbound));
+            } while (readHandle.continueReading() && !isShutdown(ChannelShutdownDirection.Inbound));
 
             readHandle.readComplete();
             pipeline.fireChannelReadComplete();
@@ -913,7 +913,7 @@ public final class KQueueSocketChannel
                     //   was "wrapped" by this Channel implementation.
                     break;
                 }
-            } while (readHandle.continueReading(isAutoRead())
+            } while (readHandle.continueReading()
                     && !isShutdown(ChannelShutdownDirection.Inbound));
 
             readHandle.readComplete();

--- a/transport/src/main/java/io/netty5/channel/MaxMessagesReadHandleFactory.java
+++ b/transport/src/main/java/io/netty5/channel/MaxMessagesReadHandleFactory.java
@@ -18,8 +18,7 @@ package io.netty5.channel;
 import static io.netty5.util.internal.ObjectUtil.checkPositive;
 
 /**
- * Base implementation of {@link ReadHandleFactory} which respects {@link ChannelOption#AUTO_READ}
- * and allows to limit the number of messages read per read loop.
+ * Base implementation of {@link ReadHandleFactory} which allows to limit the number of messages read per read loop.
  */
 public abstract class MaxMessagesReadHandleFactory implements ReadHandleFactory {
     private final int maxMessagesPerRead;
@@ -64,8 +63,8 @@ public abstract class MaxMessagesReadHandleFactory implements ReadHandleFactory 
         }
 
         @Override
-        public boolean continueReading(boolean autoRead) {
-            return autoRead && totalMessages < maxMessagesPerRead;
+        public boolean continueReading() {
+            return totalMessages < maxMessagesPerRead;
         }
 
         @Override

--- a/transport/src/main/java/io/netty5/channel/ReadHandleFactory.java
+++ b/transport/src/main/java/io/netty5/channel/ReadHandleFactory.java
@@ -49,11 +49,10 @@ public interface ReadHandleFactory {
         /**
          * Determine if the current read loop should continue.
          *
-         * @param autoRead {@code true} if {@link ChannelOption#AUTO_READ} is used, {@code false} otherwise.
          * @return {@code true} if the read loop should continue reading. {@code false}
          * if the read loop is complete.
          */
-        boolean continueReading(boolean autoRead);
+        boolean continueReading();
 
         /**
          * Method that must be called once the read loop was completed.

--- a/transport/src/main/java/io/netty5/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty5/channel/local/LocalChannel.java
@@ -229,7 +229,7 @@ public class LocalChannel extends AbstractChannel<LocalServerChannel, LocalAddre
             }
             readHandle.lastRead(0, 0, 1);
             pipeline.fireChannelRead(received);
-        } while (readHandle.continueReading(isAutoRead()) && !isShutdown(ChannelShutdownDirection.Inbound));
+        } while (readHandle.continueReading() && !isShutdown(ChannelShutdownDirection.Inbound));
 
         readHandle.readComplete();
         pipeline.fireChannelReadComplete();

--- a/transport/src/main/java/io/netty5/channel/local/LocalServerChannel.java
+++ b/transport/src/main/java/io/netty5/channel/local/LocalServerChannel.java
@@ -114,7 +114,7 @@ public class LocalServerChannel extends AbstractServerChannel<LocalChannel, Loca
             }
             readHandle.lastRead(0, 0, 1);
             pipeline.fireChannelRead(m);
-        } while (readHandle.continueReading(isAutoRead()) && !isShutdown(ChannelShutdownDirection.Inbound));
+        } while (readHandle.continueReading() && !isShutdown(ChannelShutdownDirection.Inbound));
 
         readHandle.readComplete();
         pipeline.fireChannelReadComplete();

--- a/transport/src/main/java/io/netty5/channel/nio/AbstractNioByteChannel.java
+++ b/transport/src/main/java/io/netty5/channel/nio/AbstractNioByteChannel.java
@@ -133,7 +133,7 @@ public abstract class AbstractNioByteChannel<P extends Channel, L extends Socket
                 readPending = false;
                 pipeline.fireChannelRead(buffer);
                 buffer = null;
-            } while (readHandle.continueReading(isAutoRead()) && !isShutdown(ChannelShutdownDirection.Inbound));
+            } while (readHandle.continueReading() && !isShutdown(ChannelShutdownDirection.Inbound));
 
             readHandle.readComplete();
             pipeline.fireChannelReadComplete();

--- a/transport/src/main/java/io/netty5/channel/nio/AbstractNioMessageChannel.java
+++ b/transport/src/main/java/io/netty5/channel/nio/AbstractNioMessageChannel.java
@@ -76,7 +76,7 @@ public abstract class AbstractNioMessageChannel<P extends Channel, L extends Soc
                         closed = true;
                         break;
                     }
-                } while (readHandle.continueReading(isAutoRead()) && !isShutdown(ChannelShutdownDirection.Inbound));
+                } while (readHandle.continueReading() && !isShutdown(ChannelShutdownDirection.Inbound));
             } catch (Throwable t) {
                 exception = t;
             }

--- a/transport/src/test/java/io/netty5/channel/MaxMessagesReadHandleFactoryTest.java
+++ b/transport/src/test/java/io/netty5/channel/MaxMessagesReadHandleFactoryTest.java
@@ -44,13 +44,13 @@ public class MaxMessagesReadHandleFactoryTest {
 
         EmbeddedChannel channel = new EmbeddedChannel();
         handle.lastRead(0, 0, 1);
-        assertTrue(handle.continueReading(true));
+        assertTrue(handle.continueReading());
         handle.lastRead(0, 0, 1);
-        assertFalse(handle.continueReading(true));
+        assertFalse(handle.continueReading());
 
         handle.readComplete();
         handle.lastRead(1, 1, 1);
-        assertTrue(handle.continueReading(true));
+        assertTrue(handle.continueReading());
         channel.finish();
     }
 
@@ -61,13 +61,13 @@ public class MaxMessagesReadHandleFactoryTest {
 
         EmbeddedChannel channel = new EmbeddedChannel();
         handle.lastRead(0, 0, 1);
-        assertTrue(handle.continueReading(true));
+        assertTrue(handle.continueReading());
         handle.lastRead(0, 0, 1);
-        assertFalse(handle.continueReading(true));
+        assertFalse(handle.continueReading());
 
         handle.readComplete();
         handle.lastRead(0, 0, 0);
-        assertTrue(handle.continueReading(true));
+        assertTrue(handle.continueReading());
         channel.finish();
     }
 }


### PR DESCRIPTION
Motivation:

If auto read is used or not should not affect ReadHandle.continueReading(). In all cases it should behave the same to be consistent.

Modifications:

- Remove the autoRead param from continueReading()
- Adjust unit test

Result:

More consistent and sane behaviour