### PR TITLE
Remove ChannelOption.WRITE_SPIN_COUNT

### DIFF
--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/DefaultHttp2StreamChannel.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/DefaultHttp2StreamChannel.java
@@ -51,7 +51,6 @@ import java.util.Queue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 import static io.netty5.channel.ChannelOption.ALLOW_HALF_CLOSURE;
 import static io.netty5.channel.ChannelOption.AUTO_CLOSE;
@@ -62,7 +61,6 @@ import static io.netty5.channel.ChannelOption.MAX_MESSAGES_PER_WRITE;
 import static io.netty5.channel.ChannelOption.MESSAGE_SIZE_ESTIMATOR;
 import static io.netty5.channel.ChannelOption.READ_HANDLE_FACTORY;
 import static io.netty5.channel.ChannelOption.WRITE_BUFFER_WATER_MARK;
-import static io.netty5.channel.ChannelOption.WRITE_SPIN_COUNT;
 import static io.netty5.handler.codec.http2.Http2CodecUtil.isStreamIdValid;
 import static io.netty5.util.internal.ObjectUtil.checkPositive;
 import static io.netty5.util.internal.ObjectUtil.checkPositiveOrZero;
@@ -147,9 +145,6 @@ final class DefaultHttp2StreamChannel extends DefaultAttributeMap implements Htt
 
     private static final AtomicIntegerFieldUpdater<DefaultHttp2StreamChannel> AUTOREAD_UPDATER =
             AtomicIntegerFieldUpdater.newUpdater(DefaultHttp2StreamChannel.class, "autoRead");
-    private static final AtomicReferenceFieldUpdater<DefaultHttp2StreamChannel, WriteBufferWaterMark>
-            WATERMARK_UPDATER = AtomicReferenceFieldUpdater.newUpdater(
-                    DefaultHttp2StreamChannel.class, WriteBufferWaterMark.class, "writeBufferWaterMark");
 
     private volatile BufferAllocator bufferAllocator = DefaultBufferAllocators.preferredAllocator();
     private volatile ReadHandleFactory readHandleFactory = new AdaptiveReadHandleFactory();
@@ -993,9 +988,6 @@ final class DefaultHttp2StreamChannel extends DefaultAttributeMap implements Htt
         if (option == CONNECT_TIMEOUT_MILLIS) {
             return (T) Integer.valueOf(getConnectTimeoutMillis());
         }
-        if (option == WRITE_SPIN_COUNT) {
-            return (T) Integer.valueOf(getWriteSpinCount());
-        }
         if (option == BUFFER_ALLOCATOR) {
             return (T) getBufferAllocator();
         }
@@ -1029,8 +1021,6 @@ final class DefaultHttp2StreamChannel extends DefaultAttributeMap implements Htt
             setWriteBufferWaterMark((WriteBufferWaterMark) value);
         } else if (option == CONNECT_TIMEOUT_MILLIS) {
             setConnectTimeoutMillis((Integer) value);
-        } else if (option == WRITE_SPIN_COUNT) {
-            setWriteSpinCount((Integer) value);
         } else if (option == BUFFER_ALLOCATOR) {
             setBufferAllocator((BufferAllocator) value);
         } else if (option == READ_HANDLE_FACTORY) {
@@ -1050,7 +1040,7 @@ final class DefaultHttp2StreamChannel extends DefaultAttributeMap implements Htt
     @Override
     public boolean isOptionSupported(ChannelOption<?> option) {
         return option == AUTO_READ || option == WRITE_BUFFER_WATER_MARK || option == CONNECT_TIMEOUT_MILLIS ||
-                option == WRITE_SPIN_COUNT || option == BUFFER_ALLOCATOR ||
+                option == BUFFER_ALLOCATOR ||
                 option == READ_HANDLE_FACTORY || option == AUTO_CLOSE || option == MESSAGE_SIZE_ESTIMATOR ||
                 option == MAX_MESSAGES_PER_WRITE || option == ALLOW_HALF_CLOSURE;
     }

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexTest.java
@@ -854,10 +854,8 @@ public class Http2MultiplexTest {
 
         Channel childChannel = newOutboundStream(new ChannelHandler() { });
         childChannel.setOption(ChannelOption.AUTO_READ, false);
-        childChannel.setOption(ChannelOption.WRITE_SPIN_COUNT, 1000);
         childChannel.attr(key).set("bar");
         assertFalse(childChannel.getOption(ChannelOption.AUTO_READ));
-        assertEquals(1000, childChannel.getOption(ChannelOption.WRITE_SPIN_COUNT));
         assertEquals("bar", childChannel.attr(key).get());
     }
 

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
@@ -41,7 +41,6 @@ import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.UnresolvedAddressException;
 
-import static io.netty5.channel.internal.ChannelUtils.WRITE_STATUS_SNDBUF_FULL;
 import static io.netty5.channel.unix.UnixChannelUtil.computeRemoteAddr;
 import static io.netty5.util.CharsetUtil.UTF_8;
 import static java.util.Objects.requireNonNull;
@@ -274,7 +273,7 @@ abstract class AbstractEpollChannel<P extends UnixChannel>
             in.removeBytes(bytesWritten);
             return 1; // Some data was written to the socket.
         }
