### PR TITLE
Rename Statics to InternalBufferUtils

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/BufferUtil.java
+++ b/buffer/src/main/java/io/netty5/buffer/BufferUtil.java
@@ -18,7 +18,7 @@ package io.netty5.buffer;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.buffer.api.DefaultBufferAllocators;
-import io.netty5.buffer.api.internal.Statics;
+import io.netty5.buffer.api.internal.InternalBufferUtils;
 import io.netty5.util.concurrent.FastThreadLocal;
 import io.netty5.util.internal.PlatformDependent;
 import io.netty5.util.internal.StringUtil;
@@ -165,7 +165,7 @@ public final class BufferUtil {
      */
     public static boolean equals(Buffer first, int firstReaderOffset, Buffer second, int secondReaderOffset,
                                  int length) {
-        return Statics.equals(first, firstReaderOffset, second, secondReaderOffset, length);
+        return InternalBufferUtils.equals(first, firstReaderOffset, second, secondReaderOffset, length);
     }
 
     /**

--- a/buffer/src/main/java/io/netty5/buffer/api/Buffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/Buffer.java
@@ -16,7 +16,7 @@
 package io.netty5.buffer.api;
 
 import io.netty5.buffer.api.ComponentIterator.Next;
-import io.netty5.buffer.api.internal.Statics;
+import io.netty5.buffer.api.internal.InternalBufferUtils;
 import io.netty5.util.Resource;
 
 import java.io.IOException;
@@ -403,7 +403,7 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
      * @return This buffer.
      */
     default Buffer writeCharSequence(CharSequence source, Charset charset) {
-        Statics.writeCharSequence(source, this, charset);
+        InternalBufferUtils.writeCharSequence(source, this, charset);
         return this;
     }
 
@@ -418,7 +418,7 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
      * this buffer.
      */
     default CharSequence readCharSequence(int length, Charset charset) {
-        return Statics.readCharSequence(this, length, charset);
+        return InternalBufferUtils.readCharSequence(this, length, charset);
     }
 
     /**
@@ -1117,6 +1117,6 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
      * @return Buffer's readable bytes as a string.
      */
     default String toString(Charset charset) {
-        return Statics.toString(this, charset);
+        return InternalBufferUtils.toString(this, charset);
     }
 }

--- a/buffer/src/main/java/io/netty5/buffer/api/BufferAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/BufferAllocator.java
@@ -15,7 +15,7 @@
  */
 package io.netty5.buffer.api;
 
-import io.netty5.buffer.api.internal.Statics;
+import io.netty5.buffer.api.internal.InternalBufferUtils;
 import io.netty5.buffer.api.pool.PooledBufferAllocator;
 import io.netty5.util.SafeCloseable;
 import io.netty5.util.Send;
@@ -262,7 +262,7 @@ public interface BufferAllocator extends SafeCloseable {
             for (var c = iteration.firstWritable(); c != null; c = c.nextWritable()) {
                 ByteBuffer dest = c.writableBuffer();
                 int length = Math.min(dest.capacity(), duplicate.remaining());
-                Statics.bbput(dest, 0, duplicate, duplicate.position(), length);
+                InternalBufferUtils.bbput(dest, 0, duplicate, duplicate.position(), length);
                 duplicate.position(length + duplicate.position());
             }
         }

--- a/buffer/src/main/java/io/netty5/buffer/api/BufferHolder.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/BufferHolder.java
@@ -16,7 +16,7 @@
 package io.netty5.buffer.api;
 
 import io.netty5.buffer.api.internal.ResourceSupport;
-import io.netty5.buffer.api.internal.Statics;
+import io.netty5.buffer.api.internal.InternalBufferUtils;
 import io.netty5.util.Resource;
 import io.netty5.util.Send;
 
