### PR TITLE
Add WriteHandleFactory which allows more control over the write loop.

### DIFF
--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/DefaultHttp2StreamChannel.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/DefaultHttp2StreamChannel.java
@@ -449,7 +449,7 @@ final class DefaultHttp2StreamChannel extends DefaultAttributeMap implements Htt
 
     private ReadHandleFactory.ReadHandle readHandle() {
         if (readHandle == null) {
-            readHandle = readHandleFactory.newHandle();
+            readHandle = readHandleFactory.newHandle(this);
         }
         return readHandle;
     }

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/TestChannelInitializer.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/TestChannelInitializer.java
@@ -56,7 +56,7 @@ public class TestChannelInitializer extends ChannelInitializer<Channel> {
         }
 
         @Override
-        public ReadHandle newHandle() {
+        public ReadHandle newHandle(Channel channel) {
             return new ReadHandle() {
                 private int totalNumMessagesRead;
 

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketAutoReadTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketAutoReadTest.java
@@ -164,7 +164,7 @@ public class SocketAutoReadTest extends AbstractSocketTest {
      */
     private static final class TestReadHandleFactory implements ReadHandleFactory {
         @Override
-        public ReadHandle newHandle() {
+        public ReadHandle newHandle(Channel channel) {
             return new ReadHandle() {
 
                 @Override

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -595,7 +595,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
         }
 
         @Override
-        public ReadHandle newHandle() {
+        public ReadHandle newHandle(Channel channel) {
             return new ReadHandle() {
                 private int totalNumMessagesRead;
 

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketReadPendingTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketReadPendingTest.java
@@ -139,7 +139,7 @@ public class SocketReadPendingTest extends AbstractSocketTest {
         }
 
         @Override
-        public ReadHandle newHandle() {
+        public ReadHandle newHandle(Channel channel) {
             return new ReadHandle() {
                 private int totalNumMessagesRead;
 

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
@@ -36,6 +36,7 @@ import io.netty5.channel.unix.Socket;
 import io.netty5.channel.unix.UnixChannel;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
@@ -550,12 +551,16 @@ abstract class AbstractEpollChannel<P extends UnixChannel>
     }
 
     @Override
-    protected void writeLoopComplete(boolean allWritten) throws Exception {
+    protected void writeLoopComplete(boolean allWritten) {
         super.writeLoopComplete(allWritten);
-        if (allWritten) {
-            clearFlag(Native.EPOLLOUT);
-        } else {
-            setFlag(Native.EPOLLOUT);
+        try {
+            if (allWritten) {
+                clearFlag(Native.EPOLLOUT);
+            } else {
+                setFlag(Native.EPOLLOUT);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("Error while trying to update flags", e);
         }
     }
 

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
@@ -19,8 +19,8 @@ import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.buffer.api.DefaultBufferAllocators;
 import io.netty5.channel.ChannelOption;
-import io.netty5.channel.ReadBufferAllocator;
 import io.netty5.channel.ReadHandleFactory;
+import io.netty5.channel.WriteHandleFactory;
 import io.netty5.channel.socket.DomainSocketAddress;
 import io.netty5.channel.socket.SocketProtocolFamily;
 import io.netty5.channel.unix.IntegerUnixChannelOption;
@@ -70,13 +70,16 @@ abstract class AbstractEpollChannel<P extends UnixChannel>
     private volatile SocketAddress remoteAddress;
 
     AbstractEpollChannel(EventLoop eventLoop, boolean supportingDisconnect, int initialFlag,
-                         ReadHandleFactory defaultReadHandleFactory, LinuxSocket fd) {
-        this(null, eventLoop, supportingDisconnect, initialFlag, defaultReadHandleFactory, fd, false);
+                         ReadHandleFactory defaultReadHandleFactory, WriteHandleFactory defaultWriteHandleFactory,
+                         LinuxSocket fd) {
+        this(null, eventLoop, supportingDisconnect, initialFlag, defaultReadHandleFactory, defaultWriteHandleFactory,
+                fd, false);
     }
 
     AbstractEpollChannel(P parent, EventLoop eventLoop, boolean supportingDisconnect, int initialFlag,
-                         ReadHandleFactory defaultReadHandleFactory, LinuxSocket fd, boolean active) {
-        super(parent, eventLoop, supportingDisconnect, defaultReadHandleFactory);
+                         ReadHandleFactory defaultReadHandleFactory, WriteHandleFactory defaultWriteHandleFactory,
+                         LinuxSocket fd, boolean active) {
+        super(parent, eventLoop, supportingDisconnect, defaultReadHandleFactory, defaultWriteHandleFactory);
         flags |= initialFlag;
         socket = requireNonNull(fd, "fd");
         this.active = active;
@@ -89,8 +92,9 @@ abstract class AbstractEpollChannel<P extends UnixChannel>
     }
 
     AbstractEpollChannel(P parent, EventLoop eventLoop, boolean supportingDisconnect, int initialFlag,
-                         ReadHandleFactory defaultReadHandleFactory, LinuxSocket fd, SocketAddress remote) {
-        super(parent, eventLoop, supportingDisconnect, defaultReadHandleFactory);
+                         ReadHandleFactory defaultReadHandleFactory, WriteHandleFactory defaultWriteHandleFactory,
+                         LinuxSocket fd, SocketAddress remote) {
+        super(parent, eventLoop, supportingDisconnect, defaultReadHandleFactory, defaultWriteHandleFactory);
         flags |= initialFlag;
         socket = requireNonNull(fd, "fd");
         active = true;
@@ -284,9 +288,6 @@ abstract class AbstractEpollChannel<P extends UnixChannel>
         array.addReadable(data);
         int count = array.count();
         assert count != 0;
-        if (remoteAddress == null) {
-            return socket.writevAddresses(array.memoryAddress(0), count);
-        }
         if (socket.protocolFamily() == SocketProtocolFamily.UNIX) {
              return socket.sendToAddressesDomainSocket(
                     array.memoryAddress(0), count, ((DomainSocketAddress) remoteAddress)
@@ -545,6 +546,16 @@ abstract class AbstractEpollChannel<P extends UnixChannel>
             // so fire the exception through the pipeline and close the Channel.
             pipeline().fireChannelExceptionCaught(e);
             closeTransport(newPromise());
+        }
+    }
+
+    @Override
+    protected void writeLoopComplete(boolean allWritten) throws Exception {
+        super.writeLoopComplete(allWritten);
+        if (allWritten) {
+            clearFlag(Native.EPOLLOUT);
+        } else {
+            setFlag(Native.EPOLLOUT);
         }
     }
 

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollServerSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollServerSocketChannel.java
@@ -23,6 +23,8 @@ import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.EventLoopGroup;
 import io.netty5.channel.ServerChannelReadHandleFactory;
+import io.netty5.channel.ServerChannelWriteHandleFactory;
+import io.netty5.channel.WriteHandleFactory;
 import io.netty5.channel.socket.DomainSocketAddress;
 import io.netty5.channel.socket.ServerSocketChannel;
 import io.netty5.channel.socket.SocketProtocolFamily;
@@ -103,14 +105,15 @@ public final class EpollServerSocketChannel
     private volatile Collection<InetAddress> tcpMd5SigAddresses = Collections.emptyList();
 
     public EpollServerSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup) {
-        super(eventLoop, false, 0, new ServerChannelReadHandleFactory(), LinuxSocket.newSocketStream());
+        super(eventLoop, false, 0, new ServerChannelReadHandleFactory(), new ServerChannelWriteHandleFactory(),
+                LinuxSocket.newSocketStream());
         this.childEventLoopGroup = validateEventLoopGroup(
                 childEventLoopGroup, "childEventLoopGroup", EpollSocketChannel.class);
     }
 
     public EpollServerSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup,
                                     ProtocolFamily protocolFamily) {
-        super(null, eventLoop, false, 0, new ServerChannelReadHandleFactory(),
+        super(null, eventLoop, false, 0, new ServerChannelReadHandleFactory(), new ServerChannelWriteHandleFactory(),
                 LinuxSocket.newSocket(protocolFamily), false);
         this.childEventLoopGroup = validateEventLoopGroup(
                 childEventLoopGroup, "childEventLoopGroup", EpollSocketChannel.class);
@@ -124,7 +127,8 @@ public final class EpollServerSocketChannel
     private EpollServerSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup, LinuxSocket socket) {
         // Must call this constructor to ensure this object's local address is configured correctly.
         // The local address can only be obtained from a Socket object.
-        super(null, eventLoop, false, 0, new ServerChannelReadHandleFactory(), socket, isSoErrorZero(socket));
+        super(null, eventLoop, false, 0, new ServerChannelReadHandleFactory(), new ServerChannelWriteHandleFactory(),
+                socket, isSoErrorZero(socket));
         this.childEventLoopGroup = validateEventLoopGroup(childEventLoopGroup, "childEventLoopGroup",
                 EpollSocketChannel.class);
     }
@@ -340,7 +344,7 @@ public final class EpollServerSocketChannel
     }
 
     @Override
-    protected void doWrite(ChannelOutboundBuffer in) {
+    protected void doWrite(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle) {
         throw new UnsupportedOperationException();
     }
 

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/NativeDatagramPacketArray.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/NativeDatagramPacketArray.java
@@ -264,6 +264,10 @@ final class NativeDatagramPacketArray {
             return senderPort > 0;
         }
 
+        int count() {
+            return count;
+        }
+
         DatagramPacket newDatagramPacket(Buffer buffer, InetSocketAddress recipient) throws UnknownHostException {
             InetSocketAddress sender = newAddress(senderAddr, senderAddrLen, senderPort, senderScopeId, ipv4Bytes);
             if (recipientAddrLen != 0) {

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueChannel.java
@@ -525,7 +525,7 @@ abstract class AbstractKQueueChannel<P extends UnixChannel>
     }
 
     @Override
-    protected final void writeLoopComplete(boolean allWritten) throws Exception {
+    protected final void writeLoopComplete(boolean allWritten) {
         writeFilter(!allWritten);
         super.writeLoopComplete(allWritten);
     }

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueChannel.java
@@ -20,6 +20,7 @@ import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.buffer.api.DefaultBufferAllocators;
 import io.netty5.channel.ChannelOption;
 import io.netty5.channel.ReadHandleFactory;
+import io.netty5.channel.WriteHandleFactory;
 import io.netty5.channel.kqueue.KQueueReadHandleFactory.KQueueReadHandle;
 import io.netty5.channel.socket.SocketProtocolFamily;
 import io.netty5.channel.unix.IntegerUnixChannelOption;
@@ -38,7 +39,6 @@ import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.UnresolvedAddressException;
 
-import static io.netty5.channel.unix.Limits.SSIZE_MAX;
 import static io.netty5.channel.unix.UnixChannelUtil.computeRemoteAddr;
 import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
@@ -49,8 +49,6 @@ abstract class AbstractKQueueChannel<P extends UnixChannel>
     final BsdSocket socket;
 
     protected volatile boolean active;
-
-    private volatile long maxBytesPerGatheringWrite = SSIZE_MAX;
 
     private volatile SocketAddress localAddress;
     private volatile SocketAddress remoteAddress;
@@ -75,8 +73,9 @@ abstract class AbstractKQueueChannel<P extends UnixChannel>
     private boolean eof;
 
     AbstractKQueueChannel(P parent, EventLoop eventLoop, boolean supportsDisconnect,
-                          ReadHandleFactory defaultReadHandleFactory, BsdSocket fd, boolean active) {
-        super(parent, eventLoop, supportsDisconnect, defaultReadHandleFactory);
+                          ReadHandleFactory defaultReadHandleFactory, WriteHandleFactory defaultWriteHandleFactory,
+                          BsdSocket fd, boolean active) {
+        super(parent, eventLoop, supportsDisconnect, defaultReadHandleFactory, defaultWriteHandleFactory);
         socket = requireNonNull(fd, "fd");
         this.active = active;
         if (active) {
@@ -88,8 +87,9 @@ abstract class AbstractKQueueChannel<P extends UnixChannel>
     }
 
     AbstractKQueueChannel(P parent, EventLoop eventLoop, boolean supportsDisconnect,
-                          ReadHandleFactory defaultReadHandleFactory, BsdSocket fd, SocketAddress remote) {
-        super(parent, eventLoop, supportsDisconnect, defaultReadHandleFactory);
+                          ReadHandleFactory defaultReadHandleFactory, WriteHandleFactory defaultWriteHandleFactory,
+                          BsdSocket fd, SocketAddress remote) {
+        super(parent, eventLoop, supportsDisconnect, defaultReadHandleFactory, defaultWriteHandleFactory);
         socket = requireNonNull(fd, "fd");
         active = true;
         // Directly cache the remote and local addresses
@@ -142,14 +142,6 @@ abstract class AbstractKQueueChannel<P extends UnixChannel>
             return true;
         }
         return super.isExtendedOptionSupported(option);
-    }
-
-    protected final void setMaxBytesPerGatheringWrite(long maxBytesPerGatheringWrite) {
-        this.maxBytesPerGatheringWrite = min(SSIZE_MAX, maxBytesPerGatheringWrite);
-    }
-
-    protected final long getMaxBytesPerGatheringWrite() {
-        return maxBytesPerGatheringWrite;
     }
 
     static boolean isSoErrorZero(BsdSocket fd) {
@@ -237,7 +229,7 @@ abstract class AbstractKQueueChannel<P extends UnixChannel>
         writeFilterEnabled = false;
     }
 
-    final void unregisterFilters() throws Exception {
+    final void unregisterFilters() {
         // Make sure we unregister our filters from kqueue!
         readFilter(false);
         writeFilter(false);
@@ -530,6 +522,12 @@ abstract class AbstractKQueueChannel<P extends UnixChannel>
     @Override
     protected final void doClearScheduledRead() {
         readFilter(false);
+    }
+
+    @Override
+    protected final void writeLoopComplete(boolean allWritten) throws Exception {
+        writeFilter(!allWritten);
+        super.writeLoopComplete(allWritten);
     }
 
     final void closeTransportNow() {

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueServerSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueServerSocketChannel.java
@@ -23,6 +23,8 @@ import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.EventLoopGroup;
 import io.netty5.channel.ServerChannelReadHandleFactory;
+import io.netty5.channel.ServerChannelWriteHandleFactory;
+import io.netty5.channel.WriteHandleFactory;
 import io.netty5.channel.socket.DomainSocketAddress;
 import io.netty5.channel.socket.ServerSocketChannel;
 import io.netty5.channel.socket.SocketProtocolFamily;
@@ -98,7 +100,7 @@ public final class KQueueServerSocketChannel extends
     private volatile boolean enableTcpFastOpen;
 
     public KQueueServerSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup) {
-        super(null, eventLoop, false, new ServerChannelReadHandleFactory(),
+        super(null, eventLoop, false, new ServerChannelReadHandleFactory(), new ServerChannelWriteHandleFactory(),
                 newSocketStream(), false);
         this.childEventLoopGroup = validateEventLoopGroup(childEventLoopGroup, "childEventLoopGroup",
                 KQueueSocketChannel.class);
@@ -106,7 +108,7 @@ public final class KQueueServerSocketChannel extends
 
     public KQueueServerSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup,
                                      ProtocolFamily protocolFamily) {
-        super(null, eventLoop, false, new ServerChannelReadHandleFactory(),
+        super(null, eventLoop, false, new ServerChannelReadHandleFactory(), new ServerChannelWriteHandleFactory(),
                 BsdSocket.newSocket(protocolFamily), false);
         this.childEventLoopGroup = validateEventLoopGroup(childEventLoopGroup, "childEventLoopGroup",
                 KQueueSocketChannel.class);
@@ -122,7 +124,8 @@ public final class KQueueServerSocketChannel extends
     private KQueueServerSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup, BsdSocket socket) {
         // Must call this constructor to ensure this object's local address is configured correctly.
         // The local address can only be obtained from a Socket object.
-        super(null, eventLoop, false, new ServerChannelReadHandleFactory(), socket, isSoErrorZero(socket));
+        super(null, eventLoop, false, new ServerChannelReadHandleFactory(), new ServerChannelWriteHandleFactory(),
+                socket, isSoErrorZero(socket));
         this.childEventLoopGroup = validateEventLoopGroup(childEventLoopGroup, "childEventLoopGroup",
                 KQueueSocketChannel.class);
     }
@@ -339,7 +342,7 @@ public final class KQueueServerSocketChannel extends
     }
 
     @Override
-    protected void doWrite(ChannelOutboundBuffer in) {
+    protected void doWrite(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle) {
         throw new UnsupportedOperationException();
     }
 

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueSocketChannel.java
@@ -25,7 +25,9 @@ import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.DefaultFileRegion;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.FileRegion;
+import io.netty5.channel.WriteHandleFactory;
 import io.netty5.channel.socket.SocketChannel;
+import io.netty5.channel.socket.SocketChannelWriteHandleFactory;
 import io.netty5.channel.socket.SocketProtocolFamily;
 import io.netty5.channel.unix.DomainSocketReadMode;
 import io.netty5.channel.unix.FileDescriptor;
@@ -61,9 +63,9 @@ import static io.netty5.channel.ChannelOption.SO_RCVBUF;
 import static io.netty5.channel.ChannelOption.SO_REUSEADDR;
 import static io.netty5.channel.ChannelOption.SO_SNDBUF;
 import static io.netty5.channel.ChannelOption.TCP_NODELAY;
-import static io.netty5.channel.internal.ChannelUtils.MAX_BYTES_PER_GATHERING_WRITE_ATTEMPTED_LOW_THRESHOLD;
 import static io.netty5.channel.kqueue.KQueueChannelOption.SO_SNDLOWAT;
 import static io.netty5.channel.kqueue.KQueueChannelOption.TCP_NOPUSH;
+import static io.netty5.channel.unix.Limits.SSIZE_MAX;
 import static io.netty5.channel.unix.UnixChannelOption.DOMAIN_SOCKET_READ_MODE;
 import static java.util.Objects.requireNonNull;
 
@@ -105,10 +107,6 @@ public final class KQueueSocketChannel
                     StringUtil.simpleClassName(DefaultFileRegion.class) + ')';
     private WritableByteChannel byteChannel;
 
-    // Calling flush0 directly to ensure we not try to flush messages that were added via write(...) in the
-    // meantime.
-    private final Runnable flushTask = this::writeFlushed;
-
     private volatile DomainSocketReadMode mode = DomainSocketReadMode.BYTES;
 
     private volatile boolean tcpFastopen;
@@ -118,9 +116,10 @@ public final class KQueueSocketChannel
     }
 
     public KQueueSocketChannel(EventLoop eventLoop, ProtocolFamily protocolFamily) {
-        super(null, eventLoop, false, new AdaptiveReadHandleFactory(), BsdSocket.newSocket(protocolFamily), false);
+        super(null, eventLoop, false, new AdaptiveReadHandleFactory(),
+                new SocketChannelWriteHandleFactory(Integer.MAX_VALUE, SSIZE_MAX),
+                BsdSocket.newSocket(protocolFamily), false);
         enableTcpNoDelayIfSupported();
-        calculateMaxBytesPerGatheringWrite();
     }
 
     public KQueueSocketChannel(EventLoop eventLoop, int fd, ProtocolFamily protocolFamily) {
@@ -128,16 +127,16 @@ public final class KQueueSocketChannel
     }
 
     private KQueueSocketChannel(EventLoop eventLoop, BsdSocket fd) {
-        super(null, eventLoop, false, new AdaptiveReadHandleFactory(), fd, isSoErrorZero(fd));
+        super(null, eventLoop, false, new AdaptiveReadHandleFactory(),
+                new SocketChannelWriteHandleFactory(Integer.MAX_VALUE), fd, isSoErrorZero(fd));
         enableTcpNoDelayIfSupported();
-        calculateMaxBytesPerGatheringWrite();
     }
 
     KQueueSocketChannel(KQueueServerSocketChannel parent, EventLoop eventLoop,
                         BsdSocket fd, SocketAddress remoteAddress) {
-        super(parent, eventLoop, false, new AdaptiveReadHandleFactory(), fd, remoteAddress);
+        super(parent, eventLoop, false, new AdaptiveReadHandleFactory(),
+                new SocketChannelWriteHandleFactory(Integer.MAX_VALUE), fd, remoteAddress);
         enableTcpNoDelayIfSupported();
-        calculateMaxBytesPerGatheringWrite();
     }
 
     private void enableTcpNoDelayIfSupported() {
@@ -370,7 +369,6 @@ public final class KQueueSocketChannel
     private void setSendBufferSize(int sendBufferSize) {
         try {
             socket.setSendBufferSize(sendBufferSize);
-            calculateMaxBytesPerGatheringWrite();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -412,14 +410,6 @@ public final class KQueueSocketChannel
      */
     private boolean isTcpFastOpenConnect() {
         return tcpFastopen;
-    }
-
-    private void calculateMaxBytesPerGatheringWrite() {
-        // Multiply by 2 to give some extra space in case the OS can process write data faster than we can provide.
-        int newSendBufferSize = getSendBufferSize() << 1;
-        if (newSendBufferSize > 0) {
-            setMaxBytesPerGatheringWrite(getSendBufferSize() << 1);
-        }
     }
 
     @Override
@@ -537,66 +527,54 @@ public final class KQueueSocketChannel
     /**
      * Write bytes form the given {@link Buffer} to the underlying {@link java.nio.channels.Channel}.
      * @param in the collection which contains objects to write.
+     * @param writeHandle the {@link WriteHandleFactory.WriteHandle} used to track write results.
      * @param buf the {@link Buffer} from which the bytes should be written
-     * @return write result.
-     * <ul>
-     *     <li>0 - if no write was attempted. This is appropriate if an empty {@link Buffer} (or other empty content)
-     *     is encountered</li>
-     *     <li>1 - if a single call to write data was made to the OS</li>
-     *     <li>-1 - if an attempt to write data was made to the OS, but
-     *     no data was accepted</li>
-     * </ul>
+     * @return if we should continue with writing more messages.
      */
-    private int writeBytes(ChannelOutboundBuffer in, Buffer buf) throws Exception {
+    private boolean writeBytes(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle, Buffer buf)
+            throws Exception {
         int readableBytes = buf.readableBytes();
         if (readableBytes == 0) {
             in.remove();
-            return 0;
+            return writeHandle.lastWrite(0, 0, 1);
         }
 
         int readableComponents = buf.countReadableComponents();
+        long attempted;
+        long written;
         if (readableComponents == 1) {
-            return doWriteBytes(in, buf);
-        }
-        ByteBuffer[] nioBuffers = new ByteBuffer[readableComponents];
-        int index = 0;
-        try (var iteration = buf.forEachComponent()) {
-            for (var c = iteration.firstReadable(); c != null; c = c.nextReadable()) {
-                nioBuffers[index++] = c.readableBuffer();
+            attempted = buf.readableBytes();
+            written = doWriteBytes(in, buf);
+        }  else {
+            attempted = Math.min(writeHandle.estimatedMaxBytesPerGatheringWrite(), buf.readableBytes());
+            ByteBuffer[] nioBuffers = new ByteBuffer[readableComponents];
+            try (var iteration = buf.forEachComponent()) {
+                int index = 0;
+                for (var c = iteration.first(); c != null; c = c.next()) {
+                    nioBuffers[index++] = c.readableBuffer();
+                }
+                return writeBytesMultiple(in, writeHandle, nioBuffers, nioBuffers.length, readableBytes, attempted);
             }
         }
-        return writeBytesMultiple(in, nioBuffers, nioBuffers.length, readableBytes,
-                getMaxBytesPerGatheringWrite());
-    }
 
-    private void adjustMaxBytesPerGatheringWrite(long attempted, long written, long oldMaxBytesPerGatheringWrite) {
-        // By default we track the SO_SNDBUF when ever it is explicitly set. However some OSes may dynamically change
-        // SO_SNDBUF (and other characteristics that determine how much data can be written at once) so we should try
-        // make a best effort to adjust as OS behavior changes.
-        if (attempted == written) {
-            if (attempted << 1 > oldMaxBytesPerGatheringWrite) {
-                setMaxBytesPerGatheringWrite(attempted << 1);
-            }
-        } else if (attempted > MAX_BYTES_PER_GATHERING_WRITE_ATTEMPTED_LOW_THRESHOLD && written < attempted >>> 1) {
-            setMaxBytesPerGatheringWrite(attempted >>> 1);
+        if (written > 0) {
+            return writeHandle.lastWrite(attempted, written, 1);
         }
+        writeHandle.lastWrite(attempted, written, 0);
+        return false;
     }
 
     /**
      * Write multiple bytes via {@link IovArray}.
      * @param in the collection which contains objects to write.
+     * @param writeHandle the {@link WriteHandleFactory.WriteHandle} used to track write results.
      * @param array The array which contains the content to write.
-     * @return write result.
-     * <ul>
-     *     <li>0 - if no write was attempted. This is appropriate if an empty {@link Buffer} (or other empty content)
-     *     is encountered</li>
-     *     <li>1 - if a single call to write data was made to the OS</li>
-     *     <li>-1 - if an attempt to write data was made to the OS, but
-     *     no data was accepted</li>
-     * </ul>
+     * @return if we should continue with writing more messages.
      * @throws IOException If an I/O exception occurs during write.
      */
-    private int writeBytesMultiple(ChannelOutboundBuffer in, IovArray array) throws IOException {
+    private boolean writeBytesMultiple(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle,
+                                       IovArray array)
+            throws IOException {
         final long expectedWrittenBytes = array.size();
         assert expectedWrittenBytes != 0;
         final int cnt = array.count();
@@ -604,32 +582,28 @@ public final class KQueueSocketChannel
 
         final long localWrittenBytes = socket.writevAddresses(array.memoryAddress(0), cnt);
         if (localWrittenBytes > 0) {
-            adjustMaxBytesPerGatheringWrite(expectedWrittenBytes, localWrittenBytes, array.maxBytes());
             in.removeBytes(localWrittenBytes);
-            return 1;
+            int numMessages = array.writtenMessages(0, localWrittenBytes);
+            return writeHandle.lastWrite(expectedWrittenBytes, localWrittenBytes, numMessages);
         }
-        return -1;
+        writeHandle.lastWrite(expectedWrittenBytes, localWrittenBytes, 0);
+        return false;
     }
 
     /**
      * Write multiple bytes via {@link ByteBuffer} array.
      * @param in the collection which contains objects to write.
+     * @param writeHandle the {@link WriteHandleFactory.WriteHandle} used to track write results.
      * @param nioBuffers The buffers to write.
      * @param nioBufferCnt The number of buffers to write.
      * @param expectedWrittenBytes The number of bytes we expect to write.
      * @param maxBytesPerGatheringWrite The maximum number of bytes we should attempt to write.
-     * @return write result.
-     * <ul>
-     *     <li>0 - if no write was attempted. This is appropriate if an empty {@link Buffer} (or other empty content)
-     *     is encountered</li>
-     *     <li>1 - if a single call to write data was made to the OS</li>
-     *     <li>-1 - if an attempt to write data was made to the OS, but
-     *     no data was accepted</li>
-     * </ul>
+     * @return if we should continue with writing more messages.
      * @throws IOException If an I/O exception occurs during write.
      */
-    private int writeBytesMultiple(
-            ChannelOutboundBuffer in, ByteBuffer[] nioBuffers, int nioBufferCnt, long expectedWrittenBytes,
+    private boolean writeBytesMultiple(
+            ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle,
+            ByteBuffer[] nioBuffers, int nioBufferCnt, long expectedWrittenBytes,
             long maxBytesPerGatheringWrite) throws IOException {
         assert expectedWrittenBytes != 0;
         if (expectedWrittenBytes > maxBytesPerGatheringWrite) {
@@ -638,139 +612,132 @@ public final class KQueueSocketChannel
 
         final long localWrittenBytes = socket.writev(nioBuffers, 0, nioBufferCnt, expectedWrittenBytes);
         if (localWrittenBytes > 0) {
-            adjustMaxBytesPerGatheringWrite(expectedWrittenBytes, localWrittenBytes, maxBytesPerGatheringWrite);
             in.removeBytes(localWrittenBytes);
-            return 1;
+            return writeHandle.lastWrite(expectedWrittenBytes, localWrittenBytes, 1);
         }
-        return -1;
+        writeHandle.lastWrite(expectedWrittenBytes, localWrittenBytes, 0);
+        return false;
     }
 
     /**
      * Write a {@link DefaultFileRegion}
      * @param in the collection which contains objects to write.
+     * @param writeHandle the {@link WriteHandleFactory.WriteHandle} used to track write results.
      * @param region the {@link DefaultFileRegion} from which the bytes should be written
-     * @return write result.
-     * <ul>
-     *     <li>0 - if no write was attempted. This is appropriate if an empty {@link Buffer} (or other empty content)
-     *     is encountered</li>
-     *     <li>1 - if a single call to write data was made to the OS</li>
-     *     <li>-1 - if an attempt to write data was made to the OS, but
-     *     no data was accepted</li>
-     * </ul>
+     * @return if we should continue with writing more messages.
      */
-    private int writeDefaultFileRegion(ChannelOutboundBuffer in, DefaultFileRegion region) throws Exception {
+    private boolean writeDefaultFileRegion(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle,
+                                       DefaultFileRegion region) throws Exception {
         final long regionCount = region.count();
         final long offset = region.transferred();
+        final long flushedAmount;
+        int messagesWritten  = 0;
 
         if (offset >= regionCount) {
-            in.remove();
-            return 0;
-        }
-
-        final long flushedAmount = socket.sendFile(region, region.position(), offset, regionCount - offset);
-        if (flushedAmount > 0) {
-            in.progress(flushedAmount);
-            if (region.transferred() >= regionCount) {
-                in.remove();
+            flushedAmount = 0;
+            messagesWritten = 1;
+        } else {
+            flushedAmount = socket.sendFile(region, region.position(), offset, regionCount - offset);
+            if (flushedAmount > 0) {
+                if (region.transferred() >= regionCount) {
+                    messagesWritten = 1;
+                }
+            } else if (flushedAmount == 0) {
+                validateFileRegion(region, offset);
+                writeHandle.lastWrite(regionCount, flushedAmount, 0);
+                return false;
             }
-            return 1;
         }
-        if (flushedAmount == 0) {
-            validateFileRegion(region, offset);
+        if (messagesWritten > 0) {
+            in.remove();
         }
-        return -1;
+        return writeHandle.lastWrite(regionCount, flushedAmount, messagesWritten) && flushedAmount > 0;
     }
 
     /**
      * Write a {@link FileRegion}
      * @param in the collection which contains objects to write.
+     * @param writeHandle the {@link WriteHandleFactory.WriteHandle} used to track write results.
      * @param region the {@link FileRegion} from which the bytes should be written
-     * @return write result.
-     * <ul>
-     *     <li>0 - if no write was attempted. This is appropriate if an empty {@link Buffer} (or other empty content)
-     *     is encountered</li>
-     *     <li>1 - if a single call to write data was made to the OS</li>
-     *     <li>-1 - if an attempt to write data was made to the OS, but no
-     *     data was accepted</li>
-     * </ul>
+     * @return if we should continue with writing more messages.
      */
-    private int writeFileRegion(ChannelOutboundBuffer in, FileRegion region) throws Exception {
+    private boolean writeFileRegion(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle,
+                                FileRegion region) throws Exception {
+        final long regionCount = region.count();
+        final long flushedAmount;
+        int messagesWritten  = 0;
         if (region.transferred() >= region.count()) {
-            in.remove();
-            return 0;
+            flushedAmount = 0;
+            messagesWritten = 1;
+        } else {
+            if (byteChannel == null) {
+                byteChannel = new KQueueSocketWritableByteChannel();
+            }
+            flushedAmount = region.transferTo(byteChannel, region.transferred());
+            if (flushedAmount > 0) {
+                if (region.transferred() >= region.count()) {
+                    messagesWritten = 1;
+                }
+            } else if (flushedAmount == 0) {
+                writeHandle.lastWrite(regionCount, flushedAmount, 0);
+                return false;
+            }
         }
 
-        if (byteChannel == null) {
-            byteChannel = new KQueueSocketWritableByteChannel();
+        if (messagesWritten > 0) {
+            in.remove();
         }
-        final long flushedAmount = region.transferTo(byteChannel, region.transferred());
-        if (flushedAmount > 0) {
-            in.progress(flushedAmount);
-            if (region.transferred() >= region.count()) {
-                in.remove();
-            }
-            return 1;
-        }
-        return -1;
+        return writeHandle.lastWrite(regionCount, flushedAmount, messagesWritten) && flushedAmount > 0;
     }
 
     @Override
-    protected void doWrite(ChannelOutboundBuffer in) throws Exception {
-        while (!in.isEmpty()) {
+    protected void doWrite(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle) throws Exception {
+        boolean continueWriting;
+        do {
             final int msgCount = in.size();
-            int result;
+            if (msgCount == 0) {
+                writeHandle.lastWrite(0, 0, 0);
+                return;
+            }
 
             // Do gathering write if the outbound buffer entries start with more than one Buffer.
             if (msgCount > 1 && in.current() instanceof Buffer) {
-                result = doWriteMultiple(in);
-            } else if (msgCount == 0) {
-                // Wrote all messages.
-                writeFilter(false);
-                // Return here so we don't set the WRITE flag.
-                return;
+                continueWriting = doWriteMultiple(in, writeHandle);
             } else { // msgCount == 1
-                result = doWriteSingle(in);
+                continueWriting = doWriteSingle(in, writeHandle);
             }
-            if (result == -1) {
-                // Underlying descriptor can not accept all data currently, so set the WRITE flag to be woken up
-                // when it can accept more data.
-                writeFilter(true);
-                return;
-            }
-        }
-        writeFilter(false);
+        } while (continueWriting);
     }
 
     /**
      * Attempt to write a single object.
      * @param in the collection which contains objects to write.
-     * @return write result.
-     * <ul>
-     *     <li>0 - if no write was attempted. This is appropriate if an empty {@link Buffer} (or other empty content)
-     *     is encountered</li>
-     *     <li>1 - if a single call to write data was made to the OS</li>
-     *     <li>-1 - if an attempt to write data was made to the OS, but no
-     *     data was accepted</li>
-     * </ul>
+     * @param writeHandle the {@link WriteHandleFactory.WriteHandle} used to track write results.
+     * @return if we should continue with writing more messages.
      * @throws Exception If an I/O error occurs.
      */
-    private int doWriteSingle(ChannelOutboundBuffer in) throws Exception {
+    private boolean doWriteSingle(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle)
+            throws Exception {
         // The outbound buffer contains only one message or it contains a file region.
         Object msg = in.current();
         if (socket.protocolFamily() == SocketProtocolFamily.UNIX) {
-            if (msg instanceof FileDescriptor && socket.sendFd(((FileDescriptor) msg).intValue()) > 0) {
-                // File descriptor was written, so remove it.
-                in.remove();
-                return 1;
+            if (msg instanceof FileDescriptor) {
+                if (socket.sendFd(((FileDescriptor) msg).intValue()) > 0) {
+                    // File descriptor was written, so remove it.
+                    in.remove();
+                    return writeHandle.lastWrite(0, 0, 1);
+                }
+                writeHandle.lastWrite(0, 0, 0);
+                return false;
             }
         }
 
         if (msg instanceof Buffer) {
-            return writeBytes(in, (Buffer) msg);
+            return writeBytes(in, writeHandle, (Buffer) msg);
         } else if (msg instanceof DefaultFileRegion) {
-            return writeDefaultFileRegion(in, (DefaultFileRegion) msg);
+            return writeDefaultFileRegion(in, writeHandle, (DefaultFileRegion) msg);
         } else if (msg instanceof FileRegion) {
-            return writeFileRegion(in, (FileRegion) msg);
+            return writeFileRegion(in, writeHandle, (FileRegion) msg);
         } else {
             // Should never reach here.
             throw new Error();
@@ -780,28 +747,24 @@ public final class KQueueSocketChannel
     /**
      * Attempt to write multiple {@link Buffer} objects.
      * @param in the collection which contains objects to write.
-     * @return write result.
-     * <ul>
-     *     <li>0 - if no write was attempted. This is appropriate if an empty {@link Buffer} (or other empty content)
-     *     is encountered</li>
-     *     <li>1 - if a single call to write data was made to the OS</li>
-     *     <li>-1 - if an attempt to write data was made to the OS, but no
-     *     data was accepted</li>
-     * </ul>
+     * @param writeHandle the {@link WriteHandleFactory.WriteHandle} used to track write results.
+     * @return if we should continue with writing more messages.
      * @throws Exception If an I/O error occurs.
      */
-    private int doWriteMultiple(ChannelOutboundBuffer in) throws Exception {
-        final long maxBytesPerGatheringWrite = getMaxBytesPerGatheringWrite();
+    private boolean doWriteMultiple(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle)
+            throws Exception {
+        final long maxBytesPerGatheringWrite = writeHandle.estimatedMaxBytesPerGatheringWrite();
         IovArray array = registration().cleanArray();
         array.maxBytes(maxBytesPerGatheringWrite);
         in.forEachFlushedMessage(array);
 
         if (array.count() >= 1) {
-            return writeBytesMultiple(in, array);
+            return writeBytesMultiple(in, writeHandle, array);
         }
+        int messages = in.size();
         // cnt == 0, which means the outbound buffer contained empty buffers only.
         in.removeBytes(0);
-        return 0;
+        return writeHandle.lastWrite(0, 0, messages);
     }
 
     @Override

--- a/transport/src/main/java/io/netty5/channel/AbstractServerChannel.java
+++ b/transport/src/main/java/io/netty5/channel/AbstractServerChannel.java
@@ -39,7 +39,7 @@ public abstract class AbstractServerChannel<P extends Channel, L extends SocketA
      */
     protected AbstractServerChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup,
                                     Class<? extends Channel> childChannelType) {
-        super(null, eventLoop, false, new ServerChannelReadHandleFactory());
+        super(null, eventLoop, false, new ServerChannelReadHandleFactory(), new ServerChannelWriteHandleFactory());
         this.childEventLoopGroup = validateEventLoopGroup(childEventLoopGroup, "childEventLoopGroup", childChannelType);
     }
 
@@ -69,7 +69,7 @@ public abstract class AbstractServerChannel<P extends Channel, L extends SocketA
     }
 
     @Override
-    protected final void doWrite(ChannelOutboundBuffer in) {
+    protected final void doWrite(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle) {
         throw new UnsupportedOperationException();
     }
 

--- a/transport/src/main/java/io/netty5/channel/Channel.java
+++ b/transport/src/main/java/io/netty5/channel/Channel.java
@@ -65,8 +65,8 @@ import java.net.SocketAddress;
  * <h3>Downcast to access transport-specific operations</h3>
  * <p>
  * Some transports exposes additional operations that is specific to the
- * transport.  Down-cast the {@link Channel} to sub-type to invoke such
- * operations.  For example, with the old I/O datagram transport, multicast
+ * transport. Down-cast the {@link Channel} to sub-type to invoke such
+ * operations. For example, with the old I/O datagram transport, multicast
  * join / leave operations are provided by {@link DatagramChannel}.
  *
  *
@@ -105,7 +105,9 @@ import java.net.SocketAddress;
  * </tr><tr>
  * <td>{@link ChannelOption#ALLOW_HALF_CLOSURE}</td>
  * </tr><tr>
- * <td>{@link ChannelOption#MAX_MESSAGES_PER_WRITE}</td>
+ * <td>{@link ChannelOption#WRITE_HANDLE_FACTORY}</td>
+ * </tr><tr>
+ * <td>{@link ChannelOption#READ_HANDLE_FACTORY}</td>
  * </tr><tr>
  * <td>{@link ChannelOption#ALLOW_HALF_CLOSURE}</td>
  * </tr>

--- a/transport/src/main/java/io/netty5/channel/ChannelOption.java
+++ b/transport/src/main/java/io/netty5/channel/ChannelOption.java
@@ -77,6 +77,7 @@ public class ChannelOption<T> extends AbstractConstant<ChannelOption<T>> {
 
     public static final ChannelOption<BufferAllocator> BUFFER_ALLOCATOR = valueOf("BUFFER_ALLOCATOR");
     public static final ChannelOption<ReadHandleFactory> READ_HANDLE_FACTORY = valueOf("READ_HANDLE_FACTORY");
+    public static final ChannelOption<WriteHandleFactory> WRITE_HANDLE_FACTORY = valueOf("WRITE_HANDLE_FACTORY");
     public static final ChannelOption<MessageSizeEstimator> MESSAGE_SIZE_ESTIMATOR = valueOf("MESSAGE_SIZE_ESTIMATOR");
 
     public static final ChannelOption<Integer> CONNECT_TIMEOUT_MILLIS = valueOf("CONNECT_TIMEOUT_MILLIS");

--- a/transport/src/main/java/io/netty5/channel/ChannelOutboundBuffer.java
+++ b/transport/src/main/java/io/netty5/channel/ChannelOutboundBuffer.java
@@ -203,31 +203,6 @@ public final class ChannelOutboundBuffer {
     }
 
     /**
-     * Return the current message flush progress.
-     * @return {@code 0} if nothing was flushed before for the current message or there is no current message
-     */
-    public long currentProgress() {
-        assert executor.inEventLoop();
-
-        Entry entry = flushedEntry;
-        if (entry == null) {
-            return 0;
-        }
-        return entry.progress;
-    }
-
-    /**
-     * Notify the {@link Promise} of the current message about writing progress.
-     */
-    public void progress(long amount) {
-        assert executor.inEventLoop();
-
-        Entry e = flushedEntry;
-        assert e != null;
-        e.progress += amount;
-    }
-
-    /**
      * Will remove the current message, mark its {@link Promise} as success and return {@code true}. If no
      * flushed message exists at the time this method is called it will return {@code false} to signal that no more
      * messages are ready to be handled.
@@ -322,12 +297,10 @@ public final class ChannelOutboundBuffer {
                 Buffer buf = (Buffer) msg;
                 final int readableBytes = buf.readableBytes();
                 if (readableBytes <= writtenBytes) {
-                    progress(readableBytes);
                     writtenBytes -= readableBytes;
                     remove();
                 } else { // readableBytes > writtenBytes
                     buf.readSplit(Math.toIntExact(writtenBytes)).close();
-                    progress(writtenBytes);
                     break;
                 }
             } else {

--- a/transport/src/main/java/io/netty5/channel/MaxMessagesReadHandleFactory.java
+++ b/transport/src/main/java/io/netty5/channel/MaxMessagesReadHandleFactory.java
@@ -32,7 +32,7 @@ public abstract class MaxMessagesReadHandleFactory implements ReadHandleFactory 
     }
 
     @Override
-    public final ReadHandle newHandle() {
+    public final ReadHandle newHandle(Channel channel) {
         return newMaxMessageHandle(maxMessagesPerRead);
     }
 

--- a/transport/src/main/java/io/netty5/channel/MaxMessagesWriteHandleFactory.java
+++ b/transport/src/main/java/io/netty5/channel/MaxMessagesWriteHandleFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel;
+
+import static io.netty5.util.internal.ObjectUtil.checkPositive;
+
+public class MaxMessagesWriteHandleFactory implements WriteHandleFactory {
+    private final int maxMessagesPerWrite;
+
+    public MaxMessagesWriteHandleFactory(int maxMessagesPerWrite) {
+        this.maxMessagesPerWrite = checkPositive(maxMessagesPerWrite, "maxMessagesPerWrite");
+    }
+
+    @Override
+    public final WriteHandle newHandle(Channel channel) {
+        return newHandle(channel, maxMessagesPerWrite);
+    }
+
+    protected MaxMessagesWriteHandle newHandle(Channel channel, int maxMessagesPerWrite) {
+        return new MaxMessagesWriteHandle(maxMessagesPerWrite);
+    }
+
+    protected static class MaxMessagesWriteHandle implements WriteHandle {
+        private final int maxMessagesPerWrite;
+
+        private int totalNumMessages;
+
+        protected MaxMessagesWriteHandle(int maxMessagesPerWrite) {
+            this.maxMessagesPerWrite = checkPositive(maxMessagesPerWrite, "maxMessagesPerWrite");
+        }
+
+        @Override
+        public boolean lastWrite(long attemptedBytesWrite, long actualBytesWrite, int numMessagesWrite) {
+            if (numMessagesWrite > 0) {
+                this.totalNumMessages += numMessagesWrite;
+            }
+            return totalNumMessages <= maxMessagesPerWrite;
+        }
+
+        @Override
+        public void writeComplete() {
+            this.totalNumMessages = 0;
+        }
+    }
+}

--- a/transport/src/main/java/io/netty5/channel/ReadHandleFactory.java
+++ b/transport/src/main/java/io/netty5/channel/ReadHandleFactory.java
@@ -16,14 +16,15 @@
 package io.netty5.channel;
 
 /**
- * Implementations allow to influence how much data / messages are received per read loop invocation.
+ * Implementations allow to influence how much data / messages are read per read loop invocation.
  */
 public interface ReadHandleFactory {
     /**
-     * Creates a new handle. The handle provides the actual operations and keeps the internal information which is
-     * required for predicting an optimal buffer capacity.
+     * Creates a new handle for the given {@link Channel}.
+     *
+     * @param channel   the {@link Channel} for which the {@link ReadHandle} is used.
      */
-    ReadHandle newHandle();
+    ReadHandle newHandle(Channel channel);
 
     /**
      * Handle which allows to customize how data / messages are read.

--- a/transport/src/main/java/io/netty5/channel/ServerChannelWriteHandleFactory.java
+++ b/transport/src/main/java/io/netty5/channel/ServerChannelWriteHandleFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 The Netty Project
+ * Copyright 2022 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,11 +13,24 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package io.netty5.channel.internal;
+package io.netty5.channel;
 
-public final class ChannelUtils {
-    public static final int MAX_BYTES_PER_GATHERING_WRITE_ATTEMPTED_LOW_THRESHOLD = 4096;
+public final class ServerChannelWriteHandleFactory implements WriteHandleFactory {
 
-    private ChannelUtils() {
+    private static final WriteHandle HANDLE = new WriteHandle() {
+        @Override
+        public boolean lastWrite(long attemptedBytesWrite, long actualBytesWrite, int numMessagesWrite) {
+            return false;
+        }
+
+        @Override
+        public void writeComplete() {
+            // NOOP
+        }
+    };
+
+    @Override
+    public WriteHandle newHandle(Channel channel) {
+        return HANDLE;
     }
 }

--- a/transport/src/main/java/io/netty5/channel/WriteHandleFactory.java
+++ b/transport/src/main/java/io/netty5/channel/WriteHandleFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel;
+
+/**
+ * Implementations allow to influence how much data / messages are written per write loop invocation.
+ */
+public interface WriteHandleFactory {
+
+    /**
+     * Creates a new handle for the given {@link Channel}.
+     *
+     * @param channel   the {@link Channel} for which the {@link WriteHandle} is used.
+     */
+    WriteHandle newHandle(Channel channel);
+
+    /**
+     * Handle which allows to customize how data / messages are read.
+     */
+    interface WriteHandle {
+
+        /**
+         * Estimate the maximum number of bytes that can be written with one gathering write operation.
+         */
+        default long estimatedMaxBytesPerGatheringWrite() {
+            return Integer.MAX_VALUE;
+        }
+
+        /**
+         * Notify the {@link WriteHandle} of the last write operation and its result.
+         *
+         * @param attemptedBytesWrite   The number of  bytes the write operation did attempt to write.
+         * @param actualBytesWrite      The number of bytes from the previous write operation. This may be negative if a
+         *                              write error occurs.
+         * @param numMessagesWrite      The number of messages written.
+         * @return                      {@code true} if the write loop should continue writing, {@code false} otherwise.
+         */
+        boolean lastWrite(long attemptedBytesWrite, long actualBytesWrite, int numMessagesWrite);
+
+        /**
+         * Method that must be called once the write loop was completed.
+         */
+        void writeComplete();
+    }
+}

--- a/transport/src/main/java/io/netty5/channel/nio/AbstractNioChannel.java
+++ b/transport/src/main/java/io/netty5/channel/nio/AbstractNioChannel.java
@@ -267,7 +267,7 @@ public abstract class AbstractNioChannel<P extends Channel, L extends SocketAddr
     }
 
     @Override
-    protected final void writeLoopComplete(boolean allWritten) throws Exception {
+    protected final void writeLoopComplete(boolean allWritten) {
         final SelectionKey key = selectionKey();
         // Check first if the key is still valid as it may be canceled as part of the deregistration
         // from the EventLoop

--- a/transport/src/main/java/io/netty5/channel/socket/SocketChannelWriteHandleFactory.java
+++ b/transport/src/main/java/io/netty5/channel/socket/SocketChannelWriteHandleFactory.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.socket;
+
+import io.netty5.channel.Channel;
+import io.netty5.channel.ChannelOption;
+import io.netty5.channel.MaxMessagesWriteHandleFactory;
+
+
+import static io.netty5.util.internal.ObjectUtil.checkPositive;
+
+public final class SocketChannelWriteHandleFactory extends MaxMessagesWriteHandleFactory {
+    private static final int MAX_BYTES_PER_GATHERING_WRITE_ATTEMPTED_LOW_THRESHOLD = 4096;
+
+    private final long maxBytesPerGatheringWrite;
+
+    public SocketChannelWriteHandleFactory(int maxMessagesPerWrite) {
+        this(maxMessagesPerWrite, Long.MAX_VALUE);
+    }
+
+    public SocketChannelWriteHandleFactory(int maxMessagesPerWrite, long maxBytesPerGatheringWrite) {
+        super(maxMessagesPerWrite);
+        this.maxBytesPerGatheringWrite = checkPositive(maxBytesPerGatheringWrite, "maxBytesPerGatheringWrite");
+    }
+    @Override
+    protected MaxMessagesWriteHandle newHandle(Channel channel, int maxMessagesPerWrite) {
+        return new SndBufferWriteHandle(channel, maxMessagesPerWrite, maxBytesPerGatheringWrite);
+    }
+
+    private static final class SndBufferWriteHandle extends MaxMessagesWriteHandle {
+        private final long maxBytesPerGatheringWrite;
+        private long calculatedMaxBytesPerGatheringWrite;
+
+        SndBufferWriteHandle(Channel channel, int maxMessagesPerWrite, long maxBytesPerGatheringWrite) {
+            super(maxMessagesPerWrite);
+            this.maxBytesPerGatheringWrite = maxBytesPerGatheringWrite;
+            calculatedMaxBytesPerGatheringWrite = calculateMaxBytesPerGatheringWrite(
+                    channel, maxBytesPerGatheringWrite);
+        }
+
+        @Override
+        public boolean lastWrite(long attemptedBytesWrite, long actualBytesWrite, int numMessagesWrite) {
+            boolean continueWriting = super.lastWrite(attemptedBytesWrite, actualBytesWrite, numMessagesWrite);
+            adjustMaxBytesPerGatheringWrite(attemptedBytesWrite, actualBytesWrite, maxBytesPerGatheringWrite);
+            return continueWriting;
+        }
+
+        @Override
+        public long estimatedMaxBytesPerGatheringWrite() {
+            return calculatedMaxBytesPerGatheringWrite;
+        }
+
+        private static long calculateMaxBytesPerGatheringWrite(Channel channel, long maxBytesPerGatheringWrite) {
+            // Multiply by 2 to give some extra space in case the OS can process write data faster than we can provide.
+            int newSendBufferSize = channel.getOption(ChannelOption.SO_SNDBUF) << 1;
+            if (newSendBufferSize > 0) {
+                return Math.min(newSendBufferSize, maxBytesPerGatheringWrite);
+            }
+            return maxBytesPerGatheringWrite;
+        }
+
+        private void adjustMaxBytesPerGatheringWrite(long attempted, long written, long oldMaxBytesPerGatheringWrite) {
+            // By default we track the SO_SNDBUF when ever it is explicitly set. However some OSes may dynamically
+            // change SO_SNDBUF (and other characteristics that determine how much data can be written at once) so we
+            // should try make a best effort to adjust as OS behavior changes.
+            if (attempted == written) {
+                if (attempted << 1 > oldMaxBytesPerGatheringWrite) {
+                    calculatedMaxBytesPerGatheringWrite = Math.min(maxBytesPerGatheringWrite, attempted << 1);
+                }
+            } else if (attempted > MAX_BYTES_PER_GATHERING_WRITE_ATTEMPTED_LOW_THRESHOLD && written < attempted >>> 1) {
+                calculatedMaxBytesPerGatheringWrite = Math.min(maxBytesPerGatheringWrite, attempted >>> 1);
+            }
+        }
+    }
+}

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioServerSocketChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioServerSocketChannel.java
@@ -23,6 +23,8 @@ import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.EventLoopGroup;
 import io.netty5.channel.ServerChannelReadHandleFactory;
+import io.netty5.channel.ServerChannelWriteHandleFactory;
+import io.netty5.channel.WriteHandleFactory;
 import io.netty5.channel.nio.AbstractNioMessageChannel;
 import io.netty5.util.NetUtil;
 import io.netty5.util.internal.SocketUtils;
@@ -131,7 +133,7 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel<Channel, S
             EventLoop eventLoop, EventLoopGroup childEventLoopGroup,
             ServerSocketChannel channel, ProtocolFamily family) {
         super(null, eventLoop, false, new ServerChannelReadHandleFactory(),
-                channel, SelectionKey.OP_ACCEPT);
+                new ServerChannelWriteHandleFactory(), channel, SelectionKey.OP_ACCEPT);
         this.family = toJdkFamily(family);
         this.childEventLoopGroup = validateEventLoopGroup(
                 childEventLoopGroup, "childEventLoopGroup", NioSocketChannel.class);
@@ -282,7 +284,7 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel<Channel, S
     }
 
     @Override
-    protected boolean doWriteMessage(Object msg, ChannelOutboundBuffer in) {
+    protected boolean doWriteMessage(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle) {
         throw new UnsupportedOperationException();
     }
 

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioSocketChannel.java
@@ -23,7 +23,9 @@ import io.netty5.channel.ChannelOutboundBuffer;
 import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.FileRegion;
+import io.netty5.channel.WriteHandleFactory;
 import io.netty5.channel.nio.AbstractNioByteChannel;
+import io.netty5.channel.socket.SocketChannelWriteHandleFactory;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.GlobalEventExecutor;
 import io.netty5.util.internal.PlatformDependent;
@@ -41,7 +43,6 @@ import java.nio.channels.SocketChannel;
 import java.nio.channels.spi.SelectorProvider;
 import java.util.concurrent.Executor;
 
-import static io.netty5.channel.internal.ChannelUtils.MAX_BYTES_PER_GATHERING_WRITE_ATTEMPTED_LOW_THRESHOLD;
 import static io.netty5.channel.socket.nio.NioChannelUtil.isDomainSocket;
 import static io.netty5.channel.socket.nio.NioChannelUtil.toDomainSocketAddress;
 import static io.netty5.channel.socket.nio.NioChannelUtil.toJdkFamily;
@@ -136,7 +137,7 @@ public class NioSocketChannel
      */
     public NioSocketChannel(NioServerSocketChannel parent, EventLoop eventLoop, SocketChannel socket,
                             ProtocolFamily family) {
-        super(parent, eventLoop, socket);
+        super(parent, eventLoop, new SocketChannelWriteHandleFactory(Integer.MAX_VALUE), socket);
         this.family = toJdkFamily(family);
         // Enable TCP_NODELAY by default if possible.
         if (!isDomainSocket(family) && PlatformDependent.canEnableTcpNoDelayByDefault()) {
@@ -146,7 +147,6 @@ public class NioSocketChannel
                 // Ignore.
             }
         }
-        calculateMaxBytesPerGatheringWrite();
     }
 
     @Override
@@ -282,78 +282,63 @@ public class NioSocketChannel
         return region.transferTo(javaChannel(), position);
     }
 
-    private void adjustMaxBytesPerGatheringWrite(int attempted, int written, int oldMaxBytesPerGatheringWrite) {
-        // By default we track the SO_SNDBUF when ever it is explicitly set. However some OSes may dynamically change
-        // SO_SNDBUF (and other characteristics that determine how much data can be written at once) so we should try
-        // make a best effort to adjust as OS behavior changes.
-        if (attempted == written) {
-            if (attempted << 1 > oldMaxBytesPerGatheringWrite) {
-                setMaxBytesPerGatheringWrite(attempted << 1);
-            }
-        } else if (attempted > MAX_BYTES_PER_GATHERING_WRITE_ATTEMPTED_LOW_THRESHOLD && written < attempted >>> 1) {
-            setMaxBytesPerGatheringWrite(attempted >>> 1);
-        }
-    }
-
     @Override
-    protected void doWrite(ChannelOutboundBuffer in) throws Exception {
+    protected void doWrite(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle) throws Exception {
         SocketChannel ch = javaChannel();
         if (in.isEmpty()) {
-            // All written so clear OP_WRITE
-            clearOpWrite();
-            // Directly return here so incompleteWrite(...) is not called.
+            writeHandle.lastWrite(0, 0, 0);
+            // Directly return
             return;
         }
+        boolean continueWriting;
+        do {
+            // Ensure the pending writes are made of ByteBufs only.
+            long maxBytesPerGatheringWrite = writeHandle.estimatedMaxBytesPerGatheringWrite();
+            ByteBuffer[] nioBuffers = in.nioBuffers(1024, maxBytesPerGatheringWrite);
+            int nioBufferCnt = in.nioBufferCount();
 
-        // Ensure the pending writes are made of ByteBufs only.
-        int maxBytesPerGatheringWrite = getMaxBytesPerGatheringWrite();
-        ByteBuffer[] nioBuffers = in.nioBuffers(1024, maxBytesPerGatheringWrite);
-        int nioBufferCnt = in.nioBufferCount();
+            // Always use nioBuffers() to workaround data-corruption.
+            // See https://github.com/netty/netty/issues/2761
+            switch (nioBufferCnt) {
+                case 0:
+                    // We have something else beside ByteBuffers to write so fallback to normal writes.
+                    continueWriting = writeOne(in, writeHandle);
+                    break;
+                case 1: {
+                    // Only one ByteBuf so use non-gathering write
+                    // Zero length buffers are not added to nioBuffers by ChannelOutboundBuffer, so there is no need
+                    // to check if the total size of all the buffers is non-zero.
+                    ByteBuffer buffer = nioBuffers[0];
+                    int attemptedBytes = buffer.remaining();
+                    final int localWrittenBytes = ch.write(buffer);
+                    if (localWrittenBytes <= 0) {
+                        writeHandle.lastWrite(attemptedBytes, localWrittenBytes, 0);
+                        return;
+                    }
+                    in.removeBytes(localWrittenBytes);
 
-        long result;
-        // Always use nioBuffers() to workaround data-corruption.
-        // See https://github.com/netty/netty/issues/2761
-        switch (nioBufferCnt) {
-            case 0:
-                // We have something else beside ByteBuffers to write so fallback to normal writes.
-                result = doWrite0(in);
-                break;
-            case 1: {
-                // Only one ByteBuf so use non-gathering write
-                // Zero length buffers are not added to nioBuffers by ChannelOutboundBuffer, so there is no need
-                // to check if the total size of all the buffers is non-zero.
-                ByteBuffer buffer = nioBuffers[0];
-                int attemptedBytes = buffer.remaining();
-                final int localWrittenBytes = ch.write(buffer);
-                if (localWrittenBytes <= 0) {
-                    incompleteWrite(true);
-                    return;
+                    continueWriting = writeHandle.lastWrite(attemptedBytes, localWrittenBytes,
+                            attemptedBytes == localWrittenBytes ? 1 : 0);
+                    break;
                 }
-                adjustMaxBytesPerGatheringWrite(attemptedBytes, localWrittenBytes, maxBytesPerGatheringWrite);
-                in.removeBytes(localWrittenBytes);
-                result = localWrittenBytes;
-                break;
-            }
-            default: {
-                // Zero length buffers are not added to nioBuffers by ChannelOutboundBuffer, so there is no need
-                // to check if the total size of all the buffers is non-zero.
-                // We limit the max amount to int above so cast is safe
-                long attemptedBytes = in.nioBufferSize();
-                final long localWrittenBytes = ch.write(nioBuffers, 0, nioBufferCnt);
-                if (localWrittenBytes <= 0) {
-                    incompleteWrite(true);
-                    return;
-                }
-                // Casting to int is safe because we limit the total amount of data in the nioBuffers to int above.
-                adjustMaxBytesPerGatheringWrite((int) attemptedBytes, (int) localWrittenBytes,
-                        maxBytesPerGatheringWrite);
-                in.removeBytes(localWrittenBytes);
-                result = localWrittenBytes;
-                break;
-            }
-        }
+                default: {
+                    // Zero length buffers are not added to nioBuffers by ChannelOutboundBuffer, so there is no need
+                    // to check if the total size of all the buffers is non-zero.
+                    // We limit the max amount to int above so cast is safe
+                    long attemptedBytes = in.nioBufferSize();
+                    final long localWrittenBytes = ch.write(nioBuffers, 0, nioBufferCnt);
+                    if (localWrittenBytes <= 0) {
+                        writeHandle.lastWrite(attemptedBytes, localWrittenBytes, 0);
+                        return;
+                    }
+                    in.removeBytes(localWrittenBytes);
 
-        incompleteWrite(result == -1);
+                    continueWriting = writeHandle.lastWrite(attemptedBytes, localWrittenBytes,
+                            attemptedBytes == localWrittenBytes ? 1 : 0);
+                    break;
+                }
+            }
+        } while (continueWriting);
     }
 
     @Override
@@ -404,27 +389,5 @@ public class NioSocketChannel
             return NioChannelOption.isOptionSupported(javaChannel(), socketOption);
         }
         return super.isExtendedOptionSupported(option);
-    }
-
-    private volatile int maxBytesPerGatheringWrite = Integer.MAX_VALUE;
-
-    void setMaxBytesPerGatheringWrite(int maxBytesPerGatheringWrite) {
-        this.maxBytesPerGatheringWrite = maxBytesPerGatheringWrite;
-    }
-
-    int getMaxBytesPerGatheringWrite() {
-        return maxBytesPerGatheringWrite;
-    }
-
-    private void calculateMaxBytesPerGatheringWrite() {
-        try {
-            // Multiply by 2 to give some extra space in case the OS can process write data faster than we can provide.
-            int newSendBufferSize = javaChannel().getOption(StandardSocketOptions.SO_SNDBUF) << 1;
-            if (newSendBufferSize > 0) {
-                setMaxBytesPerGatheringWrite(newSendBufferSize);
-            }
-        } catch (IOException e) {
-            throw new ChannelException(e);
-        }
     }
 }

--- a/transport/src/test/java/io/netty5/channel/AbstractChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/AbstractChannelTest.java
@@ -157,7 +157,8 @@ public class AbstractChannelTest {
             }
 
             @Override
-            protected void doWrite(ChannelOutboundBuffer in) throws Exception {
+            protected void doWrite(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle)
+                    throws Exception {
                 throw ioException;
             }
 
@@ -252,7 +253,9 @@ public class AbstractChannelTest {
         }
 
         @Override
-        protected void doWrite(ChannelOutboundBuffer in) throws Exception { }
+        protected void doWrite(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle) throws Exception {
+            // NOOP
+        }
 
         @Override
         protected void doShutdown(ChannelShutdownDirection direction) {

--- a/transport/src/test/java/io/netty5/channel/AdaptiveReadHandleFactoryTest.java
+++ b/transport/src/test/java/io/netty5/channel/AdaptiveReadHandleFactoryTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
 
 public class AdaptiveReadHandleFactoryTest {
 
@@ -28,7 +29,7 @@ public class AdaptiveReadHandleFactoryTest {
     @BeforeEach
     public void setup() {
         AdaptiveReadHandleFactory recvBufferAllocator = new AdaptiveReadHandleFactory(1, 64, 512, 1024 * 1024 * 10);
-        handle = recvBufferAllocator.newHandle();
+        handle = recvBufferAllocator.newHandle(mock(Channel.class));
     }
 
     @Test

--- a/transport/src/test/java/io/netty5/channel/ChannelOutboundBufferTest.java
+++ b/transport/src/test/java/io/netty5/channel/ChannelOutboundBufferTest.java
@@ -206,14 +206,11 @@ public class ChannelOutboundBufferTest {
             int size = buf.readableBytes();
             buffer.addMessage(buf, size, executor.newPromise());
             buffer.addFlush();
-            assertEquals(0, buffer.currentProgress());
             buffer.removeBytes(size / 2);
-            assertEquals(size / 2, buffer.currentProgress());
             assertThat(buffer.current()).isNotNull();
             buffer.removeBytes(size);
             assertNull(buffer.current());
             assertTrue(buffer.isEmpty());
-            assertEquals(0, buffer.currentProgress());
         });
     }
 

--- a/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTailTest.java
+++ b/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTailTest.java
@@ -286,7 +286,7 @@ public class DefaultChannelPipelineTailTest {
         }
 
         @Override
-        protected void doWrite(ChannelOutboundBuffer in) throws Exception {
+        protected void doWrite(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle) throws Exception {
             throw new IOException();
         }
 

--- a/transport/src/test/java/io/netty5/channel/MaxMessagesReadHandleFactoryTest.java
+++ b/transport/src/test/java/io/netty5/channel/MaxMessagesReadHandleFactoryTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 public class MaxMessagesReadHandleFactoryTest {
 
@@ -40,7 +41,7 @@ public class MaxMessagesReadHandleFactoryTest {
     @Test
     public void testRespectMaxMessages() {
         MaxMessagesReadHandleFactory allocator = newAllocator();
-        ReadHandleFactory.ReadHandle handle = allocator.newHandle();
+        ReadHandleFactory.ReadHandle handle = allocator.newHandle(mock(Channel.class));
 
         EmbeddedChannel channel = new EmbeddedChannel();
         assertTrue(handle.lastRead(0, 0, 1));
@@ -54,7 +55,7 @@ public class MaxMessagesReadHandleFactoryTest {
     @Test
     public void testIgnoreReadBytes() {
         MaxMessagesReadHandleFactory allocator = newAllocator();
-        ReadHandleFactory.ReadHandle handle = allocator.newHandle();
+        ReadHandleFactory.ReadHandle handle = allocator.newHandle(mock(Channel.class));
 
         EmbeddedChannel channel = new EmbeddedChannel();
         assertTrue(handle.lastRead(0, 0, 1));


### PR DESCRIPTION
Motivation:

We already provide some means of influence the read loop by ReadHandleFactory but we didnt offer the same for the write loop.

Modifications:

- Add WriteHandleFactory which allows to influence the write loop.
- Remove ChannelOption.MAX_MESSAGES_PER_WRITE as this should be done as a WriteHandleFactory implentation.
- Move logic for sizing the maximum bytes per gather write to SocketWriteHandleFactory and re-use it by different SocketChannel implementations

Result:

Much more control for the end-user and more code-sharing