### PR TITLE
Increase timeout in HttpToHttp2ConnectionHandlerTest

### DIFF
--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
@@ -81,7 +81,7 @@ import static org.mockito.Mockito.verify;
  * Testing the {@link HttpToHttp2ConnectionHandler} for {@link FullHttpRequest} objects into HTTP/2 frames
  */
 public class HttpToHttp2ConnectionHandlerTest {
-    private static final int WAIT_TIME_SECONDS = 5;
+    private static final int WAIT_TIME_SECONDS = 10;
 
     @Mock
     private Http2FrameListener clientListener;


### PR DESCRIPTION
Motivation:
A five-second timeout might sometimes be too small when a test runs in a virtualized CI machine on a busy host.

Modification:
Increase the timeout from to ten seconds.

Result:
Hopefully more stable test on CI, unless the failures we see are caused by something else.