### PR TITLE
Fix buffer leaks in the codec module

### DIFF
--- a/codec/src/main/java/io/netty5/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty5/handler/codec/ByteToMessageDecoder.java
@@ -299,11 +299,18 @@ public abstract class ByteToMessageDecoder extends ChannelHandlerAdapter {
             if (!ctx.isRemoved()) {
                 // Use Unpooled.EMPTY_BUFFER if cumulation become null after calling callDecode(...).
                 // See https://github.com/netty/netty/issues/10802.
-                Buffer buffer = cumulation == null ? ctx.bufferAllocator().allocate(0) : cumulation;
-                decodeLast(ctx, buffer);
+                if (cumulation == null) {
+                    try (Buffer buffer = ctx.bufferAllocator().allocate(0)) {
+                        decodeLast(ctx, buffer);
+                    }
+                } else {
+                    decodeLast(ctx, cumulation);
+                }
             }
         } else {
-            decodeLast(ctx, ctx.bufferAllocator().allocate(0));
+            try (Buffer buffer = ctx.bufferAllocator().allocate(0)) {
+                decodeLast(ctx, buffer);
+            }
         }
     }
 

--- a/codec/src/main/java/io/netty5/handler/codec/Delimiters.java
+++ b/codec/src/main/java/io/netty5/handler/codec/Delimiters.java
@@ -16,8 +16,7 @@
 package io.netty5.handler.codec;
 
 import io.netty5.buffer.api.Buffer;
-
-import static io.netty5.buffer.api.DefaultBufferAllocators.onHeapAllocator;
+import io.netty5.buffer.api.MemoryManager;
 
 /**
  * A set of commonly used delimiters for {@link DelimiterBasedFrameDecoder}.
@@ -30,7 +29,7 @@ public final class Delimiters {
      */
     public static Buffer[] nulDelimiter() {
         return new Buffer[] {
-                onHeapAllocator().copyOf(new byte[] { 0 }).makeReadOnly()
+                MemoryManager.unsafeWrap(new byte[] { 0 }).makeReadOnly()
         };
     }
 
@@ -40,8 +39,8 @@ public final class Delimiters {
      */
     public static Buffer[] lineDelimiter() {
         return new Buffer[] {
-                onHeapAllocator().copyOf(new byte[] { '\r', '\n' }).makeReadOnly(),
-                onHeapAllocator().copyOf(new byte[] { '\n' }).makeReadOnly(),
+                MemoryManager.unsafeWrap(new byte[] { '\r', '\n' }).makeReadOnly(),
+                MemoryManager.unsafeWrap(new byte[] { '\n' }).makeReadOnly(),
         };
     }
 

--- a/codec/src/test/java/io/netty5/handler/codec/ByteToMessageCodecTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/ByteToMessageCodecTest.java
@@ -53,8 +53,9 @@ public class ByteToMessageCodecTest {
         assertTrue(ch.finish());
         assertEquals(1, (Integer) ch.readInbound());
 
-        try (Buffer buf = ch.readInbound()) {
-            assertEquals(preferredAllocator().copyOf(new byte[] { '0' }), buf);
+        try (Buffer buf = ch.readInbound();
+             Buffer expected = preferredAllocator().copyOf(new byte[] { '0' })) {
+            assertEquals(expected, buf);
         }
         assertNull(ch.readInbound());
         assertNull(ch.readOutbound());

--- a/codec/src/test/java/io/netty5/handler/codec/compression/JdkZlibTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/compression/JdkZlibTest.java
@@ -553,9 +553,8 @@ public class JdkZlibTest {
         EmbeddedChannel chDecoderGZip = new EmbeddedChannel(createDecoder(ZlibWrapper.GZIP));
 
         byte[] bytes = "Foo".getBytes(UTF_8);
-        Buffer data = chDecoderGZip.bufferAllocator().copyOf(bytes);
 
-        try {
+        try (Buffer data = chDecoderGZip.bufferAllocator().copyOf(bytes)) {
             try (Buffer deflatedData = chDecoderGZip.bufferAllocator().copyOf(
                     new byte[]{
                             31, -117, // magic number

--- a/codec/src/test/java/io/netty5/handler/codec/frame/LengthFieldPrependerTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/frame/LengthFieldPrependerTest.java
@@ -20,6 +20,7 @@ import io.netty5.buffer.api.DefaultBufferAllocators;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.handler.codec.EncoderException;
 import io.netty5.handler.codec.LengthFieldPrepender;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -37,6 +38,11 @@ public class LengthFieldPrependerTest {
     @BeforeEach
     public void setUp() throws Exception {
         message = DefaultBufferAllocators.onHeapAllocator().copyOf(new byte[] {50});
+    }
+
+    @AfterEach
+    public void tearDown() {
+        message.close();
     }
 
     @Test


### PR DESCRIPTION
Motivation:
Leak detection was not properly enabled for Buffers in CI, and a number of leaks have snuck in.

Modification:
Fix leaks in test and product code in the codec module.

Result:
No more leaks in codec.

These issues were identified by #12764