-        return WRITE_STATUS_SNDBUF_FULL;
+        return -1;
     }
 
     /**

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDatagramChannel.java
@@ -369,15 +369,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel<UnixChannel
                         continue;
                     }
                 }
-                boolean done = false;
-                for (int i = getWriteSpinCount(); i > 0; --i) {
-                    if (doWriteMessage(msg)) {
-                        done = true;
-                        break;
-                    }
-                }
-
-                if (done) {
+                if (doWriteMessage(msg)) {
                     in.remove();
                     maxMessagesPerWrite --;
                 } else {

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueChannel.java
@@ -38,7 +38,6 @@ import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.UnresolvedAddressException;
 
-import static io.netty5.channel.internal.ChannelUtils.WRITE_STATUS_SNDBUF_FULL;
 import static io.netty5.channel.unix.Limits.SSIZE_MAX;
 import static io.netty5.channel.unix.UnixChannelUtil.computeRemoteAddr;
 import static java.lang.Math.min;
@@ -315,7 +314,7 @@ abstract class AbstractKQueueChannel<P extends UnixChannel>
             in.removeBytes(bytesWritten);
             return 1; // Some data was written to the socket.
         }
-        return WRITE_STATUS_SNDBUF_FULL;
+        return -1;
     }
 
     final void readFilter(boolean readFilterEnabled) {

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDatagramChannel.java
@@ -644,15 +644,7 @@ public final class KQueueDatagramChannel
             }
 
             try {
-                boolean done = false;
-                for (int i = getWriteSpinCount(); i > 0; --i) {
-                    if (doWriteMessage(msg)) {
-                        done = true;
-                        break;
-                    }
-                }
-
-                if (done) {
+                if (doWriteMessage(msg)) {
                     in.remove();
                     maxMessagesPerWrite--;
                 } else {

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueSocketChannel.java
@@ -25,7 +25,6 @@ import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.DefaultFileRegion;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.FileRegion;
-import io.netty5.channel.internal.ChannelUtils;
 import io.netty5.channel.socket.SocketChannel;
 import io.netty5.channel.socket.SocketProtocolFamily;
 import io.netty5.channel.unix.DomainSocketReadMode;
@@ -63,7 +62,6 @@ import static io.netty5.channel.ChannelOption.SO_REUSEADDR;
 import static io.netty5.channel.ChannelOption.SO_SNDBUF;
 import static io.netty5.channel.ChannelOption.TCP_NODELAY;
 import static io.netty5.channel.internal.ChannelUtils.MAX_BYTES_PER_GATHERING_WRITE_ATTEMPTED_LOW_THRESHOLD;
-import static io.netty5.channel.internal.ChannelUtils.WRITE_STATUS_SNDBUF_FULL;
 import static io.netty5.channel.kqueue.KQueueChannelOption.SO_SNDLOWAT;
 import static io.netty5.channel.kqueue.KQueueChannelOption.TCP_NOPUSH;
 import static io.netty5.channel.unix.UnixChannelOption.DOMAIN_SOCKET_READ_MODE;
@@ -540,13 +538,12 @@ public final class KQueueSocketChannel
      * Write bytes form the given {@link Buffer} to the underlying {@link java.nio.channels.Channel}.
      * @param in the collection which contains objects to write.
      * @param buf the {@link Buffer} from which the bytes should be written
-     * @return The value that should be decremented from the write-quantum which starts at
-     * {@link #getWriteSpinCount()}. The typical use cases are as follows:
+     * @return write result.
      * <ul>
      *     <li>0 - if no write was attempted. This is appropriate if an empty {@link Buffer} (or other empty content)
      *     is encountered</li>
      *     <li>1 - if a single call to write data was made to the OS</li>
-     *     <li>{@link ChannelUtils#WRITE_STATUS_SNDBUF_FULL} - if an attempt to write data was made to the OS, but
+     *     <li>-1 - if an attempt to write data was made to the OS, but
      *     no data was accepted</li>
      * </ul>
      */
