### PR TITLE
Include any core dumps in the build failure archives

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -207,3 +207,4 @@ jobs:
           path: |
             **/target/surefire-reports/
             **/hs_err*.log
+            **/core.*


### PR DESCRIPTION
Motivation:
We occasionally get JIT compiler crashes.
These produce core dumps, at least on Linux.
It's not clear where these dumps are placed, but if they are placed in our build directory, then it makes sense to include them in our failed build archives, so they have a chance to be debugged.

Modification:
Also include any `core` files produced in our build directory, in the failed build archive.

Result:
JIT and GC crashes now have a fighting chance of being debugged, when they occur.