### PR TITLE
Fix buffer leaks in the codec-http module

### DIFF
--- a/codec-http/src/main/java/io/netty5/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/HttpObjectDecoder.java
@@ -434,7 +434,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
             if (currentState == State.READ_HEADER) {
                 // If we are still in the state of reading headers we need to create a new invalid message that
                 // signals that the connection was closed before we received the headers.
-                ctx.fireChannelRead(invalidMessage(ctx, ctx.bufferAllocator().allocate(0),
+                ctx.fireChannelRead(invalidMessage(ctx,
                         new PrematureChannelClosureException("Connection closed before received headers")));
                 resetNow();
                 return;
@@ -537,11 +537,14 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
     }
 
     private HttpMessage invalidMessage(ChannelHandlerContext ctx, Buffer in, Exception cause) {
-        currentState = State.BAD_MESSAGE;
-
         // Advance the readerIndex so that ByteToMessageDecoder does not complain
         // when we produced an invalid message without consuming anything.
         in.skipReadableBytes(in.readableBytes());
+        return invalidMessage(ctx, cause);
+    }
+
+    private HttpMessage invalidMessage(ChannelHandlerContext ctx, Exception cause) {
+        currentState = State.BAD_MESSAGE;
 
         if (message == null) {
             message = createInvalidMessage(ctx);

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/HttpObjectEncoder.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/HttpObjectEncoder.java
@@ -118,6 +118,7 @@ public abstract class HttpObjectEncoder<H extends HttpMessage> extends MessageTo
         if (msg instanceof HttpContent || msg instanceof Buffer || msg instanceof FileRegion) {
             switch (state) {
                 case ST_INIT:
+                    Resource.dispose(msg);
                     throw new IllegalStateException("unexpected message type: " + StringUtil.simpleClassName(msg)
                         + ", state: " + state);
                 case ST_CONTENT_NON_CHUNK:

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketProtocolHandler.java
@@ -75,6 +75,7 @@ abstract class WebSocketProtocolHandler extends MessageToMessageDecoder<WebSocke
             return;
         }
         if (frame instanceof PongWebSocketFrame && dropPongFrames) {
+            frame.close();
             readIfNeeded(ctx);
             return;
         }

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/extensions/compression/DeflateEncoder.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/extensions/compression/DeflateEncoder.java
@@ -99,6 +99,7 @@ abstract class DeflateEncoder extends WebSocketExtensionEncoder {
             // Set empty DEFLATE block manually for unknown buffer size
             // https://tools.ietf.org/html/rfc7692#section-7.2.3.6
             compressedContent = EMPTY_DEFLATE_BLOCK.get();
+            msg.close();
         } else {
             msg.close();
             throw new CodecException("cannot compress content buffer");

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpChunkedInputTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpChunkedInputTest.java
@@ -118,8 +118,9 @@ public class HttpChunkedInputTest {
                 return 0;
             }
         };
-        HttpChunkedInput input = new HttpChunkedInput(inputStub, emptyLastContent());
-        assertNull(input.readChunk(preferredAllocator()));
+        try (HttpChunkedInput input = new HttpChunkedInput(inputStub, emptyLastContent())) {
+            assertNull(input.readChunk(preferredAllocator()));
+        }
     }
 
     private static EmptyLastHttpContent emptyLastContent() {
@@ -166,5 +167,6 @@ public class HttpChunkedInputTest {
         assertEquals(BYTES.length * inputs.length, read);
         assertThat(lastHttpContent).isInstanceOf(LastHttpContent.class);
         assertThat(lastHttpContent.payload().readableBytes()).isZero();
+        lastHttpContent.close();
     }
 }

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpClientUpgradeHandlerTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpClientUpgradeHandlerTest.java
@@ -144,9 +144,10 @@ public class HttpClientUpgradeHandlerTest {
         HttpResponse response = channel.readInbound();
         assertEquals(HttpResponseStatus.OK, response.status());
 
-        LastHttpContent<?> last = channel.readInbound();
-        assertEquals(new EmptyLastHttpContent(channel.bufferAllocator()), last);
-        last.close();
+        try (LastHttpContent<?> last = channel.readInbound();
+             EmptyLastHttpContent empty = new EmptyLastHttpContent(channel.bufferAllocator())) {
+            assertEquals(empty, last);
+        }
         assertFalse(channel.finish());
     }
 

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpContentCompressorTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpContentCompressorTest.java
@@ -453,6 +453,7 @@ public class HttpContentCompressorTest {
         assertEquals("Netty", res.trailingHeaders().get("X-Test"));
         assertEquals(DecoderResult.success(), res.decoderResult());
         assertThat((Object) ch.readOutbound()).isNull();
+        res.close();
     }
 
     @Test
@@ -493,6 +494,7 @@ public class HttpContentCompressorTest {
         assertEquals("Netty", res.trailingHeaders().get("X-Test"));
         assertEquals(DecoderResult.success(), res.decoderResult());
         assertThat((Object) ch.readOutbound()).isNull();
+        res.close();
     }
 
     @Test
@@ -605,6 +607,8 @@ public class HttpContentCompressorTest {
         assertTrue(ch.writeOutbound(res1023));
         DefaultHttpResponse response1023 = ch.readOutbound();
         assertFalse(response1023.headers().contains(HttpHeaderNames.CONTENT_ENCODING));
+        assertThat(response1023).isInstanceOf(FullHttpResponse.class);
+        ((FullHttpResponse) response1023).close();
         ch.releaseOutbound();
 
         assertTrue(ch.writeInbound(newRequest()));

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpContentDecoderTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpContentDecoderTest.java
@@ -140,11 +140,12 @@ public class HttpContentDecoderTest {
 
         Object ob3 = channel.readInbound();
         assertThat(ob3).isInstanceOf(LastHttpContent.class);
-        LastHttpContent<?> lastContent = (LastHttpContent<?>) ob3;
-        assertNotNull(lastContent.decoderResult());
-        assertTrue(lastContent.decoderResult().isSuccess());
-        assertFalse(lastContent.trailingHeaders().isEmpty());
-        assertEquals("42", lastContent.trailingHeaders().get("My-Trailer"));
+        try (LastHttpContent<?> lastContent = (LastHttpContent<?>) ob3) {
+            assertNotNull(lastContent.decoderResult());
+            assertTrue(lastContent.decoderResult().isSuccess());
+            assertFalse(lastContent.trailingHeaders().isEmpty());
+            assertEquals("42", lastContent.trailingHeaders().get("My-Trailer"));
+        }
         assertHasInboundMessages(channel, false);
         assertHasOutboundMessages(channel, false);
         assertFalse(channel.finish());

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpContentEncoderTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpContentEncoderTest.java
@@ -317,6 +317,7 @@ public class HttpContentEncoderTest {
         assertEquals("Netty", res.trailingHeaders().get("X-Test"));
         assertEquals(DecoderResult.success(), res.decoderResult());
         assertThat((Object) ch.readOutbound()).isNull();
+        res.close();
     }
 
     @Test

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpInvalidMessageTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpInvalidMessageTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Random;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -41,6 +42,8 @@ public class HttpInvalidMessageTest {
         DecoderResult dr = req.decoderResult();
         assertFalse(dr.isSuccess());
         assertTrue(dr.isFailure());
+        assertThat(req).isInstanceOf(FullHttpRequest.class);
+        ((FullHttpRequest) req).close();
         ensureInboundTrafficDiscarded(ch);
     }
 
@@ -73,6 +76,8 @@ public class HttpInvalidMessageTest {
         DecoderResult dr = res.decoderResult();
         assertFalse(dr.isSuccess());
         assertTrue(dr.isFailure());
+        assertThat(res).isInstanceOf(FullHttpResponse.class);
+        ((FullHttpResponse) res).close();
         ensureInboundTrafficDiscarded(ch);
     }
 
@@ -108,11 +113,11 @@ public class HttpInvalidMessageTest {
 
         HttpRequest req = ch.readInbound();
         assertTrue(req.decoderResult().isSuccess());
-
-        LastHttpContent<?> chunk = ch.readInbound();
-        DecoderResult dr = chunk.decoderResult();
-        assertFalse(dr.isSuccess());
-        assertTrue(dr.isFailure());
+        try (LastHttpContent<?> chunk = ch.readInbound()) {
+            DecoderResult dr = chunk.decoderResult();
+            assertFalse(dr.isSuccess());
+            assertTrue(dr.isFailure());
+        }
         ensureInboundTrafficDiscarded(ch);
     }
 

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpResponseEncoderTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpResponseEncoderTest.java
@@ -130,20 +130,22 @@ public class HttpResponseEncoderTest {
         // Test writing an empty buffer works when the encoder is at ST_INIT.
         try (Buffer emptyBuffer = channel.bufferAllocator().allocate(0)) {
             assertTrue(channel.writeOutbound(emptyBuffer.copy()));
-            Buffer buffer = channel.readOutbound();
-            assertEquals(buffer, emptyBuffer);
+            try (Buffer buffer = channel.readOutbound()) {
+                assertEquals(buffer, emptyBuffer);
+            }
 
             // Leave the ST_INIT state.
             HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
             assertTrue(channel.writeOutbound(response));
-            buffer = channel.readOutbound();
-            assertEquals("HTTP/1.1 200 OK\r\n\r\n", buffer.toString(US_ASCII));
-            buffer.close();
+            try (Buffer buffer = channel.readOutbound()) {
+                assertEquals("HTTP/1.1 200 OK\r\n\r\n", buffer.toString(US_ASCII));
+            }
 
             // Test writing an empty buffer works when the encoder is not at ST_INIT.
             channel.writeOutbound(emptyBuffer.copy());
-            buffer = channel.readOutbound();
-            assertEquals(buffer, emptyBuffer);
+            try (Buffer buffer = channel.readOutbound()) {
+                assertEquals(buffer, emptyBuffer);
+            }
         }
 
         assertFalse(channel.finish());

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpServerKeepAliveHandlerTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpServerKeepAliveHandlerTest.java
@@ -36,6 +36,7 @@ import static io.netty5.handler.codec.http.HttpUtil.isKeepAlive;
 import static io.netty5.handler.codec.http.HttpUtil.setContentLength;
 import static io.netty5.handler.codec.http.HttpUtil.setKeepAlive;
 import static io.netty5.handler.codec.http.HttpUtil.setTransferEncodingChunked;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -202,6 +203,8 @@ public class HttpServerKeepAliveHandlerTest {
             HttpResponse finalResponse = channel.readOutbound();
             assertFalse(channel.isOpen(), "channel.isOpen");
             assertFalse(isKeepAlive(finalResponse), "response keep-alive");
+            assertThat(finalResponse).isInstanceOf(FullHttpResponse.class);
+            ((FullHttpResponse) finalResponse).close();
         }
         closeIfCloseable(response);
         assertFalse(channel.finishAndReleaseAll());

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpServerUpgradeHandlerTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpServerUpgradeHandlerTest.java
@@ -170,7 +170,9 @@ public class HttpServerUpgradeHandlerTest {
         assertFalse(req instanceof FullHttpRequest); // Should not be aggregated.
         assertTrue(req.headers().contains(HttpHeaderNames.CONNECTION, "Upgrade"));
         assertTrue(req.headers().contains(HttpHeaderNames.UPGRADE, "do-not-upgrade"));
-        assertTrue(channel.readInbound() instanceof LastHttpContent);
+        Object msg = channel.readInbound();
+        assertTrue(msg instanceof LastHttpContent);
+        ((LastHttpContent<?>) msg).close();
         assertNull(channel.readInbound());
 
         // No response should be written because we're just passing through.

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/MultipleContentLengthHeadersTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/MultipleContentLengthHeadersTest.java
@@ -74,9 +74,10 @@ public class MultipleContentLengthHeadersTest {
                 assertValid(request);
                 Iterable<CharSequence> contentLengths = request.headers().values(HttpHeaderNames.CONTENT_LENGTH);
                 assertThat(contentLengths, contains("1"));
-                LastHttpContent<?> body = channel.readInbound();
-                assertThat(body.payload().readableBytes(), is(1));
-                assertThat(body.payload().readCharSequence(1, US_ASCII).toString(), is("a"));
+                try (LastHttpContent<?> body = channel.readInbound()) {
+                    assertThat(body.payload().readableBytes(), is(1));
+                    assertThat(body.payload().readCharSequence(1, US_ASCII).toString(), is("a"));
+                }
             } else {
                 assertInvalid(request);
             }

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/cors/CorsHandlerTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/cors/CorsHandlerTest.java
@@ -21,6 +21,7 @@ import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.handler.codec.http.DefaultFullHttpRequest;
 import io.netty5.handler.codec.http.DefaultFullHttpResponse;
 import io.netty5.handler.codec.http.FullHttpRequest;
+import io.netty5.handler.codec.http.FullHttpResponse;
 import io.netty5.handler.codec.http.HttpMethod;
 import io.netty5.handler.codec.http.HttpResponse;
 import io.netty5.handler.codec.http.HttpUtil;
@@ -468,10 +469,14 @@ public class CorsHandlerTest {
         final HttpResponse preFlightHost1 = preflightRequest(corsConfigs, host1, "", false);
         assertThat(preFlightHost1.headers().get(ACCESS_CONTROL_ALLOW_METHODS)).isEqualToIgnoringCase("GET");
         assertThat(preFlightHost1.headers().get(ACCESS_CONTROL_ALLOW_CREDENTIALS)).isNull();
+        assertThat(preFlightHost1).isInstanceOf(FullHttpResponse.class);
+        ((FullHttpResponse) preFlightHost1).close();
 
         final HttpResponse preFlightHost2 = preflightRequest(corsConfigs, host2, "", false);
         assertValues(preFlightHost2, ACCESS_CONTROL_ALLOW_METHODS.toString(), "GET", "POST");
         assertThat(preFlightHost2.headers().get(ACCESS_CONTROL_ALLOW_CREDENTIALS)).isEqualToIgnoringCase("true");
+        assertThat(preFlightHost2).isInstanceOf(FullHttpResponse.class);
+        ((FullHttpResponse) preFlightHost2).close();
     }
 
     @Test
@@ -488,11 +493,15 @@ public class CorsHandlerTest {
         final HttpResponse host1Response = preflightRequest(rules, host1, "", false);
         assertThat(host1Response.headers().get(ACCESS_CONTROL_ALLOW_METHODS)).isEqualToIgnoringCase("GET");
         assertThat(host1Response.headers().get(ACCESS_CONTROL_MAX_AGE)).isEqualToIgnoringCase("3600");
+        assertThat(host1Response).isInstanceOf(FullHttpResponse.class);
+        ((FullHttpResponse) host1Response).close();
 
         final HttpResponse host2Response = preflightRequest(rules, host2, "", false);
         assertValues(host2Response, ACCESS_CONTROL_ALLOW_METHODS.toString(), "POST", "GET", "OPTIONS");
         assertThat(host2Response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN)).isEqualToIgnoringCase("*");
         assertThat(host2Response.headers().get(ACCESS_CONTROL_MAX_AGE)).isEqualToIgnoringCase("1800");
+        assertThat(host2Response).isInstanceOf(FullHttpResponse.class);
+        ((FullHttpResponse) host2Response).close();
     }
 
     @Test

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/CloseWebSocketFrameTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/CloseWebSocketFrameTest.java
@@ -58,7 +58,9 @@ class CloseWebSocketFrameTest {
     }
 
     private static void doTestValidCode(CloseWebSocketFrame frame, int expectedCode, String expectedReason) {
-        assertThat(frame.statusCode()).isEqualTo(expectedCode);
-        assertThat(frame.reasonText()).isEqualTo(expectedReason);
+        try (frame) {
+            assertThat(frame.statusCode()).isEqualTo(expectedCode);
+            assertThat(frame.reasonText()).isEqualTo(expectedReason);
+        }
     }
 }

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketFrameAggregatorTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketFrameAggregatorTest.java
@@ -56,25 +56,29 @@ public class WebSocketFrameAggregatorTest {
 
         assertTrue(channel.finish());
 
-        BinaryWebSocketFrame frame = channel.readInbound();
-        assertTrue(frame.isFinalFragment());
-        assertEquals(1, frame.rsv());
-        assertArrayEquals(content1, toBytes(frame.binaryData()));
+        try (BinaryWebSocketFrame frame = channel.readInbound()) {
+            assertTrue(frame.isFinalFragment());
+            assertEquals(1, frame.rsv());
+            assertArrayEquals(content1, toBytes(frame.binaryData()));
+        }
 
-        PingWebSocketFrame frame2 = channel.readInbound();
-        assertTrue(frame2.isFinalFragment());
-        assertEquals(0, frame2.rsv());
-        assertArrayEquals(content1, toBytes(frame2.binaryData()));
+        try (PingWebSocketFrame frame2 = channel.readInbound()) {
+            assertTrue(frame2.isFinalFragment());
+            assertEquals(0, frame2.rsv());
+            assertArrayEquals(content1, toBytes(frame2.binaryData()));
+        }
 
-        PongWebSocketFrame frame3 = channel.readInbound();
-        assertTrue(frame3.isFinalFragment());
-        assertEquals(0, frame3.rsv());
-        assertArrayEquals(content1, toBytes(frame3.binaryData()));
+        try (PongWebSocketFrame frame3 = channel.readInbound()) {
+            assertTrue(frame3.isFinalFragment());
+            assertEquals(0, frame3.rsv());
+            assertArrayEquals(content1, toBytes(frame3.binaryData()));
+        }
 
-        BinaryWebSocketFrame frame4 = channel.readInbound();
-        assertTrue(frame4.isFinalFragment());
-        assertEquals(0, frame4.rsv());
-        assertArrayEquals(aggregatedContent, toBytes(frame4.binaryData()));
+        try (BinaryWebSocketFrame frame4 = channel.readInbound()) {
+            assertTrue(frame4.isFinalFragment());
+            assertEquals(0, frame4.rsv());
+            assertArrayEquals(aggregatedContent, toBytes(frame4.binaryData()));
+        }
 
         assertNull(channel.readInbound());
     }
@@ -91,25 +95,29 @@ public class WebSocketFrameAggregatorTest {
 
         assertTrue(channel.finish());
 
-        TextWebSocketFrame frame = channel.readInbound();
-        assertTrue(frame.isFinalFragment());
-        assertEquals(1, frame.rsv());
-        assertArrayEquals(content1, toBytes(frame.binaryData()));
+        try (TextWebSocketFrame frame = channel.readInbound()) {
+            assertTrue(frame.isFinalFragment());
+            assertEquals(1, frame.rsv());
+            assertArrayEquals(content1, toBytes(frame.binaryData()));
+        }
 
-        PingWebSocketFrame frame2 = channel.readInbound();
-        assertTrue(frame2.isFinalFragment());
-        assertEquals(0, frame2.rsv());
-        assertArrayEquals(content1, toBytes(frame2.binaryData()));
+        try (PingWebSocketFrame frame2 = channel.readInbound()) {
+            assertTrue(frame2.isFinalFragment());
+            assertEquals(0, frame2.rsv());
+            assertArrayEquals(content1, toBytes(frame2.binaryData()));
+        }
 
-        PongWebSocketFrame frame3 = channel.readInbound();
-        assertTrue(frame3.isFinalFragment());
-        assertEquals(0, frame3.rsv());
-        assertArrayEquals(content1, toBytes(frame3.binaryData()));
+        try (PongWebSocketFrame frame3 = channel.readInbound()) {
+            assertTrue(frame3.isFinalFragment());
+            assertEquals(0, frame3.rsv());
+            assertArrayEquals(content1, toBytes(frame3.binaryData()));
+        }
 
-        TextWebSocketFrame frame4 = channel.readInbound();
-        assertTrue(frame4.isFinalFragment());
-        assertEquals(0, frame4.rsv());
-        assertArrayEquals(aggregatedContent, toBytes(frame4.binaryData()));
+        try (TextWebSocketFrame frame4 = channel.readInbound()) {
+            assertTrue(frame4.isFinalFragment());
+            assertEquals(0, frame4.rsv());
+            assertArrayEquals(aggregatedContent, toBytes(frame4.binaryData()));
+        }
 
         assertNull(channel.readInbound());
     }

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketServerProtocolHandlerTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketServerProtocolHandlerTest.java
@@ -377,10 +377,11 @@ public class WebSocketServerProtocolHandlerTest {
         assertFalse(client.isOpen());
         assertFalse(server.isOpen());
 
-        CloseWebSocketFrame closeMessage = decode(server.readOutbound(), CloseWebSocketFrame.class);
-        assertEquals(closeMessage, new CloseWebSocketFrame(client.bufferAllocator(),
-                WebSocketCloseStatus.NORMAL_CLOSURE));
-        closeMessage.close();
+        try (CloseWebSocketFrame closeMessage1 = decode(server.readOutbound(), CloseWebSocketFrame.class);
+             CloseWebSocketFrame closeMessage2 = new CloseWebSocketFrame(client.bufferAllocator(),
+                     WebSocketCloseStatus.NORMAL_CLOSURE)) {
+            assertEquals(closeMessage1, closeMessage2);
+        }
 
         assertFalse(client.finishAndReleaseAll());
         assertFalse(server.finishAndReleaseAll());


### PR DESCRIPTION
Motivation:
Manually enabling leak detection for `codec-http`, reveals buffer leaks in tests and production code.

Modification:
- Ensure that the the original message is closed when `HttpContentEncoder` throws and exception while encoding e.g. `IllegalStateException`
- In some use cases when `HttpObjectDecoder` creates an invalid message, there is no need to create a `Buffer`
- Ensure the original message is closed when `HttpObjectEncoder#encodeAndClose` receives an unexpected message type
- Ensure the `PONG` frame is closed when `WebSocketProtocolHandler#dropPongFrames` is true
- Ensure the original frame is closed when setting `DeflateEncoder#EMPTY_DEFLATE_BLOCK` as a compressed content
- Fix leaks in tests

Result:
No more leaks in `codec-http`.
