### PR TITLE
Fix buffer leak in DefaultHttp2HeadersEncoder

### DIFF
--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/DefaultHttp2FrameWriter.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/DefaultHttp2FrameWriter.java
@@ -128,7 +128,9 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
     }
 
     @Override
-    public void close() { }
+    public void close() {
+        headersEncoder.close();
+    }
 
     @Override
     public Future<Void> writeData(ChannelHandlerContext ctx, int streamId, Buffer data,

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/DefaultHttp2HeadersEncoder.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/DefaultHttp2HeadersEncoder.java
@@ -104,4 +104,9 @@ public class DefaultHttp2HeadersEncoder implements Http2HeadersEncoder, Http2Hea
     public Configuration configuration() {
         return this;
     }
+
+    @Override
+    public void close() {
+        tableSizeChangeOutput.close();
+    }
 }

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2HeadersEncoder.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2HeadersEncoder.java
@@ -22,7 +22,17 @@ import io.netty5.util.internal.UnstableApi;
  * Encodes {@link Http2Headers} into HPACK-encoded headers blocks.
  */
 @UnstableApi
-public interface Http2HeadersEncoder {
+public interface Http2HeadersEncoder extends AutoCloseable {
+    /**
+     * Close the encoder and release all its associated data. By default, this default method does nothing,
+     * but if needed, concrete encoders may override this method in order to clean up any resources when closed.
+     *
+     * @throws IllegalStateException If this {@code Resource} has already been closed.
+     */
+    @Override
+    default void close() {
+    }
+
     /**
      * Configuration related elements for the {@link Http2HeadersEncoder} interface
      */

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/DefaultHttp2HeadersEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/DefaultHttp2HeadersEncoderTest.java
@@ -61,7 +61,9 @@ public class DefaultHttp2HeadersEncoderTest {
         assertThrows(StreamException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
-                encoder.encodeHeaders(3 /* randomly chosen */, headers, onHeapAllocator().allocate(256));
+                try (Buffer encoded = onHeapAllocator().allocate(256)) {
+                    encoder.encodeHeaders(3 /* randomly chosen */, headers, encoded);
+                }
             }
         });
     }

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/DefaultHttp2HeadersEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/DefaultHttp2HeadersEncoderTest.java
@@ -18,6 +18,7 @@ import io.netty5.buffer.api.Buffer;
 import io.netty5.handler.codec.http2.Http2Exception.StreamException;
 import io.netty5.handler.codec.http2.headers.Http2Headers;
 import io.netty5.util.AsciiString;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
