### PR TITLE
DefaultLastHttpContent doesn't allow setting trailingHeaders while other default types do

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultLastHttpContent.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultLastHttpContent.java
@@ -22,6 +22,8 @@ import io.netty.util.internal.StringUtil;
 
 import java.util.Map.Entry;
 
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
 /**
  * The default {@link LastHttpContent} implementation.
  */
@@ -41,6 +43,12 @@ public class DefaultLastHttpContent extends DefaultHttpContent implements LastHt
         super(content);
         trailingHeaders = new TrailingHttpHeaders(validateHeaders);
         this.validateHeaders = validateHeaders;
+    }
+
+    public DefaultLastHttpContent(ByteBuf content, HttpHeaders trailingHeaders) {
+        super(content);
+        this.trailingHeaders = checkNotNull(trailingHeaders, "trailingHeaders");
+        this.validateHeaders = false;
     }
 
     @Override


### PR DESCRIPTION
Motivation:

Setting trailingHeaders directly can help users to duplicate code to workaround it

Modifications:

Expose setting trailingHeaders but giving up on headers validation

Result:

Life easier for users