### PR TITLE
Move logic for read handling into AbstractChannel

### DIFF
--- a/codec/src/test/java/io/netty5/handler/codec/compression/JdkZlibTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/compression/JdkZlibTest.java
@@ -590,7 +590,7 @@ public class JdkZlibTest {
     public void testLargeEncode() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(createEncoder(ZlibWrapper.NONE));
         BufferAllocator wrapped = channel.bufferAllocator();
-        channel.setBufferAllocator(new LimitedBufferAllocator(wrapped));
+        channel.setOption(ChannelOption.BUFFER_ALLOCATOR, new LimitedBufferAllocator(wrapped));
 
         // construct a 128M buffer out of many times the same 1M buffer :)
         Supplier<Buffer> smallBuffer = wrapped.constBufferSupplier(new byte[1024 * 1024]);

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDatagramChannel.java
@@ -34,7 +34,6 @@ import io.netty5.channel.unix.UnixChannelOption;
 import io.netty5.util.Resource;
 import io.netty5.channel.AddressedEnvelope;
 import io.netty5.channel.ChannelOutboundBuffer;
-import io.netty5.channel.ChannelPipeline;
 import io.netty5.channel.DefaultBufferAddressedEnvelope;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.socket.DatagramChannel;
@@ -214,7 +213,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel<UnixChannel
 
     private void joinGroup0(InetAddress multicastAddress, NetworkInterface networkInterface,
                            InetAddress source, Promise<Void> promise) {
-        assertEventLoop();
+        assert executor().inEventLoop();
 
         try {
             socket.joinGroup(multicastAddress, networkInterface, source);
@@ -500,53 +499,37 @@ public final class EpollDatagramChannel extends AbstractEpollChannel<UnixChannel
     }
 
     @Override
-    protected boolean epollInReady(ReadHandleFactory.ReadHandle readHandle, ReadBufferAllocator readBufferAllocator,
-                                   BufferAllocator recvBufferAllocator) {
-        final ChannelPipeline pipeline = pipeline();
-        Throwable exception = null;
-        boolean readAll = false;
-        try {
-            readAll = socket.protocolFamily() == SocketProtocolFamily.UNIX ?
-                    doReadBufferDomainSocket(readHandle, readBufferAllocator, recvBufferAllocator) :
-                    doReadBuffer(readHandle, readBufferAllocator, recvBufferAllocator);
-        } catch (Throwable error) {
-            exception = error;
-        }
-        readHandle.readComplete();
-        pipeline.fireChannelReadComplete();
-
-        if (exception != null) {
-            pipeline.fireChannelExceptionCaught(exception);
-        }
-        readIfIsAutoRead();
-        return readAll;
+    protected ReadState epollInReady(ReadBufferAllocator readBufferAllocator, BufferAllocator recvBufferAllocator,
+                                     ReadSink readSink) throws Exception {
+        return socket.protocolFamily() == SocketProtocolFamily.UNIX ?
+                doReadBufferDomainSocket(readBufferAllocator, recvBufferAllocator, readSink) :
+                doReadBuffer(readBufferAllocator, recvBufferAllocator, readSink);
     }
 
-    private boolean doReadBufferDomainSocket(ReadHandleFactory.ReadHandle readHandle,
-                                             ReadBufferAllocator readBufferAllocator,
-                                             BufferAllocator allocator) throws Throwable {
+    private ReadState doReadBufferDomainSocket(ReadBufferAllocator readBufferAllocator, BufferAllocator allocator,
+                                               ReadSink readSink) throws Exception {
         Buffer buf = null;
         try {
             boolean connected = isConnected();
             boolean continueReading;
             do {
-                buf = readBufferAllocator.allocate(allocator, readHandle.estimatedBufferCapacity());
+                buf = readBufferAllocator.allocate(allocator, readSink.estimatedBufferCapacity());
                 if (buf == null) {
-                    readHandle.lastRead(0, 0, 0);
+                    readSink.read(0, 0, null);
                     break;
                 }
                 int attemptedBytesRead = buf.writableBytes();
                 assert buf.isDirect();
 
                 final DatagramPacket packet;
+                int actualBytesRead;
                 if (connected) {
-                    int actualBytesRead = doReadBytes(buf);
-                    continueReading = readHandle.lastRead(
-                            attemptedBytesRead, actualBytesRead, actualBytesRead <= 0 ? 0 : 1);
+                    actualBytesRead = doReadBytes(buf);
                     if (actualBytesRead <= 0) {
                         // nothing was read, release the buffer.
                         buf.close();
-                        return true;
+                        readSink.read(attemptedBytesRead, actualBytesRead, null);
+                        return ReadState.Closed;
                     }
                     packet = new DatagramPacket(buf, localAddress(), remoteAddress());
                 } else {
@@ -555,27 +538,24 @@ public final class EpollDatagramChannel extends AbstractEpollChannel<UnixChannel
                     final DomainDatagramSocketAddress remoteAddress = recvFrom.remoteAddress();
 
                     if (remoteAddress == null) {
-                        readHandle.lastRead(attemptedBytesRead, -1, 0);
+                        readSink.read(attemptedBytesRead, 0, null);
                         buf.close();
-                        return true;
+                        return ReadState.All;
                     }
                     DomainSocketAddress localAddress = remoteAddress.localAddress();
                     if (localAddress == null) {
                         localAddress = (DomainSocketAddress) localAddress();
                     }
-                    int actualBytesRead = remoteAddress.receivedAmount();
-                    continueReading = readHandle.lastRead(attemptedBytesRead, actualBytesRead, 1);
+                    actualBytesRead = remoteAddress.receivedAmount();
+
                     buf.skipWritableBytes(actualBytesRead);
                     packet = new DatagramPacket(buf, localAddress, remoteAddress);
                 }
 
-                readPending = false;
-                pipeline().fireChannelRead(packet);
-
+                continueReading = readSink.read(attemptedBytesRead, actualBytesRead, packet);
                 buf = null;
-
             } while (continueReading);
-            return false;
+            return ReadState.Partial;
         } catch (Throwable t) {
             if (buf != null) {
                 buf.close();
@@ -590,63 +570,54 @@ public final class EpollDatagramChannel extends AbstractEpollChannel<UnixChannel
         Nothing
     }
 
-    private boolean doReadBuffer(ReadHandleFactory.ReadHandle readHandle, ReadBufferAllocator readBufferAllocator,
-                                 BufferAllocator allocator) throws Throwable {
-        try {
-            boolean connected = isConnected();
-            for (;;) {
-                final ReadingState state;
-                int datagramSize = getMaxDatagramPayloadSize();
-
-                Buffer buf = readBufferAllocator.allocate(allocator, readHandle.estimatedBufferCapacity());
-                if (buf == null) {
-                    readHandle.lastRead(0, 0, 0);
-                    break;
-                }
-                assert buf.isDirect();
-                // Only try to use recvmmsg if its really supported by the running system.
-                int numDatagram = Native.IS_SUPPORTING_RECVMMSG ?
-                        datagramSize == 0 ? 1 : buf.writableBytes() / datagramSize :
-                        0;
-                try {
-                    if (numDatagram <= 1) {
-                        if (!connected || isUdpGro()) {
-                            state = recvmsg(readHandle, allocator, cleanDatagramPacketArray(), buf);
-                        } else {
-                            state = connectedRead(readHandle, buf, datagramSize);
-                        }
-                    } else {
-                        // Try to use scattering reads via recvmmsg(...) syscall.
-                        state = scatteringRead(readHandle, allocator, cleanDatagramPacketArray(),
-                                              buf, datagramSize, numDatagram);
-                    }
-                } catch (NativeIoException e) {
-                    if (connected) {
-                        throw translateForConnected(e);
-                    }
-                    throw e;
-                }
-
-                switch (state) {
-                    case Nothing:
-                        return true;
-                    case Stop:
-                        readPending = false;
-                        return false;
-                    case Continue:
-                        readPending = false;
-                    default:
-                        throw new AssertionError("Should never happen");
-                }
+    private ReadState doReadBuffer(ReadBufferAllocator readBufferAllocator, BufferAllocator allocator,
+                                   ReadSink readSink) throws Exception {
+        boolean connected = isConnected();
+        for (;;) {
+            final ReadingState state;
+            int datagramSize = getMaxDatagramPayloadSize();
+            Buffer buf = readBufferAllocator.allocate(allocator, readSink.estimatedBufferCapacity());
+            if (buf == null) {
+                readSink.read(0, 0, null);
+                return ReadState.Partial;
             }
-        } catch (Throwable t) {
-            throw t;
+            // Only try to use recvmmsg if its really supported by the running system.
+            int numDatagram = Native.IS_SUPPORTING_RECVMMSG ?
+                    datagramSize == 0 ? 1 : buf.writableBytes() / datagramSize :
+                    0;
+            try {
+                if (numDatagram <= 1) {
+                    if (!connected || isUdpGro()) {
+                        state = recvmsg(allocator, readSink, cleanDatagramPacketArray(), buf);
+                    } else {
+                        state = connectedRead(readSink, buf, datagramSize);
+                    }
+                } else {
+                    // Try to use scattering reads via recvmmsg(...) syscall.
+                    state = scatteringRead(allocator, readSink, cleanDatagramPacketArray(),
+                                          buf, datagramSize, numDatagram);
+                }
+            } catch (NativeIoException e) {
+                if (connected) {
+                    throw translateForConnected(e);
+                }
+                throw e;
+            }
+
+            switch (state) {
+                case Nothing:
+                    return ReadState.All;
+                case Stop:
+                    return ReadState.Partial;
+                case Continue:
+                    break;
+                default:
+                    throw new AssertionError("Should never happen");
+            }
         }
-        return false;
     }
 
-    private ReadingState connectedRead(ReadHandleFactory.ReadHandle allocHandle, Buffer buf,
-                                  int maxDatagramPacketSize) throws Exception {
+    private ReadingState connectedRead(ReadSink readSink, Buffer buf, int maxDatagramPacketSize) throws Exception {
         try {
             int attemptedBytesRead = maxDatagramPacketSize != 0 ? Math.min(buf.writableBytes(), maxDatagramPacketSize)
                     : buf.writableBytes();
@@ -664,15 +635,13 @@ public final class EpollDatagramChannel extends AbstractEpollChannel<UnixChannel
             });
             final int totalBytesRead = initialWritableBytes - buf.writableBytes();
             if (totalBytesRead == 0) {
-                allocHandle.lastRead(attemptedBytesRead, totalBytesRead, 0);
+                readSink.read(attemptedBytesRead, totalBytesRead, null);
                 // nothing was read, release the buffer.
                 return ReadingState.Nothing;
             }
 
-            boolean continueReading = allocHandle.lastRead(attemptedBytesRead, totalBytesRead, 1);
-
-            DatagramPacket packet = new DatagramPacket(buf, localAddress(), remoteAddress());
-            pipeline().fireChannelRead(packet);
+            boolean continueReading = readSink.read(attemptedBytesRead, totalBytesRead,
+                    new DatagramPacket(buf, localAddress(), remoteAddress()));
             buf = null;
             return continueReading ? ReadingState.Continue : ReadingState.Stop;
         } finally {
@@ -718,28 +687,28 @@ public final class EpollDatagramChannel extends AbstractEpollChannel<UnixChannel
         }
     }
 
-    private static boolean processPacket(ChannelPipeline pipeline, ReadHandleFactory.ReadHandle readHandle,
-                                      int attemptedBytesRead, int bytesRead, AddressedEnvelope<?, ?> packet) {
+    private static boolean processPacket(ReadSink readSink,
+                                         int attemptedBytesRead, int bytesRead, AddressedEnvelope<?, ?> packet) {
         // Avoid signalling end-of-data for zero-sized datagrams.
-        boolean continueReading = readHandle.lastRead(attemptedBytesRead, Math.max(1, bytesRead), 1);
-        pipeline.fireChannelRead(packet);
-        return continueReading;
+        return readSink.read(attemptedBytesRead, Math.max(1, bytesRead), packet);
     }
 
-    private static boolean processPacketList(ChannelPipeline pipeline, ReadHandleFactory.ReadHandle readHandle,
-                                          BufferAllocator allocator, int attemptedBytesRead, int bytesRead,
-                                          RecyclableArrayList packetList) {
+    private static boolean processPacketList(BufferAllocator allocator, ReadSink readSink,
+                                             int attemptedBytesRead, int bytesRead, RecyclableArrayList packetList) {
         int messagesRead = packetList.size();
-        // Avoid signalling end-of-data for zero-sized datagrams.
-        boolean continueReading = readHandle.lastRead(attemptedBytesRead, Math.max(1, bytesRead), messagesRead);
+        boolean continueReading = true;
         for (int i = 0; i < messagesRead; i++) {
-            pipeline.fireChannelRead(packetList.set(i, allocator.allocate(0)));
+            // Avoid signalling end-of-data for zero-sized datagrams.
+            if (!readSink.read(attemptedBytesRead, Math.max(1, bytesRead),
+                    packetList.set(i, allocator.allocate(0)))) {
+                continueReading = false;
+            }
         }
         return continueReading;
     }
 
-    private ReadingState recvmsg(ReadHandleFactory.ReadHandle readHandle, BufferAllocator allocator,
-                            NativeDatagramPacketArray array, Buffer buf) throws IOException {
+    private ReadingState recvmsg(BufferAllocator allocator, ReadSink readSink, NativeDatagramPacketArray array,
+                                 Buffer buf) throws IOException {
         RecyclableArrayList datagramPackets = null;
         try {
             int initialWriterOffset = buf.writerOffset();
@@ -753,7 +722,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel<UnixChannel
 
             int bytesReceived = socket.recvmsg(msg);
             if (!msg.hasSender()) {
-                readHandle.lastRead(attemptedBytesRead, -1, 0);
+                readSink.read(attemptedBytesRead, 0, null);
                 return ReadingState.Nothing;
             }
             buf.writerOffset(initialWriterOffset + bytesReceived);
@@ -761,7 +730,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel<UnixChannel
             DatagramPacket packet = msg.newDatagramPacket(buf, local);
             boolean continueReading;
             if (!(packet instanceof SegmentedDatagramPacket)) {
-                continueReading = processPacket(pipeline(), readHandle, attemptedBytesRead, bytesReceived, packet);
+                continueReading = processPacket(readSink, attemptedBytesRead, bytesReceived, packet);
                 buf = null;
             } else {
                 // Its important we process all received data out of the NativeDatagramPacketArray
@@ -773,7 +742,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel<UnixChannel
                 // it into the RecyclableArrayList.
                 buf = null;
 
-                continueReading = processPacketList(pipeline(), readHandle, allocator, attemptedBytesRead,
+                continueReading = processPacketList(allocator, readSink, attemptedBytesRead,
                         bytesReceived, datagramPackets);
                 datagramPackets.recycle();
                 datagramPackets = null;
@@ -785,8 +754,8 @@ public final class EpollDatagramChannel extends AbstractEpollChannel<UnixChannel
         }
     }
 
-    private ReadingState scatteringRead(ReadHandleFactory.ReadHandle allocHandle, BufferAllocator allocator,
-                                   NativeDatagramPacketArray array, Buffer buf, int datagramSize, int numDatagram)
+    private ReadingState scatteringRead(BufferAllocator allocator, ReadSink readSink, NativeDatagramPacketArray array,
+                                        Buffer buf, int datagramSize, int numDatagram)
             throws IOException {
         RecyclableArrayList datagramPackets = null;
         try {
@@ -803,7 +772,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel<UnixChannel
 
             int received = socket.recvmmsg(packets, 0, array.count());
             if (received == 0) {
-                allocHandle.lastRead(attemptedBytesRead, -1, 0);
+                readSink.read(attemptedBytesRead, 0, null);
                 return ReadingState.Nothing;
             }
             int bytesReceived = received * datagramSize;
@@ -813,7 +782,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel<UnixChannel
                 // Single packet fast-path
                 DatagramPacket packet = packets[0].newDatagramPacket(buf, local);
                 if (!(packet instanceof SegmentedDatagramPacket)) {
-                    boolean continueReading = processPacket(pipeline(), allocHandle,
+                    boolean continueReading = processPacket(readSink,
                             attemptedBytesRead, datagramSize, packet);
                     buf = null;
                     return continueReading ? ReadingState.Continue : ReadingState.Stop;
@@ -831,7 +800,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel<UnixChannel
             buf.close();
             buf = null;
 
-            boolean continueReading = processPacketList(pipeline(), allocHandle, allocator, attemptedBytesRead,
+            boolean continueReading = processPacketList(allocator, readSink, attemptedBytesRead,
                     bytesReceived, datagramPackets);
             datagramPackets.recycle();
             datagramPackets = null;

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollServerSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollServerSocketChannel.java
@@ -20,12 +20,10 @@ import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelException;
 import io.netty5.channel.ChannelOption;
 import io.netty5.channel.ChannelOutboundBuffer;
-import io.netty5.channel.ChannelPipeline;
 import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.EventLoopGroup;
 import io.netty5.channel.ReadBufferAllocator;
-import io.netty5.channel.ReadHandleFactory;
 import io.netty5.channel.ServerChannelReadHandleFactory;
 import io.netty5.channel.socket.DomainSocketAddress;
 import io.netty5.channel.socket.ServerSocketChannel;
@@ -354,37 +352,20 @@ public final class EpollServerSocketChannel
     }
 
     @Override
-    protected boolean epollInReady(ReadHandleFactory.ReadHandle readHandle, ReadBufferAllocator readBufferAllocator,
-                                   BufferAllocator recvBufferAllocator) {
-        final ChannelPipeline pipeline = pipeline();
-        Throwable exception = null;
-        boolean readAll = false;
-        try {
-            boolean continueReading;
-            do {
-                int acceptedFd = socket.accept(acceptedAddress);
-                continueReading = readHandle.lastRead(0, 0, acceptedFd == -1 ? 0 : 1);
-
-                if (acceptedFd == -1) {
-                    // this means everything was handled for now
-                    readAll = true;
-                    break;
-                }
-                readPending = false;
-                pipeline.fireChannelRead(newChildChannel(acceptedFd, acceptedAddress, 1,
-                        acceptedAddress[0]));
-            } while (continueReading && !isShutdown(ChannelShutdownDirection.Inbound));
-        } catch (Throwable t) {
-            exception = t;
-        }
-        readHandle.readComplete();
-        pipeline.fireChannelReadComplete();
-
-        if (exception != null) {
-            pipeline.fireChannelExceptionCaught(exception);
-        }
-        readIfIsAutoRead();
-        return readAll;
+    protected ReadState epollInReady(ReadBufferAllocator readBufferAllocator, BufferAllocator recvBufferAllocator,
+                                     ReadSink readSink) throws Exception {
+        boolean continueReading;
+        do {
+            int acceptedFd = socket.accept(acceptedAddress);
+            if (acceptedFd == -1) {
+                readSink.read(0, 0, null);
+                // this means everything was handled for now
+                return ReadState.All;
+            }
+            continueReading = readSink.read(0, 0,
+                    newChildChannel(acceptedFd, acceptedAddress, 1, acceptedAddress[0]));
+        } while (continueReading && !isShutdown(ChannelShutdownDirection.Inbound));
+        return ReadState.Partial;
     }
 
     @Override

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollServerSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollServerSocketChannel.java
@@ -358,11 +358,11 @@ public final class EpollServerSocketChannel
         do {
             int acceptedFd = socket.accept(acceptedAddress);
             if (acceptedFd == -1) {
-                readSink.read(0, 0, null);
+                readSink.processRead(0, 0, null);
                 // this means everything was handled for now
                 return ReadState.All;
             }
-            continueReading = readSink.read(0, 0,
+            continueReading = readSink.processRead(0, 0,
                     newChildChannel(acceptedFd, acceptedAddress, 1, acceptedAddress[0]));
         } while (continueReading && !isShutdown(ChannelShutdownDirection.Inbound));
         return ReadState.Partial;

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollSocketChannel.java
@@ -535,7 +535,7 @@ public final class EpollSocketChannel
                 // to handle direct buffers.
                 buffer = readBufferAllocator.allocate(bufferAllocator, readSink.estimatedBufferCapacity());
                 if (buffer == null) {
-                    readSink.read(0, 0, null);
+                    readSink.processRead(0, 0, null);
                     return ReadState.Partial;
                 }
                 assert buffer.isDirect();
@@ -547,14 +547,14 @@ public final class EpollSocketChannel
                     // nothing was read, release the buffer.
                     Resource.dispose(buffer);
                     buffer = null;
-                    readSink.read(attemptedBytesRead, actualBytesRead, null);
+                    readSink.processRead(attemptedBytesRead, actualBytesRead, null);
 
                     if (actualBytesRead < 0) {
                         return ReadState.Closed;
                     }
                     return ReadState.All;
                 }
-                continueReading = readSink.read(attemptedBytesRead, actualBytesRead, buffer);
+                continueReading = readSink.processRead(attemptedBytesRead, actualBytesRead, buffer);
                 buffer = null;
             } while (continueReading && readMore && !isShutdown(ChannelShutdownDirection.Inbound));
             if (readMore) {
@@ -1171,14 +1171,14 @@ public final class EpollSocketChannel
             int readFd = socket.recvFd();
             switch(readFd) {
                 case 0:
-                    readSink.read(0, 0, null);
+                    readSink.processRead(0, 0, null);
                     return ReadState.All;
                 case -1:
-                    readSink.read(0, 0, null);
+                    readSink.processRead(0, 0, null);
                     closeTransport(newPromise());
                     return ReadState.Closed;
                 default:
-                    continueReading = readSink.read(0, 0, new FileDescriptor(readFd));
+                    continueReading = readSink.processRead(0, 0, new FileDescriptor(readFd));
                     break;
             }
         } while (continueReading

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDatagramChannel.java
@@ -21,12 +21,10 @@ import io.netty5.channel.AddressedEnvelope;
 import io.netty5.channel.ChannelException;
 import io.netty5.channel.ChannelOption;
 import io.netty5.channel.ChannelOutboundBuffer;
-import io.netty5.channel.ChannelPipeline;
 import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.DefaultBufferAddressedEnvelope;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.FixedReadHandleFactory;
-import io.netty5.channel.ReadHandleFactory;
 import io.netty5.channel.ReadBufferAllocator;
 import io.netty5.channel.socket.DatagramPacket;
 import io.netty5.channel.socket.DatagramChannel;
@@ -484,26 +482,22 @@ public final class KQueueDatagramChannel
     }
 
     @Override
-    int readReady(ReadHandleFactory.ReadHandle readHandle, ReadBufferAllocator readBufferAllocator,
-                  BufferAllocator recvBufferAllocator) {
-        final ChannelPipeline pipeline = pipeline();
-
-        Throwable exception = null;
+    int readReady(ReadBufferAllocator readBufferAllocator,
+                  BufferAllocator recvBufferAllocator, ReadSink readSink) throws Exception {
         Buffer buffer = null;
         int totalReadyBytes = 0;
         try {
             boolean connected = isConnected();
             boolean continueReading;
             do {
-                buffer = readBufferAllocator.allocate(recvBufferAllocator, readHandle.estimatedBufferCapacity());
+                buffer = readBufferAllocator.allocate(recvBufferAllocator, readSink.estimatedBufferCapacity());
                 if (buffer == null) {
-                    readHandle.lastRead(0, 0, 0);
+                    readSink.read(0, 0, null);
                     break;
                 }
                 assert buffer.isDirect();
                 int attemptedBytesRead = buffer.writableBytes();
-                final int actualBytesRead;
-
+                int actualBytesRead = 0;
                 final DatagramPacket packet;
                 if (connected) {
                     try {
@@ -517,12 +511,16 @@ public final class KQueueDatagramChannel
                         }
                         throw e;
                     }
-                    continueReading = readHandle.lastRead(
-                            attemptedBytesRead, actualBytesRead, actualBytesRead <= 0 ? 0 : 1);
+
                     if (actualBytesRead <= 0) {
                         // nothing was read, release the buffer.
                         buffer.close();
-                        buffer = null;
+
+                        readSink.read(attemptedBytesRead, actualBytesRead, null);
+                        // Signal closure
+                        if (actualBytesRead == -1) {
+                            totalReadyBytes = -1;
+                        }
                         break;
                     }
                     totalReadyBytes += actualBytesRead;
@@ -530,14 +528,13 @@ public final class KQueueDatagramChannel
                 } else {
                     SocketAddress localAddress = null;
                     SocketAddress remoteAddress = null;
-                    int bytesRead = 0;
                     if (socket.protocolFamily() == SocketProtocolFamily.UNIX) {
                         final RecvFromAddressDomainSocket recvFrom = new RecvFromAddressDomainSocket(socket);
                         buffer.forEachWritable(0, recvFrom);
                         DomainDatagramSocketAddress recvAddress = recvFrom.remoteAddress();
                         if (recvAddress != null) {
                             remoteAddress = recvAddress;
-                            bytesRead = recvAddress.receivedAmount();
+                            actualBytesRead = recvAddress.receivedAmount();
                             localAddress = recvAddress.localAddress();
                         }
                     } else {
@@ -556,45 +553,33 @@ public final class KQueueDatagramChannel
                             if (datagramSocketAddress != null) {
                                 remoteAddress = datagramSocketAddress;
                                 localAddress = datagramSocketAddress.localAddress();
-                                bytesRead = datagramSocketAddress.receivedAmount();
+                                actualBytesRead = datagramSocketAddress.receivedAmount();
                             }
                         }
                     }
 
                     if (remoteAddress == null) {
-                        readHandle.lastRead(attemptedBytesRead, -1, 0);
+                        readSink.read(attemptedBytesRead, 0, null);
                         buffer.close();
                         break;
                     }
                     if (localAddress == null) {
                         localAddress = localAddress();
                     }
-                    continueReading = readHandle.lastRead(attemptedBytesRead, bytesRead, 1);
-                    totalReadyBytes += bytesRead;
-                    buffer.skipWritableBytes(bytesRead);
+                    totalReadyBytes += actualBytesRead;
+                    buffer.skipWritableBytes(actualBytesRead);
 
                     packet = new DatagramPacket(buffer, localAddress, remoteAddress);
                 }
-
-                readPending = false;
-                pipeline.fireChannelRead(packet);
-
+                continueReading = readSink.read(
+                        attemptedBytesRead, actualBytesRead, packet);
                 buffer = null;
             } while (continueReading);
         } catch (Throwable t) {
             if (buffer != null) {
                 buffer.close();
             }
-            exception = t;
-        }
-
-        readHandle.readComplete();
-        pipeline.fireChannelReadComplete();
-
-        if (exception != null) {
-            pipeline.fireChannelExceptionCaught(exception);
-        } else {
-            readIfIsAutoRead();
+            throw t;
         }
         return totalReadyBytes;
     }

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDatagramChannel.java
@@ -492,7 +492,7 @@ public final class KQueueDatagramChannel
             do {
                 buffer = readBufferAllocator.allocate(recvBufferAllocator, readSink.estimatedBufferCapacity());
                 if (buffer == null) {
-                    readSink.read(0, 0, null);
+                    readSink.processRead(0, 0, null);
                     break;
                 }
                 assert buffer.isDirect();
@@ -516,7 +516,7 @@ public final class KQueueDatagramChannel
                         // nothing was read, release the buffer.
                         buffer.close();
 
-                        readSink.read(attemptedBytesRead, actualBytesRead, null);
+                        readSink.processRead(attemptedBytesRead, actualBytesRead, null);
                         // Signal closure
                         if (actualBytesRead == -1) {
                             totalReadyBytes = -1;
@@ -559,7 +559,7 @@ public final class KQueueDatagramChannel
                     }
 
                     if (remoteAddress == null) {
-                        readSink.read(attemptedBytesRead, 0, null);
+                        readSink.processRead(attemptedBytesRead, 0, null);
                         buffer.close();
                         break;
                     }
@@ -571,7 +571,7 @@ public final class KQueueDatagramChannel
 
                     packet = new DatagramPacket(buffer, localAddress, remoteAddress);
                 }
-                continueReading = readSink.read(
+                continueReading = readSink.processRead(
                         attemptedBytesRead, actualBytesRead, packet);
                 buffer = null;
             } while (continueReading);

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueServerSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueServerSocketChannel.java
@@ -374,11 +374,11 @@ public final class KQueueServerSocketChannel extends
             int acceptFd = socket.accept(acceptedAddress);
             if (acceptFd == -1) {
                 // this means everything was handled for now
-                readSink.read(0, 0, null);
+                readSink.processRead(0, 0, null);
                 break;
             }
             totalBytesRead++;
-            continueReading = readSink.read(0, 0,
+            continueReading = readSink.processRead(0, 0,
                     newChildChannel(acceptFd, acceptedAddress, 1, acceptedAddress[0]));
         } while (continueReading && !isShutdown(ChannelShutdownDirection.Inbound));
         return totalBytesRead;

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueSocketChannel.java
@@ -514,15 +514,15 @@ public final class KQueueSocketChannel
             int recvFd = socket.recvFd();
             switch(recvFd) {
                 case 0:
-                    readSink.read(0, 0, null);
+                    readSink.processRead(0, 0, null);
                     break readLoop;
                 case -1:
-                    readSink.read(0, 0, null);
+                    readSink.processRead(0, 0, null);
                     closeTransportNow();
                     return totalBytesRead;
                 default:
                     totalBytesRead ++;
-                    continueReading = readSink.read(0, 0, new FileDescriptor(recvFd));
+                    continueReading = readSink.processRead(0, 0, new FileDescriptor(recvFd));
                     break;
             }
         } while (continueReading && !isShutdown(ChannelShutdownDirection.Inbound));
@@ -867,7 +867,7 @@ public final class KQueueSocketChannel
             do {
                 buffer = readBufferAllocator.allocate(recvBufferAllocator, readSink.estimatedBufferCapacity());
                 if (buffer == null) {
-                    readSink.read(0, 0, null);
+                    readSink.processRead(0, 0, null);
                     break;
                 }
                 // we use a direct buffer here as the native implementations only be able
@@ -880,14 +880,14 @@ public final class KQueueSocketChannel
                     // nothing was read, release the buffer.
                     Resource.dispose(buffer);
                     buffer = null;
-                    readSink.read(attemptedBytesRead, actualBytesRead, null);
+                    readSink.processRead(attemptedBytesRead, actualBytesRead, null);
                     if (actualBytesRead < 0) {
                         return -1;
                     }
                     break;
                 }
                 totalBytesRead += actualBytesRead;
-                continueReading = readSink.read(attemptedBytesRead, actualBytesRead, buffer);
+                continueReading = readSink.processRead(attemptedBytesRead, actualBytesRead, buffer);
                 buffer = null;
             } while (continueReading && !isShutdown(ChannelShutdownDirection.Inbound));
         } catch (Throwable t) {

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueSocketChannel.java
@@ -21,13 +21,11 @@ import io.netty5.channel.AdaptiveReadHandleFactory;
 import io.netty5.channel.ChannelException;
 import io.netty5.channel.ChannelOption;
 import io.netty5.channel.ChannelOutboundBuffer;
-import io.netty5.channel.ChannelPipeline;
 import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.DefaultFileRegion;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.FileRegion;
 import io.netty5.channel.ReadBufferAllocator;
-import io.netty5.channel.ReadHandleFactory;
 import io.netty5.channel.internal.ChannelUtils;
 import io.netty5.channel.socket.SocketChannel;
 import io.netty5.channel.socket.SocketProtocolFamily;
@@ -497,51 +495,38 @@ public final class KQueueSocketChannel
     }
 
     @Override
-    int readReady(ReadHandleFactory.ReadHandle readHandle, ReadBufferAllocator readBufferAllocator,
-                  BufferAllocator recvBufferAllocator) {
+    int readReady(ReadBufferAllocator readBufferAllocator,
+            BufferAllocator recvBufferAllocator, ReadSink readSink) throws Exception {
         if (socket.protocolFamily() == SocketProtocolFamily.UNIX &&
                 getReadMode() == DomainSocketReadMode.FILE_DESCRIPTORS) {
-            return readReadyFd(readHandle);
+            return readReadyFd(readSink);
         }
-        return readReadyBytes(readHandle, readBufferAllocator, recvBufferAllocator);
+        return readReadyBytes(readBufferAllocator, recvBufferAllocator, readSink);
     }
 
-    private int readReadyFd(ReadHandleFactory.ReadHandle readHandle) {
-        final ChannelPipeline pipeline = pipeline();
+    private int readReadyFd(ReadSink readSink) throws Exception {
         int totalBytesRead = 0;
-        try {
-            boolean continueReading;
-            readLoop: do {
-                // lastBytesRead represents the fd. We use lastBytesRead because it must be set so that the
-                // KQueueRecvBufferAllocatorHandle knows if it should try to read again or not when autoRead is
-                // enabled.
-                int recvFd = socket.recvFd();
-                switch(recvFd) {
-                    case 0:
-                        readHandle.lastRead(0, 0, 0);
-                        break readLoop;
-                    case -1:
-                        readHandle.lastRead(0, 0, 0);
-                        closeTransportNow();
-                        return totalBytesRead;
-                    default:
-                        continueReading = readHandle.lastRead(0, 0, 1);
-                        totalBytesRead ++;
-                        readPending = false;
-                        pipeline.fireChannelRead(new FileDescriptor(recvFd));
-                        break;
-                }
-            } while (continueReading && !isShutdown(ChannelShutdownDirection.Inbound));
+        boolean continueReading;
+        readLoop: do {
+            // lastBytesRead represents the fd. We use lastBytesRead because it must be set so that the
+            // KQueueRecvBufferAllocatorHandle knows if it should try to read again or not when autoRead is
+            // enabled.
+            int recvFd = socket.recvFd();
+            switch(recvFd) {
+                case 0:
+                    readSink.read(0, 0, null);
+                    break readLoop;
+                case -1:
+                    readSink.read(0, 0, null);
+                    closeTransportNow();
+                    return totalBytesRead;
+                default:
+                    totalBytesRead ++;
+                    continueReading = readSink.read(0, 0, new FileDescriptor(recvFd));
+                    break;
+            }
+        } while (continueReading && !isShutdown(ChannelShutdownDirection.Inbound));
 
-            readHandle.readComplete();
-            pipeline.fireChannelReadComplete();
-        } catch (Throwable t) {
-            readHandle.readComplete();
-            pipeline.fireChannelReadComplete();
-            pipeline.fireChannelExceptionCaught(t);
-        } finally {
-            readIfIsAutoRead();
-        }
         return totalBytesRead;
     }
 
@@ -873,18 +858,16 @@ public final class KQueueSocketChannel
         }
     }
 
-    private int readReadyBytes(ReadHandleFactory.ReadHandle readHandle, ReadBufferAllocator readBufferAllocator,
-                               BufferAllocator recvBufferAllocator) {
-        final ChannelPipeline pipeline = pipeline();
+    private int readReadyBytes(ReadBufferAllocator readBufferAllocator,
+            BufferAllocator recvBufferAllocator, ReadSink readSink) throws Exception {
         Buffer buffer = null;
-        boolean close = false;
         int totalBytesRead = 0;
         try {
             boolean continueReading;
             do {
-                buffer = readBufferAllocator.allocate(recvBufferAllocator, readHandle.estimatedBufferCapacity());
+                buffer = readBufferAllocator.allocate(recvBufferAllocator, readSink.estimatedBufferCapacity());
                 if (buffer == null) {
-                    readHandle.lastRead(0, 0, 0);
+                    readSink.read(0, 0, null);
                     break;
                 }
                 // we use a direct buffer here as the native implementations only be able
@@ -892,77 +875,31 @@ public final class KQueueSocketChannel
                 assert buffer.isDirect();
                 int attemptedBytesRead = buffer.writableBytes();
                 int actualBytesRead = doReadBytes(buffer);
-                continueReading = readHandle.lastRead(
-                        attemptedBytesRead, actualBytesRead, actualBytesRead <= 0 ? 0 : 1);
+
                 if (actualBytesRead <= 0) {
                     // nothing was read, release the buffer.
                     Resource.dispose(buffer);
                     buffer = null;
-                    close = actualBytesRead < 0;
-                    if (close) {
-                        // There is nothing left to read as we received an EOF.
-                        readPending = false;
+                    readSink.read(attemptedBytesRead, actualBytesRead, null);
+                    if (actualBytesRead < 0) {
+                        return -1;
                     }
                     break;
                 }
                 totalBytesRead += actualBytesRead;
-                readPending = false;
-                pipeline.fireChannelRead(buffer);
+                continueReading = readSink.read(attemptedBytesRead, actualBytesRead, buffer);
                 buffer = null;
-
-                if (shouldBreakReadReady()) {
-                    // We need to do this for two reasons:
-                    //
-                    // - If the input was shutdown in between (which may be the case when the user did it in the
-                    //   fireChannelRead(...) method we should not try to read again to not produce any
-                    //   miss-leading exceptions.
-                    //
-                    // - If the user closes the channel we need to ensure we not try to read from it again as
-                    //   the filedescriptor may be re-used already by the OS if the system is handling a lot of
-                    //   concurrent connections and so needs a lot of filedescriptors. If not do this we risk
-                    //   reading data from a filedescriptor that belongs to another socket then the socket that
-                    //   was "wrapped" by this Channel implementation.
-                    break;
-                }
             } while (continueReading && !isShutdown(ChannelShutdownDirection.Inbound));
-
-            readHandle.readComplete();
-            pipeline.fireChannelReadComplete();
-
-            if (close) {
-                shutdownInput(false);
-            } else {
-                readIfIsAutoRead();
-            }
         } catch (Throwable t) {
-            handleReadException(pipeline, buffer, t, close, readHandle);
+            if (buffer != null) {
+                buffer.close();
+            }
+            if (isConnectPending()) {
+                finishConnect();
+            }
+            throw t;
         }
         return totalBytesRead;
-    }
-
-    private void handleReadException(ChannelPipeline pipeline, Buffer buffer, Throwable cause, boolean close,
-                                     ReadHandleFactory.ReadHandle readHandle) {
-        if (buffer.readableBytes() > 0) {
-            readPending = false;
-            pipeline.fireChannelRead(buffer);
-        } else {
-            buffer.close();
-        }
-        if (isConnectPending()) {
-            finishConnect();
-        } else {
-            readHandle.readComplete();
-            pipeline.fireChannelReadComplete();
-            pipeline.fireChannelExceptionCaught(cause);
-
-            // If oom will close the read event, release connection.
-            // See https://github.com/netty/netty/issues/10434
-            if (close || cause instanceof OutOfMemoryError || cause instanceof IOException) {
-                shutdownInput(false);
-            } else {
-                readIfIsAutoRead();
-            }
-        }
     }
 
     private final class KQueueSocketWritableByteChannel extends SocketWritableByteChannel {

--- a/transport/src/main/java/io/netty5/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty5/channel/AbstractChannel.java
@@ -1888,12 +1888,11 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
          * Process the read message and fire it through the {@link ChannelPipeline}
          *
          * @param attemptedBytesRead    The number of  bytes the read operation did attempt to read.
-         * @param actualBytesRead       The number of bytes from the previous read operation. This may be negative if a
-         *                              read error occurs.
+         * @param actualBytesRead       The number of bytes the read operation actually read.
          * @param message               the read message or {@code null} if none was read.
          * @return                      {@code true} if the read loop should continue reading, {@code false} otherwise.
          */
-        public boolean read(int attemptedBytesRead, int actualBytesRead, Object message) {
+        public boolean processRead(int attemptedBytesRead, int actualBytesRead, Object message) {
             if (message == null) {
                 readHandle.lastRead(attemptedBytesRead, actualBytesRead, 0);
                 return false;
@@ -1907,7 +1906,7 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
         }
 
         /**
-         * Guess the capacity for the next receive buffer that is probably large enough to read all inbound data and
+         * Guess the capacity for the next read buffer that is probably large enough to read all inbound data and
          * small enough not to waste its space.
          */
         public int estimatedBufferCapacity() {

--- a/transport/src/main/java/io/netty5/channel/DefaultChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty5/channel/DefaultChannelHandlerContext.java
@@ -59,8 +59,6 @@ import static java.util.Objects.requireNonNull;
 
 final class DefaultChannelHandlerContext implements ChannelHandlerContext, ResourceLeakHint {
 
-    private static final ReadBufferAllocator DEFAULT_READ_BUFFER_ALLOCATOR = BufferAllocator::allocate;
-
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(DefaultChannelHandlerContext.class);
 
     /**
@@ -790,7 +788,7 @@ final class DefaultChannelHandlerContext implements ChannelHandlerContext, Resou
     public ChannelHandlerContext read() {
         EventExecutor executor = originalExecutor();
         if (executor.inEventLoop()) {
-            findAndInvokeRead(DEFAULT_READ_BUFFER_ALLOCATOR);
+            findAndInvokeRead(DefaultChannelPipeline.DEFAULT_READ_BUFFER_ALLOCATOR);
         } else {
             Tasks tasks = invokeTasks();
             executor.execute(tasks.invokeReadTask);
@@ -801,7 +799,7 @@ final class DefaultChannelHandlerContext implements ChannelHandlerContext, Resou
     private void findAndInvokeRead() {
         DefaultChannelHandlerContext ctx = findContextOutbound(MASK_READ);
         if (ctx != null) {
-            ctx.invokeRead(DEFAULT_READ_BUFFER_ALLOCATOR);
+            ctx.invokeRead(DefaultChannelPipeline.DEFAULT_READ_BUFFER_ALLOCATOR);
         }
     }
 

--- a/transport/src/main/java/io/netty5/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty5/channel/DefaultChannelPipeline.java
@@ -15,6 +15,7 @@
  */
 package io.netty5.channel;
 
+import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.util.Resource;
 import io.netty5.util.ResourceLeakDetector;
 import io.netty5.util.concurrent.EventExecutor;
@@ -47,6 +48,8 @@ import static io.netty5.channel.DefaultChannelHandlerContext.safeExecute;
  * by a {@link Channel} implementation when the {@link Channel} is created.
  */
 public abstract class DefaultChannelPipeline implements ChannelPipeline {
+
+    static final ReadBufferAllocator DEFAULT_READ_BUFFER_ALLOCATOR = BufferAllocator::allocate;
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(DefaultChannelPipeline.class);
     private static final String HEAD_NAME = generateName0(HeadHandler.class);

--- a/transport/src/main/java/io/netty5/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty5/channel/embedded/EmbeddedChannel.java
@@ -713,8 +713,13 @@ public class EmbeddedChannel extends AbstractChannel<Channel, SocketAddress, Soc
     }
 
     @Override
-    protected void doRead(ReadBufferAllocator readBufferAllocator) throws Exception {
+    protected void doRead(boolean wasReadPendingAlready) throws Exception {
         // NOOP
+    }
+
+    @Override
+    protected boolean doReadNow(ReadBufferAllocator readBufferAllocator, ReadSink readSink) {
+        return false;
     }
 
     @Override

--- a/transport/src/main/java/io/netty5/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty5/channel/local/LocalChannel.java
@@ -26,9 +26,7 @@ import io.netty5.buffer.api.internal.Statics;
 import io.netty5.channel.AbstractChannel;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelOutboundBuffer;
-import io.netty5.channel.ChannelPipeline;
 import io.netty5.channel.EventLoop;
-import io.netty5.channel.ReadHandleFactory;
 import io.netty5.util.ReferenceCountUtil;
 import io.netty5.util.concurrent.FastThreadLocal;
 import io.netty5.util.concurrent.Future;
@@ -59,10 +57,10 @@ public class LocalChannel extends AbstractChannel<LocalServerChannel, LocalAddre
 
     // To further optimize this we could write our own SPSC queue.
     final Queue<Object> inboundBuffer = PlatformDependent.newSpscQueue();
-    private final Runnable readTask = () -> {
+    private final Runnable readNowTask = () -> {
         // Ensure the inboundBuffer is not empty as readInbound() will always call fireChannelReadComplete()
         if (!inboundBuffer.isEmpty()) {
-            readInbound();
+            readNow();
         }
     };
 
@@ -219,23 +217,18 @@ public class LocalChannel extends AbstractChannel<LocalServerChannel, LocalAddre
         }
     }
 
-    private void readInbound() {
-        ReadHandleFactory.ReadHandle readHandle = readHandle();
-        ChannelPipeline pipeline = pipeline();
+    @Override
+    protected boolean doReadNow(ReadBufferAllocator readBufferAllocator, ReadSink readSink) {
         boolean continueReading;
         do {
             Object received = inboundBuffer.poll();
             if (received == null) {
-                readHandle.lastRead(0, 0, 0);
+                readSink.read(0, 0, null);
                 break;
             }
-            continueReading = readHandle.lastRead(0, 0, 1);
-            pipeline.fireChannelRead(received);
+            continueReading = readSink.read(0, 0, received);
         } while (continueReading && !isShutdown(ChannelShutdownDirection.Inbound));
-
-        readHandle.readComplete();
-        pipeline.fireChannelReadComplete();
-        readIfIsAutoRead();
+        return false;
     }
 
     private static final class ReaderStackDepth {
@@ -262,7 +255,7 @@ public class LocalChannel extends AbstractChannel<LocalServerChannel, LocalAddre
     };
 
     @Override
-    protected void doRead(ReadBufferAllocator readBufferAllocator) throws Exception {
+    protected void doRead(boolean wasReadPendingAlready) throws Exception {
         if (readInProgress) {
             return;
         }
@@ -276,13 +269,13 @@ public class LocalChannel extends AbstractChannel<LocalServerChannel, LocalAddre
         final ReaderStackDepth readerStackDepth = STACK_DEPTH.get();
         if (readerStackDepth.incrementIfPossible()) {
             try {
-                readInbound();
+                readNow();
             } finally {
                 readerStackDepth.decrement();
             }
         } else {
             try {
-                executor().execute(readTask);
+                executor().execute(readNowTask);
             } catch (Throwable cause) {
                 logger.warn("Closing Local channels {}-{} because exception occurred!", this, peer, cause);
                 close();
@@ -398,7 +391,7 @@ public class LocalChannel extends AbstractChannel<LocalServerChannel, LocalAddre
         // forward data later on.
         if (peer.readInProgress && !peer.inboundBuffer.isEmpty()) {
             peer.readInProgress = false;
-            peer.readInbound();
+            peer.readNow();
         }
     }
 

--- a/transport/src/main/java/io/netty5/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty5/channel/local/LocalChannel.java
@@ -223,10 +223,10 @@ public class LocalChannel extends AbstractChannel<LocalServerChannel, LocalAddre
         do {
             Object received = inboundBuffer.poll();
             if (received == null) {
-                readSink.read(0, 0, null);
+                readSink.processRead(0, 0, null);
                 break;
             }
-            continueReading = readSink.read(0, 0, received);
+            continueReading = readSink.processRead(0, 0, received);
         } while (continueReading && !isShutdown(ChannelShutdownDirection.Inbound));
         return false;
     }

--- a/transport/src/main/java/io/netty5/channel/local/LocalServerChannel.java
+++ b/transport/src/main/java/io/netty5/channel/local/LocalServerChannel.java
@@ -108,10 +108,10 @@ public class LocalServerChannel extends AbstractServerChannel<LocalChannel, Loca
         do {
             Object m = inboundBuffer.poll();
             if (m == null) {
-                readSink.read(0, 0, null);
+                readSink.processRead(0, 0, null);
                 break;
             }
-            continueReading = readSink.read(0, 0, m);
+            continueReading = readSink.processRead(0, 0, m);
         } while (continueReading && !isShutdown(ChannelShutdownDirection.Inbound));
         return false;
     }

--- a/transport/src/main/java/io/netty5/channel/nio/AbstractNioByteChannel.java
+++ b/transport/src/main/java/io/netty5/channel/nio/AbstractNioByteChannel.java
@@ -69,7 +69,7 @@ public abstract class AbstractNioByteChannel<P extends Channel, L extends Socket
             do {
                 buffer = readBufferAllocator.allocate(bufferAllocator, readSink.estimatedBufferCapacity());
                 if (buffer == null) {
-                    readSink.read(0, 0, null);
+                    readSink.processRead(0, 0, null);
                     break;
                 }
                 int attemptedBytesRead = buffer.writableBytes();
@@ -78,12 +78,12 @@ public abstract class AbstractNioByteChannel<P extends Channel, L extends Socket
                     // nothing was read. release the buffer.
                     Resource.dispose(buffer);
                     buffer = null;
-                    readSink.read(attemptedBytesRead, actualBytesRead, null);
+                    readSink.processRead(attemptedBytesRead, actualBytesRead, null);
                     close = actualBytesRead < 0;
                     break;
                 }
 
-                continueReading = readSink.read(attemptedBytesRead, actualBytesRead, buffer);
+                continueReading = readSink.processRead(attemptedBytesRead, actualBytesRead, buffer);
                 buffer = null;
             } while (continueReading && !isShutdown(ChannelShutdownDirection.Inbound));
 

--- a/transport/src/main/java/io/netty5/channel/nio/AbstractNioMessageChannel.java
+++ b/transport/src/main/java/io/netty5/channel/nio/AbstractNioMessageChannel.java
@@ -17,27 +17,23 @@ package io.netty5.channel.nio;
 
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelOutboundBuffer;
-import io.netty5.channel.ChannelPipeline;
 import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.ReadBufferAllocator;
 import io.netty5.channel.ReadHandleFactory;
-import io.netty5.channel.ServerChannel;
 
-import java.io.IOException;
-import java.net.PortUnreachableException;
 import java.net.SocketAddress;
 import java.nio.channels.SelectableChannel;
 import java.nio.channels.SelectionKey;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 
 /**
  * {@link AbstractNioChannel} base class for {@link Channel}s that operate on messages.
  */
 public abstract class AbstractNioMessageChannel<P extends Channel, L extends SocketAddress, R extends SocketAddress>
         extends AbstractNioChannel<P, L, R> {
-    boolean inputShutdown;
     private final List<Object> readBuf = new ArrayList<>();
 
     /**
@@ -51,75 +47,24 @@ public abstract class AbstractNioMessageChannel<P extends Channel, L extends Soc
     }
 
     @Override
-    protected void doRead(ReadBufferAllocator readBufferAllocator) throws Exception {
-        if (inputShutdown) {
-            return;
-        }
-        super.doRead(readBufferAllocator);
-    }
-
-    @Override
-    protected final void readNow(ReadBufferAllocator readBufferAllocator) {
-        assert executor().inEventLoop();
-        final ChannelPipeline pipeline = pipeline();
-        final ReadHandleFactory.ReadHandle readHandle = readHandle();
-
+    protected final boolean doReadNow(ReadBufferAllocator readBufferAllocator, ReadSink readSink) throws Exception {
         boolean closed = false;
-        Throwable exception = null;
-        try {
-            try {
-                do {
-                    int localRead = doReadMessages(readHandle, readBufferAllocator, readBuf);
-                    if (localRead == 0) {
-                        break;
-                    }
-                    if (localRead < 0) {
-                        closed = true;
-                        break;
-                    }
-                } while (!isShutdown(ChannelShutdownDirection.Inbound));
-            } catch (Throwable t) {
-                exception = t;
+        do {
+            int localRead = doReadMessages(readBufferAllocator, readSink);
+            if (localRead == 0) {
+                break;
             }
+            if (localRead < 0) {
+                closed = true;
+                break;
+            }
+        } while (!isShutdown(ChannelShutdownDirection.Inbound));
 
-            int size = readBuf.size();
-            for (int i = 0; i < size; i ++) {
-                readPending = false;
-                pipeline.fireChannelRead(readBuf.get(i));
-            }
-            readBuf.clear();
-            readHandle.readComplete();
-            pipeline.fireChannelReadComplete();
-
-            if (exception != null) {
-                closed = closeOnReadError(exception);
-
-                pipeline.fireChannelExceptionCaught(exception);
-            }
-
-            if (closed) {
-                inputShutdown = true;
-                if (isOpen()) {
-                    closeTransport(newPromise());
-                }
-            } else {
-                readIfIsAutoRead();
-            }
-        } finally {
-            // Check if there is a readPending which was not processed yet.
-            // This could be for two reasons:
-            // * The user called Channel.read() or ChannelHandlerContext.read() in channelRead(...) method
-            // * The user called Channel.read() or ChannelHandlerContext.read() in channelReadComplete(...) method
-            //
-            // See https://github.com/netty/netty/issues/2254
-            if (!readPending && !isAutoRead()) {
-                removeReadOp();
-            }
-        }
+        return closed;
     }
 
     @Override
-    protected void doWrite(ChannelOutboundBuffer in) throws Exception {
+    protected final void doWrite(ChannelOutboundBuffer in) throws Exception {
         final SelectionKey key = selectionKey();
         if (key == null) {
             return;
@@ -176,27 +121,10 @@ public abstract class AbstractNioMessageChannel<P extends Channel, L extends Soc
         return false;
     }
 
-    protected boolean closeOnReadError(Throwable cause) {
-        if (!isActive()) {
-            // If the channel is not active anymore for whatever reason we should not try to continue reading.
-            return true;
-        }
-        if (cause instanceof PortUnreachableException) {
-            return false;
-        }
-        if (cause instanceof IOException) {
-            // ServerChannel should not be closed even on IOException because it can often continue
-            // accepting incoming connections. (e.g. too many open files)
-            return !(this instanceof ServerChannel);
-        }
-        return true;
-    }
-
     /**
      * Read messages into the given array and return the amount which was read.
      */
-    protected abstract int doReadMessages(ReadHandleFactory.ReadHandle readHandle,
-                                          ReadBufferAllocator readBufferAllocator, List<Object> buf) throws Exception;
+    protected abstract int doReadMessages(ReadBufferAllocator readBufferAllocator, ReadSink readSink) throws Exception;
 
     /**
      * Write a message to the underlying {@link java.nio.channels.Channel}.

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioDatagramChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioDatagramChannel.java
@@ -377,7 +377,7 @@ public final class NioDatagramChannel
     protected int doReadMessages(ReadBufferAllocator readBufferAllocator, ReadSink readSink) throws Exception {
         Buffer data = readBufferAllocator.allocate(bufferAllocator(), readSink.estimatedBufferCapacity());
         if (data == null) {
-            readSink.read(0, 0, null);
+            readSink.processRead(0, 0, null);
             return 0;
         }
         int attemptedBytesRead = data.writableBytes();
@@ -387,12 +387,12 @@ public final class NioDatagramChannel
             data.forEachWritable(0, receiveDatagram);
             SocketAddress remoteAddress = receiveDatagram.remoteAddress;
             if (remoteAddress == null) {
-                readSink.read(attemptedBytesRead, 0, null);
+                readSink.processRead(attemptedBytesRead, 0, null);
                 return -1;
             }
             int actualBytesRead = receiveDatagram.bytesReceived;
             data.skipWritableBytes(actualBytesRead);
-            if (readSink.read(attemptedBytesRead, actualBytesRead,
+            if (readSink.processRead(attemptedBytesRead, actualBytesRead,
                     new DatagramPacket(data, localAddress(), remoteAddress))) {
                 free = false;
                 return 1;

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioServerSocketChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioServerSocketChannel.java
@@ -241,7 +241,7 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel<Channel, S
         SocketChannel ch = SocketUtils.accept(javaChannel());
         try {
             if (ch != null) {
-                if (readSink.read(0, 0,
+                if (readSink.processRead(0, 0,
                         new NioSocketChannel(this, childEventLoopGroup().next(), ch, family))) {
                     return 1;
                 }
@@ -256,7 +256,7 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel<Channel, S
                 logger.warn("Failed to close a socket.", t2);
             }
         }
-        readSink.read(0, 0, null);
+        readSink.processRead(0, 0, null);
         return 0;
     }
 

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioServerSocketChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioServerSocketChannel.java
@@ -23,7 +23,6 @@ import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.EventLoopGroup;
 import io.netty5.channel.ReadBufferAllocator;
-import io.netty5.channel.ReadHandleFactory;
 import io.netty5.channel.ServerChannelReadHandleFactory;
 import io.netty5.channel.nio.AbstractNioMessageChannel;
 import io.netty5.util.NetUtil;
@@ -40,7 +39,6 @@ import java.nio.channels.SelectionKey;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import java.nio.channels.spi.SelectorProvider;
-import java.util.List;
 
 import static io.netty5.channel.ChannelOption.SO_BACKLOG;
 import static io.netty5.channel.socket.nio.NioChannelUtil.isDomainSocket;
@@ -239,18 +237,15 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel<Channel, S
     }
 
     @Override
-    protected int doReadMessages(ReadHandleFactory.ReadHandle readHandle, ReadBufferAllocator readBufferAllocator,
-                                 List<Object> buf) throws Exception {
+    protected int doReadMessages(ReadBufferAllocator readBufferAllocator, ReadSink readSink) throws Exception {
         SocketChannel ch = SocketUtils.accept(javaChannel());
         try {
             if (ch != null) {
-                buf.add(new NioSocketChannel(this, childEventLoopGroup().next(), ch, family));
-                if (readHandle.lastRead(0, 0, 1)) {
+                if (readSink.read(0, 0,
+                        new NioSocketChannel(this, childEventLoopGroup().next(), ch, family))) {
                     return 1;
                 }
                 return 0;
-            } else {
-                readHandle.lastRead(0, 0, 0);
             }
         } catch (Throwable t) {
             logger.warn("Failed to create a new channel from an accepted socket.", t);
@@ -261,7 +256,7 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel<Channel, S
                 logger.warn("Failed to close a socket.", t2);
             }
         }
-        readHandle.lastRead(0, 0, 0);
+        readSink.read(0, 0, null);
         return 0;
     }
 
@@ -295,16 +290,5 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel<Channel, S
     @Override
     protected final Object filterOutboundMessage(Object msg) {
         throw new UnsupportedOperationException();
-    }
-
-    @Override
-    protected void autoReadCleared() {
-        clearReadPending();
-    }
-
-    // Override just to to be able to call directly via unit tests.
-    @Override
-    protected boolean closeOnReadError(Throwable cause) {
-        return super.closeOnReadError(cause);
     }
 }

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioSocketChannel.java
@@ -408,11 +408,6 @@ public class NioSocketChannel
         return super.isExtendedOptionSupported(option);
     }
 
-    @Override
-    protected void autoReadCleared() {
-        clearReadPending();
-    }
-
     private volatile int maxBytesPerGatheringWrite = Integer.MAX_VALUE;
 
     void setMaxBytesPerGatheringWrite(int maxBytesPerGatheringWrite) {

--- a/transport/src/test/java/io/netty5/channel/AbstractChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/AbstractChannelTest.java
@@ -244,7 +244,12 @@ public class AbstractChannelTest {
         protected void doClose() { }
 
         @Override
-        protected void doRead(ReadBufferAllocator readBufferAllocator) { }
+        protected void doRead(boolean wasReadPendingAlready) { }
+
+        @Override
+        protected boolean doReadNow(ReadBufferAllocator readBufferAllocator, ReadSink readSink) {
+            return false;
+        }
 
         @Override
         protected void doWrite(ChannelOutboundBuffer in) throws Exception { }

--- a/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTailTest.java
+++ b/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTailTest.java
@@ -277,7 +277,12 @@ public class DefaultChannelPipelineTailTest {
         }
 
         @Override
-        protected void doRead(ReadBufferAllocator readBufferAllocator) throws Exception {
+        protected void doRead(boolean wasReadPendingAlready) throws Exception {
+        }
+
+        @Override
+        protected boolean doReadNow(ReadBufferAllocator readBufferAllocator, ReadSink readSink) {
+            return false;
         }
 
         @Override

--- a/transport/src/test/java/io/netty5/channel/socket/nio/NioServerSocketChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/socket/nio/NioServerSocketChannelTest.java
@@ -20,34 +20,15 @@ import io.netty5.channel.MultithreadEventLoopGroup;
 import io.netty5.channel.nio.NioHandler;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketOption;
 import java.net.StandardSocketOptions;
 import java.nio.channels.NetworkChannel;
-import java.nio.channels.ServerSocketChannel;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class NioServerSocketChannelTest extends AbstractNioChannelTest<NioServerSocketChannel> {
-
-    @Test
-    public void testCloseOnError() throws Exception {
-        ServerSocketChannel jdkChannel = ServerSocketChannel.open();
-        EventLoopGroup group = new MultithreadEventLoopGroup(1, NioHandler.newFactory());
-
-        NioServerSocketChannel serverSocketChannel = new NioServerSocketChannel(group.next(), group, jdkChannel);
-        try {
-            serverSocketChannel.register().asStage().sync();
-            serverSocketChannel.bind(new InetSocketAddress(0)).asStage().sync();
-            assertFalse(serverSocketChannel.closeOnReadError(new IOException()));
-            assertTrue(serverSocketChannel.closeOnReadError(new IllegalArgumentException()));
-            serverSocketChannel.close().asStage().sync();
-        } finally {
-            group.shutdownGracefully();
-        }
-    }
 
     @Test
     public void testIsActiveFalseAfterClose() throws Exception {


### PR DESCRIPTION
Motivation:

There was a lot of duplication in the different Channel implementation when it comes to handling reads. To make things more consistent and also easier for transport implementators we should move all the complexity into AbstractChannel.

Modifications:

- Introduce AbstractChannel.readNow(...) which should be called when there is data to read from the underlying transport (like a socket).
- Add writeFlushedNow() which should be called when the underlying transport becomes writable again
- Move readPending tracking and autoRead logic into AbstractChannel
- Thighten up access and visibility
- Remove a lot of code duplication

Result:

Cleaner and more consistent code. Beside this also easier to write a custom Channel / Transport implementation
