### PR TITLE
Avoid failing cookie validation on missing space after ';'

### DIFF
--- a/codec-http/src/main/java/io/netty5/handler/codec/http/headers/DefaultHttpSetCookie.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/headers/DefaultHttpSetCookie.java
@@ -280,7 +280,7 @@ public final class DefaultHttpSetCookie implements HttpSetCookie {
                     }
                     parseState = ParseState.Unknown;
                     if (validateContent && HeaderUtils.cookieParsingPedantic) {
-                        // Only enable this check in pedantic-mode. At least the Jersey web framework typically don't
+                        // Only enable this check in pedantic-mode. At least the Jersey web framework typically doesn't
                         // include the space.
                         if (i + 1 >= length || ' ' != setCookieString.charAt(i + 1)) {
                             throw new IllegalArgumentException(

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/headers/DefaultHttpSetCookie.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/headers/DefaultHttpSetCookie.java
@@ -30,7 +30,6 @@
 package io.netty5.handler.codec.http.headers;
 
 import io.netty5.util.AsciiString;
-import io.netty5.util.internal.SystemPropertyUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/headers/DefaultHttpSetCookie.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/headers/DefaultHttpSetCookie.java
@@ -30,6 +30,7 @@
 package io.netty5.handler.codec.http.headers;
 
 import io.netty5.util.AsciiString;
+import io.netty5.util.internal.SystemPropertyUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -278,7 +279,9 @@ public final class DefaultHttpSetCookie implements HttpSetCookie {
                             break;
                     }
                     parseState = ParseState.Unknown;
-                    if (validateContent) {
+                    if (validateContent && HeaderUtils.cookieParsingPedantic) {
+                        // Only enable this check in pedantic-mode. At least the Jersey web framework typically don't
+                        // include the space.
                         if (i + 1 >= length || ' ' != setCookieString.charAt(i + 1)) {
                             throw new IllegalArgumentException(
                                     "a space is required after ; in cookie attribute-value lists");

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/headers/DefaultHttpSetCookie.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/headers/DefaultHttpSetCookie.java
@@ -36,6 +36,7 @@ import org.jetbrains.annotations.Nullable;
 import static io.netty5.handler.codec.http.headers.HeaderUtils.validateCookieNameAndValue;
 import static io.netty5.util.AsciiString.contentEquals;
 import static io.netty5.util.AsciiString.contentEqualsIgnoreCase;
+import static java.lang.Integer.toHexString;
 import static java.lang.Long.parseLong;
 
 /**
@@ -210,7 +211,7 @@ public final class DefaultHttpSetCookie implements HttpSetCookie {
                         ++i;
                         break;
                     } else {
-                        throw new IllegalArgumentException("unexpected = at index: " + i);
+                        throw new IllegalArgumentException("set-cookie '" +name + "': unexpected = at index: " + i);
                     }
                     ++i;
                     begin = i;
@@ -220,15 +221,29 @@ public final class DefaultHttpSetCookie implements HttpSetCookie {
                         if (isWrapped) {
                             parseState = ParseState.Unknown;
                             value = setCookieString.subSequence(begin, i);
-                            if (validateContent) {
-                                // Increment by 3 because we are skipping DQUOTE SEMI SP
-                                // See https://www.rfc-editor.org/rfc/rfc6265#section-4.1.1
-                                // Specifically, how set-cookie-string interacts with quoted cookie-value.
-                                i += 3;
-                            } else {
-                                // When validation is disabled, we need to check if there's an SP to skip
-                                i += i + 2 < length && setCookieString.charAt(i + 2) == ' '? 3 : 2;
-                            }
+                            // Increment by 3 because we are skipping DQUOTE SEMI SP
+                             // See https://www.rfc-editor.org/rfc/rfc6265#section-4.1.1
+                             // Specifically, how set-cookie-string interacts with quoted cookie-value.
+                             ++i;    // go to SEMI
+                             if (i < length && setCookieString.charAt(i) != ';') {
+                                 throw new IllegalArgumentException(
+                                         "set-cookie '" + name + "': unexpected character 0x" +
+                                                 toHexString(setCookieString.charAt(i)) + " at index " + i +
+                                                 ", expected semicolon ';' after quoted value");
+                             }
+                             ++i;    // go to SP
+                             if (validateContent && HeaderUtils.cookieParsingStrictRfc6265()) {
+                                 if (i < length && setCookieString.charAt(i) != ' ') {
+                                     throw new IllegalArgumentException("set-cookie '" + name +
+                                             "': a space is required after ; in cookie attribute-value lists");
+                                 }
+                                 ++i;    // skip SP
+                             } else {
+                                 // When validation is disabled, we need to check if there's an SP to skip
+                                 if (i < length && setCookieString.charAt(i) == ' ') {
+                                     ++i;
+                                 }
+                             }
                         } else {
                             isWrapped = true;
                             ++i;
@@ -237,14 +252,15 @@ public final class DefaultHttpSetCookie implements HttpSetCookie {
                         break;
                     }
                     if (value == null) {
-                        throw new IllegalArgumentException("unexpected quote at index: " + i);
+                        throw new IllegalArgumentException(
+                                "set-cookie '" + name + "': unexpected quote at index: " + i);
                     }
                     ++i;
                     break;
                 case ';':
                     // end of value, or end of av-value
                     if (i + 1 == length && validateContent) {
-                        throw new IllegalArgumentException("unexpected trailing ';'");
+                        throw new IllegalArgumentException("set-cookie '" + name + "': unexpected trailing ';'");
                     }
                     switch (parseState) {
                         case ParsingValue:
@@ -267,7 +283,7 @@ public final class DefaultHttpSetCookie implements HttpSetCookie {
                             break;
                         default:
                             if (name == null) {
-                                throw new IllegalArgumentException("cookie value not found at index " + i);
+                                throw new IllegalArgumentException("cookie name cannot be null or empty");
                             }
                             final CharSequence avName = setCookieString.subSequence(begin, i);
                             if (contentEqualsIgnoreCase(avName, "secure")) {
@@ -278,12 +294,12 @@ public final class DefaultHttpSetCookie implements HttpSetCookie {
                             break;
                     }
                     parseState = ParseState.Unknown;
-                    if (validateContent && HeaderUtils.cookieParsingPedantic) {
+                    if (validateContent && HeaderUtils.cookieParsingStrictRfc6265()) {
                         // Only enable this check in pedantic-mode. At least the Jersey web framework typically doesn't
                         // include the space.
                         if (i + 1 >= length || ' ' != setCookieString.charAt(i + 1)) {
-                            throw new IllegalArgumentException(
-                                    "a space is required after ; in cookie attribute-value lists");
+                            throw new IllegalArgumentException("set-cookie '" + name +
+                                    "': a space is required after ; in cookie attribute-value lists");
                         }
                         i += 2;
                     } else {
@@ -299,10 +315,10 @@ public final class DefaultHttpSetCookie implements HttpSetCookie {
                         if (parseState == ParseState.ParsingValue) {
                             // Cookie values need to conform to the cookie-octet rule of
                             // https://www.rfc-editor.org/rfc/rfc6265#section-4.1.1
-                            validateCookieOctetHexValue(c, i);
+                            validateCookieOctetHexValue(name, c, i);
                         } else {
                             // Cookie attribute-value rules are "any CHAR except CTLs or ';'"
-                            validateCookieAttributeValue(c, i);
+                            validateCookieAttributeValue(name, c, i);
                         }
                     }
                     ++i;
@@ -334,7 +350,7 @@ public final class DefaultHttpSetCookie implements HttpSetCookie {
                     break;
                 default:
                     if (name == null) {
-                        throw new IllegalArgumentException("cookie value not found at index " + i);
+                        throw new IllegalArgumentException("set-cookie value not found at index " + i);
                     }
                     final CharSequence avName = setCookieString.subSequence(begin, i);
                     if (contentEqualsIgnoreCase(avName, "secure")) {
@@ -576,13 +592,13 @@ public final class DefaultHttpSetCookie implements HttpSetCookie {
      * @param hexValue The decimal representation of the hexadecimal value.
      * @param index The index of the character in the inputs, for error reporting.
      */
-    private static void validateCookieOctetHexValue(final int hexValue, int index) {
+    private static void validateCookieOctetHexValue(final CharSequence name, final int hexValue, int index) {
         if (hexValue != 33 &&
                 (hexValue < 35 || hexValue > 43) &&
                 (hexValue < 45 || hexValue > 58) &&
                 (hexValue < 60 || hexValue > 91) &&
                 (hexValue < 93 || hexValue > 126)) {
-            throw unexpectedHexValue(hexValue, index);
+            throw unexpectedHexValue(name, hexValue, index);
         }
     }
 
@@ -594,15 +610,15 @@ public final class DefaultHttpSetCookie implements HttpSetCookie {
      * @param hexValue The decimal representation of the hexadecimal value.
      * @param index The index of the character in the inputs, for error reporting.
      */
-    private static void validateCookieAttributeValue(final int hexValue, int index) {
+    private static void validateCookieAttributeValue(final CharSequence name, final int hexValue, int index) {
         if (hexValue == ';' || hexValue == 0x7F || hexValue <= 0x1F) {
-            throw unexpectedHexValue(hexValue, index);
+            throw unexpectedHexValue(name, hexValue, index);
         }
     }
 
     @NotNull
-    private static IllegalArgumentException unexpectedHexValue(int hexValue, int index) {
+    private static IllegalArgumentException unexpectedHexValue(final CharSequence name, int hexValue, int index) {
         return new IllegalArgumentException(
-                "Unexpected hex value at index " + index + ": 0x" + Integer.toHexString(hexValue));
+                "set-cookie '" + name + "': unexpected hex value at index " + index + ": 0x" + toHexString(hexValue));
     }
 }

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/headers/DefaultHttpSetCookie.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/headers/DefaultHttpSetCookie.java
@@ -211,7 +211,7 @@ public final class DefaultHttpSetCookie implements HttpSetCookie {
                         ++i;
                         break;
                     } else {
-                        throw new IllegalArgumentException("set-cookie '" +name + "': unexpected = at index: " + i);
+                        throw new IllegalArgumentException("set-cookie '" + name + "': unexpected = at index: " + i);
                     }
                     ++i;
                     begin = i;

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/headers/HeaderUtils.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/headers/HeaderUtils.java
@@ -33,8 +33,8 @@ import io.netty5.handler.codec.http.HttpHeaderNames;
 import io.netty5.handler.codec.http.HttpHeaderValues;
 import io.netty5.util.AsciiString;
 import io.netty5.util.internal.SystemPropertyUtil;
-import io.netty5.util.internal.SystemPropertyUtil;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import java.util.Iterator;
 import java.util.Map;
@@ -475,9 +475,12 @@ public final class HeaderUtils {
                 if (cookieHeaderValue.length() - 2 <= semiIndex) {
                     advanceCookieHeaderValue();
                     nextNextStart = 0;
-                } else {
-                    // skip 2 characters "; " (see https://tools.ietf.org/html/rfc6265#section-4.2.1)
+                } else if (cookieHeaderValue.charAt(semiIndex + 1) == ' ') {
+                    // Skip 2 characters "; " (see https://tools.ietf.org/html/rfc6265#section-4.2.1)
                     nextNextStart = semiIndex + 2;
+                } else {
+                    // Older cookie spec delimit with just semicolon. See https://www.rfc-editor.org/rfc/rfc2965
+                    nextNextStart = semiIndex + 1;
                 }
             } else {
                 advanceCookieHeaderValue();

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/headers/HeaderUtils.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/headers/HeaderUtils.java
@@ -64,14 +64,27 @@ public final class HeaderUtils {
             (k, v) -> "<filtered>";
 
     /**
-     * Whether cookie parsing should be strictly spec compliant ({@code true}),
-     * or allow some deviations that are commonly observed in practice ({@code false}, the default).
+     * Whether cookie parsing should be strictly spec compliant with
+     * <a href="https://www.rfc-editor.org/rfc/rfc6265">RFC6265</a> ({@code true}), or allow some deviations that are
+     * commonly observed in practice and allowed by the obsolete
+     * <a href="https://www.rfc-editor.org/rfc/rfc2965">RFC2965</a>/
+     * <a href="https://www.rfc-editor.org/rfc/rfc2109">RFC2109</a> ({@code false}, the default).
      */
-    static boolean cookieParsingPedantic = SystemPropertyUtil.getBoolean(
-            "io.netty5.handler.codec.http.headers.cookieParsingPedantic", false);
+    // not final for testing
+    private static boolean cookieParsingStrictRfc6265 = SystemPropertyUtil.getBoolean(
+            "io.netty5.handler.codec.http.headers.cookieParsingStrictRfc6265", false);
 
     private HeaderUtils() {
         // no instances
+    }
+
+    static boolean cookieParsingStrictRfc6265() {
+        return cookieParsingStrictRfc6265;
+    }
+
+    @VisibleForTesting
+    static void cookieParsingStrictRfc6265(boolean value) {
+        cookieParsingStrictRfc6265 = value;
     }
 
     static String toString(final HttpHeaders headers,

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/headers/HeaderUtils.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/headers/HeaderUtils.java
@@ -481,20 +481,22 @@ public final class HeaderUtils {
             if (semiIndex > 0) {
                 if (cookieHeaderValue.length() - 2 <= semiIndex) {
                     if (cookieParsingStrictRfc6265()) {
-                        throw new IllegalArgumentException("cookie is not allowed to end with ;");
+                        throw new IllegalArgumentException("cookie '" + next.name() +
+                                "': cookie is not allowed to end with ;");
                     } else {
                         advanceCookieHeaderValue();
                         nextNextStart = 0;
                     }
                 } else if (cookieParsingStrictRfc6265()) {
                     // Skip 2 characters "; " (see https://tools.ietf.org/html/rfc6265#section-4.2.1)
+                    if (cookieHeaderValue.charAt(semiIndex + 1) != ' ') {
+                        throw new IllegalArgumentException("cookie '" + next.name() +
+                                "': a space is required after ; in cookie attribute-value lists");
+                    }
                     nextNextStart = semiIndex + 2;
                 } else {
                     // Older cookie spec delimit with just semicolon. See https://www.rfc-editor.org/rfc/rfc2965
-                    nextNextStart = semiIndex + 1;
-                    if (cookieHeaderValue.charAt(nextNextStart) == ' ') {
-                        nextNextStart++;
-                    }
+                    nextNextStart = semiIndex + (cookieHeaderValue.charAt(semiIndex + 1) == ' ' ? 2 : 1);
                 }
             } else {
                 advanceCookieHeaderValue();

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/headers/HeaderUtils.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/headers/HeaderUtils.java
@@ -67,7 +67,7 @@ public final class HeaderUtils {
      * Whether cookie parsing should be strictly spec compliant ({@code true}),
      * or allow some deviations that are commonly observed in practice ({@code false}, the default).
      */
-    public static boolean cookieParsingPedantic = SystemPropertyUtil.getBoolean(
+    static boolean cookieParsingPedantic = SystemPropertyUtil.getBoolean(
             "io.netty5.handler.codec.http.headers.cookieParsingPedantic", false);
 
     private HeaderUtils() {

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/headers/HeaderUtils.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/headers/HeaderUtils.java
@@ -32,6 +32,8 @@ package io.netty5.handler.codec.http.headers;
 import io.netty5.handler.codec.http.HttpHeaderNames;
 import io.netty5.handler.codec.http.HttpHeaderValues;
 import io.netty5.util.AsciiString;
+import io.netty5.util.internal.SystemPropertyUtil;
+import io.netty5.util.internal.SystemPropertyUtil;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Iterator;
@@ -60,6 +62,13 @@ public final class HeaderUtils {
     static final int HASH_CODE_SEED = 0xc2b2ae35;
     public static final BiFunction<? super CharSequence, ? super CharSequence, CharSequence> DEFAULT_HEADER_FILTER =
             (k, v) -> "<filtered>";
+
+    /**
+     * Whether cookie parsing should be strictly spec compliant ({@code true}),
+     * or allow some deviations that are commonly observed in practice ({@code false}, the default).
+     */
+    public static boolean cookieParsingPedantic = SystemPropertyUtil.getBoolean(
+            "io.netty5.handler.codec.http.headers.cookieParsingPedantic", false);
 
     private HeaderUtils() {
         // no instances

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/headers/AbstractHttpHeadersTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/headers/AbstractHttpHeadersTest.java
@@ -925,11 +925,20 @@ public abstract class AbstractHttpHeadersTest {
     }
 
     @Test
-    void throwIfNoSpaceBeforeCookieAttributeValue() {
+    void mustTolerateNoSpaceBeforeCookieAttributeValue() {
         final HttpHeaders headers = HttpHeaders.newHeaders();
         headers.add("set-cookie", "first=12345;Extension");
         headers.add("set-cookie", "second=12345;Expires=Mon, 22 Aug 2022 20:12:35 GMT");
-        throwIfNoSpaceBeforeCookieAttributeValue(headers);
+        tolerateNoSpaceBeforeCookieAttributeValue(headers);
+    }
+
+    private static void tolerateNoSpaceBeforeCookieAttributeValue(HttpHeaders headers) {
+        HttpSetCookie first = headers.getSetCookie("first");
+        assertEquals("12345", first.value());
+
+        HttpSetCookie second = headers.getSetCookie("second");
+        assertEquals("12345", second.value());
+        assertEquals("Mon, 22 Aug 2022 20:12:35 GMT", second.expires());
     }
 
     @Test
@@ -949,15 +958,5 @@ public abstract class AbstractHttpHeadersTest {
         HttpSetCookie setCookie = headers.getSetCookie("cook");
         assertThat(setCookie.name()).isEqualToIgnoringCase("cook");
         assertThat(setCookie.value()).isEqualToIgnoringCase("=");
-    }
-
-    private static void throwIfNoSpaceBeforeCookieAttributeValue(HttpHeaders headers) {
-        Exception exception;
-
-        exception = assertThrows(IllegalArgumentException.class, () -> headers.getSetCookie("first"));
-        MatcherAssert.assertThat(exception.getMessage(), containsString("space is required after ;"));
-
-        exception = assertThrows(IllegalArgumentException.class, () -> headers.getSetCookie("second"));
-        MatcherAssert.assertThat(exception.getMessage(), containsString("space is required after ;"));
     }
 }

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/headers/DefaultHttpSetCookieTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/headers/DefaultHttpSetCookieTest.java
@@ -56,7 +56,7 @@ class DefaultHttpSetCookieTest {
         assertThat(new DefaultHttpSetCookie(
                 "foo", "bar", "/", "servicetalk.io", null, 1L, SameSite.None, true, false, true)
         ).hasSameHashCodeAs(new DefaultHttpSetCookie(
-                        "foo", "bar", "/", "ServiceTalk.io", null, 2L, SameSite.Lax, false, true, false));
+                "foo", "bar", "/", "ServiceTalk.io", null, 2L, SameSite.Lax, false, true, false));
     }
 
     @Test
@@ -73,24 +73,24 @@ class DefaultHttpSetCookieTest {
 
         // Path is case-sensitive:
         assertThat(new DefaultHttpSetCookie("foo", "bar", "/path", "servicetalk.io",
-                        null, 1L, SameSite.None, true, false, true)
+                null, 1L, SameSite.None, true, false, true)
         ).isNotEqualTo(new DefaultHttpSetCookie("foo", "bar", "/Path", "servicetalk.io",
-                                                null, 1L, SameSite.None, true, false, true));
+                null, 1L, SameSite.None, true, false, true));
 
         assertThat(new DefaultHttpSetCookie("foo", "bar", "/path", "servicetalk.io",
-                        null, 1L, SameSite.None, true, false, true).hashCode()
+                null, 1L, SameSite.None, true, false, true).hashCode()
         ).isNotEqualTo(new DefaultHttpSetCookie("foo", "bar", "/pathh", "servicetalk.io",
-                                                null, 1L, SameSite.None, true, false, true).hashCode());
+                null, 1L, SameSite.None, true, false, true).hashCode());
 
         // Domain doesn't match:
         assertThat(new DefaultHttpSetCookie("foo", "bar", "/path", "servicetalk.io",
-                        null, 1L, SameSite.None, true, false, true)
+                null, 1L, SameSite.None, true, false, true)
         ).isNotEqualTo(new DefaultHttpSetCookie("foo", "bar", "/path", "docs.servicetalk.io",
-                                                null, 1L, SameSite.None, true, false, true));
+                null, 1L, SameSite.None, true, false, true));
 
         assertThat(new DefaultHttpSetCookie("foo", "bar", "/path", "servicetalk.io",
-                        null, 1L, SameSite.None, true, false, true).hashCode()
+                null, 1L, SameSite.None, true, false, true).hashCode()
         ).isNotEqualTo(new DefaultHttpSetCookie("foo", "bar", "/path", "docs.servicetalk.io",
-                                                null, 1L, SameSite.None, true, false, true).hashCode());
+                null, 1L, SameSite.None, true, false, true).hashCode());
     }
 }

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/headers/DefaultHttpSetCookiesPedanticTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/headers/DefaultHttpSetCookiesPedanticTest.java
@@ -93,4 +93,29 @@ public class DefaultHttpSetCookiesPedanticTest {
                 "qwerty=\"12345\"; Domain=somecompany.co.uk; Path=/; Expires=Wed, 30 Aug 2019 00:00:00 GMT");
         quotesInValuePreserved(headers);
     }
+
+    @Test
+    void cookiesWithExtraTrailingSemiColon() {
+        final HttpHeaders headers = newHeaders();
+        headers.add("cookie", "a=v1; b=v2; c=v3;");
+        Exception e = assertThrows(IllegalArgumentException.class, () -> headers.getCookies().forEach(c -> { }));
+        assertThat(e).hasMessageContaining("cookie is not allowed to end with ;");
+    }
+
+    @Test
+    void cookiesWithExtraTrailingSemiColonAndSpace() {
+        final HttpHeaders headers = newHeaders();
+        headers.add("cookie", "a=v1; b=v2; c=v3; ");
+        Exception e = assertThrows(IllegalArgumentException.class, () -> headers.getCookies().forEach(c -> { }));
+        assertThat(e).hasMessageContaining("cookie is not allowed to end with ;");
+    }
+
+    @Test
+    void cookiesWithExtraTrailingSemiColonAndTwoSpaces() {
+        final HttpHeaders headers = newHeaders();
+        headers.add("cookie", "a=v1; b=v2; lastCookie=v3;  ");
+        Exception e = assertThrows(IllegalArgumentException.class, () -> headers.getCookies().forEach(c -> { }));
+        assertThat(e).hasMessageContaining("no cookie value found after")
+                .hasMessageContaining("lastCookie");
+    }
 }

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/headers/DefaultHttpSetCookiesPedanticTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/headers/DefaultHttpSetCookiesPedanticTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+/*
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.netty5.handler.codec.http.headers;
+
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import java.lang.invoke.VarHandle;
+
+import static io.netty5.handler.codec.http.headers.HttpHeaders.newHeaders;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Isolated
+@Execution(ExecutionMode.SAME_THREAD)
+public class DefaultHttpSetCookiesPedanticTest {
+    @BeforeAll
+    public static void enablePedantic() {
+        HeaderUtils.cookieParsingPedantic = true;
+        VarHandle.fullFence();
+    }
+
+    @AfterAll
+    public static void disablePedantic() {
+        HeaderUtils.cookieParsingPedantic = false;
+        VarHandle.fullFence();
+    }
+
+    @Test
+    void throwIfNoSpaceBeforeCookieAttributeValue() {
+        final HttpHeaders headers = newHeaders();
+        headers.add("set-cookie", "first=12345;Extension");
+        headers.add("set-cookie", "second=12345;Expires=Mon, 22 Aug 2022 20:12:35 GMT");
+        throwIfNoSpaceBeforeCookieAttributeValue(headers);
+    }
+
+    private static void throwIfNoSpaceBeforeCookieAttributeValue(HttpHeaders headers) {
+        Exception exception;
+
+        exception = assertThrows(IllegalArgumentException.class, () -> headers.getSetCookie("first"));
+        MatcherAssert.assertThat(exception.getMessage(), containsString("space is required after ;"));
+
+        exception = assertThrows(IllegalArgumentException.class, () -> headers.getSetCookie("second"));
+        MatcherAssert.assertThat(exception.getMessage(), containsString("space is required after ;"));
+    }
+}

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/headers/DefaultHttpSetCookiesPedanticTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/headers/DefaultHttpSetCookiesPedanticTest.java
@@ -118,4 +118,13 @@ public class DefaultHttpSetCookiesPedanticTest {
         assertThat(e).hasMessageContaining("no cookie value found after")
                 .hasMessageContaining("lastCookie");
     }
+
+    @Test
+    void cookiesWithoutSpaceAfterSemicolon() {
+        final HttpHeaders headers = newHeaders();
+        headers.add("cookie", "firstCookie=v1;b=v2");
+        Exception e = assertThrows(IllegalArgumentException.class, () -> headers.getCookies().forEach(c -> { }));
+        assertThat(e).hasMessageContaining("a space is required after ;")
+                .hasMessageContaining("firstCookie");
+    }
 }

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/headers/DefaultHttpSetCookiesTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/headers/DefaultHttpSetCookiesTest.java
@@ -412,25 +412,25 @@ class DefaultHttpSetCookiesTest {
         assertFalse(cookieItr.hasNext());
     }
 
-     @Test
-     void quotedValueWithSpace() {
-         final HttpHeaders headers = newHeaders();
-         headers.add("set-cookie", "qwerty=\"12 345\"");
-         Exception e = assertThrows(IllegalArgumentException.class, () -> headers.getSetCookie("qwerty"));
-         assertThat(e)
-                 .hasMessageContaining("qwerty")
-                 .hasMessageContaining("unexpected hex value");
-     }
+    @Test
+    void quotedValueWithSpace() {
+        final HttpHeaders headers = newHeaders();
+        headers.add("set-cookie", "qwerty=\"12 345\"");
+        Exception e = assertThrows(IllegalArgumentException.class, () -> headers.getSetCookie("qwerty"));
+        assertThat(e)
+                .hasMessageContaining("qwerty")
+                .hasMessageContaining("unexpected hex value");
+    }
 
-     @Test
-     void noSemicolonAfterQuotedValue() {
-         final HttpHeaders headers = newHeaders();
-         headers.add("set-cookie", "qwerty=\"12345\" max-age=12");
-         Exception e = assertThrows(IllegalArgumentException.class, () -> headers.getSetCookie("qwerty"));
-         assertThat(e)
-                 .hasMessageContaining("qwerty")
-                 .hasMessageContaining("expected semicolon");
-     }
+    @Test
+    void noSemicolonAfterQuotedValue() {
+        final HttpHeaders headers = newHeaders();
+        headers.add("set-cookie", "qwerty=\"12345\" max-age=12");
+        Exception e = assertThrows(IllegalArgumentException.class, () -> headers.getSetCookie("qwerty"));
+        assertThat(e)
+                .hasMessageContaining("qwerty")
+                .hasMessageContaining("expected semicolon");
+    }
 
     @Test
     void quotesInValuePreserved() {
@@ -641,76 +641,76 @@ class DefaultHttpSetCookiesTest {
         assertNull(headers.getSetCookie("qwerty12345"));
     }
 
-     @Test
-     void expiresAfterSemicolon() {
-         final HttpHeaders headers = newHeaders();
-         headers.add("set-cookie",
-                 "qwerty=12345; Domain=somecompany.co.uk; Expires=Wed, 30 Aug 2019 00:00:00 GMT; Path=/");
-         HttpSetCookie cookie = headers.getSetCookie("qwerty");
-         assertNotNull(cookie);
-         assertThat(cookie.name()).isEqualToIgnoringCase("qwerty");
-         assertThat(cookie.value()).isEqualToIgnoringCase("12345");
-         assertThat(cookie.domain()).isEqualToIgnoringCase("somecompany.co.uk");
-         assertThat(cookie.expires()).isEqualToIgnoringCase("Wed, 30 Aug 2019 00:00:00 GMT");
-         assertThat(cookie.path()).isEqualToIgnoringCase("/");
-     }
+    @Test
+    void expiresAfterSemicolon() {
+        final HttpHeaders headers = newHeaders();
+        headers.add("set-cookie",
+                "qwerty=12345; Domain=somecompany.co.uk; Expires=Wed, 30 Aug 2019 00:00:00 GMT; Path=/");
+        HttpSetCookie cookie = headers.getSetCookie("qwerty");
+        assertNotNull(cookie);
+        assertThat(cookie.name()).isEqualToIgnoringCase("qwerty");
+        assertThat(cookie.value()).isEqualToIgnoringCase("12345");
+        assertThat(cookie.domain()).isEqualToIgnoringCase("somecompany.co.uk");
+        assertThat(cookie.expires()).isEqualToIgnoringCase("Wed, 30 Aug 2019 00:00:00 GMT");
+        assertThat(cookie.path()).isEqualToIgnoringCase("/");
+    }
 
-     @Test
-     void emptyValue() {
-         final HttpHeaders headers = newHeaders();
-         headers.add("set-cookie", "qwerty=");
-         HttpSetCookie cookie = headers.getSetCookie("qwerty");
-         assertNotNull(cookie);
-         assertThat(cookie.value()).isEmpty();
-     }
+    @Test
+    void emptyValue() {
+        final HttpHeaders headers = newHeaders();
+        headers.add("set-cookie", "qwerty=");
+        HttpSetCookie cookie = headers.getSetCookie("qwerty");
+        assertNotNull(cookie);
+        assertThat(cookie.value()).isEmpty();
+    }
 
-     @Test
-     void emptyDomain() {
-         final HttpHeaders headers = newHeaders();
-         headers.add("set-cookie", "qwerty=12345; Domain=");
-         HttpSetCookie cookie = headers.getSetCookie("qwerty");
-         assertNotNull(cookie);
-         assertThat(cookie.value()).isEqualToIgnoringCase("12345");
-         assertThat(cookie.domain()).isEmpty();
-     }
+    @Test
+    void emptyDomain() {
+        final HttpHeaders headers = newHeaders();
+        headers.add("set-cookie", "qwerty=12345; Domain=");
+        HttpSetCookie cookie = headers.getSetCookie("qwerty");
+        assertNotNull(cookie);
+        assertThat(cookie.value()).isEqualToIgnoringCase("12345");
+        assertThat(cookie.domain()).isEmpty();
+    }
 
-     @Test
-     void valueContainsEqualsSign() {
-         final HttpHeaders headers = newHeaders();
-         headers.add("set-cookie", "qwerty=123=45");
-         HttpSetCookie cookie = headers.getSetCookie("qwerty");
-         assertNotNull(cookie);
-         assertThat(cookie.value()).isEqualToIgnoringCase("123=45");
-     }
+    @Test
+    void valueContainsEqualsSign() {
+        final HttpHeaders headers = newHeaders();
+        headers.add("set-cookie", "qwerty=123=45");
+        HttpSetCookie cookie = headers.getSetCookie("qwerty");
+        assertNotNull(cookie);
+        assertThat(cookie.value()).isEqualToIgnoringCase("123=45");
+    }
 
-     @Test
-     void attributeValueContainsEqualsSign() {
-         final HttpHeaders headers = newHeaders();
-         headers.add("set-cookie", "qwerty=12345; max-age=12=1");
-         Exception e = assertThrows(IllegalArgumentException.class, () -> headers.getSetCookie("qwerty"));
-         assertThat(e).hasMessageContaining("qwerty").hasMessageContaining("=");
-     }
+    @Test
+    void attributeValueContainsEqualsSign() {
+        final HttpHeaders headers = newHeaders();
+        headers.add("set-cookie", "qwerty=12345; max-age=12=1");
+        Exception e = assertThrows(IllegalArgumentException.class, () -> headers.getSetCookie("qwerty"));
+        assertThat(e).hasMessageContaining("qwerty").hasMessageContaining("=");
+    }
 
-     @Test
-     void parseSetCookieWithEmptyName() {
-         Exception e = assertThrows(IllegalArgumentException.class, () -> parseSetCookie("=123", false));
-         assertThat(e).hasMessageContaining("cookie name cannot be null or empty");
+    @Test
+    void parseSetCookieWithEmptyName() {
+        Exception e = assertThrows(IllegalArgumentException.class, () -> parseSetCookie("=123", false));
+        assertThat(e).hasMessageContaining("cookie name cannot be null or empty");
 
-         e = assertThrows(IllegalArgumentException.class, () -> parseSetCookie("; max-age=123", false));
-         assertThat(e).hasMessageContaining("cookie name cannot be null or empty");
-     }
+        e = assertThrows(IllegalArgumentException.class, () -> parseSetCookie("; max-age=123", false));
+        assertThat(e).hasMessageContaining("cookie name cannot be null or empty");
+    }
 
-     @Test
-     void parseSetCookieWithEmptyValue() {
-         Exception e = assertThrows(IllegalArgumentException.class, () -> parseSetCookie("q", false));
-         assertThat(e).hasMessageContaining("set-cookie value not found at index 1");
-     }
+    @Test
+    void parseSetCookieWithEmptyValue() {
+        Exception e = assertThrows(IllegalArgumentException.class, () -> parseSetCookie("q", false));
+        assertThat(e).hasMessageContaining("set-cookie value not found at index 1");
+    }
 
-     @Test
-     void parseSetCookieWithUnexpectedQuote() {
-         Exception e = assertThrows(IllegalArgumentException.class, () -> parseSetCookie("\"123\"", false));
-         assertThat(e).hasMessageContaining("unexpected quote at index: 0");
-     }
+    @Test
+    void parseSetCookieWithUnexpectedQuote() {
+        Exception e = assertThrows(IllegalArgumentException.class, () -> parseSetCookie("\"123\"", false));
+        assertThat(e).hasMessageContaining("unexpected quote at index: 0");
+    }
 
     @Test
     void trailingSemiColon() {
@@ -782,15 +782,15 @@ class DefaultHttpSetCookiesTest {
 
     private static boolean areSetCookiesEqual(final HttpSetCookie cookie1, final HttpSetCookie cookie2) {
         return contentEqualsIgnoreCase(cookie1.name(), cookie2.name()) &&
-               cookie1.value().equals(cookie2.value()) &&
-               Objects.equals(cookie1.domain(), cookie2.domain()) &&
-               Objects.equals(cookie1.path(), cookie2.path()) &&
-               Objects.equals(cookie1.expires(), cookie2.expires()) &&
-               Objects.equals(cookie1.value(), cookie2.value()) &&
-               cookie1.sameSite() == cookie2.sameSite() &&
-               cookie1.isHttpOnly() == cookie2.isHttpOnly() &&
-               cookie1.isSecure() == cookie2.isSecure() &&
-               cookie1.isWrapped() == cookie2.isWrapped();
+                cookie1.value().equals(cookie2.value()) &&
+                Objects.equals(cookie1.domain(), cookie2.domain()) &&
+                Objects.equals(cookie1.path(), cookie2.path()) &&
+                Objects.equals(cookie1.expires(), cookie2.expires()) &&
+                Objects.equals(cookie1.value(), cookie2.value()) &&
+                cookie1.sameSite() == cookie2.sameSite() &&
+                cookie1.isHttpOnly() == cookie2.isHttpOnly() &&
+                cookie1.isSecure() == cookie2.isSecure() &&
+                cookie1.isWrapped() == cookie2.isWrapped();
     }
 
     private static boolean areCookiesEqual(final HttpCookiePair cookie1, final HttpCookiePair cookie2) {

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/headers/DefaultHttpSetCookiesTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/headers/DefaultHttpSetCookiesTest.java
@@ -30,7 +30,6 @@
 package io.netty5.handler.codec.http.headers;
 
 import io.netty5.handler.codec.http.headers.HttpSetCookie.SameSite;
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
@@ -43,7 +42,7 @@ import java.util.Set;
 import static io.netty5.handler.codec.http.headers.HttpHeaders.newHeaders;
 import static io.netty5.util.AsciiString.contentEqualsIgnoreCase;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -655,21 +654,20 @@ class DefaultHttpSetCookiesTest {
     }
 
     @Test
-    void throwIfNoSpaceBeforeCookieAttributeValue() {
+    void mustTolerateNoSpaceBeforeCookieAttributeValue() {
         final HttpHeaders headers = newHeaders();
         headers.add("set-cookie", "first=12345;Extension");
         headers.add("set-cookie", "second=12345;Expires=Mon, 22 Aug 2022 20:12:35 GMT");
-        throwIfNoSpaceBeforeCookieAttributeValue(headers);
+        tolerateNoSpaceBeforeCookieAttributeValue(headers);
     }
 
-    private static void throwIfNoSpaceBeforeCookieAttributeValue(HttpHeaders headers) {
-        Exception exception;
+    private static void tolerateNoSpaceBeforeCookieAttributeValue(HttpHeaders headers) {
+        HttpSetCookie first = headers.getSetCookie("first");
+        assertEquals("12345", first.value());
 
-        exception = assertThrows(IllegalArgumentException.class, () -> headers.getSetCookie("first"));
-        MatcherAssert.assertThat(exception.getMessage(), containsString("space is required after ;"));
-
-        exception = assertThrows(IllegalArgumentException.class, () -> headers.getSetCookie("second"));
-        MatcherAssert.assertThat(exception.getMessage(), containsString("space is required after ;"));
+        HttpSetCookie second = headers.getSetCookie("second");
+        assertEquals("12345", second.value());
+        assertEquals("Mon, 22 Aug 2022 20:12:35 GMT", second.expires());
     }
 
     @Test

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/headers/LegacyCookieParsingTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/headers/LegacyCookieParsingTest.java
@@ -1,0 +1,434 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty5.handler.codec.http.headers;
+
+import io.netty5.handler.codec.DateFormatter;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.TimeZone;
+
+import static io.netty5.handler.codec.http.HttpHeaderNames.COOKIE;
+import static io.netty5.handler.codec.http.HttpHeaderNames.SET_COOKIE;
+import static io.netty5.handler.codec.http.headers.HttpSetCookie.SameSite.None;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests from the old Netty 4.1 ClientCookieDecoder and ServerCookieDecoder.
+ * Those decoders were tested on cookie formats for older RFCs.
+ * We recreate those tests here, to verify that we're still compatible with those formats.
+ */
+public class LegacyCookieParsingTest {
+    HttpHeaders headers;
+
+    @BeforeEach
+    void createHeaders() {
+        headers = HttpHeaders.newHeaders(false);
+    }
+
+    // Server cookie (COOKIE header) decoder tests
+    @Test
+    void decodingSingleServerCookie() {
+        headers.add(COOKIE, "myCookie=myValue");
+        assertThat(headers.getCookies()).hasSize(1);
+        assertThat(headers.getCookies()).containsExactly(new DefaultHttpCookiePair("myCookie", "myValue"));
+    }
+
+    @Test
+    void decodingMultipleServerCookies() {
+        String c1 = "myCookie=myValue;";
+        String c2 = "myCookie2=myValue2;";
+        String c3 = "myCookie3=myValue3;";
+        headers.add(COOKIE, c1 + c2 + c3);
+        assertThat(headers.getCookies()).hasSize(3);
+        assertThat(headers.getCookies()).containsExactly(
+                new DefaultHttpCookiePair("myCookie", "myValue"),
+                new DefaultHttpCookiePair("myCookie2", "myValue2"),
+                new DefaultHttpCookiePair("myCookie3", "myValue3"));
+    }
+
+    @Test
+    void decodingMultipleSameNamedServerCookies() {
+        String c1 = "myCookie=myValue;";
+        String c2 = "myCookie=myValue2;";
+        String c3 = "myCookie=myValue3;";
+        headers.add(COOKIE, c1 + c2 + c3);
+        assertThat(headers.getCookies()).hasSize(3);
+        assertThat(headers.getCookies()).containsExactly(
+                new DefaultHttpCookiePair("myCookie", "myValue"),
+                new DefaultHttpCookiePair("myCookie", "myValue2"),
+                new DefaultHttpCookiePair("myCookie", "myValue3"));
+    }
+
+    @Test
+    void decodingGoogleAnalyticsServerCookie() {
+        String source = "ARPT=LWUKQPSWRTUN04CKKJI; " +
+                "kw-2E343B92-B097-442c-BFA5-BE371E0325A2=unfinished_furniture; " +
+                "__utma=48461872.1094088325.1258140131.1258140131.1258140131.1; " +
+                "__utmb=48461872.13.10.1258140131; __utmc=48461872; " +
+                "__utmz=48461872.1258140131.1.1.utmcsr=overstock.com|utmccn=(referral)|" +
+                "utmcmd=referral|utmcct=/Home-Garden/Furniture/Clearance/clearance/32/dept.html";
+        Iterable<HttpCookiePair> cookies = headers.add(COOKIE, source).getCookies();
+        assertThat(cookies).containsExactly(
+                new DefaultHttpCookiePair("ARPT", "LWUKQPSWRTUN04CKKJI"),
+                new DefaultHttpCookiePair("kw-2E343B92-B097-442c-BFA5-BE371E0325A2", "unfinished_furniture"),
+                new DefaultHttpCookiePair("__utma", "48461872.1094088325.1258140131.1258140131.1258140131.1"),
+                new DefaultHttpCookiePair("__utmb", "48461872.13.10.1258140131"),
+                new DefaultHttpCookiePair("__utmc", "48461872"),
+                new DefaultHttpCookiePair("__utmz", "48461872.1258140131.1.1.utmcsr=overstock.com|utmccn=(referral)|" +
+                        "utmcmd=referral|utmcct=/Home-Garden/Furniture/Clearance/clearance/32/dept.html"));
+    }
+
+    @Test
+    void decodingLongServerCookieValue() {
+        String longValue =
+                "b___$Q__$ha__<NC=MN(F__%#4__<NC=MN(F__2_d____#=IvZB__2_F____'=KqtH__2-9____" +
+                        "'=IvZM__3f:____$=HbQW__3g'____%=J^wI__3g-____%=J^wI__3g1____$=HbQW__3g2____" +
+                        "$=HbQW__3g5____%=J^wI__3g9____$=HbQW__3gT____$=HbQW__3gX____#=J^wI__3gY____" +
+                        "#=J^wI__3gh____$=HbQW__3gj____$=HbQW__3gr____$=HbQW__3gx____#=J^wI__3h_____" +
+                        "$=HbQW__3h$____#=J^wI__3h'____$=HbQW__3h_____$=HbQW__3h0____%=J^wI__3h1____" +
+                        "#=J^wI__3h2____$=HbQW__3h4____$=HbQW__3h7____$=HbQW__3h8____%=J^wI__3h:____" +
+                        "#=J^wI__3h@____%=J^wI__3hB____$=HbQW__3hC____$=HbQW__3hL____$=HbQW__3hQ____" +
+                        "$=HbQW__3hS____%=J^wI__3hU____$=HbQW__3h[____$=HbQW__3h^____$=HbQW__3hd____" +
+                        "%=J^wI__3he____%=J^wI__3hf____%=J^wI__3hg____$=HbQW__3hh____%=J^wI__3hi____" +
+                        "%=J^wI__3hv____$=HbQW__3i/____#=J^wI__3i2____#=J^wI__3i3____%=J^wI__3i4____" +
+                        "$=HbQW__3i7____$=HbQW__3i8____$=HbQW__3i9____%=J^wI__3i=____#=J^wI__3i>____" +
+                        "%=J^wI__3iD____$=HbQW__3iF____#=J^wI__3iH____%=J^wI__3iM____%=J^wI__3iS____" +
+                        "#=J^wI__3iU____%=J^wI__3iZ____#=J^wI__3i]____%=J^wI__3ig____%=J^wI__3ij____" +
+                        "%=J^wI__3ik____#=J^wI__3il____$=HbQW__3in____%=J^wI__3ip____$=HbQW__3iq____" +
+                        "$=HbQW__3it____%=J^wI__3ix____#=J^wI__3j_____$=HbQW__3j%____$=HbQW__3j'____" +
+                        "%=J^wI__3j(____%=J^wI__9mJ____'=KqtH__=SE__<NC=MN(F__?VS__<NC=MN(F__Zw`____" +
+                        "%=KqtH__j+C__<NC=MN(F__j+M__<NC=MN(F__j+a__<NC=MN(F__j_.__<NC=MN(F__n>M____" +
+                        "'=KqtH__s1X____$=MMyc__s1_____#=MN#O__ypn____'=KqtH__ypr____'=KqtH_#%h_____" +
+                        "%=KqtH_#%o_____'=KqtH_#)H6__<NC=MN(F_#*%'____%=KqtH_#+k(____'=KqtH_#-E_____" +
+                        "'=KqtH_#1)w____'=KqtH_#1)y____'=KqtH_#1*M____#=KqtH_#1*p____'=KqtH_#14Q__<N" +
+                        "C=MN(F_#14S__<NC=MN(F_#16I__<NC=MN(F_#16N__<NC=MN(F_#16X__<NC=MN(F_#16k__<N" +
+                        "C=MN(F_#17@__<NC=MN(F_#17A__<NC=MN(F_#1Cq____'=KqtH_#7)_____#=KqtH_#7)b____" +
+                        "#=KqtH_#7Ww____'=KqtH_#?cQ____'=KqtH_#His____'=KqtH_#Jrh____'=KqtH_#O@M__<N" +
+                        "C=MN(F_#O@O__<NC=MN(F_#OC6__<NC=MN(F_#Os.____#=KqtH_#YOW____#=H/Li_#Zat____" +
+                        "'=KqtH_#ZbI____%=KqtH_#Zbc____'=KqtH_#Zbs____%=KqtH_#Zby____'=KqtH_#Zce____" +
+                        "'=KqtH_#Zdc____%=KqtH_#Zea____'=KqtH_#ZhI____#=KqtH_#ZiD____'=KqtH_#Zis____" +
+                        "'=KqtH_#Zj0____#=KqtH_#Zj1____'=KqtH_#Zj[____'=KqtH_#Zj]____'=KqtH_#Zj^____" +
+                        "'=KqtH_#Zjb____'=KqtH_#Zk_____'=KqtH_#Zk6____#=KqtH_#Zk9____%=KqtH_#Zk<____" +
+                        "'=KqtH_#Zl>____'=KqtH_#]9R____$=H/Lt_#]I6____#=KqtH_#]Z#____%=KqtH_#^*N____" +
+                        "#=KqtH_#^:m____#=KqtH_#_*_____%=J^wI_#`-7____#=KqtH_#`T>____'=KqtH_#`T?____" +
+                        "'=KqtH_#`TA____'=KqtH_#`TB____'=KqtH_#`TG____'=KqtH_#`TP____#=KqtH_#`U_____" +
+                        "'=KqtH_#`U/____'=KqtH_#`U0____#=KqtH_#`U9____'=KqtH_#aEQ____%=KqtH_#b<)____" +
+                        "'=KqtH_#c9-____%=KqtH_#dxC____%=KqtH_#dxE____%=KqtH_#ev$____'=KqtH_#fBi____" +
+                        "#=KqtH_#fBj____'=KqtH_#fG)____'=KqtH_#fG+____'=KqtH_#g<d____'=KqtH_#g<e____" +
+                        "'=KqtH_#g=J____'=KqtH_#gat____#=KqtH_#s`D____#=J_#p_#sg?____#=J_#p_#t<a____" +
+                        "#=KqtH_#t<c____#=KqtH_#trY____$=JiYj_#vA$____'=KqtH_#xs_____'=KqtH_$$rO____" +
+                        "#=KqtH_$$rP____#=KqtH_$(_%____'=KqtH_$)]o____%=KqtH_$_@)____'=KqtH_$_k]____" +
+                        "'=KqtH_$1]+____%=KqtH_$3IO____%=KqtH_$3J#____'=KqtH_$3J.____'=KqtH_$3J:____" +
+                        "#=KqtH_$3JH____#=KqtH_$3JI____#=KqtH_$3JK____%=KqtH_$3JL____'=KqtH_$3JS____" +
+                        "'=KqtH_$8+M____#=KqtH_$99d____%=KqtH_$:Lw____#=LK+x_$:N@____#=KqtG_$:NC____" +
+                        "#=KqtG_$:hW____'=KqtH_$:i[____'=KqtH_$:ih____'=KqtH_$:it____'=KqtH_$:kO____" +
+                        "'=KqtH_$>*B____'=KqtH_$>hD____+=J^x0_$?lW____'=KqtH_$?ll____'=KqtH_$?lm____" +
+                        "%=KqtH_$?mi____'=KqtH_$?mx____'=KqtH_$D7]____#=J_#p_$D@T____#=J_#p_$V<g____" +
+                        "'=KqtH";
+        Iterable<HttpCookiePair> cookies = headers.add(COOKIE, "bh=\"" + longValue + "\";").getCookies();
+        assertThat(cookies).hasSize(1);
+        assertThat(cookies).containsExactly(new DefaultHttpCookiePair("bh", longValue));
+    }
+
+    /**
+     * Note: here we're deviating from Netty 4.1. We don't support RFC 2965 cookies anymore.
+     */
+    @Test
+    void decodingOldRFC2965Cookies() {
+        String source = "$Version=\"1\"; " +
+                "Part_Number1=\"Riding_Rocket_0023\"; $Path=\"/acme/ammo\"; " +
+                "Part_Number2=\"Rocket_Launcher_0001\"; $Path=\"/acme\"";
+
+        Iterable<HttpCookiePair> cookies = headers.add(COOKIE, source).getCookies();
+        assertThat(cookies).containsExactly(
+                new DefaultHttpCookiePair("$Version", "1"), // Would be hidden in RFC 2965
+                new DefaultHttpCookiePair("Part_Number1", "Riding_Rocket_0023"),
+                new DefaultHttpCookiePair("$Path", "/acme/ammo"), // Would be hidden in RFC 2965
+                new DefaultHttpCookiePair("Part_Number2", "Rocket_Launcher_0001"),
+                new DefaultHttpCookiePair("$Path", "/acme")); // Would be hidden in RFC 2965
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @Test
+    void rejectServerCookieWithSemicolonInValue() {
+        headers.add(COOKIE, "name=\"foo;bar\";");
+        var e = assertThrows(IllegalArgumentException.class, () -> headers.getCookies().iterator().hasNext());
+        assertThat(e).hasMessageContaining("The ; character cannot appear in quoted cookie values");
+
+        e = assertThrows(IllegalArgumentException.class, () -> headers.getCookies().iterator().next());
+        assertThat(e).hasMessageContaining("The ; character cannot appear in quoted cookie values");
+    }
+
+    @Test
+    void caseSensitiveServerCookieNames() {
+        Iterable<HttpCookiePair> cookies = headers.add(COOKIE, "session_id=a; Session_id=b;").getCookies();
+        assertThat(cookies).containsOnly(
+                new DefaultHttpCookiePair("Session_id", "b"),
+                new DefaultHttpCookiePair("session_id", "a"));
+    }
+
+    // Client cookie (SET_COOKIE header) decoder tests
+    @Test
+    public void testDecodingSingleCookieV0() {
+        String cookieString = "myCookie=myValue;expires="
+                + DateFormatter.format(new Date(System.currentTimeMillis() + 50000))
+                + ";path=/apathsomewhere;domain=.adomainsomewhere;secure;SameSite=None";
+
+        HttpSetCookie cookie = headers.add(SET_COOKIE, cookieString).getSetCookie("myCookie");
+        assertNotNull(cookie);
+        assertEquals("myValue", cookie.value());
+        assertEquals(".adomainsomewhere", cookie.domain());
+        assertNotEquals(Long.MIN_VALUE, cookie.maxAge(),
+                "maxAge should be defined when parsing cookie " + cookieString);
+        assertNull(cookie.maxAge());
+        assertNotNull(cookie.expiresAsMaxAge());
+        assertTrue(cookie.expiresAsMaxAge() >= 40 && cookie.expiresAsMaxAge() <= 60,
+                "maxAge should be about 50ms when parsing cookie " + cookieString);
+        assertEquals("/apathsomewhere", cookie.path());
+        assertTrue(cookie.isSecure());
+
+        MatcherAssert.assertThat(cookie, is(instanceOf(DefaultHttpSetCookie.class)));
+        assertEquals(None, cookie.sameSite());
+    }
+
+    @Test
+    public void testDecodingSingleCookieV0ExtraParamsIgnored() {
+        String cookieString = "myCookie=myValue;max-age=50;path=/apathsomewhere;" +
+                "domain=.adomainsomewhere;secure;comment=this is a comment;version=0;" +
+                "commentURL=http://aurl.com;port=\"80,8080\";discard;";
+        assertThat(headers.add(SET_COOKIE, cookieString).getSetCookies()).containsExactly(new DefaultHttpSetCookie(
+                "myCookie", "myValue", "/apathsomewhere", ".adomainsomewhere", null, 50L,
+                None, false, true, false));
+    }
+
+    @Test
+    public void testDecodingSingleCookieV1() {
+        String cookieString = "myCookie=myValue;max-age=50;path=/apathsomewhere;domain=.adomainsomewhere"
+                + ";secure;comment=this is a comment;version=1;";
+        assertThat(headers.add(SET_COOKIE, cookieString).getSetCookies()).containsExactly(new DefaultHttpSetCookie(
+                "myCookie", "myValue", "/apathsomewhere", ".adomainsomewhere", null, 50L, None, false, true, false));
+    }
+
+    @Test
+    public void testDecodingSingleCookieV1ExtraParamsIgnored() {
+        String cookieString = "myCookie=myValue;max-age=50;path=/apathsomewhere;"
+                + "domain=.adomainsomewhere;secure;comment=this is a comment;version=1;"
+                + "commentURL=http://aurl.com;port='80,8080';discard;";
+        assertThat(headers.add(SET_COOKIE, cookieString).getSetCookies()).containsExactly(new DefaultHttpSetCookie(
+                "myCookie", "myValue", "/apathsomewhere", ".adomainsomewhere", null, 50L, None, false, true, false));
+    }
+
+    @Test
+    public void testDecodingSingleCookieV2() {
+        String cookieString = "myCookie=myValue;max-age=50;path=/apathsomewhere;"
+                + "domain=.adomainsomewhere;secure;comment=this is a comment;version=2;"
+                + "commentURL=http://aurl.com;port=\"80,8080\";discard;";
+        assertThat(headers.add(SET_COOKIE, cookieString).getSetCookies()).containsExactly(new DefaultHttpSetCookie(
+                "myCookie", "myValue", "/apathsomewhere", ".adomainsomewhere", null, 50L, None, false, true, false));
+    }
+
+    @Test
+    public void testDecodingComplexCookie() {
+        String cookieString = "myCookie=myValue;max-age=50;path=/apathsomewhere;"
+                + "domain=.adomainsomewhere;secure;comment=this is a comment;version=2;"
+                + "commentURL=\"http://aurl.com\";port='80,8080';discard;";
+        assertThat(headers.add(SET_COOKIE, cookieString).getSetCookies()).containsExactly(new DefaultHttpSetCookie(
+                "myCookie", "myValue", "/apathsomewhere", ".adomainsomewhere", null, 50L, None, false, true, false));
+    }
+
+    /**
+     * Note: deviating from Netty 4.1 test, where the strings had a trailing comma ','.
+     * Use of commas as delimiters is an RFC 2965 syntax, but it never allowed trailing commas
+     */
+    @Test
+    public void testDecodingQuotedCookie() {
+        HttpSetCookie cookie = headers.add(SET_COOKIE, "a=\"\"").getSetCookie("a");
+        assertEquals("a", cookie.name());
+        assertEquals("", cookie.value());
+
+        cookie = headers.add(SET_COOKIE, "b=\"1\"").getSetCookie("b");
+        assertEquals("b", cookie.name());
+        assertEquals("1", cookie.value());
+    }
+
+    @Test
+    public void testDecodingGoogleAnalyticsCookie() {
+        String source = "ARPT=LWUKQPSWRTUN04CKKJI; "
+                + "kw-2E343B92-B097-442c-BFA5-BE371E0325A2=unfinished furniture; "
+                + "__utma=48461872.1094088325.1258140131.1258140131.1258140131.1; "
+                + "__utmb=48461872.13.10.1258140131; __utmc=48461872; "
+                + "__utmz=48461872.1258140131.1.1.utmcsr=overstock.com|utmccn=(referral)|"
+                + "utmcmd=referral|utmcct=/Home-Garden/Furniture/Clearance,/clearance,/32/dept.html";
+        headers.add(SET_COOKIE, source);
+        HttpSetCookie cookie = headers.getSetCookie("ARPT");
+
+        assertEquals("ARPT", cookie.name());
+        assertEquals("LWUKQPSWRTUN04CKKJI", cookie.value());
+    }
+
+    @Test
+    public void testDecodingLongDates() {
+        Calendar cookieDate = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        cookieDate.set(9999, Calendar.DECEMBER, 31, 23, 59, 59);
+        long expectedMaxAge = (cookieDate.getTimeInMillis() - System
+                .currentTimeMillis()) / 1000;
+
+        String source = "Format=EU; expires=Fri, 31-Dec-9999 23:59:59 GMT; path=/";
+
+        headers.add(SET_COOKIE, source);
+        HttpSetCookie cookie = headers.getSetCookie("Format");
+
+        assertTrue(Math.abs(expectedMaxAge - cookie.expiresAsMaxAge()) < 2);
+    }
+
+    /**
+     * Deviating from the old cookie parser. Since obsoleting RFC 2965, commas are no longer a field delimiter,
+     * and that means they are allowed in cookie values. Previously, parsing such a cookie would throw an exception.
+     */
+    @Test
+    public void testDecodingValueWithCommaDoesNotFail() {
+        String source = "UserCookie=timeZoneName=(GMT+04:00) Moscow, St. Petersburg, Volgograd&promocode=&region=BE;"
+                + " expires=Sat, 01-Dec-2012 10:53:31 GMT; path=/";
+
+        headers.add(SET_COOKIE, source);
+        HttpSetCookie cookie = headers.getSetCookie("UserCookie");
+        assertThat(cookie).isEqualTo(new DefaultHttpSetCookie(
+                "UserCookie", "timeZoneName=(GMT+04:00) Moscow, St. Petersburg, Volgograd&promocode=&region=BE",
+                "/", null, "Sat, 01-Dec-2012 10:53:31 GMT", null, None, false, false, false
+        ));
+    }
+
+    @Test
+    public void testDecodingWeirdNames1() {
+        String source = "path=; expires=Mon, 01-Jan-1990 00:00:00 GMT; path=/; domain=.www.google.com";
+        headers.add(SET_COOKIE, source);
+        HttpSetCookie cookie = headers.getSetCookie("path");
+        assertEquals("path", cookie.name());
+        assertEquals("", cookie.value());
+        assertEquals("/", cookie.path());
+    }
+
+    @Test
+    public void testDecodingWeirdNames2() {
+        String source = "HTTPOnly=";
+        headers.add(SET_COOKIE, source);
+        HttpSetCookie cookie = headers.getSetCookie("HTTPOnly");
+        assertEquals("HTTPOnly", cookie.name());
+        assertEquals("", cookie.value());
+    }
+
+    @Test
+    public void testDecodingValuesWithCommasAndEqualsFails() {
+        headers = HttpHeaders.newHeaders(); // Enable validation
+        String source = "A=v=1&lg=en-US,it-IT,it&intl=it&np=1;T=z=E";
+        headers.add(SET_COOKIE, source);
+        assertThrows(IllegalArgumentException.class, () -> headers.getSetCookie("A"));
+    }
+
+    @Test
+    public void testDecodingInvalidValuesWithCommaAtStart() {
+        headers = HttpHeaders.newHeaders(); // Enable validation
+        headers.add(SET_COOKIE, ",");
+        assertThrows(IllegalArgumentException.class, () -> headers.getSetCookies().iterator().next());
+        headers.clear();
+        headers.add(SET_COOKIE, ",a");
+        assertThrows(IllegalArgumentException.class, () -> headers.getSetCookies().iterator().next());
+        headers.clear();
+        headers.add(SET_COOKIE, ",a=a");
+        assertThrows(IllegalArgumentException.class, () -> headers.getSetCookies().iterator().next());
+    }
+
+    @Test
+    public void testDecodingLongValue() {
+        String longValue =
+                "b___$Q__$ha__<NC=MN(F__%#4__<NC=MN(F__2_d____#=IvZB__2_F____'=KqtH__2-9____" +
+                        "'=IvZM__3f:____$=HbQW__3g'____%=J^wI__3g-____%=J^wI__3g1____$=HbQW__3g2____" +
+                        "$=HbQW__3g5____%=J^wI__3g9____$=HbQW__3gT____$=HbQW__3gX____#=J^wI__3gY____" +
+                        "#=J^wI__3gh____$=HbQW__3gj____$=HbQW__3gr____$=HbQW__3gx____#=J^wI__3h_____" +
+                        "$=HbQW__3h$____#=J^wI__3h'____$=HbQW__3h_____$=HbQW__3h0____%=J^wI__3h1____" +
+                        "#=J^wI__3h2____$=HbQW__3h4____$=HbQW__3h7____$=HbQW__3h8____%=J^wI__3h:____" +
+                        "#=J^wI__3h@____%=J^wI__3hB____$=HbQW__3hC____$=HbQW__3hL____$=HbQW__3hQ____" +
+                        "$=HbQW__3hS____%=J^wI__3hU____$=HbQW__3h[____$=HbQW__3h^____$=HbQW__3hd____" +
+                        "%=J^wI__3he____%=J^wI__3hf____%=J^wI__3hg____$=HbQW__3hh____%=J^wI__3hi____" +
+                        "%=J^wI__3hv____$=HbQW__3i/____#=J^wI__3i2____#=J^wI__3i3____%=J^wI__3i4____" +
+                        "$=HbQW__3i7____$=HbQW__3i8____$=HbQW__3i9____%=J^wI__3i=____#=J^wI__3i>____" +
+                        "%=J^wI__3iD____$=HbQW__3iF____#=J^wI__3iH____%=J^wI__3iM____%=J^wI__3iS____" +
+                        "#=J^wI__3iU____%=J^wI__3iZ____#=J^wI__3i]____%=J^wI__3ig____%=J^wI__3ij____" +
+                        "%=J^wI__3ik____#=J^wI__3il____$=HbQW__3in____%=J^wI__3ip____$=HbQW__3iq____" +
+                        "$=HbQW__3it____%=J^wI__3ix____#=J^wI__3j_____$=HbQW__3j%____$=HbQW__3j'____" +
+                        "%=J^wI__3j(____%=J^wI__9mJ____'=KqtH__=SE__<NC=MN(F__?VS__<NC=MN(F__Zw`____" +
+                        "%=KqtH__j+C__<NC=MN(F__j+M__<NC=MN(F__j+a__<NC=MN(F__j_.__<NC=MN(F__n>M____" +
+                        "'=KqtH__s1X____$=MMyc__s1_____#=MN#O__ypn____'=KqtH__ypr____'=KqtH_#%h_____" +
+                        "%=KqtH_#%o_____'=KqtH_#)H6__<NC=MN(F_#*%'____%=KqtH_#+k(____'=KqtH_#-E_____" +
+                        "'=KqtH_#1)w____'=KqtH_#1)y____'=KqtH_#1*M____#=KqtH_#1*p____'=KqtH_#14Q__<N" +
+                        "C=MN(F_#14S__<NC=MN(F_#16I__<NC=MN(F_#16N__<NC=MN(F_#16X__<NC=MN(F_#16k__<N" +
+                        "C=MN(F_#17@__<NC=MN(F_#17A__<NC=MN(F_#1Cq____'=KqtH_#7)_____#=KqtH_#7)b____" +
+                        "#=KqtH_#7Ww____'=KqtH_#?cQ____'=KqtH_#His____'=KqtH_#Jrh____'=KqtH_#O@M__<N" +
+                        "C=MN(F_#O@O__<NC=MN(F_#OC6__<NC=MN(F_#Os.____#=KqtH_#YOW____#=H/Li_#Zat____" +
+                        "'=KqtH_#ZbI____%=KqtH_#Zbc____'=KqtH_#Zbs____%=KqtH_#Zby____'=KqtH_#Zce____" +
+                        "'=KqtH_#Zdc____%=KqtH_#Zea____'=KqtH_#ZhI____#=KqtH_#ZiD____'=KqtH_#Zis____" +
+                        "'=KqtH_#Zj0____#=KqtH_#Zj1____'=KqtH_#Zj[____'=KqtH_#Zj]____'=KqtH_#Zj^____" +
+                        "'=KqtH_#Zjb____'=KqtH_#Zk_____'=KqtH_#Zk6____#=KqtH_#Zk9____%=KqtH_#Zk<____" +
+                        "'=KqtH_#Zl>____'=KqtH_#]9R____$=H/Lt_#]I6____#=KqtH_#]Z#____%=KqtH_#^*N____" +
+                        "#=KqtH_#^:m____#=KqtH_#_*_____%=J^wI_#`-7____#=KqtH_#`T>____'=KqtH_#`T?____" +
+                        "'=KqtH_#`TA____'=KqtH_#`TB____'=KqtH_#`TG____'=KqtH_#`TP____#=KqtH_#`U_____" +
+                        "'=KqtH_#`U/____'=KqtH_#`U0____#=KqtH_#`U9____'=KqtH_#aEQ____%=KqtH_#b<)____" +
+                        "'=KqtH_#c9-____%=KqtH_#dxC____%=KqtH_#dxE____%=KqtH_#ev$____'=KqtH_#fBi____" +
+                        "#=KqtH_#fBj____'=KqtH_#fG)____'=KqtH_#fG+____'=KqtH_#g<d____'=KqtH_#g<e____" +
+                        "'=KqtH_#g=J____'=KqtH_#gat____#=KqtH_#s`D____#=J_#p_#sg?____#=J_#p_#t<a____" +
+                        "#=KqtH_#t<c____#=KqtH_#trY____$=JiYj_#vA$____'=KqtH_#xs_____'=KqtH_$$rO____" +
+                        "#=KqtH_$$rP____#=KqtH_$(_%____'=KqtH_$)]o____%=KqtH_$_@)____'=KqtH_$_k]____" +
+                        "'=KqtH_$1]+____%=KqtH_$3IO____%=KqtH_$3J#____'=KqtH_$3J.____'=KqtH_$3J:____" +
+                        "#=KqtH_$3JH____#=KqtH_$3JI____#=KqtH_$3JK____%=KqtH_$3JL____'=KqtH_$3JS____" +
+                        "'=KqtH_$8+M____#=KqtH_$99d____%=KqtH_$:Lw____#=LK+x_$:N@____#=KqtG_$:NC____" +
+                        "#=KqtG_$:hW____'=KqtH_$:i[____'=KqtH_$:ih____'=KqtH_$:it____'=KqtH_$:kO____" +
+                        "'=KqtH_$>*B____'=KqtH_$>hD____+=J^x0_$?lW____'=KqtH_$?ll____'=KqtH_$?lm____" +
+                        "%=KqtH_$?mi____'=KqtH_$?mx____'=KqtH_$D7]____#=J_#p_$D@T____#=J_#p_$V<g____" +
+                        "'=KqtH";
+
+        headers.add(SET_COOKIE, "bh=\"" + longValue + "\";");
+        HttpSetCookie cookie = headers.getSetCookie("bh");
+        assertEquals("bh", cookie.name());
+        assertEquals(longValue, cookie.value());
+    }
+
+    @Test
+    public void testIgnoreEmptyDomain() {
+        String emptyDomain = "sessionid=OTY4ZDllNTgtYjU3OC00MWRjLTkzMWMtNGUwNzk4MTY0MTUw;Domain=;Path=/";
+        headers.add(SET_COOKIE, emptyDomain);
+        HttpSetCookie cookie = headers.getSetCookie("sessionid");
+        assertThat(cookie.domain()).isEmpty();
+    }
+
+    @Test
+    public void testIgnoreEmptyPath() {
+        String emptyPath = "sessionid=OTY4ZDllNTgtYjU3OC00MWRjLTkzMWMtNGUwNzk4MTY0MTUw;Domain=;Path=";
+        headers.add(SET_COOKIE, emptyPath);
+        HttpSetCookie cookie = headers.getSetCookie("sessionid");
+        assertThat(cookie.path()).isEmpty();
+    }
+}


### PR DESCRIPTION
Motivation:

- The parsing of `set-cookie` header was made strict according to RFC6265. In practice, there are still many implementations that encode cookies according to the obsolete RFC2965 and/or RFC2109.
- Semicolon and space are not validated after a wrapped value.
- Without a cookie name in the exception message it's harder to find a problematic cookie.

Modifications:
- Allow no space after semicolon by default;
- Add a system property `io.servicetalk.http.api.headers.cookieParsingStrictRfc6265` to enforce strict parsing;
- Instead of blindly skipping `SEMI` and `SP` after `DQUOTE`, validate skipped characters;
- Include the cookie name (if already parsed) in all exception messages;
- Enhance test coverage for `DefaultHttpSetCookie#parseSetCookie`;

Result:

1. No space is required after semicolon by default.
2. Characters after a wrapped value are validated.
3. Exception messages include a cookie name when possible.
4. More test coverage.