### PR TITLE
Enable Brotli tests on m1

### DIFF
--- a/codec/src/test/java/io/netty/handler/codec/compression/BrotliDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/BrotliDecoderTest.java
@@ -21,11 +21,9 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -35,9 +33,7 @@ import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-@DisabledIf(value = "isNotSupported", disabledReason = "Brotli is not supported on this platform")
 public class BrotliDecoderTest {
 
     private static Random RANDOM;
@@ -65,10 +61,6 @@ public class BrotliDecoderTest {
             Unpooled.wrappedBuffer(BYTES_SMALL)).asReadOnly();
     private static final ByteBuf WRAPPED_BYTES_LARGE = Unpooled.unreleasableBuffer(
             Unpooled.wrappedBuffer(BYTES_LARGE)).asReadOnly();
-
-    static boolean isNotSupported() {
-        return PlatformDependent.isOsx() && "aarch_64".equals(PlatformDependent.normalizedArch());
-    }
 
     private static void fillArrayWithCompressibleData(byte[] array) {
         for (int i = 0; i < array.length; i++) {

--- a/codec/src/test/java/io/netty/handler/codec/compression/BrotliEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/BrotliEncoderTest.java
@@ -22,11 +22,8 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.condition.DisabledIf;
 
-@DisabledIf(value = "isNotSupported", disabledReason = "Brotli is not supported on this platform")
 public class BrotliEncoderTest extends AbstractEncoderTest {
 
     @BeforeAll
@@ -70,9 +67,5 @@ public class BrotliEncoderTest extends AbstractEncoderTest {
             }
         }
         return decompressed;
-    }
-
-    static boolean isNotSupported() {
-        return PlatformDependent.isOsx() && "aarch_64".equals(PlatformDependent.normalizedArch());
     }
 }


### PR DESCRIPTION
Motivation:

a06f851d3d9d27544c469b2017a20d08bd13686a updated brotli4j version to one that supports m1. Let's enable tests.

Modifications:

Enable brotli4j tests on m1 as well

Result:

More testing