### PR TITLE
Simplify AbstractChannel sub-classes by handle reading in loop.

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
@@ -314,17 +314,22 @@ abstract class AbstractEpollChannel<P extends UnixChannel>
             return readState == ReadState.Closed;
         } finally {
             this.maybeMoreDataToRead = readState == ReadState.Partial || receivedRdHup;
+        }
+    }
 
-            if (receivedRdHup || isReadPending() && maybeMoreDataToRead) {
-                // trigger a read again as there may be something left to read and because of epoll ET we
-                // will not get notified again until we read everything from the socket
-                //
-                // It is possible the last fireChannelRead call could cause the user to call read() again, or if
-                // autoRead is true the call to channelReadComplete would also call read, but maybeMoreDataToRead is set
-                // to false before every read operation to prevent re-entry into epollInReady() we will not read from
-                // the underlying OS again unless the user happens to call read again.
-                executeReadNowRunnable();
-            }
+    @Override
+    protected void readLoopComplete() {
+        super.readLoopComplete();
+
+        if (receivedRdHup || isReadPending() && maybeMoreDataToRead) {
+            // trigger a read again as there may be something left to read and because of epoll ET we
+            // will not get notified again until we read everything from the socket
+            //
+            // It is possible the last fireChannelRead call could cause the user to call read() again, or if
+            // autoRead is true the call to channelReadComplete would also call read, but maybeMoreDataToRead is set
+            // to false before every read operation to prevent re-entry into epollInReady() we will not read from
+            // the underlying OS again unless the user happens to call read again.
+            executeReadNowRunnable();
         }
     }
 

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollServerSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollServerSocketChannel.java
@@ -355,17 +355,14 @@ public final class EpollServerSocketChannel
 
     @Override
     protected ReadState epollInReady(ReadSink readSink) throws Exception {
-        boolean continueReading;
-        do {
-            int acceptedFd = socket.accept(acceptedAddress);
-            if (acceptedFd == -1) {
-                readSink.processRead(0, 0, null);
-                // this means everything was handled for now
-                return ReadState.All;
-            }
-            continueReading = readSink.processRead(0, 0,
-                    newChildChannel(acceptedFd, acceptedAddress, 1, acceptedAddress[0]));
-        } while (continueReading && !isShutdown(ChannelShutdownDirection.Inbound));
+        int acceptedFd = socket.accept(acceptedAddress);
+        if (acceptedFd == -1) {
+            readSink.processRead(0, 0, null);
+            // this means everything was handled for now
+            return ReadState.All;
+        }
+        readSink.processRead(0, 0,
+                newChildChannel(acceptedFd, acceptedAddress, 1, acceptedAddress[0]));
         return ReadState.Partial;
     }
 

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueServerSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueServerSocketChannel.java
@@ -368,19 +368,14 @@ public final class KQueueServerSocketChannel extends
 
     @Override
     int readReady(ReadSink readSink) throws Exception {
-        int totalBytesRead = 0;
-        boolean continueReading;
-        do {
-            int acceptFd = socket.accept(acceptedAddress);
-            if (acceptFd == -1) {
-                // this means everything was handled for now
-                readSink.processRead(0, 0, null);
-                break;
-            }
-            totalBytesRead++;
-            continueReading = readSink.processRead(0, 0,
-                    newChildChannel(acceptFd, acceptedAddress, 1, acceptedAddress[0]));
-        } while (continueReading && !isShutdown(ChannelShutdownDirection.Inbound));
-        return totalBytesRead;
+        int acceptFd = socket.accept(acceptedAddress);
+        if (acceptFd == -1) {
+            // this means everything was handled for now
+            readSink.processRead(0, 0, null);
+            return 0;
+        }
+        readSink.processRead(0, 0,
+                newChildChannel(acceptFd, acceptedAddress, 1, acceptedAddress[0]));
+        return 1;
     }
 }

--- a/transport/src/main/java/io/netty5/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty5/channel/AbstractChannel.java
@@ -48,7 +48,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-import java.util.function.Consumer;
 
 import static io.netty5.channel.ChannelOption.ALLOW_HALF_CLOSURE;
 import static io.netty5.channel.ChannelOption.AUTO_CLOSE;
@@ -882,37 +881,8 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
             return;
         }
 
