### PR TITLE
Fix DomainSocket handling in EpollDatagramChannel

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDatagramChannel.java
@@ -529,7 +529,8 @@ public final class EpollDatagramChannel extends AbstractEpollChannel<UnixChannel
                         // nothing was read, release the buffer.
                         buf.close();
                         readSink.processRead(attemptedBytesRead, actualBytesRead, null);
-                        return ReadState.Closed;
+
+                        return actualBytesRead == 0 ? ReadState.All : ReadState.Closed;
                     }
                     packet = new DatagramPacket(buf, localAddress(), remoteAddress());
                 } else {

--- a/transport/src/main/java/io/netty5/channel/nio/AbstractNioMessageChannel.java
+++ b/transport/src/main/java/io/netty5/channel/nio/AbstractNioMessageChannel.java
@@ -25,16 +25,12 @@ import io.netty5.channel.ReadHandleFactory;
 import java.net.SocketAddress;
 import java.nio.channels.SelectableChannel;
 import java.nio.channels.SelectionKey;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Consumer;
 
 /**
  * {@link AbstractNioChannel} base class for {@link Channel}s that operate on messages.
  */
 public abstract class AbstractNioMessageChannel<P extends Channel, L extends SocketAddress, R extends SocketAddress>
         extends AbstractNioChannel<P, L, R> {
-    private final List<Object> readBuf = new ArrayList<>();
 
     /**
      * @see AbstractNioChannel#AbstractNioChannel(Channel, EventLoop,


### PR DESCRIPTION
Motivation:

ab49cad152f83e6290476e2c93e4f6a4450bd29b introduced a bug when it comes to handling DomainSocket in EpollDatagramChannel and so closed the DatagramChannel when there was nothing to read anymore in some situations

Modifications:

- Fix logic in read loop
- Remove unused code

Result:

CI should be stable again
