### PR TITLE
WebSocket13FrameEncoder should overrides encode instead of encodeAndClose

### DIFF
--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocket13FrameEncoder.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocket13FrameEncoder.java
@@ -98,7 +98,7 @@ public class WebSocket13FrameEncoder extends MessageToMessageEncoder<WebSocketFr
     }
 
     @Override
-    protected void encodeAndClose(ChannelHandlerContext ctx, WebSocketFrame msg, List<Object> out) throws Exception {
+    protected void encode(ChannelHandlerContext ctx, WebSocketFrame msg, List<Object> out) throws Exception {
         final Buffer data = msg.binaryData();
         byte[] mask;
 
@@ -196,24 +196,19 @@ public class WebSocket13FrameEncoder extends MessageToMessageEncoder<WebSocketFr
                     buf.writeByte((byte) (byteData ^ mask[counter++ % 4]));
                 }
                 out.add(buf);
-                data.close();
             } else {
                 if (buf.writableBytes() >= data.readableBytes()) {
                     // merge buffers as this is cheaper then a gathering write if the payload is small enough
                     buf.writeBytes(data);
-                    data.close();
                     out.add(buf);
                 } else {
                     out.add(buf);
-                    out.add(data);
+                    out.add(data.split());
                 }
             }
         } catch (Throwable t) {
             if (buf != null) {
                 buf.close();
-            }
-            if (data.isAccessible()) {
-                data.close();
             }
             throw t;
         }


### PR DESCRIPTION
Motivation:

The #12773 PR has fixed a memory leak from the WebSocket13FrameEncoder.encodeAndClose method, where the websocket frame to be encoded was not always closed properly.

Now, @amizurov has suggested to do a better fix by just letting the WebSocket13FrameEncoder override the _encode_ method instead of the _encodeAndClose_. It give an autoclose for the input argument and don't need to do this manually, behaviour will be similar with 4.1.

However, care must be taken when the frame is itself appended to the "out" list of produced data. In 4.x, this was done using "data.retain", with the new Buffer API, the data can be added to the "out" list using "data.split".

Modification:

The WebSocket13FrameEncoder is now overriding the _encode_ method instead of the _encodeAndClose_, and the frame message is not closed anymore at all (this is done by the _encodeAndClose_ method from the superclass).
And when the frame message data has to be appended into the "out" list of produced encoded data, then it is done using "data.split" 

Result:

The WebSocket13FrameEncoder class is simpler and don't have to close the frame data parameter.