### PR TITLE
Automatically generate native-image conditional metadata for ChannelHandler implementations.

### DIFF
--- a/codec-dns/pom.xml
+++ b/codec-dns/pom.xml
@@ -59,6 +59,23 @@
       <artifactId>apacheds-protocol-dns</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <!-- Automatic native-image reflection metadata generation for handlers dependencies -->
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-transport</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>
 

--- a/codec-dns/src/main/resources/META-INF/native-image/codec-dns-handlers/reflect-config.json
+++ b/codec-dns/src/main/resources/META-INF/native-image/codec-dns-handlers/reflect-config.json
@@ -1,0 +1,58 @@
+[
+  {
+    "name": "io.netty.handler.codec.dns.DatagramDnsQueryDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.dns.DatagramDnsQueryDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.dns.DatagramDnsQueryEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.dns.DatagramDnsQueryEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.dns.DatagramDnsResponseDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.dns.DatagramDnsResponseDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.dns.DatagramDnsResponseEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.dns.DatagramDnsResponseEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.dns.TcpDnsQueryDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.dns.TcpDnsQueryDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.dns.TcpDnsQueryEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.dns.TcpDnsQueryEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.dns.TcpDnsResponseDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.dns.TcpDnsResponseDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.dns.TcpDnsResponseEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.dns.TcpDnsResponseEncoder"
+    },
+    "queryAllPublicMethods": true
+  }
+]

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/NativeImageHandlerMetadataTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/NativeImageHandlerMetadataTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.dns;
+
+import io.netty.nativeimage.ChannelHandlerMetadataUtil;
+import org.junit.jupiter.api.Test;
+
+public class NativeImageHandlerMetadataTest {
+
+    @Test
+    public void collectAndCompareMetadata() {
+        ChannelHandlerMetadataUtil.generateMetadata(
+                "codec-dns-handlers/reflect-config.json",
+                "io.netty.handler.codec.dns");
+    }
+
+}

--- a/codec-haproxy/pom.xml
+++ b/codec-haproxy/pom.xml
@@ -48,6 +48,23 @@
       <artifactId>netty-codec</artifactId>
       <version>${project.version}</version>
     </dependency>
+
+    <!-- Automatic native-image reflection metadata generation for handlers dependencies -->
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-transport</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>
 

--- a/codec-haproxy/src/main/resources/META-INF/native-image/haproxy-handlers/reflect-config.json
+++ b/codec-haproxy/src/main/resources/META-INF/native-image/haproxy-handlers/reflect-config.json
@@ -1,0 +1,16 @@
+[
+  {
+    "name": "io.netty.handler.codec.haproxy.HAProxyMessageDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.haproxy.HAProxyMessageDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.haproxy.HAProxyMessageEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.haproxy.HAProxyMessageEncoder"
+    },
+    "queryAllPublicMethods": true
+  }
+]

--- a/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/NativeImageHandlerMetadataTest.java
+++ b/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/NativeImageHandlerMetadataTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.haproxy;
+
+import io.netty.nativeimage.ChannelHandlerMetadataUtil;
+import org.junit.jupiter.api.Test;
+
+public class NativeImageHandlerMetadataTest {
+
+    @Test
+    public void collectAndCompareMetadata() {
+        ChannelHandlerMetadataUtil.generateMetadata(
+                "haproxy-handlers/reflect-config.json",
+                "io.netty.handler.codec.haproxy");
+    }
+
+}

--- a/codec-http/pom.xml
+++ b/codec-http/pom.xml
@@ -96,6 +96,23 @@
       <artifactId>zstd-jni</artifactId>
       <optional>true</optional>
     </dependency>
+
+    <!-- Automatic native-image reflection metadata generation for handlers dependencies -->
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-transport</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>
 

--- a/codec-http/src/main/resources/META-INF/native-image/codec-http-handlers/reflect-config.json
+++ b/codec-http/src/main/resources/META-INF/native-image/codec-http-handlers/reflect-config.json
@@ -1,0 +1,471 @@
+[
+  {
+    "name": "io.netty.handler.codec.http.cors.CorsHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.cors.CorsHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.HttpClientCodec",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpClientCodec"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.HttpClientCodec$Decoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpClientCodec$Decoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.HttpClientCodec$Encoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpClientCodec$Encoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.HttpClientUpgradeHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpClientUpgradeHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.HttpContentCompressor",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpContentCompressor"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.HttpContentDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpContentDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.HttpContentDecompressor",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpContentDecompressor"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.HttpContentEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpContentEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.HttpObjectAggregator",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpObjectAggregator"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.HttpObjectDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpObjectDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.HttpObjectEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpObjectEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.HttpRequestDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpRequestDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.HttpRequestEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpRequestEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.HttpResponseDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpResponseDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.HttpResponseEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpResponseEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.HttpServerCodec",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpServerCodec"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.HttpServerCodec$HttpServerRequestDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpServerCodec$HttpServerRequestDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.HttpServerCodec$HttpServerResponseEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpServerCodec$HttpServerResponseEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.HttpServerExpectContinueHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpServerExpectContinueHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.HttpServerKeepAliveHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpServerKeepAliveHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.HttpServerUpgradeHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpServerUpgradeHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.websocketx.extensions.compression.DeflateDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.extensions.compression.DeflateDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.websocketx.extensions.compression.DeflateEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.extensions.compression.DeflateEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.websocketx.extensions.compression.PerFrameDeflateDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.extensions.compression.PerFrameDeflateDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.websocketx.extensions.compression.PerFrameDeflateEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.extensions.compression.PerFrameDeflateEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.websocketx.extensions.compression.PerMessageDeflateDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.extensions.compression.PerMessageDeflateDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.websocketx.extensions.compression.PerMessageDeflateEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.extensions.compression.PerMessageDeflateEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketClientCompressionHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketClientCompressionHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketServerCompressionHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketServerCompressionHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.websocketx.extensions.WebSocketClientExtensionHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.extensions.WebSocketClientExtensionHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.websocketx.extensions.WebSocketExtensionDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.extensions.WebSocketExtensionDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.websocketx.extensions.WebSocketExtensionEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.extensions.WebSocketExtensionEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.websocketx.extensions.WebSocketServerExtensionHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.extensions.WebSocketServerExtensionHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.websocketx.Utf8FrameValidator",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.Utf8FrameValidator"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.websocketx.WebSocket00FrameDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocket00FrameDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.websocketx.WebSocket00FrameEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocket00FrameEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.websocketx.WebSocket07FrameDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocket07FrameDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.websocketx.WebSocket07FrameEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocket07FrameEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.websocketx.WebSocket08FrameDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocket08FrameDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.websocketx.WebSocket08FrameEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocket08FrameEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.websocketx.WebSocket13FrameDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocket13FrameDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.websocketx.WebSocket13FrameEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocket13FrameEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker$4",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker$4"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.websocketx.WebSocketClientProtocolHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocketClientProtocolHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.websocketx.WebSocketClientProtocolHandshakeHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocketClientProtocolHandshakeHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.websocketx.WebSocketFrameAggregator",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocketFrameAggregator"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.websocketx.WebSocketFrameDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocketFrameDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.websocketx.WebSocketFrameEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocketFrameEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.websocketx.WebSocketProtocolHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocketProtocolHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.websocketx.WebSocketServerHandshaker$2",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocketServerHandshaker$2"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandshakeHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandshakeHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.rtsp.RtspDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.rtsp.RtspDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.rtsp.RtspEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.rtsp.RtspEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.rtsp.RtspObjectDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.rtsp.RtspObjectDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.rtsp.RtspObjectEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.rtsp.RtspObjectEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.rtsp.RtspRequestDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.rtsp.RtspRequestDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.rtsp.RtspRequestEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.rtsp.RtspRequestEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.rtsp.RtspResponseDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.rtsp.RtspResponseDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.rtsp.RtspResponseEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.rtsp.RtspResponseEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.spdy.SpdyFrameCodec",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.spdy.SpdyFrameCodec"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.spdy.SpdyHttpCodec",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.spdy.SpdyHttpCodec"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.spdy.SpdyHttpDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.spdy.SpdyHttpDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.spdy.SpdyHttpEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.spdy.SpdyHttpEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.spdy.SpdyHttpResponseStreamIdHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.spdy.SpdyHttpResponseStreamIdHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.spdy.SpdySessionHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.spdy.SpdySessionHandler"
+    },
+    "queryAllPublicMethods": true
+  }
+]

