### PR TITLE
Fix some typos & lambda parameter naming & use short-circuit operator

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/Buffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/Buffer.java
@@ -302,14 +302,14 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
      * or {@code length}.
      *
      * @param srcPos The byte offset into this buffer from where the copying should start; the byte at this offset in
-     *              this buffer will be copied to the {@code destPos} index in the {@code dest} array.
+     *              this buffer will be copied to the {@code destPos} index in the {@code dest} byte buffer.
      * @param dest The destination byte buffer.
-     * @param destPos The index into the {@code dest} array from where the copying should start.
+     * @param destPos The index into the {@code dest} byte buffer from where the copying should start.
      * @param length The number of bytes to copy.
      * @throws NullPointerException if the destination buffer is null.
      * @throws IndexOutOfBoundsException if the source or destination positions, or the length, are negative,
-     * or if the resulting end positions reaches beyond the end of either this buffer, or the destination array.
-     * @throws java.nio.ReadOnlyBufferException if the destination buffer is read-only.
+     * or if the resulting end positions reaches beyond the end of either this buffer, or the destination byte buffer.
+     * @throws java.nio.ReadOnlyBufferException if the destination byte buffer is read-only.
      * @throws BufferClosedException if this buffer is closed.
      */
     void copyInto(int srcPos, ByteBuffer dest, int destPos, int length);
@@ -325,13 +325,13 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
      * or {@code length}.
      *
      * @param srcPos The byte offset into this buffer from where the copying should start; the byte at this offset in
-     *              this buffer will be copied to the {@code destPos} index in the {@code dest} array.
+     *              this buffer will be copied to the {@code destPos} index in the {@code dest} buffer.
      * @param dest The destination buffer.
-     * @param destPos The index into the {@code dest} array from where the copying should start.
+     * @param destPos The index into the {@code dest} buffer from where the copying should start.
      * @param length The number of bytes to copy.
      * @throws NullPointerException if the destination buffer is null.
      * @throws IndexOutOfBoundsException if the source or destination positions, or the length, are negative,
-     * or if the resulting end positions reaches beyond the end of either this buffer, or the destination array.
+     * or if the resulting end positions reaches beyond the end of either this buffer, or the destination buffer.
      * @throws BufferReadOnlyException if the destination buffer is read-only.
      * @throws BufferClosedException if this or the destination buffer is closed.
      */

--- a/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
@@ -178,7 +178,7 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
 
     @Override
     public Buffer implicitCapacityLimit(int limit) {
-        checkImplicitCapacity(limit,  capacity());
+        checkImplicitCapacity(limit, capacity());
         implicitCapacityLimit = limit;
         return this;
     }
@@ -1132,25 +1132,25 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
     }
 
     private void checkRead(int index, int size) {
-        if (index < 0 | woff < index + size) {
+        if (index < 0 || woff < index + size) {
             throw readAccessCheckException(index, size);
         }
     }
 
     private void checkGet(int index, int size) {
-        if (index < 0 | capacity() < index + size) {
+        if (index < 0 || capacity() < index + size) {
             throw readAccessCheckException(index, size);
         }
     }
 
     private void checkWrite(int index, int size, boolean mayExpand) {
-        if (index < roff | wmem.capacity() < index + size) {
+        if (index < roff || wmem.capacity() < index + size) {
             handleWriteAccessBoundsFailure(index, size, mayExpand);
         }
     }
 
     private void checkSet(int index, int size) {
-        if (index < 0 | wmem.capacity() < index + size) {
+        if (index < 0 || wmem.capacity() < index + size) {
             handleWriteAccessBoundsFailure(index, size, false);
         }
     }
@@ -1183,7 +1183,7 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
             throw bufferIsReadOnly(this);
         }
         int capacity = capacity();
-        if (mayExpand && index >= 0 && index <= capacity && woff + size <= implicitCapacityLimit && isOwned()) {
+        if (mayExpand && index >= 0 && index <= capacity && index + size <= implicitCapacityLimit && isOwned()) {
             // Grow into next power-of-two, but not beyond the implicit limit.
             int minimumGrowth = Math.min(
                     Math.max(roundToPowerOfTwo(capacity * 2), size),

--- a/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
@@ -1296,25 +1296,25 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
     }
 
     private void checkRead(int index, int size) {
-        if (index < 0 | woff < index + size) {
+        if (index < 0 || woff < index + size) {
             throw readAccessCheckException(index, size);
         }
     }
 
     private void checkGet(int index, int size) {
-        if (index < 0 | rsize < index + size) {
+        if (index < 0 || rsize < index + size) {
             throw readAccessCheckException(index, size);
         }
     }
 
     private void checkWrite(int index, int size, boolean mayExpand) {
-        if (index < roff | wsize < index + size) {
+        if (index < roff || wsize < index + size) {
             handleWriteAccessBoundsFailure(index, size, mayExpand);
         }
     }
 
     private void checkSet(int index, int size) {
-        if (index < 0 | wsize < index + size) {
+        if (index < 0 || wsize < index + size) {
             handleWriteAccessBoundsFailure(index, size, false);
         }
     }
@@ -1334,7 +1334,7 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
             throw bufferIsReadOnly(this);
         }
         int capacity = capacity();
-        if (mayExpand && index >= 0 && index <= capacity && woff + size <= implicitCapacityLimit && isOwned()) {
+        if (mayExpand && index >= 0 && index <= capacity && index + size <= implicitCapacityLimit && isOwned()) {
             // Grow into next power-of-two, but not beyond the implicit limit.
             int minimumGrowth = Math.min(
                     Math.max(roundToPowerOfTwo(capacity * 2), size),

--- a/common/src/main/java/io/netty5/util/concurrent/DefaultPromise.java
+++ b/common/src/main/java/io/netty5/util/concurrent/DefaultPromise.java
@@ -896,7 +896,7 @@ public class DefaultPromise<V> implements Promise<V>, Future<V>,
     @Override
     public FutureCompletionStage<Void> runAfterBothAsync(CompletionStage<?> other, Runnable action, Executor executor) {
         requireNonNull(action, "action");
-        return thenCombineAsync(other, (ignoreOtherValue, ignoreError) -> {
+        return thenCombineAsync(other, (ignoreThisValue, ignoreOtherValue) -> {
             action.run();
             return null;
         }, executor);


### PR DESCRIPTION
Motivation:
I've noticed some parameter naming is not correct and there's some typos in java doc and found bitwise operator in if statement.

Modification:

Fixed Typos, use short-circuit operator in if clauses, changed NioBuffer,UnsafeBuffer#handleWriteAccessBoundsFailure's local variable to check

Result:

Typos are fixed.
now using short-circuit in if clauses in NioBuffer, and UnsafeBuffer.
handleWriteAccessBoundsFailure it now checks using given parameters