### PR TITLE
HttpHeaders.addCookie only validates the first added cookie

### DIFF
--- a/codec-http/src/main/java/io/netty5/handler/codec/http/headers/DefaultHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/headers/DefaultHttpHeaders.java
@@ -271,7 +271,7 @@ public class DefaultHttpHeaders extends MultiMap<CharSequence, CharSequence> imp
             MultiMapEntry<CharSequence, CharSequence> e = bucketHead.entry;
             do {
                 if (e.keyHash == keyHash && contentEqualsIgnoreCase(COOKIE, e.getKey())) {
-                    e.value = e.value + "; " + encoded;
+                    e.value = e.value + "; " + validateValue(encoded);
                     return this;
                 }
                 e = e.bucketNext;

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/headers/DefaultHttpCookiePairTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/headers/DefaultHttpCookiePairTest.java
@@ -33,6 +33,7 @@ import io.netty5.util.AsciiString;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class DefaultHttpCookiePairTest {
 
@@ -102,5 +103,22 @@ class DefaultHttpCookiePairTest {
                 new DefaultHttpCookiePair("foo", "bar", false)
         ).isNotEqualTo(
                 new DefaultHttpCookiePair("foo", "barr", false).hashCode());
+    }
+
+    @Test
+    public void testAddOneInvalidCookie() {
+        HttpHeaders headers = HttpHeaders.newHeaders();
+        assertThrows(HeaderValidationException.class, () -> {
+            headers.addCookie(new DefaultHttpCookiePair("foo", "value-with-ctrl-char\u0000"));
+        });
+    }
+
+    @Test
+    public void testAddTwoCookiesWithLastInvalid() {
+        HttpHeaders headers = HttpHeaders.newHeaders();
+        assertThrows(HeaderValidationException.class, () -> {
+            headers.addCookie(new DefaultHttpCookiePair("valid", "foo"));
+            headers.addCookie(new DefaultHttpCookiePair("invalid", "value-with-ctrl-char\u0000"));
+        });
     }
 }


### PR DESCRIPTION
Motivation:

When adding multiple Cookies using _HttpHeaders.addCookie(HttpCookiePair cookie)_ method, then only the first cookie is validated, not the subsequently added cookies.

Modification:

Updated the _HttpHeaders.addCookie_ method, which is now validating all added cookies

Result:

Adding multiple HttpCookiePair will throw an _HeaderValidationException_ in case any added cookies have invalid syntax.
Before, the exception was thrown only if the first added cookie was invalid.