### PR TITLE
Move allocation logic into ReadSink

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollServerSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollServerSocketChannel.java
@@ -15,7 +15,6 @@
  */
 package io.netty5.channel.epoll;
 
-import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelException;
 import io.netty5.channel.ChannelOption;
@@ -23,7 +22,6 @@ import io.netty5.channel.ChannelOutboundBuffer;
 import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.EventLoopGroup;
-import io.netty5.channel.ReadBufferAllocator;
 import io.netty5.channel.ServerChannelReadHandleFactory;
 import io.netty5.channel.socket.DomainSocketAddress;
 import io.netty5.channel.socket.ServerSocketChannel;
@@ -352,8 +350,7 @@ public final class EpollServerSocketChannel
     }
 
     @Override
-    protected ReadState epollInReady(ReadBufferAllocator readBufferAllocator, BufferAllocator recvBufferAllocator,
-                                     ReadSink readSink) throws Exception {
+    protected ReadState epollInReady(ReadSink readSink) throws Exception {
         boolean continueReading;
         do {
             int acceptedFd = socket.accept(acceptedAddress);

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollSocketChannel.java
@@ -25,7 +25,6 @@ import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.DefaultFileRegion;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.FileRegion;
-import io.netty5.channel.ReadBufferAllocator;
 import io.netty5.channel.internal.ChannelUtils;
 import io.netty5.channel.socket.SocketChannel;
 import io.netty5.channel.socket.SocketProtocolFamily;
@@ -515,17 +514,15 @@ public final class EpollSocketChannel
     }
 
     @Override
-    protected ReadState epollInReady(ReadBufferAllocator readBufferAllocator, BufferAllocator recvBufferAllocator,
-                                     ReadSink readSink) throws Exception {
+    protected ReadState epollInReady(ReadSink readSink) throws Exception {
         if (socket.protocolFamily() == SocketProtocolFamily.UNIX
                 && getReadMode() == DomainSocketReadMode.FILE_DESCRIPTORS) {
             return epollInReadFd(readSink);
         }
-        return epollInReadyBytes(readBufferAllocator, recvBufferAllocator, readSink);
+        return epollInReadyBytes(readSink);
     }
 
-    private ReadState epollInReadyBytes(ReadBufferAllocator readBufferAllocator,
-                                        BufferAllocator bufferAllocator, ReadSink readSink) throws Exception {
+    private ReadState epollInReadyBytes(ReadSink readSink) throws Exception {
         Buffer buffer = null;
         boolean readMore;
         try {
@@ -533,7 +530,7 @@ public final class EpollSocketChannel
             do {
                 // we use a direct buffer here as the native implementations only be able
                 // to handle direct buffers.
-                buffer = readBufferAllocator.allocate(bufferAllocator, readSink.estimatedBufferCapacity());
+                buffer = readSink.allocateBuffer();
                 if (buffer == null) {
                     readSink.processRead(0, 0, null);
                     return ReadState.Partial;

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDatagramChannel.java
@@ -16,7 +16,6 @@
 package io.netty5.channel.kqueue;
 
 import io.netty5.buffer.api.Buffer;
-import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.channel.AddressedEnvelope;
 import io.netty5.channel.ChannelException;
 import io.netty5.channel.ChannelOption;
@@ -25,7 +24,6 @@ import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.DefaultBufferAddressedEnvelope;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.FixedReadHandleFactory;
-import io.netty5.channel.ReadBufferAllocator;
 import io.netty5.channel.socket.DatagramPacket;
 import io.netty5.channel.socket.DatagramChannel;
 import io.netty5.channel.socket.DomainSocketAddress;
@@ -482,15 +480,14 @@ public final class KQueueDatagramChannel
     }
 
     @Override
-    int readReady(ReadBufferAllocator readBufferAllocator,
-                  BufferAllocator recvBufferAllocator, ReadSink readSink) throws Exception {
+    int readReady(ReadSink readSink) throws Exception {
         Buffer buffer = null;
         int totalReadyBytes = 0;
         try {
             boolean connected = isConnected();
             boolean continueReading;
             do {
-                buffer = readBufferAllocator.allocate(recvBufferAllocator, readSink.estimatedBufferCapacity());
+                buffer = readSink.allocateBuffer();
                 if (buffer == null) {
                     readSink.processRead(0, 0, null);
                     break;

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueServerSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueServerSocketChannel.java
@@ -15,7 +15,6 @@
  */
 package io.netty5.channel.kqueue;
 
-import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelException;
 import io.netty5.channel.ChannelOption;
@@ -23,7 +22,6 @@ import io.netty5.channel.ChannelOutboundBuffer;
 import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.EventLoopGroup;
-import io.netty5.channel.ReadBufferAllocator;
 import io.netty5.channel.ServerChannelReadHandleFactory;
 import io.netty5.channel.socket.DomainSocketAddress;
 import io.netty5.channel.socket.ServerSocketChannel;
@@ -366,8 +364,7 @@ public final class KQueueServerSocketChannel extends
     }
 
     @Override
-    int readReady(ReadBufferAllocator readBufferAllocator, BufferAllocator recvBufferAllocator,
-                  ReadSink readSink) throws Exception {
+    int readReady(ReadSink readSink) throws Exception {
         int totalBytesRead = 0;
         boolean continueReading;
         do {

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueSocketChannel.java
@@ -25,7 +25,6 @@ import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.DefaultFileRegion;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.FileRegion;
-import io.netty5.channel.ReadBufferAllocator;
 import io.netty5.channel.internal.ChannelUtils;
 import io.netty5.channel.socket.SocketChannel;
 import io.netty5.channel.socket.SocketProtocolFamily;
@@ -495,13 +494,12 @@ public final class KQueueSocketChannel
     }
 
     @Override
-    int readReady(ReadBufferAllocator readBufferAllocator,
-            BufferAllocator recvBufferAllocator, ReadSink readSink) throws Exception {
+    int readReady(ReadSink readSink) throws Exception {
         if (socket.protocolFamily() == SocketProtocolFamily.UNIX &&
                 getReadMode() == DomainSocketReadMode.FILE_DESCRIPTORS) {
             return readReadyFd(readSink);
         }
-        return readReadyBytes(readBufferAllocator, recvBufferAllocator, readSink);
+        return readReadyBytes(readSink);
     }
 
     private int readReadyFd(ReadSink readSink) throws Exception {
@@ -858,14 +856,13 @@ public final class KQueueSocketChannel
         }
     }
 
-    private int readReadyBytes(ReadBufferAllocator readBufferAllocator,
-            BufferAllocator recvBufferAllocator, ReadSink readSink) throws Exception {
+    private int readReadyBytes(ReadSink readSink) throws Exception {
         Buffer buffer = null;
         int totalBytesRead = 0;
         try {
             boolean continueReading;
             do {
-                buffer = readBufferAllocator.allocate(recvBufferAllocator, readSink.estimatedBufferCapacity());
+                buffer = readSink.allocateBuffer();
                 if (buffer == null) {
                     readSink.processRead(0, 0, null);
                     break;

--- a/transport/src/main/java/io/netty5/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty5/channel/embedded/EmbeddedChannel.java
@@ -19,7 +19,6 @@ import io.netty5.buffer.api.internal.ResourceSupport;
 import io.netty5.buffer.api.internal.Statics;
 import io.netty5.channel.AdaptiveReadHandleFactory;
 import io.netty5.channel.ChannelShutdownDirection;
-import io.netty5.channel.ReadBufferAllocator;
 import io.netty5.util.Resource;
 import io.netty5.channel.AbstractChannel;
 import io.netty5.channel.Channel;
@@ -718,7 +717,7 @@ public class EmbeddedChannel extends AbstractChannel<Channel, SocketAddress, Soc
     }
 
     @Override
-    protected boolean doReadNow(ReadBufferAllocator readBufferAllocator, ReadSink readSink) {
+    protected boolean doReadNow(ReadSink readSink) {
         return false;
     }
 

--- a/transport/src/main/java/io/netty5/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty5/channel/local/LocalChannel.java
@@ -18,7 +18,6 @@ package io.netty5.channel.local;
 import io.netty5.buffer.api.DefaultBufferAllocators;
 import io.netty5.channel.ChannelOption;
 import io.netty5.channel.ChannelShutdownDirection;
-import io.netty5.channel.ReadBufferAllocator;
 import io.netty5.util.ReferenceCounted;
 import io.netty5.util.Resource;
 import io.netty5.buffer.api.internal.ResourceSupport;
@@ -218,7 +217,7 @@ public class LocalChannel extends AbstractChannel<LocalServerChannel, LocalAddre
     }
 
     @Override
-    protected boolean doReadNow(ReadBufferAllocator readBufferAllocator, ReadSink readSink) {
+    protected boolean doReadNow(ReadSink readSink) {
         boolean continueReading;
         do {
             Object received = inboundBuffer.poll();

--- a/transport/src/main/java/io/netty5/channel/local/LocalServerChannel.java
+++ b/transport/src/main/java/io/netty5/channel/local/LocalServerChannel.java
@@ -21,7 +21,6 @@ import io.netty5.channel.ChannelOption;
 import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.EventLoopGroup;
-import io.netty5.channel.ReadBufferAllocator;
 import io.netty5.channel.ServerChannel;
 
 import java.net.SocketAddress;
@@ -103,7 +102,7 @@ public class LocalServerChannel extends AbstractServerChannel<LocalChannel, Loca
     }
 
     @Override
-    protected boolean doReadNow(ReadBufferAllocator allocator, ReadSink readSink) {
+    protected boolean doReadNow(ReadSink readSink) {
         boolean continueReading;
         do {
             Object m = inboundBuffer.poll();

--- a/transport/src/main/java/io/netty5/channel/nio/AbstractNioByteChannel.java
+++ b/transport/src/main/java/io/netty5/channel/nio/AbstractNioByteChannel.java
@@ -16,10 +16,8 @@
 package io.netty5.channel.nio;
 
 import io.netty5.buffer.api.Buffer;
-import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.channel.AdaptiveReadHandleFactory;
 import io.netty5.channel.ChannelShutdownDirection;
-import io.netty5.channel.ReadBufferAllocator;
 import io.netty5.util.Resource;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelOutboundBuffer;
@@ -59,15 +57,13 @@ public abstract class AbstractNioByteChannel<P extends Channel, L extends Socket
     }
 
     @Override
-    protected final boolean doReadNow(ReadBufferAllocator readBufferAllocator, ReadSink readSink) throws Exception {
-        final BufferAllocator bufferAllocator = bufferAllocator();
-
+    protected final boolean doReadNow(ReadSink readSink) throws Exception {
         Buffer buffer = null;
         boolean close = false;
         try {
             boolean continueReading;
             do {
-                buffer = readBufferAllocator.allocate(bufferAllocator, readSink.estimatedBufferCapacity());
+                buffer = readSink.allocateBuffer();
                 if (buffer == null) {
                     readSink.processRead(0, 0, null);
                     break;

--- a/transport/src/main/java/io/netty5/channel/nio/AbstractNioMessageChannel.java
+++ b/transport/src/main/java/io/netty5/channel/nio/AbstractNioMessageChannel.java
@@ -19,7 +19,6 @@ import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelOutboundBuffer;
 import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.EventLoop;
-import io.netty5.channel.ReadBufferAllocator;
 import io.netty5.channel.ReadHandleFactory;
 
 import java.net.SocketAddress;
@@ -43,10 +42,10 @@ public abstract class AbstractNioMessageChannel<P extends Channel, L extends Soc
     }
 
     @Override
-    protected final boolean doReadNow(ReadBufferAllocator readBufferAllocator, ReadSink readSink) throws Exception {
+    protected final boolean doReadNow(ReadSink readSink) throws Exception {
         boolean closed = false;
         do {
-            int localRead = doReadMessages(readBufferAllocator, readSink);
+            int localRead = doReadMessages(readSink);
             if (localRead == 0) {
                 break;
             }
@@ -120,7 +119,7 @@ public abstract class AbstractNioMessageChannel<P extends Channel, L extends Soc
     /**
      * Read messages into the given array and return the amount which was read.
      */
-    protected abstract int doReadMessages(ReadBufferAllocator readBufferAllocator, ReadSink readSink) throws Exception;
+    protected abstract int doReadMessages(ReadSink readSink) throws Exception;
 
     /**
      * Write a message to the underlying {@link java.nio.channels.Channel}.

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioDatagramChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioDatagramChannel.java
@@ -18,7 +18,6 @@ package io.netty5.channel.socket.nio;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.FixedReadHandleFactory;
-import io.netty5.channel.ReadBufferAllocator;
 import io.netty5.util.Resource;
 import io.netty5.buffer.api.WritableComponent;
 import io.netty5.buffer.api.WritableComponentProcessor;
@@ -374,8 +373,8 @@ public final class NioDatagramChannel
     }
 
     @Override
-    protected int doReadMessages(ReadBufferAllocator readBufferAllocator, ReadSink readSink) throws Exception {
-        Buffer data = readBufferAllocator.allocate(bufferAllocator(), readSink.estimatedBufferCapacity());
+    protected int doReadMessages(ReadSink readSink) throws Exception {
+        Buffer data = readSink.allocateBuffer();
         if (data == null) {
             readSink.processRead(0, 0, null);
             return 0;

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioServerSocketChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioServerSocketChannel.java
@@ -22,7 +22,6 @@ import io.netty5.channel.ChannelOutboundBuffer;
 import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.EventLoopGroup;
-import io.netty5.channel.ReadBufferAllocator;
 import io.netty5.channel.ServerChannelReadHandleFactory;
 import io.netty5.channel.nio.AbstractNioMessageChannel;
 import io.netty5.util.NetUtil;
@@ -237,7 +236,7 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel<Channel, S
     }
 
     @Override
-    protected int doReadMessages(ReadBufferAllocator readBufferAllocator, ReadSink readSink) throws Exception {
+    protected int doReadMessages(ReadSink readSink) throws Exception {
         SocketChannel ch = SocketUtils.accept(javaChannel());
         try {
             if (ch != null) {

--- a/transport/src/test/java/io/netty5/channel/AbstractChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/AbstractChannelTest.java
@@ -247,7 +247,7 @@ public class AbstractChannelTest {
         protected void doRead(boolean wasReadPendingAlready) { }
 
         @Override
-        protected boolean doReadNow(ReadBufferAllocator readBufferAllocator, ReadSink readSink) {
+        protected boolean doReadNow(ReadSink readSink) {
             return false;
         }
 

--- a/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTailTest.java
+++ b/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTailTest.java
@@ -281,7 +281,7 @@ public class DefaultChannelPipelineTailTest {
         }
 
         @Override
-        protected boolean doReadNow(ReadBufferAllocator readBufferAllocator, ReadSink readSink) {
+        protected boolean doReadNow(ReadSink readSink) {
             return false;
         }
 


### PR DESCRIPTION
Motivation:

We can simplify things for AbstractChannel sub-classes by moving allocation logic into ReadSink.

Modifications:

Move logic into ReadSink

Result:

Simplify