@@ -587,13 +584,12 @@ public final class KQueueSocketChannel
      * Write multiple bytes via {@link IovArray}.
      * @param in the collection which contains objects to write.
      * @param array The array which contains the content to write.
-     * @return The value that should be decremented from the write quantum which starts at
-     * {@link #getWriteSpinCount()}. The typical use cases are as follows:
+     * @return write result.
      * <ul>
      *     <li>0 - if no write was attempted. This is appropriate if an empty {@link Buffer} (or other empty content)
      *     is encountered</li>
      *     <li>1 - if a single call to write data was made to the OS</li>
-     *     <li>{@link ChannelUtils#WRITE_STATUS_SNDBUF_FULL} - if an attempt to write data was made to the OS, but
+     *     <li>-1 - if an attempt to write data was made to the OS, but
      *     no data was accepted</li>
      * </ul>
      * @throws IOException If an I/O exception occurs during write.
@@ -610,7 +606,7 @@ public final class KQueueSocketChannel
             in.removeBytes(localWrittenBytes);
             return 1;
         }
-        return WRITE_STATUS_SNDBUF_FULL;
+        return -1;
     }
 
     /**
@@ -620,13 +616,12 @@ public final class KQueueSocketChannel
      * @param nioBufferCnt The number of buffers to write.
      * @param expectedWrittenBytes The number of bytes we expect to write.
      * @param maxBytesPerGatheringWrite The maximum number of bytes we should attempt to write.
-     * @return The value that should be decremented from the write quantum which starts at
-     * {@link #getWriteSpinCount()}. The typical use cases are as follows:
+     * @return write result.
      * <ul>
      *     <li>0 - if no write was attempted. This is appropriate if an empty {@link Buffer} (or other empty content)
      *     is encountered</li>
      *     <li>1 - if a single call to write data was made to the OS</li>
-     *     <li>{@link ChannelUtils#WRITE_STATUS_SNDBUF_FULL} - if an attempt to write data was made to the OS, but
+     *     <li>-1 - if an attempt to write data was made to the OS, but
      *     no data was accepted</li>
      * </ul>
      * @throws IOException If an I/O exception occurs during write.
@@ -645,20 +640,19 @@ public final class KQueueSocketChannel
             in.removeBytes(localWrittenBytes);
             return 1;
         }
-        return WRITE_STATUS_SNDBUF_FULL;
+        return -1;
     }
 
     /**
      * Write a {@link DefaultFileRegion}
      * @param in the collection which contains objects to write.
      * @param region the {@link DefaultFileRegion} from which the bytes should be written
-     * @return The value that should be decremented from the write quantum which starts at
-     * {@link #getWriteSpinCount()}. The typical use cases are as follows:
+     * @return write result.
      * <ul>
      *     <li>0 - if no write was attempted. This is appropriate if an empty {@link Buffer} (or other empty content)
      *     is encountered</li>
      *     <li>1 - if a single call to write data was made to the OS</li>
-     *     <li>{@link ChannelUtils#WRITE_STATUS_SNDBUF_FULL} - if an attempt to write data was made to the OS, but
+     *     <li>-1 - if an attempt to write data was made to the OS, but
      *     no data was accepted</li>
      * </ul>
      */
