### PR TITLE
Make some buffer tests more stable

### DIFF
--- a/buffer/src/test/java/io/netty5/buffer/tests/BufferAndChannelTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/tests/BufferAndChannelTest.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -46,6 +48,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Execution(ExecutionMode.SAME_THREAD)
 public class BufferAndChannelTest extends BufferTestSupport {
     private static FileChannel closedChannel;
     private static FileChannel channel;

--- a/buffer/src/test/java/io/netty5/buffer/tests/BufferCleanerTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/tests/BufferCleanerTest.java
@@ -59,7 +59,7 @@ public class BufferCleanerTest extends BufferTestSupport {
         try (var ignore = LeakDetection.onLeakDetected(ignore1 -> leakLatch.countDown())) {
             allocateAndForget(fixture, allocationSize);
             long sum = 0;
-            for (int i = 0; i < 15; i++) {
+            for (int i = 0; i < 30; i++) {
                 System.gc();
                 System.runFinalization();
                 sum = InternalBufferUtils.MEM_USAGE_NATIVE.sum() - initial;


### PR DESCRIPTION
Motivation:
The BufferAndChannelTest run the cases in parallel while they share a file channel. And BufferCleanerTest could try a bit harder to wait for the GC and cleaners to run.

Modification:
Change the execution mode of BufferAndChannelTest to SAME_THREAD so the cases run one by one, but the class itself is otherwise parallel with the rest of the tests in that module. Increase the iteration count when BufferCleanerTest waits for the GC to catch a leak.

Result:
The BufferAndChannelTest should no longer randomly fail in CI. And the BufferCleanerTest should be a bit more stable, though its failure can never truly be ruled out.