### PR TITLE
Add API to forward exception to Http2MultiplexHandler streams

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexHandlerTest.java
@@ -15,6 +15,17 @@
 package io.netty.handler.codec.http2;
 
 import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import javax.net.ssl.SSLException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for {@link Http2MultiplexHandler}.
@@ -39,5 +50,60 @@ public class Http2MultiplexHandlerTest extends Http2MultiplexTest<Http2FrameCode
     @Override
     protected boolean ignoreWindowUpdateFrames() {
         return true;
+    }
+
+    @Test
+    public void sslExceptionTriggersChildChannelException() throws Exception {
+        final LastInboundHandler inboundHandler = new LastInboundHandler();
+        Http2StreamChannel channel = newInboundStream(3, false, inboundHandler);
+        assertTrue(channel.isActive());
+        final RuntimeException testExc = new RuntimeException(new SSLException("foo"));
+        parentChannel.pipeline().addLast(new ChannelInboundHandlerAdapter() {
+            @Override
+            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+                if (cause != testExc) {
+                    super.exceptionCaught(ctx, cause);
+                }
+            }
+        });
+        parentChannel.pipeline().fireExceptionCaught(testExc);
+
+        assertTrue(channel.isActive());
+        RuntimeException exc = assertThrows(RuntimeException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                inboundHandler.checkException();
+            }
+        });
+        assertEquals(testExc, exc);
+    }
+
+    @Test
+    public void customExceptionForwarding() throws Exception {
+        final LastInboundHandler inboundHandler = new LastInboundHandler();
+        Http2StreamChannel channel = newInboundStream(3, false, inboundHandler);
+        assertTrue(channel.isActive());
+        final RuntimeException testExc = new RuntimeException("xyz");
+        parentChannel.pipeline().addLast(new ChannelInboundHandlerAdapter() {
+            @Override
+            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+                if (cause != testExc) {
+                    super.exceptionCaught(ctx, cause);
+                } else {
+                    ctx.pipeline().get(Http2MultiplexHandler.class)
+                            .fireExceptionToActiveStreams(cause);
+                }
+            }
+        });
+        parentChannel.pipeline().fireExceptionCaught(testExc);
+
+        assertTrue(channel.isActive());
+        RuntimeException exc = assertThrows(RuntimeException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                inboundHandler.checkException();
+            }
+        });
+        assertEquals(testExc, exc);
     }
 }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
@@ -78,7 +78,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
             .method(HttpMethod.GET.asciiName()).scheme(HttpScheme.HTTPS.name())
             .authority(new AsciiString("example.org")).path(new AsciiString("/foo"));
 
-    private EmbeddedChannel parentChannel;
+    EmbeddedChannel parentChannel;
     private Http2FrameWriter frameWriter;
     private Http2FrameInboundWriter frameInboundWriter;
     private TestChannelInitializer childChannelInitializer;
@@ -161,7 +161,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
                 any(ByteBuf.class), any(ChannelPromise.class));
     }
 
-    private Http2StreamChannel newInboundStream(int streamId, boolean endStream, final ChannelHandler childHandler) {
+    Http2StreamChannel newInboundStream(int streamId, boolean endStream, final ChannelHandler childHandler) {
         return newInboundStream(streamId, endStream, null, childHandler);
     }
 


### PR DESCRIPTION
Motivation:

Some exceptions on the parent channel are of interest to individual HTTP2 streams as well and should be forwarded. This behavior is already hardcoded for SSLException, but cannot be customized.

Modification:

Add a method to Http2MultiplexHandler to fire an exception to the child handlers.

Result:

A downstream handler on the parent channel can intercept exceptions and forward them to the stream channels using the new API.

Not sure if this is the best approach. Maybe `forEachActiveStream` should be exposed somehow. Another alternative would be to allow forwarding user events, and letting the API user wrap/unwrap exceptions in such user events where necessary.