### PR TITLE
Fix leak detection around const buffer suppliers

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/ManagedBufferAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/ManagedBufferAllocator.java
@@ -15,6 +15,7 @@
  */
 package io.netty5.buffer.api;
 
+import io.netty5.buffer.api.internal.CleanerDrop;
 import io.netty5.buffer.api.internal.InternalBufferUtils;
 import io.netty5.buffer.api.internal.WrappingAllocation;
 
@@ -59,7 +60,7 @@ class ManagedBufferAllocator implements BufferAllocator, AllocatorControl {
             throw allocatorClosedException();
         }
         Buffer constantBuffer = manager.allocateShared(
-                this, bytes.length, standardDrop(manager), allocationType);
+                this, bytes.length, drop -> CleanerDrop.wrapWithoutLeakDetection(drop, manager), allocationType);
         constantBuffer.writeBytes(bytes).makeReadOnly();
         return () -> manager.allocateConstChild(constantBuffer);
     }

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferBulkAccessTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferBulkAccessTest.java
@@ -17,6 +17,7 @@ package io.netty5.buffer.api.tests;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
+import io.netty5.buffer.api.CompositeBuffer;
 import io.netty5.buffer.api.internal.InternalBufferUtils;
 import io.netty5.buffer.api.internal.ResourceSupport;
 import io.netty5.util.Resource;
@@ -151,7 +152,7 @@ public class BufferBulkAccessTest extends BufferTestSupport {
                 int second = size - first;
                 try (var bufFirst = a.allocate(first);
                      var bufSecond = b.allocate(second)) {
-                    return a.compose(asList(bufFirst.send(), bufSecond.send())).writerOffset(size).copy();
+                    return a.compose(asList(bufFirst.send(), bufSecond.send())).writerOffset(size);
                 }
             });
         }
@@ -167,7 +168,7 @@ public class BufferBulkAccessTest extends BufferTestSupport {
                 int second = size - first;
                 try (var bufFirst = a.allocate(first);
                      var bufSecond = b.allocate(second)) {
-                    return a.compose(asList(bufFirst.send(), bufSecond.send())).writerOffset(size).copy();
+                    return a.compose(asList(bufFirst.send(), bufSecond.send())).writerOffset(size);
                 }
             });
         }
@@ -183,7 +184,7 @@ public class BufferBulkAccessTest extends BufferTestSupport {
                 int second = size - first;
                 try (var bufFirst = a.allocate(first);
                      var bufSecond = b.allocate(second)) {
-                    return a.compose(asList(bufFirst.send(), bufSecond.send())).writerOffset(size).copy();
+                    return a.compose(asList(bufFirst.send(), bufSecond.send())).writerOffset(size);
                 }
             });
         }
