### PR TITLE
Fix buffer leaks in the codec-http2 module

### DIFF
--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/CompressorHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/CompressorHttp2ConnectionEncoder.java
@@ -136,7 +136,8 @@ public class CompressorHttp2ConnectionEncoder extends DecoratingHttp2ConnectionE
             return super.writeData(ctx, streamId, data, padding, endOfStream);
         }
 
-        try {
+        // The ownership is not transferred to "Compressor.compress"
+        try (data) {
             Buffer buf = compressor.compress(data, ctx.bufferAllocator());
             if (buf.readableBytes() == 0) {
                 buf.close();

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -214,7 +214,10 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
 
     void onGoAwayRead0(ChannelHandlerContext ctx, int lastStreamId, long errorCode, Buffer debugData)
             throws Http2Exception {
-        listener.onGoAwayRead(ctx, lastStreamId, errorCode, debugData.copy(true));
+        // The ownership is not transferred to "Http2FrameListener.onGoAwayRead"
+        try (Buffer copy = debugData.copy(true)) {
+            listener.onGoAwayRead(ctx, lastStreamId, errorCode, copy);
+        }
         connection.goAwayReceived(lastStreamId, errorCode, debugData);
     }
 

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2Connection.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2Connection.java
@@ -347,6 +347,7 @@ public interface Http2Connection {
      * <a href="https://tools.ietf.org/html/rfc7540#section-6.8">GOAWAY</a> frame.
      * @param errorCode the Error Code in the
      * <a href="https://tools.ietf.org/html/rfc7540#section-6.8">GOAWAY</a> frame.
+     * @param message The Additional Debug Data in the
      * <a href="https://tools.ietf.org/html/rfc7540#section-6.8">GOAWAY</a> frame. Note that reference count ownership
      * belongs to the caller (ownership is not transferred to this method).
      * @return {@code true} if the corresponding {@code GOAWAY} frame should be sent to the remote endpoint.

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2FrameCodec.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2FrameCodec.java
@@ -582,7 +582,7 @@ public class Http2FrameCodec extends Http2ConnectionHandler {
                 return;
             }
             onHttp2Frame(ctx, new DefaultHttp2UnknownFrame(frameType, flags, payload.split())
-                    .stream(requireStream(streamId)).copy());
+                    .stream(requireStream(streamId)));
         }
 
         @Override

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/CleartextHttp2ServerUpgradeHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/CleartextHttp2ServerUpgradeHandlerTest.java
@@ -90,6 +90,7 @@ public class CleartextHttp2ServerUpgradeHandlerTest {
     @AfterEach
     public void tearDown() throws Exception {
         channel.finishAndReleaseAll();
+        channel.close();
     }
 
     @Test
@@ -186,6 +187,7 @@ public class CleartextHttp2ServerUpgradeHandlerTest {
         ((LastHttpContent<?>) channel.readInbound()).close();
 
         assertNull(channel.readInbound());
+        http2ConnectionHandler.encoder().close();
     }
 
     private static Buffer settingsFrameBuf() {

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/DataCompressionHttp2Test.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/DataCompressionHttp2Test.java
@@ -285,7 +285,7 @@ public class DataCompressionHttp2Test {
             clientHandler.flush(ctxClient());
         });
         awaitServer();
-        assertEquals(data.readerOffset(0).toString(StandardCharsets.UTF_8),
+        assertEquals(new String(bytes, StandardCharsets.UTF_8),
                      serverOut.toString(StandardCharsets.UTF_8));
     }
 

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/DefaultHttp2FrameWriterTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/DefaultHttp2FrameWriterTest.java
@@ -73,8 +73,6 @@ public class DefaultHttp2FrameWriterTest {
 
         outbound = onHeapAllocator().allocate(256);
 
-        expectedOutbound = empty();
-
         Answer<Object> answer = var1 -> {
             Object msg = var1.getArgument(0);
             if (msg instanceof Buffer) {
@@ -93,7 +91,10 @@ public class DefaultHttp2FrameWriterTest {
     @AfterEach
     public void tearDown() throws Exception {
         outbound.close();
-        expectedOutbound.close();
+        if (expectedOutbound != null) {
+            expectedOutbound.close();
+        }
+        http2HeadersEncoder.close();
         frameWriter.close();
     }
 
@@ -150,7 +151,7 @@ public class DefaultHttp2FrameWriterTest {
                 (byte) 0x04, // flags = 0x04
                 (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x01 // stream id = 1
         };
-        Buffer expectedOutbound = onHeapAllocator().allocate(256)
+        expectedOutbound = onHeapAllocator().allocate(256)
                                                    .writeBytes(expectedFrameBytes).writeBytes(expectedPayload);
         assertEquals(expectedOutbound, outbound);
     }

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ClientUpgradeCodecTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ClientUpgradeCodecTest.java
@@ -82,7 +82,6 @@ public class Http2ClientUpgradeCodecTest {
             }
 
             assertTrue(channel.finishAndReleaseAll());
-            handler.encoder().close();
         }
     }
 

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ClientUpgradeCodecTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ClientUpgradeCodecTest.java
@@ -50,36 +50,40 @@ public class Http2ClientUpgradeCodecTest {
 
     private static void testUpgrade(Http2ConnectionHandler handler, Http2MultiplexHandler multiplexer)
             throws Exception {
-        FullHttpRequest request = new DefaultFullHttpRequest(
-                HTTP_1_1, HttpMethod.OPTIONS, "*", preferredAllocator().allocate(0));
+        try (FullHttpRequest request = new DefaultFullHttpRequest(
+                HTTP_1_1, HttpMethod.OPTIONS, "*", preferredAllocator().allocate(0))) {
 
-        EmbeddedChannel channel = new EmbeddedChannel(new ChannelHandler() { });
-        ChannelHandlerContext ctx = channel.pipeline().firstContext();
+            EmbeddedChannel channel = new EmbeddedChannel(new ChannelHandler() {
+            });
+            ChannelHandlerContext ctx = channel.pipeline().firstContext();
 
-        Http2ClientUpgradeCodec codec;
+            Http2ClientUpgradeCodec codec;
 
-        if (multiplexer == null) {
-            codec = new Http2ClientUpgradeCodec("connectionHandler", handler);
-        } else {
-            codec = new Http2ClientUpgradeCodec("connectionHandler", handler, multiplexer);
+            if (multiplexer == null) {
+                codec = new Http2ClientUpgradeCodec("connectionHandler", handler);
+            } else {
+                codec = new Http2ClientUpgradeCodec("connectionHandler", handler, multiplexer);
+            }
+
+            // Only request headers are read by the codec
+            codec.setUpgradeHeaders(ctx, request);
+            // Flush the channel to ensure we write out all buffered data
+            channel.flush();
+
+            channel.executor().submit(() -> {
+                codec.upgradeTo(ctx,
+                        new DefaultFullHttpResponse(HTTP_1_1, OK, channel.bufferAllocator().allocate(0)).send());
+                return null;
+            }).asStage().sync();
+            assertNotNull(channel.pipeline().get("connectionHandler"));
+
+            if (multiplexer != null) {
+                assertNotNull(channel.pipeline().get(Http2MultiplexHandler.class));
+            }
+
+            assertTrue(channel.finishAndReleaseAll());
+            handler.encoder().close();
         }
-
-        codec.setUpgradeHeaders(ctx, request);
-        // Flush the channel to ensure we write out all buffered data
-        channel.flush();
-
-        channel.executor().submit(() -> {
-            codec.upgradeTo(ctx,
-                    new DefaultFullHttpResponse(HTTP_1_1, OK, channel.bufferAllocator().allocate(0)).send());
-            return null;
-        }).asStage().sync();
-        assertNotNull(channel.pipeline().get("connectionHandler"));
-
-        if (multiplexer != null) {
-            assertNotNull(channel.pipeline().get(Http2MultiplexHandler.class));
-        }
-
-        assertTrue(channel.finishAndReleaseAll());
     }
 
     private static final class HttpInboundHandler implements ChannelHandler {

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2EmptyDataFrameListenerTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2EmptyDataFrameListenerTest.java
@@ -52,51 +52,58 @@ public class Http2EmptyDataFrameListenerTest {
 
     @Test
     public void testEmptyDataFrames() throws Http2Exception {
-        listener.onDataRead(ctx, 1, empty(), 0, false);
-        listener.onDataRead(ctx, 1, empty(), 0, false);
+        try (Buffer empty = empty()) {
+            // the buffer ownership belongs to the caller
+            listener.onDataRead(ctx, 1, empty, 0, false);
+            listener.onDataRead(ctx, 1, empty, 0, false);
 
-        assertThrows(Http2Exception.class, new Executable() {
-            @Override
-            public void execute() throws Throwable {
-                listener.onDataRead(ctx, 1, empty(), 0, false);
-            }
-        });
+            assertThrows(Http2Exception.class, new Executable() {
+                @Override
+                public void execute() throws Throwable {
+                    listener.onDataRead(ctx, 1, empty, 0, false);
+                }
+            });
+        }
         verify(frameListener, times(2)).onDataRead(eq(ctx), eq(1), any(Buffer.class), eq(0), eq(false));
     }
 
     @Test
     public void testEmptyDataFramesWithNonEmptyInBetween() throws Http2Exception {
-        final Http2EmptyDataFrameListener listener = new Http2EmptyDataFrameListener(frameListener, 2);
-        listener.onDataRead(ctx, 1, empty(), 0, false);
-        listener.onDataRead(ctx, 1, nonEmpty, 0, false);
+        try (Buffer empty = empty()) {
+            // the buffer ownership belongs to the caller
+            listener.onDataRead(ctx, 1, empty, 0, false);
+            listener.onDataRead(ctx, 1, nonEmpty, 0, false);
 
-        listener.onDataRead(ctx, 1, empty(), 0, false);
-        listener.onDataRead(ctx, 1, empty(), 0, false);
+            listener.onDataRead(ctx, 1, empty, 0, false);
+            listener.onDataRead(ctx, 1, empty, 0, false);
 
-        assertThrows(Http2Exception.class, new Executable() {
-            @Override
-            public void execute() throws Throwable {
-                listener.onDataRead(ctx, 1, empty(), 0, false);
-            }
-        });
+            assertThrows(Http2Exception.class, new Executable() {
+                @Override
+                public void execute() throws Throwable {
+                    listener.onDataRead(ctx, 1, empty, 0, false);
+                }
+            });
+        }
         verify(frameListener, times(4)).onDataRead(eq(ctx), eq(1), any(Buffer.class), eq(0), eq(false));
     }
 
     @Test
     public void testEmptyDataFramesWithEndOfStreamInBetween() throws Http2Exception {
-        final Http2EmptyDataFrameListener listener = new Http2EmptyDataFrameListener(frameListener, 2);
-        listener.onDataRead(ctx, 1, empty(), 0, false);
-        listener.onDataRead(ctx, 1, empty(), 0, true);
+        try (Buffer empty = empty()) {
+            // the buffer ownership belongs to the caller
+            listener.onDataRead(ctx, 1, empty, 0, false);
+            listener.onDataRead(ctx, 1, empty, 0, true);
 
-        listener.onDataRead(ctx, 1, empty(), 0, false);
-        listener.onDataRead(ctx, 1, empty(), 0, false);
+            listener.onDataRead(ctx, 1, empty, 0, false);
+            listener.onDataRead(ctx, 1, empty, 0, false);
 
-        assertThrows(Http2Exception.class, new Executable() {
-            @Override
-            public void execute() throws Throwable {
-                listener.onDataRead(ctx, 1, empty(), 0, false);
-            }
-        });
+            assertThrows(Http2Exception.class, new Executable() {
+                @Override
+                public void execute() throws Throwable {
+                    listener.onDataRead(ctx, 1, empty, 0, false);
+                }
+            });
+        }
 
         verify(frameListener, times(1)).onDataRead(eq(ctx), eq(1), any(Buffer.class), eq(0), eq(true));
         verify(frameListener, times(3)).onDataRead(eq(ctx), eq(1), any(Buffer.class), eq(0), eq(false));
@@ -104,19 +111,21 @@ public class Http2EmptyDataFrameListenerTest {
 
     @Test
     public void testEmptyDataFramesWithHeaderFrameInBetween() throws Http2Exception {
-        final Http2EmptyDataFrameListener listener = new Http2EmptyDataFrameListener(frameListener, 2);
-        listener.onDataRead(ctx, 1, empty(), 0, false);
-        listener.onHeadersRead(ctx, 1, Http2Headers.emptyHeaders(), 0, true);
+        try (Buffer empty = empty()) {
+            // the buffer ownership belongs to the caller
+            listener.onDataRead(ctx, 1, empty, 0, false);
+            listener.onHeadersRead(ctx, 1, Http2Headers.emptyHeaders(), 0, true);
 
-        listener.onDataRead(ctx, 1, empty(), 0, false);
-        listener.onDataRead(ctx, 1, empty(), 0, false);
+            listener.onDataRead(ctx, 1, empty, 0, false);
+            listener.onDataRead(ctx, 1, empty, 0, false);
 
-        assertThrows(Http2Exception.class, new Executable() {
-            @Override
-            public void execute() throws Throwable {
-                listener.onDataRead(ctx, 1, empty(), 0, false);
-            }
-        });
+            assertThrows(Http2Exception.class, new Executable() {
+                @Override
+                public void execute() throws Throwable {
+                    listener.onDataRead(ctx, 1, empty, 0, false);
+                }
+            });
+        }
 
         verify(frameListener, times(1)).onHeadersRead(eq(ctx), eq(1), eq(Http2Headers.emptyHeaders()), eq(0), eq(true));
         verify(frameListener, times(3)).onDataRead(eq(ctx), eq(1), any(Buffer.class), eq(0), eq(false));
@@ -124,19 +133,21 @@ public class Http2EmptyDataFrameListenerTest {
 
     @Test
     public void testEmptyDataFramesWithHeaderFrameInBetween2() throws Http2Exception {
-        final Http2EmptyDataFrameListener listener = new Http2EmptyDataFrameListener(frameListener, 2);
-        listener.onDataRead(ctx, 1, empty(), 0, false);
-        listener.onHeadersRead(ctx, 1, Http2Headers.emptyHeaders(), 0, (short) 0, false, 0, true);
+        try (Buffer empty = empty()) {
+            // the buffer ownership belongs to the caller
+            listener.onDataRead(ctx, 1, empty, 0, false);
+            listener.onHeadersRead(ctx, 1, Http2Headers.emptyHeaders(), 0, (short) 0, false, 0, true);
 
-        listener.onDataRead(ctx, 1, empty(), 0, false);
-        listener.onDataRead(ctx, 1, empty(), 0, false);
+            listener.onDataRead(ctx, 1, empty, 0, false);
+            listener.onDataRead(ctx, 1, empty, 0, false);
 
-        assertThrows(Http2Exception.class, new Executable() {
-            @Override
-            public void execute() throws Throwable {
-                listener.onDataRead(ctx, 1, empty(), 0, false);
-            }
-        });
+            assertThrows(Http2Exception.class, new Executable() {
+                @Override
+                public void execute() throws Throwable {
+                    listener.onDataRead(ctx, 1, empty, 0, false);
+                }
+            });
+        }
 
         verify(frameListener, times(1)).onHeadersRead(eq(ctx), eq(1),
                 eq(Http2Headers.emptyHeaders()), eq(0), eq((short) 0), eq(false), eq(0), eq(true));

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameCodecTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameCodecTest.java
@@ -116,6 +116,9 @@ public class Http2FrameCodecTest {
             channel.close();
             channel = null;
         }
+        if (frameInboundWriter != null) {
+            frameInboundWriter.close();
+        }
     }
 
     private void setUp(Http2FrameCodecBuilder frameCodecBuilder, Http2Settings initialRemoteSettings) throws Exception {
@@ -276,7 +279,8 @@ public class Http2FrameCodecTest {
         assertEquals(bb, outboundData.getValue());
         assertTrue(outboundData.getValue().isAccessible());
         bb.close();
-        outboundData.getValue().close();
+        // the mock will release the data
+        //outboundData.getValue().close();
 
         verify(frameWriter, never()).writeRstStream(any(ChannelHandlerContext.class),
                 anyInt(), anyLong());

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameInboundWriter.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameInboundWriter.java
@@ -29,12 +29,14 @@ import io.netty5.util.concurrent.EventExecutor;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.Promise;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.net.SocketAddress;
 
 /**
  * Utility class which allows easy writing of HTTP2 frames via {@link EmbeddedChannel#writeInbound(Object...)}.
  */
-final class Http2FrameInboundWriter {
+final class Http2FrameInboundWriter implements Closeable {
 
     private final ChannelHandlerContext ctx;
     private final Http2FrameWriter writer;
@@ -102,6 +104,11 @@ final class Http2FrameInboundWriter {
     void writeInboundFrame(
             byte frameType, int streamId, Http2Flags flags, Buffer payload) throws Exception {
         writer.writeFrame(ctx, frameType, streamId, flags, payload).asStage().sync();
+    }
+
+    @Override
+    public void close() throws IOException {
+        writer.close();
     }
 
     private static final class WriteInboundChannelHandlerContext

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2HeaderBlockIOTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2HeaderBlockIOTest.java
@@ -43,6 +43,7 @@ public class Http2HeaderBlockIOTest {
 
     @AfterEach
     public void teardown() {
+        encoder.close();
         buffer.close();
     }
 

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexTest.java
@@ -134,6 +134,7 @@ public class Http2MultiplexTest {
         if (childChannelInitializer.handler instanceof LastInboundHandler) {
             ((LastInboundHandler) childChannelInitializer.handler).finishAndReleaseAll();
         }
+        frameInboundWriter.close();
         parentChannel.finishAndReleaseAll();
         codec = null;
     }


### PR DESCRIPTION
Motivation:
Manually enabling leak detection for `codec-http2`, reveals buffer leaks in tests and production code.

Modification:
- Ensure the original data is closed by `CompressorHttp2ConnectionEncoder#writeData` as the ownership is not transferred to `Compressor.compress`
- Ensure the copied data is closed by `DefaultHttp2ConnectionDecoder#onGoAwayRead0` as the ownership is not transferred to `Http2FrameListener.onGoAwayRead`
- Ensure the created buffer is closed by `DelegatingDecompressorFrameListener#onDataRead` as the ownership is not transferred to `Http2FrameListener.onDataRead`
- `Http2FrameCodec.FrameListener#onUnknownFrame` should not copy the `DefaultHttp2UnknownFrame` as the buffer was splitted
- Fix leaks in tests

Result:
No more leaks in `codec-http2`.
