### PR TITLE
Small updates to the cookie parsing

### DIFF
--- a/codec-http/src/main/java/io/netty5/handler/codec/http/headers/DefaultHttpSetCookie.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/headers/DefaultHttpSetCookie.java
@@ -596,6 +596,6 @@ public final class DefaultHttpSetCookie implements HttpSetCookie {
     @NotNull
     private static IllegalArgumentException unexpectedHexValue(int hexValue, int index) {
         return new IllegalArgumentException(
-                "Unexpected hex value at index " + index + ": " + Integer.toHexString(hexValue));
+                "Unexpected hex value at index " + index + ": 0x" + Integer.toHexString(hexValue));
     }
 }


### PR DESCRIPTION
Motivation:
While migrating improvements back to ServiceTalk, some small improvement possibilities were spotted.

Modification:
The cookie delimiter scan function that check for quotation marks to improve error messages, is now used in more places. The "unexpected hex value" error message now prefix the hex value with "0x" for clarity.

Result:
Better error reporting.