### PR TITLE
Fix bug in SslContext private key reading fall-back path

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContext.java
@@ -28,6 +28,7 @@ import io.netty.util.AttributeMap;
 import io.netty.util.DefaultAttributeMap;
 import io.netty.util.internal.EmptyArrays;
 
+import java.io.BufferedInputStream;
 import java.security.Provider;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
@@ -1143,10 +1144,17 @@ public abstract class SslContext {
 
         // try BC first, if this fail fallback to original key extraction process
         if (BouncyCastlePemReader.isAvailable()) {
+            if (!keyInputStream.markSupported()) {
+                // We need an input stream that supports resetting, in case BouncyCastle fails to read.
+                keyInputStream = new BufferedInputStream(keyInputStream);
+            }
+            keyInputStream.mark(1048576); // Be able to reset up to 1 MiB of data.
             PrivateKey pk = BouncyCastlePemReader.getPrivateKey(keyInputStream, keyPassword);
             if (pk != null) {
                 return pk;
             }
+            // BouncyCastle could not read the key. Reset the input stream in case the input position changed.
+            keyInputStream.reset();
         }
 
         return getPrivateKeyFromByteBuffer(PemReader.readPrivateKey(keyInputStream), keyPassword);


### PR DESCRIPTION
Motivation:
We first try to read private keys with BouncyCastle, and then fall back to our own code if that fails.
It could be the case, that BouncyCastle read some data before it failed, and in that case we need to make sure that our fallback code gets to read the key data from the original stream position - not whatever position caused a failure in BouncyCastle.

Modification:
Use the mark and reset methods of InputStream to reset the key stream position, if BouncyCastle cannot read a key.
If the provided input stream does not already support marking, then we wrap it in a BufferedInputStream which does.
We allow up to 1 MiB of data to be buffered for this purpose.
If the key is bigger than this, and BouncyCastle reads more than this before failing, then resetting will throw an exception so we don't get silent failures.

Result:
Fixed private key fallback code path.
Fixes #12745