### PR TITLE
Trim off useless buffers in the composition of buffers to make the result more compact

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/DefaultCompositeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/DefaultCompositeBuffer.java
@@ -216,6 +216,18 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
             // Bytes already read, in components after the first readable section, must be trimmed off.
             // Likewise, writable bytes prior to the last readable section must be trimmed off.
             if (firstReadable != -1) {
+                // Remove useless buffers before firstReadable
+                int removeSize = firstReadable;
+                if (removeSize > 0) {
+                    for (int i = 0; i <= removeSize - 1; i++) {
+                        Buffer buf = array[i];
+                        buf.close();
+                    }
+                    System.arraycopy(array, firstReadable, array, 0, index - firstReadable);
+                    firstReadable -= removeSize;
+                    lastReadable -= removeSize;
+                    index -= removeSize;
+                }
                 // Remove middle buffers entirely that have no readable bytes.
                 for (int i = firstReadable + 1; i < lastReadable; i++) {
                     Buffer buf = array[i];

--- a/buffer/src/test/java/io/netty5/buffer/tests/BufferCompositionTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/tests/BufferCompositionTest.java
@@ -320,13 +320,13 @@ public class BufferCompositionTest extends BufferTestSupport {
                 }
                 assertThat(composite.readableBytes()).isEqualTo(8);
                 assertThat(composite.readLong()).isEqualTo(0x00000000_00000003L);
-                assertThat(composite.capacity()).isEqualTo(16); // 2*4 writable bytes lost in the gaps. 24 - 8 = 16.
+                assertThat(composite.capacity()).isEqualTo(8); // 2*4 writable and 2*4 useless bytes lost in the gaps. 24 - 8 - 8 = 8.
                 try (Buffer b = allocator.allocate(8)) {
                     b.setInt(0, 1);
                     composite.extendWith(b.send());
                 }
-                assertThat(composite.capacity()).isEqualTo(24);
-                assertThat(composite.writerOffset()).isEqualTo(16);
+                assertThat(composite.capacity()).isEqualTo(16);
+                assertThat(composite.writerOffset()).isEqualTo(8);
             }
         }
     }

--- a/common/src/main/java/io/netty5/util/Recycler.java
+++ b/common/src/main/java/io/netty5/util/Recycler.java
@@ -116,38 +116,6 @@ public abstract class Recycler<T> {
         this(maxCapacityPerThread, RATIO, DEFAULT_QUEUE_CHUNK_SIZE_PER_THREAD);
     }
 
-    /**
-     * @deprecated Use one of the following instead:
-     * {@link #Recycler()}, {@link #Recycler(int)}, {@link #Recycler(int, int, int)}.
-     */
-    @Deprecated
-    @SuppressWarnings("unused") // Parameters we can't remove due to compatibility.
-    protected Recycler(int maxCapacityPerThread, int maxSharedCapacityFactor) {
-        this(maxCapacityPerThread, RATIO, DEFAULT_QUEUE_CHUNK_SIZE_PER_THREAD);
-    }
-
-    /**
-     * @deprecated Use one of the following instead:
-     * {@link #Recycler()}, {@link #Recycler(int)}, {@link #Recycler(int, int, int)}.
-     */
-    @Deprecated
-    @SuppressWarnings("unused") // Parameters we can't remove due to compatibility.
-    protected Recycler(int maxCapacityPerThread, int maxSharedCapacityFactor,
-                       int ratio, int maxDelayedQueuesPerThread) {
-        this(maxCapacityPerThread, ratio, DEFAULT_QUEUE_CHUNK_SIZE_PER_THREAD);
-    }
-
-    /**
-     * @deprecated Use one of the following instead:
-     * {@link #Recycler()}, {@link #Recycler(int)}, {@link #Recycler(int, int, int)}.
-     */
-    @Deprecated
-    @SuppressWarnings("unused") // Parameters we can't remove due to compatibility.
-    protected Recycler(int maxCapacityPerThread, int maxSharedCapacityFactor,
-                       int ratio, int maxDelayedQueuesPerThread, int delayedQueueRatio) {
-        this(maxCapacityPerThread, ratio, DEFAULT_QUEUE_CHUNK_SIZE_PER_THREAD);
-    }
-
     protected Recycler(int maxCapacityPerThread, int ratio, int chunkSize) {
         interval = max(0, ratio);
         if (maxCapacityPerThread <= 0) {


### PR DESCRIPTION
Motivation:
In the function `DefaultCompositeBuffer.toArray()`, the buffer components before `firstReadable` are useless because they have neither readable bytes nor writable bytes, so they can be trimmed off to free more memory space.
As we can see in the current detailed process:
1. Find the first readable buffer, so the buffers before it have no readable bytes.
2. Remove writable-bytes from front and middle buffers, so the buffers methioned in step 1 also have no writable bytes.

Modification:
Calculate the number of removable buffers and close them one by one, then adjust the inner array and related variables.

Result:
Trim off the buffers before `firstReadable` to make the composite buffer more compact.
