### PR TITLE
Fix buffer leaks in the codec module

### DIFF
--- a/codec/src/test/java/io/netty5/handler/codec/MessageAggregatorTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/MessageAggregatorTest.java
@@ -114,6 +114,12 @@ public class MessageAggregatorTest {
         protected void aggregate(BufferAllocator allocator, CompositeBuffer aggregated, Buffer content) {
             aggregated.extendWith(content.copy().send());
         }
+
+        @Override
+        public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+            first.close();
+            last.close();
+        }
     }
 
     private static Buffer message(BufferAllocator allocator, String string) {
@@ -147,6 +153,7 @@ public class MessageAggregatorTest {
                 assertTrue(out.isAccessible());
             }
             assertFalse(embedded.finish());
+            embedded.close();
         }
     }
 }

--- a/codec/src/test/java/io/netty5/handler/codec/MessageAggregatorTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/MessageAggregatorTest.java
@@ -153,7 +153,6 @@ public class MessageAggregatorTest {
                 assertTrue(out.isAccessible());
             }
             assertFalse(embedded.finish());
-            embedded.close();
         }
     }
 }

--- a/codec/src/test/java/io/netty5/handler/codec/bytes/ByteArrayEncoderTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/bytes/ByteArrayEncoderTest.java
@@ -47,8 +47,9 @@ public class ByteArrayEncoderTest {
         byte[] b = new byte[2048];
         new Random().nextBytes(b);
         ch.writeOutbound(b);
-        try (Buffer encoded = ch.readOutbound()) {
-            assertThat(encoded).isEqualTo(preferredAllocator().copyOf(b));
+        try (Buffer encoded = ch.readOutbound();
+             Buffer expected = preferredAllocator().copyOf(b)) {
+            assertThat(encoded).isEqualTo(expected);
         }
     }
 


### PR DESCRIPTION
Motivation:
Manually enabling leak detection for `codec` module, reveals buffer leaks in tests.

Modification:
- Fix leaks in tests

Result:
No more leaks in `codec` module.