-        final boolean closed;
-        try {
-            ReadSink readSink = readSink();
-            try {
-                closed = doReadNow(readSink);
-            } catch (Throwable cause) {
-                if (readSink.completeFailure(readHandle(), cause)) {
-                    shutdownReadSide();
-                } else {
-                    closeTransport(newPromise());
-                }
-                return;
-            }
-            readSink.complete(readHandle());
-        } finally {
-            // Check if there is a readPending which was not processed yet.
-            // This could be for two reasons:
-            // * The user called Channel.read() or ChannelHandlerContext.read() in channelRead(...) method
-            // * The user called Channel.read() or ChannelHandlerContext.read() in channelReadComplete(...) method
-            //
-            // See https://github.com/netty/netty/issues/2254
-            if (!isReadPending() && !isAutoRead()) {
-                clearScheduledRead();
-            }
-        }
-
-        if (closed) {
-            shutdownReadSide();
-        } else {
-            readIfIsAutoRead();
-        }
+        ReadSink readSink = readSink();
+        readSink.readLoop();
     }
 
     protected final void shutdownReadSide() {
@@ -942,11 +912,12 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
     }
 
     /**
-     * Read messages now from the transport and so propagate these through the {@link ChannelPipeline}.
+     * Try to read a message from the transport and dispatch it via {@link ReadSink#processRead(int, int, Object)}.
+     * This method is called in a loop until there is nothing more messages to read or the channel was
+     * shutdown / closed.
+     * <strong>This method should never be called directly by sub-classes, use {@link #readNow()} instead.</strong>
      *
-     * <strong>This method should never be called directly by sub-classes, use {@link #readNow()}.</strong>
-     *
-     * @param readSink      the {@link Consumer} that should be called with methods that are read from the transport
+     * @param readSink      the {@link ReadSink} that should be called with messages that are read from the transport
      *                      to propagate these.
      * @return {@code true} if the channel should be shutdown / closed.
      */
