### PR TITLE
Add native-image metadata for the different ChannelHandler implementations

### DIFF
--- a/codec-dns/pom.xml
+++ b/codec-dns/pom.xml
@@ -59,6 +59,23 @@
       <artifactId>apacheds-protocol-dns</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <!-- Automatic native-image reflection metadata generation for handlers dependencies -->
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty5-transport</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>
 

--- a/codec-dns/src/main/resources/native-image/codec-dns-handlers/reflect-config.json
+++ b/codec-dns/src/main/resources/native-image/codec-dns-handlers/reflect-config.json
@@ -1,0 +1,58 @@
+[
+  {
+    "name": "io.netty5.handler.codec.dns.DatagramDnsQueryDecoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.dns.DatagramDnsQueryDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.dns.DatagramDnsQueryEncoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.dns.DatagramDnsQueryEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.dns.DatagramDnsResponseDecoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.dns.DatagramDnsResponseDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.dns.DatagramDnsResponseEncoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.dns.DatagramDnsResponseEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.dns.TcpDnsQueryDecoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.dns.TcpDnsQueryDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.dns.TcpDnsQueryEncoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.dns.TcpDnsQueryEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.dns.TcpDnsResponseDecoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.dns.TcpDnsResponseDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.dns.TcpDnsResponseEncoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.dns.TcpDnsResponseEncoder"
+    },
+    "queryAllPublicMethods": true
+  }
+]

--- a/codec-dns/src/test/java/io/netty5/handler/codec/dns/NativeImageHandlerMetadataTest.java
+++ b/codec-dns/src/test/java/io/netty5/handler/codec/dns/NativeImageHandlerMetadataTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.handler.codec.dns;
+
+import io.netty5.nativeimage.ChannelHandlerMetadataUtil;
+import org.junit.jupiter.api.Test;
+
+public class NativeImageHandlerMetadataTest {
+
+    @Test
+    public void collectAndCompareMetadata() {
+        ChannelHandlerMetadataUtil.generateMetadata(
+                "src/main/resources/native-image/codec-dns-handlers/reflect-config.json",
+                "io.netty5.handler.codec.dns");
+    }
+
+}

--- a/codec-http/pom.xml
+++ b/codec-http/pom.xml
@@ -102,6 +102,23 @@
       <artifactId>zstd-jni</artifactId>
       <optional>true</optional>
     </dependency>
+
+    <!-- Automatic native-image reflection metadata generation for handlers dependencies -->
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty5-transport</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>
 