@@ -37,6 +38,11 @@ public class DefaultHttp2HeadersEncoderTest {
     @BeforeEach
     public void setup() {
         encoder = new DefaultHttp2HeadersEncoder(Http2HeadersEncoder.NEVER_SENSITIVE, newTestEncoder());
+    }
+
+    @AfterEach
+    public void tearDown() {
+        encoder.close();
     }
 
     @Test


### PR DESCRIPTION
Motivation:

When an Http2ConnectionHandler is not used anymore, for example when it is removed from its context pipeline, we may observe a LEAK error when the leak detector is enabled, like this:

```
17:49:38.908 [Cleaner-0] ERROR i.n.buffer.api.LoggingLeakCallback - LEAK: Object "buffer (256 bytes)" was not property closed before it was garbage collected. A life-cycle back-trace (if any) is attached as suppressed exceptions. See https://netty.io/wiki/reference-counted-objects.html for more information.
io.netty5.buffer.api.LoggingLeakCallback$LeakReport: Object life-cycle trace:
	Suppressed: io.netty5.buffer.api.internal.LifecycleTracer$Traceback: ALLOCATE (current acquires = 0) T-166735us.
		at io.netty5.buffer.api.internal.ResourceSupport.<init>(ResourceSupport.java:42)
		at io.netty5.buffer.api.internal.AdaptableBuffer.<init>(AdaptableBuffer.java:28)
		at io.netty5.buffer.api.bytebuffer.NioBuffer.<init>(NioBuffer.java:65)
		at io.netty5.buffer.api.bytebuffer.ByteBufferMemoryManager.createBuffer(ByteBufferMemoryManager.java:83)
		at io.netty5.buffer.api.bytebuffer.ByteBufferMemoryManager.allocateShared(ByteBufferMemoryManager.java:57)
		at io.netty5.buffer.api.ManagedBufferAllocator.allocate(ManagedBufferAllocator.java:54)
		at io.netty5.handler.codec.http2.DefaultHttp2HeadersEncoder.<init>(DefaultHttp2HeadersEncoder.java:30)
		at io.netty5.handler.codec.http2.DefaultHttp2HeadersEncoder.<init>(DefaultHttp2HeadersEncoder.java:37)
		at io.netty5.handler.codec.http2.DefaultHttp2FrameWriter.<init>(DefaultHttp2FrameWriter.java:89)
		at io.netty5.handler.codec.http2.AbstractHttp2ConnectionHandlerBuilder.buildFromConnection(AbstractHttp2ConnectionHandlerBuilder.java:541)
		at io.netty5.handler.codec.http2.AbstractHttp2ConnectionHandlerBuilder.build(AbstractHttp2ConnectionHandlerBuilder.java:533)
		at io.netty5.handler.codec.http2.Http2FrameCodecBuilder.build(Http2FrameCodecBuilder.java:227)
		at reactor.netty5.http.server.HttpServerConfig.configureH2Pipeline(HttpServerConfig.java:535)
		at reactor.netty5.http.server.HttpServerConfig$HttpServerChannelInitializer.onChannelInit(HttpServerConfig.java:1124)
		at reactor.netty5.transport.TransportConfig$TransportChannelInitializer.initChannel(TransportConfig.java:436)
		at io.netty5.channel.ChannelInitializer.handlerAdded(ChannelInitializer.java:86)
		at io.netty5.channel.DefaultChannelHandlerContext.callHandlerAdded(DefaultChannelHandlerContext.java:1034)
		at io.netty5.channel.DefaultChannelPipeline.callHandlerAdded0(DefaultChannelPipeline.java:564)
		at io.netty5.channel.DefaultChannelPipeline.addLast0(DefaultChannelPipeline.java:212)
		at io.netty5.channel.DefaultChannelPipeline.addLast(DefaultChannelPipeline.java:202)
		at io.netty5.channel.DefaultChannelPipeline.addLast(DefaultChannelPipeline.java:320)
		at reactor.netty5.transport.ServerTransport$Acceptor.initChild(ServerTransport.java:421)
		at reactor.netty5.transport.ServerTransport$Acceptor.lambda$channelRead$0(ServerTransport.java:381)
		at io.netty5.util.concurrent.SingleThreadEventExecutor.runTask(SingleThreadEventExecutor.java:338)
		at io.netty5.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:361)
		at io.netty5.channel.SingleThreadEventLoop.run(SingleThreadEventLoop.java:180)
		at io.netty5.util.concurrent.SingleThreadEventExecutor.lambda$doStartThread$4(SingleThreadEventExecutor.java:774)
		at io.netty5.util.internal.ThreadExecutorMap.lambda$apply$1(ThreadExecutorMap.java:68)
		at io.netty5.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
		at java.base/java.lang.Thread.run(Thread.java:833)

```

Analysis:

When reactor-netty configures an http2 pipeline, it creates an _Http2FrameCodec_ which takes as constructor arguments a _DefaultHttp2ConnectionDecoder_ and a _DefaultHttp2ConnectionEncoder_.

Now, I won't describe the whole chain of dependencies, but the _DefaultHttp2ConnectionEncoder_ indirectly refers to a _DefaultHttpFrameWriter_, which itself has a reference to an **_DefaultHttp2HeadersEncoder_** instance, and the _DefaultHttp2HeadersEncoder_ allocates a "_tableSizeChangeOutput_" buffer from its constructor.

Problem: when the _Http2FrameCodec_ is removed from its pipeline (because the channel is closed), then the associated encoder/decoder are closed, then in DefaultHttp2ConnectionEncoder.close() method, the _DefaultHttpFrameWriter_ (_frameWriter_ field) is closed, but _DefaultHttpFrameWriter.close()_ method is empty, so the headersEncoder can't be cleaned, that's why the "_tableSizeChangeOutput_" buffer that was initially created in the _DefaultHttp2ConnectionEncoder_ is not closed.

Modification:

1- Added a default empty _close_ method in the _Http2HeadersEncoder_ interface, which is now implementing an _AutoCloseable_

2- The DefaultHttp2HeadersEncoder is now implementing the close method, which closes the "_tableSizeChangeOutput_" that has been allocated in the constructor. Notice that this buffer has been allocated using "BufferAllocator.onHeapUnpooled().allocate(256)", and maybe we can make another PR in order to allocate differently, because onHeapUnpooled() always create a memory mananager.

3- The _DefaultHttp2FrameWriter.close()_ method is now calling _headersEncoder.close();_ This means that when the _Http2FrameCodec_ is removed from the pipeline, then the _DefaultHttp2FrameWriter.close()_ will call _headersEncoder.close()_, which will clean up the _tableSizeChangeOutput_ buffer that was allocated from the constructor

4- Added _DefaultHttp2HeadersEncoderTest.tearDown()_ method , which just closes the encoder after each test execution, meaning that no more leaks will be displayed if the -P leak option is used.

5- Fixed another memory leak in the _DefaultHttp2HeadersEncoderTest.headersExceedMaxSetSizeShouldFail_, where the encoded buffer should be closed after the test

Result:

No more memory leaks in reactor netty that are related to _DefaultHttp2HeadersEncoder_, and no more leaks error when running "_mvn clean test -P leak -Dtest=DefaultHttp2HeadersEncoderTest_"
