### PR TITLE
Upgrade JCTools to 4.0.1

### DIFF
--- a/common/src/main/java/io/netty5/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty5/util/internal/PlatformDependent.java
@@ -20,11 +20,11 @@ import io.netty5.util.internal.logging.InternalLoggerFactory;
 import org.jctools.queues.MpscArrayQueue;
 import org.jctools.queues.MpscChunkedArrayQueue;
 import org.jctools.queues.MpscUnboundedArrayQueue;
-import org.jctools.queues.SpscLinkedQueue;
 import org.jctools.queues.atomic.MpscAtomicArrayQueue;
 import org.jctools.queues.atomic.MpscChunkedAtomicArrayQueue;
 import org.jctools.queues.atomic.MpscUnboundedAtomicArrayQueue;
 import org.jctools.queues.atomic.SpscLinkedAtomicQueue;
+import org.jctools.queues.unpadded.SpscLinkedUnpaddedQueue;
 import org.jctools.util.Pow2;
 import org.jctools.util.UnsafeAccess;
 
@@ -946,9 +946,6 @@ public final class PlatformDependent {
     private static final class Mpsc {
         private static final boolean USE_MPSC_CHUNKED_ARRAY_QUEUE;
 
-        private Mpsc() {
-        }
-
         static {
             Object unsafe = null;
             if (hasUnsafe()) {
@@ -1020,7 +1017,7 @@ public final class PlatformDependent {
      * consumer (one thread!).
      */
     public static <T> Queue<T> newSpscQueue() {
-        return hasUnsafe() ? new SpscLinkedQueue<>() : new SpscLinkedAtomicQueue<>();
+        return hasUnsafe() ? new SpscLinkedUnpaddedQueue<>() : new SpscLinkedAtomicQueue<>();
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -737,7 +737,7 @@
       <dependency>
         <groupId>org.jctools</groupId>
         <artifactId>jctools-core</artifactId>
-        <version>3.1.0</version>
+        <version>4.0.1</version>
       </dependency>
 
       <!-- Annotations for IDE integration and analysis -->

--- a/transport/src/main/java/io/netty5/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty5/channel/local/LocalChannel.java
@@ -54,7 +54,6 @@ public class LocalChannel extends AbstractChannel<LocalServerChannel, LocalAddre
 
     private enum State { OPEN, BOUND, CONNECTED, CLOSED }
 
-    // To further optimize this we could write our own SPSC queue.
     final Queue<Object> inboundBuffer = PlatformDependent.newSpscQueue();
     private final Runnable readNowTask = () -> {
         // Ensure the inboundBuffer is not empty as readInbound() will always call fireChannelReadComplete()


### PR DESCRIPTION
Motivation:
The new JCTools include the ability to use unpadded queues, which is useful for our LocalChannel.

Modification:
Upgrade our JCTools dependency and make LocalChannel use an unpadded queue to save a small amount of memory.

Result:
Updated dependencies.