@@ -42,7 +42,8 @@ import static java.lang.invoke.MethodHandles.lookup;
  * @param <T> The concrete {@link BufferHolder} type.
  */
 public abstract class BufferHolder<T extends Resource<T>> implements Resource<T> {
-    private static final VarHandle BUF = Statics.findVarHandle(lookup(), BufferHolder.class, "buf", Buffer.class);
+    private static final VarHandle BUF = InternalBufferUtils.findVarHandle(
+            lookup(), BufferHolder.class, "buf", Buffer.class);
     private Buffer buf;
 
     /**

--- a/buffer/src/main/java/io/netty5/buffer/api/DefaultCompositeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/DefaultCompositeBuffer.java
@@ -16,8 +16,8 @@
 package io.netty5.buffer.api;
 
 import io.netty5.buffer.api.ComponentIterator.Next;
+import io.netty5.buffer.api.internal.InternalBufferUtils;
 import io.netty5.buffer.api.internal.ResourceSupport;
-import io.netty5.buffer.api.internal.Statics;
 import io.netty5.util.SafeCloseable;
 import io.netty5.util.Send;
 
@@ -39,11 +39,11 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 
-import static io.netty5.buffer.api.internal.Statics.MAX_BUFFER_SIZE;
-import static io.netty5.buffer.api.internal.Statics.bufferIsClosed;
-import static io.netty5.buffer.api.internal.Statics.bufferIsReadOnly;
-import static io.netty5.buffer.api.internal.Statics.checkImplicitCapacity;
-import static io.netty5.buffer.api.internal.Statics.checkLength;
+import static io.netty5.buffer.api.internal.InternalBufferUtils.MAX_BUFFER_SIZE;
+import static io.netty5.buffer.api.internal.InternalBufferUtils.bufferIsClosed;
+import static io.netty5.buffer.api.internal.InternalBufferUtils.bufferIsReadOnly;
+import static io.netty5.buffer.api.internal.InternalBufferUtils.checkImplicitCapacity;
+import static io.netty5.buffer.api.internal.InternalBufferUtils.checkLength;
 import static io.netty5.util.internal.ObjectUtil.checkPositiveOrZero;
 import static io.netty5.util.internal.PlatformDependent.roundToPowerOfTwo;
 import static java.lang.Math.addExact;
@@ -763,7 +763,7 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
 
     @Override
     public int bytesBefore(Buffer needle) {
-        return Statics.bytesBefore(this, null, needle, null);
+        return InternalBufferUtils.bytesBefore(this, null, needle, null);
     }
 
     @Override
@@ -873,7 +873,7 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
         }
 
         int growth = Math.max(size - writableBytes(), minimumGrowth);
-        Statics.assertValidBufferSize(capacity() + (long) growth);
+        InternalBufferUtils.assertValidBufferSize(capacity() + (long) growth);
         Buffer extension = allocator.allocate(growth);
         unsafeExtendWith(extension);
         return this;
@@ -908,7 +908,7 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
         }
 
         long newSize = capacity() + extensionCapacity;
-        Statics.assertValidBufferSize(newSize);
+        InternalBufferUtils.assertValidBufferSize(newSize);
 
         Buffer[] restoreTemp = bufs; // We need this to restore our buffer array, in case offset computations fail.
         try {
@@ -1419,7 +1419,7 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
     private boolean allConstituentsAreOwned() {
         boolean result = true;
         for (Buffer buf : bufs) {
-            result &= Statics.isOwned((ResourceSupport<?, ?>) buf);
+            result &= InternalBufferUtils.isOwned((ResourceSupport<?, ?>) buf);
         }
         return result;
     }
@@ -1545,12 +1545,12 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
 
     @Override
     public boolean equals(Object o) {
-        return o instanceof Buffer && Statics.equals(this, (Buffer) o);
+        return o instanceof Buffer && InternalBufferUtils.equals(this, (Buffer) o);
     }
 
     @Override
     public int hashCode() {
-        return Statics.hashCode(this);
+        return InternalBufferUtils.hashCode(this);
     }
 
     // <editor-fold defaultstate="collapsed" desc="Torn buffer access.">

--- a/buffer/src/main/java/io/netty5/buffer/api/ManagedBufferAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/ManagedBufferAllocator.java
@@ -15,14 +15,14 @@
  */
 package io.netty5.buffer.api;
 
-import io.netty5.buffer.api.internal.Statics;
+import io.netty5.buffer.api.internal.InternalBufferUtils;
 import io.netty5.buffer.api.internal.WrappingAllocation;
 
 import java.nio.charset.Charset;
 import java.util.function.Supplier;
 
-import static io.netty5.buffer.api.internal.Statics.allocatorClosedException;
-import static io.netty5.buffer.api.internal.Statics.standardDrop;
+import static io.netty5.buffer.api.internal.InternalBufferUtils.allocatorClosedException;
+import static io.netty5.buffer.api.internal.InternalBufferUtils.standardDrop;
 
 class ManagedBufferAllocator implements BufferAllocator, AllocatorControl {
     private final MemoryManager manager;
@@ -49,7 +49,7 @@ class ManagedBufferAllocator implements BufferAllocator, AllocatorControl {
         if (closed) {
             throw allocatorClosedException();
         }
-        Statics.assertValidBufferSize(size);
+        InternalBufferUtils.assertValidBufferSize(size);
         return manager.allocateShared(this, size, standardDrop(manager), allocationType);
     }
 

--- a/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/ByteBufferMemoryManager.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/ByteBufferMemoryManager.java
@@ -21,14 +21,14 @@ import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.Drop;
 import io.netty5.buffer.api.MemoryManager;
 import io.netty5.buffer.api.StandardAllocationTypes;
-import io.netty5.buffer.api.internal.Statics;
+import io.netty5.buffer.api.internal.InternalBufferUtils;
 import io.netty5.buffer.api.internal.WrappingAllocation;
 
 import java.nio.ByteBuffer;
 import java.util.function.Function;
 
-import static io.netty5.buffer.api.internal.Statics.bbslice;
-import static io.netty5.buffer.api.internal.Statics.convert;
+import static io.netty5.buffer.api.internal.InternalBufferUtils.bbslice;
+import static io.netty5.buffer.api.internal.InternalBufferUtils.convert;
 
 /**
  * This memory manager produces and manages {@link Buffer} instances that are backed by NIO {@link ByteBuffer}
@@ -64,7 +64,7 @@ public final class ByteBufferMemoryManager implements MemoryManager {
     }
 
     private static Drop<Buffer> drop() {
-        return Statics.NO_OP_DROP;
+        return InternalBufferUtils.NO_OP_DROP;
     }
 
     @Override
@@ -94,7 +94,7 @@ public final class ByteBufferMemoryManager implements MemoryManager {
     @Override
     public void clearMemory(Object memory) {
         ByteBuffer buffer = (ByteBuffer) memory;
-        Statics.setMemory(buffer, buffer.capacity(), (byte) 0);
+        InternalBufferUtils.setMemory(buffer, buffer.capacity(), (byte) 0);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
@@ -26,12 +26,11 @@ import io.netty5.buffer.api.ComponentIterator;
 import io.netty5.buffer.api.Drop;
 import io.netty5.buffer.api.Owned;
 import io.netty5.buffer.api.internal.AdaptableBuffer;
+import io.netty5.buffer.api.internal.InternalBufferUtils;
 import io.netty5.buffer.api.internal.NotReadOnlyReadableComponent;
-import io.netty5.buffer.api.internal.Statics;
-import io.netty5.buffer.api.internal.Statics.UncheckedLoadByte;
+import io.netty5.buffer.api.internal.InternalBufferUtils.UncheckedLoadByte;
 
 import java.io.IOException;
-import java.lang.ref.Reference;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
@@ -39,14 +38,14 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 
-import static io.netty5.buffer.api.internal.Statics.MAX_BUFFER_SIZE;
-import static io.netty5.buffer.api.internal.Statics.bbput;
-import static io.netty5.buffer.api.internal.Statics.bbslice;
-import static io.netty5.buffer.api.internal.Statics.bufferIsReadOnly;
-import static io.netty5.buffer.api.internal.Statics.checkImplicitCapacity;
-import static io.netty5.buffer.api.internal.Statics.checkLength;
-import static io.netty5.buffer.api.internal.Statics.nativeAddressWithOffset;
-import static io.netty5.buffer.api.internal.Statics.setMemory;
+import static io.netty5.buffer.api.internal.InternalBufferUtils.MAX_BUFFER_SIZE;
+import static io.netty5.buffer.api.internal.InternalBufferUtils.bbput;
+import static io.netty5.buffer.api.internal.InternalBufferUtils.bbslice;
+import static io.netty5.buffer.api.internal.InternalBufferUtils.bufferIsReadOnly;
+import static io.netty5.buffer.api.internal.InternalBufferUtils.checkImplicitCapacity;
+import static io.netty5.buffer.api.internal.InternalBufferUtils.checkLength;
+import static io.netty5.buffer.api.internal.InternalBufferUtils.nativeAddressWithOffset;
+import static io.netty5.buffer.api.internal.InternalBufferUtils.setMemory;
 import static io.netty5.util.internal.ObjectUtil.checkPositiveOrZero;
 import static io.netty5.util.internal.PlatformDependent.roundToPowerOfTwo;
 
@@ -90,7 +89,7 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
 
     @Override
     protected RuntimeException createResourceClosedException() {
-        return Statics.bufferIsClosed(this);
+        return InternalBufferUtils.bufferIsClosed(this);
     }
 
     @Override
@@ -158,7 +157,7 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
     }
 
     private long nativeAddress() {
-        return Statics.nativeAddressOfDirectByteBuffer(rmem);
+        return InternalBufferUtils.nativeAddressOfDirectByteBuffer(rmem);
     }
 
     @Override
@@ -269,7 +268,7 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
             return;
         }
 
-        Statics.copyToViaReverseLoop(this, srcPos, dest, destPos, length);
+        InternalBufferUtils.copyToViaReverseLoop(this, srcPos, dest, destPos, length);
     }
 
     @Override
@@ -370,8 +369,8 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
     @Override
     public int bytesBefore(Buffer needle) {
         UncheckedLoadByte uncheckedLoadByte = NioBuffer::uncheckedLoadByte;
-        return Statics.bytesBefore(this, uncheckedLoadByte,
-                                   needle, needle instanceof NioBuffer ? uncheckedLoadByte : null);
+        return InternalBufferUtils.bytesBefore(this, uncheckedLoadByte,
+                                               needle, needle instanceof NioBuffer ? uncheckedLoadByte : null);
     }
 
     /**
@@ -451,7 +450,7 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
 
         // Allocate a bigger buffer.
         long newSize = capacity() + (long) Math.max(size - writableBytes(), minimumGrowth);
-        Statics.assertValidBufferSize(newSize);
+        InternalBufferUtils.assertValidBufferSize(newSize);
         NioBuffer buffer = (NioBuffer) control.getAllocator().allocate((int) newSize);
 
         // Copy contents.
@@ -1197,7 +1196,7 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
     }
 
     private BufferClosedException bufferIsClosed() {
-        return attachTrace(Statics.bufferIsClosed(this));
+        return attachTrace(InternalBufferUtils.bufferIsClosed(this));
     }
 
     private IndexOutOfBoundsException outOfBounds(int index, int size) {

--- a/buffer/src/main/java/io/netty5/buffer/api/internal/AdaptableBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/internal/AdaptableBuffer.java
@@ -37,11 +37,11 @@ public abstract class AdaptableBuffer<T extends ResourceSupport<Buffer, T>>
 
     @Override
     public boolean equals(Object o) {
-        return o instanceof Buffer && Statics.equals(this, (Buffer) o);
+        return o instanceof Buffer && InternalBufferUtils.equals(this, (Buffer) o);
     }
 
     @Override
     public int hashCode() {
-        return Statics.hashCode(this);
+        return InternalBufferUtils.hashCode(this);
     }
 }

--- a/buffer/src/main/java/io/netty5/buffer/api/internal/CleanerDrop.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/internal/CleanerDrop.java
@@ -43,7 +43,7 @@ public final class CleanerDrop<T extends Buffer> implements Drop<T> {
     private static <T extends Buffer> CleanerDrop<T> innerWrap(Drop<T> drop, MemoryManager manager) {
         CleanerDrop<T> cleanerDrop = new CleanerDrop<>();
         GatedRunner<T> runner = new GatedRunner<>(drop, manager);
-        cleanerDrop.cleanable = Statics.CLEANER.register(cleanerDrop, runner);
+        cleanerDrop.cleanable = InternalBufferUtils.CLEANER.register(cleanerDrop, runner);
         cleanerDrop.runner = runner;
         return cleanerDrop;
     }

--- a/buffer/src/main/java/io/netty5/buffer/api/internal/InternalBufferUtils.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/internal/InternalBufferUtils.java
@@ -40,7 +40,7 @@ import static io.netty5.util.CharsetUtil.US_ASCII;
 import static io.netty5.util.internal.ObjectUtil.checkPositiveOrZero;
 import static java.util.Objects.requireNonNull;
 
-public interface Statics {
+public interface InternalBufferUtils {
     LongAdder MEM_USAGE_NATIVE = new LongAdder();
     Cleaner CLEANER = Cleaner.create();
     Drop<Buffer> NO_OP_DROP = new Drop<>() {

--- a/buffer/src/main/java/io/netty5/buffer/api/internal/SendFromOwned.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/internal/SendFromOwned.java
@@ -22,7 +22,7 @@ import io.netty5.util.Send;
 
 import java.lang.invoke.VarHandle;
 
-import static io.netty5.buffer.api.internal.Statics.findVarHandle;
+import static io.netty5.buffer.api.internal.InternalBufferUtils.findVarHandle;
 import static java.lang.invoke.MethodHandles.lookup;
 
 public class SendFromOwned<I extends Resource<I>, T extends ResourceSupport<I, T>> implements Send<I> {

--- a/buffer/src/main/java/io/netty5/buffer/api/pool/PooledBufferAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/pool/PooledBufferAllocator.java
@@ -23,7 +23,7 @@ import io.netty5.buffer.api.Drop;
 import io.netty5.buffer.api.MemoryManager;
 import io.netty5.buffer.api.StandardAllocationTypes;
 import io.netty5.buffer.api.internal.ArcDrop;
-import io.netty5.buffer.api.internal.Statics;
+import io.netty5.buffer.api.internal.InternalBufferUtils;
 import io.netty5.util.NettyRuntime;
 import io.netty5.util.concurrent.EventExecutor;
 import io.netty5.util.concurrent.FastThreadLocal;
@@ -41,7 +41,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
-import static io.netty5.buffer.api.internal.Statics.allocatorClosedException;
+import static io.netty5.buffer.api.internal.InternalBufferUtils.allocatorClosedException;
 import static io.netty5.util.internal.ObjectUtil.checkPositiveOrZero;
 import static java.util.Objects.requireNonNull;
 
@@ -315,7 +315,7 @@ public class PooledBufferAllocator implements BufferAllocator, BufferAllocatorMe
         if (closed) {
             throw allocatorClosedException();
         }
-        Statics.assertValidBufferSize(size);
+        InternalBufferUtils.assertValidBufferSize(size);
         UntetheredMemory memory = allocateUntethered(size);
         Drop<Buffer> drop = memory.drop();
         Buffer buffer = manager.recoverMemory(pooledAllocatorControl, memory.memory(), drop);

--- a/buffer/src/main/java/io/netty5/buffer/api/pool/UnpooledUntetheredMemory.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/pool/UnpooledUntetheredMemory.java
@@ -21,7 +21,7 @@ import io.netty5.buffer.api.Drop;
 import io.netty5.buffer.api.MemoryManager;
 import io.netty5.buffer.api.internal.DropCaptor;
 
-import static io.netty5.buffer.api.internal.Statics.standardDrop;
+import static io.netty5.buffer.api.internal.InternalBufferUtils.standardDrop;
 
 @SuppressWarnings("unchecked")
 class UnpooledUntetheredMemory implements UntetheredMemory {

--- a/buffer/src/main/java/io/netty5/buffer/api/unsafe/FreeAddress.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/unsafe/FreeAddress.java
@@ -17,7 +17,7 @@ package io.netty5.buffer.api.unsafe;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.Drop;
-import io.netty5.buffer.api.internal.Statics;
+import io.netty5.buffer.api.internal.InternalBufferUtils;
 import io.netty5.util.internal.PlatformDependent;
 
 class FreeAddress implements Runnable, Drop<Buffer> {
@@ -32,7 +32,7 @@ class FreeAddress implements Runnable, Drop<Buffer> {
     @Override
     public void run() {
         PlatformDependent.freeMemory(address);
-        Statics.MEM_USAGE_NATIVE.add(-size);
+        InternalBufferUtils.MEM_USAGE_NATIVE.add(-size);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
@@ -26,9 +26,9 @@ import io.netty5.buffer.api.ComponentIterator;
 import io.netty5.buffer.api.Drop;
 import io.netty5.buffer.api.Owned;
 import io.netty5.buffer.api.internal.AdaptableBuffer;
+import io.netty5.buffer.api.internal.InternalBufferUtils;
 import io.netty5.buffer.api.internal.NotReadOnlyReadableComponent;
-import io.netty5.buffer.api.internal.Statics;
-import io.netty5.buffer.api.internal.Statics.UncheckedLoadByte;
+import io.netty5.buffer.api.internal.InternalBufferUtils.UncheckedLoadByte;
 import io.netty5.util.internal.PlatformDependent;
 import io.netty5.util.internal.UnsafeAccess;
 import sun.misc.Unsafe;
@@ -42,12 +42,12 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 
-import static io.netty5.buffer.api.internal.Statics.MAX_BUFFER_SIZE;
-import static io.netty5.buffer.api.internal.Statics.bbslice;
-import static io.netty5.buffer.api.internal.Statics.bufferIsReadOnly;
-import static io.netty5.buffer.api.internal.Statics.checkImplicitCapacity;
-import static io.netty5.buffer.api.internal.Statics.checkLength;
-import static io.netty5.buffer.api.internal.Statics.nativeAddressWithOffset;
+import static io.netty5.buffer.api.internal.InternalBufferUtils.MAX_BUFFER_SIZE;
+import static io.netty5.buffer.api.internal.InternalBufferUtils.bbslice;
+import static io.netty5.buffer.api.internal.InternalBufferUtils.bufferIsReadOnly;
+import static io.netty5.buffer.api.internal.InternalBufferUtils.checkImplicitCapacity;
+import static io.netty5.buffer.api.internal.InternalBufferUtils.checkLength;
+import static io.netty5.buffer.api.internal.InternalBufferUtils.nativeAddressWithOffset;
 import static io.netty5.util.internal.ObjectUtil.checkPositiveOrZero;
 import static io.netty5.util.internal.PlatformDependent.roundToPowerOfTwo;
 
@@ -106,7 +106,7 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
 
     @Override
     protected RuntimeException createResourceClosedException() {
-        return Statics.bufferIsClosed(this);
+        return InternalBufferUtils.bufferIsClosed(this);
     }
 
     @Override
@@ -293,7 +293,7 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
     @Override
     public void copyInto(int srcPos, Buffer dest, int destPos, int length) {
         if (!dest.isAccessible()) {
-            throw Statics.bufferIsClosed(dest);
+            throw InternalBufferUtils.bufferIsClosed(dest);
         }
         checkCopyIntoArgs(srcPos, length, destPos, dest.capacity());
         if (dest.readOnly()) {
@@ -310,7 +310,7 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
                             base, address + srcPos, destUnsafe.base, destUnsafe.address + destPos, length);
                 }
             } else {
-                Statics.copyToViaReverseLoop(this, srcPos, dest, destPos, length);
+                InternalBufferUtils.copyToViaReverseLoop(this, srcPos, dest, destPos, length);
             }
         } finally {
             Reference.reachabilityFence(memory);
@@ -432,8 +432,8 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
     public int bytesBefore(Buffer needle) {
         try {
             UncheckedLoadByte uncheckedLoadByte = UnsafeBuffer::uncheckedLoadByte;
-            return Statics.bytesBefore(this, uncheckedLoadByte,
-                                       needle, needle instanceof UnsafeBuffer ? uncheckedLoadByte : null);
+            return InternalBufferUtils.bytesBefore(this, uncheckedLoadByte,
+                                                   needle, needle instanceof UnsafeBuffer ? uncheckedLoadByte : null);
         } finally {
             Reference.reachabilityFence(memory);
         }
@@ -517,7 +517,7 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
 
         // Allocate a bigger buffer.
         long newSize = capacity() + (long) Math.max(size - writableBytes(), minimumGrowth);
-        Statics.assertValidBufferSize(newSize);
+        InternalBufferUtils.assertValidBufferSize(newSize);
         UnsafeBuffer buffer = (UnsafeBuffer) control.getAllocator().allocate((int) newSize);
 
         // Copy contents.
@@ -1347,7 +1347,7 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
     }
 
     private BufferClosedException bufferIsClosed() {
-        return attachTrace(Statics.bufferIsClosed(this));
+        return attachTrace(InternalBufferUtils.bufferIsClosed(this));
     }
 
     private IndexOutOfBoundsException outOfBounds(int index, int size) {

--- a/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeMemoryManager.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeMemoryManager.java
@@ -22,7 +22,7 @@ import io.netty5.buffer.api.Drop;
 import io.netty5.buffer.api.MemoryManager;
 import io.netty5.buffer.api.StandardAllocationTypes;
 import io.netty5.buffer.api.internal.ArcDrop;
-import io.netty5.buffer.api.internal.Statics;
+import io.netty5.buffer.api.internal.InternalBufferUtils;
 import io.netty5.buffer.api.internal.WrappingAllocation;
 import io.netty5.util.internal.PlatformDependent;
 import io.netty5.util.internal.SystemPropertyUtil;
@@ -30,7 +30,7 @@ import io.netty5.util.internal.SystemPropertyUtil;
 import java.lang.ref.Cleaner;
 import java.util.function.Function;
 
-import static io.netty5.buffer.api.internal.Statics.convert;
+import static io.netty5.buffer.api.internal.InternalBufferUtils.convert;
 
 /**
  * This memory manager produces and manages {@link Buffer} instances that are using {@code Unsafe} to allocate and
@@ -63,12 +63,12 @@ public final class UnsafeMemoryManager implements MemoryManager {
         final long address;
         final UnsafeMemory memory;
         final int size32 = Math.toIntExact(size);
-        Cleaner cleaner = Statics.CLEANER;
-        Drop<Buffer> drop = Statics.NO_OP_DROP;
+        Cleaner cleaner = InternalBufferUtils.CLEANER;
+        Drop<Buffer> drop = InternalBufferUtils.NO_OP_DROP;
         if (allocationType == StandardAllocationTypes.OFF_HEAP) {
             base = null;
             address = PlatformDependent.allocateMemory(size);
-            Statics.MEM_USAGE_NATIVE.add(size);
+            InternalBufferUtils.MEM_USAGE_NATIVE.add(size);
             memory = new UnsafeMemory(base, address, size32);
             FreeAddress freeAddress = new FreeAddress(address, size32);
             if (FREE_IMMEDIATELY) {

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferBulkAccessTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferBulkAccessTest.java
@@ -17,8 +17,8 @@ package io.netty5.buffer.api.tests;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
+import io.netty5.buffer.api.internal.InternalBufferUtils;
 import io.netty5.buffer.api.internal.ResourceSupport;
-import io.netty5.buffer.api.internal.Statics;
 import io.netty5.util.Resource;
 import io.netty5.util.internal.PlatformDependent;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -485,7 +485,7 @@ public class BufferBulkAccessTest extends BufferTestSupport {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buffer = allocator.allocate(8)) {
             ByteBuffer source = ByteBuffer.wrap(new byte[] {0, 1, 2, 3, 4, 5, 6, 7});
-            try (Resource<?> ignore = Statics.acquire((ResourceSupport<?, ?>) buffer)) {
+            try (Resource<?> ignore = InternalBufferUtils.acquire((ResourceSupport<?, ?>) buffer)) {
                 buffer.writeBytes(source);
             }
             assertThat(buffer.capacity()).isEqualTo(source.capacity());
@@ -499,7 +499,7 @@ public class BufferBulkAccessTest extends BufferTestSupport {
              Buffer buffer = allocator.allocate(8)) {
             ByteBuffer source = ByteBuffer.wrap(new byte[] {0, 1, 2, 3, 4, 5, 6});
             buffer.writeByte((byte) -1).readByte();
-            try (Resource<?> ignore = Statics.acquire((ResourceSupport<?, ?>) buffer)) {
+            try (Resource<?> ignore = InternalBufferUtils.acquire((ResourceSupport<?, ?>) buffer)) {
                 buffer.writeBytes(source);
             }
             assertThat(buffer.capacity()).isEqualTo(8);
@@ -575,7 +575,7 @@ public class BufferBulkAccessTest extends BufferTestSupport {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buffer = allocator.allocate(8)) {
             ByteBuffer source = ByteBuffer.allocateDirect(8).put(new byte[] {0, 1, 2, 3, 4, 5, 6, 7}).flip();
-            try (Resource<?> ignore = Statics.acquire((ResourceSupport<?, ?>) buffer)) {
+            try (Resource<?> ignore = InternalBufferUtils.acquire((ResourceSupport<?, ?>) buffer)) {
                 buffer.writeBytes(source);
             }
             assertThat(buffer.capacity()).isEqualTo(8);
@@ -589,7 +589,7 @@ public class BufferBulkAccessTest extends BufferTestSupport {
              Buffer buffer = allocator.allocate(8)) {
             ByteBuffer source = ByteBuffer.allocateDirect(7).put(new byte[] {0, 1, 2, 3, 4, 5, 6}).flip();
             buffer.writeByte((byte) -1).readByte();
-            try (Resource<?> ignore = Statics.acquire((ResourceSupport<?, ?>) buffer)) {
+            try (Resource<?> ignore = InternalBufferUtils.acquire((ResourceSupport<?, ?>) buffer)) {
                 buffer.writeBytes(source);
             }
             assertThat(buffer.capacity()).isEqualTo(8);
@@ -659,7 +659,7 @@ public class BufferBulkAccessTest extends BufferTestSupport {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buffer = allocator.allocate(8)) {
             byte[] expected = {0, 1, 2, 3, 4, 5, 6, 7};
-            try (Resource<?> ignore = Statics.acquire((ResourceSupport<?, ?>) buffer)) {
+            try (Resource<?> ignore = InternalBufferUtils.acquire((ResourceSupport<?, ?>) buffer)) {
                 buffer.writeBytes(expected);
             }
             assertThat(buffer.capacity()).isEqualTo(8);
@@ -672,7 +672,7 @@ public class BufferBulkAccessTest extends BufferTestSupport {
              Buffer buffer = allocator.allocate(8)) {
             buffer.writeByte((byte) -1).readByte();
             byte[] expected = {0, 1, 2, 3, 4, 5, 6};
-            try (Resource<?> ignore = Statics.acquire((ResourceSupport<?, ?>) buffer)) {
+            try (Resource<?> ignore = InternalBufferUtils.acquire((ResourceSupport<?, ?>) buffer)) {
                 buffer.writeBytes(expected);
             }
             assertThat(buffer.capacity()).isEqualTo(8);
@@ -741,7 +741,7 @@ public class BufferBulkAccessTest extends BufferTestSupport {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buffer = allocator.allocate(8)) {
             byte[] expected = {0, 1, 2, 3, 4, 5, 6, 7};
-            try (Resource<?> ignore = Statics.acquire((ResourceSupport<?, ?>) buffer)) {
+            try (Resource<?> ignore = InternalBufferUtils.acquire((ResourceSupport<?, ?>) buffer)) {
                 buffer.writeBytes(expected, 1, expected.length - 1);
             }
             assertThat(buffer.capacity()).isEqualTo(8);
@@ -754,7 +754,7 @@ public class BufferBulkAccessTest extends BufferTestSupport {
              Buffer buffer = allocator.allocate(8)) {
             buffer.writeByte((byte) -1).readByte();
             byte[] expected = {0, 1, 2, 3, 4, 5, 6};
-            try (Resource<?> ignore = Statics.acquire((ResourceSupport<?, ?>) buffer)) {
+            try (Resource<?> ignore = InternalBufferUtils.acquire((ResourceSupport<?, ?>) buffer)) {
                 buffer.writeBytes(expected, 1, expected.length - 1);
             }
             assertThat(buffer.capacity()).isEqualTo(8);
@@ -827,7 +827,7 @@ public class BufferBulkAccessTest extends BufferTestSupport {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buffer = allocator.allocate(8)) {
             byte[] expectedByteArray = {0, 1, 2, 3, 4, 5, 6, 7};
-            try (Resource<?> ignore = Statics.acquire((ResourceSupport<?, ?>) buffer);
+            try (Resource<?> ignore = InternalBufferUtils.acquire((ResourceSupport<?, ?>) buffer);
                  Buffer expected = allocator.copyOf(expectedByteArray)) {
                 buffer.writeBytes(expected);
             }
@@ -841,7 +841,7 @@ public class BufferBulkAccessTest extends BufferTestSupport {
              Buffer buffer = allocator.allocate(8)) {
             buffer.writeByte((byte) -1).readByte();
             byte[] expectedByteArray = {0, 1, 2, 3, 4, 5, 6};
-            try (Resource<?> ignore = Statics.acquire((ResourceSupport<?, ?>) buffer);
+            try (Resource<?> ignore = InternalBufferUtils.acquire((ResourceSupport<?, ?>) buffer);
                  Buffer expected = allocator.copyOf(expectedByteArray)) {
                 buffer.writeBytes(expected);
             }

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferCleanerTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferCleanerTest.java
@@ -16,7 +16,7 @@
 package io.netty5.buffer.api.tests;
 
 import io.netty5.buffer.api.MemoryManager;
-import io.netty5.buffer.api.internal.Statics;
+import io.netty5.buffer.api.internal.InternalBufferUtils;
 import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -31,7 +31,7 @@ import static io.netty5.buffer.api.MemoryManager.using;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-@Isolated // Cannot run in parallel with any other tests because we access Statics.MEM_USAGE_NATIVE.
+@Isolated // Cannot run in parallel with any other tests because we access InternalBufferUtils.MEM_USAGE_NATIVE.
 public class BufferCleanerTest extends BufferTestSupport {
     @SuppressWarnings("unused")
     private static volatile int sink;
@@ -51,14 +51,14 @@ public class BufferCleanerTest extends BufferTestSupport {
     @ParameterizedTest
     @MethodSource("unsafeAllocators")
     public void bufferMustBeClosedByCleaner(Fixture fixture) throws InterruptedException {
-        var initial = Statics.MEM_USAGE_NATIVE.sum();
+        var initial = InternalBufferUtils.MEM_USAGE_NATIVE.sum();
         int allocationSize = 1024;
         allocateAndForget(fixture, allocationSize);
         long sum = 0;
         for (int i = 0; i < 15; i++) {
             System.gc();
             System.runFinalization();
-            sum = Statics.MEM_USAGE_NATIVE.sum() - initial;
+            sum = InternalBufferUtils.MEM_USAGE_NATIVE.sum() - initial;
             if (sum < allocationSize) {
                 // The memory must have been cleaned.
                 return;

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferCompactTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferCompactTest.java
@@ -21,7 +21,7 @@ import io.netty5.buffer.api.internal.ResourceSupport;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import static io.netty5.buffer.api.internal.Statics.acquire;
+import static io.netty5.buffer.api.internal.InternalBufferUtils.acquire;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class BufferCompactTest extends BufferTestSupport {

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferComponentIterationTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferComponentIterationTest.java
@@ -19,7 +19,7 @@ import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.buffer.api.BufferClosedException;
 import io.netty5.buffer.api.ByteCursor;
-import io.netty5.buffer.api.internal.Statics;
+import io.netty5.buffer.api.internal.InternalBufferUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -136,7 +136,7 @@ public class BufferComponentIterationTest extends BufferTestSupport {
                     assertEquals(expectedValue, bufferValue);
                     assertEquals(bufferValue, index + 1);
                     assertThrows(ReadOnlyBufferException.class, () -> buffer.put(0, (byte) 0xFF));
-                    var writableBuffer = Statics.tryGetWritableBufferFromReadableComponent(component);
+                    var writableBuffer = InternalBufferUtils.tryGetWritableBufferFromReadableComponent(component);
                     if (writableBuffer != null) {
                         int pos = writableBuffer.position();
                         bufferValue = writableBuffer.getInt();

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferCompositionTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferCompositionTest.java
@@ -23,7 +23,7 @@ import io.netty5.buffer.api.CompositeBuffer;
 import io.netty5.buffer.api.Drop;
 import io.netty5.util.Send;
 import io.netty5.buffer.api.internal.ResourceSupport;
-import io.netty5.buffer.api.internal.Statics;
+import io.netty5.buffer.api.internal.InternalBufferUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -32,8 +32,8 @@ import org.opentest4j.TestAbortedException;
 import java.lang.reflect.Field;
 import java.util.List;
 
-import static io.netty5.buffer.api.internal.Statics.acquire;
-import static io.netty5.buffer.api.internal.Statics.isOwned;
+import static io.netty5.buffer.api.internal.InternalBufferUtils.acquire;
+import static io.netty5.buffer.api.internal.InternalBufferUtils.isOwned;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -734,7 +734,7 @@ public class BufferCompositionTest extends BufferTestSupport {
                 }
             };
             try {
-                Statics.unsafeSetDrop((ResourceSupport<?, ?>) composite, throwingDrop);
+                InternalBufferUtils.unsafeSetDrop((ResourceSupport<?, ?>) composite, throwingDrop);
             } catch (Exception e) {
                 composite.close();
                 throw e;

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferImplicitCapacityTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferImplicitCapacityTest.java
@@ -20,7 +20,7 @@ import io.netty5.buffer.api.BufferAllocator;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import static io.netty5.buffer.api.internal.Statics.MAX_BUFFER_SIZE;
+import static io.netty5.buffer.api.internal.InternalBufferUtils.MAX_BUFFER_SIZE;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class BufferImplicitCapacityTest extends BufferTestSupport {

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferLifeCycleTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferLifeCycleTest.java
@@ -28,8 +28,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Supplier;
 
-import static io.netty5.buffer.api.internal.Statics.acquire;
-import static io.netty5.buffer.api.internal.Statics.isOwned;
+import static io.netty5.buffer.api.internal.InternalBufferUtils.acquire;
+import static io.netty5.buffer.api.internal.InternalBufferUtils.isOwned;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferReadOnlyTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferReadOnlyTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.function.Supplier;
 
-import static io.netty5.buffer.api.internal.Statics.isOwned;
+import static io.netty5.buffer.api.internal.InternalBufferUtils.isOwned;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferSendTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferSendTest.java
@@ -29,8 +29,8 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.Future;
 import java.util.concurrent.SynchronousQueue;
 
-import static io.netty5.buffer.api.internal.Statics.acquire;
-import static io.netty5.buffer.api.internal.Statics.isOwned;
+import static io.netty5.buffer.api.internal.InternalBufferUtils.acquire;
+import static io.netty5.buffer.api.internal.InternalBufferUtils.isOwned;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferTestSupport.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferTestSupport.java
@@ -49,7 +49,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.Stream.Builder;
 
-import static io.netty5.buffer.api.internal.Statics.acquire;
+import static io.netty5.buffer.api.internal.InternalBufferUtils.acquire;
 import static io.netty5.buffer.api.tests.Fixture.Properties.COMPOSITE;
 import static io.netty5.buffer.api.tests.Fixture.Properties.DIRECT;
 import static io.netty5.buffer.api.tests.Fixture.Properties.HEAP;

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/MemoryManagerTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/MemoryManagerTest.java
@@ -30,7 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.ServiceConfigurationError;
 
-import static io.netty5.buffer.api.internal.Statics.isOwned;
+import static io.netty5.buffer.api.internal.InternalBufferUtils.isOwned;
 import static io.netty5.buffer.api.tests.BufferTestSupport.assertEquals;
 import static io.netty5.buffer.api.tests.BufferTestSupport.verifyWriteInaccessible;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/SensitiveBufferTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/SensitiveBufferTest.java
@@ -21,7 +21,7 @@ import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.buffer.api.Drop;
 import io.netty5.buffer.api.MemoryManager;
-import io.netty5.buffer.api.internal.Statics;
+import io.netty5.buffer.api.internal.InternalBufferUtils;
 import io.netty5.util.Send;
 import org.junit.jupiter.api.Test;
 
@@ -197,7 +197,7 @@ public class SensitiveBufferTest {
             @Override
             public void drop(Buffer obj) {
                 Object memory = manager.unwrapRecoverableMemory(obj);
-                try (Buffer buf = manager.recoverMemory(() -> null, memory, Statics.NO_OP_DROP)) {
+                try (Buffer buf = manager.recoverMemory(() -> null, memory, InternalBufferUtils.NO_OP_DROP)) {
                     int capacity = buf.capacity();
                     for (int i = 0; i < capacity; i++) {
                         assertEquals((byte) 0, buf.getByte(i));

--- a/handler/src/main/java/io/netty5/handler/ssl/EngineWrapper.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/EngineWrapper.java
@@ -16,7 +16,7 @@
 package io.netty5.handler.ssl;
 
 import io.netty5.buffer.api.Buffer;
-import io.netty5.buffer.api.internal.Statics;
+import io.netty5.buffer.api.internal.InternalBufferUtils;
 import io.netty5.util.internal.PlatformDependent;
 
 import javax.net.ssl.SSLEngine;
@@ -144,7 +144,7 @@ class EngineWrapper {
             for (var c = iterator.firstReadable(); c != null; c = c.nextReadable()) {
                 // Some SSLEngine implementations require their input buffers be mutable. Let's try to accommodate.
                 // See https://bugs.openjdk.java.net/browse/JDK-8283577 for the details.
-                ByteBuffer byteBuffer = Statics.tryGetWritableBufferFromReadableComponent(c);
+                ByteBuffer byteBuffer = InternalBufferUtils.tryGetWritableBufferFromReadableComponent(c);
                 if (byteBuffer == null) {
                     byteBuffer = c.readableBuffer();
                 }

--- a/handler/src/main/java/io/netty5/handler/ssl/PemX509Certificate.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/PemX509Certificate.java
@@ -20,7 +20,7 @@ import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.util.Resource;
 import io.netty5.util.Send;
 import io.netty5.buffer.api.internal.ResourceSupport;
-import io.netty5.buffer.api.internal.Statics;
+import io.netty5.buffer.api.internal.InternalBufferUtils;
 import io.netty5.util.CharsetUtil;
 
 import java.math.BigInteger;
@@ -176,8 +176,8 @@ public final class PemX509Certificate extends X509Certificate implements PemEnco
     @Override
     public Buffer content() {
         if (!content.isAccessible()) {
-            throw Statics.attachTrace((ResourceSupport<?, ?>) content,
-                                      new IllegalStateException("PemX509Certificate is closed."));
+            throw InternalBufferUtils.attachTrace((ResourceSupport<?, ?>) content,
+                                                  new IllegalStateException("PemX509Certificate is closed."));
         }
 
         return content;

--- a/transport/src/main/java/io/netty5/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty5/channel/embedded/EmbeddedChannel.java
@@ -17,7 +17,7 @@ package io.netty5.channel.embedded;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.internal.ResourceSupport;
-import io.netty5.buffer.api.internal.Statics;
+import io.netty5.buffer.api.internal.InternalBufferUtils;
 import io.netty5.channel.AdaptiveReadHandleFactory;
 import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.MaxMessagesWriteHandleFactory;
@@ -729,7 +729,7 @@ public class EmbeddedChannel extends AbstractChannel<Channel, SocketAddress, Soc
         if (msg instanceof ResourceSupport<?, ?>) {
             // Prevent the close in ChannelOutboundBuffer.remove() from ending the lifecycle of this message.
             // This allows tests to examine the message.
-            handleOutboundMessage(Statics.acquire((ResourceSupport<?, ?>) msg));
+            handleOutboundMessage(InternalBufferUtils.acquire((ResourceSupport<?, ?>) msg));
         } else if (msg instanceof Resource<?>) {
             // Resource life-cycle otherwise normally ends in ChannelOutboundBuffer.remove(), but using send()
             // here allows the close() in remove() to become a no-op.

--- a/transport/src/main/java/io/netty5/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty5/channel/local/LocalChannel.java
@@ -17,12 +17,12 @@ package io.netty5.channel.local;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.DefaultBufferAllocators;
+import io.netty5.buffer.api.internal.InternalBufferUtils;
 import io.netty5.channel.ChannelOption;
 import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.util.ReferenceCounted;
 import io.netty5.util.Resource;
 import io.netty5.buffer.api.internal.ResourceSupport;
-import io.netty5.buffer.api.internal.Statics;
 import io.netty5.channel.AbstractChannel;
 import io.netty5.channel.Channel;
 import io.netty5.channel.EventLoop;
@@ -298,7 +298,7 @@ public class LocalChannel extends AbstractChannel<LocalServerChannel, LocalAddre
             if (msg instanceof ReferenceCounted) {
                 peer.inboundBuffer.add(ReferenceCountUtil.retain(msg));
             } else if (msg instanceof ResourceSupport) {
-                peer.inboundBuffer.add(Statics.acquire((ResourceSupport<?, ?>) msg));
+                peer.inboundBuffer.add(InternalBufferUtils.acquire((ResourceSupport<?, ?>) msg));
             } else if (msg instanceof Resource) {
                 peer.inboundBuffer.add(((Resource<?>) msg).send().receive());
             } else {


### PR DESCRIPTION
Motivation:
The name `Statics` is a hold-over from the incubation repo, where we only had the buffer code.
Now that the code has moved to Netty itself, `Statics` is too generic and meaningless a name.

Modification:
Rename it to `InternalBufferUtils`, which is what it is.

Result:
Cleaner code.