### PR TITLE
Fix buffer leak in DefaultHttp2FrameReader

### DIFF
--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/DefaultHttp2FrameReader.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/DefaultHttp2FrameReader.java
@@ -620,7 +620,9 @@ public class DefaultHttp2FrameReader implements Http2FrameReader, Http2FrameSize
 
     private void readUnknownFrame(ChannelHandlerContext ctx, Buffer payload, Http2FrameListener listener)
             throws Http2Exception {
+        try (payload) {
             listener.onUnknownFrame(ctx, frameType, streamId, flags, payload);
+        }
     }
 
     /**

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2FrameCodec.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2FrameCodec.java
@@ -581,7 +581,7 @@ public class Http2FrameCodec extends Http2ConnectionHandler {
                 // Ignore unknown frames on connection stream, for example: HTTP/2 GREASE testing
                 return;
             }
-            onHttp2Frame(ctx, new DefaultHttp2UnknownFrame(frameType, flags, payload)
+            onHttp2Frame(ctx, new DefaultHttp2UnknownFrame(frameType, flags, payload.split())
                     .stream(requireStream(streamId)).copy());
         }
 

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2FrameListener.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2FrameListener.java
@@ -29,7 +29,8 @@ public interface Http2FrameListener {
      *
      * @param ctx the context from the handler where the frame was read.
      * @param streamId the subject stream for the frame.
-     * @param data payload buffer for the frame. This buffer will be released by the codec.
+     * @param data payload buffer for the frame. This buffer will be closed by the codec when the method returns
+     *             (the buffer will be inaccessible after the method call).
      * @param padding additional bytes that should be added to obscure the true content size. Must be between 0 and
      *                256 (inclusive).
      * @param endOfStream Indicates whether this is the last frame to be sent from the remote endpoint for this stream.
@@ -189,8 +190,8 @@ public interface Http2FrameListener {
      * @param ctx the context from the handler where the frame was read.
      * @param lastStreamId the last known stream of the remote endpoint.
      * @param errorCode the error code, if abnormal closure.
-     * @param debugData application-defined debug data. If this buffer needs to be retained by the
-     *            listener they must make a copy.
+     * @param debugData application-defined debug data. This buffer will be closed by the codec when the method returns
+     *                  (the buffer will be inaccessible after the method call).
      */
     void onGoAwayRead(ChannelHandlerContext ctx, int lastStreamId, long errorCode, Buffer debugData)
             throws Http2Exception;
