### PR TITLE
Bump Brotli4j from 1.7.1 to 1.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -586,7 +586,7 @@
     <skipAutobahnTestsuite>false</skipAutobahnTestsuite>
     <skipHttp2Testsuite>false</skipHttp2Testsuite>
     <graalvm.version>19.3.6</graalvm.version>
-    <brotli4j.version>1.7.1</brotli4j.version>
+    <brotli4j.version>1.8.0</brotli4j.version>
     <!-- By default skip native testsuite as it requires a custom environment with graalvm installed -->
     <skipNativeImageTestsuite>true</skipNativeImageTestsuite>
     <skipShadingTestsuite>false</skipShadingTestsuite>


### PR DESCRIPTION
Motivation:
Brotli4j 1.8.0 has been released with native support for the Apple Silicon M1 chip.

Modification:
Upgraded to 1.8.0

Result:
Latest Brotli4j version