--- a/codec-http/src/test/java/io/netty/handler/codec/http/NativeImageHandlerMetadataTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/NativeImageHandlerMetadataTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http;
+
+import io.netty.nativeimage.ChannelHandlerMetadataUtil;
+import org.junit.jupiter.api.Test;
+
+public class NativeImageHandlerMetadataTest {
+
+    @Test
+    public void collectAndCompareMetadata() {
+        ChannelHandlerMetadataUtil.generateMetadata(
+                "codec-http-handlers/reflect-config.json",
+                "io.netty.handler.codec.http",
+                "io.netty.handler.codec.rtsp",
+                "io.netty.handler.codec.spdy");
+    }
+
+}

--- a/codec-http2/pom.xml
+++ b/codec-http2/pom.xml
@@ -100,6 +100,23 @@
       <artifactId>zstd-jni</artifactId>
       <optional>true</optional>
     </dependency>
+
+    <!-- Automatic native-image reflection metadata generation for handlers dependencies -->
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-transport</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>
 

--- a/codec-http2/src/main/resources/META-INF/native-image/codec-http2-handlers/reflect-config.json
+++ b/codec-http2/src/main/resources/META-INF/native-image/codec-http2-handlers/reflect-config.json
@@ -1,0 +1,72 @@
+[
+  {
+    "name": "io.netty.handler.codec.http2.CleartextHttp2ServerUpgradeHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http2.CleartextHttp2ServerUpgradeHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http2.Http2ChannelDuplexHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http2.Http2ChannelDuplexHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http2.Http2ConnectionHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http2.Http2ConnectionHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http2.Http2FrameCodec",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http2.Http2FrameCodec"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http2.Http2FrameLogger",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http2.Http2FrameLogger"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http2.Http2MultiplexCodec",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http2.Http2MultiplexCodec"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http2.Http2MultiplexHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http2.Http2MultiplexHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http2.Http2StreamFrameToHttpObjectCodec",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http2.Http2StreamFrameToHttpObjectCodec"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http2.HttpToHttp2ConnectionHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http2.HttpToHttp2ConnectionHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.http2.InboundHttpToHttp2Adapter",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http2.InboundHttpToHttp2Adapter"
+    },
+    "queryAllPublicMethods": true
+  }
+]

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/NativeImageHandlerMetadataTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/NativeImageHandlerMetadataTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http2;
+
+import io.netty.nativeimage.ChannelHandlerMetadataUtil;
+import org.junit.jupiter.api.Test;
+
+public class NativeImageHandlerMetadataTest {
+
+    @Test
+    public void collectAndCompareMetadata() {
+        ChannelHandlerMetadataUtil.generateMetadata(
+                "codec-http2-handlers/reflect-config.json",
+                "io.netty.handler.codec.http2");
+    }
+
+}

--- a/codec-memcache/pom.xml
+++ b/codec-memcache/pom.xml
@@ -53,6 +53,23 @@
       <artifactId>netty-codec</artifactId>
       <version>${project.version}</version>
     </dependency>
+
+    <!-- Automatic native-image reflection metadata generation for handlers dependencies -->
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-transport</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/codec-memcache/src/main/resources/META-INF/native-image/memcache-handlers/reflect-config.json
+++ b/codec-memcache/src/main/resources/META-INF/native-image/memcache-handlers/reflect-config.json
@@ -1,0 +1,100 @@
+[
+  {
+    "name": "io.netty.handler.codec.memcache.AbstractMemcacheObjectAggregator",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.memcache.AbstractMemcacheObjectAggregator"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.memcache.AbstractMemcacheObjectDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.memcache.AbstractMemcacheObjectDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.memcache.AbstractMemcacheObjectEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.memcache.AbstractMemcacheObjectEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.memcache.binary.AbstractBinaryMemcacheDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.memcache.binary.AbstractBinaryMemcacheDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.memcache.binary.AbstractBinaryMemcacheEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.memcache.binary.AbstractBinaryMemcacheEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.memcache.binary.BinaryMemcacheClientCodec",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.memcache.binary.BinaryMemcacheClientCodec"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.memcache.binary.BinaryMemcacheClientCodec$Decoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.memcache.binary.BinaryMemcacheClientCodec$Decoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.memcache.binary.BinaryMemcacheClientCodec$Encoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.memcache.binary.BinaryMemcacheClientCodec$Encoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.memcache.binary.BinaryMemcacheObjectAggregator",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.memcache.binary.BinaryMemcacheObjectAggregator"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.memcache.binary.BinaryMemcacheRequestDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.memcache.binary.BinaryMemcacheRequestDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.memcache.binary.BinaryMemcacheRequestEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.memcache.binary.BinaryMemcacheRequestEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.memcache.binary.BinaryMemcacheResponseDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.memcache.binary.BinaryMemcacheResponseDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.memcache.binary.BinaryMemcacheResponseEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.memcache.binary.BinaryMemcacheResponseEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.memcache.binary.BinaryMemcacheServerCodec",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.memcache.binary.BinaryMemcacheServerCodec"
+    },
+    "queryAllPublicMethods": true
+  }
+]

