### PR TITLE
Reject HTTP/2 header values with invalid characters

### DIFF
--- a/codec-http/src/main/java/io/netty5/handler/codec/http/DefaultLastHttpContent.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/DefaultLastHttpContent.java
@@ -109,13 +109,13 @@ public class DefaultLastHttpContent extends DefaultHttpObject implements LastHtt
         }
 
         @Override
-        protected CharSequence validateKey(@Nullable CharSequence name) {
+        protected CharSequence validateKey(@Nullable CharSequence name, boolean forAdd) {
             if (HttpHeaderNames.CONTENT_LENGTH.contentEqualsIgnoreCase(name)
                 || HttpHeaderNames.TRANSFER_ENCODING.contentEqualsIgnoreCase(name)
                 || HttpHeaderNames.TRAILER.contentEqualsIgnoreCase(name)) {
                 throw new IllegalArgumentException("Prohibited trailing header: " + name);
             }
-            return super.validateKey(name);
+            return super.validateKey(name, forAdd);
         }
     }
 }

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/HttpMessageUtil.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/HttpMessageUtil.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package io.netty5.handler.codec.http;
 
 import io.netty5.handler.codec.http.headers.HttpHeaders;

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/headers/DefaultHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/headers/DefaultHttpHeaders.java
@@ -51,7 +51,6 @@ import static io.netty5.handler.codec.http.headers.HeaderUtils.domainMatches;
 import static io.netty5.handler.codec.http.headers.HeaderUtils.isSetCookieNameMatches;
 import static io.netty5.handler.codec.http.headers.HeaderUtils.parseCookiePair;
 import static io.netty5.handler.codec.http.headers.HeaderUtils.pathMatches;
-import static io.netty5.handler.codec.http.headers.HeaderUtils.validateToken;
 import static io.netty5.util.AsciiString.contentEquals;
 import static io.netty5.util.AsciiString.contentEqualsIgnoreCase;
 import static io.netty5.util.AsciiString.trim;
@@ -271,7 +270,7 @@ public class DefaultHttpHeaders extends MultiMap<CharSequence, CharSequence> imp
             MultiMapEntry<CharSequence, CharSequence> e = bucketHead.entry;
             do {
                 if (e.keyHash == keyHash && contentEqualsIgnoreCase(COOKIE, e.getKey())) {
-                    e.value = e.value + "; " + validateValue(encoded);
+                    e.value = e.value + "; " + validateValue(COOKIE, encoded);
                     return this;
                 }
                 e = e.bucketNext;
@@ -608,7 +607,7 @@ public class DefaultHttpHeaders extends MultiMap<CharSequence, CharSequence> imp
     }
 
     @Override
