### PR TITLE
Update to netty-build 30 and so remove all junit4 dependencies

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
@@ -23,7 +23,6 @@ import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelPromise;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import junit.framework.AssertionFailedError;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
@@ -55,6 +54,7 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyInt;
@@ -231,7 +231,13 @@ public class DefaultHttp2ConnectionDecoderTest {
         decode().onSettingsAckRead(ctx);
 
         // Disallow any further flushes now that settings ACK has been sent
-        when(ctx.flush()).thenThrow(new AssertionFailedError("forbidden"));
+        when(ctx.flush()).then(new Answer<ChannelHandlerContext>() {
+            @Override
+            public ChannelHandlerContext answer(InvocationOnMock invocationOnMock) {
+                fail();
+                return null;
+            }
+        });
     }
 
     @Test

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
@@ -30,7 +30,6 @@ import io.netty.channel.DefaultChannelPromise;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http2.Http2RemoteFlowController.FlowControlled;
 import io.netty.util.concurrent.ImmediateEventExecutor;
-import junit.framework.AssertionFailedError;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -217,7 +216,13 @@ public class DefaultHttp2ConnectionEncoderTest {
                 return newSucceededFuture();
             }
         }).when(ctx).newSucceededFuture();
-        when(ctx.flush()).thenThrow(new AssertionFailedError("forbidden"));
+        when(ctx.flush()).thenAnswer(new Answer<ChannelHandlerContext>() {
+            @Override
+            public ChannelHandlerContext answer(InvocationOnMock invocationOnMock) {
+                fail("forbidden");
+                return null;
+            }
+        });
         when(channel.alloc()).thenReturn(PooledByteBufAllocator.DEFAULT);
 
         // Use a server-side connection so we can test server push.

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowControllerTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.eq;
@@ -38,7 +39,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http2.Http2Stream.State;
 import io.netty.util.concurrent.EventExecutor;
-import junit.framework.AssertionFailedError;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
@@ -89,7 +89,13 @@ public class DefaultHttp2LocalFlowControllerTest {
                 }
             });
         } else {
-            when(ctx.flush()).thenThrow(new AssertionFailedError("forbidden"));
+            when(ctx.flush()).then(new Answer<ChannelHandlerContext>() {
+                @Override
+                public ChannelHandlerContext answer(InvocationOnMock invocationOnMock) {
+                    fail("forbidden");
+                    return null;
+                }
+            });
         }
         when(ctx.executor()).thenReturn(executor);
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2TestUtil.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2TestUtil.java
@@ -29,7 +29,6 @@ import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import io.netty.util.concurrent.ImmediateEventExecutor;
-import junit.framework.AssertionFailedError;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -44,6 +43,7 @@ import static io.netty.util.ReferenceCountUtil.release;
 import static java.lang.Math.min;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyByte;
@@ -277,13 +277,15 @@ public final class Http2TestUtil {
             @Override
             public ChannelPromise addListener(
                     GenericFutureListener<? extends Future<? super Void>> listener) {
-                throw new AssertionFailedError();
+                fail();
+                return null;
             }
 
             @Override
             public ChannelPromise addListeners(
                     GenericFutureListener<? extends Future<? super Void>>... listeners) {
-                throw new AssertionFailedError();
+                fail();
+                return null;
             }
 
             @Override

--- a/handler/src/test/java/io/netty/handler/ssl/JdkSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/JdkSslEngineTest.java
@@ -25,10 +25,10 @@ import io.netty.handler.ssl.util.SelfSignedCertificate;
 import java.security.Provider;
 
 import io.netty.util.internal.EmptyArrays;
-import org.junit.AssumptionViolatedException;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.opentest4j.TestAbortedException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -186,7 +186,7 @@ public class JdkSslEngineTest extends SSLEngineTest {
         } catch (SkipTestException e) {
             // ALPN availability is dependent on the java version. If ALPN is not available because of
             // java version incompatibility don't fail the test, but instead just skip the test
-            throw new AssumptionViolatedException("Not expected", e);
+            throw new TestAbortedException("Not expected", e);
         }
     }
 
@@ -204,7 +204,7 @@ public class JdkSslEngineTest extends SSLEngineTest {
         } catch (SkipTestException e) {
             // ALPN availability is dependent on the java version. If ALPN is not available because of
             // java version incompatibility don't fail the test, but instead just skip the test
-            throw new AssumptionViolatedException("Not expected", e);
+            throw new TestAbortedException("Not expected", e);
         }
     }
 
@@ -262,7 +262,7 @@ public class JdkSslEngineTest extends SSLEngineTest {
         } catch (SkipTestException e) {
             // ALPN availability is dependent on the java version. If ALPN is not available because of
             // java version incompatibility don't fail the test, but instead just skip the test
-            throw new AssumptionViolatedException("Not expected", e);
+            throw new TestAbortedException("Not expected", e);
         }
     }
 
@@ -282,7 +282,7 @@ public class JdkSslEngineTest extends SSLEngineTest {
         } catch (SkipTestException e) {
             // ALPN availability is dependent on the java version. If ALPN is not available because of
             // java version incompatibility don't fail the test, but instead just skip the test
-            throw new AssumptionViolatedException("Not expected", e);
+            throw new TestAbortedException("Not expected", e);
         }
     }
 
@@ -307,7 +307,7 @@ public class JdkSslEngineTest extends SSLEngineTest {
         } catch (SkipTestException e) {
             // ALPN availability is dependent on the java version. If ALPN is not available because of
             // java version incompatibility don't fail the test, but instead just skip the test
-            throw new AssumptionViolatedException("Not expected", e);
+            throw new TestAbortedException("Not expected", e);
         }
     }
 

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
@@ -25,12 +25,12 @@ import io.netty.internal.tcnative.SSL;
 import io.netty.util.CharsetUtil;
 import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.PlatformDependent;
-import org.junit.AssumptionViolatedException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.opentest4j.TestAbortedException;
 
 import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
@@ -1030,7 +1030,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
             } catch (SSLException e) {
                 if (e.getMessage().contains("unsupported protocol") ||
                         e.getMessage().contains("no protocols available")) {
-                    throw new AssumptionViolatedException(protocol + " not supported with cipher " + cipher, e);
+                    throw new TestAbortedException(protocol + " not supported with cipher " + cipher, e);
                 }
                 throw e;
             }

--- a/pom.xml
+++ b/pom.xml
@@ -543,7 +543,7 @@
     <netty.dev.tools.directory>${project.build.directory}/dev-tools</netty.dev.tools.directory>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <netty.build.version>30</netty.build.version>
+    <netty.build.version>31</netty.build.version>
     <jboss.marshalling.version>1.4.11.Final</jboss.marshalling.version>
     <jetty.alpnAgent.version>2.0.10</jetty.alpnAgent.version>
     <jetty.alpnAgent.path>"${settings.localRepository}"/org/mortbay/jetty/alpn/jetty-alpn-agent/${jetty.alpnAgent.version}/jetty-alpn-agent-${jetty.alpnAgent.version}.jar</jetty.alpnAgent.path>


### PR DESCRIPTION
Motivation:

netty-build versions < 30 did bring junit4 with it as transist dependency.

Modifications:

Update to netty-build 30 and fix junit 4 usage

Result:

No more dependency on junit 4 at all