### PR TITLE
Cleanup AbstractChannel and javadocs

### DIFF
--- a/transport/src/main/java/io/netty5/channel/AbstractServerChannel.java
+++ b/transport/src/main/java/io/netty5/channel/AbstractServerChannel.java
@@ -20,16 +20,7 @@ import io.netty5.buffer.api.Buffer;
 import java.net.SocketAddress;
 
 /**
- * A skeletal server-side {@link Channel} implementation.  A server-side
- * {@link Channel} does not allow the following operations:
- * <ul>
- * <li>{@link #connect(SocketAddress)}</li>
- * <li>{@link #disconnect()}</li>
- * <li>{@link #write(Object)}</li>
- * <li>{@link #flush()}</li>
- * <li>{@link #shutdown(ChannelShutdownDirection)}</li>
- * <li>and the shortcut methods which calls the methods mentioned above
- * </ul>
+ * A skeletal {@link ServerChannel} implementation.
  */
 public abstract class AbstractServerChannel<P extends Channel, L extends SocketAddress, R extends SocketAddress>
         extends AbstractChannel<P, L, R> implements ServerChannel {
@@ -81,12 +72,12 @@ public abstract class AbstractServerChannel<P extends Channel, L extends SocketA
     }
 
     @Override
-    protected boolean doConnect(SocketAddress remoteAddress, SocketAddress localAddress, Buffer initialData) {
+    protected final boolean doConnect(SocketAddress remoteAddress, SocketAddress localAddress, Buffer initialData) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    protected boolean doFinishConnect(R requestedRemoteAddress) {
+    protected final boolean doFinishConnect(R requestedRemoteAddress) {
         throw new UnsupportedOperationException();
     }
 }

--- a/transport/src/main/java/io/netty5/channel/ServerChannel.java
+++ b/transport/src/main/java/io/netty5/channel/ServerChannel.java
@@ -15,17 +15,28 @@
  */
 package io.netty5.channel;
 
-import io.netty5.channel.socket.ServerSocketChannel;
+import io.netty5.util.concurrent.Future;
+
+import java.net.SocketAddress;
 
 /**
- * A {@link Channel} that accepts an incoming connection attempt and creates
- * its child {@link Channel}s by accepting them. {@link ServerSocketChannel} is
- * a good example.
+ * A {@link Channel} that accepts an incoming connection attempts and creates
+ * its child {@link Channel}s by accepting them.
+ * A {@link ServerChannel} does not allow the following operations and so will fail the returned
+ * {@link Future} of these operations:
+ * <ul>
+ * <li>{@link #connect(SocketAddress)}</li>
+ * <li>{@link #disconnect()}</li>
+ * <li>{@link #write(Object)}</li>
+ * <li>{@link #flush()}</li>
+ * <li>{@link #shutdown(ChannelShutdownDirection)}</li>
+ * </ul>
  */
 public interface ServerChannel extends Channel {
 
     /**
-     * Returns the {@link EventLoopGroup} that is used to register the child {@link Channel}s on.
+     * Returns the {@link EventLoopGroup} that is used to register the child {@link Channel}s on after accepting
+     * these.
      */
     EventLoopGroup childEventLoopGroup();
 }

--- a/transport/src/main/java/io/netty5/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty5/channel/embedded/EmbeddedChannel.java
@@ -758,14 +758,6 @@ public class EmbeddedChannel extends AbstractChannel<Channel, SocketAddress, Soc
     }
 
     @Override
-    protected void runAfterTransportAction() {
-        super.runAfterTransportAction();
-        if (!((EmbeddedEventLoop) executor()).running) {
-            runPendingTasks();
-        }
-    }
-
-    @Override
     protected boolean doConnect(SocketAddress remoteAddress, SocketAddress localAddress, Buffer initialData) {
         return true;
     }
@@ -788,6 +780,14 @@ public class EmbeddedChannel extends AbstractChannel<Channel, SocketAddress, Soc
         @Override
         protected void onUnhandledInboundMessage(ChannelHandlerContext ctx, Object msg) {
             handleInboundMessage(msg);
+        }
+
+        @Override
+        protected void runAfterTransportOperation() {
+            super.runAfterTransportOperation();
+            if (!((EmbeddedEventLoop) executor()).running) {
+                runPendingTasks();
+            }
         }
     }
 }

--- a/transport/src/main/java/io/netty5/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty5/channel/local/LocalChannel.java
@@ -208,12 +208,10 @@ public class LocalChannel extends AbstractChannel<LocalServerChannel, LocalAddre
     }
 
     private void tryClose(boolean isActive) {
-        if (isActive) {
-            closeTransport(newPromise());
-        } else {
+        if (!isActive) {
             releaseInboundBuffers();
-            closeForciblyTransport();
         }
+        closeTransport(newPromise());
     }
 
     @Override


### PR DESCRIPTION
Motivation:

Various protected methods did not have javadocs / incomplete javadocs. Beside this there were also a few methods left that can be private

Modifications:

- Add javadocs
- Adjust visibility

Result:

Cleanup
