### PR TITLE
LeakDetector errors not logged when using leak profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -474,7 +474,7 @@
     <profile>
       <id>leak</id>
       <properties>
-        <argLine.leak>-Dio.netty5.leakDetection.level=paranoid -Dio.netty5.leakDetection.targetRecords=32 -Dio.netty5.buffer.lifecycleTracingEnabled=true</argLine.leak>
+        <argLine.leak>-Dio.netty5.leakDetection.level=paranoid -Dio.netty5.leakDetection.targetRecords=32 -Dio.netty5.buffer.lifecycleTracingEnabled=true -Dio.netty5.buffer.leakDetectionEnabled=true</argLine.leak>
       </properties>
     </profile>
     <profile>


### PR DESCRIPTION
Motivation:

the "leak" profile is expected to log LeakDetector errors in case of buffer leaks, but when runnning "mvn test -P leak", 
but there is no logs in case there is a memory leak.

However, I'm not sure if this PR can be merged now, because it seems that many tests are now logging some leak errors when the "leak" profile is used and this may make the CI fail (i'm not sure  ?).
And I don't know if the logged leak errors are real errors, or if it's just the tests which are using some unpooled allocators. 

Modification:

add the following in the **argLine.leak** property from the "leak" profile of the netty parent pom:
```
-Dio.netty5.buffer.leakDetectionEnabled=true
```

Result:

Any memory leaks will be logged when running tests using the "leak" profile.