### PR TITLE
Fix inconsistent synchronization of PoolSubpage.doNotDestroy

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -157,7 +157,7 @@ abstract class PoolArena<T> extends SizeClasses implements PoolArenaMetric {
          * Synchronize on the head. This is needed as {@link PoolChunk#allocateSubpage(int)} and
          * {@link PoolChunk#free(long)} may modify the doubly linked list as well.
          */
-        final PoolSubpage<T> head = smallSubpagePools[sizeIdx];
+        final PoolSubpage<T> head = findSubpagePoolHead(sizeIdx);
         final boolean needsNormalAllocation;
         head.lock();
         try {

--- a/buffer/src/main/java/io/netty/buffer/PoolChunk.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunk.java
@@ -479,12 +479,12 @@ final class PoolChunk<T> implements PoolChunkMetric {
 
             int sIdx = runOffset(handle);
             PoolSubpage<T> subpage = subpages[sIdx];
-            assert subpage != null && subpage.doNotDestroy;
 
             // Obtain the head of the PoolSubPage pool that is owned by the PoolArena and synchronize on it.
             // This is need as we may add it back and so alter the linked-list structure.
             head.lock();
             try {
+                assert subpage != null && subpage.doNotDestroy;
                 if (subpage.free(head, bitmapIdx(handle))) {
                     //the subpage is still used, do not free it
                     return;


### PR DESCRIPTION
Motivation:
This field is modified under lock, and thus should not be accessed (toString excepted) without locking.

Modification:
Move an assert check on PoolSubpage.doNotDestroy into a nearby critical region.

Also encapsulate the findSubpagePoolHead logic better; PoolArena now always use this method instead of that one place that was accessing the array directly. This should not have any influence on the logic.

Result:
Assert in PoolChunk is no longer racy.