### PR TITLE
Hide ChannelOutboundBuffer and WriteHandle from the sub-classes of Ab…

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
@@ -241,7 +241,8 @@ abstract class AbstractEpollChannel<P extends UnixChannel>
     }
 
     /**
-     * Read bytes into the given {@link Buffer} and return the amount.
+     * Read bytes into the given {@link Buffer} and return the amount. This method does not modify the offset of the
+     * buffer.
      */
     protected final int doReadBytes(Buffer buffer) throws Exception {
         try (var iterator = buffer.forEachComponent()) {
@@ -251,11 +252,7 @@ abstract class AbstractEpollChannel<P extends UnixChannel>
             }
             long address = component.writableNativeAddress();
             assert address != 0;
-            int localReadAmount = socket.recvAddress(address, 0, component.writableBytes());
-            if (localReadAmount > 0) {
-                component.skipWritableBytes(localReadAmount);
-            }
-            return localReadAmount;
+            return socket.recvAddress(address, 0, component.writableBytes());
         }
     }
 

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
@@ -28,7 +28,6 @@ import io.netty5.channel.unix.RawUnixChannelOption;
 import io.netty5.util.Resource;
 import io.netty5.channel.AbstractChannel;
 import io.netty5.channel.ChannelException;
-import io.netty5.channel.ChannelOutboundBuffer;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.unix.FileDescriptor;
 import io.netty5.channel.unix.IovArray;
@@ -260,7 +259,7 @@ abstract class AbstractEpollChannel<P extends UnixChannel>
         }
     }
 
-    protected final int doWriteBytes(ChannelOutboundBuffer in, Buffer buf) throws Exception {
+    protected final int doWriteBytes(Buffer buf) throws Exception {
         int written = 0;
         try (var iterator = buf.forEachComponent()) {
             var component = iterator.firstReadable();
@@ -270,11 +269,7 @@ abstract class AbstractEpollChannel<P extends UnixChannel>
                 written = socket.sendAddress(address, 0, component.readableBytes());
             }
         }
-        if (written > 0) {
-            in.removeBytes(written);
-            return 1; // Some data was written to the socket.
-        }
-        return -1;
+        return written;
     }
 
     /**
@@ -436,7 +431,8 @@ abstract class AbstractEpollChannel<P extends UnixChannel>
     /**
      * Connect to the remote peer
      */