@@ -199,7 +200,7 @@ public class BufferBulkAccessTest extends BufferTestSupport {
                 int second = size - first;
                 try (var bufFirst = a.allocate(first);
                      var bufSecond = b.allocate(second)) {
-                    return a.compose(asList(bufFirst.send(), bufSecond.send())).writerOffset(size).copy();
+                    return a.compose(asList(bufFirst.send(), bufSecond.send())).writerOffset(size);
                 }
             });
         }

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferTestSupport.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferTestSupport.java
@@ -228,8 +228,7 @@ public abstract class BufferTestSupport {
 
         @Override
         public Supplier<Buffer> constBufferSupplier(byte[] bytes) {
-            Buffer parent = delegate.copyOf(bytes).makeReadOnly();
-            return () -> parent.copy(true);
+            return delegate.constBufferSupplier(bytes);
         }
 
         @Override

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/CleanerDropTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/CleanerDropTest.java
@@ -21,6 +21,9 @@ import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.buffer.api.Drop;
 import io.netty5.buffer.api.MemoryManager;
+import io.netty5.buffer.api.SensitiveBufferAllocator;
+import io.netty5.buffer.api.internal.LeakDetection;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -29,6 +32,7 @@ import java.util.ServiceConfigurationError;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -36,6 +40,7 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Isolated
 public class CleanerDropTest {
     static Stream<MemoryManager> managers() {
         return MemoryManager.availableManagers().flatMap(provider -> {
@@ -53,7 +58,8 @@ public class CleanerDropTest {
                 supplier("onHeapUnpooled", BufferAllocator::onHeapUnpooled),
                 supplier("offHeapUnpooled", BufferAllocator::offHeapUnpooled),
                 supplier("onHeapPooled", BufferAllocator::onHeapPooled),
-                supplier("offHeapPooled", BufferAllocator::offHeapPooled));
+                supplier("offHeapPooled", BufferAllocator::offHeapPooled),
+                supplier("sensitive", SensitiveBufferAllocator::sensitiveOffHeapAllocator));
     }
 
     static <T> Supplier<T> supplier(String name, Supplier<T> supplier) {
@@ -76,13 +82,37 @@ public class CleanerDropTest {
 
     @ParameterizedTest
     @MethodSource("parameters")
-    public void leakedBufferMustBeDroppedByCleaner(MemoryManager manager,
-                                                   Supplier<BufferAllocator> allocatorSupplier) {
+    public void leakedBufferMustBeDroppedByCleanerWhenLeakDetectionIsEnabled(
+            MemoryManager manager, Supplier<BufferAllocator> allocatorSupplier) throws Exception {
+        Semaphore leakDetectorSemaphore = new Semaphore(0);
+        try (var ignore = LeakDetection.onLeakDetected(ignore1 -> leakDetectorSemaphore.release())) {
+            Semaphore leakSemaphore = new Semaphore(0);
+            int count = MemoryManager.using(new LeakTrappingMemoryManager(leakSemaphore, manager), () -> {
+                int counter = 0;
+                try (BufferAllocator allocator = allocatorSupplier.get()) {
+                    leakBuffer(allocator);
+                    do {
+                        produceGarbage();
+                        counter++;
+                        assertThat(counter).isLessThan(5000);
+                    } while (!tryAcquireForOneMillisecond(leakSemaphore));
+                    return counter;
+                }
+            });
+            // Make sure we capture all the buffers we create in this test.
+            leakDetectorSemaphore.acquire(count);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void constBufferSuppliersAreClosedByCleaner(
+            MemoryManager manager, Supplier<BufferAllocator> allocatorSupplier) throws Exception {
         Semaphore leakSemaphore = new Semaphore(0);
         MemoryManager.using(new LeakTrappingMemoryManager(leakSemaphore, manager), () -> {
+            int counter = 0;
             try (BufferAllocator allocator = allocatorSupplier.get()) {
-                leakBuffer(allocator);
-                int counter = 0;
+                leakConstBufferSupplier(allocator);
                 do {
                     produceGarbage();
                     counter++;
@@ -93,8 +123,39 @@ public class CleanerDropTest {
         });
     }
 
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void constBufferSuppliersAreClosedByCleanerButDoNotLeak(
+            MemoryManager manager, Supplier<BufferAllocator> allocatorSupplier) throws Exception {
+        AtomicInteger leakCounter = new AtomicInteger();
+        try (var ignore = LeakDetection.onLeakDetected(ignore1 -> leakCounter.incrementAndGet())) {
+            Semaphore leakSemaphore = new Semaphore(0);
+            MemoryManager.using(new LeakTrappingMemoryManager(leakSemaphore, manager), () -> {
+                int counter = 0;
+                try (BufferAllocator allocator = allocatorSupplier.get()) {
+                    leakConstBufferSupplier(allocator);
+                    do {
+                        produceGarbage();
+                        counter++;
+                        assertThat(counter).isLessThan(5000);
+                    } while (!tryAcquireForOneMillisecond(leakSemaphore));
+                    return null;
+                }
+            });
+            assertThat(leakCounter).hasValue(0);
+        }
+    }
+
     private static void leakBuffer(BufferAllocator allocator) {
         allocator.allocate(128);
+    }
+
+    private static void leakConstBufferSupplier(BufferAllocator allocator) {
+        // The allocation of the supplier itself will likely require an internal buffer to be allocated,
+        // to capture a snapshot of the input array, and for use in structural sharign.
+        // This buffer cannot be closed, so we cannot reasonably consider it to be leaked.
+        // Buffers allocated from the supplier, however, could leak. Hence, we only allocate the supplier.
+        allocator.constBufferSupplier(new byte[128]);
     }
 
     private static boolean tryAcquireForOneMillisecond(Semaphore leakSemaphore) {


### PR DESCRIPTION
Fix leak detection around const buffer suppliers

Motivation:
Const-buffer suppliers have no direct way to close them, so they can only be closed by `Cleaners`.
We should not consider this a leak.

Modification:
Make sure that the parent buffer used in a const-buffer supplier always gets a `CleanerDrop`, and that this drop will not report it to the `LeakDetection`.
Update tests to cover this particular case.
Make the `LoggingLeakCallback` only be used for reporting when there are no other leak callbacks installed - otherwise tests that intentionally cause leaks will fail the `-Pleak` build.
Fix a number of leaks in tests.

Result:
No more leaks reported by the use of `BufferAllocator#constBufferSupplier`.