--- a/codec-http/src/main/resources/native-image/codec-http-handlers/reflect-config.json
+++ b/codec-http/src/main/resources/native-image/codec-http-handlers/reflect-config.json
@@ -1,0 +1,345 @@
+[
+  {
+    "name": "io.netty5.handler.codec.http.cors.CorsHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.cors.CorsHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.HttpClientCodec",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.HttpClientCodec"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.HttpClientCodec$Decoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.HttpClientCodec$Decoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.HttpClientCodec$Encoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.HttpClientCodec$Encoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.HttpClientUpgradeHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.HttpClientUpgradeHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.HttpContentCompressor",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.HttpContentCompressor"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.HttpContentDecoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.HttpContentDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.HttpContentDecompressor",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.HttpContentDecompressor"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.HttpContentEncoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.HttpContentEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.HttpObjectAggregator",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.HttpObjectAggregator"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.HttpObjectDecoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.HttpObjectDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.HttpObjectEncoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.HttpObjectEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.HttpRequestDecoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.HttpRequestDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.HttpRequestEncoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.HttpRequestEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.HttpResponseDecoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.HttpResponseDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.HttpResponseEncoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.HttpResponseEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.HttpServerCodec",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.HttpServerCodec"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.HttpServerCodec$HttpServerRequestDecoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.HttpServerCodec$HttpServerRequestDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.HttpServerCodec$HttpServerResponseEncoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.HttpServerCodec$HttpServerResponseEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.HttpServerExpectContinueHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.HttpServerExpectContinueHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.HttpServerKeepAliveHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.HttpServerKeepAliveHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.HttpServerUpgradeHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.HttpServerUpgradeHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.websocketx.extensions.compression.DeflateDecoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.websocketx.extensions.compression.DeflateDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.websocketx.extensions.compression.DeflateEncoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.websocketx.extensions.compression.DeflateEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.websocketx.extensions.compression.PerFrameDeflateDecoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.websocketx.extensions.compression.PerFrameDeflateDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.websocketx.extensions.compression.PerFrameDeflateEncoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.websocketx.extensions.compression.PerFrameDeflateEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.websocketx.extensions.compression.PerMessageDeflateDecoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.websocketx.extensions.compression.PerMessageDeflateDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.websocketx.extensions.compression.PerMessageDeflateEncoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.websocketx.extensions.compression.PerMessageDeflateEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.websocketx.extensions.compression.WebSocketClientCompressionHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.websocketx.extensions.compression.WebSocketClientCompressionHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.websocketx.extensions.compression.WebSocketServerCompressionHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.websocketx.extensions.compression.WebSocketServerCompressionHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.websocketx.extensions.WebSocketClientExtensionHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.websocketx.extensions.WebSocketClientExtensionHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.websocketx.extensions.WebSocketExtensionDecoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.websocketx.extensions.WebSocketExtensionDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.websocketx.extensions.WebSocketExtensionEncoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.websocketx.extensions.WebSocketExtensionEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.websocketx.extensions.WebSocketServerExtensionHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.websocketx.extensions.WebSocketServerExtensionHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.websocketx.Utf8FrameValidator",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.websocketx.Utf8FrameValidator"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.websocketx.WebSocket13FrameDecoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.websocketx.WebSocket13FrameDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.websocketx.WebSocket13FrameEncoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.websocketx.WebSocket13FrameEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.websocketx.WebSocketClientHandshaker$1",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.websocketx.WebSocketClientHandshaker$1"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.websocketx.WebSocketClientProtocolHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.websocketx.WebSocketClientProtocolHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.websocketx.WebSocketClientProtocolHandshakeHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.websocketx.WebSocketClientProtocolHandshakeHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.websocketx.WebSocketFrameAggregator",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.websocketx.WebSocketFrameAggregator"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.websocketx.WebSocketFrameDecoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.websocketx.WebSocketFrameDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.websocketx.WebSocketFrameEncoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.websocketx.WebSocketFrameEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.websocketx.WebSocketProtocolHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.websocketx.WebSocketProtocolHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.websocketx.WebSocketServerHandshaker$1",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.websocketx.WebSocketServerHandshaker$1"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.websocketx.WebSocketServerProtocolHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.websocketx.WebSocketServerProtocolHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http.websocketx.WebSocketServerProtocolHandshakeHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http.websocketx.WebSocketServerProtocolHandshakeHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.rtsp.RtspDecoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.rtsp.RtspDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.rtsp.RtspEncoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.rtsp.RtspEncoder"
+    },
+    "queryAllPublicMethods": true
+  }
+]

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/NativeImageHandlerMetadataTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/NativeImageHandlerMetadataTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.handler.codec.http;
+
+import io.netty5.nativeimage.ChannelHandlerMetadataUtil;
+import org.junit.jupiter.api.Test;
+
+public class NativeImageHandlerMetadataTest {
+
+    @Test
+    public void collectAndCompareMetadata() {
+        ChannelHandlerMetadataUtil.generateMetadata(
+                "src/main/resources/native-image/codec-http-handlers/reflect-config.json",
+                "io.netty5.handler.codec.http", "io.netty5.handler.codec.rtsp");
+    }
+
+}

--- a/codec-http2/pom.xml
+++ b/codec-http2/pom.xml
@@ -113,6 +113,23 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+
+    <!-- Automatic native-image reflection metadata generation for handlers dependencies -->
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty5-transport</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>
 

