### PR TITLE
Remove ByteBuffer[] related methods from ChannelOutboundBuffer

### DIFF
--- a/transport/src/main/java/io/netty5/channel/socket/nio/ByteBufferCollector.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/ByteBufferCollector.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.socket.nio;
+
+import io.netty5.buffer.api.Buffer;
+import io.netty5.channel.ChannelOutboundBuffer;
+import io.netty5.util.concurrent.FastThreadLocal;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+final class ByteBufferCollector implements ChannelOutboundBuffer.MessageProcessor<RuntimeException> {
+
+    private static final FastThreadLocal<BufferCache> NIO_BUFFERS = new FastThreadLocal<>() {
+        @Override
+        protected BufferCache initialValue() {
+            BufferCache cache = new BufferCache();
+            cache.buffers = new ByteBuffer[1024];
+            return cache;
+        }
+    };
+
+    private int maxCount;
+    private long maxBytes;
+    private BufferCache cache;
+
+    /**
+     * Returns the number of {@link ByteBuffer} that can be written out of the {@link ByteBuffer} array that was
+     * obtained via {@link #collect(ChannelOutboundBuffer, int, long)}. This method <strong>MUST</strong> be
+     * called after {@link #collect(ChannelOutboundBuffer, int, long)} was called.
+     */
+    public int nioBufferCount() {
+        return cache.bufferCount;
+    }
+
+    /**
+     * Returns the number of bytes that can be written out of the {@link ByteBuffer} array that was
+     * obtained via {@link #collect(ChannelOutboundBuffer, int, long)}. This method <strong>MUST</strong> be called
+     * after {@link #collect(ChannelOutboundBuffer, int, long)}was called.
+     */
+    public long nioBufferSize() {
+        return cache.totalSize;
+    }
+
+    /**
+     * Thread-local cache of {@link ByteBuffer} array, and processing meta-data.
+     */
+    private static final class BufferCache {
+        ByteBuffer[] buffers;
+        long totalSize;
+        int bufferCount;
+    }
+
+    // Clear all ByteBuffer from the array so these can be GC'ed.
+    // See https://github.com/netty/netty/issues/3837
+    void reset() {
+        int count = cache.bufferCount;
+        if (count > 0) {
+            Arrays.fill(cache.buffers, 0, count, null);
+        }
+        cache.bufferCount = 0;
+        cache.totalSize = 0;
+        cache = null;
+    }
+
+    /**
+     * Returns an array of direct NIO buffers if the currently pending messages are made of {@link Buffer} only.
+     * {@link #nioBufferCount()} and {@link #nioBufferSize()} will return the number of NIO buffers in the returned
+     * array and the total number of readable bytes of the NIO buffers respectively.
+     *
+     * @param maxCount The maximum amount of buffers that will be added to the return value.
+     * @param maxBytes A hint toward the maximum number of bytes to include as part of the return value. Note that this
+     *                 value maybe exceeded because we make a best effort to include at least 1 {@link ByteBuffer}
+     *                 in the return value to ensure write progress is made.
+     */
+    public ByteBuffer[] collect(ChannelOutboundBuffer outboundBuffer, int maxCount, long maxBytes) {
+        assert maxCount > 0;
+        assert maxBytes > 0;
+        this.maxCount = maxCount;
+        this.maxBytes = maxBytes;
+        this.cache = NIO_BUFFERS.get();
+        this.cache.bufferCount = 0;
+        this.cache.totalSize = 0;
+        outboundBuffer.forEachFlushedMessage(this);
+        return cache.buffers;
+    }
+
+    @Override
+    public boolean processMessage(Object msg) throws RuntimeException {
+        if (!(msg instanceof Buffer)) {
+            return false;
+        }
+        Buffer buf = (Buffer) msg;
+        if (buf.readableBytes() == 0) {
+            return true;
+        }
+        try (var iterator = buf.forEachComponent()) {
+            for (var c = iterator.firstReadable(); c != null; c = c.nextReadable()) {
+                ByteBuffer byteBuffer = c.readableBuffer();
+                if (cache.bufferCount > 0 && cache.totalSize + byteBuffer.remaining() > maxBytes) {
+                    // If the nioBufferSize + readableBytes will overflow maxBytes, and there is at least
+                    // one entry we stop populate the ByteBuffer array. This is done for 2 reasons:
+                    // 1. bsd/osx don't allow to write more bytes then Integer.MAX_VALUE with one
+                    // writev(...) call and so will return 'EINVAL', which will raise an IOException.
+                    // On Linux it may work depending on the architecture and kernel but to be safe we also
+                    // enforce the limit here.
+                    // 2. There is no sense in putting more data in the array than is likely to be accepted
+                    // by the OS.
+                    //
+                    // See also:
+                    // - https://www.freebsd.org/cgi/man.cgi?query=write&sektion=2
+                    // - https://linux.die.net//man/2/writev
+                    return false;
+                }
+                cache.totalSize += byteBuffer.remaining();
+                ByteBuffer[] buffers = cache.buffers;
+                int bufferCount = cache.bufferCount;
+                if (buffers.length == bufferCount && bufferCount < maxCount) {
+                    buffers = cache.buffers = expandNioBufferArray(buffers, bufferCount + 1, bufferCount);
+                }
+                buffers[cache.bufferCount] = byteBuffer;
+                bufferCount++;
+                cache.bufferCount = bufferCount;
+                if (maxCount <= bufferCount) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private static ByteBuffer[] expandNioBufferArray(ByteBuffer[] array, int neededSpace, int size) {
+        int newCapacity = array.length;
+        do {
+            // double capacity until it is big enough
+            // See https://github.com/netty/netty/issues/1890
+            newCapacity <<= 1;
+
+            if (newCapacity < 0) {
+                throw new IllegalStateException();
+            }
+
+        } while (neededSpace > newCapacity);
+
+        ByteBuffer[] newArray = new ByteBuffer[newCapacity];
+        System.arraycopy(array, 0, newArray, 0, size);
+
+        return newArray;
+    }
+}

--- a/transport/src/main/java/io/netty5/channel/socket/nio/ByteBufferCollector.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/ByteBufferCollector.java
@@ -67,6 +67,9 @@ final class ByteBufferCollector implements ChannelOutboundBuffer.MessageProcesso
     // Clear all ByteBuffer from the array so these can be GC'ed.
     // See https://github.com/netty/netty/issues/3837
     void reset() {
+        if (cache == null) {
+            cache = NIO_BUFFERS.get();
+        }
         int count = cache.bufferCount;
         if (count > 0) {
             Arrays.fill(cache.buffers, 0, count, null);

--- a/transport/src/test/java/io/netty5/channel/ChannelOutboundBufferTest.java
+++ b/transport/src/test/java/io/netty5/channel/ChannelOutboundBufferTest.java
@@ -17,7 +17,6 @@ package io.netty5.channel;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
-import io.netty5.buffer.api.CompositeBuffer;
 import io.netty5.channel.ChannelOutboundBuffer.MessageProcessor;
 import io.netty5.util.CharsetUtil;
 import io.netty5.util.concurrent.EventExecutor;
@@ -25,11 +24,8 @@ import io.netty5.util.concurrent.Promise;
 import io.netty5.util.concurrent.SingleThreadEventExecutor;
 import org.junit.jupiter.api.Test;
 
-import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -58,19 +54,6 @@ public class ChannelOutboundBufferTest {
     }
 
     @Test
-    public void testEmptyNioBuffers() throws InterruptedException {
-        testChannelOutboundBuffer((buffer, executor) -> {
-            assertEquals(0, buffer.nioBufferCount());
-            ByteBuffer[] buffers = buffer.nioBuffers();
-            assertNotNull(buffers);
-            for (ByteBuffer b : buffers) {
-                assertNull(b);
-            }
-            assertEquals(0, buffer.nioBufferCount());
-        });
-    }
-
-    @Test
     public void flushingEmptyBuffers() throws InterruptedException {
         testChannelOutboundBuffer((buffer, executor) -> {
             Buffer buf = BufferAllocator.onHeapUnpooled().allocate(0);
@@ -88,114 +71,6 @@ public class ChannelOutboundBufferTest {
             messageCounter.set(0);
             buffer.forEachFlushedMessage(messageProcessor);
             assertThat(messageCounter.get()).isZero();
-        });
-    }
-
-    @Test
-    public void testNioBuffersSingleBacked() throws InterruptedException {
-        testChannelOutboundBuffer((buffer, executor) -> {
-            assertEquals(0, buffer.nioBufferCount());
-
-            Buffer buf = BufferAllocator.onHeapUnpooled().copyOf("buf1", CharsetUtil.US_ASCII);
-            buffer.addMessage(buf, buf.readableBytes(), executor.newPromise());
-            assertEquals(0, buffer.nioBufferCount(), "Should still be 0 as not flushed yet");
-            buffer.addFlush();
-            ByteBuffer[] buffers = buffer.nioBuffers();
-            assertNotNull(buffers);
-            assertEquals(1, buffer.nioBufferCount(), "Should still be 0 as not flushed yet");
-            for (int i = 0; i < buffer.nioBufferCount(); i++) {
-                if (i == 0) {
-                    assertEquals(1, buf.countReadableComponents());
-                    try (var iteration = buf.forEachComponent()) {
-                        var component = iteration.firstReadable();
-                        assertEquals(buffers[0], component.readableBuffer());
-                        assertNull(component.nextReadable(), "Expected buffer to only have a single component.");
-                    }
-                } else {
-                    assertNull(buffers[i]);
-                }
-            }
-        });
-    }
-
-    @Test
-    public void testNioBuffersExpand() throws InterruptedException {
-        testChannelOutboundBuffer((buffer, executor) -> {
-            Buffer buf = BufferAllocator.offHeapUnpooled().copyOf("buf1", CharsetUtil.US_ASCII);
-            for (int i = 0; i < 64; i++) {
-                buffer.addMessage(buf.copy(), buf.readableBytes(), executor.newPromise());
-            }
-            assertEquals(0, buffer.nioBufferCount(), "Should still be 0 as not flushed yet");
-            buffer.addFlush();
-            ByteBuffer[] buffers = buffer.nioBuffers();
-            assertEquals(64, buffer.nioBufferCount());
-            assertEquals(1, buf.countReadableComponents());
-            try (var iteration = buf.forEachComponent()) {
-                var component = iteration.firstReadable();
-                ByteBuffer expected = component.readableBuffer();
-                for (int i = 0; i < buffer.nioBufferCount(); i++) {
-                    assertEquals(expected, buffers[i]);
-                }
-                assertNull(component.nextReadable());
-            }
-            buf.close();
-        });
-    }
-
-    @Test
-    public void testNioBuffersExpand2() throws InterruptedException {
-        testChannelOutboundBuffer((buffer, executor) -> {
-            Buffer buf = BufferAllocator.offHeapUnpooled().copyOf("buf1", CharsetUtil.US_ASCII);
-            var sends = Stream.generate(() -> buf.copy().send()).limit(65).collect(Collectors.toList());
-            CompositeBuffer comp = BufferAllocator.offHeapUnpooled().compose(sends);
-
-            buffer.addMessage(comp, comp.readableBytes(), executor.newPromise());
-
-            assertEquals(0, buffer.nioBufferCount(), "Should still be 0 as not flushed yet");
-            buffer.addFlush();
-            ByteBuffer[] buffers = buffer.nioBuffers();
-            assertEquals(65, buffer.nioBufferCount());
-            assertEquals(1, buf.countReadableComponents());
-            try (var iteration = buf.forEachComponent()) {
-                var component = iteration.firstReadable();
-                ByteBuffer expected = component.readableBuffer();
-                for (int i = 0; i < buffer.nioBufferCount(); i++) {
-                    if (i < 65) {
-                        assertEquals(expected, buffers[i]);
-                    } else {
-                        assertNull(buffers[i]);
-                    }
-                }
-                assertNull(component.nextReadable());
-            }
-            buf.close();
-        });
-    }
-
-    @Test
-    public void testNioBuffersMaxCount() throws InterruptedException {
-        testChannelOutboundBuffer((buffer, executor) -> {
-            Buffer buf = BufferAllocator.offHeapUnpooled().copyOf("buf1", CharsetUtil.US_ASCII);
-            assertEquals(4, buf.readableBytes());
-            var sends = Stream.generate(() -> buf.copy().send()).limit(65).collect(Collectors.toList());
-            CompositeBuffer comp = BufferAllocator.offHeapUnpooled().compose(sends);
-
-            assertEquals(65, comp.countComponents());
-            buffer.addMessage(comp, comp.readableBytes(), executor.newPromise());
-            assertEquals(0, buffer.nioBufferCount(), "Should still be 0 as not flushed yet");
-            buffer.addFlush();
-            final int maxCount = 10;    // less than comp.nioBufferCount()
-            ByteBuffer[] buffers = buffer.nioBuffers(maxCount, Integer.MAX_VALUE);
-            assertTrue(buffer.nioBufferCount() <= maxCount, "Should not be greater than maxCount");
-            try (var iteration = buf.forEachComponent()) {
-                var component = iteration.firstReadable();
-                ByteBuffer expected = component.readableBuffer();
-                for (int i = 0; i < buffer.nioBufferCount(); i++) {
-                    assertEquals(expected, buffers[i]);
-                }
-                assertNull(component.nextReadable());
-            }
-            buf.close();
         });
     }
 

--- a/transport/src/test/java/io/netty5/channel/socket/nio/ByteBufferCollectorTest.java
+++ b/transport/src/test/java/io/netty5/channel/socket/nio/ByteBufferCollectorTest.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.socket.nio;
+
+import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.api.BufferAllocator;
+import io.netty5.buffer.api.CompositeBuffer;
+import io.netty5.channel.AbstractChannel;
+import io.netty5.channel.Channel;
+import io.netty5.channel.ChannelOutboundBuffer;
+import io.netty5.channel.ChannelShutdownDirection;
+import io.netty5.channel.EventLoop;
+
+import io.netty5.channel.WriteHandleFactory;
+import io.netty5.util.concurrent.ImmediateEventExecutor;
+import org.junit.jupiter.api.Test;
+
+import java.net.SocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static io.netty5.util.concurrent.ImmediateEventExecutor.INSTANCE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ByteBufferCollectorTest {
+
+    @Test
+    public void testEmptyNioBuffers() {
+        ByteBufferCollector collector = newCollector();
+        ChannelOutboundBuffer buffer = newOutboundBuffer();
+        assertEmpty(collector, buffer);
+    }
+
+    private static void assertEmpty(ByteBufferCollector collector, ChannelOutboundBuffer buffer) {
+        ByteBuffer[] buffers = collector.collect(buffer, Integer.MAX_VALUE, Long.MAX_VALUE);
+        assertEquals(0, collector.nioBufferCount());
+        assertNotNull(buffers);
+        for (ByteBuffer b : buffers) {
+            assertNull(b);
+        }
+        assertEquals(0, collector.nioBufferSize());
+    }
+
+    @Test
+    public void testNioBuffersSingleBacked() {
+        ByteBufferCollector collector = newCollector();
+        ChannelOutboundBuffer buffer = newOutboundBuffer();
+        Buffer buf = BufferAllocator.onHeapUnpooled().copyOf("buf1", StandardCharsets.US_ASCII);
+        buffer.addMessage(buf, buf.readableBytes(), ImmediateEventExecutor.INSTANCE.newPromise());
+
+        // Still empty as not flushed.
+        assertEmpty(collector, buffer);
+
+        buffer.addFlush();
+        ByteBuffer[] buffers = collector.collect(buffer, Integer.MAX_VALUE, Long.MAX_VALUE);
+        assertNotNull(buffers);
+        assertEquals(1, collector.nioBufferCount(), "Should still be 0 as not flushed yet");
+        for (int i = 0; i < collector.nioBufferCount(); i++) {
+            if (i == 0) {
+                assertEquals(1, buf.countReadableComponents());
+                try (var iteration = buf.forEachComponent()) {
+                    var component = iteration.firstReadable();
+                    assertEquals(buffers[0], component.readableBuffer());
+                    assertNull(component.nextReadable(), "Expected buffer to only have a single component.");
+                }
+            } else {
+                assertNull(buffers[i]);
+            }
+        }
+    }
+
+    @Test
+    public void testNioBuffersExpand() {
+        ByteBufferCollector collector = newCollector();
+        ChannelOutboundBuffer buffer = newOutboundBuffer();
+
+        try (Buffer buf = BufferAllocator.offHeapUnpooled().copyOf("buf1", StandardCharsets.US_ASCII)) {
+            for (int i = 0; i < 64; i++) {
+                buffer.addMessage(buf.copy(), buf.readableBytes(), ImmediateEventExecutor.INSTANCE.newPromise());
+            }
+            // Still empty as not flushed.
+            assertEmpty(collector, buffer);
+
+            buffer.addFlush();
+            ByteBuffer[] buffers = collector.collect(buffer, Integer.MAX_VALUE, Long.MAX_VALUE);
+            assertEquals(64, collector.nioBufferCount());
+            assertEquals(1, buf.countReadableComponents());
+            try (var iteration = buf.forEachComponent()) {
+                var component = iteration.firstReadable();
+                ByteBuffer expected = component.readableBuffer();
+                for (int i = 0; i < collector.nioBufferCount(); i++) {
+                    assertEquals(expected, buffers[i]);
+                }
+                assertNull(component.nextReadable());
+            }
+        }
+    }
+
+    @Test
+    public void testNioBuffersExpand2() {
+        ByteBufferCollector collector = newCollector();
+        ChannelOutboundBuffer buffer = newOutboundBuffer();
+
+        try (Buffer buf = BufferAllocator.offHeapUnpooled().copyOf("buf1", StandardCharsets.US_ASCII)) {
+            var sends = Stream.generate(() -> buf.copy().send()).limit(65).collect(Collectors.toList());
+            CompositeBuffer comp = BufferAllocator.offHeapUnpooled().compose(sends);
+
+            buffer.addMessage(comp, comp.readableBytes(), ImmediateEventExecutor.INSTANCE.newPromise());
+
+            // Still empty as not flushed.
+            assertEmpty(collector, buffer);
+
+            buffer.addFlush();
+            ByteBuffer[] buffers = collector.collect(buffer, Integer.MAX_VALUE, Long.MAX_VALUE);
+            assertEquals(65, collector.nioBufferCount());
+            assertEquals(1, buf.countReadableComponents());
+            try (var iteration = buf.forEachComponent()) {
+                var component = iteration.firstReadable();
+                ByteBuffer expected = component.readableBuffer();
+                for (int i = 0; i < collector.nioBufferCount(); i++) {
+                    if (i < 65) {
+                        assertEquals(expected, buffers[i]);
+                    } else {
+                        assertNull(buffers[i]);
+                    }
+                }
+                assertNull(component.nextReadable());
+            }
+        }
+    }
+
+    @Test
+    public void testNioBuffersMaxCount() {
+        ByteBufferCollector collector = newCollector();
+        ChannelOutboundBuffer buffer = newOutboundBuffer();
+
+        try (Buffer buf = BufferAllocator.offHeapUnpooled().copyOf("buf1", StandardCharsets.US_ASCII)) {
+            assertEquals(4, buf.readableBytes());
+            var sends = Stream.generate(() -> buf.copy().send()).limit(65).collect(Collectors.toList());
+            CompositeBuffer comp = BufferAllocator.offHeapUnpooled().compose(sends);
+
+            assertEquals(65, comp.countComponents());
+            buffer.addMessage(comp, comp.readableBytes(), ImmediateEventExecutor.INSTANCE.newPromise());
+
+            // Still empty as not flushed.
+            assertEmpty(collector, buffer);
+
+            buffer.addFlush();
+            final int maxCount = 10;    // less than comp.nioBufferCount()
+            ByteBuffer[] buffers = collector.collect(buffer, maxCount, Integer.MAX_VALUE);
+            assertTrue(collector.nioBufferCount() <= maxCount, "Should not be greater than maxCount");
+            try (var iteration = buf.forEachComponent()) {
+                var component = iteration.firstReadable();
+                ByteBuffer expected = component.readableBuffer();
+                for (int i = 0; i < collector.nioBufferCount(); i++) {
+                    assertEquals(expected, buffers[i]);
+                }
+                assertNull(component.nextReadable());
+            }
+        }
+    }
+
+    private static ByteBufferCollector newCollector() {
+        ByteBufferCollector collector = new ByteBufferCollector();
+        collector.reset();
+        return collector;
+    }
+
+    private static ChannelOutboundBuffer newOutboundBuffer() {
+        EventLoop eventLoop = mock(EventLoop.class);
+        // This allows us to have a single-threaded test
+        when(eventLoop.inEventLoop()).thenReturn(true);
+        when(eventLoop.newPromise()).thenReturn(INSTANCE.newPromise());
+        when(eventLoop.isCompatible(any())).thenReturn(true);
+
+        return new TestChannel(eventLoop).outbound();
+    }
+
+    private static class TestChannel extends AbstractChannel<Channel, SocketAddress, SocketAddress> {
+
+        TestChannel(EventLoop eventLoop) {
+            super(null, eventLoop, false);
+        }
+
+        ChannelOutboundBuffer outbound() {
+            return outboundBuffer();
+        }
+
+        @Override
+        public boolean isOpen() {
+            return true;
+        }
+
+        @Override
+        public boolean isActive() {
+            return true;
+        }
+
+        @Override
+        protected boolean doConnect(SocketAddress remoteAddress, SocketAddress localAddress) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        protected boolean doFinishConnect(SocketAddress requestedRemoteAddress) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        protected SocketAddress localAddress0() {
+            return null;
+        }
+
+        @Override
+        protected SocketAddress remoteAddress0() {
+            return null;
+        }
+
+        @Override
+        protected void doBind(SocketAddress localAddress) { }
+
+        @Override
+        protected void doDisconnect() { }
+
+        @Override
+        protected void doClose() { }
+
+        @Override
+        protected void doRead(boolean wasReadPendingAlready) { }
+
+        @Override
+        protected boolean doReadNow(ReadSink readSink) {
+            return false;
+        }
+
+        @Override
+        protected void doWrite(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle) throws Exception {
+            // NOOP
+        }
+
+        @Override
+        protected void doShutdown(ChannelShutdownDirection direction) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isShutdown(ChannelShutdownDirection direction) {
+            return !isActive();
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

The ByteBuffer[] related methods are only needed for NioSocketChannel and can be implemented in a MessageProcessor. Let's remove these from ChannelOutboundBuffer.

Modifications:

Move ByteBuffer[] collecting into a MessageProcessor implementation that is hidden by the end-user.

Result:

Cleanup of API
