### PR TITLE
Replace stdlib write/read with send/recv (Fixes #12673) (#12679)

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
@@ -252,7 +252,7 @@ abstract class AbstractEpollChannel<P extends UnixChannel>
             }
             long address = component.writableNativeAddress();
             assert address != 0;
-            int localReadAmount = socket.readAddress(address, 0, component.writableBytes());
+            int localReadAmount = socket.recvAddress(address, 0, component.writableBytes());
             if (localReadAmount > 0) {
                 component.skipWritableBytes(localReadAmount);
             }
@@ -267,7 +267,7 @@ abstract class AbstractEpollChannel<P extends UnixChannel>
             if (component != null) {
                 long address = component.readableNativeAddress();
                 assert address != 0;
-                written = socket.writeAddress(address, 0, component.readableBytes());
+                written = socket.sendAddress(address, 0, component.readableBytes());
             }
         }
         if (written > 0) {

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDatagramChannel.java
@@ -639,7 +639,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel<UnixChannel
                 for (var c = iteration.firstWritable(); c != null; c = c.nextWritable()) {
                     long address = c.writableNativeAddress();
                     assert address != 0;
-                    int bytesRead = socket.readAddress(address, 0, c.writableBytes());
+                    int bytesRead = socket.recvAddress(address, 0, c.writableBytes());
                     if (bytesRead <= 0) {
                         break;
                     }

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollSocketChannel.java
@@ -502,6 +502,11 @@ public final class EpollSocketChannel
         }
 
         @Override
+        protected int write(final ByteBuffer buf, final int pos, final int limit) throws IOException {
+            return socket.send(buf, pos, limit);
+        }
+
+        @Override
         protected BufferAllocator alloc() {
             return bufferAllocator();
         }

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDomainSocketShutdownOutputByPeerTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDomainSocketShutdownOutputByPeerTest.java
@@ -59,7 +59,7 @@ public class EpollDomainSocketShutdownOutputByPeerTest extends AbstractSocketShu
         final ByteBuffer buf = Buffer.allocateDirectWithNativeOrder(4);
         buf.putInt(data);
         buf.flip();
-        s.write(buf, buf.position(), buf.limit());
+        s.send(buf, buf.position(), buf.limit());
         Buffer.free(buf);
     }
 

--- a/transport-native-unix-common/src/main/c/netty5_unix_socket.c
+++ b/transport-native-unix-common/src/main/c/netty5_unix_socket.c
@@ -435,6 +435,52 @@ static jobject _recvFromDomainSocket(JNIEnv* env, jint fd, void* buffer, jint po
     return createDomainDatagramSocketAddress(env, &addr, res, NULL);
 }
 
+static jint _send(JNIEnv* env, jclass clazz, jint fd, void* buffer, jint pos, jint limit) {
+    ssize_t res;
+    int err;
+    do {
+       res = send(fd, buffer + pos, (size_t) (limit - pos), 0);
+       // keep on writing if it was interrupted
+    } while (res == -1 && ((err = errno) == EINTR));
+
+    if (res < 0) {
+        return -err;
+    }
+    return (jint) res;
+}
+
+static jint netty5_unix_socket_send(JNIEnv* env, jclass clazz, jint fd, jobject jbuffer, jint pos, jint limit) {
+    // We check that GetDirectBufferAddress will not return NULL in OnLoad
+    return _send(env, clazz, fd, (*env)->GetDirectBufferAddress(env, jbuffer), pos, limit);
+}
+
+static jint netty5_unix_socket_sendAddress(JNIEnv* env, jclass clazz, jint fd, jlong address, jint pos, jint limit) {
+    return _send(env, clazz, fd, (void*) (intptr_t) address, pos, limit);
+}
+
+static jint _recv(JNIEnv* env, jclass clazz, jint fd, void* buffer, jint pos, jint limit) {
+    ssize_t res;
+    int err;
+    do {
+        res = recv(fd, buffer + pos, (size_t) (limit - pos), 0);
+        // Keep on reading if we was interrupted
+    } while (res == -1 && ((err = errno) == EINTR));
+
+    if (res < 0) {
+        return -err;
+    }
+    return (jint) res;
+}
+
+static jint netty5_unix_socket_recv(JNIEnv* env, jclass clazz, jint fd, jobject jbuffer, jint pos, jint limit) {
+    // We check that GetDirectBufferAddress will not return NULL in OnLoad
+    return _recv(env, clazz, fd, (*env)->GetDirectBufferAddress(env, jbuffer), pos, limit);
+}
+
+static jint netty5_unix_socket_recvAddress(JNIEnv* env, jclass clazz, jint fd, jlong address, jint pos, jint limit) {
+    return _recv(env, clazz, fd, (void*) (intptr_t) address, pos, limit);
+}
+
 void netty5_unix_socket_getOptionHandleError(JNIEnv* env, int err) {
     netty5_unix_socket_optionHandleError(env, err, "getsockopt() failed: ");
 }
