### PR TITLE
UnsafeBuffer don't need to zero memory on allocation

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/BufferAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/BufferAllocator.java
@@ -121,6 +121,12 @@ public interface BufferAllocator extends SafeCloseable {
      * is not enough free memory available to allocate a {@link Buffer} of the requested size.
      * <p>
      * The buffer will use big endian byte order.
+     * <p>
+     * <strong>Note:</strong> unlike the JDK {@link ByteBuffer}s, Netty {@code Buffers} are not guaranteed to be zeroed
+     * when allocated. In other words, the memory of a newly allocated buffer may contain garbage data from prior
+     * allocations, and the memory is likewise not guaranteed to be erased when the buffer is closed.
+     * If the data is sensitive and needs to be overwritten when the buffer is closed,
+     * then the buffer should be allocated with the {@link SensitiveBufferAllocator}.
      *
      * @param size The size of {@link Buffer} to allocate.
      * @return The newly allocated {@link Buffer}.

--- a/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeMemoryManager.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeMemoryManager.java
@@ -69,7 +69,6 @@ public final class UnsafeMemoryManager implements MemoryManager {
             base = null;
             address = PlatformDependent.allocateMemory(size);
             Statics.MEM_USAGE_NATIVE.add(size);
-            PlatformDependent.setMemory(address, size, (byte) 0);
             memory = new UnsafeMemory(base, address, size32);
             FreeAddress freeAddress = new FreeAddress(address, size32);
             if (FREE_IMMEDIATELY) {

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferBulkAccessTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferBulkAccessTest.java
@@ -337,7 +337,7 @@ public class BufferBulkAccessTest extends BufferTestSupport {
     @MethodSource("allocators")
     public void writeBytesMustWriteAllBytesFromByteArray(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buffer = allocator.allocate(8)) {
+             Buffer buffer = allocator.allocate(8).fill((byte) 0)) {
             buffer.writeByte((byte) 1);
             buffer.writeBytes(new byte[] {2, 3, 4, 5, 6, 7});
             assertThat(buffer.writerOffset()).isEqualTo(7);

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferByteOffsettedAccessorsTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferByteOffsettedAccessorsTest.java
@@ -246,7 +246,7 @@ public class BufferByteOffsettedAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void offsettedSetOfByteMustBoundsCheckWhenWriteOffsetIsNegative(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             assertEquals(Long.BYTES, buf.capacity());
             byte value = 0x01;
             assertThrows(IndexOutOfBoundsException.class, () -> buf.setByte(-1, value));
@@ -260,7 +260,7 @@ public class BufferByteOffsettedAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void offsettedSetOfByteMustBoundsCheckWhenWriteOffsetAndSizeIsBeyondCapacity(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             assertEquals(Long.BYTES, buf.capacity());
             byte value = 0x01;
             assertThrows(IndexOutOfBoundsException.class, () -> buf.setByte(8, value));
@@ -274,7 +274,7 @@ public class BufferByteOffsettedAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void offsettedSetOfByteMustHaveDefaultEndianByteOrder(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             byte value = 0x01;
             buf.setByte(0, value);
             buf.writerOffset(Long.BYTES);
@@ -293,7 +293,7 @@ public class BufferByteOffsettedAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void offsettedSetOfUnsignedByteMustBoundsCheckWhenWriteOffsetIsNegative(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             assertEquals(Long.BYTES, buf.capacity());
             int value = 0x01;
             assertThrows(IndexOutOfBoundsException.class, () -> buf.setUnsignedByte(-1, value));
@@ -307,7 +307,7 @@ public class BufferByteOffsettedAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void offsettedSetOfUnsignedByteMustBoundsCheckWhenWriteOffsetAndSizeIsBeyondCapacity(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             assertEquals(Long.BYTES, buf.capacity());
             int value = 0x01;
             assertThrows(IndexOutOfBoundsException.class, () -> buf.setUnsignedByte(8, value));
@@ -321,7 +321,7 @@ public class BufferByteOffsettedAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void offsettedSetOfUnsignedByteMustHaveDefaultEndianByteOrder(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             int value = 0x01;
             buf.setUnsignedByte(0, value);
             buf.writerOffset(Long.BYTES);

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferCharOffsettedAccessorsTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferCharOffsettedAccessorsTest.java
@@ -144,7 +144,7 @@ public class BufferCharOffsettedAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void offsettedSetOfCharMustBoundsCheckWhenWriteOffsetIsNegative(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             assertEquals(Long.BYTES, buf.capacity());
             char value = 0x0102;
             assertThrows(IndexOutOfBoundsException.class, () -> buf.setChar(-1, value));
@@ -158,7 +158,7 @@ public class BufferCharOffsettedAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void offsettedSetOfCharMustBoundsCheckWhenWriteOffsetAndSizeIsBeyondCapacity(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             assertEquals(Long.BYTES, buf.capacity());
             char value = 0x0102;
             assertThrows(IndexOutOfBoundsException.class, () -> buf.setChar(7, value));
@@ -172,7 +172,7 @@ public class BufferCharOffsettedAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void offsettedSetOfCharMustHaveDefaultEndianByteOrder(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             char value = 0x0102;
             buf.setChar(0, value);
             buf.writerOffset(Long.BYTES);

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferDoubleOffsettedAccessorsTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferDoubleOffsettedAccessorsTest.java
@@ -126,7 +126,7 @@ public class BufferDoubleOffsettedAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void offsettedSetOfDoubleMustBoundsCheckWhenWriteOffsetIsNegative(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             assertEquals(Long.BYTES, buf.capacity());
             double value = Double.longBitsToDouble(0x0102030405060708L);
             assertThrows(IndexOutOfBoundsException.class, () -> buf.setDouble(-1, value));
@@ -140,7 +140,7 @@ public class BufferDoubleOffsettedAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void offsettedSetOfDoubleMustBoundsCheckWhenWriteOffsetAndSizeIsBeyondCapacity(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             assertEquals(Long.BYTES, buf.capacity());
             double value = Double.longBitsToDouble(0x0102030405060708L);
             assertThrows(IndexOutOfBoundsException.class, () -> buf.setDouble(1, value));

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferFloatOffsettedAccessorsTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferFloatOffsettedAccessorsTest.java
@@ -145,7 +145,7 @@ public class BufferFloatOffsettedAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void offsettedSetOfFloatMustBoundsCheckWhenWriteOffsetIsNegative(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             assertEquals(Long.BYTES, buf.capacity());
             float value = Float.intBitsToFloat(0x01020304);
             assertThrows(IndexOutOfBoundsException.class, () -> buf.setFloat(-1, value));
@@ -159,7 +159,7 @@ public class BufferFloatOffsettedAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void offsettedSetOfFloatMustBoundsCheckWhenWriteOffsetAndSizeIsBeyondCapacity(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             assertEquals(Long.BYTES, buf.capacity());
             float value = Float.intBitsToFloat(0x01020304);
             assertThrows(IndexOutOfBoundsException.class, () -> buf.setFloat(5, value));
@@ -173,7 +173,7 @@ public class BufferFloatOffsettedAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void offsettedSetOfFloatMustHaveDefaultEndianByteOrder(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             float value = Float.intBitsToFloat(0x01020304);
             buf.setFloat(0, value);
             buf.writerOffset(Long.BYTES);

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferIntOffsettedAccessorsTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferIntOffsettedAccessorsTest.java
@@ -245,7 +245,7 @@ public class BufferIntOffsettedAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void offsettedSetOfIntMustBoundsCheckWhenWriteOffsetIsNegative(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             assertEquals(Long.BYTES, buf.capacity());
             int value = 0x01020304;
             assertThrows(IndexOutOfBoundsException.class, () -> buf.setInt(-1, value));
@@ -259,7 +259,7 @@ public class BufferIntOffsettedAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void offsettedSetOfIntMustBoundsCheckWhenWriteOffsetAndSizeIsBeyondCapacity(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             assertEquals(Long.BYTES, buf.capacity());
             int value = 0x01020304;
             assertThrows(IndexOutOfBoundsException.class, () -> buf.setInt(5, value));
@@ -273,7 +273,7 @@ public class BufferIntOffsettedAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void offsettedSetOfIntMustHaveDefaultEndianByteOrder(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             int value = 0x01020304;
             buf.setInt(0, value);
             buf.writerOffset(Long.BYTES);
@@ -292,7 +292,7 @@ public class BufferIntOffsettedAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void offsettedSetOfUnsignedIntMustBoundsCheckWhenWriteOffsetIsNegative(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             assertEquals(Long.BYTES, buf.capacity());
             long value = 0x01020304;
             assertThrows(IndexOutOfBoundsException.class, () -> buf.setUnsignedInt(-1, value));
@@ -306,7 +306,7 @@ public class BufferIntOffsettedAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void offsettedSetOfUnsignedIntMustBoundsCheckWhenWriteOffsetAndSizeIsBeyondCapacity(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             assertEquals(Long.BYTES, buf.capacity());
             long value = 0x01020304;
             assertThrows(IndexOutOfBoundsException.class, () -> buf.setUnsignedInt(5, value));
@@ -320,7 +320,7 @@ public class BufferIntOffsettedAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void offsettedSetOfUnsignedIntMustHaveDefaultEndianByteOrder(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             long value = 0x01020304;
             buf.setUnsignedInt(0, value);
             buf.writerOffset(Long.BYTES);

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferLongOffsettedAccessorsTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferLongOffsettedAccessorsTest.java
@@ -126,7 +126,7 @@ public class BufferLongOffsettedAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void offsettedSetOfLongMustBoundsCheckWhenWriteOffsetIsNegative(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             assertEquals(Long.BYTES, buf.capacity());
             long value = 0x0102030405060708L;
             assertThrows(IndexOutOfBoundsException.class, () -> buf.setLong(-1, value));
@@ -140,7 +140,7 @@ public class BufferLongOffsettedAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void offsettedSetOfLongMustBoundsCheckWhenWriteOffsetAndSizeIsBeyondCapacity(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             assertEquals(Long.BYTES, buf.capacity());
             long value = 0x0102030405060708L;
             assertThrows(IndexOutOfBoundsException.class, () -> buf.setLong(1, value));

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferMediumOffsettedAccessorsTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferMediumOffsettedAccessorsTest.java
@@ -265,7 +265,7 @@ public class BufferMediumOffsettedAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void offsettedSetOfMediumMustBoundsCheckWhenWriteOffsetIsNegative(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             assertEquals(Long.BYTES, buf.capacity());
             int value = 0x010203;
             assertThrows(IndexOutOfBoundsException.class, () -> buf.setMedium(-1, value));
@@ -279,7 +279,7 @@ public class BufferMediumOffsettedAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void offsettedSetOfMediumMustBoundsCheckWhenWriteOffsetAndSizeIsBeyondCapacity(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             assertEquals(Long.BYTES, buf.capacity());
             int value = 0x010203;
             assertThrows(IndexOutOfBoundsException.class, () -> buf.setMedium(6, value));
@@ -293,7 +293,7 @@ public class BufferMediumOffsettedAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void offsettedSetOfMediumMustHaveDefaultEndianByteOrder(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             int value = 0x010203;
             buf.setMedium(0, value);
             buf.writerOffset(Long.BYTES);
@@ -312,7 +312,7 @@ public class BufferMediumOffsettedAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void offsettedSetOfUnsignedMediumMustBoundsCheckWhenWriteOffsetIsNegative(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             assertEquals(Long.BYTES, buf.capacity());
             int value = 0x010203;
             assertThrows(IndexOutOfBoundsException.class, () -> buf.setUnsignedMedium(-1, value));
@@ -326,7 +326,7 @@ public class BufferMediumOffsettedAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void offsettedSetOfUnsignedMediumMustBoundsCheckWhenWriteOffsetAndSizeIsBeyondCapacity(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             assertEquals(Long.BYTES, buf.capacity());
             int value = 0x010203;
             assertThrows(IndexOutOfBoundsException.class, () -> buf.setUnsignedMedium(6, value));
@@ -340,7 +340,7 @@ public class BufferMediumOffsettedAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void offsettedSetOfUnsignedMediumMustHaveDefaultEndianByteOrder(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             int value = 0x010203;
             buf.setUnsignedMedium(0, value);
             buf.writerOffset(Long.BYTES);

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferPrimitiveRelativeAccessorsTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferPrimitiveRelativeAccessorsTest.java
@@ -227,7 +227,7 @@ public class BufferPrimitiveRelativeAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void relativeWriteOfByteMustHaveDefaultEndianByteOrder(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             byte value = 0x01;
             buf.writeByte(value);
             buf.writerOffset(Long.BYTES);
@@ -261,7 +261,7 @@ public class BufferPrimitiveRelativeAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void relativeWriteOfUnsignedByteMustHaveDefaultEndianByteOrder(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             int value = 0x01;
             buf.writeUnsignedByte(value);
             buf.writerOffset(Long.BYTES);
@@ -362,7 +362,7 @@ public class BufferPrimitiveRelativeAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void relativeWriteOfCharMustHaveDefaultEndianByteOrder(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             char value = 0x0102;
             buf.writeChar(value);
             buf.writerOffset(Long.BYTES);
@@ -544,7 +544,7 @@ public class BufferPrimitiveRelativeAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void relativeWriteOfShortMustHaveDefaultEndianByteOrder(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             short value = 0x0102;
             buf.writeShort(value);
             buf.writerOffset(Long.BYTES);
@@ -578,7 +578,7 @@ public class BufferPrimitiveRelativeAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void relativeWriteOfUnsignedShortMustHaveDefaultEndianByteOrder(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             int value = 0x0102;
             buf.writeUnsignedShort(value);
             buf.writerOffset(Long.BYTES);
@@ -760,7 +760,7 @@ public class BufferPrimitiveRelativeAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void relativeWriteOfMediumMustHaveDefaultEndianByteOrder(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             int value = 0x010203;
             buf.writeMedium(value);
             buf.writerOffset(Long.BYTES);
@@ -794,7 +794,7 @@ public class BufferPrimitiveRelativeAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void relativeWriteOfUnsignedMediumMustHaveDefaultEndianByteOrder(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             int value = 0x010203;
             buf.writeUnsignedMedium(value);
             buf.writerOffset(Long.BYTES);
@@ -976,7 +976,7 @@ public class BufferPrimitiveRelativeAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void relativeWriteOfIntMustHaveDefaultEndianByteOrder(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             int value = 0x01020304;
             buf.writeInt(value);
             buf.writerOffset(Long.BYTES);
@@ -1010,7 +1010,7 @@ public class BufferPrimitiveRelativeAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void relativeWriteOfUnsignedIntMustHaveDefaultEndianByteOrder(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             long value = 0x01020304;
             buf.writeUnsignedInt(value);
             buf.writerOffset(Long.BYTES);
@@ -1111,7 +1111,7 @@ public class BufferPrimitiveRelativeAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void relativeWriteOfFloatMustHaveDefaultEndianByteOrder(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             float value = Float.intBitsToFloat(0x01020304);
             buf.writeFloat(value);
             buf.writerOffset(Long.BYTES);

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferSearchTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferSearchTest.java
@@ -253,13 +253,13 @@ public class BufferSearchTest extends BufferTestSupport {
             try (Buffer buffer = allocator.allocate(0)) {
                 assertThat(buffer.bytesBefore(needle)).isEqualTo(-1);
             }
-            try (Buffer buffer = allocator.allocate(1).writerOffset(1)) {
+            try (Buffer buffer = allocator.allocate(1).fill((byte) 0).writerOffset(1)) {
                 assertThat(buffer.bytesBefore(needle)).isEqualTo(-1);
             }
-            try (Buffer buffer = allocator.allocate(2).writerOffset(2)) {
+            try (Buffer buffer = allocator.allocate(2).fill((byte) 0).writerOffset(2)) {
                 assertThat(buffer.bytesBefore(needle)).isEqualTo(-1);
             }
-            try (Buffer buffer = allocator.allocate(3).writerOffset(3)) {
+            try (Buffer buffer = allocator.allocate(3).fill((byte) 0).writerOffset(3)) {
                 assertThat(buffer.bytesBefore(needle)).isEqualTo(0);
             }
         }

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferShortOffsettedAccessorsTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferShortOffsettedAccessorsTest.java
@@ -263,7 +263,7 @@ public class BufferShortOffsettedAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void offsettedSetOfShortMustBoundsCheckWhenWriteOffsetIsNegative(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             assertEquals(Long.BYTES, buf.capacity());
             short value = 0x0102;
             assertThrows(IndexOutOfBoundsException.class, () -> buf.setShort(-1, value));
@@ -277,7 +277,7 @@ public class BufferShortOffsettedAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void offsettedSetOfShortMustBoundsCheckWhenWriteOffsetAndSizeIsBeyondCapacity(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             assertEquals(Long.BYTES, buf.capacity());
             short value = 0x0102;
             assertThrows(IndexOutOfBoundsException.class, () -> buf.setShort(7, value));
@@ -291,7 +291,7 @@ public class BufferShortOffsettedAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void offsettedSetOfShortMustHaveDefaultEndianByteOrder(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             short value = 0x0102;
             buf.setShort(0, value);
             buf.writerOffset(Long.BYTES);
@@ -310,7 +310,7 @@ public class BufferShortOffsettedAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void offsettedSetOfUnsignedShortMustBoundsCheckWhenWriteOffsetIsNegative(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             assertEquals(Long.BYTES, buf.capacity());
             int value = 0x0102;
             assertThrows(IndexOutOfBoundsException.class, () -> buf.setUnsignedShort(-1, value));
@@ -324,7 +324,7 @@ public class BufferShortOffsettedAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void offsettedSetOfUnsignedShortMustBoundsCheckWhenWriteOffsetAndSizeIsBeyondCapacity(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             assertEquals(Long.BYTES, buf.capacity());
             int value = 0x0102;
             assertThrows(IndexOutOfBoundsException.class, () -> buf.setUnsignedShort(7, value));
@@ -338,7 +338,7 @@ public class BufferShortOffsettedAccessorsTest extends BufferTestSupport {
     @MethodSource("allocators")
     void offsettedSetOfUnsignedShortMustHaveDefaultEndianByteOrder(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
+             Buffer buf = allocator.allocate(8).fill((byte) 0)) {
             int value = 0x0102;
             buf.setUnsignedShort(0, value);
             buf.writerOffset(Long.BYTES);

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferTestSupport.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferTestSupport.java
@@ -602,7 +602,7 @@ public abstract class BufferTestSupport {
                 buf.copyInto(0, buffer, 0, buffer.capacity());
             }
 
-            try (Buffer buffer = bbAlloc.apply(8)) {
+            try (Buffer buffer = bbAlloc.apply(8).fill((byte) 0)) {
                 buf.copyInto(0, buffer, 0, 0);
                 buffer.writerOffset(8);
                 assertEquals(0L, buffer.readLong());
@@ -621,7 +621,7 @@ public abstract class BufferTestSupport {
                 assertEquals((byte) 0x08, buffer.readByte());
             }
 
-            try (Buffer buffer = bbAlloc.apply(6)) {
+            try (Buffer buffer = bbAlloc.apply(6).fill((byte) 0)) {
                 buf.copyInto(1, buffer, 1, 3);
                 buffer.writerOffset(6);
                 assertEquals((byte) 0x00, buffer.readByte());
@@ -632,7 +632,7 @@ public abstract class BufferTestSupport {
                 assertEquals((byte) 0x00, buffer.readByte());
             }
 
-            try (Buffer buffer = bbAlloc.apply(6)) {
+            try (Buffer buffer = bbAlloc.apply(6).fill((byte) 0)) {
                 buffer.writerOffset(3).readerOffset(3);
                 buf.copyInto(1, buffer, 1, 3);
                 assertEquals(3, buffer.readerOffset());

--- a/pom.xml
+++ b/pom.xml
@@ -354,7 +354,7 @@
     <profile>
       <id>unsafeBuffer</id>
       <properties>
-        <argLine.java9>-Dio.netty5.tryReflectionSetAccessible=true --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED -Dio.netty5.buffer.api.MemoryManager=Unsafe</argLine.java9>
+        <argLine.java9.extras>-Dio.netty5.tryReflectionSetAccessible=true --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED -Dio.netty5.buffer.api.MemoryManager=Unsafe</argLine.java9.extras>
       </properties>
     </profile>
 


### PR DESCRIPTION
Motivation:
Our Buffer API (and the ByteBuf API before it) do not guarantee that newly allocated buffers are zeroed.
Our pooling buffer allocator already do not zero buffers when reusing them.
I discovered that our UnsafeMemoryManager did zeroing, and then I also discovered that Intellij did not properly activate the unsafeBuffer profile; it activated but had no effect.

Modification:
Remove zeroing from the UnsafeMemoryManager, when it allocates a new buffer.
Fix all of the tests that started failing.
Change the effect of activating the unsafeBuffer profile, so that it works around the different property resolution in Intellij.

Result:
Allocating unsafe, off-heap buffers is now faster, when not using pooling.
And the unsafeBuffer profile now has the effect you would expect, when enabled in Intellij.