### PR TITLE
Default composite buffer issue when extending read-only instances

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/DefaultCompositeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/DefaultCompositeBuffer.java
@@ -239,7 +239,7 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
                 // Remove writable-bytes from front and middle buffers.
                 for (int i = 0; i < lastReadable; i++) {
                     Buffer buf = array[i];
-                    if (buf.writableBytes() > 0) {
+                    if (buf.writerOffset() > 0 && buf.writerOffset() < buf.capacity()) {
                         array[i] = buf.split();
                         buf.close();
                     }


### PR DESCRIPTION
Motivation:

When extending a composite buffer whose trailing component contain an unwritten gap but is read-only and therefore has no writable bytes the current logic does not split the buffer and thereby leaves an accounting error in the capacity vs the index values computed and subsequent read operations encounter IndexOutOfBoundsExceptions

Modification:

Change the default composite buffer check to query the write offset vs the capacity instead of the writable bytes which will always be zero on read-only buffers

Result:

Buffer continuity is maintained and exceptions on read are avoided.