@@ -1896,12 +1867,22 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
     }
 
     /**
-     * Sink that will be used by {@link #doReadNow(ReadSink)} implementations.
+     * Called once the read loop completed for this Channel. Sub-classes might override this method but should also
+     * call super.
+     */
+    protected void readLoopComplete() {
+        // NOOP
+    }
+
+    /**
+     * Sink that will be used by {@link #doReadNow(ReadSink)} implementations to perform the actual
+     * read from the underlying transport (for example a socket).
      */
     protected final class ReadSink {
         final ReadHandleFactory.ReadHandle readHandle;
 
         private boolean readSomething;
+        private boolean continueReading;
 
         ReadSink(ReadHandleFactory.ReadHandle readHandle) {
             this.readHandle = readHandle;
@@ -1913,18 +1894,16 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
          * @param attemptedBytesRead    The number of  bytes the read operation did attempt to read.
          * @param actualBytesRead       The number of bytes the read operation actually read.
          * @param message               the read message or {@code null} if none was read.
-         * @return                      {@code true} if the read loop should continue reading, {@code false} otherwise.
          */
-        public boolean processRead(int attemptedBytesRead, int actualBytesRead, Object message) {
+        public void processRead(int attemptedBytesRead, int actualBytesRead, Object message) {
             if (message == null) {
                 readHandle.lastRead(attemptedBytesRead, actualBytesRead, 0);
-                return false;
+                continueReading = false;
             } else {
                 readSomething = true;
                 currentBufferAllocator = null;
-                boolean continueReading = readHandle.lastRead(attemptedBytesRead, actualBytesRead, 1);
+                continueReading = readHandle.lastRead(attemptedBytesRead, actualBytesRead, 1);
                 pipeline().fireChannelRead(message);
-                return continueReading;
             }
         }
 
@@ -1942,28 +1921,75 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
             return readBufferAllocator.allocate(readBufferAllocator(), readHandle.estimatedBufferCapacity());
         }
 
-        void complete(ReadHandleFactory.ReadHandle readHandle) {
-            // Check if something was read as in this case we wall need to call the *ReadComplete methods.
-            if (readSomething) {
-                readSomething = false;
-                readHandle.readComplete();
-                pipeline().fireChannelReadComplete();
+        private void complete() {
+            try {
+                readSomething();
+            } finally {
+                continueReading = false;
+                readLoopComplete();
             }
         }
 
-        boolean completeFailure(ReadHandleFactory.ReadHandle readHandle, Throwable cause) {
-            complete(readHandle);
-            pipeline().fireChannelExceptionCaught(cause);
+        private boolean completeFailure(Throwable cause) {
+            try {
+                readSomething();
 
-            if (cause instanceof PortUnreachableException) {
-                return false;
+                pipeline().fireChannelExceptionCaught(cause);
+
+                if (cause instanceof PortUnreachableException) {
+                    return false;
+                }
+                // If oom will close the read event, release connection.
+                // See https://github.com/netty/netty/issues/10434
+                return cause instanceof IOException && !(AbstractChannel.this instanceof ServerChannel);
+            } finally {
+                continueReading = false;
+                readLoopComplete();
             }
-            // If oom will close the read event, release connection.
-            // See https://github.com/netty/netty/issues/10434
-            if (cause instanceof IOException && !(AbstractChannel.this instanceof ServerChannel)) {
-                return true;
+        }
+
+        private void readSomething() {
+            // Check if something was read as in this case we wall need to call the *ReadComplete methods.
+            if (readSomething) {
+                readSomething = false;
+                pipeline().fireChannelReadComplete();
             }
-            return false;
+            readHandle.readComplete();
+        }
+
+        void readLoop() {
+            boolean closed;
+            try {
+                do {
+                    try {
+                        closed = doReadNow(this);
+                    } catch (Throwable cause) {
+                        if (completeFailure(cause)) {
+                            shutdownReadSide();
+                        } else {
+                            closeTransport(newPromise());
+                        }
+                        return;
+                    }
+                } while (continueReading && !closed && !isShutdown(ChannelShutdownDirection.Inbound));
+                complete();
+            } finally {
+                // Check if there is a readPending which was not processed yet.
+                // This could be for two reasons:
+                // * The user called Channel.read() or ChannelHandlerContext.read() in channelRead(...) method
+                // * The user called Channel.read() or ChannelHandlerContext.read() in channelReadComplete(...) method
+                //
+                // See https://github.com/netty/netty/issues/2254
+                if (!isReadPending() && !isAutoRead()) {
+                    clearScheduledRead();
+                }
+            }
+
+            if (closed) {
+                shutdownReadSide();
+            } else {
+                readIfIsAutoRead();
+            }
         }
     }
 }

--- a/transport/src/main/java/io/netty5/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty5/channel/AbstractChannel.java
@@ -1958,6 +1958,7 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
         }
 
         void readLoop() {
+            continueReading = false;
             boolean closed;
             try {
                 do {

--- a/transport/src/main/java/io/netty5/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty5/channel/local/LocalChannel.java
@@ -219,15 +219,8 @@ public class LocalChannel extends AbstractChannel<LocalServerChannel, LocalAddre
 
     @Override
     protected boolean doReadNow(ReadSink readSink) {
-        boolean continueReading;
-        do {
-            Object received = inboundBuffer.poll();
-            if (received == null) {
-                readSink.processRead(0, 0, null);
-                break;
-            }
-            continueReading = readSink.processRead(0, 0, received);
-        } while (continueReading && !isShutdown(ChannelShutdownDirection.Inbound));
+        Object received = inboundBuffer.poll();
+        readSink.processRead(0, 0, received);
         return false;
     }
 

--- a/transport/src/main/java/io/netty5/channel/local/LocalServerChannel.java
+++ b/transport/src/main/java/io/netty5/channel/local/LocalServerChannel.java
@@ -103,15 +103,8 @@ public class LocalServerChannel extends AbstractServerChannel<LocalChannel, Loca
 
     @Override
     protected boolean doReadNow(ReadSink readSink) {
-        boolean continueReading;
-        do {
-            Object m = inboundBuffer.poll();
-            if (m == null) {
-                readSink.processRead(0, 0, null);
-                break;
-            }
-            continueReading = readSink.processRead(0, 0, m);
-        } while (continueReading && !isShutdown(ChannelShutdownDirection.Inbound));
+        Object m = inboundBuffer.poll();
+        readSink.processRead(0, 0, m);
         return false;
     }
 

--- a/transport/src/main/java/io/netty5/channel/nio/AbstractNioMessageChannel.java
+++ b/transport/src/main/java/io/netty5/channel/nio/AbstractNioMessageChannel.java
@@ -45,19 +45,8 @@ public abstract class AbstractNioMessageChannel<P extends Channel, L extends Soc
 
     @Override
     protected final boolean doReadNow(ReadSink readSink) throws Exception {
-        boolean closed = false;
-        do {
-            int localRead = doReadMessages(readSink);
-            if (localRead == 0) {
-                break;
-            }
-            if (localRead < 0) {
-                closed = true;
-                break;
-            }
-        } while (!isShutdown(ChannelShutdownDirection.Inbound));
-
-        return closed;
+        int localRead = doReadMessages(readSink);
+        return localRead < 0;
     }
 
     @Override

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioDatagramChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioDatagramChannel.java
@@ -399,13 +399,10 @@ public final class NioDatagramChannel
                 return -1;
             }
             data.skipWritableBytes(actualBytesRead);
-            if (readSink.processRead(attemptedBytesRead, actualBytesRead,
-                    new DatagramPacket(data, localAddress(), remoteAddress))) {
-                free = false;
-                return 1;
-            }
+            readSink.processRead(attemptedBytesRead, actualBytesRead,
+                    new DatagramPacket(data, localAddress(), remoteAddress));
             free = false;
-            return 0;
+            return 1;
         } finally {
             if (free) {
                 data.close();

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioServerSocketChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioServerSocketChannel.java
@@ -242,11 +242,9 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel<Channel, S
         SocketChannel ch = SocketUtils.accept(javaChannel());
         try {
             if (ch != null) {
-                if (readSink.processRead(0, 0,
-                        new NioSocketChannel(this, childEventLoopGroup().next(), ch, family))) {
-                    return 1;
-                }
-                return 0;
+                readSink.processRead(0, 0,
+                        new NioSocketChannel(this, childEventLoopGroup().next(), ch, family));
+                return 1;
             }
         } catch (Throwable t) {
             logger.warn("Failed to create a new channel from an accepted socket.", t);


### PR DESCRIPTION
Motivation:

At the moment we had to handle the looping in each sub-class, we can move the logic to AbstractChannel and so simplify things.

Modifications:

Move looping logic to AbstractChannel

Result:

Easier handling of reading for AbstractChannel sub-classes