### PR TITLE
Fix profile selection when running release via m1

### DIFF
--- a/scripts/finish_release.sh
+++ b/scripts/finish_release.sh
@@ -39,7 +39,7 @@ fi
 
 CROSS_COMPILE_PROFILE="mac-m1-cross-compile"
 if [ "$ARCH" == "arm" ]; then
-    PROFILE="mac-intel-cross-compile"
+    CROSS_COMPILE_PROFILE="mac-intel-cross-compile"
 fi
 
 git fetch


### PR DESCRIPTION
Motivation:

We had a typo in the variable name so the wrong profile was selected for cross-compilation on m1

Modifications:

Fix variable name

Result:

Release works on m1 as well
