### PR TITLE
Upgrade Bouncy Castle to the latest version

### DIFF
--- a/codec-http2/pom.xml
+++ b/codec-http2/pom.xml
@@ -86,7 +86,7 @@
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
+      <artifactId>bcpkix-jdk18on</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -105,11 +105,11 @@
     <!-- Needed for OCSP -->
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
+      <artifactId>bcpkix-jdk18on</artifactId>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15on</artifactId>
+      <artifactId>bcprov-jdk18on</artifactId>
     </dependency>
 
     <!-- Needed on Java11 and later -->

--- a/handler/pom.xml
+++ b/handler/pom.xml
@@ -76,7 +76,7 @@
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
+      <artifactId>bcpkix-jdk18on</artifactId>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -533,7 +533,7 @@
     <conscrypt.artifactId>conscrypt-openjdk-uber</conscrypt.artifactId>
     <conscrypt.version>2.5.2</conscrypt.version>
     <conscrypt.classifier />
-    <bouncycastle.version>1.69</bouncycastle.version>
+    <bouncycastle.version>1.71.1</bouncycastle.version>
     <jni.classifier>${os.detected.name}-${os.detected.arch}</jni.classifier>
     <logging.config>${project.basedir}/../common/src/test/resources/logback-test.xml</logging.config>
     <logging.logLevel>debug</logging.logLevel>
@@ -662,7 +662,7 @@
       -->
       <dependency>
         <groupId>org.bouncycastle</groupId>
-        <artifactId>bcpkix-jdk15on</artifactId>
+        <artifactId>bcpkix-jdk18on</artifactId>
         <version>${bouncycastle.version}</version>
         <scope>compile</scope>
         <optional>true</optional>
@@ -674,7 +674,7 @@
       -->
       <dependency>
         <groupId>org.bouncycastle</groupId>
-        <artifactId>bcprov-jdk15on</artifactId>
+        <artifactId>bcprov-jdk18on</artifactId>
         <version>${bouncycastle.version}</version>
         <scope>compile</scope>
         <optional>true</optional>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -106,12 +106,12 @@
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
+      <artifactId>bcpkix-jdk18on</artifactId>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15on</artifactId>
+      <artifactId>bcprov-jdk18on</artifactId>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/transport-blockhound-tests/pom.xml
+++ b/transport-blockhound-tests/pom.xml
@@ -120,7 +120,7 @@
 
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
+      <artifactId>bcpkix-jdk18on</artifactId>
       <optional>true</optional>
     </dependency>
     <dependency>


### PR DESCRIPTION
Motivation:
Since Netty 5 is now based on Java 11, we can use the latest `18on` versions of Bouncy Castle.

Modification:
Upgrade Bouncy Castle to the latest versions available.

Result:
Fresh new Bouncy Castle dependencies.