### PR TITLE
Fix bug in forEachByte on nested composite bytebuf with leak detection

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/WrappedCompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/WrappedCompositeByteBuf.java
@@ -409,6 +409,16 @@ class WrappedCompositeByteBuf extends CompositeByteBuf {
     }
 
     @Override
+    protected int forEachByteAsc0(int start, int end, ByteProcessor processor) throws Exception {
+        return wrapped.forEachByteAsc0(start, end, processor);
+    }
+
+    @Override
+    protected int forEachByteDesc0(int rStart, int rEnd, ByteProcessor processor) throws Exception {
+        return wrapped.forEachByteDesc0(rStart, rEnd, processor);
+    }
+
+    @Override
     public final int hashCode() {
         return wrapped.hashCode();
     }


### PR DESCRIPTION
Motivation:
An NPE could occur when forEachByte was called on nested leak-aware composite byte buffers.

Modification:
WrappedCompositeByteBuf extends CompositeByteBuf but must delegate all calls to the wrapped instance. Add delegation calls for forEachByteAsc0 and forEachByteDesc0. Without delegation, those calls would, from an outer composite buffer, go to the composite structure of the wrapper buffer, which have no components.

Result:
No more NPE when calling forEachByte on nested composite leak-aware buffers.

Fixes #12787