-    protected CharSequence validateKey(@Nullable final CharSequence name) {
+    protected CharSequence validateKey(@Nullable final CharSequence name, boolean forAdd) {
         if (name == null || name.length() == 0) {
             throw new HeaderValidationException("Empty header names are not allowed");
         }
@@ -619,7 +618,7 @@ public class DefaultHttpHeaders extends MultiMap<CharSequence, CharSequence> imp
     }
 
     @Override
-    protected CharSequence validateValue(final CharSequence value) {
+    protected CharSequence validateValue(CharSequence key, final CharSequence value) {
         if (validateValues) {
             validateHeaderValue(value);
         }
@@ -632,7 +631,7 @@ public class DefaultHttpHeaders extends MultiMap<CharSequence, CharSequence> imp
      * @param name The filed-name to validate.
      */
     protected static void validateHeaderName(final CharSequence name) {
-        validateToken(name);
+        HeaderUtils.validateToken(name);
     }
 
     /**

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/headers/DefaultHttpSetCookie.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/headers/DefaultHttpSetCookie.java
@@ -34,7 +34,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import static io.netty5.handler.codec.http.headers.HeaderUtils.validateCookieNameAndValue;
-import static io.netty5.handler.codec.http.headers.HeaderUtils.validateToken;
 import static io.netty5.util.AsciiString.contentEquals;
 import static io.netty5.util.AsciiString.contentEqualsIgnoreCase;
 import static java.lang.Long.parseLong;
@@ -194,7 +193,13 @@ public final class DefaultHttpSetCookie implements HttpSetCookie {
                         }
                         name = setCookieString.subSequence(begin, i);
                         if (validateContent) {
-                            validateToken(name);
+                            int index = HttpHeaderValidationUtil.validateToken(name);
+                            if (index != -1) {
+                                throw new HeaderValidationException(
+                                        "a cookie name can only contain \"token\" characters, " +
+                                        "but found invalid character 0x" + Integer.toHexString(c) +
+                                        " at index " + index + " of header '" + name + "'.");
+                            }
                         }
                         parseState = ParseState.ParsingValue;
                     } else if (parseState == ParseState.Unknown) {

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/headers/HttpHeaderValidationUtil.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/headers/HttpHeaderValidationUtil.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.handler.codec.http.headers;
+
+import io.netty5.handler.codec.http.HttpHeaderNames;
+import io.netty5.handler.codec.http.HttpHeaderValues;
+import io.netty5.util.AsciiString;
+import io.netty5.util.internal.UnstableApi;
+
+import static io.netty5.util.AsciiString.contentEqualsIgnoreCase;
+
+/**
+ * Functions used to perform various validations of HTTP header names and values.
+ */
+@UnstableApi
+public final class HttpHeaderValidationUtil {
+    private HttpHeaderValidationUtil() {
+    }
+
+    /**
+     * Check if a header name is "connection related".
+     * <p>
+     * The <a href="https://datatracker.ietf.org/doc/html/rfc9110#section-7.6.1">RFC9110</a> only specify an incomplete
+     * list of the following headers:
+     *
+     * <ul>
+     *     <li><tt>Connection</tt></li>
+     *     <li><tt>Proxy-Connection</tt></li>
+     *     <li><tt>Keep-Alive</tt></li>
+     *     <li><tt>TE</tt></li>
+     *     <li><tt>Transfer-Encoding</tt></li>
+     *     <li><tt>Upgrade</tt></li>
+     * </ul>
+     *
+     * @param name the name of the header to check. The check is case-insensitive.
+     * @param ignoreTeHeader {@code true} if the <tt>TE</tt> header should be ignored by this check.
+     * This is relevant for HTTP/2 header validation, where the <tt>TE</tt> header has special rules.
+     * @return {@code true} if the given header name is one of the specified connection-related headers.
+     */
+    @SuppressWarnings("deprecation") // We need to check for deprecated headers as well.
+    public static boolean isConnectionHeader(CharSequence name, boolean ignoreTeHeader) {
+        // These are the known standard and non-standard connection related headers:
+        // - upgrade (7 chars)
+        // - connection (10 chars)
+        // - keep-alive (10 chars)
+        // - proxy-connection (16 chars)
+        // - transfer-encoding (17 chars)
+        //
+        // See https://datatracker.ietf.org/doc/html/rfc9113#section-8.2.2
+        // and https://datatracker.ietf.org/doc/html/rfc9110#section-7.6.1
+        // for the list of connection related headers.
+        //
+        // We scan for these based on the length, then double-check any matching name.
+        int len = name.length();
+        switch (len) {
+            case 2: return ignoreTeHeader? false : contentEqualsIgnoreCase(name, HttpHeaderNames.TE);
+            case 7: return contentEqualsIgnoreCase(name, HttpHeaderNames.UPGRADE);
+            case 10: return contentEqualsIgnoreCase(name, HttpHeaderNames.CONNECTION) ||
+                    contentEqualsIgnoreCase(name, HttpHeaderNames.KEEP_ALIVE);
+            case 16: return contentEqualsIgnoreCase(name, HttpHeaderNames.PROXY_CONNECTION);
+            case 17: return contentEqualsIgnoreCase(name, HttpHeaderNames.TRANSFER_ENCODING);
+            default:
+                return false;
+        }
+    }
+
+    /**
+     * If the given header is {@link HttpHeaderNames#TE} and the given header value is <em>not</em>
+     * {@link HttpHeaderValues#TRAILERS}, then return {@code true}. Otherwie, {@code false}.
+     * <p>
+     * The string comparisons are case-insensitive.
+     * <p>
+     * This check is important for HTTP/2 header validation.
+     *
+     * @param name the header name to check if it is <tt>TE</tt> or not.
+     * @param value the header value to check if it is something other than <tt>TRAILERS</tt>.
+     * @return {@code true} only if the header name is <tt>TE</tt>, and the header value is <em>not</em>
+     * <tt>TRAILERS</tt>. Otherwise, {@code false}.
+     */
+    public static boolean isTeNotTrailers(CharSequence name, CharSequence value) {
+        if (name.length() == 2) {
+            return contentEqualsIgnoreCase(name, HttpHeaderNames.TE) &&
+                    !contentEqualsIgnoreCase(value, HttpHeaderValues.TRAILERS);
+        }
+        return false;
+    }
+
+    /**
+     * Validate the given HTTP header value by searching for any illegal characters.
+     *
+     * @param value the HTTP header value to validate.
+     * @return the index of the first illegal character found, or {@code -1} if there are none and the header value is
+     * valid.
+     */
+    public static int validateValidHeaderValue(CharSequence value) {
+        int length = value.length();
+        if (length == 0) {
+            return -1;
+        }
+        if (value instanceof AsciiString) {
+            return verifyValidHeaderValueAsciiString((AsciiString) value);
+        }
+        return verifyValidHeaderValueCharSequence(value);
+    }
+
+    private static int verifyValidHeaderValueAsciiString(AsciiString value) {
+        // Validate value to field-content rule.
+        //  field-content  = field-vchar [ 1*( SP / HTAB ) field-vchar ]
+        //  field-vchar    = VCHAR / obs-text
+        //  VCHAR          = %x21-7E ; visible (printing) characters
+        //  obs-text       = %x80-FF
+        //  SP             = %x20
+        //  HTAB           = %x09 ; horizontal tab
+        //  See: https://datatracker.ietf.org/doc/html/rfc7230#section-3.2
+        //  And: https://datatracker.ietf.org/doc/html/rfc5234#appendix-B.1
+        final byte[] array = value.array();
+        final int start = value.arrayOffset();
+        int b = array[start] & 0xFF;
+        if (b < 0x21 || b == 0x7F) {
+            return 0;
+        }
+        int length = value.length();
+        for (int i = start + 1; i < length; i++) {
+            b = array[i] & 0xFF;
+            if (b < 0x20 && b != 0x09 || b == 0x7F) {
+                return i - start;
+            }
+        }
+        return -1;
+    }
+
+    private static int verifyValidHeaderValueCharSequence(CharSequence value) {
+        // Validate value to field-content rule.
+        //  field-content  = field-vchar [ 1*( SP / HTAB ) field-vchar ]
+        //  field-vchar    = VCHAR / obs-text
+        //  VCHAR          = %x21-7E ; visible (printing) characters
+        //  obs-text       = %x80-FF
+        //  SP             = %x20
+        //  HTAB           = %x09 ; horizontal tab
+        //  See: https://datatracker.ietf.org/doc/html/rfc7230#section-3.2
+        //  And: https://datatracker.ietf.org/doc/html/rfc5234#appendix-B.1
+        int b = value.charAt(0);
+        if (b < 0x21 || b == 0x7F) {
+            return 0;
+        }
+        int length = value.length();
+        for (int i = 1; i < length; i++) {
+            b = value.charAt(i);
+            if (b < 0x20 && b != 0x09 || b == 0x7F) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Validate a <a href="https://tools.ietf.org/html/rfc7230#section-3.2.6">token</a> contains only allowed
+     * characters.
+     * <p>
+     * The <a href="https://tools.ietf.org/html/rfc2616#section-2.2">token</a> format is used for variety of HTTP
+     * components, like  <a href="https://tools.ietf.org/html/rfc6265#section-4.1.1">cookie-name</a>,
+     * <a href="https://tools.ietf.org/html/rfc7230#section-3.2.6">field-name</a> of a
+     * <a href="https://tools.ietf.org/html/rfc7230#section-3.2">header-field</a>, or
+     * <a href="https://tools.ietf.org/html/rfc7231#section-4">request method</a>.
+     *
+     * @param token the token to validate.
+     * @return the index of the first invalid token character found, or {@code -1} if there are none.
+     */
+    public static int validateToken(CharSequence token) {
+        if (token instanceof AsciiString) {
+            return validateAsciiStringToken((AsciiString) token);
+        }
+        return validateCharSequenceToken(token);
+    }
+
+    /**
+     * Validate that an {@link AsciiString} contain onlu valid
+     * <a href="https://tools.ietf.org/html/rfc7230#section-3.2.6">token</a> characters.
+     *
+     * @param token the ascii string to validate.
+     */
+    private static int validateAsciiStringToken(AsciiString token) {
+        byte[] array = token.array();
+        for (int i = token.arrayOffset(), len = token.arrayOffset() + token.length(); i < len; i++) {
+            if (!BitSet128.contains(array[i], TOKEN_CHARS_HIGH, TOKEN_CHARS_LOW)) {
+                return i - token.arrayOffset();
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Validate that a {@link CharSequence} contain onlu valid
+     * <a href="https://tools.ietf.org/html/rfc7230#section-3.2.6">token</a> characters.
+     *
+     * @param token the character sequence to validate.
+     */
+    private static int validateCharSequenceToken(CharSequence token) {
+        for (int i = 0, len = token.length(); i < len; i++) {
+            byte value = (byte) token.charAt(i);
+            if (!BitSet128.contains(value, TOKEN_CHARS_HIGH, TOKEN_CHARS_LOW)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static final long TOKEN_CHARS_HIGH;
+    private static final long TOKEN_CHARS_LOW;
+    static {
+        // HEADER
+        // header-field   = field-name ":" OWS field-value OWS
+        //
+        // field-name     = token
+        // token          = 1*tchar
+        //
+        // tchar          = "!" / "#" / "$" / "%" / "&" / "'" / "*"
+        //                    / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~"
+        //                    / DIGIT / ALPHA
+        //                    ; any VCHAR, except delimiters.
+        //  Delimiters are chosen
+        //   from the set of US-ASCII visual characters not allowed in a token
+        //   (DQUOTE and "(),/:;<=>?@[\]{}")
+        //
+        // COOKIE
+        // cookie-pair       = cookie-name "=" cookie-value
+        // cookie-name       = token
+        // token          = 1*<any CHAR except CTLs or separators>
+        // CTL = <any US-ASCII control character
+        //       (octets 0 - 31) and DEL (127)>
+        // separators     = "(" | ")" | "<" | ">" | "@"
+        //                      | "," | ";" | ":" | "\" | <">
+        //                      | "/" | "[" | "]" | "?" | "="
+        //                      | "{" | "}" | SP | HT
+        //
+        // field-name's token is equivalent to cookie-name's token, we can reuse the tchar mask for both:
+        BitSet128 tokenChars = new BitSet128()
+                .range('0', '9').range('a', 'z').range('A', 'Z') // Alphanumeric.
+                .bits('-', '.', '_', '~') // Unreserved characters.
+                .bits('!', '#', '$', '%', '&', '\'', '*', '+', '^', '`', '|'); // Token special characters.
+        TOKEN_CHARS_HIGH = tokenChars.high();
+        TOKEN_CHARS_LOW = tokenChars.low();
+    }
+
+    private static final class BitSet128 {
+        private long high;
+        private long low;
+
+        BitSet128 range(char fromInc, char toInc) {
+            for (int bit = fromInc; bit <= toInc; bit++) {
+                if (bit < 64) {
+                    low |= 1L << bit;
+                } else {
+                    high |= 1L << bit - 64;
+                }
+            }
+            return this;
+        }
+
+        BitSet128 bits(char... bits) {
+            for (char bit : bits) {
+                if (bit < 64) {
+                    low |= 1L << bit;
+                } else {
+                    high |= 1L << bit - 64;
+                }
+            }
+            return this;
+        }
+
+        long high() {
+            return high;
+        }
+
+        long low() {
+            return low;
+        }
+
+        static boolean contains(byte bit, long high, long low) {
+            if (bit < 0) {
+                return false;
+            }
+            if (bit < 64) {
+                return 0 != (low & 1L << bit);
+            }
+            return 0 != (high & 1L << bit - 64);
+        }
+    }
+}

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/headers/HttpHeaderValidationUtil.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/headers/HttpHeaderValidationUtil.java
@@ -19,13 +19,14 @@ import io.netty5.handler.codec.http.HttpHeaderNames;
 import io.netty5.handler.codec.http.HttpHeaderValues;
 import io.netty5.util.AsciiString;
 import io.netty5.util.internal.UnstableApi;
+import org.jetbrains.annotations.ApiStatus;
 
 import static io.netty5.util.AsciiString.contentEqualsIgnoreCase;
 
 /**
  * Functions used to perform various validations of HTTP header names and values.
  */
-@UnstableApi
+@ApiStatus.Internal
 public final class HttpHeaderValidationUtil {
     private HttpHeaderValidationUtil() {
     }

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/headers/HeaderUtilsTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/headers/HeaderUtilsTest.java
@@ -35,7 +35,6 @@ import org.junit.jupiter.api.Test;
 import static io.netty5.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
 import static io.netty5.handler.codec.http.HttpHeaderNames.TRANSFER_ENCODING;
 import static io.netty5.handler.codec.http.HttpHeaderValues.CHUNKED;
-import static io.netty5.handler.codec.http.headers.HeaderUtils.TOKEN_CHARS;
 import static io.netty5.handler.codec.http.headers.HeaderUtils.isTransferEncodingChunked;
 import static io.netty5.handler.codec.http.headers.HeaderUtils.pathMatches;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -96,16 +95,6 @@ class HeaderUtilsTest {
     private static void assertOneTransferEncodingChunked(final HttpHeaders headers) {
         assertEquals(1, headers.size());
         assertTrue(isTransferEncodingChunked(headers));
-    }
-
-    @Test
-    void validateToken() {
-        // Make sure the old and new validation logic is equivalent:
-        for (int b = Byte.MIN_VALUE; b <= Byte.MAX_VALUE; ++b) {
-            final byte value = (byte) (b & 0xff);
-            assertEquals(originalValidateTokenLogic(value), TOKEN_CHARS.contains(value),
-                    () -> "Unexpected result for byte: " + value);
-        }
     }
 
     @Test

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/headers/HttpHeaderValidationUtilTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/headers/HttpHeaderValidationUtilTest.java
@@ -1,0 +1,580 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.handler.codec.http.headers;
+
+import io.netty5.handler.codec.http.HttpHeaderNames;
+import io.netty5.handler.codec.http.HttpHeaderValues;
+import io.netty5.util.AsciiString;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+import static io.netty5.handler.codec.http.headers.HttpHeaderValidationUtil.validateToken;
+import static io.netty5.handler.codec.http.headers.HttpHeaderValidationUtil.validateValidHeaderValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+@Execution(ExecutionMode.CONCURRENT) // We have a couple of fairly slow tests here. Better to run them in parallel.
+public class HttpHeaderValidationUtilTest {
+    @SuppressWarnings("deprecation") // We need to check for deprecated headers as well.
+    public static List<Arguments> connectionRelatedHeaders() {
+        List<Arguments> list = new ArrayList<Arguments>();
+
+        list.add(header(false, HttpHeaderNames.ACCEPT));
+        list.add(header(false, HttpHeaderNames.ACCEPT_CHARSET));
+        list.add(header(false, HttpHeaderNames.ACCEPT_ENCODING));
+        list.add(header(false, HttpHeaderNames.ACCEPT_LANGUAGE));
+        list.add(header(false, HttpHeaderNames.ACCEPT_RANGES));
+        list.add(header(false, HttpHeaderNames.ACCEPT_PATCH));
+        list.add(header(false, HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS));
+        list.add(header(false, HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS));
+        list.add(header(false, HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS));
+        list.add(header(false, HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN));
+        list.add(header(false, HttpHeaderNames.ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK));
+        list.add(header(false, HttpHeaderNames.ACCESS_CONTROL_EXPOSE_HEADERS));
+        list.add(header(false, HttpHeaderNames.ACCESS_CONTROL_MAX_AGE));
+        list.add(header(false, HttpHeaderNames.ACCESS_CONTROL_REQUEST_HEADERS));
+        list.add(header(false, HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD));
+        list.add(header(false, HttpHeaderNames.ACCESS_CONTROL_REQUEST_PRIVATE_NETWORK));
+        list.add(header(false, HttpHeaderNames.AGE));
+        list.add(header(false, HttpHeaderNames.ALLOW));
+        list.add(header(false, HttpHeaderNames.AUTHORIZATION));
+        list.add(header(false, HttpHeaderNames.CACHE_CONTROL));
+        list.add(header(true, HttpHeaderNames.CONNECTION));
+        list.add(header(false, HttpHeaderNames.CONTENT_BASE));
+        list.add(header(false, HttpHeaderNames.CONTENT_ENCODING));
+        list.add(header(false, HttpHeaderNames.CONTENT_LANGUAGE));
+        list.add(header(false, HttpHeaderNames.CONTENT_LENGTH));
+        list.add(header(false, HttpHeaderNames.CONTENT_LOCATION));
+        list.add(header(false, HttpHeaderNames.CONTENT_TRANSFER_ENCODING));
+        list.add(header(false, HttpHeaderNames.CONTENT_DISPOSITION));
+        list.add(header(false, HttpHeaderNames.CONTENT_MD5));
+        list.add(header(false, HttpHeaderNames.CONTENT_RANGE));
+        list.add(header(false, HttpHeaderNames.CONTENT_SECURITY_POLICY));
+        list.add(header(false, HttpHeaderNames.CONTENT_TYPE));
+        list.add(header(false, HttpHeaderNames.COOKIE));
+        list.add(header(false, HttpHeaderNames.DATE));
+        list.add(header(false, HttpHeaderNames.DNT));
+        list.add(header(false, HttpHeaderNames.ETAG));
+        list.add(header(false, HttpHeaderNames.EXPECT));
+        list.add(header(false, HttpHeaderNames.EXPIRES));
+        list.add(header(false, HttpHeaderNames.FROM));
+        list.add(header(false, HttpHeaderNames.HOST));
+        list.add(header(false, HttpHeaderNames.IF_MATCH));
+        list.add(header(false, HttpHeaderNames.IF_MODIFIED_SINCE));
+        list.add(header(false, HttpHeaderNames.IF_NONE_MATCH));
+        list.add(header(false, HttpHeaderNames.IF_RANGE));
+        list.add(header(false, HttpHeaderNames.IF_UNMODIFIED_SINCE));
+        list.add(header(true, HttpHeaderNames.KEEP_ALIVE));
+        list.add(header(false, HttpHeaderNames.LAST_MODIFIED));
+        list.add(header(false, HttpHeaderNames.LOCATION));
+        list.add(header(false, HttpHeaderNames.MAX_FORWARDS));
+        list.add(header(false, HttpHeaderNames.ORIGIN));
+        list.add(header(false, HttpHeaderNames.PRAGMA));
+        list.add(header(false, HttpHeaderNames.PROXY_AUTHENTICATE));
+        list.add(header(false, HttpHeaderNames.PROXY_AUTHORIZATION));
+        list.add(header(true, HttpHeaderNames.PROXY_CONNECTION));
+        list.add(header(false, HttpHeaderNames.RANGE));
+        list.add(header(false, HttpHeaderNames.REFERER));
+        list.add(header(false, HttpHeaderNames.RETRY_AFTER));
+        list.add(header(false, HttpHeaderNames.SEC_WEBSOCKET_ORIGIN));
+        list.add(header(false, HttpHeaderNames.SEC_WEBSOCKET_PROTOCOL));
+        list.add(header(false, HttpHeaderNames.SEC_WEBSOCKET_VERSION));
+        list.add(header(false, HttpHeaderNames.SEC_WEBSOCKET_KEY));
+        list.add(header(false, HttpHeaderNames.SEC_WEBSOCKET_ACCEPT));
+        list.add(header(false, HttpHeaderNames.SEC_WEBSOCKET_EXTENSIONS));
+        list.add(header(false, HttpHeaderNames.SERVER));
+        list.add(header(false, HttpHeaderNames.SET_COOKIE));
+        list.add(header(false, HttpHeaderNames.SET_COOKIE2));
+        list.add(header(true, HttpHeaderNames.TE));
+        list.add(header(false, HttpHeaderNames.TRAILER));
+        list.add(header(true, HttpHeaderNames.TRANSFER_ENCODING));
+        list.add(header(true, HttpHeaderNames.UPGRADE));
+        list.add(header(false, HttpHeaderNames.UPGRADE_INSECURE_REQUESTS));
+        list.add(header(false, HttpHeaderNames.USER_AGENT));
+        list.add(header(false, HttpHeaderNames.VARY));
+        list.add(header(false, HttpHeaderNames.VIA));
+        list.add(header(false, HttpHeaderNames.WARNING));
+        list.add(header(false, HttpHeaderNames.WWW_AUTHENTICATE));
+        list.add(header(false, HttpHeaderNames.X_FRAME_OPTIONS));
+        list.add(header(false, HttpHeaderNames.X_REQUESTED_WITH));
+
+        return list;
+    }
+
+    private static Arguments header(final boolean isConnectionRelated, final AsciiString headerName) {
+        return new Arguments() {
+            @Override
+            public Object[] get() {
+                return new Object[]{headerName, isConnectionRelated};
+            }
+        };
+    }
+
+    @ParameterizedTest
+    @MethodSource("connectionRelatedHeaders")
+    void mustIdentifyConnectionRelatedHeadersAsciiString(AsciiString headerName, boolean isConnectionRelated) {
+        assertEquals(isConnectionRelated, HttpHeaderValidationUtil.isConnectionHeader(headerName, false));
+    }
+
+    @ParameterizedTest
+    @MethodSource("connectionRelatedHeaders")
+    void mustIdentifyConnectionRelatedHeadersString(AsciiString headerName, boolean isConnectionRelated) {
+        assertEquals(isConnectionRelated, HttpHeaderValidationUtil.isConnectionHeader(headerName.toString(), false));
+    }
+
+    @Test
+    void teHeaderIsNotConnectionRelatedWhenIgnoredAsciiString() {
+        assertFalse(HttpHeaderValidationUtil.isConnectionHeader(HttpHeaderNames.TE, true));
+    }
+
+    @Test
+    void teHeaderIsNotConnectionRelatedWhenIgnoredString() {
+        assertFalse(HttpHeaderValidationUtil.isConnectionHeader(HttpHeaderNames.TE.toString(), true));
+    }
+
+    public static List<Arguments> teIsTrailersTruthTable() {
+        List<Arguments> list = new ArrayList<Arguments>();
+
+        list.add(teIsTrailter(HttpHeaderNames.TE, HttpHeaderValues.TRAILERS, false));
+        list.add(teIsTrailter(HttpHeaderNames.TE, HttpHeaderValues.CHUNKED, true));
+        list.add(teIsTrailter(HttpHeaderNames.COOKIE, HttpHeaderValues.CHUNKED, false));
+        list.add(teIsTrailter(HttpHeaderNames.COOKIE, HttpHeaderValues.TRAILERS, false));
+        list.add(teIsTrailter(HttpHeaderNames.TRAILER, HttpHeaderValues.TRAILERS, false));
+        list.add(teIsTrailter(HttpHeaderNames.TRAILER, HttpHeaderValues.CHUNKED, false));
+
+        return list;
+    }
+
+    private static Arguments teIsTrailter(
+            final AsciiString headerName, final AsciiString headerValue, final boolean result) {
+        return new Arguments() {
+            @Override
+            public Object[] get() {
+                return new Object[]{headerName, headerValue, result};
+            }
+        };
+    }
+
+    @ParameterizedTest
+    @MethodSource("teIsTrailersTruthTable")
+    void whenTeIsNotTrailerOrNotWithNameAndValueAsciiString(
+            AsciiString headerName, AsciiString headerValue, boolean result) {
+        assertEquals(result, HttpHeaderValidationUtil.isTeNotTrailers(headerName, headerValue));
+    }
+
+    @ParameterizedTest
+    @MethodSource("teIsTrailersTruthTable")
+    void whenTeIsNotTrailerOrNotSWithNameAndValueString(
+            AsciiString headerName, AsciiString headerValue, boolean result) {
+        assertEquals(result, HttpHeaderValidationUtil.isTeNotTrailers(headerName.toString(), headerValue.toString()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("teIsTrailersTruthTable")
+    void whenTeIsNotTrailerOrNotSWithNameAsciiStringAndValueString(
+            AsciiString headerName, AsciiString headerValue, boolean result) {
+        assertEquals(result, HttpHeaderValidationUtil.isTeNotTrailers(headerName, headerValue.toString()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("teIsTrailersTruthTable")
+    void whenTeIsNotTrailerOrNotSWithNametringAndValueAsciiString(
+            AsciiString headerName, AsciiString headerValue, boolean result) {
+        assertEquals(result, HttpHeaderValidationUtil.isTeNotTrailers(headerName.toString(), headerValue));
+    }
+
+    public static List<AsciiString> illegalFirstChar() {
+        List<AsciiString> list = new ArrayList<AsciiString>();
+
+        for (byte i = 0; i < 0x21; i++) {
+            list.add(new AsciiString(new byte[]{i, 'a'}));
+        }
+        list.add(new AsciiString(new byte[]{0x7F, 'a'}));
+
+        return list;
+    }
+
+    @ParameterizedTest
+    @MethodSource("illegalFirstChar")
+    void decodingInvalidHeaderValuesMustFailIfFirstCharIsIllegalAsciiString(AsciiString value) {
+        assertEquals(0, validateValidHeaderValue(value));
+    }
+
+    @ParameterizedTest
+    @MethodSource("illegalFirstChar")
+    void decodingInvalidHeaderValuesMustFailIfFirstCharIsIllegalCharSequence(AsciiString value) {
+        assertEquals(0, validateValidHeaderValue(asCharSequence(value)));
+    }
+
+    public static List<AsciiString> legalFirstChar() {
+        List<AsciiString> list = new ArrayList<AsciiString>();
+
+        for (int i = 0x21; i <= 0xFF; i++) {
+            if (i == 0x7F) {
+                continue;
+            }
+            list.add(new AsciiString(new byte[]{(byte) i, 'a'}));
+        }
+
+        return list;
+    }
+
+    @ParameterizedTest
+    @MethodSource("legalFirstChar")
+    void allOtherCharsAreLegalFirstCharsAsciiString(AsciiString value) {
+        assertEquals(-1, validateValidHeaderValue(value));
+    }
+
+    @ParameterizedTest
+    @MethodSource("legalFirstChar")
+    void allOtherCharsAreLegalFirstCharsCharSequence(AsciiString value) {
+        assertEquals(-1, validateValidHeaderValue(value));
+    }
+
+    public static List<AsciiString> illegalNotFirstChar() {
+        ArrayList<AsciiString> list = new ArrayList<AsciiString>();
+
+        for (byte i = 0; i < 0x21; i++) {
+            if (i == ' ' || i == '\t') {
+                continue; // Space and horizontal tab are only illegal as first chars.
+            }
+            list.add(new AsciiString(new byte[]{'a', i}));
+        }
+        list.add(new AsciiString(new byte[]{'a', 0x7F}));
+
+        return list;
+    }
+
+    @ParameterizedTest
+    @MethodSource("illegalNotFirstChar")
+    void decodingInvalidHeaderValuesMustFailIfNotFirstCharIsIllegalAsciiString(AsciiString value) {
+        assertEquals(1, validateValidHeaderValue(value));
+    }
+
+    @ParameterizedTest
+    @MethodSource("illegalNotFirstChar")
+    void decodingInvalidHeaderValuesMustFailIfNotFirstCharIsIllegalCharSequence(AsciiString value) {
+        assertEquals(1, validateValidHeaderValue(asCharSequence(value)));
+    }
+
+    public static List<AsciiString> legalNotFirstChar() {
+        List<AsciiString> list = new ArrayList<AsciiString>();
+
+        for (int i = 0; i < 0xFF; i++) {
+            if (i == 0x7F || i < 0x21 && (i != ' ' || i != '\t')) {
+                continue;
+            }
+            list.add(new AsciiString(new byte[] {'a', (byte) i}));
+        }
+
+        return list;
+    }
+
+    @ParameterizedTest
+    @MethodSource("legalNotFirstChar")
+    void allOtherCharsArgLegalNotFirstCharsAsciiString(AsciiString value) {
+        assertEquals(-1, validateValidHeaderValue(value));
+    }
+
+    @ParameterizedTest
+    @MethodSource("legalNotFirstChar")
+    void allOtherCharsArgLegalNotFirstCharsCharSequence(AsciiString value) {
+        assertEquals(-1, validateValidHeaderValue(asCharSequence(value)));
+    }
+
+    @Test
+    void emptyValuesHaveNoIllegalCharsAsciiString() {
+        assertEquals(-1, validateValidHeaderValue(AsciiString.EMPTY_STRING));
+    }
+
+    @Test
+    void emptyValuesHaveNoIllegalCharsCharSequence() {
+        assertEquals(-1, validateValidHeaderValue(asCharSequence(AsciiString.EMPTY_STRING)));
+    }
+
+    @Test
+    void headerValuesCannotEndWithNewlinesAsciiString() {
+        assertEquals(1, validateValidHeaderValue(AsciiString.of("a\n")));
+        assertEquals(1, validateValidHeaderValue(AsciiString.of("a\r")));
+    }
+
+    @Test
+    void headerValuesCannotEndWithNewlinesCharSequence() {
+        assertEquals(1, validateValidHeaderValue("a\n"));
+        assertEquals(1, validateValidHeaderValue("a\r"));
+    }
+
+    /**
+     * This method returns a {@link CharSequence} instance that has the same contents as the given {@link AsciiString},
+     * but which is, critically, <em>not</em> itself an {@link AsciiString}.
+     * <p>
+     * Some methods specialise on {@link AsciiString}, while having a {@link CharSequence} based fallback.
+     * <p>
+     * This method exist to test those fallback methods.
+     *
+     * @param value The {@link AsciiString} instance to wrap.
+     * @return A new {@link CharSequence} instance which backed by the given {@link AsciiString},
+     * but which is itself not an {@link AsciiString}.
+     */
+    private static CharSequence asCharSequence(final AsciiString value) {
+        return new CharSequence() {
+            @Override
+            public int length() {
+                return value.length();
+            }
+
+            @Override
+            public char charAt(int index) {
+                return value.charAt(index);
+            }
+
+            @Override
+            public CharSequence subSequence(int start, int end) {
+                return asCharSequence(value.subSequence(start, end));
+            }
+        };
+    }
+
+    private static final IllegalArgumentException VALIDATION_EXCEPTION = new IllegalArgumentException() {
+        private static final long serialVersionUID = -8857428534361331089L;
+
+        @Override
+        public synchronized Throwable fillInStackTrace() {
+            return this;
+        }
+    };
+
+    @DisabledForJreRange(max = JRE.JAVA_17) // This test is much too slow on older Java versions.
+    @Test
+    void headerValueValidationMustRejectAllValuesRejectedByOldAlgorithm() {
+        byte[] array = new byte[4];
+        final ByteBuffer buffer = ByteBuffer.wrap(array);
+        final AsciiString asciiString = new AsciiString(buffer, false);
+        CharSequence charSequence = asCharSequence(asciiString);
+        int i = Integer.MIN_VALUE;
+        Supplier<String> failureMessageSupplier = new Supplier<String>() {
+            @Override
+            public String get() {
+                return "validation mismatch on string '" + asciiString + "', iteration " + buffer.getInt(0);
+            }
+        };
+
+        do {
+            buffer.putInt(0, i);
+            try {
+                oldHeaderValueValidationAlgorithm(asciiString);
+            } catch (IllegalArgumentException ignore) {
+                assertNotEquals(-1, validateValidHeaderValue(asciiString), failureMessageSupplier);
+                assertNotEquals(-1, validateValidHeaderValue(charSequence), failureMessageSupplier);
+            }
+            i++;
+        } while (i != Integer.MIN_VALUE);
+    }
+
+    private static void oldHeaderValueValidationAlgorithm(CharSequence seq) {
+        int state = 0;
+        // Start looping through each of the character
+        for (int index = 0; index < seq.length(); index++) {
+            state = oldValidationAlgorithmValidateValueChar(state, seq.charAt(index));
+        }
+
+        if (state != 0) {
+            throw VALIDATION_EXCEPTION;
+        }
+    }
+
+    private static int oldValidationAlgorithmValidateValueChar(int state, char character) {
+        /*
+         * State:
+         * 0: Previous character was neither CR nor LF
+         * 1: The previous character was CR
+         * 2: The previous character was LF
+         */
+        if ((character & ~15) == 0) {
+            // Check the absolutely prohibited characters.
+            switch (character) {
+                case 0x0: // NULL
+                    throw VALIDATION_EXCEPTION;
+                case 0x0b: // Vertical tab
+                    throw VALIDATION_EXCEPTION;
+                case '\f':
+                    throw VALIDATION_EXCEPTION;
+                default:
+                    break;
+            }
+        }
+
+        // Check the CRLF (HT | SP) pattern
+        switch (state) {
+            case 0:
+                switch (character) {
+                    case '\r':
+                        return 1;
+                    case '\n':
+                        return 2;
+                    default:
+                        break;
+                }
+                break;
+            case 1:
+                if (character == '\n') {
+                    return 2;
+                }
+                throw VALIDATION_EXCEPTION;
+            case 2:
+                switch (character) {
+                    case '\t':
+                    case ' ':
+                        return 0;
+                    default:
+                        throw VALIDATION_EXCEPTION;
+                }
+            default:
+                break;
+        }
+        return state;
+    }
+
+    @DisabledForJreRange(max = JRE.JAVA_17) // This test is much too slow on older Java versions.
+    @Test
+    void headerNameValidationMustRejectAllNamesRejectedByOldAlgorithm() throws Exception {
+        byte[] array = new byte[4];
+        final ByteBuffer buffer = ByteBuffer.wrap(array);
+        final AsciiString asciiString = new AsciiString(buffer, false);
+        CharSequence charSequence = asCharSequence(asciiString);
+        int i = Integer.MIN_VALUE;
+        Supplier<String> failureMessageSupplier = new Supplier<String>() {
+            @Override
+            public String get() {
+                return "validation mismatch on string '" + asciiString + "', iteration " + buffer.getInt(0);
+            }
+        };
+
+        do {
+            buffer.putInt(0, i);
+            try {
+                oldHeaderNameValidationAlgorithmAsciiString(asciiString);
+            } catch (IllegalArgumentException ignore) {
+                assertNotEquals(-1, validateToken(asciiString), failureMessageSupplier);
+                assertNotEquals(-1, validateToken(charSequence), failureMessageSupplier);
+            }
+            i++;
+        } while (i != Integer.MIN_VALUE);
+    }
+
+    private static void oldHeaderNameValidationAlgorithmAsciiString(AsciiString name) throws Exception {
+        byte[] array = name.array();
+        for (int i = name.arrayOffset(), len = name.arrayOffset() + name.length(); i < len; i++) {
+            validateHeaderNameElement(array[i]);
+        }
+    }
+
+    private static void validateHeaderNameElement(byte value) {
+        switch (value) {
+            case 0x1c:
+            case 0x1d:
+            case 0x1e:
+            case 0x1f:
+            case 0x00:
+            case '\t':
+            case '\n':
+            case 0x0b:
+            case '\f':
+            case '\r':
+            case ' ':
+            case ',':
+            case ':':
+            case ';':
+            case '=':
+                throw VALIDATION_EXCEPTION;
+            default:
+                // Check to see if the character is not an ASCII character, or invalid
+                if (value < 0) {
+                    throw VALIDATION_EXCEPTION;
+                }
+        }
+    }
+
+    public static List<Character> validTokenChars() {
+        List<Character> list = new ArrayList<Character>();
+        for (char c = '0'; c <= '9'; c++) {
+            list.add(c);
+        }
+        for (char c = 'a'; c <= 'z'; c++) {
+            list.add(c);
+        }
+        for (char c = 'A'; c <= 'Z'; c++) {
+            list.add(c);
+        }
+
+        // Unreserved characters:
+        list.add('-');
+        list.add('.');
+        list.add('_');
+        list.add('~');
+
+        // Token special characters:
+        list.add('!');
+        list.add('#');
+        list.add('$');
+        list.add('%');
+        list.add('&');
+        list.add('\'');
+        list.add('*');
+        list.add('+');
+        list.add('^');
+        list.add('`');
+        list.add('|');
+
+        return list;
+    }
+
+    @ParameterizedTest
+    @MethodSource("validTokenChars")
+    void allTokenCharsAreValidFirstCharHeaderName(char tokenChar) {
+        AsciiString asciiString = new AsciiString(new byte[] {(byte) tokenChar, 'a'});
+        CharSequence charSequence = asCharSequence(asciiString);
+        String string = tokenChar + "a";
+
+        assertEquals(-1, validateToken(asciiString));
+        assertEquals(-1, validateToken(charSequence));
+        assertEquals(-1, validateToken(string));
+    }
+
+    @ParameterizedTest
+    @MethodSource("validTokenChars")
+    void allTokenCharsAreValidSecondCharHeaderName(char tokenChar) {
+        AsciiString asciiString = new AsciiString(new byte[] {'a', (byte) tokenChar});
+        CharSequence charSequence = asCharSequence(asciiString);
+        String string = "a" + tokenChar;
+
+        assertEquals(-1, validateToken(asciiString));
+        assertEquals(-1, validateToken(charSequence));
+        assertEquals(-1, validateToken(string));
+    }
+}

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/HpackEncoder.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/HpackEncoder.java
@@ -108,7 +108,7 @@ final class HpackEncoder {
 
     /**
      * Encode the header field into the header block.
-     *
+     * <p>
      * <strong>The given {@link CharSequence}s must be immutable!</strong>
      */
     public void encodeHeaders(int streamId, Buffer out, Http2Headers headers, SensitivityDetector sensitivityDetector)
@@ -150,7 +150,7 @@ final class HpackEncoder {
 
     /**
      * Encode the header field into the header block.
-     *
+     * <p>
      * <strong>The given {@link CharSequence}s must be immutable!</strong>
      */
     private void encodeHeader(Buffer out, CharSequence name, CharSequence value, boolean sensitive, long headerSize) {

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/DefaultHttp2HeadersTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/DefaultHttp2HeadersTest.java
@@ -174,6 +174,23 @@ public class DefaultHttp2HeadersTest {
         assertFalse(headers.contains("2name", "Value3"));
     }
 
+    @Test
+    void setMustOverwritePseudoHeaders() {
+        Http2Headers headers = newHeaders();
+        // The headers are already populated with pseudo headers.
+        headers.method(of("GET"));
+        headers.path(of("/index2.html"));
+        headers.status(of("101"));
+        headers.authority(of("github.com"));
+        headers.scheme(of("http"));
+        headers.set(of(":protocol"), of("http"));
+        assertEquals(of("GET"), headers.method());
+        assertEquals(of("/index2.html"), headers.path());
+        assertEquals(of("101"), headers.status());
+        assertEquals(of("github.com"), headers.authority());
+        assertEquals(of("http"), headers.scheme());
+    }
+
     private static void verifyAllPseudoHeadersPresent(Http2Headers headers) {
         for (PseudoHeaderName pseudoName : PseudoHeaderName.values()) {
             assertNotNull(headers.get(pseudoName.value()), () -> "did not find pseudo-header " + pseudoName);

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/HpackDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/HpackDecoderTest.java
@@ -374,7 +374,6 @@ public class HpackDecoderTest {
         sb.append("417F811F");
         sb.append("61".repeat(4096)); // 'a'
         decode(sb.toString());
-        verify(mockHeaders).contains(of(":authority"));
         verify(mockHeaders).add(of(":authority"), of(value));
         verifyNoMoreInteractions(mockHeaders);
         reset(mockHeaders);
@@ -582,7 +581,7 @@ public class HpackDecoderTest {
             toEncode.add(":test", "1");
             hpackEncoder.encodeHeaders(1, in, toEncode, NEVER_SENSITIVE);
 
-            final Http2Headers decoded = Http2Headers.newHeaders();
+            final Http2Headers decoded = Http2Headers.newHeaders(true);
 
             assertThrows(Http2Exception.StreamException.class, new Executable() {
                 @Override

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/HpackDynamicTableTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/HpackDynamicTableTest.java
@@ -14,6 +14,7 @@
  */
 package io.netty5.handler.codec.http2;
 
+import io.netty5.util.AsciiString;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
@@ -22,12 +23,16 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class HpackDynamicTableTest {
+    private static final AsciiString FOO = AsciiString.cached("foo");
+    private static final AsciiString BAR = AsciiString.cached("bar");
+    private static final AsciiString HELLO = AsciiString.cached("hello");
+    private static final AsciiString WORLD = AsciiString.cached("world");
 
     @Test
     public void testLength() {
         HpackDynamicTable table = new HpackDynamicTable(100);
         assertEquals(0, table.length());
-        HpackHeaderField entry = new HpackHeaderField("foo", "bar");
+        HpackHeaderField entry = new HpackHeaderField(FOO, BAR);
         table.add(entry);
         assertEquals(1, table.length());
         table.clear();
@@ -38,7 +43,7 @@ public class HpackDynamicTableTest {
     public void testSize() {
         HpackDynamicTable table = new HpackDynamicTable(100);
         assertEquals(0, table.size());
-        HpackHeaderField entry = new HpackHeaderField("foo", "bar");
+        HpackHeaderField entry = new HpackHeaderField(FOO, BAR);
         table.add(entry);
         assertEquals(entry.size(), table.size());
         table.clear();
@@ -48,7 +53,7 @@ public class HpackDynamicTableTest {
     @Test
     public void testGetEntry() {
         final HpackDynamicTable table = new HpackDynamicTable(100);
-        HpackHeaderField entry = new HpackHeaderField("foo", "bar");
+        HpackHeaderField entry = new HpackHeaderField(FOO, BAR);
         table.add(entry);
         assertEquals(entry, table.getEntry(1));
         table.clear();
@@ -76,8 +81,8 @@ public class HpackDynamicTableTest {
     public void testRemove() {
         HpackDynamicTable table = new HpackDynamicTable(100);
         assertNull(table.remove());
-        HpackHeaderField entry1 = new HpackHeaderField("foo", "bar");
-        HpackHeaderField entry2 = new HpackHeaderField("hello", "world");
+        HpackHeaderField entry1 = new HpackHeaderField(FOO, BAR);
+        HpackHeaderField entry2 = new HpackHeaderField(HELLO, WORLD);
         table.add(entry1);
         table.add(entry2);
         assertEquals(entry1, table.remove());
@@ -88,8 +93,8 @@ public class HpackDynamicTableTest {
 
     @Test
     public void testSetCapacity() {
-        HpackHeaderField entry1 = new HpackHeaderField("foo", "bar");
-        HpackHeaderField entry2 = new HpackHeaderField("hello", "world");
+        HpackHeaderField entry1 = new HpackHeaderField(FOO, BAR);
+        HpackHeaderField entry2 = new HpackHeaderField(HELLO, WORLD);
         final int size1 = entry1.size();
         final int size2 = entry2.size();
         HpackDynamicTable table = new HpackDynamicTable(size1 + size2);
@@ -114,8 +119,8 @@ public class HpackDynamicTableTest {
     public void testAdd() {
         HpackDynamicTable table = new HpackDynamicTable(100);
         assertEquals(0, table.size());
-        HpackHeaderField entry1 = new HpackHeaderField("foo", "bar"); //size:3+3+32=38
-        HpackHeaderField entry2 = new HpackHeaderField("hello", "world");
+        HpackHeaderField entry1 = new HpackHeaderField(FOO, BAR); //size:3+3+32=38
+        HpackHeaderField entry2 = new HpackHeaderField(HELLO, WORLD);
         table.add(entry1); //success
         assertEquals(entry1.size(), table.size());
         table.setCapacity(32); //entry1 is removed from table

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameRoundtripTest.java
@@ -98,7 +98,7 @@ public class Http2FrameRoundtripTest {
                 GlobalEventExecutor.INSTANCE.newPromise()).when(ctx).newPromise();
 
         writer = new DefaultHttp2FrameWriter(new DefaultHttp2HeadersEncoder(NEVER_SENSITIVE, newTestEncoder()));
-        reader = new DefaultHttp2FrameReader(new DefaultHttp2HeadersDecoder(false, newTestDecoder()));
+        reader = new DefaultHttp2FrameReader(new DefaultHttp2HeadersDecoder(false, false, newTestDecoder()));
     }
 
     @Test

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/HttpConversionUtilTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/HttpConversionUtilTest.java
@@ -146,7 +146,7 @@ public class HttpConversionUtilTest {
 
     @Test
     public void stripTEHeadersAccountsForOWS() {
-        HttpHeaders inHeaders = HttpHeaders.newHeaders();
+        HttpHeaders inHeaders = HttpHeaders.newHeaders(false);
         inHeaders.add(TE, " " + TRAILERS + ' ');
         Http2Headers out = Http2Headers.newHeaders();
         HttpConversionUtil.toHttp2Headers(inHeaders, out);

--- a/codec/src/main/java/io/netty5/handler/codec/DefaultHeaders.java
+++ b/codec/src/main/java/io/netty5/handler/codec/DefaultHeaders.java
@@ -52,6 +52,7 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
     private final byte hashMask;
     private final ValueConverter<V> valueConverter;
     private final NameValidator<K> nameValidator;
+    private final ValueValidator<V> valueValidator;
     private final HashingStrategy<K> hashingStrategy;
     int size;
 
@@ -65,6 +66,18 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
 
         @SuppressWarnings("rawtypes")
         NameValidator NOT_NULL = name -> requireNonNull(name, "name");
+    }
+
+    public interface ValueValidator<V> {
+        /**
+         * Validate the given value. If the validation fails, then an implementation specific runtime exception may be
+         * thrown.
+         *
+         * @param value The value to validate.
+         */
+        void validate(V value);
+
+        ValueValidator<?> NO_VALIDATION = value -> { };
     }
 
     @SuppressWarnings("unchecked")
@@ -97,10 +110,27 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
      */
     @SuppressWarnings("unchecked")
     public DefaultHeaders(HashingStrategy<K> nameHashingStrategy,
-            ValueConverter<V> valueConverter, NameValidator<K> nameValidator, int arraySizeHint) {
+                          ValueConverter<V> valueConverter, NameValidator<K> nameValidator, int arraySizeHint) {
+        this(nameHashingStrategy, valueConverter, nameValidator, arraySizeHint,
+                (ValueValidator<V>) ValueValidator.NO_VALIDATION);
+    }
+
+    /**
+     * Create a new instance.
+     * @param nameHashingStrategy Used to hash and equality compare names.
+     * @param valueConverter Used to convert values to/from native types.
+     * @param nameValidator Used to validate name elements.
+     * @param arraySizeHint A hint as to how large the hash data structure should be.
+     * The next positive power of two will be used. An upper bound may be enforced.
+     * @param valueValidator The validation strategy for entry values.
+     */
+    @SuppressWarnings("unchecked")
+    public DefaultHeaders(HashingStrategy<K> nameHashingStrategy, ValueConverter<V> valueConverter,
+                          NameValidator<K> nameValidator, int arraySizeHint, ValueValidator<V> valueValidator) {
         this.valueConverter = requireNonNull(valueConverter, "valueConverter");
         this.nameValidator = requireNonNull(nameValidator, "nameValidator");
         hashingStrategy = requireNonNull(nameHashingStrategy, "nameHashingStrategy");
+        this.valueValidator = requireNonNull(valueValidator, "valueValidator");
         // Enforce a bound of [2, 128] because hashMask is a byte. The max possible value of hashMask is one less
         // than the length of this array, and we want the mask to be > 0.
         entries = new HeaderEntry[findNextPositivePowerOfTwo(max(2, min(arraySizeHint, 128)))];
@@ -292,7 +322,8 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
 
     @Override
     public T add(K name, V value) {
-        nameValidator.validateName(name);
+        validateName(nameValidator, true, name);
+        validateValue(valueValidator, name, value);
         requireNonNull(value, "value");
         int h = hashingStrategy.hashCode(name);
         int i = index(h);
@@ -302,10 +333,11 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
 
     @Override
     public T add(K name, Iterable<? extends V> values) {
-        nameValidator.validateName(name);
+        validateName(nameValidator, true, name);
         int h = hashingStrategy.hashCode(name);
         int i = index(h);
         for (V v: values) {
+            validateValue(valueValidator, name, v);
             add0(h, i, name, v);
         }
         return thisT();
@@ -313,10 +345,11 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
 
     @Override
     public T add(K name, V... values) {
-        nameValidator.validateName(name);
+        validateName(nameValidator, true, name);
         int h = hashingStrategy.hashCode(name);
         int i = index(h);
         for (V v: values) {
+            validateValue(valueValidator, name, v);
             add0(h, i, name, v);
         }
         return thisT();
@@ -427,7 +460,8 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
 
     @Override
     public T set(K name, V value) {
-        nameValidator.validateName(name);
+        validateName(nameValidator, false, name);
+        validateValue(valueValidator, name, value);
         requireNonNull(value, "value");
         int h = hashingStrategy.hashCode(name);
         int i = index(h);
@@ -438,7 +472,7 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
 
     @Override
     public T set(K name, Iterable<? extends V> values) {
-        nameValidator.validateName(name);
+        validateName(nameValidator, false, name);
         requireNonNull(values, "values");
 
         int h = hashingStrategy.hashCode(name);
@@ -449,6 +483,7 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
             if (v == null) {
                 break;
             }
+            validateValue(valueValidator, name, v);
             add0(h, i, name, v);
         }
 
@@ -457,7 +492,7 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
 
     @Override
     public T set(K name, V... values) {
-        nameValidator.validateName(name);
+        validateName(nameValidator, false, name);
         requireNonNull(values, "values");
 
         int h = hashingStrategy.hashCode(name);
@@ -468,6 +503,7 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
             if (v == null) {
                 break;
             }
+            validateValue(valueValidator, name, v);
             add0(h, i, name, v);
         }
 
@@ -482,7 +518,7 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
 
     @Override
     public T setObject(K name, Iterable<?> values) {
-        nameValidator.validateName(name);
+        validateName(nameValidator, false, name);
 
         int h = hashingStrategy.hashCode(name);
         int i = index(h);
@@ -500,7 +536,7 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
 
     @Override
     public T setObject(K name, Object... values) {
-        nameValidator.validateName(name);
+        validateName(nameValidator, false, name);
 
         int h = hashingStrategy.hashCode(name);
         int i = index(h);
@@ -956,12 +992,36 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
         return HeadersUtils.toString(getClass(), iterator(), size());
     }
 
+    /**
+     * Call out to the given {@link NameValidator} to validate the given name.
+     *
+     * @param validator the validator to use
+     * @param forAdd {@code true } if this validation is for adding to the headers, or {@code false} if this is for
+     * setting (overwriting) the given header.
+     * @param name the name to validate.
+     */
+    protected void validateName(NameValidator<K> validator, boolean forAdd, K name) {
+        validator.validateName(name);
+    }
+
+    protected void validateValue(ValueValidator<V> validator, K name, V value) {
+        validator.validate(value);
+    }
+
     protected HeaderEntry<K, V> newHeaderEntry(int h, K name, V value, HeaderEntry<K, V> next) {
         return new HeaderEntry<>(h, name, value, next, head);
     }
 
     protected ValueConverter<V> valueConverter() {
         return valueConverter;
+    }
+
+    protected NameValidator<K> nameValidator() {
+        return nameValidator;
+    }
+
+    protected ValueValidator<V> valueValidator() {
+        return valueValidator;
     }
 
     private int index(int hash) {
@@ -1203,7 +1263,7 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
         return copy;
     }
 
-    private final class HeaderIterator implements Iterator<Map.Entry<K, V>> {
+    private final class HeaderIterator implements Iterator<Entry<K, V>> {
         private HeaderEntry<K, V> current = head;
 
         @Override
@@ -1280,7 +1340,7 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
         }
     }
 
-    protected static class HeaderEntry<K, V> implements Map.Entry<K, V> {
+    protected static class HeaderEntry<K, V> implements Entry<K, V> {
         protected final int hash;
         protected final K key;
         protected V value;
@@ -1361,7 +1421,7 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
             if (!(o instanceof Map.Entry)) {
                 return false;
             }
-            Map.Entry<?, ?> other = (Map.Entry<?, ?>) o;
+            Entry<?, ?> other = (Entry<?, ?>) o;
             return (getKey() == null ? other.getKey() == null : getKey().equals(other.getKey()))  &&
                    (getValue() == null ? other.getValue() == null : getValue().equals(other.getValue()));
         }

--- a/codec/src/main/java/io/netty5/handler/codec/DefaultHeadersImpl.java
+++ b/codec/src/main/java/io/netty5/handler/codec/DefaultHeadersImpl.java
@@ -26,4 +26,9 @@ public final class DefaultHeadersImpl<K, V> extends DefaultHeaders<K, V, Default
             ValueConverter<V> valueConverter, NameValidator<K> nameValidator) {
         super(nameHashingStrategy, valueConverter, nameValidator);
     }
+
+    public DefaultHeadersImpl(HashingStrategy<K> nameHashingStrategy, ValueConverter<V> valueConverter,
+                              NameValidator<K> nameValidator, int arraySizeHint, ValueValidator<V> valueValidator) {
+        super(nameHashingStrategy, valueConverter, nameValidator, arraySizeHint, valueValidator);
+    }
 }


### PR DESCRIPTION
Motivation:
In https://datatracker.ietf.org/doc/html/rfc7540#section-10.3 it says that only certain characters are valid in a header value:

> Any request or response that contains a character not permitted
> in a header field value MUST be treated as malformed (Section 8.1.2.6).
> Valid characters are defined by the "field-content" ABNF rule in
> Section 3.2 of [RFC7230].

Modification:
Add a header value validation step to HpackDecoder.

Result:
Header values are now validated against the Section 10.3, etc. rules.

This is the forward port of #12760