### PR TITLE
Improve logging when MacOSDnsServerAddressStreamProvider cannot be found/loaded

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddressStreamProviders.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddressStreamProviders.java
@@ -68,11 +68,11 @@ public final class DnsServerAddressStreamProviders {
                 }
             } catch (ClassNotFoundException cause) {
                 LOGGER.warn("Can not find {} in the classpath, fallback to system defaults. This may result in "
-                        + "incorrect DNS resolutions on MacOS. Check whether you have a dependency to "
+                        + "incorrect DNS resolutions on MacOS. Check whether you have a dependency on "
                         + "'io.netty:netty-resolver-dns-native-macos'", MACOS_PROVIDER_CLASS_NAME);
             } catch (Throwable cause) {
                 LOGGER.error("Unable to load {}, fallback to system defaults. This may result in "
-                        + "incorrect DNS resolutions on MacOS. Check whether you have a dependency to "
+                        + "incorrect DNS resolutions on MacOS. Check whether you have a dependency on "
                         + "'io.netty:netty-resolver-dns-native-macos'", MACOS_PROVIDER_CLASS_NAME, cause);
                 constructor = null;
             }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddressStreamProviders.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddressStreamProviders.java
@@ -68,10 +68,12 @@ public final class DnsServerAddressStreamProviders {
                 }
             } catch (ClassNotFoundException cause) {
                 LOGGER.warn("Can not find {} in the classpath, fallback to system defaults. This may result in "
-                        + "incorrect DNS resolutions on MacOS.", MACOS_PROVIDER_CLASS_NAME);
+                        + "incorrect DNS resolutions on MacOS. Check whether you have a dependency to "
+                        + "'io.netty:netty-resolver-dns-native-macos'", MACOS_PROVIDER_CLASS_NAME);
             } catch (Throwable cause) {
                 LOGGER.error("Unable to load {}, fallback to system defaults. This may result in "
-                        + "incorrect DNS resolutions on MacOS.", MACOS_PROVIDER_CLASS_NAME, cause);
+                        + "incorrect DNS resolutions on MacOS. Check whether you have a dependency to "
+                        + "'io.netty:netty-resolver-dns-native-macos'", MACOS_PROVIDER_CLASS_NAME, cause);
                 constructor = null;
             }
         }


### PR DESCRIPTION
Motivation:

When `MacOSDnsServerAddressStreamProvider` cannot be found/loaded, a warning/error appears
in the logs, specifying that without this functionality the DNS resolution might be incorrect.
However there is no guidance how this can be fixed.

Modifications:

- Extend the log message with information for the dependency that is needed in order to resolve this issue.

Result:
Users will be informed for the missing dependency that will resolve the issue.
Related to #11020