@@ -682,20 +676,19 @@ public final class KQueueSocketChannel
         if (flushedAmount == 0) {
             validateFileRegion(region, offset);
         }
-        return WRITE_STATUS_SNDBUF_FULL;
+        return -1;
     }
 
     /**
      * Write a {@link FileRegion}
      * @param in the collection which contains objects to write.
      * @param region the {@link FileRegion} from which the bytes should be written
-     * @return The value that should be decremented from the write quantum which starts at
-     * {@link #getWriteSpinCount()}. The typical use cases are as follows:
+     * @return write result.
      * <ul>
      *     <li>0 - if no write was attempted. This is appropriate if an empty {@link Buffer} (or other empty content)
      *     is encountered</li>
      *     <li>1 - if a single call to write data was made to the OS</li>
-     *     <li>{@link ChannelUtils#WRITE_STATUS_SNDBUF_FULL} - if an attempt to write data was made to the OS, but no
+     *     <li>-1 - if an attempt to write data was made to the OS, but no
      *     data was accepted</li>
      * </ul>
      */
@@ -716,57 +709,45 @@ public final class KQueueSocketChannel
             }
             return 1;
         }
-        return WRITE_STATUS_SNDBUF_FULL;
+        return -1;
     }
 
     @Override
     protected void doWrite(ChannelOutboundBuffer in) throws Exception {
-        int writeSpinCount = getWriteSpinCount();
-        do {
+        while (!in.isEmpty()) {
             final int msgCount = in.size();
+            int result;
+
             // Do gathering write if the outbound buffer entries start with more than one Buffer.
             if (msgCount > 1 && in.current() instanceof Buffer) {
-                writeSpinCount -= doWriteMultiple(in);
+                result = doWriteMultiple(in);
             } else if (msgCount == 0) {
                 // Wrote all messages.
                 writeFilter(false);
                 // Return here so we don't set the WRITE flag.
                 return;
             } else { // msgCount == 1
-                writeSpinCount -= doWriteSingle(in);
+                result = doWriteSingle(in);
             }
-
-            // We do not break the loop here even if the outbound buffer was flushed completely,
-            // because a user might have triggered another write and flush when we notify his or her
-            // listeners.
-        } while (writeSpinCount > 0);
-
-        if (writeSpinCount == 0) {
-            // It is possible that we have set the write filter, woken up by KQUEUE because the socket is writable, and
-            // then use our write quantum. In this case we no longer want to set the write filter because the socket is
-            // still writable (as far as we know). We will find out next time we attempt to write if the socket is
-            // writable and set the write filter if necessary.
-            writeFilter(false);
-
-            // We used our writeSpin quantum, and should try to write again later.
-            executor().execute(flushTask);
-        } else {
-            // Underlying descriptor can not accept all data currently, so set the WRITE flag to be woken up
-            // when it can accept more data.
-            writeFilter(true);
+            if (result == -1) {
+                // Underlying descriptor can not accept all data currently, so set the WRITE flag to be woken up
+                // when it can accept more data.
+                writeFilter(true);
+                return;
+            }
         }
+        writeFilter(false);
     }
 
     /**
      * Attempt to write a single object.
      * @param in the collection which contains objects to write.
-     * @return The value that should be decremented from the write quantum which starts at
-     * {@link #getWriteSpinCount()}. The typical use cases are as follows:
+     * @return write result.
      * <ul>
      *     <li>0 - if no write was attempted. This is appropriate if an empty {@link Buffer} (or other empty content)
      *     is encountered</li>
      *     <li>1 - if a single call to write data was made to the OS</li>
-     *     <li>{@link ChannelUtils#WRITE_STATUS_SNDBUF_FULL} - if an attempt to write data was made to the OS, but no
+     *     <li>-1 - if an attempt to write data was made to the OS, but no
      *     data was accepted</li>
      * </ul>
      * @throws Exception If an I/O error occurs.
@@ -797,13 +778,12 @@ public final class KQueueSocketChannel
     /**
      * Attempt to write multiple {@link Buffer} objects.
      * @param in the collection which contains objects to write.
-     * @return The value that should be decremented from the write quantum which starts at
-     * {@link #getWriteSpinCount()}. The typical use cases are as follows:
+     * @return write result.
      * <ul>
      *     <li>0 - if no write was attempted. This is appropriate if an empty {@link Buffer} (or other empty content)
      *     is encountered</li>
      *     <li>1 - if a single call to write data was made to the OS</li>
-     *     <li>{@link ChannelUtils#WRITE_STATUS_SNDBUF_FULL} - if an attempt to write data was made to the OS, but no
+     *     <li>-1 - if an attempt to write data was made to the OS, but no
      *     data was accepted</li>
      * </ul>
      * @throws Exception If an I/O error occurs.

--- a/transport/src/main/java/io/netty5/channel/Channel.java
+++ b/transport/src/main/java/io/netty5/channel/Channel.java
@@ -97,8 +97,6 @@ import java.net.SocketAddress;
  * </tr><tr>
  * <td>{@link ChannelOption#CONNECT_TIMEOUT_MILLIS}</td>
  * </tr><tr>
- * <td>{@link ChannelOption#WRITE_SPIN_COUNT}</td>
- * </tr><tr>
  * <td>{@link ChannelOption#WRITE_BUFFER_WATER_MARK}</td>
  * </tr><tr>
  * <td>{@link ChannelOption#BUFFER_ALLOCATOR}</td>

--- a/transport/src/main/java/io/netty5/channel/ChannelOption.java
+++ b/transport/src/main/java/io/netty5/channel/ChannelOption.java
@@ -83,8 +83,6 @@ public class ChannelOption<T> extends AbstractConstant<ChannelOption<T>> {
 
     public static final ChannelOption<Integer> MAX_MESSAGES_PER_WRITE = valueOf("MAX_MESSAGES_PER_WRITE");
 
-    public static final ChannelOption<Integer> WRITE_SPIN_COUNT = valueOf("WRITE_SPIN_COUNT");
-
     public static final ChannelOption<WriteBufferWaterMark> WRITE_BUFFER_WATER_MARK =
             valueOf("WRITE_BUFFER_WATER_MARK");
 

--- a/transport/src/main/java/io/netty5/channel/internal/ChannelUtils.java
+++ b/transport/src/main/java/io/netty5/channel/internal/ChannelUtils.java
@@ -17,7 +17,6 @@ package io.netty5.channel.internal;
 
 public final class ChannelUtils {
     public static final int MAX_BYTES_PER_GATHERING_WRITE_ATTEMPTED_LOW_THRESHOLD = 4096;
-    public static final int WRITE_STATUS_SNDBUF_FULL = Integer.MAX_VALUE;
 
     private ChannelUtils() {
     }

--- a/transport/src/main/java/io/netty5/channel/nio/AbstractNioMessageChannel.java
+++ b/transport/src/main/java/io/netty5/channel/nio/AbstractNioMessageChannel.java
@@ -73,15 +73,7 @@ public abstract class AbstractNioMessageChannel<P extends Channel, L extends Soc
                 break;
             }
             try {
-                boolean done = false;
-                for (int i = getWriteSpinCount() - 1; i >= 0; i--) {
-                    if (doWriteMessage(msg, in)) {
-                        done = true;
-                        break;
-                    }
-                }
-
-                if (done) {
+                if (doWriteMessage(msg, in)) {
                     maxMessagesPerWrite--;
                     in.remove();
                 } else {


### PR DESCRIPTION
Motivation:

Let's remove the WRITE_SPIN_COUNT as it is actually harmful in practise and it is better to just stop writing and let other IO happen.

Modifications:

Remove the WRITE_SPIN_COUNT and its handling

Result:

Remove harmful feature