--- a/codec-http2/src/main/resources/native-image/codec-http2-handlers/reflect-config.json
+++ b/codec-http2/src/main/resources/native-image/codec-http2-handlers/reflect-config.json
@@ -1,0 +1,58 @@
+[
+  {
+    "name": "io.netty5.handler.codec.http2.CleartextHttp2ServerUpgradeHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http2.CleartextHttp2ServerUpgradeHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http2.Http2ChannelDuplexHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http2.Http2ChannelDuplexHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http2.Http2ConnectionHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http2.Http2ConnectionHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http2.Http2FrameCodec",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http2.Http2FrameCodec"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http2.Http2MultiplexHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http2.Http2MultiplexHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http2.Http2StreamFrameToHttpObjectCodec",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http2.Http2StreamFrameToHttpObjectCodec"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http2.HttpToHttp2ConnectionHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http2.HttpToHttp2ConnectionHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.http2.InboundHttpToHttp2Adapter",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.http2.InboundHttpToHttp2Adapter"
+    },
+    "queryAllPublicMethods": true
+  }
+]

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/NativeImageHandlerMetadataTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/NativeImageHandlerMetadataTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.handler.codec.http2;
+
+import io.netty5.nativeimage.ChannelHandlerMetadataUtil;
+import org.junit.jupiter.api.Test;
+
+public class NativeImageHandlerMetadataTest {
+
+    @Test
+    public void collectAndCompareMetadata() {
+        ChannelHandlerMetadataUtil.generateMetadata(
+                "src/main/resources/native-image/codec-http2-handlers/reflect-config.json",
+                "io.netty5.handler.codec.http2");
+    }
+
+}

--- a/codec/pom.xml
+++ b/codec/pom.xml
@@ -101,6 +101,7 @@
       <scope>test</scope>
     </dependency>
 
+    <!-- Automatic native-image reflection metadata generation for handlers dependencies -->
     <dependency>
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>

--- a/codec/pom.xml
+++ b/codec/pom.xml
@@ -100,6 +100,22 @@
       <artifactId>commons-compress</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty5-transport</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>
 

--- a/codec/src/main/resources/native-image/codec-handlers/reflect-config.json
+++ b/codec/src/main/resources/native-image/codec-handlers/reflect-config.json
@@ -1,0 +1,191 @@
+[
+  {
+    "name": "io.netty5.handler.codec.base64.Base64Decoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.base64.Base64Decoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.base64.Base64Encoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.base64.Base64Encoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.bytes.ByteArrayDecoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.bytes.ByteArrayDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.bytes.ByteArrayEncoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.bytes.ByteArrayEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.ByteToMessageCodec",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.ByteToMessageCodec"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.ByteToMessageCodec$1",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.ByteToMessageCodec$1"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.ByteToMessageCodec$Encoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.ByteToMessageCodec$Encoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.ByteToMessageDecoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.ByteToMessageDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.compression.CompressionHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.compression.CompressionHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.compression.DecompressionHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.compression.DecompressionHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.DatagramPacketDecoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.DatagramPacketDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.DatagramPacketEncoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.DatagramPacketEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.DelimiterBasedFrameDecoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.DelimiterBasedFrameDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.FixedLengthFrameDecoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.FixedLengthFrameDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.LengthFieldBasedFrameDecoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.LengthFieldBasedFrameDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.LengthFieldPrepender",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.LengthFieldPrepender"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.LineBasedFrameDecoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.LineBasedFrameDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.MessageAggregator",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.MessageAggregator"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.MessageToByteEncoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.MessageToByteEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.MessageToMessageCodec",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.MessageToMessageCodec"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.MessageToMessageCodec$1",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.MessageToMessageCodec$1"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.MessageToMessageCodec$2",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.MessageToMessageCodec$2"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.MessageToMessageDecoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.MessageToMessageDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.MessageToMessageEncoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.MessageToMessageEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.string.LineEncoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.string.LineEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.string.StringDecoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.string.StringDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.string.StringEncoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.string.StringEncoder"
+    },
+    "queryAllPublicMethods": true
+  }
+]

