### PR TITLE
expand SelectionKey array when we need it.

### DIFF
--- a/transport/src/main/java/io/netty/channel/nio/SelectedSelectionKeySet.java
+++ b/transport/src/main/java/io/netty/channel/nio/SelectedSelectionKeySet.java
@@ -36,11 +36,11 @@ final class SelectedSelectionKeySet extends AbstractSet<SelectionKey> {
             return false;
         }
 
-        keys[size++] = o;
         if (size == keys.length) {
             increaseCapacity();
         }
 
+        keys[size++] = o;
         return true;
     }
 


### PR DESCRIPTION
Motivation:
we better allocate memory right before we need it.

Modifications:

invoke #increaseCapacity() right before we need it.

Result:

save some memory.