### PR TITLE
Gradle build issue when depending on netty5-codec-http2 SNAPSHOT

### DIFF
--- a/codec-http2/pom.xml
+++ b/codec-http2/pom.xml
@@ -111,6 +111,7 @@
       <artifactId>netty5-codec-http</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Motivation:

The Reactor-Netty branch based on netty5 snapshot does not build anymore, and we have the following build exception (we are using Gradle):

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':reactor-netty5-http:compileJava'.
15 actionable tasks: 11 executed, 4 up-to-date
> Could not resolve all files for configuration ':reactor-netty5-http:compileClasspath'.
   > Could not find netty5-codec-http-5.0.0.Alpha5-SNAPSHOT-tests.jar (io.netty:netty5-codec-http:5.0.0.Alpha5-SNAPSHOT).
     Searched in the following locations:
         file:/home/runner/.m2/repository/io/netty/netty5-codec-http/5.0.0.Alpha5-SNAPSHOT/netty5-codec-http-5.0.0.Alpha5-SNAPSHOT-tests.jar

```

I think we have this problem since the #12691, where a **test** dependency over netty5-codec-http-5.0.0.Alpha5-SNAPSHOT-tests.jar has been introduced in the pom of the netty5-codec-http2 artifact, but without a missing <scope>test</scope> attribute,: [see here](https://github.com/netty/netty/pull/12691/files#diff-171c0894327a3dd9c7977fb746350c8c35fe3cc5c9bc07d6fda19461baa65e6e)


This does not seem to cause problems with Maven, but with Gradle our build is failing.
I have attached a sample project which reproduces the problem: [netty-compile-issue.tgz](https://github.com/netty/netty/files/9382880/netty-compile-issue.tgz)

typing "./gradlew jar" will reproduce the issue.

Modification:

Just adding a test scope in the netty5-codec-http2 pom seems to fix our issue.

Result:

It unblocks the Reactor-Netty builds that are based on Netty5.

