### PR TITLE
Reject connection related headers in HTTP/2 frames

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackDecoder.java
@@ -32,6 +32,8 @@
 package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http2.HpackUtil.IndexType;
 import io.netty.util.AsciiString;
 
@@ -48,6 +50,7 @@ import static io.netty.handler.codec.http2.Http2Exception.streamError;
 import static io.netty.handler.codec.http2.Http2Headers.PseudoHeaderName.getPseudoHeader;
 import static io.netty.handler.codec.http2.Http2Headers.PseudoHeaderName.hasPseudoHeaderFormat;
 import static io.netty.util.AsciiString.EMPTY_STRING;
+import static io.netty.util.AsciiString.contentEqualsIgnoreCase;
 import static io.netty.util.internal.ObjectUtil.checkPositive;
 
 final class HpackDecoder {
@@ -380,7 +383,8 @@ final class HpackDecoder {
     }
 
     private static HeaderType validate(int streamId, CharSequence name,
-                                       HeaderType previousHeaderType, Http2Headers headers) throws Http2Exception {
+                                       HeaderType previousHeaderType, Http2Headers headers, CharSequence value)
+            throws Http2Exception {
         if (hasPseudoHeaderFormat(name)) {
             if (previousHeaderType == HeaderType.REGULAR_HEADER) {
                 throw streamError(streamId, PROTOCOL_ERROR,
@@ -404,8 +408,48 @@ final class HpackDecoder {
 
             return currentHeaderType;
         }
+        if (isConnectionHeader(name)) {
+            throw streamError(streamId, PROTOCOL_ERROR, "Illegal connection-specific header '%s' encountered.", name);
+        }
+        if (contentEqualsIgnoreCase(name, HttpHeaderNames.TE) &&
+                !contentEqualsIgnoreCase(value, HttpHeaderValues.TRAILERS)) {
+            throw streamError(streamId, PROTOCOL_ERROR,
+                    "Illegal value specified for the 'TE' header (only 'trailers' is allowed).");
+        }
 
         return HeaderType.REGULAR_HEADER;
+    }
+
+    @SuppressWarnings("deprecation") // We need to check for deprecated headers as well.
+    private static boolean isConnectionHeader(CharSequence name) {
+        // These are the known standard and non-standard connection related headers:
+        // - upgrade (7 chars)
+        // - connection (10 chars)
+        // - keep-alive (10 chars)
+        // - proxy-connection (16 chars)
+        // - transfer-encoding (17 chars)
+        // - upgrade-insecure-requests (25 chars)
+        //
+        // We scan for these based on the length, then double-check any matching name.
+        int len = name.length();
+        if (len < 7 || len > 25) {
+            return false;
+        }
+        if (len <= 10) {
+            if (len == 7 && contentEqualsIgnoreCase(name, HttpHeaderNames.UPGRADE)) {
+                return true;
+            }
+            return len == 10 && (contentEqualsIgnoreCase(name, HttpHeaderNames.CONNECTION) ||
+                    contentEqualsIgnoreCase(name, HttpHeaderNames.KEEP_ALIVE));
+        }
+        if (len == 17) {
+            // Transfer-Encoding is more common, so check it first.
+            return contentEqualsIgnoreCase(name, HttpHeaderNames.TRANSFER_ENCODING);
+        }
+        if (len == 16) {
+            return contentEqualsIgnoreCase(name, HttpHeaderNames.PROXY_CONNECTION);
+        }
+        return len == 25 && contentEqualsIgnoreCase(name, HttpHeaderNames.UPGRADE_INSECURE_REQUESTS);
     }
 
     private static boolean contains(Http2Headers headers, CharSequence name) {
@@ -592,7 +636,7 @@ final class HpackDecoder {
 
             if (validate) {
                 try {
-                    previousType = validate(streamId, name, previousType, headers);
+                    previousType = validate(streamId, name, previousType, headers, value);
                 } catch (Http2Exception ex) {
                     validationException = ex;
                     return;

--- a/codec-http2/src/test/resources/io/netty/handler/codec/http2/testdata/testStaticTableEntries.json
+++ b/codec-http2/src/test/resources/io/netty/handler/codec/http2/testdata/testStaticTableEntries.json
@@ -52,7 +52,6 @@
         { "server": "" },
         { "set-cookie": "" },
         { "strict-transport-security": "" },
-        { "transfer-encoding": "" },
         { "user-agent": "" },
         { "vary": "" },
         { "via": "" },
@@ -62,7 +61,7 @@
         "8182 8384 8586 87 8f90",
         "9192 9394 9596 9798 999a 9b9c 9d9e 9fa0",
         "a1a2 a3a4 a5a6 a7a8 a9aa abac adae afb0",
-        "b1b2 b3b4 b5b6 b7b8 b9ba bbbc bd"
+        "b1b2 b3b4 b5b6 b7b8 babb bcbd"
       ],
       "dynamic_table": [
       ],


### PR DESCRIPTION
Motivation:
In https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.2 is says "any message containing connection-specific header fields MUST be treated as malformed".
We already filter these out in our HTTP/1 to HTTP/2 translation code, but if the HTTP/2 frames are originally sent to us with these headers, then we must reject them as malformed.

Modification:
Improve the header validation code used by the DefaultHttp2HeadersDecoder to check for, and reject, any connection related headers.

Result:
Frames with illegal headers are now correctly rejected, though only when header validation is turned on.