### PR TITLE
Remove checks for Java versions older than 11.

### DIFF
--- a/common/src/test/java/io/netty5/util/internal/PlatformDependent0Test.java
+++ b/common/src/test/java/io/netty5/util/internal/PlatformDependent0Test.java
@@ -76,7 +76,7 @@ public class PlatformDependent0Test {
                 }
             });
 
-            assertEquals(6, PlatformDependent0.majorVersionFromJavaSpecificationVersion());
+            assertEquals(11, PlatformDependent0.majorVersionFromJavaSpecificationVersion());
         } finally {
             System.setSecurityManager(current);
         }
@@ -90,5 +90,7 @@ public class PlatformDependent0Test {
         assertEquals(8, PlatformDependent0.majorVersion("8"));
         assertEquals(9, PlatformDependent0.majorVersion("1.9")); // early version of JDK 9 before Project Verona
         assertEquals(9, PlatformDependent0.majorVersion("9"));
+        assertEquals(10, PlatformDependent0.majorVersion("10"));
+        assertEquals(11, PlatformDependent0.majorVersion("11"));
     }
 }


### PR DESCRIPTION
Motivation:

Netty 5's runtime requirement is Java 11 or newer

PlatformDependent0 was not included in previous clean up (#11787)

No need to check if the method
Unsafe#copyMemory(Object, long, Object, long, long) exists or not since Netty 5 requires Java 11 or newer. (#1061)

Modifications:

Remove version checks and compatibility fallbacks.

set default javaVersion to 11

Result:

Clean up