### PR TITLE
Include autobahn reports in uploaded artifacts

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -206,5 +206,6 @@ jobs:
           name: build-${{ matrix.setup }}-target
           path: |
             **/target/surefire-reports/
+            **/target/autobahntestsuite-reports/
             **/hs_err*.log
             **/core.*


### PR DESCRIPTION
Motivation:
The autobahn test suite occasionally fails, and without the result files we have no way to debug them.

Modification:
Add a autobahntestsuite-reports folder to the uploaded artifacts.

Result:
Maybe we'll be able to debug these in the future.