--- a/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/NativeImageHandlerMetadataTest.java
+++ b/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/NativeImageHandlerMetadataTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.memcache.binary;
+
+import io.netty.nativeimage.ChannelHandlerMetadataUtil;
+import org.junit.jupiter.api.Test;
+
+public class NativeImageHandlerMetadataTest {
+
+    @Test
+    public void collectAndCompareMetadata() {
+        ChannelHandlerMetadataUtil.generateMetadata(
+                "memcache-handlers/reflect-config.json",
+                "io.netty.handler.codec.memcache");
+    }
+
+}

--- a/codec-mqtt/pom.xml
+++ b/codec-mqtt/pom.xml
@@ -57,5 +57,22 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
     </dependency>
+
+    <!-- Automatic native-image reflection metadata generation for handlers dependencies -->
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-transport</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/codec-mqtt/src/main/resources/META-INF/native-image/codec-mqtt-handlers/reflect-config.json
+++ b/codec-mqtt/src/main/resources/META-INF/native-image/codec-mqtt-handlers/reflect-config.json
@@ -1,0 +1,16 @@
+[
+  {
+    "name": "io.netty.handler.codec.mqtt.MqttDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.mqtt.MqttDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.mqtt.MqttEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.mqtt.MqttEncoder"
+    },
+    "queryAllPublicMethods": true
+  }
+]

--- a/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/NativeImageHandlerMetadataTest.java
+++ b/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/NativeImageHandlerMetadataTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.mqtt;
+
+import io.netty.nativeimage.ChannelHandlerMetadataUtil;
+import org.junit.jupiter.api.Test;
+
+public class NativeImageHandlerMetadataTest {
+
+    @Test
+    public void collectAndCompareMetadata() {
+        ChannelHandlerMetadataUtil.generateMetadata(
+                "codec-mqtt-handlers/reflect-config.json",
+                "io.netty.handler.codec.mqtt");
+    }
+
+}

--- a/codec-redis/pom.xml
+++ b/codec-redis/pom.xml
@@ -53,6 +53,23 @@
       <artifactId>netty-codec</artifactId>
       <version>${project.version}</version>
     </dependency>
+
+    <!-- Automatic native-image reflection metadata generation for handlers dependencies -->
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-transport</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/codec-redis/src/main/resources/META-INF/native-image/codec-redis-handlers/reflect-config.json
+++ b/codec-redis/src/main/resources/META-INF/native-image/codec-redis-handlers/reflect-config.json
@@ -1,0 +1,30 @@
+[
+  {
+    "name": "io.netty.handler.codec.redis.RedisArrayAggregator",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.redis.RedisArrayAggregator"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.redis.RedisBulkStringAggregator",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.redis.RedisBulkStringAggregator"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.redis.RedisDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.redis.RedisDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.redis.RedisEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.redis.RedisEncoder"
+    },
+    "queryAllPublicMethods": true
+  }
+]

--- a/codec-redis/src/test/java/io/netty/handler/codec/redis/NativeImageHandlerMetadataTest.java
+++ b/codec-redis/src/test/java/io/netty/handler/codec/redis/NativeImageHandlerMetadataTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.redis;
+
+import io.netty.nativeimage.ChannelHandlerMetadataUtil;
+import org.junit.jupiter.api.Test;
+
+public class NativeImageHandlerMetadataTest {
+
+    @Test
+    public void collectAndCompareMetadata() {
+        ChannelHandlerMetadataUtil.generateMetadata(
+                "codec-redis-handlers/reflect-config.json",
+                "io.netty.handler.codec.redis");
+    }
+
+}

--- a/codec-smtp/pom.xml
+++ b/codec-smtp/pom.xml
@@ -53,6 +53,23 @@
       <artifactId>netty-codec</artifactId>
       <version>${project.version}</version>
     </dependency>
+
+    <!-- Automatic native-image reflection metadata generation for handlers dependencies -->
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-transport</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>
 

--- a/codec-smtp/src/main/resources/META-INF/native-image/codec-smtp-handlers/reflect-config.json
+++ b/codec-smtp/src/main/resources/META-INF/native-image/codec-smtp-handlers/reflect-config.json
@@ -1,0 +1,16 @@
+[
+  {
+    "name": "io.netty.handler.codec.smtp.SmtpRequestEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.smtp.SmtpRequestEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.smtp.SmtpResponseDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.smtp.SmtpResponseDecoder"
+    },
+    "queryAllPublicMethods": true
+  }
+]

--- a/codec-smtp/src/test/java/io/netty/handler/codec/smtp/NativeImageHandlerMetadataTest.java
+++ b/codec-smtp/src/test/java/io/netty/handler/codec/smtp/NativeImageHandlerMetadataTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.smtp;
+
+import io.netty.nativeimage.ChannelHandlerMetadataUtil;
+import org.junit.jupiter.api.Test;
+
+public class NativeImageHandlerMetadataTest {
+
+    @Test
+    public void collectAndCompareMetadata() {
+        ChannelHandlerMetadataUtil.generateMetadata(
+                "codec-smtp-handlers/reflect-config.json",
+                "io.netty.handler.codec.smtp");
+    }
+
+}

--- a/codec-socks/pom.xml
+++ b/codec-socks/pom.xml
@@ -53,6 +53,23 @@
       <artifactId>netty-codec</artifactId>
       <version>${project.version}</version>
     </dependency>
+
+    <!-- Automatic native-image reflection metadata generation for handlers dependencies -->
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-transport</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>
 

--- a/codec-socks/src/main/resources/META-INF/native-image/codec-socks-handlers/reflect-config.json
+++ b/codec-socks/src/main/resources/META-INF/native-image/codec-socks-handlers/reflect-config.json
@@ -1,0 +1,142 @@
+[
+  {
+    "name": "io.netty.handler.codec.socks.SocksAuthRequestDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.socks.SocksAuthRequestDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.socks.SocksAuthResponseDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.socks.SocksAuthResponseDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.socks.SocksCmdRequestDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.socks.SocksCmdRequestDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.socks.SocksCmdResponseDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.socks.SocksCmdResponseDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.socks.SocksInitRequestDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.socks.SocksInitRequestDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.socks.SocksInitResponseDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.socks.SocksInitResponseDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.socks.SocksMessageEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.socks.SocksMessageEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.socksx.SocksPortUnificationServerHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.socksx.SocksPortUnificationServerHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.socksx.v4.Socks4ClientDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.socksx.v4.Socks4ClientDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.socksx.v4.Socks4ClientEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.socksx.v4.Socks4ClientEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.socksx.v4.Socks4ServerDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.socksx.v4.Socks4ServerDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.socksx.v4.Socks4ServerEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.socksx.v4.Socks4ServerEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.socksx.v5.Socks5ClientEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.socksx.v5.Socks5ClientEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.socksx.v5.Socks5CommandRequestDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.socksx.v5.Socks5CommandRequestDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.socksx.v5.Socks5CommandResponseDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.socksx.v5.Socks5CommandResponseDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.socksx.v5.Socks5InitialRequestDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.socksx.v5.Socks5InitialRequestDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.socksx.v5.Socks5InitialResponseDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.socksx.v5.Socks5InitialResponseDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.socksx.v5.Socks5PasswordAuthRequestDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.socksx.v5.Socks5PasswordAuthRequestDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.socksx.v5.Socks5PasswordAuthResponseDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.socksx.v5.Socks5PasswordAuthResponseDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.socksx.v5.Socks5ServerEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.socksx.v5.Socks5ServerEncoder"
+    },
+    "queryAllPublicMethods": true
+  }
+]

