### PR TITLE
Use local stored Unsafe instance

### DIFF
--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
@@ -779,7 +779,7 @@ public final class NioEventLoop extends SingleThreadEventLoop {
             // Process OP_WRITE first as we may be able to write some queued buffers and so free memory.
             if ((readyOps & SelectionKey.OP_WRITE) != 0) {
                 // Call forceFlush which will also take care of clear the OP_WRITE once there is nothing left to write
-                ch.unsafe().forceFlush();
+               unsafe.forceFlush();
             }
 
             // Also check for readOps of 0 to workaround possible JDK bug which may otherwise lead


### PR DESCRIPTION
Motivation:

We already store the Unsafe instance in a local variable. No need to retrieve it again

Modifications:

Use local stored Unsafe instance

Result:

Cleanup, fixes https://github.com/netty/netty/issues/12812
