### PR TITLE
Fix CleanerDropTest

### DIFF
--- a/buffer/src/test/java/io/netty5/buffer/api/tests/CleanerDropTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/CleanerDropTest.java
@@ -39,6 +39,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Isolated
 public class CleanerDropTest {
@@ -100,7 +101,8 @@ public class CleanerDropTest {
                 }
             });
             // Make sure we capture all the buffers we create in this test.
-            leakDetectorSemaphore.acquire(count);
+            assertTrue(leakDetectorSemaphore.tryAcquire(count, 5, TimeUnit.MINUTES),
+                    "Not all leaked objects were captured by the leak detector.");
         }
     }
 

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/CleanerDropTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/CleanerDropTest.java
@@ -120,7 +120,7 @@ public class CleanerDropTest {
                 }
             });
             // Make sure we capture all the buffers we create in this test.
-            assertTrue(leakDetectorSemaphore.tryAcquire(count, 5, TimeUnit.MINUTES),
+            assertTrue(leakDetectorSemaphore.tryAcquire(1, 5, TimeUnit.MINUTES),
                     "Not all leaked objects were captured by the leak detector.");
         }
     }


### PR DESCRIPTION
Motivation:
The CleanerDropTest was mistakenly hoping to get a release of the semaphore for every iteration of its inner loop.
However, only one leaked const buffer supplier was created, so the semaphore could only release once.
This lead to tests failing through build timeouts, as the semaphore was never going to see enough releases if the wait loop iterated more than once.

Modification:
Only wait for one release of the semaphore.
Also add a timeout that fails the test after 5 minutes, instead of waiting for the entire build to time out.

Result:
The test should now always pass.
And even if it doesn't, it should now fail much more quickly than a build timeout.