--- a/codec-socks/src/test/java/io/netty/handler/codec/socks/NativeImageHandlerMetadataTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socks/NativeImageHandlerMetadataTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.socks;
+
+import io.netty.nativeimage.ChannelHandlerMetadataUtil;
+import org.junit.jupiter.api.Test;
+
+public class NativeImageHandlerMetadataTest {
+
+    @Test
+    public void collectAndCompareMetadata() {
+        ChannelHandlerMetadataUtil.generateMetadata(
+                "codec-socks-handlers/reflect-config.json",
+                "io.netty.handler.codec.socks", "io.netty.handler.codec.socksx");
+    }
+
+}

--- a/codec-stomp/pom.xml
+++ b/codec-stomp/pom.xml
@@ -53,6 +53,23 @@
       <artifactId>netty-codec</artifactId>
       <version>${project.version}</version>
     </dependency>
+
+    <!-- Automatic native-image reflection metadata generation for handlers dependencies -->
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-transport</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>
 

--- a/codec-stomp/src/main/resources/META-INF/native-image/stomp-handlers/reflect-config.json
+++ b/codec-stomp/src/main/resources/META-INF/native-image/stomp-handlers/reflect-config.json
@@ -1,0 +1,23 @@
+[
+  {
+    "name": "io.netty.handler.codec.stomp.StompSubframeAggregator",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.stomp.StompSubframeAggregator"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.stomp.StompSubframeDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.stomp.StompSubframeDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.stomp.StompSubframeEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.stomp.StompSubframeEncoder"
+    },
+    "queryAllPublicMethods": true
+  }
+]

--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/NativeImageHandlerMetadataTest.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/NativeImageHandlerMetadataTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.stomp;
+
+import io.netty.nativeimage.ChannelHandlerMetadataUtil;
+import org.junit.jupiter.api.Test;
+
+public class NativeImageHandlerMetadataTest {
+
+    @Test
+    public void collectAndCompareMetadata() {
+        ChannelHandlerMetadataUtil.generateMetadata(
+                "stomp-handlers/reflect-config.json",
+                "io.netty.handler.codec.stomp");
+    }
+
+}

--- a/codec-xml/pom.xml
+++ b/codec-xml/pom.xml
@@ -52,6 +52,23 @@
       <groupId>com.fasterxml</groupId>
       <artifactId>aalto-xml</artifactId>
     </dependency>
+
+    <!-- Automatic native-image reflection metadata generation for handlers dependencies -->
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-transport</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>
 

--- a/codec-xml/src/main/resources/META-INF/native-image/codec-xml-handlers/reflect-config.json
+++ b/codec-xml/src/main/resources/META-INF/native-image/codec-xml-handlers/reflect-config.json
@@ -1,0 +1,16 @@
+[
+  {
+    "name": "io.netty.handler.codec.xml.XmlDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.xml.XmlDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.xml.XmlFrameDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.xml.XmlFrameDecoder"
+    },
+    "queryAllPublicMethods": true
+  }
+]

--- a/codec-xml/src/test/java/io/netty/handler/codec/xml/NativeImageHandlerMetadataTest.java
+++ b/codec-xml/src/test/java/io/netty/handler/codec/xml/NativeImageHandlerMetadataTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.xml;
+
+import io.netty.nativeimage.ChannelHandlerMetadataUtil;
+import org.junit.jupiter.api.Test;
+
+public class NativeImageHandlerMetadataTest {
+
+    @Test
+    public void collectAndCompareMetadata() {
+        ChannelHandlerMetadataUtil.generateMetadata(
+                "codec-xml-handlers/reflect-config.json",
+                "io.netty.handler.codec.xml");
+    }
+
+}

--- a/codec/pom.xml
+++ b/codec/pom.xml
@@ -132,6 +132,23 @@
       <artifactId>commons-compress</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <!-- Automatic native-image reflection metadata generation for handlers dependencies -->
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-transport</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>
 

--- a/codec/src/main/resources/META-INF/native-image/codec-handlers/native-image.properties
+++ b/codec/src/main/resources/META-INF/native-image/codec-handlers/native-image.properties
@@ -1,4 +1,4 @@
-# Copyright 2019 The Netty Project
+# Copyright 2022 The Netty Project
 #
 # The Netty Project licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance
@@ -12,5 +12,4 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-Args = --initialize-at-build-time=io.netty \
-       --initialize-at-run-time=io.netty.handler.codec.http.HttpObjectEncoder,io.netty.handler.codec.http.websocketx.WebSocket00FrameEncoder,io.netty.handler.codec.http.websocketx.extensions.compression.DeflateDecoder
+Args = --initialize-at-run-time=io.netty.handler.codec.compression.BrotliDecoder

