### PR TITLE
Clarify javadoc from WebSocketServerHandshaker hanshake methods

### DIFF
--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketServerHandshaker.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketServerHandshaker.java
@@ -156,8 +156,9 @@ public abstract class WebSocketServerHandshaker {
     }
 
     /**
-     * Performs the opening handshake. When call this method you <strong>MUST NOT</strong> retain the
-     * {@link FullHttpRequest} which is passed in.
+     * Performs the opening handshake. Note that the ownership of the {@link FullHttpRequest} which is passed in
+     * belongs to the caller (ownership is not transferred to this method, and caller is responsible
+     * to close the request parameter).
      *
      * @param channel Channel
      * @param req     HTTP Request
@@ -171,7 +172,9 @@ public abstract class WebSocketServerHandshaker {
     /**
      * Performs the opening handshake
      * <p>
-     * When call this method you <strong>MUST NOT</strong> retain the {@link FullHttpRequest} which is passed in.
+     * Note that the ownership of the {@link FullHttpRequest} which is passed in
+     * belongs to the caller (ownership is not transferred to this method, and caller is responsible
+     * to close the request parameter).
      *
      * @param channel         Channel
      * @param req             HTTP Request
@@ -220,8 +223,9 @@ public abstract class WebSocketServerHandshaker {
     }
 
     /**
-     * Performs the opening handshake. When call this method you <strong>MUST NOT</strong> retain the
-     * {@link FullHttpRequest} which is passed in.
+     * Performs the opening handshake. Note that the ownership of the {@link FullHttpRequest} which is passed in
+     * belongs to the caller (ownership is not transferred to this method, and caller is responsible
+     * to close the request parameter).
      *
      * @param channel Channel
      * @param req     HTTP Request
@@ -235,7 +239,9 @@ public abstract class WebSocketServerHandshaker {
     /**
      * Performs the opening handshake
      * <p>
-     * When call this method you <strong>MUST NOT</strong> retain the {@link HttpRequest} which is passed in.
+     * Note that the ownership of the {@link FullHttpRequest} which is passed in
+     * belongs to the caller (ownership is not transferred to this method, and caller is responsible
+     * to close the request parameter).
      *
      * @param channel         Channel
      * @param req             HTTP Request


### PR DESCRIPTION
Motivation:

This PR proposes to clarify the javadoc for the various _handshake_ methods from the _WebSocketServerHandshaker_ class.
Indeed, the following note that was coming from the old 4.x version is not applicable anymore and the _request_ parameter which is passed in to the _WebSocketServerHandshaker.hanshake_ methods should be closed by the user (the ownership is not transferred to the method):

> When call this method you <strong>MUST NOT</strong> retain the {@link FullHttpRequest} which is passed in. 


Modification:

Replaced the old javadoc note for all the _WebSocketServerHandshaker.hanshake_ methods using this new one:

> Note that the ownership of the FullHttpRequest which is passed in belongs to the caller (ownership is not transferred to this method, and caller is responsible to close the request parameter).


Result:

The javadoc has been clarified.