### PR TITLE
Fix buffer leak in AbstractSniHandler

### DIFF
--- a/handler/src/main/java/io/netty5/handler/ssl/AbstractSniHandler.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/AbstractSniHandler.java
@@ -16,6 +16,7 @@
 package io.netty5.handler.ssl;
 
 import io.netty5.buffer.Buffer;
+import io.netty5.buffer.internal.InternalBufferUtils;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.util.concurrent.Future;
 
@@ -102,7 +103,8 @@ public abstract class AbstractSniHandler<T> extends SslClientHelloHandler<T> {
                                 break;
                             }
 
-                            String hostname = in.copy(offset, serverNameLength).toString(StandardCharsets.US_ASCII);
+                            String hostname = InternalBufferUtils.copyToCharSequence(in, offset, serverNameLength,
+                                            StandardCharsets.US_ASCII).toString();
                             return hostname.toLowerCase(Locale.US);
                         } else {
                             // invalid enum value


### PR DESCRIPTION
Motivation:

In Reactor-Netty, the following memory leak is reproduced:

```
15:51:08.307 [Cleaner-0] ERROR io.netty5.buffer.LoggingLeakCallback - LEAK: Object "buffer (8 bytes)" was not property closed before it was garbage collected. A life-cycle back-trace (if any) is attached as suppressed exceptions. See https://netty.io/wiki/reference-counted-objects.html for more information.
io.netty5.buffer.LoggingLeakCallback$LeakReport: Object life-cycle trace:
	Suppressed: io.netty5.buffer.internal.LifecycleTracer$Traceback: ALLOCATE (current acquires = 0) T-152484us.
		at io.netty5.buffer.internal.ResourceSupport.<init>(ResourceSupport.java:42)
		at io.netty5.buffer.internal.AdaptableBuffer.<init>(AdaptableBuffer.java:28)
		at io.netty5.buffer.bytebuffer.NioBuffer.<init>(NioBuffer.java:65)
		at io.netty5.buffer.bytebuffer.ByteBufferMemoryManager.createBuffer(ByteBufferMemoryManager.java:85)
		at io.netty5.buffer.bytebuffer.ByteBufferMemoryManager.recoverMemory(ByteBufferMemoryManager.java:80)
		at io.netty5.buffer.pool.PooledBufferAllocator.allocate(PooledBufferAllocator.java:321)
		at io.netty5.buffer.bytebuffer.NioBuffer.copy(NioBuffer.java:205)
		at io.netty5.buffer.Buffer.copy(Buffer.java:766)
		at io.netty5.handler.ssl.AbstractSniHandler.extractSniHostname(AbstractSniHandler.java:106)
		at io.netty5.handler.ssl.AbstractSniHandler.lookup(AbstractSniHandler.java:125)
		at io.netty5.handler.ssl.SslClientHelloHandler.select(SslClientHelloHandler.java:184)
		at io.netty5.handler.ssl.SslClientHelloHandler.decode(SslClientHelloHandler.java:151)
		at io.netty5.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:387)
		at io.netty5.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:330)
		at io.netty5.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:204)
		at io.netty5.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:455)
		at io.netty5.channel.DefaultChannelHandlerContext.findAndInvokeChannelRead(DefaultChannelHandlerContext.java:445)
		at io.netty5.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:426)
		at io.netty5.channel.ChannelHandler.channelRead(ChannelHandler.java:235)
		at io.netty5.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:455)
		at io.netty5.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:838)
		at io.netty5.channel.AbstractChannel$ReadSink.processRead(AbstractChannel.java:1975)
		at io.netty5.channel.nio.AbstractNioByteChannel.doReadNow(AbstractNioByteChannel.java:74)
		at io.netty5.channel.AbstractChannel$ReadSink.readLoop(AbstractChannel.java:2035)
		at io.netty5.channel.AbstractChannel.readNow(AbstractChannel.java:910)
		at io.netty5.channel.nio.AbstractNioChannel.access$100(AbstractNioChannel.java:42)
		at io.netty5.channel.nio.AbstractNioChannel$1.handle(AbstractNioChannel.java:108)
		at io.netty5.channel.nio.NioHandler.processSelectedKey(NioHandler.java:506)
		at io.netty5.channel.nio.NioHandler.processSelectedKeysOptimized(NioHandler.java:489)
		at io.netty5.channel.nio.NioHandler.processSelectedKeys(NioHandler.java:430)
		at io.netty5.channel.nio.NioHandler.run(NioHandler.java:407)
		at io.netty5.channel.SingleThreadEventLoop.runIO(SingleThreadEventLoop.java:192)
		at io.netty5.channel.SingleThreadEventLoop.run(SingleThreadEventLoop.java:176)
		at io.netty5.util.concurrent.SingleThreadEventExecutor.lambda$doStartThread$4(SingleThreadEventExecutor.java:774)
		at io.netty5.util.internal.ThreadExecutorMap.lambda$apply$1(ThreadExecutorMap.java:68)
		at io.netty5.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
		at java.base/java.lang.Thread.run(Thread.java:833)

```

It is caused by a small memory leak in AbstractSniHandler.extractSniHostname method, where a substring is extracted from a Buffer using "buffer.copy(...).toString()", and the copied buffer is then not closed.

Modification:

Do not copy the buffer, and use InternalBufferUtils.copyToCharSequence in order to extract the substring.

Result:

No more memory leaks when calling the AbstractSniHandler.extractSniHostname method.