### PR TITLE
Update java versions used via docker

### DIFF
--- a/docker/docker-compose.centos-6.111.yaml
+++ b/docker/docker-compose.centos-6.111.yaml
@@ -6,7 +6,7 @@ services:
     image: netty:centos-6-1.11
     build:
       args:
-        java_version : "11.0.15-zulu"
+        java_version : "11.0.16-zulu"
 
   build:
     image: netty:centos-6-1.11

--- a/docker/docker-compose.centos-6.18.yaml
+++ b/docker/docker-compose.centos-6.18.yaml
@@ -6,7 +6,7 @@ services:
     image: netty:centos-6-1.8
     build:
       args:
-        java_version : "8.0.332-zulu"
+        java_version : "8.0.345-zulu"
 
   build:
     image: netty:centos-6-1.8

--- a/docker/docker-compose.centos-7.117.yaml
+++ b/docker/docker-compose.centos-7.117.yaml
@@ -6,7 +6,7 @@ services:
     image: netty:centos-7-1.17
     build:
       args:
-        java_version : "17.0.3-zulu"
+        java_version : "17.0.4-zulu"
 
   build:
     image: netty:centos-7-1.17

--- a/docker/docker-compose.centos-7.118.yaml
+++ b/docker/docker-compose.centos-7.118.yaml
@@ -6,7 +6,7 @@ services:
     image: netty:centos-7-1.17
     build:
       args:
-        java_version : "18.0.1-zulu"
+        java_version : "18.0.2-zulu"
 
   build:
     image: netty:centos-7-1.17


### PR DESCRIPTION
Motivation:

There are newjava releases, let's update so we use these on the CI

Modifications:

- Update java 8, 11, 17 and 18 releases

Result:

Use latest versions