### PR TITLE
Optimize HpackStaticTable by using a perfect hash function

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackStaticTable.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackStaticTable.java
@@ -32,6 +32,7 @@
 package io.netty.handler.codec.http2;
 
 import io.netty.util.AsciiString;
+import io.netty.util.internal.PlatformDependent;
 
 import java.util.Arrays;
 import java.util.List;
@@ -120,7 +121,7 @@ final class HpackStaticTable {
     private static final int HEADER_NAMES_TABLE_SIZE = 1 << 9;
 
     // a bit shift chosen so that each header name will hash into a single bucket
-    private static final int HEADER_NAMES_TABLE_SHIFT = 18;
+    private static final int HEADER_NAMES_TABLE_SHIFT = PlatformDependent.BIG_ENDIAN_NATIVE_ORDER ? 22 : 18;
 
     // A table holding header names and their associated indexes.
     private static final HeaderNameIndex[] HEADER_NAMES = new HeaderNameIndex[HEADER_NAMES_TABLE_SIZE];
@@ -143,7 +144,8 @@ final class HpackStaticTable {
     private static final int HEADERS_WITH_NON_EMPTY_VALUES_TABLE_SIZE = 1 << 6;
 
     // a bit shift chosen so that each header will hash into a single bucket
-    private static final int HEADERS_WITH_NON_EMPTY_VALUES_TABLE_SHIFT = 6;
+    private static final int HEADERS_WITH_NON_EMPTY_VALUES_TABLE_SHIFT =
+      PlatformDependent.BIG_ENDIAN_NATIVE_ORDER ? 0 : 6;
 
     // A table holding header names and values for non-empty values.
     // This table is keyed by value which is possible since each non-empty value is unique.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackStaticTable.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackStaticTable.java
@@ -117,12 +117,12 @@ final class HpackStaticTable {
         return new HpackHeaderField(AsciiString.cached(name), AsciiString.cached(value));
     }
 
+    // The table size and bit shift are chosen so that each hash bucket contains a single header name.
     private static final int HEADER_NAMES_TABLE_SIZE = 1 << 9;
 
-    // a bit shift chosen so that each header name will hash into a single bucket
     private static final int HEADER_NAMES_TABLE_SHIFT = PlatformDependent.BIG_ENDIAN_NATIVE_ORDER ? 22 : 18;
 
-    // A table holding header names and their associated indexes.
+    // A table mapping header names to their associated indexes.
     private static final HeaderNameIndex[] HEADER_NAMES = new HeaderNameIndex[HEADER_NAMES_TABLE_SIZE];
     static {
         // Iterate through the static table in reverse order to
@@ -140,14 +140,13 @@ final class HpackStaticTable {
         }
     }
 
+    // The table size and bit shift are chosen so that each hash bucket contains a single header.
     private static final int HEADERS_WITH_NON_EMPTY_VALUES_TABLE_SIZE = 1 << 6;
 
-    // a bit shift chosen so that each header will hash into a single bucket
     private static final int HEADERS_WITH_NON_EMPTY_VALUES_TABLE_SHIFT =
       PlatformDependent.BIG_ENDIAN_NATIVE_ORDER ? 0 : 6;
 
-    // A table holding header names and values for non-empty values.
-    // This table is keyed by value which is possible since each non-empty value is unique.
+    // A table mapping headers with non-empty values to their associated indexes.
     private static final HeaderIndex[] HEADERS_WITH_NON_EMPTY_VALUES =
       new HeaderIndex[HEADERS_WITH_NON_EMPTY_VALUES_TABLE_SIZE];
     static {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackStaticTable.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackStaticTable.java
@@ -236,11 +236,11 @@ final class HpackStaticTable {
     }
 
     private static final class HeaderNameIndex {
-        private final CharSequence name;
-        private final int index;
-        private final boolean emptyValue;
+        final CharSequence name;
+        final int index;
+        final boolean emptyValue;
 
-        private HeaderNameIndex(CharSequence name, int index, boolean emptyValue) {
+        HeaderNameIndex(CharSequence name, int index, boolean emptyValue) {
             this.name = name;
             this.index = index;
             this.emptyValue = emptyValue;
@@ -248,11 +248,11 @@ final class HpackStaticTable {
     }
 
     private static final class HeaderIndex {
-        private final CharSequence name;
-        private final CharSequence value;
-        private final int index;
+        final CharSequence name;
+        final CharSequence value;
+        final int index;
 
-        private HeaderIndex(CharSequence name, CharSequence value, int index) {
+        HeaderIndex(CharSequence name, CharSequence value, int index) {
             this.name = name;
             this.value = value;
             this.index = index;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackStaticTable.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackStaticTable.java
@@ -38,7 +38,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import static io.netty.handler.codec.http2.HpackUtil.equalsVariableTime;
-import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 final class HpackStaticTable {
 
@@ -184,7 +183,6 @@ final class HpackStaticTable {
      * -1 if the header field name is not in the static table.
      */
     static int getIndex(CharSequence name) {
-        checkNotNull(name, "name");
         HeaderNameIndex entry = getEntry(name);
         return entry == null ? NOT_FOUND : entry.index;
     }
@@ -194,10 +192,6 @@ final class HpackStaticTable {
      * header field is not in the static table.
      */
     static int getIndexInsensitive(CharSequence name, CharSequence value) {
-        checkNotNull(name, "name");
-        if (value == null) {
-            return NOT_FOUND;
-        }
         if (value.length() == 0) {
             HeaderNameIndex entry = getEntry(name);
             return entry == null || !entry.emptyValue ? NOT_FOUND : entry.index;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackStaticTable.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackStaticTable.java
@@ -194,17 +194,16 @@ final class HpackStaticTable {
         if (value.length() == 0) {
             HeaderNameIndex entry = getEntry(name);
             return entry == null || !entry.emptyValue ? NOT_FOUND : entry.index;
-        } else {
-            int bucket = headerBucket(value);
-            HeaderIndex header = HEADERS_WITH_NON_EMPTY_VALUES[bucket];
-            if (header == null) {
-                return NOT_FOUND;
-            }
-            if (equalsVariableTime(header.name, name) && equalsVariableTime(header.value, value)) {
-                return header.index;
-            }
+        }
+        int bucket = headerBucket(value);
+        HeaderIndex header = HEADERS_WITH_NON_EMPTY_VALUES[bucket];
+        if (header == null) {
             return NOT_FOUND;
         }
+        if (equalsVariableTime(header.name, name) && equalsVariableTime(header.value, value)) {
+            return header.index;
+        }
+        return NOT_FOUND;
     }
 
     private static HeaderNameIndex getEntry(CharSequence name) {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackStaticTableTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackStaticTableTest.java
@@ -17,51 +17,14 @@ package io.netty.handler.codec.http2;
 
 import io.netty.util.AsciiString;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class HpackStaticTableTest {
 
     @Test
-    public void testNullHeaderName() {
-        assertThrows(NullPointerException.class, new Executable() {
-            @Override
-            public void execute() {
-                HpackStaticTable.getIndex(null);
-            }
-        });
-    }
-
-    @Test
     public void testEmptyHeaderName() {
         assertEquals(-1, HpackStaticTable.getIndex(""));
-    }
-
-    @Test
-    public void testNullHeaderNameEmptyValue() {
-        assertThrows(NullPointerException.class, new Executable() {
-            @Override
-            public void execute() {
-                HpackStaticTable.getIndexInsensitive(null, "");
-            }
-        });
-    }
-
-    @Test
-    public void testEmptyHeaderNameNullValue() {
-        assertEquals(-1, HpackStaticTable.getIndexInsensitive("", null));
-    }
-
-    @Test
-    public void testNullHeaderNameAndValue() {
-        assertThrows(NullPointerException.class, new Executable() {
-            @Override
-            public void execute() {
-                HpackStaticTable.getIndexInsensitive(null, null);
-            }
-        });
     }
 
     @Test
@@ -103,11 +66,6 @@ public class HpackStaticTableTest {
     @Test
     public void testExistingHeaderNameAndEmptyValueMatch() {
         assertEquals(27, HpackStaticTable.getIndexInsensitive("content-language", ""));
-    }
-
-    @Test
-    public void testExistingHeaderNameAndNullValue() {
-        assertEquals(-1, HpackStaticTable.getIndexInsensitive("content-language", null));
     }
 
     @Test

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackStaticTableTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackStaticTableTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.netty.handler.codec.http2;
+
+import io.netty.util.AsciiString;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class HpackStaticTableTest {
+
+    @Test
+    public void testNullHeaderName() {
+        assertThrows(NullPointerException.class, new Executable() {
+            @Override
+            public void execute() {
+                HpackStaticTable.getIndex(null);
+            }
+        });
+    }
+
+    @Test
+    public void testEmptyHeaderName() {
+        assertEquals(-1, HpackStaticTable.getIndex(""));
+    }
+
+    @Test
+    public void testNullHeaderNameEmptyValue() {
+        assertThrows(NullPointerException.class, new Executable() {
+            @Override
+            public void execute() {
+                HpackStaticTable.getIndexInsensitive(null, "");
+            }
+        });
+    }
+
+    @Test
+    public void testEmptyHeaderNameNullValue() {
+        assertEquals(-1, HpackStaticTable.getIndexInsensitive("", null));
+    }
+
+    @Test
+    public void testNullHeaderNameAndValue() {
+        assertThrows(NullPointerException.class, new Executable() {
+            @Override
+            public void execute() {
+                HpackStaticTable.getIndexInsensitive(null, null);
+            }
+        });
+    }
+
+    @Test
+    public void testMissingHeaderName() {
+        assertEquals(-1, HpackStaticTable.getIndex("missing"));
+    }
+
+    @Test
+    public void testExistingHeaderName() {
+        assertEquals(6, HpackStaticTable.getIndex(":scheme"));
+    }
+
+    @Test
+    public void testMissingHeaderNameAndValue() {
+        assertEquals(-1, HpackStaticTable.getIndexInsensitive("missing", "value"));
+    }
+
+    @Test
+    public void testMissingHeaderNameButValueExists() {
+        assertEquals(-1, HpackStaticTable.getIndexInsensitive("missing", "https"));
+    }
+
+    @Test
+    public void testExistingHeaderNameAndValueFirstMatch() {
+        assertEquals(6, HpackStaticTable.getIndexInsensitive(":scheme", "http"));
+    }
+
+    @Test
+    public void testExistingHeaderNameAndValueSecondMatch() {
+        assertEquals(7, HpackStaticTable.getIndexInsensitive(
+          AsciiString.cached(":scheme"), AsciiString.cached("https")));
+    }
+
+    @Test
+    public void testLongHeaderValue() {
+        assertEquals(-1, HpackStaticTable.getIndexInsensitive(":scheme", "longer then longest static value"));
+    }
+
+    @Test
+    public void testExistingHeaderNameAndEmptyValueMismatch() {
+        assertEquals(-1, HpackStaticTable.getIndexInsensitive(":scheme", ""));
+    }
+
+    @Test
+    public void testExistingHeaderNameAndEmptyValueMatch() {
+        assertEquals(27, HpackStaticTable.getIndexInsensitive("content-language", ""));
+    }
+
+    @Test
+    public void testExistingHeaderNameAndNullValue() {
+        assertEquals(-1, HpackStaticTable.getIndexInsensitive("content-language", null));
+    }
+
+    @Test
+    public void testExistingHeaderNameButMissingValue() {
+        assertEquals(-1, HpackStaticTable.getIndexInsensitive(":scheme", "missing"));
+    }
+
+}

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackStaticTableTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackStaticTableTest.java
@@ -96,11 +96,6 @@ public class HpackStaticTableTest {
     }
 
     @Test
-    public void testLongHeaderValue() {
-        assertEquals(-1, HpackStaticTable.getIndexInsensitive(":scheme", "longer then longest static value"));
-    }
-
-    @Test
     public void testExistingHeaderNameAndEmptyValueMismatch() {
         assertEquals(-1, HpackStaticTable.getIndexInsensitive(":scheme", ""));
     }

--- a/microbench/src/main/java/io/netty/handler/codec/http2/HpackStaticTableBenchmark.java
+++ b/microbench/src/main/java/io/netty/handler/codec/http2/HpackStaticTableBenchmark.java
@@ -66,6 +66,24 @@ public class HpackStaticTableBenchmark extends AbstractMicrobenchmark {
 
     @Benchmark
     @BenchmarkMode(Mode.AverageTime)
+    public int lookupNameAndValueMatchFirst() {
+        return HpackStaticTable.getIndexInsensitive(STATUS, STATUS_200);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    public int lookupNameAndValueMatchLast() {
+        return HpackStaticTable.getIndexInsensitive(STATUS, STATUS_500);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    public int lookupNameOnlyMatchBeginTable() {
+        return HpackStaticTable.getIndexInsensitive(AUTHORITY, AUTHORITY_NETTY);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
     public int lookupHttp() {
         return HpackStaticTable.getIndexInsensitive(SCHEME, HTTP);
     }
@@ -78,7 +96,7 @@ public class HpackStaticTableBenchmark extends AbstractMicrobenchmark {
 
     @Benchmark
     @BenchmarkMode(Mode.AverageTime)
-    public int lookupNameOnlyMatch() {
+    public int lookupNameOnlyMatchEndTable() {
         return HpackStaticTable.getIndexInsensitive(USER_AGENT, USER_AGENT_CURL);
     }
 }

--- a/microbench/src/main/java/io/netty/handler/codec/http2/HpackStaticTableBenchmark.java
+++ b/microbench/src/main/java/io/netty/handler/codec/http2/HpackStaticTableBenchmark.java
@@ -43,6 +43,9 @@ public class HpackStaticTableBenchmark extends AbstractMicrobenchmark {
     private static final CharSequence X_CONTENT_ENCODING =
             new AsciiString("x-content-encoding".getBytes(CharsetUtil.US_ASCII), false);
     private static final CharSequence X_GZIP = new AsciiString("x-gzip".getBytes(CharsetUtil.US_ASCII), false);
+    private static final CharSequence SCHEME = new AsciiString(":scheme".getBytes(CharsetUtil.US_ASCII), false);
+    private static final CharSequence HTTP = new AsciiString("http".getBytes(CharsetUtil.US_ASCII), false);
+    private static final CharSequence HTTPS = new AsciiString("https".getBytes(CharsetUtil.US_ASCII), false);
     private static final CharSequence STATUS = new AsciiString(":status".getBytes(CharsetUtil.US_ASCII), false);
     private static final CharSequence STATUS_200 = new AsciiString("200".getBytes(CharsetUtil.US_ASCII), false);
     private static final CharSequence STATUS_500 = new AsciiString("500".getBytes(CharsetUtil.US_ASCII), false);
@@ -63,25 +66,19 @@ public class HpackStaticTableBenchmark extends AbstractMicrobenchmark {
 
     @Benchmark
     @BenchmarkMode(Mode.AverageTime)
-    public int lookupNameAndValueMatchFirst() {
-        return HpackStaticTable.getIndexInsensitive(STATUS, STATUS_200);
+    public int lookupHttp() {
+        return HpackStaticTable.getIndexInsensitive(SCHEME, HTTP);
     }
 
     @Benchmark
     @BenchmarkMode(Mode.AverageTime)
-    public int lookupNameAndValueMatchLast() {
-        return HpackStaticTable.getIndexInsensitive(STATUS, STATUS_500);
+    public int lookupHttps() {
+        return HpackStaticTable.getIndexInsensitive(SCHEME, HTTPS);
     }
 
     @Benchmark
     @BenchmarkMode(Mode.AverageTime)
-    public int lookupNameOnlyMatchBeginTable() {
-        return HpackStaticTable.getIndexInsensitive(AUTHORITY, AUTHORITY_NETTY);
-    }
-
-    @Benchmark
-    @BenchmarkMode(Mode.AverageTime)
-    public int lookupNameOnlyMatchEndTable() {
+    public int lookupNameOnlyMatch() {
         return HpackStaticTable.getIndexInsensitive(USER_AGENT, USER_AGENT_CURL);
     }
 }


### PR DESCRIPTION
Motivation:

HpackStaticTable performance can be improved by using a perfect hash function.

Modifications:

Use 2 tables, one for mapping header name -> index and one for mapping header name + value -> index.
Choose the tables size and the hash function in such a way that each hash bucket contains a single entry.

Results:

|Benchmark|                                      (optimized)|  Mode|  Cnt|   Score|   Error|  Units|
|:-|:-:|:-:|:-:|:-:|:-:|:-:|
|HpackStaticTableBenchmark.lookupHttp|                 false|  avgt|   10|  15.998| ±1.646|  ns/op|
|HpackStaticTableBenchmark.lookupHttp|                  true|  avgt|   10|  10.457| ±0.274|  ns/op|
|HpackStaticTableBenchmark.lookupHttps|                false|  avgt|   10|  20.942| ±1.365|  ns/op|
|HpackStaticTableBenchmark.lookupHttps|                 true|  avgt|   10|  10.618| ±0.138|  ns/op|
|HpackStaticTableBenchmark.lookupNameOnlyMatchEndTable|        false|  avgt|   10|  13.710| ±0.273|  ns/op|
|HpackStaticTableBenchmark.lookupNameOnlyMatchEndTable|        true|  avgt|   10|   3.156| ±0.052|  ns/op|
|HpackStaticTableBenchmark.lookupNoNameMatch|         false|  avgt|   10|   3.528| ±0.047|  ns/op|
|HpackStaticTableBenchmark.lookupNoNameMatch|           true|  avgt|   10|   3.145| ±0.031|  ns/op|

Caveats:

This implementation couples HpackStaticTable implementation to the implementation of AsciiString.hashCode, relying on the values it returns for the static table headers to yield a perfect hash function. If AsciiString.hashCode implementation changes, HpackStaticTable implementation will also need to change. Moreover, if AsciiString.hashCode can return different values on different jvm instances (for reasons other than endianness), then it invalidates the approach taken here (or at least makes its implementation much more complex).