### PR TITLE
Add heap / thread dumps to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,10 @@
 hs_err_pid*.log
 replay_pid*.log
 
+# JVM dumps
+*.hprof.xz
+*.threads
+
 dependency-reduced-pom.xml
 
 */.unison.*


### PR DESCRIPTION
Motivation:

We should not commit heap / thread dumps by mistake.

Modifications:

Add dump related files to .gitignore

Result:

No commit dumps by mistake