### PR TITLE
Reject HTTP/2 header values with invalid characters

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/CombinedHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/CombinedHttpHeaders.java
@@ -38,7 +38,8 @@ import static io.netty.util.internal.StringUtil.unescapeCsvFields;
  */
 public class CombinedHttpHeaders extends DefaultHttpHeaders {
     public CombinedHttpHeaders(boolean validate) {
-        super(new CombinedHttpHeadersImpl(CASE_INSENSITIVE_HASHER, valueConverter(validate), nameValidator(validate)));
+        super(new CombinedHttpHeadersImpl(CASE_INSENSITIVE_HASHER, valueConverter(), nameValidator(validate),
+                valueValidator(validate)));
     }
 
     @Override
@@ -87,9 +88,10 @@ public class CombinedHttpHeaders extends DefaultHttpHeaders {
         }
 
         CombinedHttpHeadersImpl(HashingStrategy<CharSequence> nameHashingStrategy,
-                ValueConverter<CharSequence> valueConverter,
-                DefaultHeaders.NameValidator<CharSequence> nameValidator) {
-            super(nameHashingStrategy, valueConverter, nameValidator);
+                                ValueConverter<CharSequence> valueConverter,
+                                NameValidator<CharSequence> nameValidator,
+                                ValueValidator<CharSequence> valueValidator) {
+            super(nameHashingStrategy, valueConverter, nameValidator, 16, valueValidator);
         }
 
         @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
@@ -22,9 +22,6 @@ import io.netty.handler.codec.DefaultHeaders.NameValidator;
 import io.netty.handler.codec.DefaultHeadersImpl;
 import io.netty.handler.codec.HeadersUtils;
 import io.netty.handler.codec.ValueConverter;
-import io.netty.util.AsciiString;
-import io.netty.util.ByteProcessor;
-import io.netty.util.internal.PlatformDependent;
 
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -43,31 +40,16 @@ import static io.netty.util.AsciiString.CASE_SENSITIVE_HASHER;
  * Default implementation of {@link HttpHeaders}.
  */
 public class DefaultHttpHeaders extends HttpHeaders {
-    private static final int HIGHEST_INVALID_VALUE_CHAR_MASK = ~15;
-    private static final ByteProcessor HEADER_NAME_VALIDATOR = new ByteProcessor() {
-        @Override
-        public boolean process(byte value) throws Exception {
-            validateHeaderNameElement(value);
-            return true;
-        }
-    };
     static final NameValidator<CharSequence> HttpNameValidator = new NameValidator<CharSequence>() {
         @Override
         public void validateName(CharSequence name) {
             if (name == null || name.length() == 0) {
-                throw new IllegalArgumentException("empty headers are not allowed [" + name + "]");
+                throw new IllegalArgumentException("empty headers are not allowed [" + name + ']');
             }
-            if (name instanceof AsciiString) {
-                try {
-                    ((AsciiString) name).forEachByte(HEADER_NAME_VALIDATOR);
-                } catch (Exception e) {
-                    PlatformDependent.throwException(e);
-                }
-            } else {
-                // Go through each character in the name
-                for (int index = 0; index < name.length(); ++index) {
-                    validateHeaderNameElement(name.charAt(index));
-                }
+            int index = HttpHeaderValidationUtil.validateToken(name);
+            if (index != -1) {
+                throw new IllegalArgumentException("a header name can only contain \"token\" characters, " +
+                        "but found invalid character '" + name.charAt(index) + "' at index " + index + '.');
             }
         }
     };
@@ -79,7 +61,7 @@ public class DefaultHttpHeaders extends HttpHeaders {
     }
 
     /**
-     * <b>Warning!</b> Setting <code>validate</code> to <code>false</code> will mean that Netty won't
+     * <b>Warning!</b> Setting {@code validate} to {@code false} will mean that Netty won't
      * validate & protect against user-supplied header values that are malicious.
      * This can leave your server implementation vulnerable to
      * <a href="https://cwe.mitre.org/data/definitions/113.html">
@@ -88,16 +70,19 @@ public class DefaultHttpHeaders extends HttpHeaders {
      * When disabling this validation, it is the responsibility of the caller to ensure that the values supplied
      * do not contain a non-url-escaped carriage return (CR) and/or line feed (LF) characters.
      *
-     * @param validate Should Netty validate Header values to ensure they aren't malicious.
+     * @param validate Should Netty validate header values to ensure they aren't malicious.
      */
     public DefaultHttpHeaders(boolean validate) {
         this(validate, nameValidator(validate));
     }
 
     protected DefaultHttpHeaders(boolean validate, NameValidator<CharSequence> nameValidator) {
-        this(new DefaultHeadersImpl<CharSequence, CharSequence>(CASE_INSENSITIVE_HASHER,
-                                                                valueConverter(validate),
-                                                                nameValidator));
+        this(new DefaultHeadersImpl<CharSequence, CharSequence>(
+                CASE_INSENSITIVE_HASHER,
+                HeaderValueConverter.INSTANCE,
+                nameValidator,
+                16,
+                valueValidator(validate)));
     }
 
     protected DefaultHttpHeaders(DefaultHeaders<CharSequence, CharSequence, ?> headers) {
@@ -365,65 +350,14 @@ public class DefaultHttpHeaders extends HttpHeaders {
         return new DefaultHttpHeaders(headers.copy());
     }
 
-    private static void validateHeaderNameElement(byte value) {
-        switch (value) {
-        case 0x1c:
-        case 0x1d:
-        case 0x1e:
-        case 0x1f:
-        case 0x00:
-        case '\t':
-        case '\n':
-        case 0x0b:
-        case '\f':
-        case '\r':
-        case ' ':
-        case ',':
-        case ':':
-        case ';':
-        case '=':
-            throw new IllegalArgumentException(
-               "a header name cannot contain the following prohibited characters: =,;: \\t\\r\\n\\v\\f: " +
-                       value);
-        default:
-            // Check to see if the character is not an ASCII character, or invalid
-            if (value < 0) {
-                throw new IllegalArgumentException("a header name cannot contain non-ASCII character: " + value);
-            }
-        }
+    static ValueConverter<CharSequence> valueConverter() {
+        return HeaderValueConverter.INSTANCE;
     }
 
-    private static void validateHeaderNameElement(char value) {
-        switch (value) {
-        case 0x1c:
-        case 0x1d:
-        case 0x1e:
-        case 0x1f:
-        case 0x00:
-        case '\t':
-        case '\n':
-        case 0x0b:
-        case '\f':
-        case '\r':
-        case ' ':
-        case ',':
-        case ':':
-        case ';':
-        case '=':
-            throw new IllegalArgumentException(
-               "a header name cannot contain the following prohibited characters: =,;: \\t\\r\\n\\v\\f: " +
-                       value);
-        default:
-            // Check to see if the character is not an ASCII character, or invalid
-            if (value > 127) {
-                throw new IllegalArgumentException("a header name cannot contain non-ASCII character: " +
-                        value);
-            }
-        }
-    }
-
-    static ValueConverter<CharSequence> valueConverter(boolean validate) {
-        return validate ? HeaderValueConverterAndValidator.INSTANCE : HeaderValueConverter.INSTANCE;
+    @SuppressWarnings("unchecked")
+    static DefaultHeaders.ValueValidator<CharSequence> valueValidator(boolean validate) {
+        return validate ? HeaderValueValidator.INSTANCE :
+                (DefaultHeaders.ValueValidator<CharSequence>) DefaultHeaders.ValueValidator.NO_VALIDATION;
     }
 
     @SuppressWarnings("unchecked")
@@ -449,74 +383,16 @@ public class DefaultHttpHeaders extends HttpHeaders {
         }
     }
 
-    private static final class HeaderValueConverterAndValidator extends HeaderValueConverter {
-        static final HeaderValueConverterAndValidator INSTANCE = new HeaderValueConverterAndValidator();
+    private static final class HeaderValueValidator implements DefaultHeaders.ValueValidator<CharSequence> {
+        static final HeaderValueValidator INSTANCE = new HeaderValueValidator();
 
         @Override
-        public CharSequence convertObject(Object value) {
-            CharSequence seq = super.convertObject(value);
-            int state = 0;
-            // Start looping through each of the character
-            for (int index = 0; index < seq.length(); index++) {
-                state = validateValueChar(seq, state, seq.charAt(index));
+        public void validate(CharSequence value) {
+            int index = HttpHeaderValidationUtil.validateValidHeaderValue(value);
+            if (index != -1) {
+                throw new IllegalArgumentException("a header value contains prohibited character 0x" +
+                        Integer.toHexString(value.charAt(index)) + " at index " + index + '.');
             }
-
-            if (state != 0) {
-                throw new IllegalArgumentException("a header value must not end with '\\r' or '\\n'");
-            }
-            return seq;
-        }
-
-        private static int validateValueChar(CharSequence seq, int state, char character) {
-            /*
-             * State:
-             * 0: Previous character was neither CR nor LF
-             * 1: The previous character was CR
-             * 2: The previous character was LF
-             */
-            if ((character & HIGHEST_INVALID_VALUE_CHAR_MASK) == 0) {
-                // Check the absolutely prohibited characters.
-                switch (character) {
-                case 0x0: // NULL
-                    throw new IllegalArgumentException("a header value contains a prohibited character '\0'");
-                case 0x0b: // Vertical tab
-                    throw new IllegalArgumentException("a header value contains a prohibited character '\\v'");
-                case '\f':
-                    throw new IllegalArgumentException("a header value contains a prohibited character '\\f'");
-                default:
-                    break;
-                }
-            }
-
-            // Check the CRLF (HT | SP) pattern
-            switch (state) {
-                case 0:
-                    switch (character) {
-                        case '\r':
-                            return 1;
-                        case '\n':
-                            return 2;
-                        default:
-                            break;
-                    }
-                    break;
-                case 1:
-                    if (character == '\n') {
-                        return 2;
-                    }
-                    throw new IllegalArgumentException("only '\\n' is allowed after '\\r'");
-                case 2:
-                    switch (character) {
-                        case '\t':
-                        case ' ':
-                            return 0;
-                        default:
-                            throw new IllegalArgumentException("only ' ' and '\\t' are allowed after '\\n'");
-                    }
-                default:
-                    break;
-            }
-            return state;
         }
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
@@ -49,7 +49,8 @@ public class DefaultHttpHeaders extends HttpHeaders {
             int index = HttpHeaderValidationUtil.validateToken(name);
             if (index != -1) {
                 throw new IllegalArgumentException("a header name can only contain \"token\" characters, " +
-                        "but found invalid character '" + name.charAt(index) + "' at index " + index + '.');
+                        "but found invalid character 0x" + Integer.toHexString(name.charAt(index)) +
+                        " at index " + index + " of header '" + name + "'.");
             }
         }
     };

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderValidationUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderValidationUtil.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http;
+
+import io.netty.util.AsciiString;
+import io.netty.util.internal.UnstableApi;
+
+import static io.netty.util.AsciiString.contentEqualsIgnoreCase;
+
+/**
+ * Functions used to perform various validations of HTTP header names and values.
+ */
+@UnstableApi
+public final class HttpHeaderValidationUtil {
+    private HttpHeaderValidationUtil() {
+    }
+
+    /**
+     * Check if a header name is "connection related".
+     * <p>
+     * The <a href="https://datatracker.ietf.org/doc/html/rfc9110#section-7.6.1">RFC9110</a> only specify an incomplete
+     * list of the following headers:
+     *
+     * <ul>
+     *     <li><tt>Connection</tt></li>
+     *     <li><tt>Proxy-Connection</tt></li>
+     *     <li><tt>Keep-Alive</tt></li>
+     *     <li><tt>TE</tt></li>
+     *     <li><tt>Transfer-Encoding</tt></li>
+     *     <li><tt>Upgrade</tt></li>
+     * </ul>
+     *
+     * @param name the name of the header to check. The check is case-insensitive.
+     * @param ignoreTeHeader {@code true} if the <tt>TE</tt> header should be ignored by this check.
+     * This is relevant for HTTP/2 header validation, where the <tt>TE</tt> header has special rules.
+     * @return {@code true} if the given header name is one of the specified connection-related headers.
+     */
+    @SuppressWarnings("deprecation") // We need to check for deprecated headers as well.
+    public static boolean isConnectionHeader(CharSequence name, boolean ignoreTeHeader) {
+        // These are the known standard and non-standard connection related headers:
+        // - upgrade (7 chars)
+        // - connection (10 chars)
+        // - keep-alive (10 chars)
+        // - proxy-connection (16 chars)
+        // - transfer-encoding (17 chars)
+        //
+        // See https://datatracker.ietf.org/doc/html/rfc9113#section-8.2.2
+        // and https://datatracker.ietf.org/doc/html/rfc9110#section-7.6.1
+        // for the list of connection related headers.
+        //
+        // We scan for these based on the length, then double-check any matching name.
+        int len = name.length();
+        switch (len) {
+            case 2: return ignoreTeHeader? false : contentEqualsIgnoreCase(name, HttpHeaderNames.TE);
+            case 7: return contentEqualsIgnoreCase(name, HttpHeaderNames.UPGRADE);
+            case 10: return contentEqualsIgnoreCase(name, HttpHeaderNames.CONNECTION) ||
+                    contentEqualsIgnoreCase(name, HttpHeaderNames.KEEP_ALIVE);
+            case 16: return contentEqualsIgnoreCase(name, HttpHeaderNames.PROXY_CONNECTION);
+            case 17: return contentEqualsIgnoreCase(name, HttpHeaderNames.TRANSFER_ENCODING);
+            default:
+                return false;
+        }
+    }
+
+    /**
+     * If the given header is {@link HttpHeaderNames#TE} and the given header value is <em>not</em>
+     * {@link HttpHeaderValues#TRAILERS}, then return {@code true}. Otherwie, {@code false}.
+     * <p>
+     * The string comparisons are case-insensitive.
+     * <p>
+     * This check is important for HTTP/2 header validation.
+     *
+     * @param name the header name to check if it is <tt>TE</tt> or not.
+     * @param value the header value to check if it is something other than <tt>TRAILERS</tt>.
+     * @return {@code true} only if the header name is <tt>TE</tt>, and the header value is <em>not</em>
+     * <tt>TRAILERS</tt>. Otherwise, {@code false}.
+     */
+    public static boolean isTeNotTrailers(CharSequence name, CharSequence value) {
+        if (name.length() == 2) {
+            return contentEqualsIgnoreCase(name, HttpHeaderNames.TE) &&
+                    !contentEqualsIgnoreCase(value, HttpHeaderValues.TRAILERS);
+        }
+        return false;
+    }
+
+    /**
+     * Validate the given HTTP header value by searching for any illegal characters.
+     *
+     * @param value the HTTP header value to validate.
+     * @return the index of the first illegal character found, or {@code -1} if there are none and the header value is
+     * valid.
+     */
+    public static int validateValidHeaderValue(CharSequence value) {
+        // Validate value to field-content rule.
+        //  field-content  = field-vchar [ 1*( SP / HTAB ) field-vchar ]
+        //  field-vchar    = VCHAR / obs-text
+        //  VCHAR          = %x21-7E ; visible (printing) characters
+        //  obs-text       = %x80-FF
+        //  SP             = %x20
+        //  HTAB           = %x09 ; horizontal tab
+        //  See: https://datatracker.ietf.org/doc/html/rfc7230#section-3.2
+        //  And: https://datatracker.ietf.org/doc/html/rfc5234#appendix-B.1
+        int length = value.length();
+        if (length == 0) {
+            return -1;
+        }
+        if (value instanceof AsciiString) {
+            return verifyValidHeaderValueAsciiString((AsciiString) value);
+        } else {
+            return verifyValidHeaderValueCharSequence(value);
+        }
+    }
+
+    private static int verifyValidHeaderValueAsciiString(AsciiString value) {
+        final byte[] array = value.array();
+        final int start = value.arrayOffset();
+        int b = array[start] & 0xFF;
+        if (b < 0x21 || b == 0x7F) {
+            return 0;
+        }
+        int length = value.length();
+        for (int i = start + 1; i < length; i++) {
+            b = array[i] & 0xFF;
+            if (b < 0x20 && b != 0x09 || b == 0x7F) {
+                return i - start;
+            }
+        }
+        return -1;
+    }
+
+    private static int verifyValidHeaderValueCharSequence(CharSequence value) {
+        int b = value.charAt(0);
+        if (b < 0x21 || b == 0x7F) {
+            return 0;
+        }
+        int length = value.length();
+        for (int i = 1; i < length; i++) {
+            b = value.charAt(i);
+            if (b < 0x20 && b != 0x09 || b == 0x7F) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Validate a <a href="https://tools.ietf.org/html/rfc7230#section-3.2.6">token</a> contains only allowed
+     * characters.
+     * <p>
+     * The <a href="https://tools.ietf.org/html/rfc2616#section-2.2">token</a> format is used for variety of HTTP
+     * components, like  <a href="https://tools.ietf.org/html/rfc6265#section-4.1.1">cookie-name</a>,
+     * <a href="https://tools.ietf.org/html/rfc7230#section-3.2.6">field-name</a> of a
+     * <a href="https://tools.ietf.org/html/rfc7230#section-3.2">header-field</a>, or
+     * <a href="https://tools.ietf.org/html/rfc7231#section-4">request method</a>.
+     *
+     * @param token the token to validate.
+     * @return the index of the first invalid token character found, or {@code -1} if there are none.
+     */
+    public static int validateToken(CharSequence token) {
+        if (token instanceof AsciiString) {
+            return validateAsciiStringToken((AsciiString) token);
+        }
+        return validateCharSequenceToken(token);
+    }
+
+    /**
+     * Validate that an {@link AsciiString} contain onlu valid
+     * <a href="https://tools.ietf.org/html/rfc7230#section-3.2.6">token</a> characters.
+     *
+     * @param token the ascii string to validate.
+     */
+    private static int validateAsciiStringToken(AsciiString token) {
+        byte[] array = token.array();
+        for (int i = token.arrayOffset(), len = token.arrayOffset() + token.length(); i < len; i++) {
+            if (!BitSet128.contains(array[i], TOKEN_CHARS_HIGH, TOKEN_CHARS_LOW)) {
+                return i - token.arrayOffset();
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Validate that a {@link CharSequence} contain onlu valid
+     * <a href="https://tools.ietf.org/html/rfc7230#section-3.2.6">token</a> characters.
+     *
+     * @param token the character sequence to validate.
+     */
+    private static int validateCharSequenceToken(CharSequence token) {
+        for (int i = 0, len = token.length(); i < len; i++) {
+            byte value = (byte) token.charAt(i);
+            if (!BitSet128.contains(value, TOKEN_CHARS_HIGH, TOKEN_CHARS_LOW)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static final long TOKEN_CHARS_HIGH;
+    private static final long TOKEN_CHARS_LOW;
+    static {
+        // HEADER
+        // header-field   = field-name ":" OWS field-value OWS
+        //
+        // field-name     = token
+        // token          = 1*tchar
+        //
+        // tchar          = "!" / "#" / "$" / "%" / "&" / "'" / "*"
+        //                    / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~"
+        //                    / DIGIT / ALPHA
+        //                    ; any VCHAR, except delimiters.
+        //  Delimiters are chosen
+        //   from the set of US-ASCII visual characters not allowed in a token
+        //   (DQUOTE and "(),/:;<=>?@[\]{}")
+        //
+        // COOKIE
+        // cookie-pair       = cookie-name "=" cookie-value
+        // cookie-name       = token
+        // token          = 1*<any CHAR except CTLs or separators>
+        // CTL = <any US-ASCII control character
+        //       (octets 0 - 31) and DEL (127)>
+        // separators     = "(" | ")" | "<" | ">" | "@"
+        //                      | "," | ";" | ":" | "\" | <">
+        //                      | "/" | "[" | "]" | "?" | "="
+        //                      | "{" | "}" | SP | HT
+        //
+        // field-name's token is equivalent to cookie-name's token, we can reuse the tchar mask for both:
+        BitSet128 tokenChars = new BitSet128()
+                .range('0', '9').range('a', 'z').range('A', 'Z') // Alphanumeric.
+                .bits('-', '.', '_', '~') // Unreserved characters.
+                .bits('!', '#', '$', '%', '&', '\'', '*', '+', '^', '`', '|'); // Token special characters.
+        TOKEN_CHARS_HIGH = tokenChars.high();
+        TOKEN_CHARS_LOW = tokenChars.low();
+    }
+
+    private static final class BitSet128 {
+        private long high;
+        private long low;
+
+        BitSet128 range(char fromInc, char toInc) {
+            for (int bit = fromInc; bit <= toInc; bit++) {
+                if (bit < 64) {
+                    low |= 1L << bit;
+                } else {
+                    high |= 1L << bit - 64;
+                }
+            }
+            return this;
+        }
+
+        BitSet128 bits(char... bits) {
+            for (char bit : bits) {
+                if (bit < 64) {
+                    low |= 1L << bit;
+                } else {
+                    high |= 1L << bit - 64;
+                }
+            }
+            return this;
+        }
+
+        long high() {
+            return high;
+        }
+
+        long low() {
+            return low;
+        }
+
+        static boolean contains(byte bit, long high, long low) {
+            if (bit < 0) {
+                return false;
+            }
+            if (bit < 64) {
+                return 0 != (low & 1L << bit);
+            }
+            return 0 != (high & 1L << bit - 64);
+        }
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderValidationUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderValidationUtil.java
@@ -104,6 +104,17 @@ public final class HttpHeaderValidationUtil {
      * valid.
      */
     public static int validateValidHeaderValue(CharSequence value) {
+        int length = value.length();
+        if (length == 0) {
+            return -1;
+        }
+        if (value instanceof AsciiString) {
+            return verifyValidHeaderValueAsciiString((AsciiString) value);
+        }
+        return verifyValidHeaderValueCharSequence(value);
+    }
+
+    private static int verifyValidHeaderValueAsciiString(AsciiString value) {
         // Validate value to field-content rule.
         //  field-content  = field-vchar [ 1*( SP / HTAB ) field-vchar ]
         //  field-vchar    = VCHAR / obs-text
@@ -113,18 +124,6 @@ public final class HttpHeaderValidationUtil {
         //  HTAB           = %x09 ; horizontal tab
         //  See: https://datatracker.ietf.org/doc/html/rfc7230#section-3.2
         //  And: https://datatracker.ietf.org/doc/html/rfc5234#appendix-B.1
-        int length = value.length();
-        if (length == 0) {
-            return -1;
-        }
-        if (value instanceof AsciiString) {
-            return verifyValidHeaderValueAsciiString((AsciiString) value);
-        } else {
-            return verifyValidHeaderValueCharSequence(value);
-        }
-    }
-
-    private static int verifyValidHeaderValueAsciiString(AsciiString value) {
         final byte[] array = value.array();
         final int start = value.arrayOffset();
         int b = array[start] & 0xFF;
@@ -142,6 +141,15 @@ public final class HttpHeaderValidationUtil {
     }
 
     private static int verifyValidHeaderValueCharSequence(CharSequence value) {
+        // Validate value to field-content rule.
+        //  field-content  = field-vchar [ 1*( SP / HTAB ) field-vchar ]
+        //  field-vchar    = VCHAR / obs-text
+        //  VCHAR          = %x21-7E ; visible (printing) characters
+        //  obs-text       = %x80-FF
+        //  SP             = %x20
+        //  HTAB           = %x09 ; horizontal tab
+        //  See: https://datatracker.ietf.org/doc/html/rfc7230#section-3.2
+        //  And: https://datatracker.ietf.org/doc/html/rfc5234#appendix-B.1
         int b = value.charAt(0);
         if (b < 0x21 || b == 0x7F) {
             return 0;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpMessageUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpMessageUtil.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package io.netty.handler.codec.http;
 
 import io.netty.util.internal.StringUtil;

--- a/codec-http/src/test/java/io/netty/handler/codec/http/DefaultHttpHeadersTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/DefaultHttpHeadersTest.java
@@ -17,6 +17,7 @@ package io.netty.handler.codec.http;
 
 import io.netty.handler.codec.http.HttpHeadersTestUtils.HeaderValue;
 import io.netty.util.AsciiString;
+import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.StringUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
@@ -80,11 +81,11 @@ public class DefaultHttpHeadersTest {
     @Test
     public void keysShouldBeCaseInsensitiveInHeadersEquals() {
         DefaultHttpHeaders headers1 = new DefaultHttpHeaders();
-        headers1.add(of("name1"), Arrays.asList("value1", "value2", "value3"));
+        headers1.add(of("name1"), asList("value1", "value2", "value3"));
         headers1.add(of("nAmE2"), of("value4"));
 
         DefaultHttpHeaders headers2 = new DefaultHttpHeaders();
-        headers2.add(of("naMe1"), Arrays.asList("value1", "value2", "value3"));
+        headers2.add(of("naMe1"), asList("value1", "value2", "value3"));
         headers2.add(of("NAME2"), of("value4"));
 
         assertEquals(headers1, headers1);
@@ -259,7 +260,7 @@ public class DefaultHttpHeadersTest {
                 .add(HttpHeaderNames.CONTENT_LENGTH, 10)
                 .names();
 
-        String[] namesArray = nettyHeaders.toArray(new String[0]);
+        String[] namesArray = nettyHeaders.toArray(EmptyArrays.EMPTY_STRINGS);
         assertArrayEquals(namesArray, new String[] { HttpHeaderNames.CONTENT_LENGTH.toString() });
     }
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpHeaderValidationUtilTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpHeaderValidationUtilTest.java
@@ -1,0 +1,585 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http;
+
+import io.netty.util.AsciiString;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledForJreRange;
+import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.JRE;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+import static io.netty.handler.codec.http.HttpHeaderValidationUtil.validateToken;
+import static io.netty.handler.codec.http.HttpHeaderValidationUtil.validateValidHeaderValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+@Execution(ExecutionMode.CONCURRENT) // We have a couple of fairly slow tests here. Better to run them in parallel.
+public class HttpHeaderValidationUtilTest {
+    @SuppressWarnings("deprecation") // We need to check for deprecated headers as well.
+    public static List<Arguments> connectionRelatedHeaders() {
+        List<Arguments> list = new ArrayList<Arguments>();
+
+        list.add(header(false, HttpHeaderNames.ACCEPT));
+        list.add(header(false, HttpHeaderNames.ACCEPT_CHARSET));
+        list.add(header(false, HttpHeaderNames.ACCEPT_ENCODING));
+        list.add(header(false, HttpHeaderNames.ACCEPT_LANGUAGE));
+        list.add(header(false, HttpHeaderNames.ACCEPT_RANGES));
+        list.add(header(false, HttpHeaderNames.ACCEPT_PATCH));
+        list.add(header(false, HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS));
+        list.add(header(false, HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS));
+        list.add(header(false, HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS));
+        list.add(header(false, HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN));
+        list.add(header(false, HttpHeaderNames.ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK));
+        list.add(header(false, HttpHeaderNames.ACCESS_CONTROL_EXPOSE_HEADERS));
+        list.add(header(false, HttpHeaderNames.ACCESS_CONTROL_MAX_AGE));
+        list.add(header(false, HttpHeaderNames.ACCESS_CONTROL_REQUEST_HEADERS));
+        list.add(header(false, HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD));
+        list.add(header(false, HttpHeaderNames.ACCESS_CONTROL_REQUEST_PRIVATE_NETWORK));
+        list.add(header(false, HttpHeaderNames.AGE));
+        list.add(header(false, HttpHeaderNames.ALLOW));
+        list.add(header(false, HttpHeaderNames.AUTHORIZATION));
+        list.add(header(false, HttpHeaderNames.CACHE_CONTROL));
+        list.add(header(true, HttpHeaderNames.CONNECTION));
+        list.add(header(false, HttpHeaderNames.CONTENT_BASE));
+        list.add(header(false, HttpHeaderNames.CONTENT_ENCODING));
+        list.add(header(false, HttpHeaderNames.CONTENT_LANGUAGE));
+        list.add(header(false, HttpHeaderNames.CONTENT_LENGTH));
+        list.add(header(false, HttpHeaderNames.CONTENT_LOCATION));
+        list.add(header(false, HttpHeaderNames.CONTENT_TRANSFER_ENCODING));
+        list.add(header(false, HttpHeaderNames.CONTENT_DISPOSITION));
+        list.add(header(false, HttpHeaderNames.CONTENT_MD5));
+        list.add(header(false, HttpHeaderNames.CONTENT_RANGE));
+        list.add(header(false, HttpHeaderNames.CONTENT_SECURITY_POLICY));
+        list.add(header(false, HttpHeaderNames.CONTENT_TYPE));
+        list.add(header(false, HttpHeaderNames.COOKIE));
+        list.add(header(false, HttpHeaderNames.DATE));
+        list.add(header(false, HttpHeaderNames.DNT));
+        list.add(header(false, HttpHeaderNames.ETAG));
+        list.add(header(false, HttpHeaderNames.EXPECT));
+        list.add(header(false, HttpHeaderNames.EXPIRES));
+        list.add(header(false, HttpHeaderNames.FROM));
+        list.add(header(false, HttpHeaderNames.HOST));
+        list.add(header(false, HttpHeaderNames.IF_MATCH));
+        list.add(header(false, HttpHeaderNames.IF_MODIFIED_SINCE));
+        list.add(header(false, HttpHeaderNames.IF_NONE_MATCH));
+        list.add(header(false, HttpHeaderNames.IF_RANGE));
+        list.add(header(false, HttpHeaderNames.IF_UNMODIFIED_SINCE));
+        list.add(header(true, HttpHeaderNames.KEEP_ALIVE));
+        list.add(header(false, HttpHeaderNames.LAST_MODIFIED));
+        list.add(header(false, HttpHeaderNames.LOCATION));
+        list.add(header(false, HttpHeaderNames.MAX_FORWARDS));
+        list.add(header(false, HttpHeaderNames.ORIGIN));
+        list.add(header(false, HttpHeaderNames.PRAGMA));
+        list.add(header(false, HttpHeaderNames.PROXY_AUTHENTICATE));
+        list.add(header(false, HttpHeaderNames.PROXY_AUTHORIZATION));
+        list.add(header(true, HttpHeaderNames.PROXY_CONNECTION));
+        list.add(header(false, HttpHeaderNames.RANGE));
+        list.add(header(false, HttpHeaderNames.REFERER));
+        list.add(header(false, HttpHeaderNames.RETRY_AFTER));
+        list.add(header(false, HttpHeaderNames.SEC_WEBSOCKET_KEY1));
+        list.add(header(false, HttpHeaderNames.SEC_WEBSOCKET_KEY2));
+        list.add(header(false, HttpHeaderNames.SEC_WEBSOCKET_LOCATION));
+        list.add(header(false, HttpHeaderNames.SEC_WEBSOCKET_ORIGIN));
+        list.add(header(false, HttpHeaderNames.SEC_WEBSOCKET_PROTOCOL));
+        list.add(header(false, HttpHeaderNames.SEC_WEBSOCKET_VERSION));
+        list.add(header(false, HttpHeaderNames.SEC_WEBSOCKET_KEY));
+        list.add(header(false, HttpHeaderNames.SEC_WEBSOCKET_ACCEPT));
+        list.add(header(false, HttpHeaderNames.SEC_WEBSOCKET_EXTENSIONS));
+        list.add(header(false, HttpHeaderNames.SERVER));
+        list.add(header(false, HttpHeaderNames.SET_COOKIE));
+        list.add(header(false, HttpHeaderNames.SET_COOKIE2));
+        list.add(header(true, HttpHeaderNames.TE));
+        list.add(header(false, HttpHeaderNames.TRAILER));
+        list.add(header(true, HttpHeaderNames.TRANSFER_ENCODING));
+        list.add(header(true, HttpHeaderNames.UPGRADE));
+        list.add(header(false, HttpHeaderNames.UPGRADE_INSECURE_REQUESTS));
+        list.add(header(false, HttpHeaderNames.USER_AGENT));
+        list.add(header(false, HttpHeaderNames.VARY));
+        list.add(header(false, HttpHeaderNames.VIA));
+        list.add(header(false, HttpHeaderNames.WARNING));
+        list.add(header(false, HttpHeaderNames.WEBSOCKET_LOCATION));
+        list.add(header(false, HttpHeaderNames.WEBSOCKET_ORIGIN));
+        list.add(header(false, HttpHeaderNames.WEBSOCKET_PROTOCOL));
+        list.add(header(false, HttpHeaderNames.WWW_AUTHENTICATE));
+        list.add(header(false, HttpHeaderNames.X_FRAME_OPTIONS));
+        list.add(header(false, HttpHeaderNames.X_REQUESTED_WITH));
+
+        return list;
+    }
+
+    private static Arguments header(final boolean isConnectionRelated, final AsciiString headerName) {
+        return new Arguments() {
+            @Override
+            public Object[] get() {
+                return new Object[]{headerName, isConnectionRelated};
+            }
+        };
+    }
+
+    @ParameterizedTest
+    @MethodSource("connectionRelatedHeaders")
+    void mustIdentifyConnectionRelatedHeadersAsciiString(AsciiString headerName, boolean isConnectionRelated) {
+        assertEquals(isConnectionRelated, HttpHeaderValidationUtil.isConnectionHeader(headerName, false));
+    }
+
+    @ParameterizedTest
+    @MethodSource("connectionRelatedHeaders")
+    void mustIdentifyConnectionRelatedHeadersString(AsciiString headerName, boolean isConnectionRelated) {
+        assertEquals(isConnectionRelated, HttpHeaderValidationUtil.isConnectionHeader(headerName.toString(), false));
+    }
+
+    @Test
+    void teHeaderIsNotConnectionRelatedWhenIgnoredAsciiString() {
+        assertFalse(HttpHeaderValidationUtil.isConnectionHeader(HttpHeaderNames.TE, true));
+    }
+
+    @Test
+    void teHeaderIsNotConnectionRelatedWhenIgnoredString() {
+        assertFalse(HttpHeaderValidationUtil.isConnectionHeader(HttpHeaderNames.TE.toString(), true));
+    }
+
+    public static List<Arguments> teIsTrailersTruthTable() {
+        List<Arguments> list = new ArrayList<Arguments>();
+
+        list.add(teIsTrailter(HttpHeaderNames.TE, HttpHeaderValues.TRAILERS, false));
+        list.add(teIsTrailter(HttpHeaderNames.TE, HttpHeaderValues.CHUNKED, true));
+        list.add(teIsTrailter(HttpHeaderNames.COOKIE, HttpHeaderValues.CHUNKED, false));
+        list.add(teIsTrailter(HttpHeaderNames.COOKIE, HttpHeaderValues.TRAILERS, false));
+        list.add(teIsTrailter(HttpHeaderNames.TRAILER, HttpHeaderValues.TRAILERS, false));
+        list.add(teIsTrailter(HttpHeaderNames.TRAILER, HttpHeaderValues.CHUNKED, false));
+
+        return list;
+    }
+
+    private static Arguments teIsTrailter(
+            final AsciiString headerName, final AsciiString headerValue, final boolean result) {
+        return new Arguments() {
+            @Override
+            public Object[] get() {
+                return new Object[]{headerName, headerValue, result};
+            }
+        };
+    }
+
+    @ParameterizedTest
+    @MethodSource("teIsTrailersTruthTable")
+    void whenTeIsNotTrailerOrNotWithNameAndValueAsciiString(
+            AsciiString headerName, AsciiString headerValue, boolean result) {
+        assertEquals(result, HttpHeaderValidationUtil.isTeNotTrailers(headerName, headerValue));
+    }
+
+    @ParameterizedTest
+    @MethodSource("teIsTrailersTruthTable")
+    void whenTeIsNotTrailerOrNotSWithNameAndValueString(
+            AsciiString headerName, AsciiString headerValue, boolean result) {
+        assertEquals(result, HttpHeaderValidationUtil.isTeNotTrailers(headerName.toString(), headerValue.toString()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("teIsTrailersTruthTable")
+    void whenTeIsNotTrailerOrNotSWithNameAsciiStringAndValueString(
+            AsciiString headerName, AsciiString headerValue, boolean result) {
+        assertEquals(result, HttpHeaderValidationUtil.isTeNotTrailers(headerName, headerValue.toString()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("teIsTrailersTruthTable")
+    void whenTeIsNotTrailerOrNotSWithNametringAndValueAsciiString(
+            AsciiString headerName, AsciiString headerValue, boolean result) {
+        assertEquals(result, HttpHeaderValidationUtil.isTeNotTrailers(headerName.toString(), headerValue));
+    }
+
+    public static List<AsciiString> illegalFirstChar() {
+        List<AsciiString> list = new ArrayList<AsciiString>();
+
+        for (byte i = 0; i < 0x21; i++) {
+            list.add(new AsciiString(new byte[]{i, 'a'}));
+        }
+        list.add(new AsciiString(new byte[]{0x7F, 'a'}));
+
+        return list;
+    }
+
+    @ParameterizedTest
+    @MethodSource("illegalFirstChar")
+    void decodingInvalidHeaderValuesMustFailIfFirstCharIsIllegalAsciiString(AsciiString value) {
+        assertEquals(0, validateValidHeaderValue(value));
+    }
+
+    @ParameterizedTest
+    @MethodSource("illegalFirstChar")
+    void decodingInvalidHeaderValuesMustFailIfFirstCharIsIllegalCharSequence(AsciiString value) {
+        assertEquals(0, validateValidHeaderValue(asCharSequence(value)));
+    }
+
+    public static List<AsciiString> legalFirstChar() {
+        List<AsciiString> list = new ArrayList<AsciiString>();
+
+        for (int i = 0x21; i <= 0xFF; i++) {
+            if (i == 0x7F) {
+                continue;
+            }
+            list.add(new AsciiString(new byte[]{(byte) i, 'a'}));
+        }
+
+        return list;
+    }
+
+    @ParameterizedTest
+    @MethodSource("legalFirstChar")
+    void allOtherCharsAreLegalFirstCharsAsciiString(AsciiString value) {
+        assertEquals(-1, validateValidHeaderValue(value));
+    }
+
+    @ParameterizedTest
+    @MethodSource("legalFirstChar")
+    void allOtherCharsAreLegalFirstCharsCharSequence(AsciiString value) {
+        assertEquals(-1, validateValidHeaderValue(value));
+    }
+
+    public static List<AsciiString> illegalNotFirstChar() {
+        ArrayList<AsciiString> list = new ArrayList<AsciiString>();
+
+        for (byte i = 0; i < 0x21; i++) {
+            if (i == ' ' || i == '\t') {
+                continue; // Space and horizontal tab are only illegal as first chars.
+            }
+            list.add(new AsciiString(new byte[]{'a', i}));
+        }
+        list.add(new AsciiString(new byte[]{'a', 0x7F}));
+
+        return list;
+    }
+
+    @ParameterizedTest
+    @MethodSource("illegalNotFirstChar")
+    void decodingInvalidHeaderValuesMustFailIfNotFirstCharIsIllegalAsciiString(AsciiString value) {
+        assertEquals(1, validateValidHeaderValue(value));
+    }
+
+    @ParameterizedTest
+    @MethodSource("illegalNotFirstChar")
+    void decodingInvalidHeaderValuesMustFailIfNotFirstCharIsIllegalCharSequence(AsciiString value) {
+        assertEquals(1, validateValidHeaderValue(asCharSequence(value)));
+    }
+
+    public static List<AsciiString> legalNotFirstChar() {
+        List<AsciiString> list = new ArrayList<AsciiString>();
+
+        for (int i = 0; i < 0xFF; i++) {
+            if (i == 0x7F || i < 0x21 && (i != ' ' || i != '\t')) {
+                continue;
+            }
+            list.add(new AsciiString(new byte[] {'a', (byte) i}));
+        }
+
+        return list;
+    }
+
+    @ParameterizedTest
+    @MethodSource("legalNotFirstChar")
+    void allOtherCharsArgLegalNotFirstCharsAsciiString(AsciiString value) {
+        assertEquals(-1, validateValidHeaderValue(value));
+    }
+
+    @ParameterizedTest
+    @MethodSource("legalNotFirstChar")
+    void allOtherCharsArgLegalNotFirstCharsCharSequence(AsciiString value) {
+        assertEquals(-1, validateValidHeaderValue(asCharSequence(value)));
+    }
+
+    @Test
+    void emptyValuesHaveNoIllegalCharsAsciiString() {
+        assertEquals(-1, validateValidHeaderValue(AsciiString.EMPTY_STRING));
+    }
+
+    @Test
+    void emptyValuesHaveNoIllegalCharsCharSequence() {
+        assertEquals(-1, validateValidHeaderValue(asCharSequence(AsciiString.EMPTY_STRING)));
+    }
+
+    @Test
+    void headerValuesCannotEndWithNewlinesAsciiString() {
+        assertEquals(1, validateValidHeaderValue(AsciiString.of("a\n")));
+        assertEquals(1, validateValidHeaderValue(AsciiString.of("a\r")));
+    }
+
+    @Test
+    void headerValuesCannotEndWithNewlinesCharSequence() {
+        assertEquals(1, validateValidHeaderValue("a\n"));
+        assertEquals(1, validateValidHeaderValue("a\r"));
+    }
+
+    /**
+     * This method returns a {@link CharSequence} instance that has the same contents as the given {@link AsciiString},
+     * but which is, critically, <em>not</em> itself an {@link AsciiString}.
+     * <p>
+     * Some methods specialise on {@link AsciiString}, while having a {@link CharSequence} based fallback.
+     * <p>
+     * This method exist to test those fallback methods.
+     *
+     * @param value The {@link AsciiString} instance to wrap.
+     * @return A new {@link CharSequence} instance which backed by the given {@link AsciiString},
+     * but which is itself not an {@link AsciiString}.
+     */
+    private static CharSequence asCharSequence(final AsciiString value) {
+        return new CharSequence() {
+            @Override
+            public int length() {
+                return value.length();
+            }
+
+            @Override
+            public char charAt(int index) {
+                return value.charAt(index);
+            }
+
+            @Override
+            public CharSequence subSequence(int start, int end) {
+                return asCharSequence(value.subSequence(start, end));
+            }
+        };
+    }
+
+    private static final IllegalArgumentException VALIDATION_EXCEPTION = new IllegalArgumentException() {
+        private static final long serialVersionUID = -8857428534361331089L;
+
+        @Override
+        public synchronized Throwable fillInStackTrace() {
+            return this;
+        }
+    };
+
+    @DisabledForJreRange(max = JRE.JAVA_17) // This test is much too slow on older Java versions.
+    @Test
+    void headerValueValidationMustRejectAllValuesRejectedByOldAlgorithm() {
+        byte[] array = new byte[4];
+        final ByteBuffer buffer = ByteBuffer.wrap(array);
+        final AsciiString asciiString = new AsciiString(buffer, false);
+        CharSequence charSequence = asCharSequence(asciiString);
+        int i = Integer.MIN_VALUE;
+        Supplier<String> failureMessageSupplier = new Supplier<String>() {
+            @Override
+            public String get() {
+                return "validation mismatch on string '" + asciiString + "', iteration " + buffer.getInt(0);
+            }
+        };
+
+        do {
+            buffer.putInt(0, i);
+            try {
+                oldHeaderValueValidationAlgorithm(asciiString);
+            } catch (IllegalArgumentException ignore) {
+                assertNotEquals(-1, validateValidHeaderValue(asciiString), failureMessageSupplier);
+                assertNotEquals(-1, validateValidHeaderValue(charSequence), failureMessageSupplier);
+            }
+            i++;
+        } while (i != Integer.MIN_VALUE);
+    }
+
+    private static void oldHeaderValueValidationAlgorithm(CharSequence seq) {
+        int state = 0;
+        // Start looping through each of the character
+        for (int index = 0; index < seq.length(); index++) {
+            state = oldValidationAlgorithmValidateValueChar(state, seq.charAt(index));
+        }
+
+        if (state != 0) {
+            throw VALIDATION_EXCEPTION;
+        }
+    }
+
+    private static int oldValidationAlgorithmValidateValueChar(int state, char character) {
+        /*
+         * State:
+         * 0: Previous character was neither CR nor LF
+         * 1: The previous character was CR
+         * 2: The previous character was LF
+         */
+        if ((character & ~15) == 0) {
+            // Check the absolutely prohibited characters.
+            switch (character) {
+                case 0x0: // NULL
+                    throw VALIDATION_EXCEPTION;
+                case 0x0b: // Vertical tab
+                    throw VALIDATION_EXCEPTION;
+                case '\f':
+                    throw VALIDATION_EXCEPTION;
+                default:
+                    break;
+            }
+        }
+
+        // Check the CRLF (HT | SP) pattern
+        switch (state) {
+            case 0:
+                switch (character) {
+                    case '\r':
+                        return 1;
+                    case '\n':
+                        return 2;
+                    default:
+                        break;
+                }
+                break;
+            case 1:
+                if (character == '\n') {
+                    return 2;
+                }
+                throw VALIDATION_EXCEPTION;
+            case 2:
+                switch (character) {
+                    case '\t':
+                    case ' ':
+                        return 0;
+                    default:
+                        throw VALIDATION_EXCEPTION;
+                }
+            default:
+                break;
+        }
+        return state;
+    }
+
+    @DisabledForJreRange(max = JRE.JAVA_17) // This test is much too slow on older Java versions.
+    @Test
+    void headerNameValidationMustRejectAllNamesRejectedByOldAlgorithm() throws Exception {
+        byte[] array = new byte[4];
+        final ByteBuffer buffer = ByteBuffer.wrap(array);
+        final AsciiString asciiString = new AsciiString(buffer, false);
+        CharSequence charSequence = asCharSequence(asciiString);
+        int i = Integer.MIN_VALUE;
+        Supplier<String> failureMessageSupplier = new Supplier<String>() {
+            @Override
+            public String get() {
+                return "validation mismatch on string '" + asciiString + "', iteration " + buffer.getInt(0);
+            }
+        };
+
+        do {
+            buffer.putInt(0, i);
+            try {
+                oldHeaderNameValidationAlgorithmAsciiString(asciiString);
+            } catch (IllegalArgumentException ignore) {
+                assertNotEquals(-1, validateToken(asciiString), failureMessageSupplier);
+                assertNotEquals(-1, validateToken(charSequence), failureMessageSupplier);
+            }
+            i++;
+        } while (i != Integer.MIN_VALUE);
+    }
+
+    private static void oldHeaderNameValidationAlgorithmAsciiString(AsciiString name) throws Exception {
+        byte[] array = name.array();
+        for (int i = name.arrayOffset(), len = name.arrayOffset() + name.length(); i < len; i++) {
+            validateHeaderNameElement(array[i]);
+        }
+    }
+
+    private static void validateHeaderNameElement(byte value) {
+        switch (value) {
+            case 0x1c:
+            case 0x1d:
+            case 0x1e:
+            case 0x1f:
+            case 0x00:
+            case '\t':
+            case '\n':
+            case 0x0b:
+            case '\f':
+            case '\r':
+            case ' ':
+            case ',':
+            case ':':
+            case ';':
+            case '=':
+                throw VALIDATION_EXCEPTION;
+            default:
+                // Check to see if the character is not an ASCII character, or invalid
+                if (value < 0) {
+                    throw VALIDATION_EXCEPTION;
+                }
+        }
+    }
+
+    public static List<Character> validTokenChars() {
+        List<Character> list = new ArrayList<Character>();
+        for (char c = '0'; c <= '9'; c++) {
+            list.add(c);
+        }
+        for (char c = 'a'; c <= 'z'; c++) {
+            list.add(c);
+        }
+        for (char c = 'A'; c <= 'Z'; c++) {
+            list.add(c);
+        }
+
+        // Unreserved characters:
+        list.add('-');
+        list.add('.');
+        list.add('_');
+        list.add('~');
+
+        // Token special characters:
+        list.add('!');
+        list.add('#');
+        list.add('$');
+        list.add('%');
+        list.add('&');
+        list.add('\'');
+        list.add('*');
+        list.add('+');
+        list.add('^');
+        list.add('`');
+        list.add('|');
+
+        return list;
+    }
+
+    @ParameterizedTest
+    @MethodSource("validTokenChars")
+    void allTokenCharsAreValidFirstCharHeaderName(char tokenChar) {
+        AsciiString asciiString = new AsciiString(new byte[] {(byte) tokenChar, 'a'});
+        CharSequence charSequence = asCharSequence(asciiString);
+        String string = tokenChar + "a";
+
+        assertEquals(-1, validateToken(asciiString));
+        assertEquals(-1, validateToken(charSequence));
+        assertEquals(-1, validateToken(string));
+    }
+
+    @ParameterizedTest
+    @MethodSource("validTokenChars")
+    void allTokenCharsAreValidSecondCharHeaderName(char tokenChar) {
+        AsciiString asciiString = new AsciiString(new byte[] {'a', (byte) tokenChar});
+        CharSequence charSequence = asCharSequence(asciiString);
+        String string = "a" + tokenChar;
+
+        assertEquals(-1, validateToken(asciiString));
+        assertEquals(-1, validateToken(charSequence));
+        assertEquals(-1, validateToken(string));
+    }
+}

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
@@ -16,6 +16,7 @@ package io.netty.handler.codec.http2;
 
 import io.netty.handler.codec.CharSequenceValueConverter;
 import io.netty.handler.codec.DefaultHeaders;
+import io.netty.handler.codec.http.HttpHeaderValidationUtil;
 import io.netty.util.AsciiString;
 import io.netty.util.ByteProcessor;
 import io.netty.util.internal.PlatformDependent;
@@ -23,6 +24,7 @@ import io.netty.util.internal.UnstableApi;
 
 import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
 import static io.netty.handler.codec.http2.Http2Exception.connectionError;
+import static io.netty.handler.codec.http2.Http2Headers.PseudoHeaderName.getPseudoHeader;
 import static io.netty.handler.codec.http2.Http2Headers.PseudoHeaderName.hasPseudoHeaderFormat;
 import static io.netty.util.AsciiString.CASE_INSENSITIVE_HASHER;
 import static io.netty.util.AsciiString.CASE_SENSITIVE_HASHER;
@@ -44,6 +46,7 @@ public class DefaultHttp2Headers
                 PlatformDependent.throwException(connectionError(PROTOCOL_ERROR,
                         "empty headers are not allowed [%s]", name));
             }
+
             if (name instanceof AsciiString) {
                 final int index;
                 try {
@@ -68,6 +71,28 @@ public class DefaultHttp2Headers
                                 "invalid header name [%s]", name));
                     }
                 }
+            }
+
+            if (hasPseudoHeaderFormat(name)) {
+                final Http2Headers.PseudoHeaderName pseudoHeader = getPseudoHeader(name);
+                if (pseudoHeader == null) {
+                    PlatformDependent.throwException(connectionError(
+                            PROTOCOL_ERROR, "Invalid HTTP/2 pseudo-header '%s' encountered.", name));
+                }
+            } else if (HttpHeaderValidationUtil.isConnectionHeader(name, true)) {
+                PlatformDependent.throwException(connectionError(
+                        PROTOCOL_ERROR, "Illegal connection-specific header '%s' encountered.", name));
+            }
+        }
+    };
+
+    private static final ValueValidator<CharSequence> VALUE_VALIDATOR = new ValueValidator<CharSequence>() {
+        @Override
+        public void validate(CharSequence value) {
+            int index = HttpHeaderValidationUtil.validateValidHeaderValue(value);
+            if (index != -1) {
+                throw new IllegalArgumentException("a header value contains prohibited character 0x" +
+                        Integer.toHexString(value.charAt(index)) + " at index " + index + '.');
             }
         }
     };
@@ -113,6 +138,46 @@ public class DefaultHttp2Headers
               CharSequenceValueConverter.INSTANCE,
               validate ? HTTP2_NAME_VALIDATOR : NameValidator.NOT_NULL,
               arraySizeHint);
+    }
+
+    /**
+     * Create a new instance.
+     * @param validate {@code true} to validate header names according to
+     * <a href="https://tools.ietf.org/html/rfc7540">rfc7540</a>. {@code false} to not validate header names.
+     * @param arraySizeHint A hint as to how large the hash data structure should be.
+     * The next positive power of two will be used. An upper bound may be enforced.
+     */
+    @SuppressWarnings("unchecked")
+    public DefaultHttp2Headers(boolean validate, boolean validateValues, int arraySizeHint) {
+        // Case sensitive compare is used because it is cheaper, and header validation can be used to catch invalid
+        // headers.
+        super(CASE_SENSITIVE_HASHER,
+                CharSequenceValueConverter.INSTANCE,
+                validate ? HTTP2_NAME_VALIDATOR : NameValidator.NOT_NULL,
+                arraySizeHint,
+                validateValues ? VALUE_VALIDATOR : (ValueValidator<CharSequence>) ValueValidator.NO_VALIDATION);
+    }
+
+    @Override
+    protected void validateName(NameValidator<CharSequence> validator, boolean forAdd, CharSequence name) {
+        super.validateName(validator, forAdd, name);
+        if (nameValidator() == HTTP2_NAME_VALIDATOR && forAdd && hasPseudoHeaderFormat(name)) {
+            if (contains(name)) {
+                PlatformDependent.throwException(connectionError(
+                        PROTOCOL_ERROR, "Duplicate HTTP/2 pseudo-header '%s' encountered.", name));
+            }
+        }
+    }
+
+    @Override
+    protected void validateValue(ValueValidator<CharSequence> validator, CharSequence name, CharSequence value) {
+        if (nameValidator() == HTTP2_NAME_VALIDATOR) {
+            if (HttpHeaderValidationUtil.isTeNotTrailers(name, value)) {
+                PlatformDependent.throwException(connectionError(PROTOCOL_ERROR,
+                        "Illegal value specified for the 'TE' header (only 'trailers' is allowed)."));
+            }
+        }
+        super.validateValue(validator, name, value);
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
@@ -129,6 +129,7 @@ public class DefaultHttp2Headers
      * <a href="https://tools.ietf.org/html/rfc7540">rfc7540</a>. {@code false} to not validate header names.
      * @param arraySizeHint A hint as to how large the hash data structure should be.
      * The next positive power of two will be used. An upper bound may be enforced.
+     * @see DefaultHttp2Headers#DefaultHttp2Headers(boolean, boolean, int)
      */
     @SuppressWarnings("unchecked")
     public DefaultHttp2Headers(boolean validate, int arraySizeHint) {
@@ -144,6 +145,10 @@ public class DefaultHttp2Headers
      * Create a new instance.
      * @param validate {@code true} to validate header names according to
      * <a href="https://tools.ietf.org/html/rfc7540">rfc7540</a>. {@code false} to not validate header names.
+     * @param validateValues {@code true} to validate header values according to
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7230#section-3.2">rfc7230</a> and
+     * <a href="https://datatracker.ietf.org/doc/html/rfc5234#appendix-B.1">rfc5234</a>. Otherwise, {@code false}
+     * (the default) to not validate values.
      * @param arraySizeHint A hint as to how large the hash data structure should be.
      * The next positive power of two will be used. An upper bound may be enforced.
      */

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoder.java
@@ -189,7 +189,7 @@ public class DefaultHttp2HeadersDecoder implements Http2HeadersDecoder, Http2Hea
      * {@linkplain #validateHeaders() headers}.
      * @return {@code true} if the header values should be validated as a result of the decode operation.
      */
-    protected final boolean validateHeaderValues() {
+    protected boolean validateHeaderValues() { // Not 'final' due to backwards compatibility.
         return validateHeaderValues;
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoder.java
@@ -107,7 +107,7 @@ public class DefaultHttp2HeadersDecoder implements Http2HeadersDecoder, Http2Hea
     }
 
     /**
-     * Exposed Used for testing only! Default values used in the initial settings frame are overridden intentionally
+     * Exposed for testing only! Default values used in the initial settings frame are overridden intentionally
      * for testing but violate the RFC if used outside the scope of testing.
      */
     DefaultHttp2HeadersDecoder(boolean validateHeaders, boolean validateHeaderValues, HpackDecoder hpackDecoder) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoder.java
@@ -157,7 +157,7 @@ public class DefaultHttp2HeadersDecoder implements Http2HeadersDecoder, Http2Hea
     public Http2Headers decodeHeaders(int streamId, ByteBuf headerBlock) throws Http2Exception {
         try {
             final Http2Headers headers = newHeaders();
-            hpackDecoder.decode(streamId, headerBlock, headers, validateHeaders, validateHeaderValues);
+            hpackDecoder.decode(streamId, headerBlock, headers, validateHeaders);
             headerArraySizeAccumulator = HEADERS_COUNT_WEIGHT_NEW * headers.size() +
                                          HEADERS_COUNT_WEIGHT_HISTORICAL * headerArraySizeAccumulator;
             return headers;
@@ -208,6 +208,6 @@ public class DefaultHttp2HeadersDecoder implements Http2HeadersDecoder, Http2Hea
      * @return a new {@link Http2Headers} object which will store the results of the decode operation.
      */
     protected Http2Headers newHeaders() {
-        return new DefaultHttp2Headers(validateHeaders, (int) headerArraySizeAccumulator);
+        return new DefaultHttp2Headers(validateHeaders, validateHeaderValues, (int) headerArraySizeAccumulator);
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoder.java
@@ -55,9 +55,10 @@ public class DefaultHttp2HeadersDecoder implements Http2HeadersDecoder, Http2Hea
     /**
      * Create a new instance.
      *
-     * @param validateHeaders      {@code true} to validate headers are valid according to the RFC.
-     * @param validateHeaderValues {@code true} to additionally validate that header values are valid according to the
-     *                             RFC. This has no effect if {@code validateHeaders} is {@code false}.
+     * @param validateHeaders {@code true} to validate headers are valid according to the RFC.
+     * This validates everything except header values.
+     * @param validateHeaderValues {@code true} to validate that header <em>values</em> are valid according to the RFC.
+     * Since this is potentially expensive, it can be enabled separately from {@code validateHeaders}.
      */
     public DefaultHttp2HeadersDecoder(boolean validateHeaders, boolean validateHeaderValues) {
         this(validateHeaders, validateHeaderValues, DEFAULT_HEADER_LIST_SIZE);
@@ -78,8 +79,9 @@ public class DefaultHttp2HeadersDecoder implements Http2HeadersDecoder, Http2Hea
     /**
      * Create a new instance.
      * @param validateHeaders {@code true} to validate headers are valid according to the RFC.
-     * @param validateHeaderValues {@code true} to additionally validate that header values are valid according to the
-     *                                        RFC. This has no effect if {@code validateHeaders} is {@code false}.
+     * This validates everything except header values.
+     * @param validateHeaderValues {@code true} to validate that header <em>values</em> are valid according to the RFC.
+     * Since this is potentially expensive, it can be enabled separately from {@code validateHeaders}.
      * @param maxHeaderListSize This is the only setting that can be configured before notifying the peer.
      *  This is because <a href="https://tools.ietf.org/html/rfc7540#section-6.5.1">SETTINGS_MAX_HEADER_LIST_SIZE</a>
      *  allows a lower than advertised limit from being enforced, and the default limit is unlimited
@@ -92,6 +94,7 @@ public class DefaultHttp2HeadersDecoder implements Http2HeadersDecoder, Http2Hea
     /**
      * Create a new instance.
      * @param validateHeaders {@code true} to validate headers are valid according to the RFC.
+     * This validates everything except header values.
      * @param maxHeaderListSize This is the only setting that can be configured before notifying the peer.
      *  This is because <a href="https://tools.ietf.org/html/rfc7540#section-6.5.1">SETTINGS_MAX_HEADER_LIST_SIZE</a>
      *  allows a lower than advertised limit from being enforced, and the default limit is unlimited
@@ -178,6 +181,10 @@ public class DefaultHttp2HeadersDecoder implements Http2HeadersDecoder, Http2Hea
 
     /**
      * Determines if the headers should be validated as a result of the decode operation.
+     * <p>
+     * <strong>Note:</strong> This does not include validation of header <em>values</em>, since that is potentially
+     * expensive to do. Value validation is instead {@linkplain #validateHeaderValues() enabled separately}.
+     *
      * @return {@code true} if the headers should be validated as a result of the decode operation.
      */
     protected final boolean validateHeaders() {
@@ -185,8 +192,11 @@ public class DefaultHttp2HeadersDecoder implements Http2HeadersDecoder, Http2Hea
     }
 
     /**
-     * Determines if the header values should be validated as a result of the decode operation, in addition to the
-     * {@linkplain #validateHeaders() headers}.
+     * Determines if the header values should be validated as a result of the decode operation.
+     * <p>
+     * <strong>Note:</strong> This <em>only</em> validates the values of headers. All other header validations are
+     * instead {@linkplain #validateHeaders() enabled separately}.
+     *
      * @return {@code true} if the header values should be validated as a result of the decode operation.
      */
     protected boolean validateHeaderValues() { // Not 'final' due to backwards compatibility.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackDecoder.java
@@ -432,24 +432,18 @@ final class HpackDecoder {
         // - proxy-connection (16 chars)
         // - transfer-encoding (17 chars)
         //
+        // See https://datatracker.ietf.org/doc/html/rfc9113#section-8.2.2
+        // and https://datatracker.ietf.org/doc/html/rfc9110#section-7.6.1
+        // for the list of connection related headers.
+        //
         // We scan for these based on the length, then double-check any matching name.
         int len = name.length();
-        if (len < 7 || len > 25) {
-            return false;
-        }
-        if (len <= 10) {
-            if (len == 7 && contentEqualsIgnoreCase(name, HttpHeaderNames.UPGRADE)) {
-                return true;
-            }
-            return len == 10 && (contentEqualsIgnoreCase(name, HttpHeaderNames.CONNECTION) ||
-                    contentEqualsIgnoreCase(name, HttpHeaderNames.KEEP_ALIVE));
-        }
-        if (len == 17) {
-            // Transfer-Encoding is more common, so check it first.
-            return contentEqualsIgnoreCase(name, HttpHeaderNames.TRANSFER_ENCODING);
-        }
-        if (len == 16) {
-            return contentEqualsIgnoreCase(name, HttpHeaderNames.PROXY_CONNECTION);
+        switch (len) {
+            case 7: return contentEqualsIgnoreCase(name, HttpHeaderNames.UPGRADE);
+            case 10: return contentEqualsIgnoreCase(name, HttpHeaderNames.CONNECTION) ||
+                    contentEqualsIgnoreCase(name, HttpHeaderNames.KEEP_ALIVE);
+            case 16: return contentEqualsIgnoreCase(name, HttpHeaderNames.PROXY_CONNECTION);
+            case 17: return contentEqualsIgnoreCase(name, HttpHeaderNames.TRANSFER_ENCODING);
         }
         return false;
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackDecoder.java
@@ -442,8 +442,9 @@ final class HpackDecoder {
                     contentEqualsIgnoreCase(name, HttpHeaderNames.KEEP_ALIVE);
             case 16: return contentEqualsIgnoreCase(name, HttpHeaderNames.PROXY_CONNECTION);
             case 17: return contentEqualsIgnoreCase(name, HttpHeaderNames.TRANSFER_ENCODING);
+            default:
+                return false;
         }
-        return false;
     }
 
     private static boolean contains(Http2Headers headers, AsciiString name) {
@@ -666,11 +667,11 @@ final class HpackDecoder {
             }
 
             try {
-                if (validateHeaders) {
-                    previousType = validateHeader(streamId, name, previousType, headers, value);
-                }
                 if (validateHeaderValues) {
                     validateValidHeaderValue(streamId, name, value);
+                }
+                if (validateHeaders) {
+                    previousType = validateHeader(streamId, name, previousType, headers, value);
                 }
                 headers.add(name, value);
             } catch (Http2Exception ex) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackDecoder.java
@@ -499,13 +499,13 @@ final class HpackDecoder {
     private static boolean isValidHeaderValueAsciiString(AsciiString value) {
         final byte[] array = value.array();
         final int start = value.arrayOffset();
-        byte b = array[start];
+        int b = array[start] & 0xFF;
         if (b < 0x21 || b == 0x7F) {
             return false;
         }
         int length = value.length();
         for (int i = start + 1; i < length; i++) {
-            b = array[i];
+            b = array[i] & 0xFF;
             if (b < 0x20 && b != 0x09 || b == 0x7F) {
                 return false;
             }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackEncoder.java
@@ -107,7 +107,7 @@ final class HpackEncoder {
 
     /**
      * Encode the header field into the header block.
-     *
+     * <p>
      * <strong>The given {@link CharSequence}s must be immutable!</strong>
      */
     public void encodeHeaders(int streamId, ByteBuf out, Http2Headers headers, SensitivityDetector sensitivityDetector)
@@ -149,7 +149,7 @@ final class HpackEncoder {
 
     /**
      * Encode the header field into the header block.
-     *
+     * <p>
      * <strong>The given {@link CharSequence}s must be immutable!</strong>
      */
     private void encodeHeader(ByteBuf out, CharSequence name, CharSequence value, boolean sensitive, long headerSize) {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoderTest.java
@@ -151,7 +151,7 @@ public class DefaultHttp2HeadersDecoderTest {
 
     @Test
     public void decodingConnectionRelatedHeadersMustFailValidation() throws Exception {
-        final DefaultHttp2HeadersDecoder decoder = new DefaultHttp2HeadersDecoder(true);
+        final DefaultHttp2HeadersDecoder decoder = new DefaultHttp2HeadersDecoder(true, true);
         // Standard connection related headers
         verifyValidationFails(decoder, encode(b(":method"), b("GET"), b("keep-alive"), b("timeout=5")));
         verifyValidationFails(decoder, encode(b(":method"), b("GET"),
@@ -173,7 +173,7 @@ public class DefaultHttp2HeadersDecoderTest {
 
     @Test
     public void decodingInvalidHeaderValueMustFailValidation() throws Exception {
-        final DefaultHttp2HeadersDecoder decoder = new DefaultHttp2HeadersDecoder(true);
+        final DefaultHttp2HeadersDecoder decoder = new DefaultHttp2HeadersDecoder(true, true);
 
         for (int illegalFirstChar = 0; illegalFirstChar < 0x21; illegalFirstChar++) {
             verifyValidationFails(decoder, encode(b(":method"), b("GET"),

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoderTest.java
@@ -12,7 +12,6 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
@@ -138,7 +137,7 @@ public class DefaultHttp2HeadersDecoderTest {
     }
 
     @Test
-    void decodingTrailersTeHeaderMustNotFailValidation() throws Exception {
+    public void decodingTrailersTeHeaderMustNotFailValidation() throws Exception {
         // The TE header is expressly allowed to have the value "trailers".
         ByteBuf buf = null;
         try {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersTest.java
@@ -173,6 +173,23 @@ public class DefaultHttp2HeadersTest {
         assertFalse(headers.contains("2name", "Value3", false));
     }
 
+    @Test
+    void setMustOverwritePseudoHeaders() {
+        Http2Headers headers = newHeaders();
+        // The headers are already populated with pseudo headers.
+        headers.method(of("GET"));
+        headers.path(of("/index2.html"));
+        headers.status(of("101"));
+        headers.authority(of("github.com"));
+        headers.scheme(of("http"));
+        headers.set(of(":protocol"), of("http"));
+        assertEquals(of("GET"), headers.method());
+        assertEquals(of("/index2.html"), headers.path());
+        assertEquals(of("101"), headers.status());
+        assertEquals(of("github.com"), headers.authority());
+        assertEquals(of("http"), headers.scheme());
+    }
+
     private static void verifyAllPseudoHeadersPresent(Http2Headers headers) {
         for (PseudoHeaderName pseudoName : PseudoHeaderName.values()) {
             assertNotNull(headers.get(pseudoName.value()));

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackDecoderTest.java
@@ -52,7 +52,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockingDetails;
 import static org.mockito.Mockito.reset;
@@ -664,11 +663,11 @@ public class HpackDecoderTest {
         try {
             HpackEncoder hpackEncoder = new HpackEncoder(true);
 
-            Http2Headers toEncode = new DefaultHttp2Headers();
+            Http2Headers toEncode = new DefaultHttp2Headers(false);
             toEncode.add(":test", "1");
             hpackEncoder.encodeHeaders(1, in, toEncode, NEVER_SENSITIVE);
 
-            final Http2Headers decoded = new DefaultHttp2Headers();
+            final Http2Headers decoded = new DefaultHttp2Headers(true);
 
             assertThrows(Http2Exception.StreamException.class, new Executable() {
                 @Override
@@ -687,13 +686,13 @@ public class HpackDecoderTest {
         try {
             HpackEncoder hpackEncoder = new HpackEncoder(true);
 
-            Http2Headers toEncode = new DefaultHttp2Headers();
+            Http2Headers toEncode = new DefaultHttp2Headers(false);
             toEncode.add(":test", "1");
             toEncode.add(":status", "200");
             toEncode.add(":method", "GET");
             hpackEncoder.encodeHeaders(1, in, toEncode, NEVER_SENSITIVE);
 
-            Http2Headers decoded = new DefaultHttp2Headers();
+            Http2Headers decoded = new DefaultHttp2Headers(false);
 
             hpackDecoder.decode(1, in, decoded, false);
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackDynamicTableTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackDynamicTableTest.java
@@ -24,10 +24,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class HpackDynamicTableTest {
-    AsciiString foo = AsciiString.cached("foo");
-    AsciiString bar = AsciiString.cached("bar");
-    AsciiString hello = AsciiString.cached("hello");
-    AsciiString world = AsciiString.cached("world");
+    private final AsciiString foo = AsciiString.cached("foo");
+    private final AsciiString bar = AsciiString.cached("bar");
+    private final AsciiString hello = AsciiString.cached("hello");
+    private final AsciiString world = AsciiString.cached("world");
 
     @Test
     public void testLength() {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackDynamicTableTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackDynamicTableTest.java
@@ -15,6 +15,7 @@
 
 package io.netty.handler.codec.http2;
 
+import io.netty.util.AsciiString;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
@@ -23,12 +24,16 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class HpackDynamicTableTest {
+    AsciiString foo = AsciiString.cached("foo");
+    AsciiString bar = AsciiString.cached("bar");
+    AsciiString hello = AsciiString.cached("hello");
+    AsciiString world = AsciiString.cached("world");
 
     @Test
     public void testLength() {
         HpackDynamicTable table = new HpackDynamicTable(100);
         assertEquals(0, table.length());
-        HpackHeaderField entry = new HpackHeaderField("foo", "bar");
+        HpackHeaderField entry = new HpackHeaderField(foo, bar);
         table.add(entry);
         assertEquals(1, table.length());
         table.clear();
@@ -39,7 +44,7 @@ public class HpackDynamicTableTest {
     public void testSize() {
         HpackDynamicTable table = new HpackDynamicTable(100);
         assertEquals(0, table.size());
-        HpackHeaderField entry = new HpackHeaderField("foo", "bar");
+        HpackHeaderField entry = new HpackHeaderField(foo, bar);
         table.add(entry);
         assertEquals(entry.size(), table.size());
         table.clear();
@@ -49,7 +54,7 @@ public class HpackDynamicTableTest {
     @Test
     public void testGetEntry() {
         final HpackDynamicTable table = new HpackDynamicTable(100);
-        HpackHeaderField entry = new HpackHeaderField("foo", "bar");
+        HpackHeaderField entry = new HpackHeaderField(foo, bar);
         table.add(entry);
         assertEquals(entry, table.getEntry(1));
         table.clear();
@@ -77,8 +82,8 @@ public class HpackDynamicTableTest {
     public void testRemove() {
         HpackDynamicTable table = new HpackDynamicTable(100);
         assertNull(table.remove());
-        HpackHeaderField entry1 = new HpackHeaderField("foo", "bar");
-        HpackHeaderField entry2 = new HpackHeaderField("hello", "world");
+        HpackHeaderField entry1 = new HpackHeaderField(foo, bar);
+        HpackHeaderField entry2 = new HpackHeaderField(hello, world);
         table.add(entry1);
         table.add(entry2);
         assertEquals(entry1, table.remove());
@@ -89,8 +94,8 @@ public class HpackDynamicTableTest {
 
     @Test
     public void testSetCapacity() {
-        HpackHeaderField entry1 = new HpackHeaderField("foo", "bar");
-        HpackHeaderField entry2 = new HpackHeaderField("hello", "world");
+        HpackHeaderField entry1 = new HpackHeaderField(foo, bar);
+        HpackHeaderField entry2 = new HpackHeaderField(hello, world);
         final int size1 = entry1.size();
         final int size2 = entry2.size();
         HpackDynamicTable table = new HpackDynamicTable(size1 + size2);
@@ -115,8 +120,8 @@ public class HpackDynamicTableTest {
     public void testAdd() {
         HpackDynamicTable table = new HpackDynamicTable(100);
         assertEquals(0, table.size());
-        HpackHeaderField entry1 = new HpackHeaderField("foo", "bar"); //size:3+3+32=38
-        HpackHeaderField entry2 = new HpackHeaderField("hello", "world");
+        HpackHeaderField entry1 = new HpackHeaderField(foo, bar); //size:3+3+32=38
+        HpackHeaderField entry2 = new HpackHeaderField(hello, world);
         table.add(entry1); //success
         assertEquals(entry1.size(), table.size());
         table.setCapacity(32); //entry1 is removed from table

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackDynamicTableTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackDynamicTableTest.java
@@ -24,16 +24,16 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class HpackDynamicTableTest {
-    private final AsciiString foo = AsciiString.cached("foo");
-    private final AsciiString bar = AsciiString.cached("bar");
-    private final AsciiString hello = AsciiString.cached("hello");
-    private final AsciiString world = AsciiString.cached("world");
+    private static final AsciiString FOO = AsciiString.cached("foo");
+    private static final AsciiString BAR = AsciiString.cached("bar");
+    private static final AsciiString HELLO = AsciiString.cached("hello");
+    private static final AsciiString WORLD = AsciiString.cached("world");
 
     @Test
     public void testLength() {
         HpackDynamicTable table = new HpackDynamicTable(100);
         assertEquals(0, table.length());
-        HpackHeaderField entry = new HpackHeaderField(foo, bar);
+        HpackHeaderField entry = new HpackHeaderField(FOO, BAR);
         table.add(entry);
         assertEquals(1, table.length());
         table.clear();
@@ -44,7 +44,7 @@ public class HpackDynamicTableTest {
     public void testSize() {
         HpackDynamicTable table = new HpackDynamicTable(100);
         assertEquals(0, table.size());
-        HpackHeaderField entry = new HpackHeaderField(foo, bar);
+        HpackHeaderField entry = new HpackHeaderField(FOO, BAR);
         table.add(entry);
         assertEquals(entry.size(), table.size());
         table.clear();
@@ -54,7 +54,7 @@ public class HpackDynamicTableTest {
     @Test
     public void testGetEntry() {
         final HpackDynamicTable table = new HpackDynamicTable(100);
-        HpackHeaderField entry = new HpackHeaderField(foo, bar);
+        HpackHeaderField entry = new HpackHeaderField(FOO, BAR);
         table.add(entry);
         assertEquals(entry, table.getEntry(1));
         table.clear();
@@ -82,8 +82,8 @@ public class HpackDynamicTableTest {
     public void testRemove() {
         HpackDynamicTable table = new HpackDynamicTable(100);
         assertNull(table.remove());
-        HpackHeaderField entry1 = new HpackHeaderField(foo, bar);
-        HpackHeaderField entry2 = new HpackHeaderField(hello, world);
+        HpackHeaderField entry1 = new HpackHeaderField(FOO, BAR);
+        HpackHeaderField entry2 = new HpackHeaderField(HELLO, WORLD);
         table.add(entry1);
         table.add(entry2);
         assertEquals(entry1, table.remove());
@@ -94,8 +94,8 @@ public class HpackDynamicTableTest {
 
     @Test
     public void testSetCapacity() {
-        HpackHeaderField entry1 = new HpackHeaderField(foo, bar);
-        HpackHeaderField entry2 = new HpackHeaderField(hello, world);
+        HpackHeaderField entry1 = new HpackHeaderField(FOO, BAR);
+        HpackHeaderField entry2 = new HpackHeaderField(HELLO, WORLD);
         final int size1 = entry1.size();
         final int size2 = entry2.size();
         HpackDynamicTable table = new HpackDynamicTable(size1 + size2);
@@ -120,8 +120,8 @@ public class HpackDynamicTableTest {
     public void testAdd() {
         HpackDynamicTable table = new HpackDynamicTable(100);
         assertEquals(0, table.size());
-        HpackHeaderField entry1 = new HpackHeaderField(foo, bar); //size:3+3+32=38
-        HpackHeaderField entry2 = new HpackHeaderField(hello, world);
+        HpackHeaderField entry1 = new HpackHeaderField(FOO, BAR); //size:3+3+32=38
+        HpackHeaderField entry2 = new HpackHeaderField(HELLO, WORLD);
         table.add(entry1); //success
         assertEquals(entry1.size(), table.size());
         table.setCapacity(32); //entry1 is removed from table

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ClientUpgradeCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ClientUpgradeCodecTest.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-
 public class Http2ClientUpgradeCodecTest {
 
     @Test

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -12,7 +12,6 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameRoundtripTest.java
@@ -118,7 +118,7 @@ public class Http2FrameRoundtripTest {
         }).when(ctx).newPromise();
 
         writer = new DefaultHttp2FrameWriter(new DefaultHttp2HeadersEncoder(NEVER_SENSITIVE, newTestEncoder()));
-        reader = new DefaultHttp2FrameReader(new DefaultHttp2HeadersDecoder(false, newTestDecoder()));
+        reader = new DefaultHttp2FrameReader(new DefaultHttp2HeadersDecoder(false, false, newTestDecoder()));
     }
 
     @AfterEach

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilTest.java
@@ -145,7 +145,7 @@ public class HttpConversionUtilTest {
 
     @Test
     public void stripTEHeadersAccountsForOWS() {
-        HttpHeaders inHeaders = new DefaultHttpHeaders();
+        HttpHeaders inHeaders = new DefaultHttpHeaders(false);
         inHeaders.add(TE, " " + TRAILERS + ' ');
         Http2Headers out = new DefaultHttp2Headers();
         HttpConversionUtil.toHttp2Headers(inHeaders, out);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
@@ -164,7 +164,6 @@ public class HttpToHttp2ConnectionHandlerTest {
         final Http2Headers http2Headers =
                 new DefaultHttp2Headers().method(new AsciiString("GET")).path(new AsciiString("/example"))
                         .authority(new AsciiString("www.example.org:5555")).scheme(new AsciiString("http"))
-                        .scheme(new AsciiString("http"))
                         .add(new AsciiString("foo"), new AsciiString("goo"))
                         .add(new AsciiString("foo"), new AsciiString("goo2"))
                         .add(new AsciiString("foo2"), new AsciiString("goo2"));

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
@@ -164,6 +164,7 @@ public class HttpToHttp2ConnectionHandlerTest {
         final Http2Headers http2Headers =
                 new DefaultHttp2Headers().method(new AsciiString("GET")).path(new AsciiString("/example"))
                         .authority(new AsciiString("www.example.org:5555")).scheme(new AsciiString("http"))
+                        .scheme(new AsciiString("http"))
                         .add(new AsciiString("foo"), new AsciiString("goo"))
                         .add(new AsciiString("foo"), new AsciiString("goo2"))
                         .add(new AsciiString("foo2"), new AsciiString("goo2"));

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/ReadOnlyHttp2HeadersTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/ReadOnlyHttp2HeadersTest.java
@@ -71,9 +71,9 @@ public class ReadOnlyHttp2HeadersTest {
         assertThrows(IllegalArgumentException.class, new Executable() {
             @Override
             public void execute() {
-                ReadOnlyHttp2Headers.trailers(true, new AsciiString(":name"), new AsciiString("foo"),
+                ReadOnlyHttp2Headers.trailers(true, new AsciiString(":scheme"), new AsciiString("foo"),
                         new AsciiString("othername"), new AsciiString("goo"),
-                        new AsciiString(":pseudo"), new AsciiString("val"));
+                        new AsciiString(":path"), new AsciiString("val"));
             }
         });
     }

--- a/codec/src/main/java/io/netty/handler/codec/DefaultHeaders.java
+++ b/codec/src/main/java/io/netty/handler/codec/DefaultHeaders.java
@@ -144,7 +144,7 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
         entries = new HeaderEntry[findNextPositivePowerOfTwo(max(2, min(arraySizeHint, 128)))];
         hashMask = (byte) (entries.length - 1);
         head = new HeaderEntry<K, V>();
-        this.valueValidator = valueValidator;
+        this.valueValidator = checkNotNull(valueValidator, "valueValidator");
     }
 
     @Override

--- a/codec/src/main/java/io/netty/handler/codec/DefaultHeaders.java
+++ b/codec/src/main/java/io/netty/handler/codec/DefaultHeaders.java
@@ -52,6 +52,7 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
     private final byte hashMask;
     private final ValueConverter<V> valueConverter;
     private final NameValidator<K> nameValidator;
+    private final ValueValidator<V> valueValidator;
     private final HashingStrategy<K> hashingStrategy;
     int size;
 
@@ -68,6 +69,22 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
             @Override
             public void validateName(Object name) {
                 checkNotNull(name, "name");
+            }
+        };
+    }
+
+    public interface ValueValidator<V> {
+        /**
+         * Validate the given value. If the validation fails, then an implementation specific runtime exception may be
+         * thrown.
+         *
+         * @param value The value to validate.
+         */
+        void validate(V value);
+
+        ValueValidator<?> NO_VALIDATION = new ValueValidator<Object>() {
+            @Override
+            public void validate(Object value) {
             }
         };
     }
@@ -102,7 +119,23 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
      */
     @SuppressWarnings("unchecked")
     public DefaultHeaders(HashingStrategy<K> nameHashingStrategy,
-            ValueConverter<V> valueConverter, NameValidator<K> nameValidator, int arraySizeHint) {
+                          ValueConverter<V> valueConverter, NameValidator<K> nameValidator, int arraySizeHint) {
+        this(nameHashingStrategy, valueConverter, nameValidator, arraySizeHint,
+                (ValueValidator<V>) ValueValidator.NO_VALIDATION);
+    }
+
+    /**
+     * Create a new instance.
+     * @param nameHashingStrategy Used to hash and equality compare names.
+     * @param valueConverter Used to convert values to/from native types.
+     * @param nameValidator Used to validate name elements.
+     * @param arraySizeHint A hint as to how large the hash data structure should be.
+     * The next positive power of two will be used. An upper bound may be enforced.
+     * @param valueValidator The validation strategy for entry values.
+     */
+    @SuppressWarnings("unchecked")
+    public DefaultHeaders(HashingStrategy<K> nameHashingStrategy, ValueConverter<V> valueConverter,
+                          NameValidator<K> nameValidator, int arraySizeHint, ValueValidator<V> valueValidator) {
         this.valueConverter = checkNotNull(valueConverter, "valueConverter");
         this.nameValidator = checkNotNull(nameValidator, "nameValidator");
         hashingStrategy = checkNotNull(nameHashingStrategy, "nameHashingStrategy");
@@ -111,6 +144,7 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
         entries = new HeaderEntry[findNextPositivePowerOfTwo(max(2, min(arraySizeHint, 128)))];
         hashMask = (byte) (entries.length - 1);
         head = new HeaderEntry<K, V>();
+        this.valueValidator = valueValidator;
     }
 
     @Override
@@ -292,7 +326,8 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
 
     @Override
     public T add(K name, V value) {
-        nameValidator.validateName(name);
+        validateName(nameValidator, true, name);
+        validateValue(valueValidator, name, value);
         checkNotNull(value, "value");
         int h = hashingStrategy.hashCode(name);
         int i = index(h);
@@ -302,10 +337,11 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
 
     @Override
     public T add(K name, Iterable<? extends V> values) {
-        nameValidator.validateName(name);
+        validateName(nameValidator, true, name);
         int h = hashingStrategy.hashCode(name);
         int i = index(h);
         for (V v: values) {
+            validateValue(valueValidator, name, v);
             add0(h, i, name, v);
         }
         return thisT();
@@ -313,10 +349,11 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
 
     @Override
     public T add(K name, V... values) {
-        nameValidator.validateName(name);
+        validateName(nameValidator, true, name);
         int h = hashingStrategy.hashCode(name);
         int i = index(h);
         for (V v: values) {
+            validateValue(valueValidator, name, v);
             add0(h, i, name, v);
         }
         return thisT();
@@ -427,7 +464,8 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
 
     @Override
     public T set(K name, V value) {
-        nameValidator.validateName(name);
+        validateName(nameValidator, false, name);
+        validateValue(valueValidator, name, value);
         checkNotNull(value, "value");
         int h = hashingStrategy.hashCode(name);
         int i = index(h);
@@ -438,7 +476,7 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
 
     @Override
     public T set(K name, Iterable<? extends V> values) {
-        nameValidator.validateName(name);
+        validateName(nameValidator, false, name);
         checkNotNull(values, "values");
 
         int h = hashingStrategy.hashCode(name);
@@ -449,6 +487,7 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
             if (v == null) {
                 break;
             }
+            validateValue(valueValidator, name, v);
             add0(h, i, name, v);
         }
 
@@ -457,7 +496,7 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
 
     @Override
     public T set(K name, V... values) {
-        nameValidator.validateName(name);
+        validateName(nameValidator, false, name);
         checkNotNull(values, "values");
 
         int h = hashingStrategy.hashCode(name);
@@ -468,6 +507,7 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
             if (v == null) {
                 break;
             }
+            validateValue(valueValidator, name, v);
             add0(h, i, name, v);
         }
 
@@ -482,7 +522,7 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
 
     @Override
     public T setObject(K name, Iterable<?> values) {
-        nameValidator.validateName(name);
+        validateName(nameValidator, false, name);
 
         int h = hashingStrategy.hashCode(name);
         int i = index(h);
@@ -500,7 +540,7 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
 
     @Override
     public T setObject(K name, Object... values) {
-        nameValidator.validateName(name);
+        validateName(nameValidator, false, name);
 
         int h = hashingStrategy.hashCode(name);
         int i = index(h);
@@ -956,12 +996,36 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
         return HeadersUtils.toString(getClass(), iterator(), size());
     }
 
+    /**
+     * Call out to the given {@link NameValidator} to validate the given name.
+     *
+     * @param validator the validator to use
+     * @param forAdd {@code true } if this validation is for adding to the headers, or {@code false} if this is for
+     * setting (overwriting) the given header.
+     * @param name the name to validate.
+     */
+    protected void validateName(NameValidator<K> validator, boolean forAdd, K name) {
+        validator.validateName(name);
+    }
+
+    protected void validateValue(ValueValidator<V> validator, K name, V value) {
+        validator.validate(value);
+    }
+
     protected HeaderEntry<K, V> newHeaderEntry(int h, K name, V value, HeaderEntry<K, V> next) {
         return new HeaderEntry<K, V>(h, name, value, next, head);
     }
 
     protected ValueConverter<V> valueConverter() {
         return valueConverter;
+    }
+
+    protected NameValidator<K> nameValidator() {
+        return nameValidator;
+    }
+
+    protected ValueValidator<V> valueValidator() {
+        return valueValidator;
     }
 
     private int index(int hash) {
@@ -1203,7 +1267,7 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
         return copy;
     }
 
-    private final class HeaderIterator implements Iterator<Map.Entry<K, V>> {
+    private final class HeaderIterator implements Iterator<Entry<K, V>> {
         private HeaderEntry<K, V> current = head;
 
         @Override
@@ -1280,7 +1344,7 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
         }
     }
 
-    protected static class HeaderEntry<K, V> implements Map.Entry<K, V> {
+    protected static class HeaderEntry<K, V> implements Entry<K, V> {
         protected final int hash;
         protected final K key;
         protected V value;
@@ -1361,7 +1425,7 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
             if (!(o instanceof Map.Entry)) {
                 return false;
             }
-            Map.Entry<?, ?> other = (Map.Entry<?, ?>) o;
+            Entry<?, ?> other = (Entry<?, ?>) o;
             return (getKey() == null ? other.getKey() == null : getKey().equals(other.getKey()))  &&
                    (getValue() == null ? other.getValue() == null : getValue().equals(other.getValue()));
         }

--- a/codec/src/main/java/io/netty/handler/codec/DefaultHeaders.java
+++ b/codec/src/main/java/io/netty/handler/codec/DefaultHeaders.java
@@ -139,12 +139,12 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
         this.valueConverter = checkNotNull(valueConverter, "valueConverter");
         this.nameValidator = checkNotNull(nameValidator, "nameValidator");
         hashingStrategy = checkNotNull(nameHashingStrategy, "nameHashingStrategy");
+        this.valueValidator = checkNotNull(valueValidator, "valueValidator");
         // Enforce a bound of [2, 128] because hashMask is a byte. The max possible value of hashMask is one less
         // than the length of this array, and we want the mask to be > 0.
         entries = new HeaderEntry[findNextPositivePowerOfTwo(max(2, min(arraySizeHint, 128)))];
         hashMask = (byte) (entries.length - 1);
         head = new HeaderEntry<K, V>();
-        this.valueValidator = checkNotNull(valueValidator, "valueValidator");
     }
 
     @Override

--- a/codec/src/main/java/io/netty/handler/codec/DefaultHeadersImpl.java
+++ b/codec/src/main/java/io/netty/handler/codec/DefaultHeadersImpl.java
@@ -26,4 +26,9 @@ public final class DefaultHeadersImpl<K, V> extends DefaultHeaders<K, V, Default
             ValueConverter<V> valueConverter, NameValidator<K> nameValidator) {
         super(nameHashingStrategy, valueConverter, nameValidator);
     }
+
+    public DefaultHeadersImpl(HashingStrategy<K> nameHashingStrategy, ValueConverter<V> valueConverter,
+                              NameValidator<K> nameValidator, int arraySizeHint, ValueValidator<V> valueValidator) {
+        super(nameHashingStrategy, valueConverter, nameValidator, arraySizeHint, valueValidator);
+    }
 }


### PR DESCRIPTION
This PR builds upon #12755.

Motivation:
In https://datatracker.ietf.org/doc/html/rfc7540#section-10.3 it says that only certain characters are valid in a header value:

> Any request or response that contains a character not permitted
> in a header field value MUST be treated as malformed (Section 8.1.2.6).
> Valid characters are defined by the "field-content" ABNF rule in
> Section 3.2 of [RFC7230].

Modification:
Add a header value validation step to HpackDecoder.

Result:
Header values are now validated against the Section 10.3, etc. rules.