--- a/codec/src/main/resources/META-INF/native-image/codec-handlers/reflect-config.json
+++ b/codec/src/main/resources/META-INF/native-image/codec-handlers/reflect-config.json
@@ -1,0 +1,443 @@
+[
+  {
+    "name": "io.netty.handler.codec.base64.Base64Decoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.base64.Base64Decoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.base64.Base64Encoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.base64.Base64Encoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.bytes.ByteArrayDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.bytes.ByteArrayDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.bytes.ByteArrayEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.bytes.ByteArrayEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.ByteToMessageCodec",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.ByteToMessageCodec"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.ByteToMessageCodec$1",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.ByteToMessageCodec$1"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.ByteToMessageCodec$Encoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.ByteToMessageCodec$Encoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.ByteToMessageDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.ByteToMessageDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.BrotliDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.BrotliDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.BrotliEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.BrotliEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.Bzip2Decoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.Bzip2Decoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.Bzip2Encoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.Bzip2Encoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.FastLzFrameDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.FastLzFrameDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.FastLzFrameEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.FastLzFrameEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.JdkZlibDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.JdkZlibDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.JdkZlibEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.JdkZlibEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.JZlibDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.JZlibDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.JZlibEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.JZlibEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.Lz4FrameDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.Lz4FrameDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.Lz4FrameEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.Lz4FrameEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.LzfDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.LzfDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.LzfEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.LzfEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.LzmaFrameEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.LzmaFrameEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.SnappyFramedDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.SnappyFramedDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.SnappyFrameDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.SnappyFrameDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.SnappyFramedEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.SnappyFramedEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.SnappyFrameEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.SnappyFrameEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.ZlibDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.ZlibDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.ZlibEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.ZlibEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.ZstdEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.ZstdEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.DatagramPacketDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.DatagramPacketDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.DatagramPacketEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.DatagramPacketEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.DelimiterBasedFrameDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.DelimiterBasedFrameDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.FixedLengthFrameDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.FixedLengthFrameDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.json.JsonObjectDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.json.JsonObjectDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.LengthFieldBasedFrameDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.LengthFieldBasedFrameDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.LengthFieldPrepender",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.LengthFieldPrepender"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.LineBasedFrameDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.LineBasedFrameDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.marshalling.CompatibleMarshallingDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.marshalling.CompatibleMarshallingDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.marshalling.CompatibleMarshallingEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.marshalling.CompatibleMarshallingEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.marshalling.MarshallingDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.marshalling.MarshallingDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.marshalling.MarshallingEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.marshalling.MarshallingEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.MessageAggregator",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.MessageAggregator"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.MessageToByteEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.MessageToByteEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.MessageToMessageCodec",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.MessageToMessageCodec"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.MessageToMessageCodec$1",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.MessageToMessageCodec$1"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.MessageToMessageCodec$2",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.MessageToMessageCodec$2"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.MessageToMessageDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.MessageToMessageDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.MessageToMessageEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.MessageToMessageEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.protobuf.ProtobufDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.protobuf.ProtobufDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.protobuf.ProtobufDecoderNano",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.protobuf.ProtobufDecoderNano"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.protobuf.ProtobufEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.protobuf.ProtobufEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.protobuf.ProtobufEncoderNano",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.protobuf.ProtobufEncoderNano"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.protobuf.ProtobufVarint32FrameDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.protobuf.ProtobufVarint32FrameDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.protobuf.ProtobufVarint32LengthFieldPrepender",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.protobuf.ProtobufVarint32LengthFieldPrepender"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.ReplayingDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.ReplayingDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.serialization.CompatibleObjectEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.serialization.CompatibleObjectEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.serialization.ObjectDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.serialization.ObjectDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.serialization.ObjectEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.serialization.ObjectEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.string.LineEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.string.LineEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.string.StringDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.string.StringDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.string.StringEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.string.StringEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.xml.XmlFrameDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.xml.XmlFrameDecoder"
+    },
+    "queryAllPublicMethods": true
+  }
+]

--- a/codec/src/test/java/io/netty/handler/codec/NativeImageHandlerMetadataTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/NativeImageHandlerMetadataTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec;
+
+import org.junit.jupiter.api.Test;
+
+import io.netty.nativeimage.ChannelHandlerMetadataUtil;
+
+public class NativeImageHandlerMetadataTest {
+
+    @Test
+    public void collectAndCompareMetadata() {
+        ChannelHandlerMetadataUtil.generateMetadata(
+                "codec-handlers/reflect-config.json",
+                "io.netty.handler.codec");
+    }
+
+}

--- a/handler-proxy/pom.xml
+++ b/handler-proxy/pom.xml
@@ -76,6 +76,23 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
     </dependency>
+
+    <!-- Automatic native-image reflection metadata generation for handlers dependencies -->
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-transport</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>
 

--- a/handler-proxy/src/main/resources/META-INF/native-image/handler-proxy-handlers/reflect-config.json
+++ b/handler-proxy/src/main/resources/META-INF/native-image/handler-proxy-handlers/reflect-config.json
@@ -1,0 +1,37 @@
+[
+  {
+    "name": "io.netty.handler.proxy.HttpProxyHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.proxy.HttpProxyHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.proxy.HttpProxyHandler$HttpClientCodecWrapper",
+    "condition": {
+      "typeReachable": "io.netty.handler.proxy.HttpProxyHandler$HttpClientCodecWrapper"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.proxy.ProxyHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.proxy.ProxyHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.proxy.Socks4ProxyHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.proxy.Socks4ProxyHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.proxy.Socks5ProxyHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.proxy.Socks5ProxyHandler"
+    },
+    "queryAllPublicMethods": true
+  }
+]

--- a/handler-proxy/src/test/java/io/netty/handler/proxy/NativeImageHandlerMetadataTest.java
+++ b/handler-proxy/src/test/java/io/netty/handler/proxy/NativeImageHandlerMetadataTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.proxy;
+
+import io.netty.nativeimage.ChannelHandlerMetadataUtil;
+import org.junit.jupiter.api.Test;
+
+public class NativeImageHandlerMetadataTest {
+
+    @Test
+    public void collectAndCompareMetadata() {
+        ChannelHandlerMetadataUtil.generateMetadata(
+                "handler-proxy-handlers/reflect-config.json",
+                "io.netty.handler.proxy");
+    }
+
+}

--- a/handler/pom.xml
+++ b/handler/pom.xml
@@ -109,6 +109,23 @@
       <classifier>linux-x86_64</classifier>
       <scope>test</scope>
     </dependency>
+
+    <!-- Automatic native-image reflection metadata generation for handlers dependencies -->
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-transport</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>
 