@@ -213,7 +214,8 @@ public interface Http2FrameListener {
      * @param frameType the frame type from the HTTP/2 header.
      * @param streamId the stream the frame was sent on.
      * @param flags the flags in the frame header.
-     * @param payload the payload of the frame.
+     * @param payload the payload of the frame. This buffer will be closed by the codec when the method returns
+     *                (the buffer will be inaccessible after the method call).
      */
     void onUnknownFrame(ChannelHandlerContext ctx, byte frameType, int streamId, Http2Flags flags, Buffer payload)
             throws Http2Exception;


### PR DESCRIPTION
Motivation:

The _DefaultHttp2FrameReader.processPayloadState_ method performs a _readSplit_ in order to get a payload, which is passed to the various _readXXXFrame_ methods. Some _readXXXFrame_ methods are closing the payload, while some other are not, and in reactor-netty tests, we observe the following memory leak which is reported by the leak detector:

```
2022-09-07T15:45:34.552+0200 [ERROR] [org.gradle.api.Task] ERROR: Test: Test testConnectionNoIdleTimeElasticPool()(reactor.netty5.http.client.HttpClientTest) produced resource leak: io.netty5.buffer.api.LoggingLeakCallback$LeakReport: Object life-cycle trace:
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     io.netty5.buffer.api.LoggingLeakCallback$LeakReport: Object life-cycle trace:
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     	Suppressed: io.netty5.buffer.api.internal.LifecycleTracer$Traceback: ALLOCATE (current acquires = 0) T-80497us.
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.buffer.api.internal.ResourceSupport.<init>(ResourceSupport.java:42)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.buffer.api.internal.AdaptableBuffer.<init>(AdaptableBuffer.java:28)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.buffer.api.bytebuffer.NioBuffer.<init>(NioBuffer.java:65)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.buffer.api.bytebuffer.NioBuffer.split(NioBuffer.java:500)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.buffer.api.Buffer.readSplit(Buffer.java:871)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.handler.codec.http2.DefaultHttp2FrameReader.processPayloadState(DefaultHttp2FrameReader.java:238)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.handler.codec.http2.DefaultHttp2FrameReader.readFrame(DefaultHttp2FrameReader.java:158)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.handler.codec.http2.Http2InboundFrameLogger.readFrame(Http2InboundFrameLogger.java:42)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.handler.codec.http2.DefaultHttp2ConnectionDecoder.decodeFrame(DefaultHttp2ConnectionDecoder.java:173)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.handler.codec.http2.DecoratingHttp2ConnectionDecoder.decodeFrame(DecoratingHttp2ConnectionDecoder.java:61)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.handler.codec.http2.Http2ConnectionHandler$FrameDecoder.decode(Http2ConnectionHandler.java:392)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.handler.codec.http2.Http2ConnectionHandler$PrefaceDecoder.decode(Http2ConnectionHandler.java:245)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.handler.codec.http2.Http2ConnectionHandler.decode(Http2ConnectionHandler.java:452)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:387)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:330)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:204)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:456)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.channel.DefaultChannelHandlerContext.findAndInvokeChannelRead(DefaultChannelHandlerContext.java:446)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:427)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.handler.logging.LoggingHandler.channelRead(LoggingHandler.java:280)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:456)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.channel.DefaultChannelHandlerContext.findAndInvokeChannelRead(DefaultChannelHandlerContext.java:446)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:427)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.channel.internal.DelegatingChannelHandlerContext.fireChannelRead(DelegatingChannelHandlerContext.java:113)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.handler.codec.ByteToMessageDecoder$ByteToMessageDecoderContext.fireChannelRead(ByteToMessageDecoder.java:446)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.handler.ssl.SslHandler.unwrap(SslHandler.java:1206)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.handler.ssl.SslHandler.decodeNonJdkCompatible(SslHandler.java:1083)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.handler.ssl.SslHandler.decode(SslHandler.java:1121)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:387)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:330)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:204)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:456)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.channel.DefaultChannelHandlerContext.findAndInvokeChannelRead(DefaultChannelHandlerContext.java:446)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:427)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.channel.ChannelHandler.channelRead(ChannelHandler.java:235)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:456)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:838)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.channel.AbstractChannel$ReadSink.processRead(AbstractChannel.java:1975)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.channel.nio.AbstractNioByteChannel.doReadNow(AbstractNioByteChannel.java:74)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.channel.AbstractChannel$ReadSink.readLoop(AbstractChannel.java:2035)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.channel.AbstractChannel.readNow(AbstractChannel.java:910)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.channel.nio.AbstractNioChannel.access$100(AbstractNioChannel.java:42)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.channel.nio.AbstractNioChannel$1.handle(AbstractNioChannel.java:108)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.channel.nio.NioHandler.processSelectedKey(NioHandler.java:506)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.channel.nio.NioHandler.processSelectedKeysOptimized(NioHandler.java:489)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.channel.nio.NioHandler.processSelectedKeys(NioHandler.java:430)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.channel.nio.NioHandler.run(NioHandler.java:407)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.channel.SingleThreadEventLoop.runIO(SingleThreadEventLoop.java:192)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.channel.SingleThreadEventLoop.run(SingleThreadEventLoop.java:176)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.util.concurrent.SingleThreadEventExecutor.lambda$doStartThread$4(SingleThreadEventExecutor.java:774)
2022-09-07T15:45:34.552+0200 [DEBUG] [TestEventLogger]     		at io.netty5.util.internal.ThreadExecutorMap.lambda$apply$1(ThreadExecutorMap.java:68) (edited) 
```
This PR is an attempt to close the payload, when necessary.

Modification:

1. the payload is now closed using some try-with-resource from the following methods in the DefaultHttp2FrameReader class:

- readHeadersFrame() 
- readPriorityFrame()
- readRstStreamFrame()
- readSettingsFrame() 
- readPushPromiseFrame() 
- readGoAwayFrame() 
- readWindowUpdateFrame() 
- readContinuationFrame()
- readUnknownFrame()

2. Updated the DefaultHttp2FrameReaderTest.readHeaderAndData() test which is now using a _doAnswer_ mockito in order to intercept the listener.onDataRead during method invocation, because the buffer passed in argument will be closed when the invoked onDataRead method will return, that's why we need to test the buffer during method invocation, not afterward (before, the buffer passed to the listener.onDataRead was tested after the method had been invoked, using "verify(listener).onDataRead(ctx, 1, dataPayload.readerOffset(0), 0, true);").

3. Updated the Http2FrameRoundtripTest.emptyDataShouldMatch() test: the doAnwser is now used instead of the "verify(listener).onDataRead" for the same kind of reasons than in -4

4. Same thing for Http2FrameRoundtripTest.dataShouldMatch() method, as well as dataWithPaddingShouldMatch()

5. SImilar update made in Http2FrameRoundtripTest.largeDataFrameShouldMatch where the buffer passed to the onDataRead method call is copied and appended to a list of buffers (we need to copy because the buffer will be closed when the method returns)

6. Similar update made in Http2FrameRoundtripTest.goAwayFrameShouldMatch, which is using doAnwser, in order to test the buffer parameter during method call, not afterward

Result:

No more memory leaks produced by the DefaultHttp2FrameReader.processPayloadState method.