--- a/codec/src/test/java/io/netty5/handler/codec/NativeImageHandlerMetadataTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/NativeImageHandlerMetadataTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.handler.codec;
+
+import io.netty5.nativeimage.ChannelHandlerMetadataUtil;
+import org.junit.jupiter.api.Test;
+
+public class NativeImageHandlerMetadataTest {
+
+    @Test
+    public void collectAndCompareMetadata() {
+        ChannelHandlerMetadataUtil.generateMetadata(
+                "src/main/resources/native-image/codec-handlers/reflect-config.json",
+                "io.netty5.handler.codec");
+    }
+
+}

--- a/handler/pom.xml
+++ b/handler/pom.xml
@@ -107,6 +107,23 @@
       <classifier>linux-x86_64</classifier>
       <scope>test</scope>
     </dependency>
+
+    <!-- Automatic native-image reflection metadata generation for handlers dependencies -->
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty5-transport</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>
 

--- a/handler/src/main/resources/native-image/handler-handlers/reflect-config.json
+++ b/handler/src/main/resources/native-image/handler-handlers/reflect-config.json
@@ -1,0 +1,373 @@
+[
+  {
+    "name": "io.netty5.handler.address.DynamicAddressConnectHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.address.DynamicAddressConnectHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.address.ResolveAddressHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.address.ResolveAddressHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.base64.Base64Decoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.base64.Base64Decoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.base64.Base64Encoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.base64.Base64Encoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.bytes.ByteArrayDecoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.bytes.ByteArrayDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.bytes.ByteArrayEncoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.bytes.ByteArrayEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.ByteToMessageCodec",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.ByteToMessageCodec"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.ByteToMessageCodec$1",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.ByteToMessageCodec$1"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.ByteToMessageCodec$Encoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.ByteToMessageCodec$Encoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.ByteToMessageDecoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.ByteToMessageDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.compression.CompressionHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.compression.CompressionHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.compression.DecompressionHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.compression.DecompressionHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.DatagramPacketDecoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.DatagramPacketDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.DatagramPacketEncoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.DatagramPacketEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.DelimiterBasedFrameDecoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.DelimiterBasedFrameDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.FixedLengthFrameDecoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.FixedLengthFrameDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.LengthFieldBasedFrameDecoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.LengthFieldBasedFrameDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.LengthFieldPrepender",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.LengthFieldPrepender"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.LineBasedFrameDecoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.LineBasedFrameDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.MessageAggregator",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.MessageAggregator"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.MessageToByteEncoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.MessageToByteEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.MessageToMessageCodec",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.MessageToMessageCodec"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.MessageToMessageCodec$1",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.MessageToMessageCodec$1"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.MessageToMessageCodec$2",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.MessageToMessageCodec$2"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.MessageToMessageDecoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.MessageToMessageDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.MessageToMessageEncoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.MessageToMessageEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.string.LineEncoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.string.LineEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.string.StringDecoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.string.StringDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.codec.string.StringEncoder",
+    "condition": {
+      "typeReachable": "io.netty5.handler.codec.string.StringEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.flow.FlowControlHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.flow.FlowControlHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.flush.FlushConsolidationHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.flush.FlushConsolidationHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.ipfilter.AbstractRemoteAddressFilter",
+    "condition": {
+      "typeReachable": "io.netty5.handler.ipfilter.AbstractRemoteAddressFilter"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.ipfilter.IpSubnetFilter",
+    "condition": {
+      "typeReachable": "io.netty5.handler.ipfilter.IpSubnetFilter"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.ipfilter.RuleBasedIpFilter",
+    "condition": {
+      "typeReachable": "io.netty5.handler.ipfilter.RuleBasedIpFilter"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.ipfilter.UniqueIpFilter",
+    "condition": {
+      "typeReachable": "io.netty5.handler.ipfilter.UniqueIpFilter"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.logging.LoggingHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.logging.LoggingHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.ssl.AbstractSniHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.ssl.AbstractSniHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.ssl.ApplicationProtocolNegotiationHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.ssl.ApplicationProtocolNegotiationHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.ssl.ocsp.OcspClientHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.ssl.ocsp.OcspClientHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.ssl.OptionalSslHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.ssl.OptionalSslHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.ssl.SniHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.ssl.SniHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.ssl.SslClientHelloHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.ssl.SslClientHelloHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.ssl.SslHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.ssl.SslHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.ssl.SslMasterKeyHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.ssl.SslMasterKeyHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.ssl.SslMasterKeyHandler$WiresharkSslMasterKeyHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.ssl.SslMasterKeyHandler$WiresharkSslMasterKeyHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.stream.ChunkedWriteHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.stream.ChunkedWriteHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.timeout.IdleStateHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.timeout.IdleStateHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.timeout.ReadTimeoutHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.timeout.ReadTimeoutHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.timeout.WriteTimeoutHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.timeout.WriteTimeoutHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.traffic.AbstractTrafficShapingHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.traffic.AbstractTrafficShapingHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.traffic.ChannelTrafficShapingHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.traffic.ChannelTrafficShapingHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.traffic.GlobalChannelTrafficShapingHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.traffic.GlobalChannelTrafficShapingHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.handler.traffic.GlobalTrafficShapingHandler",
+    "condition": {
+      "typeReachable": "io.netty5.handler.traffic.GlobalTrafficShapingHandler"
+    },
+    "queryAllPublicMethods": true
+  }
+]

--- a/handler/src/test/java/io/netty5/handler/nativeimage/NativeImageHandlerMetadataTest.java
+++ b/handler/src/test/java/io/netty5/handler/nativeimage/NativeImageHandlerMetadataTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.handler.nativeimage;
+
+import io.netty5.nativeimage.ChannelHandlerMetadataUtil;
+import org.junit.jupiter.api.Test;
+
+public class NativeImageHandlerMetadataTest {
+
+    @Test
+    public void collectAndCompareMetadata() {
+        ChannelHandlerMetadataUtil.generateMetadata(
+                "src/main/resources/native-image/handler-handlers/reflect-config.json",
+                "io.netty5.handler");
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -821,6 +821,12 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>org.reflections</groupId>
+        <artifactId>reflections</artifactId>
+        <version>0.10.2</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
         <version>1.2.3</version>

--- a/resolver-dns/pom.xml
+++ b/resolver-dns/pom.xml
@@ -89,6 +89,23 @@
       <version>2.6</version>
       <scope>test</scope>
     </dependency>
+
+    <!-- Automatic native-image reflection metadata generation for handlers dependencies -->
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty5-transport</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>
 

--- a/resolver-dns/src/main/resources/native-image/resolver-dns-handlers/reflect-config.json
+++ b/resolver-dns/src/main/resources/native-image/resolver-dns-handlers/reflect-config.json
@@ -1,0 +1,30 @@
+[
+  {
+    "name": "io.netty5.resolver.dns.DnsNameResolver$1",
+    "condition": {
+      "typeReachable": "io.netty5.resolver.dns.DnsNameResolver$1"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.resolver.dns.DnsNameResolver$3",
+    "condition": {
+      "typeReachable": "io.netty5.resolver.dns.DnsNameResolver$3"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.resolver.dns.DnsNameResolver$DnsResponseHandler",
+    "condition": {
+      "typeReachable": "io.netty5.resolver.dns.DnsNameResolver$DnsResponseHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.resolver.dns.DnsNameResolver$DnsResponseHandler$1",
+    "condition": {
+      "typeReachable": "io.netty5.resolver.dns.DnsNameResolver$DnsResponseHandler$1"
+    },
+    "queryAllPublicMethods": true
+  }
+]

--- a/resolver-dns/src/test/java/io/netty5/resolver/dns/NativeImageHandlerMetadataTest.java
+++ b/resolver-dns/src/test/java/io/netty5/resolver/dns/NativeImageHandlerMetadataTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.resolver.dns;
+
+import io.netty5.nativeimage.ChannelHandlerMetadataUtil;
+import org.junit.jupiter.api.Test;
+
+public class NativeImageHandlerMetadataTest {
+
+    @Test
+    public void collectAndCompareMetadata() {
+        ChannelHandlerMetadataUtil.generateMetadata(
+                "src/main/resources/native-image/resolver-dns-handlers/reflect-config.json",
+                "io.netty5.resolver.dns");
+    }
+
+}

--- a/transport/pom.xml
+++ b/transport/pom.xml
@@ -52,6 +52,14 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
   </dependencies>
 </project>
 

--- a/transport/src/main/resources/native-image/transport-handlers/reflect-config.json
+++ b/transport/src/main/resources/native-image/transport-handlers/reflect-config.json
@@ -1,0 +1,79 @@
+[
+  {
+    "name": "io.netty5.bootstrap.ServerBootstrap$1",
+    "condition": {
+      "typeReachable": "io.netty5.bootstrap.ServerBootstrap$1"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.bootstrap.ServerBootstrap$ServerBootstrapAcceptor",
+    "condition": {
+      "typeReachable": "io.netty5.bootstrap.ServerBootstrap$ServerBootstrapAcceptor"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.channel.ChannelHandler",
+    "condition": {
+      "typeReachable": "io.netty5.channel.ChannelHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.channel.ChannelHandlerAdapter",
+    "condition": {
+      "typeReachable": "io.netty5.channel.ChannelHandlerAdapter"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.channel.ChannelInitializer",
+    "condition": {
+      "typeReachable": "io.netty5.channel.ChannelInitializer"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.channel.CombinedChannelDuplexHandler",
+    "condition": {
+      "typeReachable": "io.netty5.channel.CombinedChannelDuplexHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.channel.DefaultChannelPipeline$HeadHandler",
+    "condition": {
+      "typeReachable": "io.netty5.channel.DefaultChannelPipeline$HeadHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.channel.DefaultChannelPipeline$TailHandler",
+    "condition": {
+      "typeReachable": "io.netty5.channel.DefaultChannelPipeline$TailHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.channel.embedded.EmbeddedChannel$1",
+    "condition": {
+      "typeReachable": "io.netty5.channel.embedded.EmbeddedChannel$1"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.channel.SimpleChannelInboundHandler",
+    "condition": {
+      "typeReachable": "io.netty5.channel.SimpleChannelInboundHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty5.channel.SimpleUserEventChannelHandler",
+    "condition": {
+      "typeReachable": "io.netty5.channel.SimpleUserEventChannelHandler"
+    },
+    "queryAllPublicMethods": true
+  }
+]

--- a/transport/src/test/java/io/netty5/channel/NativeImageHandlerMetadataTest.java
+++ b/transport/src/test/java/io/netty5/channel/NativeImageHandlerMetadataTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel;
+
+import io.netty5.nativeimage.ChannelHandlerMetadataUtil;
+import org.junit.jupiter.api.Test;
+
+public class NativeImageHandlerMetadataTest {
+
+    @Test
+    public void collectAndCompareMetadata() {
+        ChannelHandlerMetadataUtil.generateMetadata(
+                "src/main/resources/native-image/transport-handlers/reflect-config.json",
+                "io.netty5.bootstrap", "io.netty5.channel");
+    }
+
+}

--- a/transport/src/test/java/io/netty5/nativeimage/ChannelHandlerMetadataUtil.java
+++ b/transport/src/test/java/io/netty5/nativeimage/ChannelHandlerMetadataUtil.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.nativeimage;
+
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.netty5.channel.ChannelHandler;
+import io.netty5.channel.NativeImageHandlerMetadataTest;
+import org.junit.jupiter.api.Assertions;
+import org.reflections.Reflections;
+import org.reflections.util.ConfigurationBuilder;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.text.Collator;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Generates native-image reflection metadata for subtypes of {@link io.netty5.channel.ChannelHandler}.
+ * <p>
+ * To use, create a JUnit test in the desired Netty module and invoke {@link #generateMetadata(String, String...)} with:
+ * 1. The relative path to the native-image handler reflection metadata file in the Netty module.
+ * This path is relative to the root of the target Netty module.
+ * 2. A list of packages present in the target Netty module that may contain subtypes of the ChannelHandler.
+ * <p>
+ * See {@link NativeImageHandlerMetadataTest}
+ */
+public final class ChannelHandlerMetadataUtil {
+
+    @SuppressWarnings("UnstableApiUsage")
+    private static final Type HANDLER_METADATA_LIST_TYPE = new TypeToken<List<HandlerMetadata>>() {
+    }.getType();
+    private static final Gson gson = new GsonBuilder().setPrettyPrinting().create();
+
+    private ChannelHandlerMetadataUtil() {
+    }
+
+    public static void generateMetadata(String projectRelativeResourcePath, String... packageNames) {
+        Set<Class<? extends ChannelHandler>> subtypes = findChannelHandlerSubclasses(packageNames);
+
+        if (Arrays.asList(packageNames).contains("io.netty5.channel")) {
+            // We want the metadata for the ChannelHandler itself too
+            subtypes.add(ChannelHandler.class);
+        }
+
+        Set<HandlerMetadata> handlerMetadata = subtypes.stream()
+                .map(type -> new HandlerMetadata(type.getName(), new Condition(type.getName()), true))
+                .collect(Collectors.toSet());
+
+        Path existingMetadataPath = new File(projectRelativeResourcePath).toPath().toAbsolutePath();
+        if (!Files.exists(existingMetadataPath)) {
+            if (handlerMetadata.size() == 0) {
+                return;
+            }
+
+            System.err.println("Native Image reflection metadata is required for handlers in this project. " +
+                    "This metadata was not found under " + existingMetadataPath);
+            System.err.println("Please create this file with the following content: ");
+            System.err.println(getMetadataJsonString(handlerMetadata));
+            Assertions.fail();
+        }
+
+        String existingMetadataJson = "";
+        try {
+            existingMetadataJson = Files.readString(existingMetadataPath);
+        } catch (IOException e) {
+            Assertions.fail("Failed to open the native-image metadata file at: " + existingMetadataPath, e);
+        }
+        List<HandlerMetadata> existingMetadata = gson.fromJson(existingMetadataJson, HANDLER_METADATA_LIST_TYPE);
+
+        Set<HandlerMetadata> newMetadata = new HashSet<>(handlerMetadata);
+        newMetadata.removeAll(existingMetadata);
+
+        Set<HandlerMetadata> removedMetadata = new HashSet<>(existingMetadata);
+        removedMetadata.removeAll(handlerMetadata);
+
+        if (!newMetadata.isEmpty() || !removedMetadata.isEmpty()) {
+            System.err.println("In the native-image handler metadata file at " + existingMetadataPath);
+
+            if (!newMetadata.isEmpty()) {
+                System.err.println("The following new metadata must be added:\n");
+                System.err.println(getMetadataJsonString(newMetadata));
+                System.err.println();
+            }
+            if (!removedMetadata.isEmpty()) {
+                System.err.println("The following metadata must be removed:\n");
+                System.err.println(getMetadataJsonString(removedMetadata));
+                System.err.println();
+            }
+
+            System.err.println("Expected metadata file contents:\n");
+            System.err.println(getMetadataJsonString(handlerMetadata));
+            Assertions.fail();
+        }
+    }
+
+    private static Set<Class<? extends ChannelHandler>> findChannelHandlerSubclasses(String... packageNames) {
+        Reflections reflections = new Reflections(
+                new ConfigurationBuilder()
+                        .forPackages(packageNames)
+                        .filterInputsBy(s -> !s.contains("Test")));
+
+        Set<Class<? extends ChannelHandler>> classes = reflections.getSubTypesOf(ChannelHandler.class);
+        classes = classes.stream()
+                .filter(ChannelHandlerMetadataUtil::isTestClass)
+                .filter(clazz -> Stream.of(packageNames).anyMatch(name -> clazz.getName().startsWith(name)))
+                .collect(Collectors.toSet());
+        return classes;
+    }
+
+    private static boolean isTestClass(Class<? extends ChannelHandler> clazz) {
+        String[] parts = clazz.getName().split("\\.");
+        if (parts.length > 0) {
+            URL classFile = clazz.getResource(parts[parts.length - 1] + ".class");
+            if (classFile != null) {
+                return !classFile.toString().contains(File.separator + "test-classes" + File.separator);
+            }
+        }
+        return true;
+    }
+
+    private static String getMetadataJsonString(Set<HandlerMetadata> metadata) {
+        List<HandlerMetadata> metadataList = new ArrayList<>(metadata);
+        metadataList.sort((h1, h2) -> Collator.getInstance().compare(h1.name, h2.name));
+        return gson.toJson(metadataList, HANDLER_METADATA_LIST_TYPE);
+    }
+
+    private static class Condition {
+        Condition(String typeReachable) {
+            this.typeReachable = typeReachable;
+        }
+
+        String typeReachable;
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            Condition condition = (Condition) o;
+            return Objects.equals(typeReachable, condition.typeReachable);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(typeReachable);
+        }
+    }
+
+    private static class HandlerMetadata {
+        String name;
+
+        Condition condition;
+
+        boolean queryAllPublicMethods;
+
+        HandlerMetadata(String name, Condition condition, boolean queryAllPublicMethods) {
+            this.name = name;
+            this.condition = condition;
+            this.queryAllPublicMethods = queryAllPublicMethods;
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            HandlerMetadata that = (HandlerMetadata) o;
+            return queryAllPublicMethods == that.queryAllPublicMethods
+                    && Objects.equals(name, that.name)
+                    && Objects.equals(condition, that.condition);
+        }
+
+        @Override
+        public int hashCode() {
+            return name.hashCode();
+        }
+    }
+}

--- a/transport/src/test/java/io/netty5/nativeimage/ChannelHandlerMetadataUtil.java
+++ b/transport/src/test/java/io/netty5/nativeimage/ChannelHandlerMetadataUtil.java
@@ -127,18 +127,18 @@ public final class ChannelHandlerMetadataUtil {
 
         Set<Class<? extends ChannelHandler>> classes = reflections.getSubTypesOf(ChannelHandler.class);
         classes = classes.stream()
-                .filter(ChannelHandlerMetadataUtil::isTestClass)
+                .filter(ChannelHandlerMetadataUtil::isNotTestClass)
                 .filter(clazz -> Stream.of(packageNames).anyMatch(name -> clazz.getName().startsWith(name)))
                 .collect(Collectors.toSet());
         return classes;
     }
 
-    private static boolean isTestClass(Class<? extends ChannelHandler> clazz) {
+    private static boolean isNotTestClass(Class<? extends ChannelHandler> clazz) {
         String[] parts = clazz.getName().split("\\.");
         if (parts.length > 0) {
             URL classFile = clazz.getResource(parts[parts.length - 1] + ".class");
             if (classFile != null) {
-                return !classFile.toString().contains(File.separator + "test-classes" + File.separator);
+                return !classFile.toString().contains("/test-classes/");
             }
         }
         return true;


### PR DESCRIPTION
Motivation:

Due to a specific reflection usage pattern in `io.netty5.channel.ChannelHandlerMask#mask0`, the agent cannot automatically infer the necessary conditional metadata. Therefor, we must manually add such metadata for subclasses of the `ChannelHandler`.

See also https://github.com/netty/netty/issues/12725#issuecomment-1225694049

Modification:

This PR adds the necessary metadata for handlers used in the Netty 5 testsuite.

Result:

Should fix [#12725](https://github.com/netty/netty/issues/12725)

Note that for user-defined `ChannelHandler` implementations, users will still need to supply necessary metadata, either manually or by using the tracing agent