### PR TITLE
Make PoolSubpage more resilient to certain errors

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolSubpage.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolSubpage.java
@@ -90,6 +90,12 @@ final class PoolSubpage<T> implements PoolSubpageMetric {
         }
 
         final int bitmapIdx = getNextAvail();
+        if (bitmapIdx < 0) {
+            removeFromPool(); // Subpage appear to be in an invalid state. Remove to prevent repeated errors.
+            throw new AssertionError("No next available bitmap index found (bitmapIdx = " + bitmapIdx + "), " +
+                    "even though there are supposed to be (numAvail = " + numAvail + ") " +
+                    "out of (maxNumElems = " + maxNumElems + ") available indexes.");
+        }
         int q = bitmapIdx >>> 6;
         int r = bitmapIdx & 63;
         assert (bitmap[q] >>> r & 1) == 0;


### PR DESCRIPTION
Motivation:
We occasionally see a strange `ArrayIndexOutOfBoundsException: Index 67108863 out of bounds for length 8` exception, which is caused by `getNextAvail()` returning `-1`, even though `numAvail` is positive.

Modification:
Improve the error message when this occurs, and include a few more details to verify the assumption that `bitmapIdx` really is `-1` even though `numAvail` is positive. Also remove the PoolSubpage from the arena when this happens, as it likely means the subpage is in a broken state, and we should not use it anymore.

Result:
We have no fixed the root cause, but hopefully the system will be better able to recover, or at least we'll get slightly better diagnostics.

Specifically, this is trying to help diagnose #12564