-    protected boolean doConnect(SocketAddress remoteAddress, SocketAddress localAddress) throws Exception {
+    protected boolean doConnect(SocketAddress remoteAddress, SocketAddress localAddress, Buffer initialData)
+            throws Exception {
         if (localAddress instanceof InetSocketAddress) {
             checkResolvable((InetSocketAddress) localAddress);
         }
@@ -451,7 +447,7 @@ abstract class AbstractEpollChannel<P extends UnixChannel>
             socket.bind(localAddress);
         }
 
-        boolean connected = doConnect0(remoteAddress);
+        boolean connected = doConnect0(remoteAddress, initialData);
         if (connected) {
             this.remoteAddress = remoteSocketAddr == null ?
                     remoteAddress : computeRemoteAddr(remoteSocketAddr, socket.remoteAddress());
@@ -466,7 +462,7 @@ abstract class AbstractEpollChannel<P extends UnixChannel>
         return connected;
     }
 
-    protected boolean doConnect0(SocketAddress remote) throws Exception {
+    protected boolean doConnect0(SocketAddress remote, Buffer initialData) throws Exception {
         boolean success = false;
         try {
             boolean connected = socket.connect(remote);

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
@@ -553,7 +553,6 @@ abstract class AbstractEpollChannel<P extends UnixChannel>
 
     @Override
     protected void writeLoopComplete(boolean allWritten) {
-        super.writeLoopComplete(allWritten);
         try {
             if (allWritten) {
                 clearFlag(Native.EPOLLOUT);
@@ -563,6 +562,7 @@ abstract class AbstractEpollChannel<P extends UnixChannel>
         } catch (IOException e) {
             throw new UncheckedIOException("Error while trying to update flags", e);
         }
+        super.writeLoopComplete(allWritten);
     }
 
     @Override

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDatagramChannel.java
@@ -346,14 +346,13 @@ public final class EpollDatagramChannel extends AbstractEpollChannel<UnixChannel
             int cnt = array.count();
 
             if (cnt >= 1) {
-                    // Try to use gathering writes via sendmmsg(...) syscall.
-                    int offset = 0;
-                    NativeDatagramPacketArray.NativeDatagramPacket[] packets = array.packets();
+                // Try to use gathering writes via sendmmsg(...) syscall.
+                int offset = 0;
+                NativeDatagramPacketArray.NativeDatagramPacket[] packets = array.packets();
                 long sentBytes = 0;
                 long notSentBytes = 0;
-                int send = 0;
                 try {
-                    send = socket.sendmmsg(packets, offset, cnt);
+                    int send = socket.sendmmsg(packets, offset, cnt);
                     for (int i = 0; i < cnt; i++) {
                         int count = packets[i].count();
                         if (i < send) {

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDatagramChannel.java
@@ -513,6 +513,8 @@ public final class EpollDatagramChannel extends AbstractEpollChannel<UnixChannel
 
                     return actualBytesRead == 0 ? ReadState.All : ReadState.Closed;
                 }
+
+                buf.skipWritableBytes(actualBytesRead);
                 packet = new DatagramPacket(buf, localAddress(), remoteAddress());
             } else {
                 final DomainDatagramSocketAddress remoteAddress;

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDatagramChannel.java
@@ -22,7 +22,6 @@ import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.FixedReadHandleFactory;
 import io.netty5.channel.MaxMessagesWriteHandleFactory;
 import io.netty5.channel.ReadHandleFactory;
-import io.netty5.channel.WriteHandleFactory;
 import io.netty5.channel.socket.DomainSocketAddress;
 import io.netty5.channel.socket.SocketProtocolFamily;
 import io.netty5.channel.unix.DomainDatagramSocketAddress;
@@ -32,7 +31,6 @@ import io.netty5.channel.unix.UnixChannel;
 import io.netty5.channel.unix.UnixChannelOption;
 import io.netty5.util.Resource;
 import io.netty5.channel.AddressedEnvelope;
-import io.netty5.channel.ChannelOutboundBuffer;
 import io.netty5.channel.DefaultBufferAddressedEnvelope;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.socket.DatagramChannel;
@@ -336,71 +334,54 @@ public final class EpollDatagramChannel extends AbstractEpollChannel<UnixChannel
     }
 
     @Override
-    protected void doWrite(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle) throws Exception {
-        boolean continueWriting;
-        do {
-            if (in.isEmpty()) {
-                // Wrote all messages.
-                break;
-            }
-            // Check if sendmmsg(...) is supported which is only the case for GLIBC 2.14+
-            if (Native.IS_SUPPORTING_SENDMMSG && socket.protocolFamily() != SocketProtocolFamily.UNIX &&
-                    in.size() > 1 ||
-                    // We only handle UDP_SEGMENT in sendmmsg.
-                    in.current() instanceof SegmentedDatagramPacket) {
-                NativeDatagramPacketArray array = cleanDatagramPacketArray();
-                array.add(in, isConnected(), Integer.MAX_VALUE);
-                int cnt = array.count();
+    protected void doWriteNow(WriteSink writeSink) throws Exception {
+        // Check if sendmmsg(...) is supported which is only the case for GLIBC 2.14+
 
-                if (cnt >= 1) {
-                        // Try to use gathering writes via sendmmsg(...) syscall.
-                        int offset = 0;
-                        NativeDatagramPacketArray.NativeDatagramPacket[] packets = array.packets();
-                    long sentBytes = 0;
-                    long notSentBytes = 0;
-                    int send = 0;
-                    try {
-                        send = socket.sendmmsg(packets, offset, cnt);
-                        if (send == 0) {
-                            // Did not write all messages.
-                            break;
-                        }
-                        for (int i = 0; i < cnt; i++) {
-                            int count = packets[i].count();
-                            if (i < send) {
-                                sentBytes += count;
-                                in.remove();
-                            } else {
-                                notSentBytes += count;
-                            }
-                        }
-                    } catch (IOException e) {
-                        for (int i = 0; i < cnt; i++) {
-                            int count = packets[i].count();
+        if (Native.IS_SUPPORTING_SENDMMSG && socket.protocolFamily() != SocketProtocolFamily.UNIX &&
+                writeSink.size() > 1 ||
+                // We only handle UDP_SEGMENT in sendmmsg.
+                writeSink.first() instanceof SegmentedDatagramPacket) {
+            NativeDatagramPacketArray array = cleanDatagramPacketArray();
+            writeSink.forEach(array.addFunction(isConnected(), Integer.MAX_VALUE));
+            int cnt = array.count();
+
+            if (cnt >= 1) {
+                    // Try to use gathering writes via sendmmsg(...) syscall.
+                    int offset = 0;
+                    NativeDatagramPacketArray.NativeDatagramPacket[] packets = array.packets();
+                long sentBytes = 0;
+                long notSentBytes = 0;
+                int send = 0;
+                try {
+                    send = socket.sendmmsg(packets, offset, cnt);
+                    for (int i = 0; i < cnt; i++) {
+                        int count = packets[i].count();
+                        if (i < send) {
+                            sentBytes += count;
+                        } else {
                             notSentBytes += count;
                         }
-
-                        // Continue on write error as a DatagramChannel can write to multiple remote peers
-                        //
-                        // See https://github.com/netty/netty/issues/2665
-                        in.remove(e);
                     }
-                    continueWriting = writeHandle.lastWrite(sentBytes + notSentBytes, sentBytes, send);
-                } else {
-                    continueWriting = doWriteMessage(in, writeHandle);
+                    writeSink.complete(sentBytes + notSentBytes, sentBytes, send, send > 0);
+                } catch (IOException e) {
+                    for (int i = 0; i < cnt; i++) {
+                        int count = packets[i].count();
+                        notSentBytes += count;
+                    }
+                    // Continue on write error as a DatagramChannel can write to multiple remote peers
+                    //
+                    // See https://github.com/netty/netty/issues/2665
+                    writeSink.complete(sentBytes + notSentBytes, e, true);
                 }
-            } else {
-                continueWriting = doWriteMessage(in, writeHandle);
+                return;
             }
-        } while (continueWriting);
+        }
+        doWriteMessage(writeSink);
     }
 
-    private boolean doWriteMessage(ChannelOutboundBuffer in,  WriteHandleFactory.WriteHandle writeHandle)
+    private void doWriteMessage(WriteSink writeSink)
             throws Exception {
-        Object msg = in.current();
-        if (msg == null) {
-            return writeHandle.lastWrite(0, 0, 0);
-        }
+        Object msg = writeSink.first();
         final Buffer data;
         final SocketAddress remoteAddress;
         if (msg instanceof AddressedEnvelope) {
@@ -414,17 +395,12 @@ public final class EpollDatagramChannel extends AbstractEpollChannel<UnixChannel
         }
 
         if (data.readableBytes() == 0) {
-            in.remove();
-            return writeHandle.lastWrite(0, 0, 1);
+            writeSink.complete(0, 0, 1, true);
+            return;
         }
 
         long result = doWriteOrSendBytes(data, remoteAddress, false);
-        if (result > 0) {
-            in.remove();
-            return writeHandle.lastWrite(data.readableBytes(), result, 1);
-        }
-        writeHandle.lastWrite(data.readableBytes(), result, 0);
-        return false;
+        writeSink.complete(data.readableBytes(),  result, result > 0 ? 1: 0, result > 0);
     }
 
     @Override
@@ -490,8 +466,9 @@ public final class EpollDatagramChannel extends AbstractEpollChannel<UnixChannel
     }
 
     @Override
-    protected boolean doConnect(SocketAddress remoteAddress, SocketAddress localAddress) throws Exception {
-        if (super.doConnect(remoteAddress, localAddress)) {
+    protected boolean doConnect(SocketAddress remoteAddress, SocketAddress localAddress, Buffer initialData)
+            throws Exception {
+        if (super.doConnect(remoteAddress, localAddress, initialData)) {
             connected = true;
             return true;
         }

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDatagramChannel.java
@@ -338,11 +338,11 @@ public final class EpollDatagramChannel extends AbstractEpollChannel<UnixChannel
         // Check if sendmmsg(...) is supported which is only the case for GLIBC 2.14+
 
         if (Native.IS_SUPPORTING_SENDMMSG && socket.protocolFamily() != SocketProtocolFamily.UNIX &&
-                writeSink.size() > 1 ||
+                writeSink.numFlushedMessages() > 1 ||
                 // We only handle UDP_SEGMENT in sendmmsg.
-                writeSink.first() instanceof SegmentedDatagramPacket) {
+                writeSink.currentFlushedMessage() instanceof SegmentedDatagramPacket) {
             NativeDatagramPacketArray array = cleanDatagramPacketArray();
-            writeSink.forEach(array.addFunction(isConnected(), Integer.MAX_VALUE));
+            writeSink.forEachFlushedMessage(array.addFunction(isConnected(), Integer.MAX_VALUE));
             int cnt = array.count();
 
             if (cnt >= 1) {
@@ -381,7 +381,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel<UnixChannel
 
     private void doWriteMessage(WriteSink writeSink)
             throws Exception {
-        Object msg = writeSink.first();
+        Object msg = writeSink.currentFlushedMessage();
         final Buffer data;
         final SocketAddress remoteAddress;
         if (msg instanceof AddressedEnvelope) {

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollServerSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollServerSocketChannel.java
@@ -15,16 +15,15 @@
  */
 package io.netty5.channel.epoll;
 
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelException;
 import io.netty5.channel.ChannelOption;
-import io.netty5.channel.ChannelOutboundBuffer;
 import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.EventLoopGroup;
 import io.netty5.channel.ServerChannelReadHandleFactory;
 import io.netty5.channel.ServerChannelWriteHandleFactory;
-import io.netty5.channel.WriteHandleFactory;
 import io.netty5.channel.socket.DomainSocketAddress;
 import io.netty5.channel.socket.ServerSocketChannel;
 import io.netty5.channel.socket.SocketProtocolFamily;
@@ -344,7 +343,7 @@ public final class EpollServerSocketChannel
     }
 
     @Override
-    protected void doWrite(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle) {
+    protected void doWriteNow(WriteSink writeHandle) {
         throw new UnsupportedOperationException();
     }
 
@@ -383,7 +382,7 @@ public final class EpollServerSocketChannel
     }
 
     @Override
-    protected boolean doConnect(SocketAddress remoteAddress, SocketAddress localAddress) {
+    protected boolean doConnect(SocketAddress remoteAddress, SocketAddress localAddress, Buffer initialData) {
         throw new UnsupportedOperationException();
     }
 

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollSocketChannel.java
@@ -20,7 +20,6 @@ import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.channel.AdaptiveReadHandleFactory;
 import io.netty5.channel.ChannelException;
 import io.netty5.channel.ChannelOption;
-import io.netty5.channel.ChannelOutboundBuffer;
 import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.DefaultFileRegion;
 import io.netty5.channel.EventLoop;
@@ -171,68 +170,59 @@ public final class EpollSocketChannel
 
     /**
      * Write bytes form the given {@link Buffer} to the underlying {@link java.nio.channels.Channel}.
-     * @param in the collection which contains objects to write.
-     * @param writeHandle the {@link WriteHandleFactory.WriteHandle} used to track write results.
-     * @param buf the {@link Buffer} from which the bytes should be written.
+     * @param writeSink the {@link WriteSink} used to track write results.
      * @return if we should continue with writing more messages.
      */
-    private boolean writeBytes(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle, Buffer buf)
+    private void writeBytes(WriteSink writeSink)
             throws Exception {
+        Buffer buf = (Buffer) writeSink.first();
         int readableBytes = buf.readableBytes();
         if (readableBytes == 0) {
-            in.remove();
-            return writeHandle.lastWrite(0, 0, 1);
+            writeSink.complete(0, 0, 1, true);
+            return;
         }
 
         int readableComponents = buf.countReadableComponents();
         long attempted;
-        long written;
+        int written;
         if (readableComponents == 1) {
             attempted = buf.readableBytes();
-            written = doWriteBytes(in, buf);
+            written = doWriteBytes(buf);
         }  else {
-            attempted = Math.min(writeHandle.estimatedMaxBytesPerGatheringWrite(), buf.readableBytes());
+            attempted = Math.min(writeSink.estimatedMaxBytesPerGatheringWrite(), buf.readableBytes());
             ByteBuffer[] nioBuffers = new ByteBuffer[readableComponents];
             try (var iteration = buf.forEachComponent()) {
                 int index = 0;
                 for (var c = iteration.first(); c != null; c = c.next()) {
                    nioBuffers[index++] = c.readableBuffer();
                 }
-                written = writeBytesMultiple(in, nioBuffers, nioBuffers.length, readableBytes, attempted);
+                written = (int) writeBytesMultiple(nioBuffers, nioBuffers.length, readableBytes, attempted);
             }
         }
-        return writeHandle.lastWrite(attempted, written, written >= 0 ? 1: 0) && written != -1;
+        if (written > 0) {
+            buf.skipReadableBytes(written);
+        }
+        writeSink.complete(attempted, written, readableBytes == written ? 1 : 0, written > 0);
     }
 
     /**
      * Write multiple bytes via {@link IovArray}.
-     * @param in the collection which contains objects to write.
-     * @param writeHandle the {@link WriteHandleFactory.WriteHandle} used to track write results.
      * @param array The array which contains the content to write.
      * @return if we should continue with writing more messages.
      * @throws IOException If an I/O exception occurs during write.
      */
-    private boolean writeBytesMultiple(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle,
-                                       IovArray array)
+    private long writeBytesMultiple(IovArray array)
             throws IOException {
         final long expectedWrittenBytes = array.size();
         assert expectedWrittenBytes != 0;
         final int cnt = array.count();
         assert cnt != 0;
 
-        final long localWrittenBytes = socket.writevAddresses(array.memoryAddress(0), cnt);
-        if (localWrittenBytes > 0) {
-            in.removeBytes(localWrittenBytes);
-            int numMessages = array.writtenMessages(0, localWrittenBytes);
-            return writeHandle.lastWrite(expectedWrittenBytes, localWrittenBytes, numMessages);
-        }
-        writeHandle.lastWrite(expectedWrittenBytes, localWrittenBytes, 0);
-        return false;
+        return socket.writevAddresses(array.memoryAddress(0), cnt);
     }
 
     /**
      * Write multiple bytes via {@link ByteBuffer} array.
-     * @param in the collection which contains objects to write.
      * @param nioBuffers The buffers to write.
      * @param nioBufferCnt The number of buffers to write.
      * @param expectedWrittenBytes The number of bytes we expect to write.
@@ -240,128 +230,97 @@ public final class EpollSocketChannel
      * @return write result.
      * @throws IOException If an I/O exception occurs during write.
      */
-    private int writeBytesMultiple(
-            ChannelOutboundBuffer in, ByteBuffer[] nioBuffers, int nioBufferCnt, long expectedWrittenBytes,
+    private long writeBytesMultiple(ByteBuffer[] nioBuffers, int nioBufferCnt, long expectedWrittenBytes,
             long maxBytesPerGatheringWrite) throws IOException {
         assert expectedWrittenBytes != 0;
         if (expectedWrittenBytes > maxBytesPerGatheringWrite) {
             expectedWrittenBytes = maxBytesPerGatheringWrite;
         }
 
-        final long localWrittenBytes = socket.writev(nioBuffers, 0, nioBufferCnt, expectedWrittenBytes);
-        if (localWrittenBytes > 0) {
-            in.removeBytes(localWrittenBytes);
-            return 1;
-        }
-        return -1;
+        return socket.writev(nioBuffers, 0, nioBufferCnt, expectedWrittenBytes);
     }
 
     /**
      * Write a {@link DefaultFileRegion}
-     * @param in the collection which contains objects to write.
-     * @param writeHandle the {@link WriteHandleFactory.WriteHandle} used to track write results.
-     * @param region the {@link DefaultFileRegion} from which the bytes should be written
+     * @param writeSink the {@link WriteSink} used to track write results.
      * @return if we should continue with writing more messages.
      */
-    private boolean writeDefaultFileRegion(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle,
-                                           DefaultFileRegion region) throws Exception {
+    private void writeDefaultFileRegion(WriteSink writeSink) throws Exception {
+        final DefaultFileRegion region = (DefaultFileRegion) writeSink.first();
         final long regionCount = region.count();
-        final long offset = region.transferred();
-        final long flushedAmount;
-        int messagesWritten  = 0;
+        final long transferred = region.transferred();
 
-        if (offset >= regionCount) {
-            flushedAmount = 0;
-            messagesWritten = 1;
+        if (transferred >= regionCount) {
+            writeSink.complete(0, 0, 1, true);
         } else {
-            flushedAmount = socket.sendFile(region, region.position(), offset, regionCount - offset);
-            if (flushedAmount > 0) {
-                if (region.transferred() >= regionCount) {
-                    messagesWritten = 1;
-                }
-            } else if (flushedAmount == 0) {
-                validateFileRegion(region, offset);
+            long flushedAmount = socket.sendFile(region, region.position(), transferred, regionCount - transferred);
+            if (flushedAmount == 0) {
+                validateFileRegion(region, transferred);
             }
+            writeSink.complete(regionCount, flushedAmount, region.transferred() >= regionCount ? 1: 0,
+                    flushedAmount > 0);
         }
-        if (messagesWritten > 0) {
-            in.remove();
-        }
-        return writeHandle.lastWrite(regionCount, flushedAmount, messagesWritten) && flushedAmount > 0;
     }
 
     /**
      * Write a {@link FileRegion}
-     * @param in the collection which contains objects to write.
-     * @param writeHandle the {@link WriteHandleFactory.WriteHandle} used to track write results.
-     * @param region the {@link FileRegion} from which the bytes should be written
+     * @param writeSink the {@link WriteSink} used to track write results.
      * @return if we should continue with writing more messages.
      */
-    private boolean writeFileRegion(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle,
-                                FileRegion region) throws Exception {
+    private void writeFileRegion(WriteSink writeSink) throws Exception {
+        final FileRegion region = (FileRegion) writeSink.first();
         final long regionCount = region.count();
-        final long flushedAmount;
-        int messagesWritten  = 0;
-        if (region.transferred() >= region.count()) {
-            flushedAmount = 0;
-            messagesWritten = 1;
+        final long transferred = region.transferred();
+        if (transferred >= regionCount) {
+            writeSink.complete(0, 0, 1, true);
         } else {
             if (byteChannel == null) {
                 byteChannel = new EpollSocketWritableByteChannel();
             }
-            flushedAmount = region.transferTo(byteChannel, region.transferred());
-            if (flushedAmount > 0) {
-                if (region.transferred() >= region.count()) {
-                    messagesWritten = 1;
-                }
-            }
+            long flushedAmount = region.transferTo(byteChannel, region.transferred());
+            writeSink.complete(regionCount, flushedAmount, region.transferred() >= regionCount ? 1: 0,
+                    flushedAmount > 0);
         }
-
-        if (messagesWritten > 0) {
-            in.remove();
-        }
-        return writeHandle.lastWrite(regionCount, flushedAmount, messagesWritten) && flushedAmount > 0;
     }
 
     @Override
-    protected void doWrite(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle) throws Exception {
-        boolean continueWriting;
-        do {
-            final int msgCount = in.size();
-            if (msgCount == 0) {
-                writeHandle.lastWrite(0, 0, 0);
-                return;
-            }
-            // Do gathering write if the outbound buffer entries start with more than one Buffer.
-            if (msgCount > 1 && in.current() instanceof Buffer) {
-                continueWriting = doWriteMultiple(in, writeHandle);
-            } else {
-                continueWriting = doWriteSingle(in, writeHandle);
-            }
-        } while (continueWriting);
+    protected void doWriteNow(WriteSink writeSink) throws Exception {
+        final int msgCount = writeSink.size();
+        // Do gathering write if the outbound buffer entries start with more than one Buffer.
+        if (msgCount > 1 && writeSink.first() instanceof Buffer) {
+            doWriteMultiple(writeSink);
+        } else {
+            doWriteSingle(writeSink);
+        }
     }
 
     /**
      * Attempt to write a single object.
-     * @param in the collection which contains objects to write.
-     * @param writeHandle the {@link WriteHandleFactory.WriteHandle} used to track write results.
+     * @param writeSink the {@link WriteSink} used to track write results.
      * @return if we should continue with writing more messages.
      * @throws Exception If an I/O error occurs.
      */
-    private boolean doWriteSingle(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle)
-            throws Exception {
+    private void doWriteSingle(WriteSink writeSink) throws Exception {
         // The outbound buffer contains only one message or it contains a file region.
-        Object msg = in.current();
-        if (msg instanceof FileDescriptor && socket.sendFd(((FileDescriptor) msg).intValue()) > 0) {
-            // File descriptor was written, so remove it.
-            in.remove();
-            return writeHandle.lastWrite(0, 0, 1);
+        Object msg = writeSink.first();
+        if (socket.protocolFamily() == SocketProtocolFamily.UNIX) {
+            if (msg instanceof FileDescriptor) {
+                if (socket.sendFd(((FileDescriptor) msg).intValue()) > 0) {
+                    // File descriptor was written, so remove it.
+                    writeSink.complete(0, 0, 1, true);
+                } else {
+                    writeSink.complete(0, 0, 0, false);
+                }
+                return;
+            }
         }
+
         if (msg instanceof Buffer) {
-            return writeBytes(in, writeHandle, (Buffer) msg);
+            writeBytes(writeSink);
         } else if (msg instanceof DefaultFileRegion) {
-            return writeDefaultFileRegion(in, writeHandle, (DefaultFileRegion) msg);
+            writeDefaultFileRegion(writeSink);
         } else if (msg instanceof FileRegion) {
-            return writeFileRegion(in, writeHandle, (FileRegion) msg);
+            writeFileRegion(writeSink);
         } else {
             // Should never reach here.
             throw new Error();
@@ -370,25 +329,22 @@ public final class EpollSocketChannel
 
     /**
      * Attempt to write multiple {@link Buffer} objects.
-     * @param in the collection which contains objects to write.
-     * @param writeHandle the {@link WriteHandleFactory.WriteHandle} used to track write results.
+     * @param writeSink the {@link WriteSink} used to track write results.
      * @return if we should continue with writing more messages.
      * @throws Exception If an I/O error occurs.
      */
-    private boolean doWriteMultiple(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle)
-            throws Exception {
-        final long maxBytesPerGatheringWrite = writeHandle.estimatedMaxBytesPerGatheringWrite();
+    private void doWriteMultiple(WriteSink writeSink) throws Exception {
         IovArray array = registration().cleanIovArray();
-        array.maxBytes(maxBytesPerGatheringWrite);
-        in.forEachFlushedMessage(array);
+        array.maxBytes(writeSink.estimatedMaxBytesPerGatheringWrite());
+        writeSink.forEach(array);
 
         if (array.count() >= 1) {
-            return writeBytesMultiple(in, writeHandle, array);
+            long result = writeBytesMultiple(array);
+            writeSink.complete(array.size(), result, -1, result > 0);
+        } else {
+            // cnt == 0, which means the outbound buffer contained empty buffers only.
+            writeSink.complete(0, 0, -1, true);
         }
-        int messages = in.size();
-        // cnt == 0, which means the outbound buffer contained empty buffers only.
-        in.removeBytes(0);
-        return writeHandle.lastWrite(0, 0, messages);
     }
 
     @Override
@@ -1015,27 +971,23 @@ public final class EpollSocketChannel
     }
 
     @Override
-    protected boolean doConnect0(SocketAddress remote) throws Exception {
+    protected boolean doConnect0(SocketAddress remote, Buffer initialData) throws Exception {
         if (IS_SUPPORTING_TCP_FASTOPEN_CLIENT && socket.protocolFamily() != SocketProtocolFamily.UNIX &&
                 isTcpFastOpenConnect()) {
-            ChannelOutboundBuffer outbound = outboundBuffer();
-            outbound.addFlush();
-            Object curr = outbound.current();
-            if (curr instanceof Buffer) {
+            if (initialData != null) {
                 // If no cookie is present, the write fails with EINPROGRESS and this call basically
                 // becomes a normal async connect. All writes will be sent normally afterwards.
                 final long localFlushedAmount;
-                Buffer initialData = (Buffer) curr;
                 localFlushedAmount = doWriteOrSendBytes(initialData, remote, true);
                 if (localFlushedAmount > 0) {
                     // We had a cookie and our fast-open proceeded. Remove written data
                     // then continue with normal TCP operation.
-                    outbound.removeBytes(localFlushedAmount);
+                    initialData.skipReadableBytes((int) localFlushedAmount);
                     return true;
                 }
             }
         }
-        return super.doConnect0(remote);
+        return super.doConnect0(remote, initialData);
     }
 
     @Override

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollSocketChannel.java
@@ -438,6 +438,8 @@ public final class EpollSocketChannel
                 }
                 return ReadState.All;
             }
+
+            buffer.skipWritableBytes(actualBytesRead);
             readSink.processRead(attemptedBytesRead, actualBytesRead, buffer);
             buffer = null;
             if (readMore) {

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/NativeDatagramPacketArray.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/NativeDatagramPacketArray.java
@@ -125,7 +125,6 @@ final class NativeDatagramPacketArray {
                         }
                     }
                 }
-
             }
             // Add one packet for sendmmsg(...) now.
             NativeDatagramPacket p = packets[count];

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/NativeDatagramPacketArray.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/NativeDatagramPacketArray.java
@@ -110,13 +110,16 @@ final class NativeDatagramPacketArray {
                 int writableBytes = c.readableBytes();
                 int byteCount = segmentLen == 0? writableBytes : Math.min(writableBytes, segmentLen);
                 if (iovArray.addReadable(c, byteCount)) {
-                    NativeDatagramPacket p = packets[count];
-                    long packetAddr = iovArray.memoryAddress(iovArrayStart);
-                    p.init(packetAddr, iovArray.count() - iovArrayStart, segmentLen, recipient);
-                    count++;
                     c.skipReadableBytes(byteCount);
+                } else {
+                    break;
                 }
             }
+            // Add one packet for sendmmsg(...) now.
+            NativeDatagramPacket p = packets[count];
+            long packetAddr = iovArray.memoryAddress(iovArrayStart);
+            p.init(packetAddr, iovArray.count() - iovArrayStart, segmentLen, recipient);
+            count++;
             return true;
         }
     }

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/NativeDatagramPacketArray.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/NativeDatagramPacketArray.java
@@ -16,9 +16,6 @@
 package io.netty5.channel.epoll;
 
 import io.netty5.buffer.api.Buffer;
-import io.netty5.buffer.api.BufferComponent;
-import io.netty5.channel.ChannelOutboundBuffer;
-import io.netty5.channel.ChannelOutboundBuffer.MessageProcessor;
 import io.netty5.channel.socket.DatagramPacket;
 import io.netty5.channel.unix.IovArray;
 import io.netty5.channel.unix.Limits;
@@ -29,6 +26,7 @@ import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
+import java.util.function.Predicate;
 
 import static io.netty5.channel.unix.Limits.UIO_MAX_IOV;
 import static io.netty5.channel.unix.NativeInetAddress.copyIpv4MappedIpv6Address;
@@ -123,10 +121,10 @@ final class NativeDatagramPacketArray {
         }
     }
 
-    void add(ChannelOutboundBuffer buffer, boolean connected, int maxMessagesPerWrite) throws Exception {
+    Predicate<Object> addFunction(boolean connected, int maxMessagesPerWrite) {
         processor.connected = connected;
         processor.maxMessagesPerWrite = maxMessagesPerWrite;
-        buffer.forEachFlushedMessage(processor);
+        return processor;
     }
 
     /**
@@ -152,12 +150,12 @@ final class NativeDatagramPacketArray {
         iovArray.release();
     }
 
-    private final class MyMessageProcessor implements MessageProcessor<RuntimeException> {
+    private final class MyMessageProcessor implements Predicate<Object> {
         private boolean connected;
         private int maxMessagesPerWrite;
 
         @Override
-        public boolean processMessage(Object msg) {
+        public boolean test(Object msg) {
             final boolean added;
             if (msg instanceof DatagramPacket) {
                 DatagramPacket packet = (DatagramPacket) msg;

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueChannel.java
@@ -28,7 +28,6 @@ import io.netty5.channel.unix.RawUnixChannelOption;
 import io.netty5.util.Resource;
 import io.netty5.channel.AbstractChannel;
 import io.netty5.channel.ChannelException;
-import io.netty5.channel.ChannelOutboundBuffer;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.unix.FileDescriptor;
 import io.netty5.channel.unix.UnixChannel;
@@ -280,15 +279,11 @@ abstract class AbstractKQueueChannel<P extends UnixChannel>
             }
             long address = component.writableNativeAddress();
             assert address != 0;
-            int localReadAmount = socket.readAddress(address, 0, component.writableBytes());
-            if (localReadAmount > 0) {
-                component.skipWritableBytes(localReadAmount);
-            }
-            return localReadAmount;
+            return socket.readAddress(address, 0, component.writableBytes());
         }
     }
 
-    protected final int doWriteBytes(ChannelOutboundBuffer in, Buffer buf) throws Exception {
+    protected final int doWriteBytes(Buffer buf) throws Exception {
         int written = 0;
         try (var iteration = buf.forEachComponent()) {
             var component = iteration.firstReadable();
@@ -298,11 +293,7 @@ abstract class AbstractKQueueChannel<P extends UnixChannel>
                 written = socket.writeAddress(address, 0, component.readableBytes());
             }
         }
-        if (written > 0) {
-            in.removeBytes(written);
-            return 1; // Some data was written to the socket.
-        }
-        return -1;
+        return written;
     }
 
     final void readFilter(boolean readFilterEnabled) {
@@ -464,7 +455,8 @@ abstract class AbstractKQueueChannel<P extends UnixChannel>
     /**
      * Connect to the remote peer
      */
-    protected boolean doConnect(SocketAddress remoteAddress, SocketAddress localAddress) throws Exception {
+    protected boolean doConnect(SocketAddress remoteAddress, SocketAddress localAddress, Buffer initialData)
+            throws Exception {
         if (localAddress instanceof InetSocketAddress) {
             checkResolvable((InetSocketAddress) localAddress);
         }
@@ -479,7 +471,7 @@ abstract class AbstractKQueueChannel<P extends UnixChannel>
             doBind(localAddress);
         }
 
-        boolean connected = doConnect0(remoteAddress, localAddress);
+        boolean connected = doConnect0(remoteAddress, localAddress, initialData);
         if (connected) {
             active = true;
             this.remoteAddress = remoteSocketAddr == null?
@@ -495,7 +487,8 @@ abstract class AbstractKQueueChannel<P extends UnixChannel>
         return connected;
     }
 
-    protected boolean doConnect0(SocketAddress remoteAddress, SocketAddress localAddress) throws Exception {
+    protected boolean doConnect0(SocketAddress remoteAddress, SocketAddress localAddress, Buffer data)
+            throws Exception {
         boolean success = false;
         try {
             boolean connected = socket.connect(remoteAddress);

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDatagramChannel.java
@@ -344,7 +344,7 @@ public final class KQueueDatagramChannel
 
     @Override
     protected void doWriteNow(WriteSink writeSink) {
-        Object msg = writeSink.first();
+        Object msg = writeSink.currentFlushedMessage();
         final Buffer data;
         SocketAddress remoteAddress;
         if (msg instanceof AddressedEnvelope) {
@@ -544,9 +544,9 @@ public final class KQueueDatagramChannel
                         DatagramSocketAddress datagramSocketAddress;
                         if (addr != 0) {
                             // has a memory address so use optimized call
-                        datagramSocketAddress = socket.recvFromAddress(addr, 0, component.writableBytes());
+                            datagramSocketAddress = socket.recvFromAddress(addr, 0, component.writableBytes());
                         } else {
-                        ByteBuffer nioData = component.writableBuffer();
+                            ByteBuffer nioData = component.writableBuffer();
                             datagramSocketAddress = socket.recvFrom(
                                     nioData, nioData.position(), nioData.limit());
                         }

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDatagramChannel.java
@@ -519,6 +519,7 @@ public final class KQueueDatagramChannel
                     readSink.processRead(attemptedBytesRead, actualBytesRead, null);
                     return actualBytesRead;
                 }
+                buffer.skipWritableBytes(actualBytesRead);
                 packet = new DatagramPacket(buffer, localAddress(), remoteAddress());
             } else {
                 SocketAddress localAddress = null;

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueServerSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueServerSocketChannel.java
@@ -15,16 +15,15 @@
  */
 package io.netty5.channel.kqueue;
 
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelException;
 import io.netty5.channel.ChannelOption;
-import io.netty5.channel.ChannelOutboundBuffer;
 import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.EventLoopGroup;
 import io.netty5.channel.ServerChannelReadHandleFactory;
 import io.netty5.channel.ServerChannelWriteHandleFactory;
-import io.netty5.channel.WriteHandleFactory;
 import io.netty5.channel.socket.DomainSocketAddress;
 import io.netty5.channel.socket.ServerSocketChannel;
 import io.netty5.channel.socket.SocketProtocolFamily;
@@ -342,7 +341,7 @@ public final class KQueueServerSocketChannel extends
     }
 
     @Override
-    protected void doWrite(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle) {
+    protected void doWriteNow(WriteSink writeHandle) {
         throw new UnsupportedOperationException();
     }
 
@@ -352,7 +351,7 @@ public final class KQueueServerSocketChannel extends
     }
 
     @Override
-    protected boolean doConnect(SocketAddress remoteAddress, SocketAddress localAddress) {
+    protected boolean doConnect(SocketAddress remoteAddress, SocketAddress localAddress, Buffer initialData) {
         throw new UnsupportedOperationException();
     }
 

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueSocketChannel.java
@@ -103,6 +103,7 @@ public final class KQueueSocketChannel
     private static final String EXPECTED_TYPES =
             " (expected: " + StringUtil.simpleClassName(Buffer.class) + ", " +
                     StringUtil.simpleClassName(DefaultFileRegion.class) + ')';
+
     private WritableByteChannel byteChannel;
 
     private volatile DomainSocketReadMode mode = DomainSocketReadMode.BYTES;
@@ -516,7 +517,7 @@ public final class KQueueSocketChannel
      * @param   writeSink the {@link WriteSink} used.
      */
     private void writeBytes(WriteSink writeSink) throws Exception {
-        Buffer buf = (Buffer) writeSink.first();
+        Buffer buf = (Buffer) writeSink.currentFlushedMessage();
         int readableBytes = buf.readableBytes();
         if (readableBytes == 0) {
             writeSink.complete(0, 0, 1, true);
@@ -586,7 +587,7 @@ public final class KQueueSocketChannel
      * @param   writeSink the {@link WriteSink} used.
      */
     private void writeDefaultFileRegion(WriteSink writeSink) throws Exception {
-        final DefaultFileRegion region = (DefaultFileRegion) writeSink.first();
+        final DefaultFileRegion region = (DefaultFileRegion) writeSink.currentFlushedMessage();
         final long regionCount = region.count();
         final long transferred = region.transferred();
 
@@ -607,7 +608,7 @@ public final class KQueueSocketChannel
      * @param   writeSink the {@link WriteSink} used.
      */
     private void writeFileRegion(WriteSink writeSink) throws Exception {
-        final FileRegion region = (FileRegion) writeSink.first();
+        final FileRegion region = (FileRegion) writeSink.currentFlushedMessage();
         final long regionCount = region.count();
         final long transferred = region.transferred();
         if (transferred >= regionCount) {
@@ -624,9 +625,9 @@ public final class KQueueSocketChannel
 
     @Override
     protected void doWriteNow(WriteSink writeSink) throws Exception {
-        final int msgCount = writeSink.size();
+        final int msgCount = writeSink.numFlushedMessages();
         // Do gathering write if the outbound buffer entries start with more than one Buffer.
-        if (msgCount > 1 && writeSink.first() instanceof Buffer) {
+        if (msgCount > 1 && writeSink.currentFlushedMessage() instanceof Buffer) {
             doWriteMultiple(writeSink);
         } else {
             doWriteSingle(writeSink);
@@ -640,7 +641,7 @@ public final class KQueueSocketChannel
      */
     private void doWriteSingle(WriteSink writeSink) throws Exception {
         // The outbound buffer contains only one message or it contains a file region.
-        Object msg = writeSink.first();
+        Object msg = writeSink.currentFlushedMessage();
         if (socket.protocolFamily() == SocketProtocolFamily.UNIX) {
             if (msg instanceof FileDescriptor) {
                 if (socket.sendFd(((FileDescriptor) msg).intValue()) > 0) {
@@ -674,14 +675,16 @@ public final class KQueueSocketChannel
             throws Exception {
         IovArray array = registration().cleanArray();
         array.maxBytes(writeSink.estimatedMaxBytesPerGatheringWrite());
-        writeSink.forEach(array);
+        writeSink.forEachFlushedMessage(array);
 
         if (array.count() >= 1) {
             long result = writeBytesMultiple(array);
-            writeSink.complete(array.size(), result, -1, result > 0);
+            // Update readerOffset of buffers and return how many are completely written.
+            int messages = writeSink.updateBufferReaderOffsets(result);
+            writeSink.complete(array.size(), result, messages, result > 0);
         } else {
             // cnt == 0, which means the outbound buffer contained empty buffers only.
-            writeSink.complete(0, 0, -1, true);
+            writeSink.complete(0, 0, writeSink.numFlushedMessages(), true);
         }
     }
 

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueSocketChannel.java
@@ -20,12 +20,10 @@ import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.channel.AdaptiveReadHandleFactory;
 import io.netty5.channel.ChannelException;
 import io.netty5.channel.ChannelOption;
-import io.netty5.channel.ChannelOutboundBuffer;
 import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.DefaultFileRegion;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.FileRegion;
-import io.netty5.channel.WriteHandleFactory;
 import io.netty5.channel.socket.SocketChannel;
 import io.netty5.channel.socket.SocketChannelWriteHandleFactory;
 import io.netty5.channel.socket.SocketProtocolFamily;
@@ -431,32 +429,28 @@ public final class KQueueSocketChannel
     }
 
     @Override
-    protected boolean doConnect0(SocketAddress remoteAddress, SocketAddress localAddress) throws Exception {
+    protected boolean doConnect0(SocketAddress remoteAddress, SocketAddress localAddress, Buffer initialData)
+            throws Exception {
         if (isTcpFastOpenConnect()) {
-            ChannelOutboundBuffer outbound = outboundBuffer();
-            outbound.addFlush();
-            Object curr;
-            if ((curr = outbound.current()) instanceof Buffer) {
-                Buffer initialData = (Buffer) curr;
-                // Don't bother with TCP FastOpen if we don't have any initial data to send anyway.
-                if (initialData.readableBytes() > 0) {
-                    IovArray iov = new IovArray();
-                    try {
-                        iov.addReadable(initialData);
-                        int bytesSent = socket.connectx(
-                                (InetSocketAddress) localAddress, (InetSocketAddress) remoteAddress, iov, true);
-                        writeFilter(true);
-                        outbound.removeBytes(Math.abs(bytesSent));
-                        // The `connectx` method returns a negative number if connection is in-progress.
-                        // So we should return `true` to indicate that connection was established, if it's positive.
-                        return bytesSent > 0;
-                    } finally {
-                        iov.release();
-                    }
+            // Don't bother with TCP FastOpen if we don't have any initial data to send anyway.
+            if (initialData != null && initialData.readableBytes() > 0) {
+                IovArray iov = new IovArray();
+                try {
+                    iov.addReadable(initialData);
+                    int bytesSent = socket.connectx(
+                            (InetSocketAddress) localAddress, (InetSocketAddress) remoteAddress, iov, true);
+                    writeFilter(true);
+
+                    initialData.skipReadableBytes(Math.abs(bytesSent));
+                    // The `connectx` method returns a negative number if connection is in-progress.
+                    // So we should return `true` to indicate that connection was established, if it's positive.
+                    return bytesSent > 0;
+                } finally {
+                    iov.release();
                 }
             }
         }
-        return super.doConnect0(remoteAddress, localAddress);
+        return super.doConnect0(remoteAddress, localAddress, initialData);
     }
 
     @Override
@@ -519,218 +513,152 @@ public final class KQueueSocketChannel
 
     /**
      * Write bytes form the given {@link Buffer} to the underlying {@link java.nio.channels.Channel}.
-     * @param in the collection which contains objects to write.
-     * @param writeHandle the {@link WriteHandleFactory.WriteHandle} used to track write results.
-     * @param buf the {@link Buffer} from which the bytes should be written
-     * @return if we should continue with writing more messages.
+     * @param   writeSink the {@link WriteSink} used.
      */
-    private boolean writeBytes(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle, Buffer buf)
-            throws Exception {
+    private void writeBytes(WriteSink writeSink) throws Exception {
+        Buffer buf = (Buffer) writeSink.first();
         int readableBytes = buf.readableBytes();
         if (readableBytes == 0) {
-            in.remove();
-            return writeHandle.lastWrite(0, 0, 1);
+            writeSink.complete(0, 0, 1, true);
+            return;
         }
 
         int readableComponents = buf.countReadableComponents();
-        long attempted;
-        long written;
+        final long attempted;
+        final int written;
         if (readableComponents == 1) {
-            attempted = buf.readableBytes();
-            written = doWriteBytes(in, buf);
+            attempted = readableBytes;
+            written = doWriteBytes(buf);
         }  else {
-            attempted = Math.min(writeHandle.estimatedMaxBytesPerGatheringWrite(), buf.readableBytes());
+            attempted = Math.min(writeSink.estimatedMaxBytesPerGatheringWrite(), buf.readableBytes());
             ByteBuffer[] nioBuffers = new ByteBuffer[readableComponents];
             try (var iteration = buf.forEachComponent()) {
                 int index = 0;
                 for (var c = iteration.first(); c != null; c = c.next()) {
                     nioBuffers[index++] = c.readableBuffer();
                 }
-                return writeBytesMultiple(in, writeHandle, nioBuffers, nioBuffers.length, readableBytes, attempted);
+                written = (int) writeBytesMultiple(nioBuffers, nioBuffers.length, readableBytes, attempted);
             }
         }
-
         if (written > 0) {
-            return writeHandle.lastWrite(attempted, written, 1);
+            buf.skipReadableBytes(written);
         }
-        writeHandle.lastWrite(attempted, written, 0);
-        return false;
+        writeSink.complete(attempted, written, readableBytes == written ? 1 : 0, written > 0);
     }
 
     /**
      * Write multiple bytes via {@link IovArray}.
-     * @param in the collection which contains objects to write.
-     * @param writeHandle the {@link WriteHandleFactory.WriteHandle} used to track write results.
      * @param array The array which contains the content to write.
-     * @return if we should continue with writing more messages.
+     * @return number of written bytes.
      * @throws IOException If an I/O exception occurs during write.
      */
-    private boolean writeBytesMultiple(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle,
-                                       IovArray array)
+    private long writeBytesMultiple(IovArray array)
             throws IOException {
         final long expectedWrittenBytes = array.size();
         assert expectedWrittenBytes != 0;
         final int cnt = array.count();
         assert cnt != 0;
 
-        final long localWrittenBytes = socket.writevAddresses(array.memoryAddress(0), cnt);
-        if (localWrittenBytes > 0) {
-            in.removeBytes(localWrittenBytes);
-            int numMessages = array.writtenMessages(0, localWrittenBytes);
-            return writeHandle.lastWrite(expectedWrittenBytes, localWrittenBytes, numMessages);
-        }
-        writeHandle.lastWrite(expectedWrittenBytes, localWrittenBytes, 0);
-        return false;
+        return socket.writevAddresses(array.memoryAddress(0), cnt);
     }
 
     /**
      * Write multiple bytes via {@link ByteBuffer} array.
-     * @param in the collection which contains objects to write.
-     * @param writeHandle the {@link WriteHandleFactory.WriteHandle} used to track write results.
      * @param nioBuffers The buffers to write.
      * @param nioBufferCnt The number of buffers to write.
      * @param expectedWrittenBytes The number of bytes we expect to write.
      * @param maxBytesPerGatheringWrite The maximum number of bytes we should attempt to write.
-     * @return if we should continue with writing more messages.
+     * @return number of written bytes.
      * @throws IOException If an I/O exception occurs during write.
      */
-    private boolean writeBytesMultiple(
-            ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle,
-            ByteBuffer[] nioBuffers, int nioBufferCnt, long expectedWrittenBytes,
+    private long writeBytesMultiple(ByteBuffer[] nioBuffers, int nioBufferCnt, long expectedWrittenBytes,
             long maxBytesPerGatheringWrite) throws IOException {
         assert expectedWrittenBytes != 0;
         if (expectedWrittenBytes > maxBytesPerGatheringWrite) {
             expectedWrittenBytes = maxBytesPerGatheringWrite;
         }
 
-        final long localWrittenBytes = socket.writev(nioBuffers, 0, nioBufferCnt, expectedWrittenBytes);
-        if (localWrittenBytes > 0) {
-            in.removeBytes(localWrittenBytes);
-            return writeHandle.lastWrite(expectedWrittenBytes, localWrittenBytes, 1);
-        }
-        writeHandle.lastWrite(expectedWrittenBytes, localWrittenBytes, 0);
-        return false;
+        return socket.writev(nioBuffers, 0, nioBufferCnt, expectedWrittenBytes);
     }
 
     /**
      * Write a {@link DefaultFileRegion}
-     * @param in the collection which contains objects to write.
-     * @param writeHandle the {@link WriteHandleFactory.WriteHandle} used to track write results.
-     * @param region the {@link DefaultFileRegion} from which the bytes should be written
-     * @return if we should continue with writing more messages.
+     * @param   writeSink the {@link WriteSink} used.
      */
-    private boolean writeDefaultFileRegion(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle,
-                                       DefaultFileRegion region) throws Exception {
+    private void writeDefaultFileRegion(WriteSink writeSink) throws Exception {
+        final DefaultFileRegion region = (DefaultFileRegion) writeSink.first();
         final long regionCount = region.count();
-        final long offset = region.transferred();
-        final long flushedAmount;
-        int messagesWritten  = 0;
+        final long transferred = region.transferred();
 
-        if (offset >= regionCount) {
-            flushedAmount = 0;
-            messagesWritten = 1;
+        if (transferred >= regionCount) {
+            writeSink.complete(0, 0, 1, true);
         } else {
-            flushedAmount = socket.sendFile(region, region.position(), offset, regionCount - offset);
-            if (flushedAmount > 0) {
-                if (region.transferred() >= regionCount) {
-                    messagesWritten = 1;
-                }
-            } else if (flushedAmount == 0) {
-                validateFileRegion(region, offset);
-                writeHandle.lastWrite(regionCount, flushedAmount, 0);
-                return false;
+            long flushedAmount = socket.sendFile(region, region.position(), transferred, regionCount - transferred);
+            if (flushedAmount == 0) {
+                validateFileRegion(region, transferred);
             }
+            writeSink.complete(regionCount, flushedAmount, region.transferred() >= regionCount ? 1: 0,
+                    flushedAmount > 0);
         }
-        if (messagesWritten > 0) {
-            in.remove();
-        }
-        return writeHandle.lastWrite(regionCount, flushedAmount, messagesWritten) && flushedAmount > 0;
     }
 
     /**
      * Write a {@link FileRegion}
-     * @param in the collection which contains objects to write.
-     * @param writeHandle the {@link WriteHandleFactory.WriteHandle} used to track write results.
-     * @param region the {@link FileRegion} from which the bytes should be written
-     * @return if we should continue with writing more messages.
+     * @param   writeSink the {@link WriteSink} used.
      */
-    private boolean writeFileRegion(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle,
-                                FileRegion region) throws Exception {
+    private void writeFileRegion(WriteSink writeSink) throws Exception {
+        final FileRegion region = (FileRegion) writeSink.first();
         final long regionCount = region.count();
-        final long flushedAmount;
-        int messagesWritten  = 0;
-        if (region.transferred() >= region.count()) {
-            flushedAmount = 0;
-            messagesWritten = 1;
+        final long transferred = region.transferred();
+        if (transferred >= regionCount) {
+            writeSink.complete(0, 0, 1, true);
         } else {
             if (byteChannel == null) {
                 byteChannel = new KQueueSocketWritableByteChannel();
             }
-            flushedAmount = region.transferTo(byteChannel, region.transferred());
-            if (flushedAmount > 0) {
-                if (region.transferred() >= region.count()) {
-                    messagesWritten = 1;
-                }
-            } else if (flushedAmount == 0) {
-                writeHandle.lastWrite(regionCount, flushedAmount, 0);
-                return false;
-            }
+            long flushedAmount = region.transferTo(byteChannel, region.transferred());
+            writeSink.complete(regionCount, flushedAmount, region.transferred() >= regionCount ? 1: 0,
+                    flushedAmount > 0);
         }
-
-        if (messagesWritten > 0) {
-            in.remove();
-        }
-        return writeHandle.lastWrite(regionCount, flushedAmount, messagesWritten) && flushedAmount > 0;
     }
 
     @Override
-    protected void doWrite(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle) throws Exception {
-        boolean continueWriting;
-        do {
-            final int msgCount = in.size();
-            if (msgCount == 0) {
-                writeHandle.lastWrite(0, 0, 0);
-                return;
-            }
-
-            // Do gathering write if the outbound buffer entries start with more than one Buffer.
-            if (msgCount > 1 && in.current() instanceof Buffer) {
-                continueWriting = doWriteMultiple(in, writeHandle);
-            } else { // msgCount == 1
-                continueWriting = doWriteSingle(in, writeHandle);
-            }
-        } while (continueWriting);
+    protected void doWriteNow(WriteSink writeSink) throws Exception {
+        final int msgCount = writeSink.size();
+        // Do gathering write if the outbound buffer entries start with more than one Buffer.
+        if (msgCount > 1 && writeSink.first() instanceof Buffer) {
+            doWriteMultiple(writeSink);
+        } else {
+            doWriteSingle(writeSink);
+        }
     }
 
     /**
      * Attempt to write a single object.
-     * @param in the collection which contains objects to write.
-     * @param writeHandle the {@link WriteHandleFactory.WriteHandle} used to track write results.
-     * @return if we should continue with writing more messages.
+     * @param   writeSink the {@link WriteSink} used.
      * @throws Exception If an I/O error occurs.
      */
-    private boolean doWriteSingle(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle)
-            throws Exception {
+    private void doWriteSingle(WriteSink writeSink) throws Exception {
         // The outbound buffer contains only one message or it contains a file region.
-        Object msg = in.current();
+        Object msg = writeSink.first();
         if (socket.protocolFamily() == SocketProtocolFamily.UNIX) {
             if (msg instanceof FileDescriptor) {
                 if (socket.sendFd(((FileDescriptor) msg).intValue()) > 0) {
                     // File descriptor was written, so remove it.
-                    in.remove();
-                    return writeHandle.lastWrite(0, 0, 1);
+                    writeSink.complete(0, 0, 1, true);
+                } else {
+                    writeSink.complete(0, 0, 0, false);
                 }
-                writeHandle.lastWrite(0, 0, 0);
-                return false;
+                return;
             }
         }
 
         if (msg instanceof Buffer) {
-            return writeBytes(in, writeHandle, (Buffer) msg);
+            writeBytes(writeSink);
         } else if (msg instanceof DefaultFileRegion) {
-            return writeDefaultFileRegion(in, writeHandle, (DefaultFileRegion) msg);
+            writeDefaultFileRegion(writeSink);
         } else if (msg instanceof FileRegion) {
-            return writeFileRegion(in, writeHandle, (FileRegion) msg);
+            writeFileRegion(writeSink);
         } else {
             // Should never reach here.
             throw new Error();
@@ -739,25 +667,22 @@ public final class KQueueSocketChannel
 
     /**
      * Attempt to write multiple {@link Buffer} objects.
-     * @param in the collection which contains objects to write.
-     * @param writeHandle the {@link WriteHandleFactory.WriteHandle} used to track write results.
-     * @return if we should continue with writing more messages.
+     * @param   writeSink the {@link WriteSink} used.
      * @throws Exception If an I/O error occurs.
      */
-    private boolean doWriteMultiple(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle)
+    private void doWriteMultiple(WriteSink writeSink)
             throws Exception {
-        final long maxBytesPerGatheringWrite = writeHandle.estimatedMaxBytesPerGatheringWrite();
         IovArray array = registration().cleanArray();
-        array.maxBytes(maxBytesPerGatheringWrite);
-        in.forEachFlushedMessage(array);
+        array.maxBytes(writeSink.estimatedMaxBytesPerGatheringWrite());
+        writeSink.forEach(array);
 
         if (array.count() >= 1) {
-            return writeBytesMultiple(in, writeHandle, array);
+            long result = writeBytesMultiple(array);
+            writeSink.complete(array.size(), result, -1, result > 0);
+        } else {
+            // cnt == 0, which means the outbound buffer contained empty buffers only.
+            writeSink.complete(0, 0, -1, true);
         }
-        int messages = in.size();
-        // cnt == 0, which means the outbound buffer contained empty buffers only.
-        in.removeBytes(0);
-        return writeHandle.lastWrite(0, 0, messages);
     }
 
     @Override
@@ -818,6 +743,7 @@ public final class KQueueSocketChannel
                 }
                 return 0;
             }
+            buffer.skipWritableBytes(actualBytesRead);
             readSink.processRead(attemptedBytesRead, actualBytesRead, buffer);
             buffer = null;
             return actualBytesRead;

--- a/transport-native-unix-common/src/main/java/io/netty5/channel/unix/IovArray.java
+++ b/transport-native-unix-common/src/main/java/io/netty5/channel/unix/IovArray.java
@@ -17,11 +17,11 @@ package io.netty5.channel.unix;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferComponent;
-import io.netty5.channel.ChannelOutboundBuffer.MessageProcessor;
 import io.netty5.util.internal.PlatformDependent;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.function.Predicate;
 
 import static io.netty5.channel.unix.Buffer.addressSize;
 import static io.netty5.channel.unix.Buffer.allocateDirectWithNativeOrder;
@@ -49,7 +49,7 @@ import static java.lang.Math.min;
  * <a href="https://rkennke.wordpress.com/2007/07/30/efficient-jni-programming-iv-wrapping-native-data-objects/"
  * >Efficient JNI programming IV: Wrapping native data objects</a>.
  */
-public final class IovArray implements MessageProcessor<RuntimeException> {
+public final class IovArray implements Predicate<Object> {
 
     /** The size of an address which should be 8 for 64 bits and 4 for 32 bits. */
     private static final int ADDRESS_SIZE = addressSize();
@@ -190,10 +190,10 @@ public final class IovArray implements MessageProcessor<RuntimeException> {
 
     /**
      * Set the maximum amount of bytes that can be added to this {@link IovArray} via {@link #add(long, long, int)} or
-     * {@link #processMessage(Object)}.
+     * {@link #test(Object)}.
      * <p>
      * This will not impact the existing state of the {@link IovArray}, and only applies to subsequent calls to
-     * {@link #add(long, long, int)} or {@link #processMessage(Object)}.
+     * {@link #add(long, long, int)} or {@link #test(Object)}.
      * <p>
      * In order to ensure some progress is made at least one {@link Buffer} will be accepted even if it's size exceeds
      * this value.
@@ -226,7 +226,7 @@ public final class IovArray implements MessageProcessor<RuntimeException> {
     }
 
     @Override
-    public boolean processMessage(Object msg) {
+    public boolean test(Object msg) {
         if (msg instanceof Buffer) {
             var buffer = (Buffer) msg;
             if (buffer.readableBytes() == 0) {

--- a/transport/src/main/java/io/netty5/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty5/channel/AbstractChannel.java
@@ -48,6 +48,8 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 import static io.netty5.channel.ChannelOption.ALLOW_HALF_CLOSURE;
 import static io.netty5.channel.ChannelOption.AUTO_CLOSE;
@@ -56,8 +58,10 @@ import static io.netty5.channel.ChannelOption.BUFFER_ALLOCATOR;
 import static io.netty5.channel.ChannelOption.CONNECT_TIMEOUT_MILLIS;
 import static io.netty5.channel.ChannelOption.MESSAGE_SIZE_ESTIMATOR;
 import static io.netty5.channel.ChannelOption.READ_HANDLE_FACTORY;
+import static io.netty5.channel.ChannelOption.TCP_FASTOPEN_CONNECT;
 import static io.netty5.channel.ChannelOption.WRITE_BUFFER_WATER_MARK;
 import static io.netty5.channel.ChannelOption.WRITE_HANDLE_FACTORY;
+import static io.netty5.util.internal.ObjectUtil.checkInRange;
 import static io.netty5.util.internal.ObjectUtil.checkPositiveOrZero;
 import static java.util.Objects.requireNonNull;
 
@@ -122,7 +126,8 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
     private ReadBufferAllocator readBeforeActive;
 
     private ReadSink readSink;
-    private WriteHandleFactory.WriteHandle writeHandle;
+
+    private WriteSink writeSink;
 
     private MessageSizeEstimator.Handle estimatorHandler;
     private boolean inWriteFlushed;
@@ -406,10 +411,7 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
     }
 
     protected final WriteHandleFactory.WriteHandle writeHandle() {
-        if (writeHandle == null) {
-            writeHandle = getWriteHandleFactory().newHandle(this);
-        }
-        return writeHandle;
+        return writeSink().writeHandle;
     }
 
     private ReadSink readSink() {
@@ -419,6 +421,15 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
             readSink = new ReadSink(getReadHandleFactory().newHandle(this));
         }
         return readSink;
+    }
+
+    private WriteSink writeSink() {
+        assertEventLoop();
+
+        if (writeSink == null) {
+            writeSink = new WriteSink(getWriteHandleFactory().newHandle(this));
+        }
+        return writeSink;
     }
 
     private void registerTransport(final Promise<Void> promise) {
@@ -1037,9 +1048,9 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
 
         inWriteFlushed = true;
 
-        // Mark all pending write requests as failure if the channel is inactive.
-        if (!isActive()) {
-            try {
+        try {
+            // Mark all pending write requests as failure if the channel is inactive.
+            if (!isActive()) {
                 // Check if we need to generate the exception at all.
                 if (!outboundBuffer.isEmpty()) {
                     if (isOpen()) {
@@ -1050,32 +1061,12 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
                         outboundBuffer.failFlushed(newClosedChannelException(initialCloseCause, "writeFlushed()"));
                     }
                 }
-            } finally {
-                inWriteFlushed = false;
+                return;
             }
-            return;
-        }
 
-        WriteHandleFactory.WriteHandle writeHandle = writeHandle();
-        try {
-            try {
-                doWrite(outboundBuffer, writeHandle);
-            } catch (Throwable t) {
-                handleWriteError(t);
-            } finally {
-                try {
-                    writeLoopComplete(outboundBuffer.isEmpty());
-                } catch (Throwable cause) {
-                    // Something is really seriously wrong!
-                    closeWithErrorFromWriteFlushed(cause);
-                }
-            }
+            WriteSink writeSink = writeSink();
+            writeSink.processWriteLoop(outboundBuffer);
         } finally {
-            writeHandle.writeComplete();
-
-            // It's important that we call this with notifyLater true so we not get into trouble when flush() is called
-            // again in channelWritabilityChanged(...).
-            updateWritabilityIfNeeded(true, true);
             inWriteFlushed = false;
         }
     }
@@ -1225,7 +1216,7 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
      *
      * @return the outbound buffer.
      */
-    protected final ChannelOutboundBuffer outboundBuffer() {
+    final ChannelOutboundBuffer outboundBuffer() {
         return outboundBuffer;
     }
 
@@ -1270,22 +1261,31 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
     protected abstract void doRead(boolean wasReadPendingAlready) throws Exception;
 
     /**
-     * Flush the content of the given buffer to the remote peer.
+     * Called in a loop when writes should be performed until this methods returns {@code false} or there are
+     * no more messages to write.
+     *
+     * @param writeSink                             the {@link WriteSink} that must be completed with the write
+     *                                              progress.
+     *                                              {@link WriteSink#complete(long, long, int, boolean)} or
+     *                                              {@link WriteSink#complete(long, Throwable, boolean)} must be called
+     *                                              exactly once before this method returns non-exceptional.
+     * @throws Exception                            if and error happened during writing.
      */
-    protected abstract void doWrite(ChannelOutboundBuffer in,  WriteHandleFactory.WriteHandle writeHandle)
-            throws Exception;
+    protected abstract void doWriteNow(WriteSink writeSink) throws Exception;
 
     /**
      * Connect to remote peer.
      *
      * @param remoteAddress     the address of the remote peer.
      * @param localAddress      the local address of this channel.
+     * @param initialData       the initial data that is written during connect
+     *                          (if {@link ChannelOption#TCP_FASTOPEN_CONNECT} is supported)
      * @return                  {@code true} if the connect was completed, {@code false} if {@link #finishConnect()}
      *                          will be called later again to try finishing the connect.
      * @throws Exception        thrown on error.
      */
     protected abstract boolean doConnect(
-            SocketAddress remoteAddress, SocketAddress localAddress) throws Exception;
+            SocketAddress remoteAddress, SocketAddress localAddress, Buffer initialData) throws Exception;
 
     /**
      * Finish a connect request.
@@ -1326,8 +1326,21 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
             }
 
             boolean wasActive = isActive();
-            if (doConnect(remoteAddress, localAddress)) {
+            int readable = 0;
+            Buffer message = null;
+            if (isOptionSupported(ChannelOption.TCP_FASTOPEN_CONNECT) && getOption(TCP_FASTOPEN_CONNECT)) {
+                outboundBuffer.addFlush();
+                Object current = outboundBuffer.current();
+                if (current instanceof Buffer) {
+                    message = (Buffer) current;
+                    readable = message.readableBytes();
+                }
+            }
+            if (doConnect(remoteAddress, localAddress, message)) {
                 fulfillConnectPromise(promise, wasActive);
+                if (message != null) {
+                    outboundBuffer.removeBytes(readable - message.readableBytes());
+                }
             } else {
                 connectPromise = promise;
                 requestedRemoteAddress = (R) remoteAddress;
@@ -1990,6 +2003,174 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
                 shutdownReadSide();
             } else {
                 readIfIsAutoRead();
+            }
+        }
+    }
+
+    /**
+     * Sink that will be used by {@link #doWriteNow(WriteSink)} implementations.
+     */
+    protected final class WriteSink {
+        final WriteHandleFactory.WriteHandle writeHandle;
+        private ChannelOutboundBuffer outboundBuffer;
+
+        private long attemptedBytesWrite;
+        private long actualBytesWrite;
+        private int messagesWritten;
+        private Throwable writeError;
+
+        private Boolean continueWriting;
+
+        WriteSink(WriteHandleFactory.WriteHandle writeHandle) {
+            this.writeHandle = writeHandle;
+        }
+
+        void processWriteLoop(ChannelOutboundBuffer outboundBuffer) {
+            this.outboundBuffer = outboundBuffer;
+            try {
+                try {
+                    // We checked before is the outboundBuffer is empty so let's use a do-while loop.
+                    do {
+                        doWriteNow(writeSink);
+                    } while (continueWriting() && !outboundBuffer.isEmpty());
+                } catch (Throwable t) {
+                    handleWriteError(t);
+                } finally {
+                    try {
+                        writeLoopComplete(outboundBuffer.isEmpty());
+                    } catch (Throwable cause) {
+                        // Something is really seriously wrong!
+                        closeWithErrorFromWriteFlushed(cause);
+                    }
+                }
+            } finally {
+                writeHandle.writeComplete();
+
+                // It's important that we call this with notifyLater true so we not get into trouble when flush() is
+                // called again in channelWritabilityChanged(...).
+                updateWritabilityIfNeeded(true, true);
+            }
+        }
+
+        /**
+         * Return the estimated maximum number of bytes that can be written with one gathering write operation.
+         *
+         * @return number of bytes.
+         */
+        public long estimatedMaxBytesPerGatheringWrite() {
+            return writeHandle.estimatedMaxBytesPerGatheringWrite();
+        }
+
+        /**
+         * The number of flushed messages that are ready to be written.
+         *
+         * @return the number of messages.
+         */
+        public int size() {
+            return outboundBuffer.size();
+        }
+
+        /**
+         * Return the first message that should be written.
+         *
+         * @return                          the first message.
+         * @throws IllegalStateException    if called after {@link #complete(long, long, int, boolean)}
+         *                                  or {@link #complete(long, Throwable, boolean)} was called.
+         */
+        public Object first() {
+            return outboundBuffer.current();
+        }
+
+        /**
+         * Call {@link Predicate#test(Object)} for each message that is flushed until
+         * {@link Predicate#test(Object)} returns {@code false} or there are no more flushed messages.
+         *
+         * @param processor                 the {@link Function} to use.
+         * @throws IllegalStateException    if called after {@link #complete(long, long, int, boolean)}
+         *                                  or {@link #complete(long, Throwable, boolean)} was called.
+         */
+        public void forEach(Predicate<Object> processor) {
+            outboundBuffer.forEachFlushedMessage(processor);
+        }
+
+        /**
+         * Notify of the last write operation and its result.
+         *
+         * @param attemptedBytesWrite       The number of  bytes the write operation did attempt to write.
+         * @param actualBytesWrite          The number of bytes from the previous write operation. This may be negative
+         *                                  if a write error occurs.
+         * @param messagesWritten           The number of written messages, or {@code -1} if the amount of written
+         *                                  messages is unknown.
+         * @param mightContinueWriting      {@code true} if the write loop might continue writing messages,
+         *                                  {@code false} otherwise
+         *
+         * @throws IllegalStateException    if called after {@link #complete(long, long, int, boolean)}
+         *                                  or {@link #complete(long, Throwable, boolean)} was called.
+         */
+        public void complete(long attemptedBytesWrite, long actualBytesWrite, int messagesWritten,
+                             boolean mightContinueWriting) {
+            checkCompleteAlready();
+            this.attemptedBytesWrite = checkPositiveOrZero(attemptedBytesWrite, "attemptedBytesWrite");
+            this.actualBytesWrite = actualBytesWrite;
+            this.messagesWritten = checkInRange(messagesWritten, -1, Integer.MAX_VALUE, "messagesWritten");
+            this.continueWriting = mightContinueWriting ? Boolean.TRUE : Boolean.FALSE;
+            this.writeError = null;
+        }
+
+        /**
+         * Notify of the last write operation and its result.
+         *
+         * @param attemptedBytesWrite       The number of  bytes the write operation did attempt to write.
+         * @param cause                     The error that happened during the write and can be recovered.
+         * @param mightContinueWriting      {@code true} if the write loop might continue writing messages,
+         *                                  {@code false} otherwise.
+         *
+         * @throws IllegalStateException    if called after {@link #complete(long, long, int, boolean)}
+         *                                  or {@link #complete(long, Throwable, boolean)} was called.
+         */
+        public void complete(long attemptedBytesWrite, Throwable cause, boolean mightContinueWriting) {
+            checkCompleteAlready();
+            this.attemptedBytesWrite = checkPositiveOrZero(attemptedBytesWrite, "attemptedBytesWrite");
+            this.writeError = requireNonNull(cause, "cause");
+            this.actualBytesWrite = 0;
+            this.messagesWritten = 0;
+            this.continueWriting = mightContinueWriting ? Boolean.TRUE : Boolean.FALSE;
+        }
+
+        private void checkCompleteAlready() {
+            if (continueWriting != null) {
+                throw new IllegalStateException(StringUtil.simpleClassName(WriteSink.class) +
+                        ".complete(...) was already called");
+            }
+        }
+
+        private boolean continueWriting() {
+            if (continueWriting == null) {
+                throw new IllegalStateException(StringUtil.simpleClassName(WriteSink.class) +
+                        ".complete(...) was not called");
+            }
+            try {
+                if (writeError != null) {
+                    outboundBuffer.remove(writeError);
+                } else {
+                    if (messagesWritten > 0) {
+                        int written = messagesWritten;
+                        do {
+                            outboundBuffer.remove();
+                            written--;
+                        } while (written > 0);
+                    } else if (messagesWritten == -1 && actualBytesWrite >= 0) {
+                        messagesWritten = outboundBuffer.removeBytes(actualBytesWrite);
+                    }
+                }
+                return writeHandle.lastWrite(attemptedBytesWrite, actualBytesWrite, messagesWritten) &&
+                        continueWriting == Boolean.TRUE;
+            } finally {
+                writeError = null;
+                messagesWritten = 0;
+                attemptedBytesWrite = 0;
+                actualBytesWrite = 0;
+                continueWriting = null;
             }
         }
     }

--- a/transport/src/main/java/io/netty5/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty5/channel/AbstractChannel.java
@@ -2166,7 +2166,8 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
         private int verifyMessagesWritten(int messagesWritten) {
             checkPositiveOrZero(messagesWritten, "messagesWritten");
             if (messagesWritten > numFlushedMessages()) {
-                throw new IllegalArgumentException("messagesWritten > size()");
+                throw new IllegalArgumentException("messagesWritten > size(): " +
+                        messagesWritten + " (expected: " + 0 + "-" + numFlushedMessages() + ")");
             }
             return messagesWritten;
         }

--- a/transport/src/main/java/io/netty5/channel/AbstractServerChannel.java
+++ b/transport/src/main/java/io/netty5/channel/AbstractServerChannel.java
@@ -15,6 +15,8 @@
  */
 package io.netty5.channel;
 
+import io.netty5.buffer.api.Buffer;
+
 import java.net.SocketAddress;
 
 /**
@@ -69,7 +71,7 @@ public abstract class AbstractServerChannel<P extends Channel, L extends SocketA
     }
 
     @Override
-    protected final void doWrite(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle) {
+    protected final void doWriteNow(WriteSink writeSink) {
         throw new UnsupportedOperationException();
     }
 
@@ -79,7 +81,7 @@ public abstract class AbstractServerChannel<P extends Channel, L extends SocketA
     }
 
     @Override
-    protected boolean doConnect(SocketAddress remoteAddress, SocketAddress localAddress) {
+    protected boolean doConnect(SocketAddress remoteAddress, SocketAddress localAddress, Buffer initialData) {
         throw new UnsupportedOperationException();
     }
 

--- a/transport/src/main/java/io/netty5/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty5/channel/embedded/EmbeddedChannel.java
@@ -725,7 +725,7 @@ public class EmbeddedChannel extends AbstractChannel<Channel, SocketAddress, Soc
 
     @Override
     protected void doWriteNow(WriteSink writeSink) throws Exception {
-        Object msg = writeSink.first();
+        Object msg = writeSink.currentFlushedMessage();
         if (msg instanceof ResourceSupport<?, ?>) {
             // Prevent the close in ChannelOutboundBuffer.remove() from ending the lifecycle of this message.
             // This allows tests to examine the message.

--- a/transport/src/main/java/io/netty5/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty5/channel/local/LocalChannel.java
@@ -293,7 +293,7 @@ public class LocalChannel extends AbstractChannel<LocalServerChannel, LocalAddre
 
         writeInProgress = true;
 
-        Object msg = writeSink.first();
+        Object msg = writeSink.currentFlushedMessage();
         // It is possible the peer could have closed while we are writing, and in this case we should
         // simulate real socket behavior and ensure the write operation is failed.
         if (peer.state == State.CONNECTED) {

--- a/transport/src/main/java/io/netty5/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty5/channel/local/LocalChannel.java
@@ -15,17 +15,16 @@
  */
 package io.netty5.channel.local;
 
+import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.DefaultBufferAllocators;
 import io.netty5.channel.ChannelOption;
 import io.netty5.channel.ChannelShutdownDirection;
-import io.netty5.channel.WriteHandleFactory;
 import io.netty5.util.ReferenceCounted;
 import io.netty5.util.Resource;
 import io.netty5.buffer.api.internal.ResourceSupport;
 import io.netty5.buffer.api.internal.Statics;
 import io.netty5.channel.AbstractChannel;
 import io.netty5.channel.Channel;
-import io.netty5.channel.ChannelOutboundBuffer;
 import io.netty5.channel.EventLoop;
 import io.netty5.util.ReferenceCountUtil;
 import io.netty5.util.concurrent.FastThreadLocal;
@@ -279,7 +278,7 @@ public class LocalChannel extends AbstractChannel<LocalServerChannel, LocalAddre
     }
 
     @Override
-    protected void doWrite(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle) throws Exception {
+    protected void doWriteNow(WriteSink writeSink) throws Exception {
         switch (state) {
         case OPEN:
         case BOUND:
@@ -293,48 +292,40 @@ public class LocalChannel extends AbstractChannel<LocalServerChannel, LocalAddre
         final LocalChannel peer = this.peer;
 
         writeInProgress = true;
+
+        Object msg = writeSink.first();
+        // It is possible the peer could have closed while we are writing, and in this case we should
+        // simulate real socket behavior and ensure the write operation is failed.
+        if (peer.state == State.CONNECTED) {
+            if (msg instanceof ReferenceCounted) {
+                peer.inboundBuffer.add(ReferenceCountUtil.retain(msg));
+            } else if (msg instanceof ResourceSupport) {
+                peer.inboundBuffer.add(Statics.acquire((ResourceSupport<?, ?>) msg));
+            } else if (msg instanceof Resource) {
+                peer.inboundBuffer.add(((Resource<?>) msg).send().receive());
+            } else {
+                peer.inboundBuffer.add(msg);
+            }
+            writeSink.complete(0, 0, 1, true);
+        } else {
+            writeSink.complete(0, 0, 0, false);
+        }
+    }
+
+    @Override
+    protected void writeLoopComplete(boolean allWritten) {
         try {
-            boolean continueWriting;
-            do {
-                Object msg = in.current();
-                if (msg == null) {
-                    writeHandle.lastWrite(0, 0, 0);
-                    break;
-                }
-                try {
-                    // It is possible the peer could have closed while we are writing, and in this case we should
-                    // simulate real socket behavior and ensure the write operation is failed.
-                    if (peer.state == State.CONNECTED) {
-                        if (msg instanceof ReferenceCounted) {
-                            peer.inboundBuffer.add(ReferenceCountUtil.retain(msg));
-                        } else if (msg instanceof ResourceSupport) {
-                            peer.inboundBuffer.add(Statics.acquire((ResourceSupport<?, ?>) msg));
-                        } else if (msg instanceof Resource) {
-                            peer.inboundBuffer.add(((Resource<?>) msg).send().receive());
-                        } else {
-                            peer.inboundBuffer.add(msg);
-                        }
-                        continueWriting = writeHandle.lastWrite(0, 0, 1);
-                        in.remove();
-                    } else {
-                        writeHandle.lastWrite(0, 0, 0);
-                        break;
-                    }
-                } catch (Throwable cause) {
-                    in.remove(cause);
-                    continueWriting = writeHandle.lastWrite(0, 0, 0);
-                }
-            } while (continueWriting);
-        } finally {
             // The following situation may cause trouble:
             // 1. Write (with promise X)
             // 2. promise X is completed when in.remove() is called, and a listener on this promise calls close()
             // 3. Then the close event will be executed for the peer before the write events, when the write events
             // actually happened before the close event.
             writeInProgress = false;
-        }
 
-        finishPeerRead(peer);
+            finishPeerRead(peer);
+        } finally {
+            super.writeLoopComplete(allWritten);
+        }
     }
 
     private void finishPeerRead(final LocalChannel peer) {
@@ -394,7 +385,8 @@ public class LocalChannel extends AbstractChannel<LocalServerChannel, LocalAddre
     }
 
     @Override
-    protected boolean doConnect(SocketAddress remoteAddress, SocketAddress localAddress) throws Exception {
+    protected boolean doConnect(SocketAddress remoteAddress, SocketAddress localAddress, Buffer initialData)
+            throws Exception {
         if (state == State.CONNECTED) {
             throw new AlreadyConnectedException();
         }

--- a/transport/src/main/java/io/netty5/channel/nio/AbstractNioByteChannel.java
+++ b/transport/src/main/java/io/netty5/channel/nio/AbstractNioByteChannel.java
@@ -20,7 +20,6 @@ import io.netty5.channel.AdaptiveReadHandleFactory;
 import io.netty5.channel.WriteHandleFactory;
 import io.netty5.util.Resource;
 import io.netty5.channel.Channel;
-import io.netty5.channel.ChannelOutboundBuffer;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.FileRegion;
 import io.netty5.util.internal.StringUtil;
@@ -83,86 +82,45 @@ public abstract class AbstractNioByteChannel<P extends Channel, L extends Socket
         }
     }
 
-    /**
-     * Write objects to the OS.
-     * @param in the collection which contains objects to write.
-     * @return write result.
-     * <ul>
-     *     <li>0 - if no write was attempted. This is appropriate if an empty {@link Buffer} (or other empty content)
-     *     is encountered</li>
-     *     <li>1 - if a single call to write data was made to the OS</li>
-     *     <li>-1 - if an attempt to write data was made to the OS, but no
-     *     data was accepted</li>
-     * </ul>
-     * @throws Exception if an I/O exception occurs during write.
-     */
-    protected final boolean writeOne(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle)
-            throws Exception {
-        Object msg = in.current();
-        if (msg == null) {
-            writeHandle.lastWrite(0, 0, 0);
-            return false;
-        }
-        final long attemptedBytesWrite;
-        final long localFlushAmount;
-        final int messageWritten;
+    @Override
+    protected void doWriteNow(WriteSink writeSink) throws Exception {
+        Object msg = writeSink.first();
 
+        final long attemptedBytesWrite;
+        final long actualBytesWrite;
+        final int messages;
+        final boolean continueWriting;
         if (msg instanceof Buffer) {
             Buffer buf = (Buffer) msg;
             if (buf.readableBytes() == 0) {
                 attemptedBytesWrite = 0;
-                localFlushAmount = 0;
-                messageWritten = 1;
+                actualBytesWrite = 0;
+                messages = 1;
+                continueWriting = true;
             } else {
                 attemptedBytesWrite = buf.readableBytes();
-                localFlushAmount = doWriteBytes(buf);
-                if (localFlushAmount > 0) {
-                    if (buf.readableBytes() == 0) {
-                        messageWritten = 1;
-                    } else {
-                        messageWritten = 0;
-                    }
-                } else {
-                    writeHandle.lastWrite(attemptedBytesWrite, localFlushAmount, 0);
-                    return false;
-                }
+                actualBytesWrite = doWriteBytes(buf);
+                messages = actualBytesWrite == attemptedBytesWrite ? 1 : 0;
+                continueWriting = actualBytesWrite > 0;
             }
         } else if (msg instanceof FileRegion) {
             FileRegion region = (FileRegion) msg;
             if (region.transferred() >= region.count()) {
                 attemptedBytesWrite = 0;
-                localFlushAmount = 0;
-                messageWritten = 1;
+                actualBytesWrite = 0;
+                messages = 1;
+                continueWriting = true;
             } else {
                 attemptedBytesWrite = region.count();
-                localFlushAmount = doWriteFileRegion(region);
-                if (localFlushAmount > 0) {
-                    if (region.transferred() >= attemptedBytesWrite) {
-                        messageWritten = 1;
-                    } else {
-                        messageWritten = 0;
-                    }
-                } else {
-                    writeHandle.lastWrite(attemptedBytesWrite, localFlushAmount, 0);
-                    return false;
-                }
+                actualBytesWrite = doWriteFileRegion(region);
+                messages = actualBytesWrite == attemptedBytesWrite ? 1 : 0;
+                continueWriting = actualBytesWrite > 0;
             }
         } else {
             // Should not reach here.
             throw new Error();
         }
-        if (messageWritten != 0) {
-            in.remove();
-        }
-        return writeHandle.lastWrite(attemptedBytesWrite, localFlushAmount, messageWritten);
-    }
-
-    @Override
-    protected void doWrite(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle) throws Exception {
-        boolean continueWriting;
-        do {
-            continueWriting = writeOne(in, writeHandle);
-        } while (continueWriting);
+        writeSink.complete(attemptedBytesWrite, actualBytesWrite, messages, continueWriting);
     }
 
     @Override

--- a/transport/src/main/java/io/netty5/channel/nio/AbstractNioByteChannel.java
+++ b/transport/src/main/java/io/netty5/channel/nio/AbstractNioByteChannel.java
@@ -84,7 +84,7 @@ public abstract class AbstractNioByteChannel<P extends Channel, L extends Socket
 
     @Override
     protected void doWriteNow(WriteSink writeSink) throws Exception {
-        Object msg = writeSink.first();
+        Object msg = writeSink.currentFlushedMessage();
 
         final long attemptedBytesWrite;
         final long actualBytesWrite;

--- a/transport/src/main/java/io/netty5/channel/nio/AbstractNioMessageChannel.java
+++ b/transport/src/main/java/io/netty5/channel/nio/AbstractNioMessageChannel.java
@@ -16,7 +16,6 @@
 package io.netty5.channel.nio;
 
 import io.netty5.channel.Channel;
-import io.netty5.channel.ChannelOutboundBuffer;
 import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.ReadHandleFactory;
@@ -49,25 +48,9 @@ public abstract class AbstractNioMessageChannel<P extends Channel, L extends Soc
         return localRead < 0;
     }
 
-    @Override
-    protected final void doWrite(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle)
-            throws Exception {
-        boolean continueWriting;
-        do {
-            continueWriting = doWriteMessage(in, writeHandle);
-        } while (continueWriting);
-    }
-
     /**
      * Read messages into the given array and return the amount which was read.
      */
     protected abstract int doReadMessages(ReadSink readSink) throws Exception;
 
-    /**
-     * Write a message to the underlying {@link java.nio.channels.Channel}.
-     *
-     * @return {@code true} if and only if the message has been written
-     */
-    protected abstract boolean doWriteMessage(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle)
-            throws Exception;
 }

--- a/transport/src/main/java/io/netty5/channel/socket/nio/ByteBufferCollector.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/ByteBufferCollector.java
@@ -16,13 +16,13 @@
 package io.netty5.channel.socket.nio;
 
 import io.netty5.buffer.api.Buffer;
-import io.netty5.channel.ChannelOutboundBuffer;
 import io.netty5.util.concurrent.FastThreadLocal;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.function.Predicate;
 
-final class ByteBufferCollector implements ChannelOutboundBuffer.MessageProcessor<RuntimeException> {
+final class ByteBufferCollector implements Predicate<Object> {
 
     private static final FastThreadLocal<BufferCache> NIO_BUFFERS = new FastThreadLocal<>() {
         @Override
@@ -39,20 +39,24 @@ final class ByteBufferCollector implements ChannelOutboundBuffer.MessageProcesso
 
     /**
      * Returns the number of {@link ByteBuffer} that can be written out of the {@link ByteBuffer} array that was
-     * obtained via {@link #collect(ChannelOutboundBuffer, int, long)}. This method <strong>MUST</strong> be
-     * called after {@link #collect(ChannelOutboundBuffer, int, long)} was called.
+     * obtained via {@link #test(Object)}. This method <strong>MUST</strong> be
+     * called after {@link #test(Object)} was called.
      */
-    public int nioBufferCount() {
+    int nioBufferCount() {
         return cache.bufferCount;
     }
 
     /**
      * Returns the number of bytes that can be written out of the {@link ByteBuffer} array that was
-     * obtained via {@link #collect(ChannelOutboundBuffer, int, long)}. This method <strong>MUST</strong> be called
-     * after {@link #collect(ChannelOutboundBuffer, int, long)}was called.
+     * obtained via {@link #test(Object)}. This method <strong>MUST</strong> be called
+     * after {@link #test(Object)} was called.
      */
-    public long nioBufferSize() {
+    long nioBufferSize() {
         return cache.totalSize;
+    }
+
+    ByteBuffer[] nioBuffers() {
+        return cache.buffers;
     }
 
     /**
@@ -85,11 +89,11 @@ final class ByteBufferCollector implements ChannelOutboundBuffer.MessageProcesso
      * array and the total number of readable bytes of the NIO buffers respectively.
      *
      * @param maxCount The maximum amount of buffers that will be added to the return value.
-     * @param maxBytes A hint toward the maximum number of bytes to include as part of the return value. Note that this
-     *                 value maybe exceeded because we make a best effort to include at least 1 {@link ByteBuffer}
-     *                 in the return value to ensure write progress is made.
+     * @param maxBytes A hint toward the maximum number of bytes to include as part of the return value. Note that
+     *                 this value maybe exceeded because we make a best effort to include at least 1
+     *                 {@link ByteBuffer} in the return value to ensure write progress is made.
      */
-    public ByteBuffer[] collect(ChannelOutboundBuffer outboundBuffer, int maxCount, long maxBytes) {
+    void prepare(int maxCount, long maxBytes) {
         assert maxCount > 0;
         assert maxBytes > 0;
         this.maxCount = maxCount;
@@ -97,12 +101,10 @@ final class ByteBufferCollector implements ChannelOutboundBuffer.MessageProcesso
         this.cache = NIO_BUFFERS.get();
         this.cache.bufferCount = 0;
         this.cache.totalSize = 0;
-        outboundBuffer.forEachFlushedMessage(this);
-        return cache.buffers;
     }
 
     @Override
-    public boolean processMessage(Object msg) throws RuntimeException {
+    public boolean test(Object msg) throws RuntimeException {
         if (!(msg instanceof Buffer)) {
             return false;
         }

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioDatagramChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioDatagramChannel.java
@@ -410,7 +410,7 @@ public final class NioDatagramChannel
 
     @Override
     protected void doWriteNow(WriteSink writeSink) throws Exception {
-        Object msg = writeSink.first();
+        Object msg = writeSink.currentFlushedMessage();
         final SocketAddress remoteAddress;
         final Buffer buf;
         if (msg instanceof AddressedEnvelope) {

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioDatagramChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioDatagramChannel.java
@@ -20,13 +20,11 @@ import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.FixedReadHandleFactory;
 import io.netty5.channel.MaxMessagesWriteHandleFactory;
-import io.netty5.channel.WriteHandleFactory;
 import io.netty5.util.Resource;
 import io.netty5.channel.AddressedEnvelope;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelException;
 import io.netty5.channel.ChannelOption;
-import io.netty5.channel.ChannelOutboundBuffer;
 import io.netty5.channel.DefaultBufferAddressedEnvelope;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.nio.AbstractNioMessageChannel;
@@ -344,7 +342,7 @@ public final class NioDatagramChannel
 
     @Override
     protected boolean doConnect(SocketAddress remoteAddress,
-            SocketAddress localAddress) throws Exception {
+            SocketAddress localAddress, Buffer initialData) throws Exception {
         if (localAddress != null) {
             doBind0(localAddress);
         }
@@ -411,12 +409,8 @@ public final class NioDatagramChannel
     }
 
     @Override
-    protected boolean doWriteMessage(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle) {
-        Object msg = in.current();
-        if (msg == null) {
-            writeHandle.lastWrite(0, 0, 0);
-            return false;
-        }
+    protected void doWriteNow(WriteSink writeSink) throws Exception {
+        Object msg = writeSink.first();
         final SocketAddress remoteAddress;
         final Buffer buf;
         if (msg instanceof AddressedEnvelope) {
@@ -431,8 +425,8 @@ public final class NioDatagramChannel
 
         final int length = buf.readableBytes();
         if (length == 0) {
-            in.remove();
-            return writeHandle.lastWrite(0, 0, 1);
+            writeSink.complete(0, 0, 1, true);
+            return;
         }
 
         int readable = buf.readableBytes();
@@ -450,18 +444,12 @@ public final class NioDatagramChannel
             } else {
                 writtenBytes = write(buf, remoteAddress);
             }
-            if (writtenBytes > 0) {
-                in.remove();
-                return writeHandle().lastWrite(readable, writtenBytes, 1);
-            }
-            writeHandle().lastWrite(readable, writtenBytes, 0);
-            return false;
+            writeSink.complete(readable, writtenBytes,  writtenBytes > 0 ? 1 : 0, writtenBytes > 0);
         } catch (Throwable e) {
             // Continue on write error as a DatagramChannel can write to multiple remote peers
             //
             // See https://github.com/netty/netty/issues/2665
-            in.remove(e);
-            return writeHandle().lastWrite(readable, 0, 0);
+            writeSink.complete(readable, e, true);
         }
     }
 

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioServerSocketChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioServerSocketChannel.java
@@ -15,16 +15,15 @@
  */
 package io.netty5.channel.socket.nio;
 
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelException;
 import io.netty5.channel.ChannelOption;
-import io.netty5.channel.ChannelOutboundBuffer;
 import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.EventLoopGroup;
 import io.netty5.channel.ServerChannelReadHandleFactory;
 import io.netty5.channel.ServerChannelWriteHandleFactory;
-import io.netty5.channel.WriteHandleFactory;
 import io.netty5.channel.nio.AbstractNioMessageChannel;
 import io.netty5.util.NetUtil;
 import io.netty5.util.internal.SocketUtils;
@@ -262,7 +261,7 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel<Channel, S
     // Unnecessary stuff
     @Override
     protected boolean doConnect(
-            SocketAddress remoteAddress, SocketAddress localAddress) {
+            SocketAddress remoteAddress, SocketAddress localAddress, Buffer initialData) {
         throw new UnsupportedOperationException();
     }
 
@@ -282,7 +281,7 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel<Channel, S
     }
 
     @Override
-    protected boolean doWriteMessage(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle) {
+    protected void doWriteNow(WriteSink writeHandle) throws Exception {
         throw new UnsupportedOperationException();
     }
 

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioSocketChannel.java
@@ -19,11 +19,9 @@ import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelException;
 import io.netty5.channel.ChannelOption;
-import io.netty5.channel.ChannelOutboundBuffer;
 import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.FileRegion;
-import io.netty5.channel.WriteHandleFactory;
 import io.netty5.channel.nio.AbstractNioByteChannel;
 import io.netty5.channel.socket.SocketChannelWriteHandleFactory;
 import io.netty5.util.concurrent.Future;
@@ -233,7 +231,7 @@ public class NioSocketChannel
     }
 
     @Override
-    protected boolean doConnect(SocketAddress remoteAddress, SocketAddress localAddress) throws Exception {
+    protected boolean doConnect(SocketAddress remoteAddress, SocketAddress localAddress, Buffer data) throws Exception {
         if (localAddress != null) {
             doBind0(localAddress);
         }
@@ -284,65 +282,40 @@ public class NioSocketChannel
     }
 
     @Override
-    protected void doWrite(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle) throws Exception {
+    protected void doWriteNow(WriteSink writeSink)
+            throws Exception {
         SocketChannel ch = javaChannel();
-        if (in.isEmpty()) {
-            writeHandle.lastWrite(0, 0, 0);
-            // Directly return
-            return;
-        }
-        boolean continueWriting;
-        try {
-            do {
-                // Ensure the pending writes are made of ByteBufs only.
-                long maxBytesPerGatheringWrite = writeHandle.estimatedMaxBytesPerGatheringWrite();
-                ByteBuffer[] nioBuffers = collector.collect(in, 1024, maxBytesPerGatheringWrite);
-                int nioBufferCnt = collector.nioBufferCount();
+        // Ensure the pending writes are made of Buffers only.
+        collector.prepare(1024, writeSink.estimatedMaxBytesPerGatheringWrite());
+        writeSink.forEach(collector);
+        ByteBuffer[] nioBuffers = collector.nioBuffers();
+        int nioBufferCnt = collector.nioBufferCount();
 
-                // Always use nioBuffers() to workaround data-corruption.
-                // See https://github.com/netty/netty/issues/2761
-                switch (nioBufferCnt) {
-                    case 0:
-                        // We have something else beside ByteBuffers to write so fallback to normal writes.
-                        continueWriting = writeOne(in, writeHandle);
-                        break;
-                    case 1: {
-                        // Only one ByteBuf so use non-gathering write
-                        // Zero length buffers are not added to nioBuffers by ChannelOutboundBuffer, so there is no need
-                        // to check if the total size of all the buffers is non-zero.
-                        ByteBuffer buffer = nioBuffers[0];
-                        int attemptedBytes = buffer.remaining();
-                        final int localWrittenBytes = ch.write(buffer);
-                        if (localWrittenBytes <= 0) {
-                            writeHandle.lastWrite(attemptedBytes, localWrittenBytes, 0);
-                            return;
-                        }
-                        in.removeBytes(localWrittenBytes);
-
-                        continueWriting = writeHandle.lastWrite(attemptedBytes, localWrittenBytes,
-                                attemptedBytes == localWrittenBytes ? 1 : 0);
-                        break;
-                    }
-                    default: {
-                        // Zero length buffers are not added to nioBuffers by ChannelOutboundBuffer, so there is no need
-                        // to check if the total size of all the buffers is non-zero.
-                        // We limit the max amount to int above so cast is safe
-                        long attemptedBytes = collector.nioBufferSize();
-                        final long localWrittenBytes = ch.write(nioBuffers, 0, nioBufferCnt);
-                        if (localWrittenBytes <= 0) {
-                            writeHandle.lastWrite(attemptedBytes, localWrittenBytes, 0);
-                            return;
-                        }
-                        in.removeBytes(localWrittenBytes);
-
-                        continueWriting = writeHandle.lastWrite(attemptedBytes, localWrittenBytes,
-                                attemptedBytes == localWrittenBytes ? 1 : 0);
-                        break;
-                    }
-                }
-            } while (continueWriting);
-        } finally {
-            collector.reset();
+        // Always use nioBuffers() to workaround data-corruption.
+        // See https://github.com/netty/netty/issues/2761
+        switch (nioBufferCnt) {
+            case 0:
+                // We have something else beside ByteBuffers to write so fallback to normal writes.
+                super.doWriteNow(writeSink);
+                return;
+            case 1: {
+                // Only one ByteBuf so use non-gathering write
+                // Zero length buffers are not added to nioBuffers by ChannelOutboundBuffer, so there is no need
+                // to check if the total size of all the buffers is non-zero.
+                ByteBuffer buffer = nioBuffers[0];
+                int attemptedBytes = buffer.remaining();
+                final int localWrittenBytes = ch.write(buffer);
+                writeSink.complete(attemptedBytes, localWrittenBytes, -1, localWrittenBytes > 0);
+                return;
+            }
+            default: {
+                // Zero length buffers are not added to nioBuffers by ChannelOutboundBuffer, so there is no need
+                // to check if the total size of all the buffers is non-zero.
+                // We limit the max amount to int above so cast is safe
+                long attemptedBytes = collector.nioBufferSize();
+                final long localWrittenBytes = ch.write(nioBuffers, 0, nioBufferCnt);
+                writeSink.complete(attemptedBytes, localWrittenBytes, -1, localWrittenBytes > 0);
+            }
         }
     }
 

--- a/transport/src/test/java/io/netty5/channel/AbstractChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/AbstractChannelTest.java
@@ -15,6 +15,7 @@
  */
 package io.netty5.channel;
 
+import io.netty5.buffer.api.Buffer;
 import io.netty5.util.NetUtil;
 import io.netty5.util.concurrent.Future;
 import org.junit.jupiter.api.Test;
@@ -145,7 +146,7 @@ public class AbstractChannelTest {
             private boolean active;
 
             @Override
-            protected boolean doConnect(SocketAddress remoteAddress, SocketAddress localAddress) {
+            protected boolean doConnect(SocketAddress remoteAddress, SocketAddress localAddress, Buffer initalData) {
                 active = true;
                 return true;
             }
@@ -157,8 +158,7 @@ public class AbstractChannelTest {
             }
 
             @Override
-            protected void doWrite(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle)
-                    throws Exception {
+            protected void doWriteNow(WriteSink writeHandle) throws Exception {
                 throw ioException;
             }
 
@@ -216,7 +216,7 @@ public class AbstractChannelTest {
         }
 
         @Override
-        protected boolean doConnect(SocketAddress remoteAddress, SocketAddress localAddress) {
+        protected boolean doConnect(SocketAddress remoteAddress, SocketAddress localAddress, Buffer initalData) {
             throw new UnsupportedOperationException();
         }
 
@@ -253,8 +253,8 @@ public class AbstractChannelTest {
         }
 
         @Override
-        protected void doWrite(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle) throws Exception {
-            // NOOP
+        protected void doWriteNow(WriteSink writeSink) throws Exception {
+            throw new UnsupportedOperationException();
         }
 
         @Override

--- a/transport/src/test/java/io/netty5/channel/ChannelOutboundBufferTest.java
+++ b/transport/src/test/java/io/netty5/channel/ChannelOutboundBufferTest.java
@@ -17,7 +17,6 @@ package io.netty5.channel;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
-import io.netty5.channel.ChannelOutboundBuffer.MessageProcessor;
 import io.netty5.util.CharsetUtil;
 import io.netty5.util.concurrent.EventExecutor;
 import io.netty5.util.concurrent.Promise;
@@ -26,10 +25,12 @@ import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -60,7 +61,7 @@ public class ChannelOutboundBufferTest {
             buffer.addMessage(buf, 0, executor.newPromise());
             buffer.addFlush();
             AtomicInteger messageCounter = new AtomicInteger();
-            MessageProcessor<RuntimeException> messageProcessor = msg -> {
+            Predicate<Object> messageProcessor = msg -> {
                 assertNotNull(msg);
                 messageCounter.incrementAndGet();
                 return true;
@@ -102,11 +103,11 @@ public class ChannelOutboundBufferTest {
                 buffer.addFlush();
                 // Should have 1 entries.
                 assertNotNull(buffer.current());
-                assertTrue(buffer.remove());
+                assertEquals(size, buffer.remove());
 
                 assertNull(buffer.current());
                 assertTrue(buffer.isEmpty());
-                assertFalse(buffer.remove());
+                assertEquals(-1, buffer.remove());
             }
         });
     }
@@ -124,11 +125,11 @@ public class ChannelOutboundBufferTest {
                 buffer.addFlush();
                 // Should have 1 entries.
                 assertNotNull(buffer.current());
-                assertTrue(buffer.remove());
+                assertEquals(size, buffer.remove());
 
                 assertNull(buffer.current());
                 assertTrue(buffer.isEmpty());
-                assertFalse(buffer.remove());
+                assertEquals(-1, buffer.remove());
             }
         });
     }
@@ -147,22 +148,21 @@ public class ChannelOutboundBufferTest {
 
                 // Should have two entries.
                 assertNotNull(buffer.current());
-                assertTrue(buffer.remove());
+                assertEquals(size, buffer.remove());
                 assertNotNull(buffer.current());
-                assertTrue(buffer.remove());
+                assertEquals(size, buffer.remove());
 
                 assertNull(buffer.current());
                 assertTrue(buffer.isEmpty());
-                assertFalse(buffer.remove());
+                assertEquals(-1, buffer.remove());
             }
         });
     }
 
     private static void release(ChannelOutboundBuffer buffer) {
-        for (;;) {
-            if (!buffer.remove()) {
-                break;
-            }
+        while (!buffer.isEmpty()) {
+            assertNotEquals(-1, buffer.remove());
         }
+        assertEquals(-1, buffer.remove());
     }
 }

--- a/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTailTest.java
+++ b/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTailTest.java
@@ -16,6 +16,7 @@
 package io.netty5.channel;
 
 
+import io.netty5.buffer.api.Buffer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -286,7 +287,7 @@ public class DefaultChannelPipelineTailTest {
         }
 
         @Override
-        protected void doWrite(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle) throws Exception {
+        protected void doWriteNow(WriteSink writeHandle) throws Exception {
             throw new IOException();
         }
 
@@ -320,7 +321,7 @@ public class DefaultChannelPipelineTailTest {
         }
 
         @Override
-        protected boolean doConnect(SocketAddress remoteAddress, SocketAddress localAddress) {
+        protected boolean doConnect(SocketAddress remoteAddress, SocketAddress localAddress, Buffer initalData) {
             active = true;
             return true;
         }

--- a/transport/src/test/java/io/netty5/channel/socket/nio/ByteBufferCollectorTest.java
+++ b/transport/src/test/java/io/netty5/channel/socket/nio/ByteBufferCollectorTest.java
@@ -18,42 +18,33 @@ package io.netty5.channel.socket.nio;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.buffer.api.CompositeBuffer;
-import io.netty5.channel.AbstractChannel;
-import io.netty5.channel.Channel;
-import io.netty5.channel.ChannelOutboundBuffer;
-import io.netty5.channel.ChannelShutdownDirection;
-import io.netty5.channel.EventLoop;
 
-import io.netty5.channel.WriteHandleFactory;
-import io.netty5.util.concurrent.ImmediateEventExecutor;
 import org.junit.jupiter.api.Test;
 
-import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static io.netty5.util.concurrent.ImmediateEventExecutor.INSTANCE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class ByteBufferCollectorTest {
 
     @Test
     public void testEmptyNioBuffers() {
         ByteBufferCollector collector = newCollector();
-        ChannelOutboundBuffer buffer = newOutboundBuffer();
-        assertEmpty(collector, buffer);
+        assertEmpty(collector, new TestBuffer());
     }
 
-    private static void assertEmpty(ByteBufferCollector collector, ChannelOutboundBuffer buffer) {
-        ByteBuffer[] buffers = collector.collect(buffer, Integer.MAX_VALUE, Long.MAX_VALUE);
+    private static void assertEmpty(ByteBufferCollector collector, TestBuffer buffer) {
+        collector.prepare(Integer.MAX_VALUE, Long.MAX_VALUE);
+        buffer.forEach(collector);
+        ByteBuffer[] buffers = collector.nioBuffers();
         assertEquals(0, collector.nioBufferCount());
         assertNotNull(buffers);
         for (ByteBuffer b : buffers) {
@@ -65,15 +56,17 @@ public class ByteBufferCollectorTest {
     @Test
     public void testNioBuffersSingleBacked() {
         ByteBufferCollector collector = newCollector();
-        ChannelOutboundBuffer buffer = newOutboundBuffer();
+        TestBuffer buffer = new TestBuffer();
         Buffer buf = BufferAllocator.onHeapUnpooled().copyOf("buf1", StandardCharsets.US_ASCII);
-        buffer.addMessage(buf, buf.readableBytes(), ImmediateEventExecutor.INSTANCE.newPromise());
 
         // Still empty as not flushed.
         assertEmpty(collector, buffer);
 
-        buffer.addFlush();
-        ByteBuffer[] buffers = collector.collect(buffer, Integer.MAX_VALUE, Long.MAX_VALUE);
+        buffer.add(buf);
+        collector.prepare(Integer.MAX_VALUE, Long.MAX_VALUE);
+        buffer.forEach(collector);
+        ByteBuffer[] buffers = collector.nioBuffers();
+
         assertNotNull(buffers);
         assertEquals(1, collector.nioBufferCount(), "Should still be 0 as not flushed yet");
         for (int i = 0; i < collector.nioBufferCount(); i++) {
@@ -93,17 +86,17 @@ public class ByteBufferCollectorTest {
     @Test
     public void testNioBuffersExpand() {
         ByteBufferCollector collector = newCollector();
-        ChannelOutboundBuffer buffer = newOutboundBuffer();
+        TestBuffer buffer = new TestBuffer();
+        assertEmpty(collector, buffer);
 
         try (Buffer buf = BufferAllocator.offHeapUnpooled().copyOf("buf1", StandardCharsets.US_ASCII)) {
             for (int i = 0; i < 64; i++) {
-                buffer.addMessage(buf.copy(), buf.readableBytes(), ImmediateEventExecutor.INSTANCE.newPromise());
+                buffer.add(buf.copy());
             }
-            // Still empty as not flushed.
-            assertEmpty(collector, buffer);
 
-            buffer.addFlush();
-            ByteBuffer[] buffers = collector.collect(buffer, Integer.MAX_VALUE, Long.MAX_VALUE);
+            collector.prepare(Integer.MAX_VALUE, Long.MAX_VALUE);
+            buffer.forEach(collector);
+            ByteBuffer[] buffers = collector.nioBuffers();
             assertEquals(64, collector.nioBufferCount());
             assertEquals(1, buf.countReadableComponents());
             try (var iteration = buf.forEachComponent()) {
@@ -120,19 +113,16 @@ public class ByteBufferCollectorTest {
     @Test
     public void testNioBuffersExpand2() {
         ByteBufferCollector collector = newCollector();
-        ChannelOutboundBuffer buffer = newOutboundBuffer();
+        TestBuffer buffer = new TestBuffer();
+        assertEmpty(collector, buffer);
 
         try (Buffer buf = BufferAllocator.offHeapUnpooled().copyOf("buf1", StandardCharsets.US_ASCII)) {
             var sends = Stream.generate(() -> buf.copy().send()).limit(65).collect(Collectors.toList());
             CompositeBuffer comp = BufferAllocator.offHeapUnpooled().compose(sends);
-
-            buffer.addMessage(comp, comp.readableBytes(), ImmediateEventExecutor.INSTANCE.newPromise());
-
-            // Still empty as not flushed.
-            assertEmpty(collector, buffer);
-
-            buffer.addFlush();
-            ByteBuffer[] buffers = collector.collect(buffer, Integer.MAX_VALUE, Long.MAX_VALUE);
+            buffer.add(comp);
+            collector.prepare(Integer.MAX_VALUE, Long.MAX_VALUE);
+            buffer.forEach(collector);
+            ByteBuffer[] buffers = collector.nioBuffers();
             assertEquals(65, collector.nioBufferCount());
             assertEquals(1, buf.countReadableComponents());
             try (var iteration = buf.forEachComponent()) {
@@ -153,7 +143,7 @@ public class ByteBufferCollectorTest {
     @Test
     public void testNioBuffersMaxCount() {
         ByteBufferCollector collector = newCollector();
-        ChannelOutboundBuffer buffer = newOutboundBuffer();
+        TestBuffer buffer = new TestBuffer();
 
         try (Buffer buf = BufferAllocator.offHeapUnpooled().copyOf("buf1", StandardCharsets.US_ASCII)) {
             assertEquals(4, buf.readableBytes());
@@ -161,14 +151,13 @@ public class ByteBufferCollectorTest {
             CompositeBuffer comp = BufferAllocator.offHeapUnpooled().compose(sends);
 
             assertEquals(65, comp.countComponents());
-            buffer.addMessage(comp, comp.readableBytes(), ImmediateEventExecutor.INSTANCE.newPromise());
+            buffer.add(comp);
 
-            // Still empty as not flushed.
-            assertEmpty(collector, buffer);
-
-            buffer.addFlush();
             final int maxCount = 10;    // less than comp.nioBufferCount()
-            ByteBuffer[] buffers = collector.collect(buffer, maxCount, Integer.MAX_VALUE);
+            collector.prepare(maxCount, Long.MAX_VALUE);
+            buffer.forEach(collector);
+            ByteBuffer[] buffers = collector.nioBuffers();
+
             assertTrue(collector.nioBufferCount() <= maxCount, "Should not be greater than maxCount");
             try (var iteration = buf.forEachComponent()) {
                 var component = iteration.firstReadable();
@@ -187,86 +176,14 @@ public class ByteBufferCollectorTest {
         return collector;
     }
 
-    private static ChannelOutboundBuffer newOutboundBuffer() {
-        EventLoop eventLoop = mock(EventLoop.class);
-        // This allows us to have a single-threaded test
-        when(eventLoop.inEventLoop()).thenReturn(true);
-        when(eventLoop.newPromise()).thenReturn(INSTANCE.newPromise());
-        when(eventLoop.isCompatible(any())).thenReturn(true);
+    private static final class TestBuffer extends ArrayList<Object> {
 
-        return new TestChannel(eventLoop).outbound();
-    }
-
-    private static class TestChannel extends AbstractChannel<Channel, SocketAddress, SocketAddress> {
-
-        TestChannel(EventLoop eventLoop) {
-            super(null, eventLoop, false);
-        }
-
-        ChannelOutboundBuffer outbound() {
-            return outboundBuffer();
-        }
-
-        @Override
-        public boolean isOpen() {
-            return true;
-        }
-
-        @Override
-        public boolean isActive() {
-            return true;
-        }
-
-        @Override
-        protected boolean doConnect(SocketAddress remoteAddress, SocketAddress localAddress) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        protected boolean doFinishConnect(SocketAddress requestedRemoteAddress) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        protected SocketAddress localAddress0() {
-            return null;
-        }
-
-        @Override
-        protected SocketAddress remoteAddress0() {
-            return null;
-        }
-
-        @Override
-        protected void doBind(SocketAddress localAddress) { }
-
-        @Override
-        protected void doDisconnect() { }
-
-        @Override
-        protected void doClose() { }
-
-        @Override
-        protected void doRead(boolean wasReadPendingAlready) { }
-
-        @Override
-        protected boolean doReadNow(ReadSink readSink) {
-            return false;
-        }
-
-        @Override
-        protected void doWrite(ChannelOutboundBuffer in, WriteHandleFactory.WriteHandle writeHandle) throws Exception {
-            // NOOP
-        }
-
-        @Override
-        protected void doShutdown(ChannelShutdownDirection direction) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public boolean isShutdown(ChannelShutdownDirection direction) {
-            return !isActive();
+        void forEach(Predicate<Object> function) {
+            for (Object o: this) {
+                if (!function.test(o)) {
+                    return;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
…stractChannel

Motivation:

Correctly manage the ChannelOutboundBuffer and WriteHandle can be tricky. We can remove a lot of complexity by hiding these from the end-user.

Modifications:

- Add the concept of WriteSink which handles the ChannelOutboundBuffer and WriteHandle details for the end-user.
- Change the doWrite(...) method to doWriteNow(...) to be more consistent with the doReadNow(...)
- Make ChannelOutboundBuffer package-private and so an implementation detail
- Add initalData to doConnect(...) to better support TCP fast open.

Result:

Easier to write own AbstractChannel sub-classes