--- a/handler/src/main/resources/META-INF/native-image/handler-handlers/reflect-config.json
+++ b/handler/src/main/resources/META-INF/native-image/handler-handlers/reflect-config.json
@@ -1,0 +1,632 @@
+[
+  {
+    "name": "io.netty.handler.address.DynamicAddressConnectHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.address.DynamicAddressConnectHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.address.ResolveAddressHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.address.ResolveAddressHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.base64.Base64Decoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.base64.Base64Decoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.base64.Base64Encoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.base64.Base64Encoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.bytes.ByteArrayDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.bytes.ByteArrayDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.bytes.ByteArrayEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.bytes.ByteArrayEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.ByteToMessageCodec",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.ByteToMessageCodec"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.ByteToMessageCodec$1",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.ByteToMessageCodec$1"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.ByteToMessageCodec$Encoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.ByteToMessageCodec$Encoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.ByteToMessageDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.ByteToMessageDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.BrotliDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.BrotliDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.BrotliEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.BrotliEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.Bzip2Decoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.Bzip2Decoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.Bzip2Encoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.Bzip2Encoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.FastLzFrameDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.FastLzFrameDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.FastLzFrameEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.FastLzFrameEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.JdkZlibDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.JdkZlibDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.JdkZlibEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.JdkZlibEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.JZlibDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.JZlibDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.JZlibEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.JZlibEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.Lz4FrameDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.Lz4FrameDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.Lz4FrameEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.Lz4FrameEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.LzfDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.LzfDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.LzfEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.LzfEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.LzmaFrameEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.LzmaFrameEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.SnappyFramedDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.SnappyFramedDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.SnappyFrameDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.SnappyFrameDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.SnappyFramedEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.SnappyFramedEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.SnappyFrameEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.SnappyFrameEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.ZlibDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.ZlibDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.ZlibEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.ZlibEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.compression.ZstdEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.ZstdEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.DatagramPacketDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.DatagramPacketDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.DatagramPacketEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.DatagramPacketEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.DelimiterBasedFrameDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.DelimiterBasedFrameDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.FixedLengthFrameDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.FixedLengthFrameDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.json.JsonObjectDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.json.JsonObjectDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.LengthFieldBasedFrameDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.LengthFieldBasedFrameDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.LengthFieldPrepender",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.LengthFieldPrepender"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.LineBasedFrameDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.LineBasedFrameDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.marshalling.CompatibleMarshallingDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.marshalling.CompatibleMarshallingDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.marshalling.CompatibleMarshallingEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.marshalling.CompatibleMarshallingEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.marshalling.MarshallingDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.marshalling.MarshallingDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.marshalling.MarshallingEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.marshalling.MarshallingEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.MessageAggregator",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.MessageAggregator"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.MessageToByteEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.MessageToByteEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.MessageToMessageCodec",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.MessageToMessageCodec"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.MessageToMessageCodec$1",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.MessageToMessageCodec$1"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.MessageToMessageCodec$2",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.MessageToMessageCodec$2"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.MessageToMessageDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.MessageToMessageDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.MessageToMessageEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.MessageToMessageEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.protobuf.ProtobufDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.protobuf.ProtobufDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.protobuf.ProtobufDecoderNano",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.protobuf.ProtobufDecoderNano"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.protobuf.ProtobufEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.protobuf.ProtobufEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.protobuf.ProtobufEncoderNano",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.protobuf.ProtobufEncoderNano"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.protobuf.ProtobufVarint32FrameDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.protobuf.ProtobufVarint32FrameDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.protobuf.ProtobufVarint32LengthFieldPrepender",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.protobuf.ProtobufVarint32LengthFieldPrepender"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.ReplayingDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.ReplayingDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.serialization.CompatibleObjectEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.serialization.CompatibleObjectEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.serialization.ObjectDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.serialization.ObjectDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.serialization.ObjectEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.serialization.ObjectEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.string.LineEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.string.LineEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.string.StringDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.string.StringDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.string.StringEncoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.string.StringEncoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.xml.XmlFrameDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.xml.XmlFrameDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.flow.FlowControlHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.flow.FlowControlHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.flush.FlushConsolidationHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.flush.FlushConsolidationHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.ipfilter.AbstractRemoteAddressFilter",
+    "condition": {
+      "typeReachable": "io.netty.handler.ipfilter.AbstractRemoteAddressFilter"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.ipfilter.IpSubnetFilter",
+    "condition": {
+      "typeReachable": "io.netty.handler.ipfilter.IpSubnetFilter"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.ipfilter.RuleBasedIpFilter",
+    "condition": {
+      "typeReachable": "io.netty.handler.ipfilter.RuleBasedIpFilter"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.ipfilter.UniqueIpFilter",
+    "condition": {
+      "typeReachable": "io.netty.handler.ipfilter.UniqueIpFilter"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.logging.LoggingHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.logging.LoggingHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.pcap.PcapWriteHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.pcap.PcapWriteHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.ssl.AbstractSniHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.ssl.AbstractSniHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.ssl.ApplicationProtocolNegotiationHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.ssl.ApplicationProtocolNegotiationHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.ssl.ocsp.OcspClientHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.ssl.ocsp.OcspClientHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.ssl.OptionalSslHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.ssl.OptionalSslHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.ssl.SniHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.ssl.SniHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.ssl.SslClientHelloHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.ssl.SslClientHelloHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.ssl.SslHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.ssl.SslHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.ssl.SslMasterKeyHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.ssl.SslMasterKeyHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.ssl.SslMasterKeyHandler$WiresharkSslMasterKeyHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.ssl.SslMasterKeyHandler$WiresharkSslMasterKeyHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.stream.ChunkedWriteHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.stream.ChunkedWriteHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.timeout.IdleStateHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.timeout.IdleStateHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.timeout.ReadTimeoutHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.timeout.ReadTimeoutHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.timeout.WriteTimeoutHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.timeout.WriteTimeoutHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.traffic.AbstractTrafficShapingHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.traffic.AbstractTrafficShapingHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.traffic.ChannelTrafficShapingHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.traffic.ChannelTrafficShapingHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.traffic.GlobalChannelTrafficShapingHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.traffic.GlobalChannelTrafficShapingHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.traffic.GlobalTrafficShapingHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.traffic.GlobalTrafficShapingHandler"
+    },
+    "queryAllPublicMethods": true
+  }
+]

--- a/handler/src/test/java/io/netty/handler/NativeImageHandlerMetadataTest.java
+++ b/handler/src/test/java/io/netty/handler/NativeImageHandlerMetadataTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler;
+
+import io.netty.nativeimage.ChannelHandlerMetadataUtil;
+import org.junit.jupiter.api.Test;
+
+public class NativeImageHandlerMetadataTest {
+
+    @Test
+    public void collectAndCompareMetadata() {
+        ChannelHandlerMetadataUtil.generateMetadata(
+                "handler-handlers/reflect-config.json",
+                "io.netty.handler");
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -928,6 +928,12 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>org.reflections</groupId>
+        <artifactId>reflections</artifactId>
+        <version>0.10.2</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
         <version>1.2.3</version>

--- a/resolver-dns/pom.xml
+++ b/resolver-dns/pom.xml
@@ -89,6 +89,23 @@
       <version>2.6</version>
       <scope>test</scope>
     </dependency>
+
+    <!-- Automatic native-image reflection metadata generation for handlers dependencies -->
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-transport</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>
 

--- a/resolver-dns/src/main/resources/META-INF/native-image/resolver-dns-handlers/reflect-config.json
+++ b/resolver-dns/src/main/resources/META-INF/native-image/resolver-dns-handlers/reflect-config.json
@@ -1,0 +1,30 @@
+[
+  {
+    "name": "io.netty.resolver.dns.DnsNameResolver$1",
+    "condition": {
+      "typeReachable": "io.netty.resolver.dns.DnsNameResolver$1"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.resolver.dns.DnsNameResolver$3",
+    "condition": {
+      "typeReachable": "io.netty.resolver.dns.DnsNameResolver$3"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.resolver.dns.DnsNameResolver$DnsResponseHandler",
+    "condition": {
+      "typeReachable": "io.netty.resolver.dns.DnsNameResolver$DnsResponseHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.resolver.dns.DnsNameResolver$DnsResponseHandler$1$1",
+    "condition": {
+      "typeReachable": "io.netty.resolver.dns.DnsNameResolver$DnsResponseHandler$1$1"
+    },
+    "queryAllPublicMethods": true
+  }
+]

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/NativeImageHandlerMetadataTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/NativeImageHandlerMetadataTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import io.netty.nativeimage.ChannelHandlerMetadataUtil;
+import org.junit.jupiter.api.Test;
+
+public class NativeImageHandlerMetadataTest {
+
+    @Test
+    public void collectAndCompareMetadata() {
+        ChannelHandlerMetadataUtil.generateMetadata(
+                "resolver-dns-handlers/reflect-config.json",
+                "io.netty.resolver.dns");
+    }
+
+}

--- a/transport-sctp/pom.xml
+++ b/transport-sctp/pom.xml
@@ -53,6 +53,23 @@
       <artifactId>netty-transport</artifactId>
       <version>${project.version}</version>
     </dependency>
+
+    <!-- Automatic native-image reflection metadata generation for handlers dependencies -->
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-transport</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/transport-sctp/src/main/resources/META-INF/native-image/transport-sctp-handlers/reflect-config.json
+++ b/transport-sctp/src/main/resources/META-INF/native-image/transport-sctp-handlers/reflect-config.json
@@ -1,0 +1,30 @@
+[
+  {
+    "name": "io.netty.handler.codec.sctp.SctpInboundByteStreamHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.sctp.SctpInboundByteStreamHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.sctp.SctpMessageCompletionHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.sctp.SctpMessageCompletionHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.sctp.SctpMessageToMessageDecoder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.sctp.SctpMessageToMessageDecoder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.handler.codec.sctp.SctpOutboundByteStreamHandler",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.sctp.SctpOutboundByteStreamHandler"
+    },
+    "queryAllPublicMethods": true
+  }
+]

--- a/transport-sctp/src/test/java/io/netty/handler/codec/sctp/NativeImageHandlerMetadataTest.java
+++ b/transport-sctp/src/test/java/io/netty/handler/codec/sctp/NativeImageHandlerMetadataTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.sctp;
+
+import io.netty.nativeimage.ChannelHandlerMetadataUtil;
+import org.junit.jupiter.api.Test;
+
+public class NativeImageHandlerMetadataTest {
+
+    @Test
+    public void collectAndCompareMetadata() {
+        ChannelHandlerMetadataUtil.generateMetadata(
+                "transport-sctp-handlers/reflect-config.json",
+                "io.netty.handler.codec.sctp");
+    }
+
+}

--- a/transport/pom.xml
+++ b/transport/pom.xml
@@ -52,6 +52,15 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
   </dependencies>
 </project>
 

--- a/transport/src/main/resources/META-INF/native-image/transport-handlers/reflect-config.json
+++ b/transport/src/main/resources/META-INF/native-image/transport-handlers/reflect-config.json
@@ -1,0 +1,121 @@
+[
+  {
+    "name": "io.netty.bootstrap.ServerBootstrap$1",
+    "condition": {
+      "typeReachable": "io.netty.bootstrap.ServerBootstrap$1"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.bootstrap.ServerBootstrap$ServerBootstrapAcceptor",
+    "condition": {
+      "typeReachable": "io.netty.bootstrap.ServerBootstrap$ServerBootstrapAcceptor"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.channel.ChannelDuplexHandler",
+    "condition": {
+      "typeReachable": "io.netty.channel.ChannelDuplexHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.channel.ChannelHandler",
+    "condition": {
+      "typeReachable": "io.netty.channel.ChannelHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.channel.ChannelHandlerAdapter",
+    "condition": {
+      "typeReachable": "io.netty.channel.ChannelHandlerAdapter"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.channel.ChannelInboundHandler",
+    "condition": {
+      "typeReachable": "io.netty.channel.ChannelInboundHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.channel.ChannelInboundHandlerAdapter",
+    "condition": {
+      "typeReachable": "io.netty.channel.ChannelInboundHandlerAdapter"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.channel.ChannelInitializer",
+    "condition": {
+      "typeReachable": "io.netty.channel.ChannelInitializer"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.channel.ChannelOutboundHandler",
+    "condition": {
+      "typeReachable": "io.netty.channel.ChannelOutboundHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.channel.ChannelOutboundHandlerAdapter",
+    "condition": {
+      "typeReachable": "io.netty.channel.ChannelOutboundHandlerAdapter"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.channel.CombinedChannelDuplexHandler",
+    "condition": {
+      "typeReachable": "io.netty.channel.CombinedChannelDuplexHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.channel.DefaultChannelPipeline$HeadContext",
+    "condition": {
+      "typeReachable": "io.netty.channel.DefaultChannelPipeline$HeadContext"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.channel.DefaultChannelPipeline$TailContext",
+    "condition": {
+      "typeReachable": "io.netty.channel.DefaultChannelPipeline$TailContext"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.channel.embedded.EmbeddedChannel$2",
+    "condition": {
+      "typeReachable": "io.netty.channel.embedded.EmbeddedChannel$2"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.channel.pool.SimpleChannelPool$1",
+    "condition": {
+      "typeReachable": "io.netty.channel.pool.SimpleChannelPool$1"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.channel.SimpleChannelInboundHandler",
+    "condition": {
+      "typeReachable": "io.netty.channel.SimpleChannelInboundHandler"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.channel.SimpleUserEventChannelHandler",
+    "condition": {
+      "typeReachable": "io.netty.channel.SimpleUserEventChannelHandler"
+    },
+    "queryAllPublicMethods": true
+  }
+]

--- a/transport/src/test/java/io/netty/channel/NativeImageHandlerMetadataTest.java
+++ b/transport/src/test/java/io/netty/channel/NativeImageHandlerMetadataTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel;
+
+import io.netty.nativeimage.ChannelHandlerMetadataUtil;
+import org.junit.jupiter.api.Test;
+
+public class NativeImageHandlerMetadataTest {
+
+    @Test
+    public void collectAndCompareMetadata() {
+        ChannelHandlerMetadataUtil.generateMetadata(
+                "transport-handlers/reflect-config.json",
+                "io.netty.bootstrap", "io.netty.channel");
+    }
+
+}

--- a/transport/src/test/java/io/netty/nativeimage/ChannelHandlerMetadataUtil.java
+++ b/transport/src/test/java/io/netty/nativeimage/ChannelHandlerMetadataUtil.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.nativeimage;
+
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.NativeImageHandlerMetadataTest;
+import org.junit.jupiter.api.Assertions;
+import org.reflections.Reflections;
+import org.reflections.util.ConfigurationBuilder;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.net.URL;
+import java.text.Collator;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Generates native-image reflection metadata for subtypes of {@link io.netty.channel.ChannelHandler}.
+ * <p>
+ * To use, create a JUnit test in the desired Netty module and invoke {@link #generateMetadata(String, String...)} with:
+ * 1. The relative path to the native-image handler reflection metadata file in the Netty module.
+ * This path is relative to the root of the target Netty module.
+ * 2. A list of packages present in the target Netty module that may contain subtypes of the ChannelHandler.
+ * <p>
+ * See {@link NativeImageHandlerMetadataTest}
+ */
+public final class ChannelHandlerMetadataUtil {
+
+    @SuppressWarnings("UnstableApiUsage")
+    private static final Type HANDLER_METADATA_LIST_TYPE = new TypeToken<List<HandlerMetadata>>() {
+    }.getType();
+    private static final Gson gson = new GsonBuilder().setPrettyPrinting().create();
+
+    private ChannelHandlerMetadataUtil() {
+    }
+
+    public static void generateMetadata(String resourcePath, String... packageNames) {
+        Set<Class<? extends ChannelHandler>> subtypes = findChannelHandlerSubclasses(packageNames);
+
+        if (Arrays.asList(packageNames).contains("io.netty.channel")) {
+            // We want the metadata for the ChannelHandler itself too
+            subtypes.add(ChannelHandler.class);
+        }
+
+        Set<HandlerMetadata> handlerMetadata = new HashSet<HandlerMetadata>();
+        for (Class<?> subtype : subtypes) {
+            handlerMetadata.add(new HandlerMetadata(subtype.getName(), new Condition(subtype.getName()), true));
+        }
+
+        String projectRelativeResourcePath = "src/main/resources/META-INF/native-image/" + resourcePath;
+        File existingMetadataFile = new File(projectRelativeResourcePath);
+        String existingMetadataPath = existingMetadataFile.getAbsolutePath();
+        if (!existingMetadataFile.exists()) {
+            if (handlerMetadata.size() == 0) {
+                return;
+            }
+
+            String message = "Native Image reflection metadata is required for handlers in this project. " +
+                    "This metadata was not found under " +
+                    existingMetadataPath +
+                    "\nPlease create this file with the following content: \n" +
+                    getMetadataJsonString(handlerMetadata) +
+                    "\n";
+            Assertions.fail(message);
+        }
+
+        List<HandlerMetadata> existingMetadata = null;
+        try {
+            FileReader reader = new FileReader(existingMetadataFile);
+            existingMetadata = gson.fromJson(reader, HANDLER_METADATA_LIST_TYPE);
+        } catch (IOException e) {
+            Assertions.fail("Failed to open the native-image metadata file at: " + existingMetadataPath, e);
+        }
+
+        Set<HandlerMetadata> newMetadata = new HashSet<HandlerMetadata>(handlerMetadata);
+        newMetadata.removeAll(existingMetadata);
+
+        Set<HandlerMetadata> removedMetadata = new HashSet<HandlerMetadata>(existingMetadata);
+        removedMetadata.removeAll(handlerMetadata);
+
+        if (!newMetadata.isEmpty() || !removedMetadata.isEmpty()) {
+            StringBuilder builder = new StringBuilder();
+            builder.append("In the native-image handler metadata file at ")
+                    .append(existingMetadataPath)
+                    .append("\n");
+
+            if (!newMetadata.isEmpty()) {
+                builder.append("The following new metadata must be added:\n\n")
+                        .append(getMetadataJsonString(newMetadata))
+                        .append("\n\n");
+            }
+            if (!removedMetadata.isEmpty()) {
+                builder.append("The following metadata must be removed:\n\n")
+                        .append(getMetadataJsonString(removedMetadata))
+                        .append("\n\n");
+            }
+
+            builder.append("Expected metadata file contents:\n\n")
+                    .append(getMetadataJsonString(handlerMetadata))
+                    .append("\n");
+            Assertions.fail(builder.toString());
+        }
+    }
+
+    private static Set<Class<? extends ChannelHandler>> findChannelHandlerSubclasses(String... packageNames) {
+        Reflections reflections = new Reflections(
+                new ConfigurationBuilder()
+                        .forPackages(packageNames));
+
+        Set<Class<? extends ChannelHandler>> allSubtypes = reflections.getSubTypesOf(ChannelHandler.class);
+        Set<Class<? extends ChannelHandler>> targetSubtypes = new HashSet<Class<? extends ChannelHandler>>();
+
+        for (Class<? extends ChannelHandler> subtype : allSubtypes) {
+            if (isTestClass(subtype)) {
+                continue;
+            }
+            String className = subtype.getName();
+            boolean shouldInclude = false;
+            for (String packageName : packageNames) {
+                if (className.startsWith(packageName)) {
+                    shouldInclude = true;
+                    break;
+                }
+            }
+
+            if (shouldInclude) {
+                targetSubtypes.add(subtype);
+            }
+        }
+
+        return targetSubtypes;
+    }
+
+    private static boolean isTestClass(Class<? extends ChannelHandler> clazz) {
+        String[] parts = clazz.getName().split("\\.");
+        if (parts.length > 0) {
+            URL classFile = clazz.getResource(parts[parts.length - 1] + ".class");
+            if (classFile != null) {
+                return classFile.toString().contains("/test-classes/");
+            }
+        }
+        return false;
+    }
+
+    private static String getMetadataJsonString(Set<HandlerMetadata> metadata) {
+        List<HandlerMetadata> metadataList = new ArrayList<HandlerMetadata>(metadata);
+        Collections.sort(metadataList, new Comparator<HandlerMetadata>() {
+            @Override
+            public int compare(HandlerMetadata h1, HandlerMetadata h2) {
+                return Collator.getInstance().compare(h1.name, h2.name);
+            }
+        });
+        return gson.toJson(metadataList, HANDLER_METADATA_LIST_TYPE);
+    }
+
+    private static final class Condition {
+        Condition(String typeReachable) {
+            this.typeReachable = typeReachable;
+        }
+
+        final String typeReachable;
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            Condition condition = (Condition) o;
+            return typeReachable != null && typeReachable.equals(condition.typeReachable);
+        }
+
+        @Override
+        public int hashCode() {
+            return typeReachable.hashCode();
+        }
+    }
+
+    private static final class HandlerMetadata {
+        final String name;
+
+        final Condition condition;
+
+        final boolean queryAllPublicMethods;
+
+        HandlerMetadata(String name, Condition condition, boolean queryAllPublicMethods) {
+            this.name = name;
+            this.condition = condition;
+            this.queryAllPublicMethods = queryAllPublicMethods;
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            HandlerMetadata that = (HandlerMetadata) o;
+            return queryAllPublicMethods == that.queryAllPublicMethods
+                    && (name != null && name.equals(that.name))
+                    && (condition != null && condition.equals(that.condition));
+        }
+
+        @Override
+        public int hashCode() {
+            return name.hashCode();
+        }
+    }
+}


### PR DESCRIPTION
Motivation:
Analogous to https://github.com/netty/netty/pull/12738, this PR introduces automatic conditional native-image metadata generation for different ChannelHandler implementations

Modification:
This PR is basically the same as https://github.com/netty/netty/pull/12738, but adapted to conform to the Java language level 6.
This PR also adds the metadata generation to more subprojects that contain ChannelHandler implementations.

Result:

Fixes https://github.com/netty/netty/issues/12725
