### PR TITLE
Run HTTP/1 and HTTP/2 tests in parallel

### DIFF
--- a/codec-http/src/test/resources/junit-platform.properties
+++ b/codec-http/src/test/resources/junit-platform.properties
@@ -1,0 +1,2 @@
+junit.jupiter.execution.parallel.enabled = true
+junit.jupiter.execution.parallel.mode.default = concurrent

--- a/codec-http/src/test/resources/junit-platform.properties
+++ b/codec-http/src/test/resources/junit-platform.properties
@@ -1,2 +1,16 @@
+# Copyright 2022 The Netty Project
+#
+# The Netty Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
 junit.jupiter.execution.parallel.enabled = true
 junit.jupiter.execution.parallel.mode.default = concurrent

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -12,7 +12,6 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package io.netty.handler.codec.http2;
 
 import io.netty.bootstrap.Bootstrap;
@@ -1240,7 +1239,7 @@ public class Http2ConnectionRoundtripTest {
             }
         });
 
-        serverChannel = sb.bind(new LocalAddress("Http2ConnectionRoundtripTest")).sync().channel();
+        serverChannel = sb.bind(new LocalAddress(getClass())).sync().channel();
 
         ChannelFuture ccf = cb.connect(serverChannel.localAddress());
         assertTrue(ccf.awaitUninterruptibly().isSuccess());

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexCodecBuilderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexCodecBuilderTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package io.netty.handler.codec.http2;
 
 import io.netty.bootstrap.Bootstrap;
@@ -44,8 +43,8 @@ import java.util.concurrent.CountDownLatch;
 import static io.netty.handler.codec.http2.Http2CodecUtil.isStreamIdValid;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -69,7 +68,7 @@ public class Http2MultiplexCodecBuilderTest {
     @BeforeEach
     public void setUp() throws InterruptedException {
         final CountDownLatch serverChannelLatch = new CountDownLatch(1);
-        LocalAddress serverAddress = new LocalAddress(getClass().getName());
+        LocalAddress serverAddress = new LocalAddress(getClass());
         serverLastInboundHandler = new SharableLastInboundHandler();
         ServerBootstrap sb = new ServerBootstrap()
                 .channel(LocalServerChannel.class)

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
@@ -42,7 +42,6 @@ import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.codec.http2.Http2TestUtil.FrameCountDown;
 import io.netty.util.AsciiString;
 import io.netty.util.concurrent.Future;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -73,8 +72,8 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyShort;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -601,7 +600,7 @@ public class HttpToHttp2ConnectionHandlerTest {
             }
         });
 
-        serverChannel = sb.bind(new LocalAddress("HttpToHttp2ConnectionHandlerTest")).sync().channel();
+        serverChannel = sb.bind(new LocalAddress(getClass())).sync().channel();
 
         ChannelFuture ccf = cb.connect(serverChannel.localAddress());
         assertTrue(ccf.awaitUninterruptibly().isSuccess());

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
@@ -746,7 +746,7 @@ public class InboundHttp2ToHttpAdapterTest {
             }
         });
 
-        serverChannel = sb.bind(new LocalAddress("InboundHttp2ToHttpAdapterTest")).sync().channel();
+        serverChannel = sb.bind(new LocalAddress(getClass())).sync().channel();
 
         ChannelFuture ccf = cb.connect(serverChannel.localAddress());
         assertTrue(ccf.awaitUninterruptibly().isSuccess());

--- a/codec-http2/src/test/resources/junit-platform.properties
+++ b/codec-http2/src/test/resources/junit-platform.properties
@@ -1,0 +1,2 @@
+junit.jupiter.execution.parallel.enabled = true
+junit.jupiter.execution.parallel.mode.default = concurrent

--- a/codec-http2/src/test/resources/junit-platform.properties
+++ b/codec-http2/src/test/resources/junit-platform.properties
@@ -1,2 +1,16 @@
+# Copyright 2022 The Netty Project
+#
+# The Netty Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
 junit.jupiter.execution.parallel.enabled = true
 junit.jupiter.execution.parallel.mode.default = concurrent

--- a/transport/src/main/java/io/netty/channel/local/LocalAddress.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalAddress.java
@@ -20,6 +20,7 @@ import static io.netty.util.internal.ObjectUtil.checkNonEmptyAfterTrim;
 import io.netty.channel.Channel;
 
 import java.net.SocketAddress;
+import java.util.UUID;
 
 /**
  * An endpoint in the local transport.  Each endpoint is identified by a unique
@@ -53,7 +54,14 @@ public final class LocalAddress extends SocketAddress implements Comparable<Loca
      */
     public LocalAddress(String id) {
         this.id = checkNonEmptyAfterTrim(id, "id").toLowerCase();
-        this.strVal = "local:" + this.id;
+        strVal = "local:" + this.id;
+    }
+
+    /**
+     * Creates a new instance with a random ID based on the given class.
+     */
+    public LocalAddress(Class<?> cls) {
+        this(cls.getSimpleName() + '/' + UUID.randomUUID());
     }
 
     /**


### PR DESCRIPTION
Motivation:
Running tests in parallel can speed up the build.
And while the http codec tests are not slow, they are also not too picky about running parallel, so this should not make the build more flaky.

Modification:
Configure JUnit to run tests in parallel in these two modules. Also backport the LocalAddress changes from Netty 5 that allow each individual test case in the same test file, to get their own independent local addresses, and avoid test isolation failures. Without this, the slowest handful of all the tests would still run one-by-one.

Result:
Faster build.