### PR TITLE
Properly make MessageFormatter and FormattingTuple public

### DIFF
--- a/common/src/main/java/io/netty/util/internal/logging/FormattingTuple.java
+++ b/common/src/main/java/io/netty/util/internal/logging/FormattingTuple.java
@@ -47,7 +47,7 @@ public final class FormattingTuple {
     private final String message;
     private final Throwable throwable;
 
-    FormattingTuple(String message, Throwable throwable) {
+    public FormattingTuple(String message, Throwable throwable) {
         this.message = message;
         this.throwable = throwable;
     }

--- a/common/src/main/java/io/netty/util/internal/logging/MessageFormatter.java
+++ b/common/src/main/java/io/netty/util/internal/logging/MessageFormatter.java
@@ -129,7 +129,7 @@ public final class MessageFormatter {
      * @param arg            The argument to be substituted in place of the formatting anchor
      * @return The formatted message
      */
-    static FormattingTuple format(String messagePattern, Object arg) {
+    public static FormattingTuple format(String messagePattern, Object arg) {
         return arrayFormat(messagePattern, new Object[]{arg});
     }
 
@@ -152,7 +152,7 @@ public final class MessageFormatter {
      *                       anchor
      * @return The formatted message
      */
-    static FormattingTuple format(final String messagePattern,
+    public static FormattingTuple format(final String messagePattern,
                                   Object argA, Object argB) {
         return arrayFormat(messagePattern, new Object[]{argA, argB});
     }
@@ -167,7 +167,7 @@ public final class MessageFormatter {
      *                       anchors
      * @return The formatted message
      */
-    static FormattingTuple arrayFormat(final String messagePattern,
+    public static FormattingTuple arrayFormat(final String messagePattern,
                                        final Object[] argArray) {
         if (argArray == null || argArray.length == 0) {
             return new FormattingTuple(messagePattern, null);


### PR DESCRIPTION
Motivation:

_Taken from #12761_

Classes `io.netty.util.internal.logging.FormattingTuple` and `io.netty.util.internal.logging.MessageFormatter` are public classes, but the latters's format methods are package-private while the former's constructor is package-private making their use in custom in InternalLoggerFactory implementations impossible.

Modification:

Make necessary methods public

Result:

Fixes #12761. 
