### PR TITLE
To be able to release on m1 we need to fix the artifactIds

### DIFF
--- a/resolver-dns-native-macos/pom.xml
+++ b/resolver-dns-native-macos/pom.xml
@@ -268,7 +268,7 @@
                 </goals>
                 <configuration>
                   <includeGroupIds>${project.groupId}</includeGroupIds>
-                  <includeArtifactIds>netty-transport-native-unix-common</includeArtifactIds>
+                  <includeArtifactIds>netty5-transport-native-unix-common</includeArtifactIds>
                   <classifier>${jni.classifier}</classifier>
                   <outputDirectory>${unix.common.lib.dir}</outputDirectory>
                   <includes>META-INF/native/**</includes>
@@ -340,7 +340,7 @@
       <dependencies>
         <dependency>
           <groupId>io.netty</groupId>
-          <artifactId>netty-transport-native-unix-common</artifactId>
+          <artifactId>netty5-transport-native-unix-common</artifactId>
           <version>${project.version}</version>
           <classifier>${jni.classifier}</classifier>
           <!--

--- a/transport-native-kqueue/pom.xml
+++ b/transport-native-kqueue/pom.xml
@@ -269,7 +269,7 @@
                 </goals>
                 <configuration>
                   <includeGroupIds>${project.groupId}</includeGroupIds>
-                  <includeArtifactIds>netty-transport-native-unix-common</includeArtifactIds>
+                  <includeArtifactIds>netty5-transport-native-unix-common</includeArtifactIds>
                   <classifier>${jni.classifier}</classifier>
                   <outputDirectory>${unix.common.lib.dir}</outputDirectory>
                   <includes>META-INF/native/**</includes>
@@ -342,7 +342,7 @@
       <dependencies>
         <dependency>
           <groupId>io.netty</groupId>
-          <artifactId>netty-transport-native-unix-common</artifactId>
+          <artifactId>netty5-transport-native-unix-common</artifactId>
           <version>${project.version}</version>
           <classifier>${jni.classifier}</classifier>
           <!--


### PR DESCRIPTION
Motivation:

We used netty-* artifactIds as dependencies. This is not correct.

Modifications:

Use netty5-*

Result:

Release on m1 works as well
