### PR TITLE
Fix buffer leak in WebSocket13FrameEncoder

### DIFF
--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocket13FrameEncoder.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocket13FrameEncoder.java
@@ -196,6 +196,7 @@ public class WebSocket13FrameEncoder extends MessageToMessageEncoder<WebSocketFr
                     buf.writeByte((byte) (byteData ^ mask[counter++ % 4]));
                 }
                 out.add(buf);
+                data.close();
             } else {
                 if (buf.writableBytes() >= data.readableBytes()) {
                     // merge buffers as this is cheaper then a gathering write if the payload is small enough
@@ -210,6 +211,9 @@ public class WebSocket13FrameEncoder extends MessageToMessageEncoder<WebSocketFr
         } catch (Throwable t) {
             if (buf != null) {
                 buf.close();
+            }
+            if (data.isAccessible()) {
+                data.close();
             }
             throw t;
         }

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketServerProtocolHandlerTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketServerProtocolHandlerTest.java
@@ -343,7 +343,8 @@ public class WebSocketServerProtocolHandlerTest {
         assertFalse(client.writeInbound((Buffer) server.readOutbound()));
 
         // When client channel closed with explicit close-frame
-        assertTrue(client.writeOutbound(new CloseWebSocketFrame(client.bufferAllocator(), closeStatus)));
+        CloseWebSocketFrame closeFrame = new CloseWebSocketFrame(client.bufferAllocator(), closeStatus);
+        assertTrue(client.writeOutbound(closeFrame));
         client.close();
 
         // Then client receives provided close-frame
@@ -357,6 +358,7 @@ public class WebSocketServerProtocolHandlerTest {
 
         assertFalse(client.finishAndReleaseAll());
         assertFalse(server.finishAndReleaseAll());
+        assertFalse(closeFrame.isAccessible());
     }
 
     @Test


### PR DESCRIPTION
Motivation:

When encoding a CloseWebSocketFrame frame using the WebSocket13FrameEncoder.encode method, the binary data associated to the frame is not always disposed, causing a memory leak, and when using the leak detector, the following kind of logs can be observed:

```
15:51:00.952 [Cleaner-0] ERROR i.n.buffer.api.LoggingLeakCallback - LEAK: Object "buffer (22 bytes)" was not property closed before it was garbage collected. A life-cycle back-trace (if any) is attached as suppressed exceptions. See https://netty.io/wiki/reference-counted-objects.html for more information.
io.netty5.buffer.api.LoggingLeakCallback$LeakReport: Object life-cycle trace:
	Suppressed: io.netty5.buffer.api.internal.LifecycleTracer$Traceback: ALLOCATE (current acquires = 0) T-641565us.
		at io.netty5.buffer.api.internal.ResourceSupport.<init>(ResourceSupport.java:42)
		at io.netty5.buffer.api.internal.AdaptableBuffer.<init>(AdaptableBuffer.java:28)
		at io.netty5.buffer.api.bytebuffer.NioBuffer.<init>(NioBuffer.java:65)
		at io.netty5.buffer.api.bytebuffer.ByteBufferMemoryManager.createBuffer(ByteBufferMemoryManager.java:83)
		at io.netty5.buffer.api.bytebuffer.ByteBufferMemoryManager.recoverMemory(ByteBufferMemoryManager.java:78)
		at io.netty5.buffer.api.pool.PooledBufferAllocator.allocate(PooledBufferAllocator.java:321)
		at io.netty5.buffer.api.DefaultBufferAllocators$UncloseableBufferAllocator.allocate(DefaultBufferAllocators.java:123)
		at io.netty5.handler.codec.http.websocketx.CloseWebSocketFrame.newBinaryData(CloseWebSocketFrame.java:99)
		at io.netty5.handler.codec.http.websocketx.CloseWebSocketFrame.<init>(CloseWebSocketFrame.java:88)
		at io.netty5.handler.codec.http.websocketx.CloseWebSocketFrame.<init>(CloseWebSocketFrame.java:62)
		at io.netty5.handler.codec.http.websocketx.CloseWebSocketFrame.<init>(CloseWebSocketFrame.java:36)
		at io.netty5.handler.codec.http.websocketx.WebSocketServerProtocolHandlerTest.testExplicitCloseFrameSentWhenClientChannelClosed(WebSocketServerProtocolHandlerTest.java:354)
		at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:725)
		at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
		at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
		at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:149)
		at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:140)
		at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:84)
		at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(ExecutableInvoker.java:115)
		at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
		at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
		at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
		at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
		at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
		at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:104)
		at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:98)
		at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$7(TestMethodTestDescriptor.java:214)
		at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
		at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:210)
		at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:135)
		at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:66)
		at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:151)
		at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
		at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
		at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
		at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
		at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
		at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
		at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
		at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
		at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
		at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
		at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
		at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
		at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
		at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
		at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
		at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
		at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
		at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
		at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	Suppressed: io.netty5.buffer.api.internal.LifecycleTracer$Traceback: TOUCH (ChannelHandlerContext(WebSocketClientProtocolHandler#0, [id: 0xembedded])) T-642854us.
		at io.netty5.buffer.api.internal.ResourceSupport.touch(ResourceSupport.java:224)
		at io.netty5.buffer.api.internal.AdaptableBuffer.touch(AdaptableBuffer.java:34)
		at io.netty5.buffer.api.internal.AdaptableBuffer.touch(AdaptableBuffer.java:22)
		at io.netty5.buffer.api.BufferHolder.touch(BufferHolder.java:156)
		at io.netty5.util.Resource.touch(Resource.java:130)
		at io.netty5.channel.DefaultChannelPipeline.touch(DefaultChannelPipeline.java:113)
		at io.netty5.channel.DefaultChannelHandlerContext.invokeWrite(DefaultChannelHandlerContext.java:846)
		at io.netty5.channel.DefaultChannelHandlerContext$AbstractWriteTask.write(DefaultChannelHandlerContext.java:1217)
		at io.netty5.channel.DefaultChannelHandlerContext$AbstractWriteTask.run(DefaultChannelHandlerContext.java:1187)
		at io.netty5.channel.embedded.EmbeddedEventLoop.runTasks(EmbeddedEventLoop.java:139)
		at io.netty5.channel.embedded.EmbeddedEventLoop.execute(EmbeddedEventLoop.java:125)
		at io.netty5.channel.DefaultChannelHandlerContext.safeExecute(DefaultChannelHandlerContext.java:1094)
		at io.netty5.channel.DefaultChannelHandlerContext.write(DefaultChannelHandlerContext.java:935)
		at io.netty5.channel.DefaultChannelHandlerContext.write(DefaultChannelHandlerContext.java:842)
		at io.netty5.channel.DefaultChannelPipeline.write(DefaultChannelPipeline.java:914)
		at io.netty5.channel.Channel.write(Channel.java:306)
		at io.netty5.channel.embedded.EmbeddedChannel.writeOutbound(EmbeddedChannel.java:343)
		at io.netty5.handler.codec.http.websocketx.WebSocketServerProtocolHandlerTest.testExplicitCloseFrameSentWhenClientChannelClosed(WebSocketServerProtocolHandlerTest.java:354)
		at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:725)
		at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
		at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
		at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:149)
		at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:140)
		at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:84)
		at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(ExecutableInvoker.java:115)
		at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
		at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
		at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
		at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
		at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
		at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:104)
		at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:98)
		at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$7(TestMethodTestDescriptor.java:214)
		at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
		at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:210)
		at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:135)
		at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:66)
		at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:151)
		at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
		at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
		at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
		at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
		at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
		at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
		at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
		at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
		at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
		at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
		at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
		at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
		at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	Suppressed: io.netty5.buffer.api.internal.LifecycleTracer$Traceback: TOUCH (ChannelHandlerContext(ws-encoder, [id: 0xembedded])) T-643103us.
		at io.netty5.buffer.api.internal.ResourceSupport.touch(ResourceSupport.java:224)
		at io.netty5.buffer.api.internal.AdaptableBuffer.touch(AdaptableBuffer.java:34)
		at io.netty5.buffer.api.internal.AdaptableBuffer.touch(AdaptableBuffer.java:22)
		at io.netty5.buffer.api.BufferHolder.touch(BufferHolder.java:156)
		at io.netty5.util.Resource.touch(Resource.java:130)
		at io.netty5.channel.DefaultChannelPipeline.touch(DefaultChannelPipeline.java:113)
		at io.netty5.channel.DefaultChannelHandlerContext.invokeWrite(DefaultChannelHandlerContext.java:846)
		at io.netty5.channel.DefaultChannelHandlerContext.write(DefaultChannelHandlerContext.java:926)
		at io.netty5.channel.DefaultChannelHandlerContext.write(DefaultChannelHandlerContext.java:842)
		at io.netty5.handler.codec.http.websocketx.WebSocketProtocolHandler.write(WebSocketProtocolHandler.java:116)
		at io.netty5.handler.codec.http.websocketx.WebSocketClientProtocolHandler.write(WebSocketClientProtocolHandler.java:47)
		at io.netty5.channel.DefaultChannelHandlerContext.invokeWrite(DefaultChannelHandlerContext.java:854)
		at io.netty5.channel.DefaultChannelHandlerContext$AbstractWriteTask.write(DefaultChannelHandlerContext.java:1217)
		at io.netty5.channel.DefaultChannelHandlerContext$AbstractWriteTask.run(DefaultChannelHandlerContext.java:1187)
		at io.netty5.channel.embedded.EmbeddedEventLoop.runTasks(EmbeddedEventLoop.java:139)
		at io.netty5.channel.embedded.EmbeddedEventLoop.execute(EmbeddedEventLoop.java:125)
		at io.netty5.channel.DefaultChannelHandlerContext.safeExecute(DefaultChannelHandlerContext.java:1094)
		at io.netty5.channel.DefaultChannelHandlerContext.write(DefaultChannelHandlerContext.java:935)
		at io.netty5.channel.DefaultChannelHandlerContext.write(DefaultChannelHandlerContext.java:842)
		at io.netty5.channel.DefaultChannelPipeline.write(DefaultChannelPipeline.java:914)
		at io.netty5.channel.Channel.write(Channel.java:306)
		at io.netty5.channel.embedded.EmbeddedChannel.writeOutbound(EmbeddedChannel.java:343)
		at io.netty5.handler.codec.http.websocketx.WebSocketServerProtocolHandlerTest.testExplicitCloseFrameSentWhenClientChannelClosed(WebSocketServerProtocolHandlerTest.java:354)
		at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:725)
		at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
		at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
		at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:149)
		at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:140)
		at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:84)
		at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(ExecutableInvoker.java:115)
		at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
		at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
		at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
		at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
		at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
		at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:104)
		at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:98)
		at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$7(TestMethodTestDescriptor.java:214)
		at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
		at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:210)
		at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:135)
		at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:66)
		at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:151)
		at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
		at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
		at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
		at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
		at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
		at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
		at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
		at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)

```

The issue only happens when using netty5 latest snapshot version, not using netty 4.x version.

Modification:

Updated the WebSocket13FrameEncoder.encode in order to always close the frame data (when necessary).
Also, update the WebSocketServerProtocolHandlerTest.testExplicitCloseFrameSentWhenClientChannelClosed test

Result:

Using the proposed patch we don't see anymore leaks when encoding CloseWebSocketFrame frames using the WebSocket13FrameEncoder.