### PR TITLE
Fix buffer leak in HttpObjectEncoder

### DIFF
--- a/codec-http/src/main/java/io/netty5/handler/codec/http/HttpObjectEncoder.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/HttpObjectEncoder.java
@@ -140,6 +140,9 @@ public abstract class HttpObjectEncoder<H extends HttpMessage> extends MessageTo
                         }
 
                         break;
+                    } else {
+                        Resource.dispose(msg);
+                        // do not break, let's fall-through
                     }
 
                     // fall-through!

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/HttpObjectEncoder.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/HttpObjectEncoder.java
@@ -211,6 +211,10 @@ public abstract class HttpObjectEncoder<H extends HttpMessage> extends MessageTo
                                                  TRAILERS_WEIGHT_HISTORICAL * trailersEncodedSizeAccumulator;
                 out.add(buf);
             }
+            if (contentLength == 0) {
+                // EmptyLastHttpContent or LastHttpContent with empty payload
+                ((LastHttpContent<?>) msg).close();
+            }
         } else if (contentLength == 0) {
             // Need to produce some output otherwise an
             // IllegalStateException will be thrown

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpRequestEncoderTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpRequestEncoderTest.java
@@ -246,6 +246,30 @@ public class HttpRequestEncoderTest {
         assertFalse(lastHttpContent.isAccessible());
     }
 
+    @Test
+    public void testFullHttpRequestWithEmptyPayloadClosed() {
+        doTestFullHttpRequest(preferredAllocator().allocate(0));
+    }
+
+    @Test
+    public void testFullHttpRequestWithPayloadClosed() {
+        doTestFullHttpRequest(preferredAllocator().copyOf("test", US_ASCII));
+    }
+
+    private static void doTestFullHttpRequest(Buffer payload) {
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestEncoder());
+
+        DefaultFullHttpRequest request =
+                new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/", payload);
+        request.headers().setInt(HttpHeaderNames.CONTENT_LENGTH, payload.readableBytes());
+
+        assertTrue(channel.writeOutbound(request));
+
+        assertTrue(channel.finishAndReleaseAll());
+
+        assertFalse(payload.isAccessible());
+    }
+
     /**
      * This class is required to triggered the desired initialization order of {@link EmptyHttpHeaders}.
      * If {@link DefaultHttpRequest} is used, the {@link HttpHeaders} class will be initialized before {@link HttpUtil}


### PR DESCRIPTION
Motivation:
When encoding chunked content, `HttpObjectEncoder` processes the trailing headers
provided by `LastHttpContent`, but doesn't close `EmptyLastHttpContent`/`LastHttpContent`
with empty payload.

Modification:
- `HttpObjectEncoder` closes `EmptyLastHttpContent`/`LastHttpContent` with empty payload
when encoding chunked content
- Add junit tests

Result:
No more buffer leak in `HttpObjectEncoder`.