### PR TITLE
Simplify ReadHandleFactory by removing continueReading() method

### DIFF
--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/TestChannelInitializer.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/TestChannelInitializer.java
@@ -58,7 +58,7 @@ public class TestChannelInitializer extends ChannelInitializer<Channel> {
         @Override
         public ReadHandle newHandle() {
             return new ReadHandle() {
-                private int numMessagesRead;
+                private int totalNumMessagesRead;
 
                 @Override
                 public int estimatedBufferCapacity() {
@@ -66,18 +66,16 @@ public class TestChannelInitializer extends ChannelInitializer<Channel> {
                 }
 
                 @Override
-                public void lastRead(int attemptedBytesRead, int actualBytesRead, int numMessagesRead) {
-                    this.numMessagesRead += numMessagesRead;
-                }
-
-                @Override
-                public boolean continueReading() {
-                    return numMessagesRead < numReads.get();
+                public boolean lastRead(int attemptedBytesRead, int actualBytesRead, int numMessagesRead) {
+                    if (numMessagesRead > 0) {
+                        this.totalNumMessagesRead += numMessagesRead;
+                    }
+                    return totalNumMessagesRead < numReads.get();
                 }
 
                 @Override
                 public void readComplete() {
-                    numMessagesRead = 0;
+                    totalNumMessagesRead = 0;
                 }
             };
         }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketAutoReadTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketAutoReadTest.java
@@ -173,12 +173,7 @@ public class SocketAutoReadTest extends AbstractSocketTest {
                 }
 
                 @Override
-                public void lastRead(int attemptedBytesRead, int actualBytesRead, int numMessagesRead) {
-                    // NOOP
-                }
-
-                @Override
-                public boolean continueReading() {
+                public boolean lastRead(int attemptedBytesRead, int actualBytesRead, int numMessagesRead) {
                     // Reading until there is nothing left to read.
                     return true;
                 }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -597,7 +597,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
         @Override
         public ReadHandle newHandle() {
             return new ReadHandle() {
-                private int numMessagesRead;
+                private int totalNumMessagesRead;
 
                 @Override
                 public int estimatedBufferCapacity() {
@@ -605,18 +605,16 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                 }
 
                 @Override
-                public void lastRead(int attemptedBytesRead, int actualBytesRead, int numMessagesRead) {
-                    this.numMessagesRead += numMessagesRead;
-                }
-
-                @Override
-                public boolean continueReading() {
-                    return numMessagesRead < numReads;
+                public boolean lastRead(int attemptedBytesRead, int actualBytesRead, int numMessagesRead) {
+                    if (numMessagesRead > 0) {
+                        this.totalNumMessagesRead += numMessagesRead;
+                    }
+                    return totalNumMessagesRead < numReads;
                 }
 
                 @Override
                 public void readComplete() {
-                    numMessagesRead = 0;
+                    totalNumMessagesRead = 0;
                 }
             };
         }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketReadPendingTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketReadPendingTest.java
@@ -141,7 +141,7 @@ public class SocketReadPendingTest extends AbstractSocketTest {
         @Override
         public ReadHandle newHandle() {
             return new ReadHandle() {
-                private int numMessagesRead;
+                private int totalNumMessagesRead;
 
                 @Override
                 public int estimatedBufferCapacity() {
@@ -149,18 +149,16 @@ public class SocketReadPendingTest extends AbstractSocketTest {
                 }
 
                 @Override
-                public void lastRead(int attemptedBytesRead, int actualBytesRead, int numMessagesRead) {
-                    this.numMessagesRead += numMessagesRead;
-                }
-
-                @Override
-                public boolean continueReading() {
-                    return numMessagesRead < numReads;
+                public boolean lastRead(int attemptedBytesRead, int actualBytesRead, int numMessagesRead) {
+                    if (numMessagesRead > 0) {
+                        this.totalNumMessagesRead += numMessagesRead;
+                    }
+                    return totalNumMessagesRead < numReads;
                 }
 
                 @Override
                 public void readComplete() {
-                    numMessagesRead = 0;
+                    totalNumMessagesRead = 0;
                 }
             };
         }

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollServerSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollServerSocketChannel.java
@@ -358,9 +358,10 @@ public final class EpollServerSocketChannel
         Throwable exception = null;
         boolean readAll = false;
         try {
+            boolean continueReading;
             do {
                 int acceptedFd = socket.accept(acceptedAddress);
-                readHandle.lastRead(0, 0, acceptedFd == -1 ? 0 : 1);
+                continueReading = readHandle.lastRead(0, 0, acceptedFd == -1 ? 0 : 1);
 
                 if (acceptedFd == -1) {
                     // this means everything was handled for now
@@ -370,7 +371,7 @@ public final class EpollServerSocketChannel
                 readPending = false;
                 pipeline.fireChannelRead(newChildChannel(acceptedFd, acceptedAddress, 1,
                         acceptedAddress[0]));
-            } while (readHandle.continueReading() && !isShutdown(ChannelShutdownDirection.Inbound));
+            } while (continueReading && !isShutdown(ChannelShutdownDirection.Inbound));
         } catch (Throwable t) {
             exception = t;
         }

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueServerSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueServerSocketChannel.java
@@ -372,6 +372,7 @@ public final class KQueueServerSocketChannel extends
         Throwable exception = null;
         int totalBytesRead = 0;
         try {
+            boolean continueReading;
             do {
                 int acceptFd = socket.accept(acceptedAddress);
                 if (acceptFd == -1) {
@@ -379,12 +380,12 @@ public final class KQueueServerSocketChannel extends
                     readHandle.lastRead(0, 0, 0);
                     break;
                 }
-                readHandle.lastRead(0, 0, 1);
+                continueReading = readHandle.lastRead(0, 0, 1);
                 totalBytesRead++;
                 readPending = false;
                 pipeline.fireChannelRead(newChildChannel(acceptFd, acceptedAddress, 1,
                         acceptedAddress[0]));
-            } while (readHandle.continueReading() &&
+            } while (continueReading &&
                     !isShutdown(ChannelShutdownDirection.Inbound));
         } catch (Throwable t) {
             exception = t;

--- a/transport/src/main/java/io/netty5/channel/AdaptiveReadHandleFactory.java
+++ b/transport/src/main/java/io/netty5/channel/AdaptiveReadHandleFactory.java
@@ -104,7 +104,7 @@ public class AdaptiveReadHandleFactory extends MaxMessagesReadHandleFactory {
         }
 
         @Override
-        public void lastRead(int attemptedBytesRead, int actualBytesRead, int numMessagesRead) {
+        public boolean lastRead(int attemptedBytesRead, int actualBytesRead, int numMessagesRead) {
             // If we read as much as we asked for we should check if we need to ramp up the size of our next guess.
             // This helps adjust more quickly when large amounts of data is pending and can avoid going back to
             // the selector to check for more data. Going back to the selector can add significant latency for large
@@ -115,7 +115,7 @@ public class AdaptiveReadHandleFactory extends MaxMessagesReadHandleFactory {
             if (actualBytesRead > 0) {
                 totalBytesRead += actualBytesRead;
             }
-            super.lastRead(attemptedBytesRead, actualBytesRead, numMessagesRead);
+            return super.lastRead(attemptedBytesRead, actualBytesRead, numMessagesRead);
         }
 
         @Override

--- a/transport/src/main/java/io/netty5/channel/MaxMessagesReadHandleFactory.java
+++ b/transport/src/main/java/io/netty5/channel/MaxMessagesReadHandleFactory.java
@@ -45,7 +45,7 @@ public abstract class MaxMessagesReadHandleFactory implements ReadHandleFactory 
     protected abstract MaxMessageReadHandle newMaxMessageHandle(int maxMessagesPerRead);
 
     /**
-     * Focuses on enforcing the maximum messages per read condition for {@link #continueReading(boolean)}.
+     * Focuses on enforcing the maximum messages per read condition for {@link #lastRead(int, int, int)}.
      */
     protected abstract static class MaxMessageReadHandle implements ReadHandle {
         private final int maxMessagesPerRead;
@@ -56,14 +56,10 @@ public abstract class MaxMessagesReadHandleFactory implements ReadHandleFactory 
         }
 
         @Override
-        public void lastRead(int attemptedBytesRead, int actualBytesRead, int numMessagesRead) {
+        public boolean lastRead(int attemptedBytesRead, int actualBytesRead, int numMessagesRead) {
             if (numMessagesRead > 0) {
                 totalMessages += numMessagesRead;
             }
-        }
-
-        @Override
-        public boolean continueReading() {
             return totalMessages < maxMessagesPerRead;
         }
 

--- a/transport/src/main/java/io/netty5/channel/ReadHandleFactory.java
+++ b/transport/src/main/java/io/netty5/channel/ReadHandleFactory.java
@@ -43,16 +43,9 @@ public interface ReadHandleFactory {
          * @param actualBytesRead       The number of bytes from the previous read operation. This may be negative if a
          *                              read error occurs.
          * @param numMessagesRead       The number of messages read.
+         * @return                      {@code true} if the read loop should continue reading, {@code false} otherwise.
          */
-        void lastRead(int attemptedBytesRead, int actualBytesRead, int numMessagesRead);
-
-        /**
-         * Determine if the current read loop should continue.
-         *
-         * @return {@code true} if the read loop should continue reading. {@code false}
-         * if the read loop is complete.
-         */
-        boolean continueReading();
+        boolean lastRead(int attemptedBytesRead, int actualBytesRead, int numMessagesRead);
 
         /**
          * Method that must be called once the read loop was completed.

--- a/transport/src/main/java/io/netty5/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty5/channel/local/LocalChannel.java
@@ -221,15 +221,16 @@ public class LocalChannel extends AbstractChannel<LocalServerChannel, LocalAddre
     private void readInbound() {
         ReadHandleFactory.ReadHandle readHandle = readHandle();
         ChannelPipeline pipeline = pipeline();
+        boolean continueReading;
         do {
             Object received = inboundBuffer.poll();
             if (received == null) {
                 readHandle.lastRead(0, 0, 0);
                 break;
             }
-            readHandle.lastRead(0, 0, 1);
+            continueReading = readHandle.lastRead(0, 0, 1);
             pipeline.fireChannelRead(received);
-        } while (readHandle.continueReading() && !isShutdown(ChannelShutdownDirection.Inbound));
+        } while (continueReading && !isShutdown(ChannelShutdownDirection.Inbound));
 
         readHandle.readComplete();
         pipeline.fireChannelReadComplete();

--- a/transport/src/main/java/io/netty5/channel/local/LocalServerChannel.java
+++ b/transport/src/main/java/io/netty5/channel/local/LocalServerChannel.java
@@ -106,15 +106,16 @@ public class LocalServerChannel extends AbstractServerChannel<LocalChannel, Loca
     private void readInbound() {
         ReadHandleFactory.ReadHandle readHandle = readHandle();
         ChannelPipeline pipeline = pipeline();
+        boolean continueReading;
         do {
             Object m = inboundBuffer.poll();
             if (m == null) {
                 readHandle.lastRead(0, 0, 0);
                 break;
             }
-            readHandle.lastRead(0, 0, 1);
+            continueReading = readHandle.lastRead(0, 0, 1);
             pipeline.fireChannelRead(m);
-        } while (readHandle.continueReading() && !isShutdown(ChannelShutdownDirection.Inbound));
+        } while (continueReading && !isShutdown(ChannelShutdownDirection.Inbound));
 
         readHandle.readComplete();
         pipeline.fireChannelReadComplete();

--- a/transport/src/main/java/io/netty5/channel/nio/AbstractNioMessageChannel.java
+++ b/transport/src/main/java/io/netty5/channel/nio/AbstractNioMessageChannel.java
@@ -76,7 +76,7 @@ public abstract class AbstractNioMessageChannel<P extends Channel, L extends Soc
                         closed = true;
                         break;
                     }
-                } while (readHandle.continueReading() && !isShutdown(ChannelShutdownDirection.Inbound));
+                } while (!isShutdown(ChannelShutdownDirection.Inbound));
             } catch (Throwable t) {
                 exception = t;
             }

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioDatagramChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioDatagramChannel.java
@@ -384,15 +384,17 @@ public final class NioDatagramChannel
             SocketAddress remoteAddress = receiveDatagram.remoteAddress;
             if (remoteAddress == null) {
                 readHandle.lastRead(attemptedBytesRead, 0, 0);
-                return 0;
+                return -1;
             }
             int actualBytesRead = receiveDatagram.bytesReceived;
             data.skipWritableBytes(actualBytesRead);
             buf.add(new DatagramPacket(data, localAddress(), remoteAddress));
-
-            readHandle.lastRead(attemptedBytesRead, actualBytesRead, 1);
             free = false;
-            return 1;
+
+            if (readHandle.lastRead(attemptedBytesRead, actualBytesRead, 1)) {
+                return 1;
+            }
+            return 0;
         } finally {
             if (free) {
                 data.close();

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioServerSocketChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioServerSocketChannel.java
@@ -244,8 +244,10 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel<Channel, S
         try {
             if (ch != null) {
                 buf.add(new NioSocketChannel(this, childEventLoopGroup().next(), ch, family));
-                readHandle.lastRead(0, 0, 1);
-                return 1;
+                if (readHandle.lastRead(0, 0, 1)) {
+                    return 1;
+                }
+                return 0;
             }
         } catch (Throwable t) {
             logger.warn("Failed to create a new channel from an accepted socket.", t);
@@ -257,7 +259,7 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel<Channel, S
             }
         }
         readHandle.lastRead(0, 0, 0);
-        return 0;
+        return -1;
     }
 
     // Unnecessary stuff

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioServerSocketChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioServerSocketChannel.java
@@ -259,7 +259,7 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel<Channel, S
             }
         }
         readHandle.lastRead(0, 0, 0);
-        return -1;
+        return 0;
     }
 
     // Unnecessary stuff

--- a/transport/src/test/java/io/netty5/channel/MaxMessagesReadHandleFactoryTest.java
+++ b/transport/src/test/java/io/netty5/channel/MaxMessagesReadHandleFactoryTest.java
@@ -43,14 +43,11 @@ public class MaxMessagesReadHandleFactoryTest {
         ReadHandleFactory.ReadHandle handle = allocator.newHandle();
 
         EmbeddedChannel channel = new EmbeddedChannel();
-        handle.lastRead(0, 0, 1);
-        assertTrue(handle.continueReading());
-        handle.lastRead(0, 0, 1);
-        assertFalse(handle.continueReading());
+        assertTrue(handle.lastRead(0, 0, 1));
+        assertFalse(handle.lastRead(0, 0, 1));
 
         handle.readComplete();
-        handle.lastRead(1, 1, 1);
-        assertTrue(handle.continueReading());
+        assertTrue(handle.lastRead(1, 1, 1));
         channel.finish();
     }
 
@@ -60,14 +57,11 @@ public class MaxMessagesReadHandleFactoryTest {
         ReadHandleFactory.ReadHandle handle = allocator.newHandle();
 
         EmbeddedChannel channel = new EmbeddedChannel();
-        handle.lastRead(0, 0, 1);
-        assertTrue(handle.continueReading());
-        handle.lastRead(0, 0, 1);
-        assertFalse(handle.continueReading());
+        assertTrue(handle.lastRead(0, 0, 1));
+        assertFalse(handle.lastRead(0, 0, 1));
 
         handle.readComplete();
-        handle.lastRead(0, 0, 0);
-        assertTrue(handle.continueReading());
+        assertTrue(handle.lastRead(0, 0, 0));
         channel.finish();
     }
 }


### PR DESCRIPTION
Motivation:

We don't need the continueReading() method as we can just return the value via lastRead(...) directly

Modifications:

Remove method and so simplify and make miss-usage harder.

Result:

Tighten up API