@@ -1120,6 +1166,10 @@ static const JNINativeMethod fixed_method_table[] = {
   // "recvFromAddress" has a dynamic signature
   // "recvFromDomainSocket" has a dynamic signature
   // "recvFromAddressDomainSocket" has a dynamic signature
+  { "send", "(ILjava/nio/ByteBuffer;II)I", (void *) netty5_unix_socket_send },
+  { "sendAddress", "(IJII)I", (void *) netty5_unix_socket_sendAddress },
+  { "recv", "(ILjava/nio/ByteBuffer;II)I", (void *) netty5_unix_socket_recv },
+  { "recvAddress", "(IJII)I", (void *) netty5_unix_socket_recvAddress },
   { "recvFd", "(I)I", (void *) netty5_unix_socket_recvFd },
   { "sendFd", "(II)I", (void *) netty5_unix_socket_sendFd },
   { "bindDomainSocket", "(I[B)I", (void *) netty5_unix_socket_bindDomainSocket },

--- a/transport-native-unix-common/src/main/java/io/netty5/channel/unix/Socket.java
+++ b/transport-native-unix-common/src/main/java/io/netty5/channel/unix/Socket.java
@@ -275,6 +275,44 @@ public class Socket extends FileDescriptor {
         return recvFromAddressDomainSocket(fd, memoryAddress, pos, limit);
     }
 
+    public final int recv(ByteBuffer buf, int pos, int limit) throws IOException {
+        int res = recv(intValue(), buf, pos, limit);
+        if (res > 0) {
+            return res;
+        }
+        if (res == 0) {
+            return -1;
+        }
+        return ioResult("recv", res);
+    }
+
+    public final int recvAddress(long address, int pos, int limit) throws IOException {
+        int res = recvAddress(intValue(), address, pos, limit);
+        if (res > 0) {
+            return res;
+        }
+        if (res == 0) {
+            return -1;
+        }
+        return ioResult("recvAddress", res);
+    }
+
+    public final int send(ByteBuffer buf, int pos, int limit) throws IOException {
+        int res = send(intValue(), buf, pos, limit);
+        if (res >= 0) {
+            return res;
+        }
+        return ioResult("send", res);
+    }
+
+    public final int sendAddress(long address, int pos, int limit) throws IOException {
+        int res = sendAddress(intValue(), address, pos, limit);
+        if (res >= 0) {
+            return res;
+        }
+        return ioResult("sendAddress", res);
+    }
+
     public final int recvFd() throws IOException {
         int res = recvFd(fd);
         if (res > 0) {
@@ -614,6 +652,12 @@ public class Socket extends FileDescriptor {
 
     private static native byte[] remoteAddress(int fd);
     private static native byte[] localAddress(int fd);
+
+    private static native int send(int fd, ByteBuffer buf, int pos, int limit);
+    private static native int sendAddress(int fd, long address, int pos, int limit);
+    private static native int recv(int fd, ByteBuffer buf, int pos, int limit);
+
+    private static native int recvAddress(int fd, long address, int pos, int limit);
 
     private static native int sendTo(
             int fd, boolean ipv6, ByteBuffer buf, int pos, int limit, byte[] address, int scopeId, int port,

--- a/transport-native-unix-common/src/main/java/io/netty5/channel/unix/SocketWritableByteChannel.java
+++ b/transport-native-unix-common/src/main/java/io/netty5/channel/unix/SocketWritableByteChannel.java
@@ -34,13 +34,17 @@ public abstract class SocketWritableByteChannel implements WritableByteChannel {
         this.fd = requireNonNull(fd, "fd");
     }
 
+    protected int write(ByteBuffer buf, int pos, int limit) throws IOException {
+        return fd.write(buf, pos, limit);
+    }
+
     @Override
     public final int write(ByteBuffer src) throws IOException {
         final int written;
         int position = src.position();
         int limit = src.limit();
         if (src.isDirect()) {
-            written = fd.write(src, position, src.limit());
+            written = write(src, position, src.limit());
         } else {
             final int readableBytes = limit - position;
             final BufferAllocator alloc = alloc();
@@ -61,7 +65,7 @@ public abstract class SocketWritableByteChannel implements WritableByteChannel {
                 try (var iterator = buffer.forEachComponent()) {
                     var component = iterator.firstReadable();
                     ByteBuffer nioBuffer = component.readableBuffer();
-                    written = fd.write(nioBuffer, nioBuffer.position(), nioBuffer.limit());
+                    written = write(nioBuffer, nioBuffer.position(), nioBuffer.limit());
                     assert component.next() == null;
                 }
             } catch (Throwable throwable) {


### PR DESCRIPTION
Motivation:

The performance Unix write/read paths is more involved (and slower) then the specialized socket send/rcv ones.

Modification:

Replace Unix write/read paths with send/recv

Result:

Better performance for single buffer send/recv
