### PR TITLE
Add substringBefore method in StringUtil

### DIFF
--- a/common/src/main/java/io/netty5/util/internal/StringUtil.java
+++ b/common/src/main/java/io/netty5/util/internal/StringUtil.java
@@ -136,6 +136,19 @@ public final class StringUtil {
     }
 
     /**
+     * Get the item before one char delim if the delim is found (else null).
+     * This operation is a simplified and optimized
+     * version of {@link String#split(String, int)}.
+     */
+    public static String substringBefore(String value, char delim) {
+        int pos = value.indexOf(delim);
+        if (pos >= 0) {
+            return value.substring(0, pos);
+        }
+        return null;
+    }
+
+    /**
      * Checks if two strings have the same suffix of specified length
      *
      * @param s   string


### PR DESCRIPTION
Motivation:

The mutlipart PR #12664 that has recently been added in 4.1 introduces a new  [substringBefore](https://github.com/netty/netty/blob/4.1/common/src/main/java/io/netty/util/internal/StringUtil.java#L105-L116) method in the common StringUtil class.

So, to be able to properly merge the #12664 PR into the new netty-contrib multipart project, It is needed to also add the new **substringBefore** in the common StringUtil class in the netty5 main branch.

Modification:

Have added the substringBefore in the common/src/main/java/io/netty/util/internal/StringUtil.java, on the main branch.

Result:

It will allow me to properly merge the #12664 into the netty-contrib multipart project.

