### PR TITLE
Respect jdk.tls.client.protocols and jdk.tls.server.protocols

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
@@ -743,7 +743,7 @@ public final class OpenSsl {
         if (defaultProtocols == null) {
             return null;
         }
-        List<String> protocols = new ArrayList<>(defaultProtocols.size());
+        List<String> protocols = new ArrayList<String>(defaultProtocols.size());
         for (String proto : defaultProtocols) {
             if (SUPPORTED_PROTOCOLS_SET.contains(proto)) {
                 protocols.add(proto);

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
@@ -39,6 +39,7 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -65,6 +66,8 @@ public final class OpenSsl {
     private static final boolean SUPPORTS_OCSP;
     private static final boolean TLSV13_SUPPORTED;
     private static final boolean IS_BORINGSSL;
+    private static final Set<String> CLIENT_DEFAULT_PROTOCOLS;
+    private static final Set<String> SERVER_DEFAULT_PROTOCOLS;
     static final Set<String> SUPPORTED_PROTOCOLS_SET;
     static final String[] EXTRA_SUPPORTED_TLS_1_3_CIPHERS;
     static final String EXTRA_SUPPORTED_TLS_1_3_CIPHERS_STRING;
@@ -179,6 +182,8 @@ public final class OpenSsl {
         }
 
         UNAVAILABILITY_CAUSE = cause;
+        CLIENT_DEFAULT_PROTOCOLS = protocols("jdk.tls.client.protocols");
+        SERVER_DEFAULT_PROTOCOLS = protocols("jdk.tls.server.protocols");
 
         if (cause == null) {
             logger.debug("netty-tcnative using native library: {}", SSL.versionString());
@@ -718,6 +723,33 @@ public final class OpenSsl {
 
     static boolean isTlsv13Supported() {
         return TLSV13_SUPPORTED;
+    }
+
+    private static Set<String> protocols(String property) {
+        String protocolsString = SystemPropertyUtil.get(property, null);
+        if (protocolsString != null) {
+            Set<String> protocols = new HashSet<String>();
+            for (String proto : protocolsString.split(",")) {
+                String p = proto.trim();
+                protocols.add(p);
+            }
+            return protocols;
+        }
+        return null;
+    }
+
+    static String[] defaultProtocols(boolean isClient) {
+        final Collection<String> defaultProtocols = isClient ? CLIENT_DEFAULT_PROTOCOLS : SERVER_DEFAULT_PROTOCOLS;
+        if (defaultProtocols == null) {
+            return null;
+        }
+        List<String> protocols = new ArrayList<>(defaultProtocols.size());
+        for (String proto : defaultProtocols) {
+            if (SUPPORTED_PROTOCOLS_SET.contains(proto)) {
+                protocols.add(proto);
+            }
+        }
+        return protocols.toArray(new String[0]);
     }
 
     static boolean isBoringSSL() {

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -215,7 +215,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
     private static String[] protocols(String property) {
         String protocolsString = SystemPropertyUtil.get(property, null);
         if (protocolsString != null) {
-            Set<String> protocols = new HashSet<>();
+            Set<String> protocols = new HashSet<String>();
             for (String proto : protocolsString.split(",")) {
                 String p = proto.trim();
                 if (OpenSsl.SUPPORTED_PROTOCOLS_SET.contains(p)) {

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -50,11 +50,9 @@ import java.security.cert.CertificateRevokedException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -120,10 +118,6 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
     // https://mail.openjdk.java.net/pipermail/security-dev/2021-March/024758.html
     static final boolean CLIENT_ENABLE_SESSION_CACHE =
             SystemPropertyUtil.getBoolean("io.netty.handler.ssl.openssl.sessionCacheClient", false);
-
-    private static final String[] CLIENT_DEFAULT_PROTOCOLS;
-
-    private static final String[] SERVER_DEFAULT_PROTOCOLS;
 
     /**
      * The OpenSSL SSL_CTX object.
@@ -207,31 +201,9 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
             // ignore
         }
         DH_KEY_LENGTH = dhLen;
-
-        CLIENT_DEFAULT_PROTOCOLS = protocols("jdk.tls.client.protocols");
-        SERVER_DEFAULT_PROTOCOLS = protocols("jdk.tls.server.protocols");
-    }
-
-    private static String[] protocols(String property) {
-        String protocolsString = SystemPropertyUtil.get(property, null);
-        if (protocolsString != null) {
-            Set<String> protocols = new HashSet<String>();
-            for (String proto : protocolsString.split(",")) {
-                String p = proto.trim();
-                if (OpenSsl.SUPPORTED_PROTOCOLS_SET.contains(p)) {
-                    protocols.add(p);
-                }
-            }
-            return protocols.toArray(new String[0]);
-        }
-        return null;
     }
 
     final boolean tlsFalseStart;
-
-    private static String[] defaultProtocols(boolean isClient) {
-        return isClient ? CLIENT_DEFAULT_PROTOCOLS : SERVER_DEFAULT_PROTOCOLS;
-    }
 
     ReferenceCountedOpenSslContext(Iterable<String> ciphers, CipherSuiteFilter cipherFilter,
                                    OpenSslApplicationProtocolNegotiator apn, int mode, Certificate[] keyCertChain,
@@ -287,7 +259,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
         leak = leakDetection ? leakDetector.track(this) : null;
         this.mode = mode;
         this.clientAuth = isServer() ? checkNotNull(clientAuth, "clientAuth") : ClientAuth.NONE;
-        this.protocols = protocols == null ? defaultProtocols(mode == SSL.SSL_MODE_CLIENT) : protocols;
+        this.protocols = protocols == null ? OpenSsl.defaultProtocols(mode == SSL.SSL_MODE_CLIENT) : protocols;
         this.enableOcsp = enableOcsp;
 
         this.keyCertChain = keyCertChain == null ? null : keyCertChain.clone();


### PR DESCRIPTION
Motivation:

We should respect jdk.tls.client.protocols and jdk.tls.server.protocols system property to allow easily to enable / disable protocols

Modifications:

Respect the system properties

Result:

Be able to easily enable / disable TLS protocols in a consistent way