### PR TITLE
Make the EmbeddedEventLoop thread-safe

### DIFF
--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameCodecTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameCodecTest.java
@@ -41,7 +41,6 @@ import io.netty5.util.concurrent.Promise;
 import io.netty5.util.internal.ReflectionUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
@@ -70,6 +69,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyLong;
@@ -635,7 +635,9 @@ public class Http2FrameCodecTest {
                }
                );
         Future<Void> f = channel.writeAndFlush(new DefaultHttp2DataFrame(bb(100).send()).stream(stream));
-        assertTrue(f.isSuccess());
+        if (!f.asStage().await(5, TimeUnit.SECONDS) || !f.isSuccess()) {
+            fail("Expected data-frame future to have succeeded: " + f, f.cause());
+        }
 
         listenerExecuted.asFuture().asStage().sync();
         assertTrue(listenerExecuted.isSuccess());

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameCodecTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameCodecTest.java
@@ -100,11 +100,6 @@ public class Http2FrameCodecTest {
     private final Http2Headers response = Http2Headers.newHeaders()
             .status(HttpResponseStatus.OK.codeAsText());
 
-    @BeforeEach
-    public void setUp() throws Exception {
-        setUp(Http2FrameCodecBuilder.forServer(), new Http2Settings());
-    }
-
     @AfterEach
     public void tearDown() throws Exception {
         if (inboundHandler != null) {
@@ -121,14 +116,11 @@ public class Http2FrameCodecTest {
         }
     }
 
-    private void setUp(Http2FrameCodecBuilder frameCodecBuilder, Http2Settings initialRemoteSettings) throws Exception {
-        /*
-          Some tests call this method twice. Once with JUnit's @Before and once directly to pass special settings.
-          This call ensures that in case of two consecutive calls to setUp(), the previous channel is shutdown and
-          ByteBufs are released correctly.
-         */
-        tearDown();
+    private void setUp() throws Exception {
+        setUp(Http2FrameCodecBuilder.forServer(), new Http2Settings());
+    }
 
+    private void setUp(Http2FrameCodecBuilder frameCodecBuilder, Http2Settings initialRemoteSettings) throws Exception {
         frameWriter = Http2TestUtil.mockedFrameWriter();
 
         frameCodec = frameCodecBuilder.frameWriter(frameWriter).frameLogger(new Http2FrameLogger(LogLevel.TRACE))
@@ -161,6 +153,7 @@ public class Http2FrameCodecTest {
 
     @Test
     public void stateChanges() throws Exception {
+        setUp();
         frameInboundWriter.writeInboundHeaders(1, request, 31, true);
 
         Http2Stream stream = frameCodec.connection().stream(1);
@@ -193,6 +186,7 @@ public class Http2FrameCodecTest {
 
     @Test
     public void headerRequestHeaderResponse() throws Exception {
+        setUp();
         frameInboundWriter.writeInboundHeaders(1, request, 31, true);
 
         Http2Stream stream = frameCodec.connection().stream(1);
@@ -245,6 +239,7 @@ public class Http2FrameCodecTest {
 
     @Test
     public void entityRequestEntityResponse() throws Exception {
+        setUp();
         frameInboundWriter.writeInboundHeaders(1, request, 0, false);
 
         Http2Stream stream = frameCodec.connection().stream(1);
@@ -289,6 +284,7 @@ public class Http2FrameCodecTest {
 
     @Test
     public void sendRstStream() throws Exception {
+        setUp();
         frameInboundWriter.writeInboundHeaders(3, request, 31, true);
 
         Http2Stream stream = frameCodec.connection().stream(3);
@@ -311,6 +307,7 @@ public class Http2FrameCodecTest {
 
     @Test
     public void receiveRstStream() throws Exception {
+        setUp();
         frameInboundWriter.writeInboundHeaders(3, request, 31, false);
 
         Http2Stream stream = frameCodec.connection().stream(3);
@@ -332,6 +329,7 @@ public class Http2FrameCodecTest {
 
     @Test
     public void sendGoAway() throws Exception {
+        setUp();
         frameInboundWriter.writeInboundHeaders(3, request, 31, false);
         Http2Stream stream = frameCodec.connection().stream(3);
         assertNotNull(stream);
@@ -354,6 +352,7 @@ public class Http2FrameCodecTest {
 
     @Test
     public void receiveGoaway() throws Exception {
+        setUp();
         Buffer debugData = bb("foo");
         frameInboundWriter.writeInboundGoAway(2, NO_ERROR.code(), debugData);
         Http2GoAwayFrame expectedFrame = new DefaultHttp2GoAwayFrame(2, NO_ERROR.code(), bb("foo").send());
@@ -366,6 +365,7 @@ public class Http2FrameCodecTest {
 
     @Test
     public void unknownFrameTypeShouldThrowAndBeReleased() throws Exception {
+        setUp();
         class UnknownHttp2Frame extends AbstractReferenceCounted implements Http2Frame {
             @Override
             public String name() {
@@ -395,6 +395,7 @@ public class Http2FrameCodecTest {
 
     @Test
     public void unknownFrameTypeOnConnectionStream() throws Exception {
+        setUp();
         // handle the case where unknown frames are sent before a stream is created,
         // for example: HTTP/2 GREASE testing
         Buffer debugData = bb("debug");
@@ -407,6 +408,7 @@ public class Http2FrameCodecTest {
 
     @Test
     public void goAwayLastStreamIdOverflowed() throws Exception {
+        setUp();
         frameInboundWriter.writeInboundHeaders(5, request, 31, false);
 
         Http2Stream stream = frameCodec.connection().stream(5);
@@ -429,6 +431,7 @@ public class Http2FrameCodecTest {
 
     @Test
     public void streamErrorShouldFireExceptionForInbound() throws Exception {
+        setUp();
         frameInboundWriter.writeInboundHeaders(3, request, 31, false);
 
         Http2Stream stream = frameCodec.connection().stream(3);
@@ -452,6 +455,7 @@ public class Http2FrameCodecTest {
 
     @Test
     public void streamErrorShouldNotFireExceptionForOutbound() throws Exception {
+        setUp();
         frameInboundWriter.writeInboundHeaders(3, request, 31, false);
 
         Http2Stream stream = frameCodec.connection().stream(3);
@@ -474,6 +478,7 @@ public class Http2FrameCodecTest {
 
     @Test
     public void windowUpdateFrameDecrementsConsumedBytes() throws Exception {
+        setUp();
         frameInboundWriter.writeInboundHeaders(3, request, 31, false);
 
         Http2Connection connection = frameCodec.connection();
@@ -498,6 +503,7 @@ public class Http2FrameCodecTest {
 
     @Test
     public void windowUpdateMayFail() throws Exception {
+        setUp();
         frameInboundWriter.writeInboundHeaders(3, request, 31, false);
         Http2Connection connection = frameCodec.connection();
         Http2Stream stream = connection.stream(3);
@@ -517,6 +523,7 @@ public class Http2FrameCodecTest {
 
     @Test
     public void inboundWindowUpdateShouldBeForwarded() throws Exception {
+        setUp();
         frameInboundWriter.writeInboundHeaders(3, request, 31, false);
         frameInboundWriter.writeInboundWindowUpdate(3, 100);
         // Connection-level window update
@@ -535,7 +542,8 @@ public class Http2FrameCodecTest {
     }
 
     @Test
-    public void streamZeroWindowUpdateIncrementsConnectionWindow() throws Http2Exception {
+    public void streamZeroWindowUpdateIncrementsConnectionWindow() throws Exception {
+        setUp();
         Http2Connection connection = frameCodec.connection();
         Http2LocalFlowController localFlow = connection.local().flowController();
         int initialWindowSizeBefore = localFlow.initialWindowSize();
@@ -570,7 +578,8 @@ public class Http2FrameCodecTest {
     }
 
     @Test
-    public void windowUpdateDoesNotOverflowConnectionWindow() {
+    public void windowUpdateDoesNotOverflowConnectionWindow() throws Exception {
+        setUp();
         Http2Connection connection = frameCodec.connection();
         Http2LocalFlowController localFlow = connection.local().flowController();
         int initialWindowSizeBefore = localFlow.initialWindowSize();
@@ -584,7 +593,8 @@ public class Http2FrameCodecTest {
     }
 
     @Test
-    public void writeUnknownFrame() {
+    public void writeUnknownFrame() throws Exception {
+        setUp();
         final Http2FrameStream stream = frameCodec.newStream();
 
         Buffer buffer = onHeapAllocator().allocate(1).writeByte((byte) 1);
@@ -598,7 +608,8 @@ public class Http2FrameCodecTest {
     }
 
     @Test
-    public void sendSettingsFrame() {
+    public void sendSettingsFrame() throws Exception {
+        setUp();
         Http2Settings settings = new Http2Settings();
         channel.write(new DefaultHttp2SettingsFrame(settings));
 
@@ -608,6 +619,7 @@ public class Http2FrameCodecTest {
     @Test
     @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
     public void newOutboundStream() throws Exception {
+        setUp();
         final Http2FrameStream stream = frameCodec.newStream();
 
         assertNotNull(stream);
@@ -723,6 +735,7 @@ public class Http2FrameCodecTest {
 
     @Test
     public void streamIdentifiersExhausted() throws Exception {
+        setUp();
         int maxServerStreamId = Integer.MAX_VALUE - 1;
 
         channel.executor().submit(() -> {
@@ -746,6 +759,7 @@ public class Http2FrameCodecTest {
 
     @Test
     public void receivePing() throws Exception {
+        setUp();
         frameInboundWriter.writeInboundPing(false, 12345L);
 
         Http2PingFrame pingFrame = inboundHandler.readInbound();
@@ -756,7 +770,8 @@ public class Http2FrameCodecTest {
     }
 
     @Test
-    public void sendPing() {
+    public void sendPing() throws Exception {
+        setUp();
         channel.writeAndFlush(new DefaultHttp2PingFrame(12345));
 
         verify(frameWriter).writePing(any(ChannelHandlerContext.class), eq(false),
@@ -765,6 +780,7 @@ public class Http2FrameCodecTest {
 
     @Test
     public void receiveSettings() throws Exception {
+        setUp();
         Http2Settings settings = new Http2Settings().maxConcurrentStreams(1);
         frameInboundWriter.writeInboundSettings(settings);
 
@@ -774,7 +790,8 @@ public class Http2FrameCodecTest {
     }
 
     @Test
-    public void sendSettings() {
+    public void sendSettings() throws Exception {
+        setUp();
         Http2Settings settings = new Http2Settings().maxConcurrentStreams(1);
         channel.writeAndFlush(new DefaultHttp2SettingsFrame(settings));
 
@@ -852,7 +869,8 @@ public class Http2FrameCodecTest {
     }
 
     @Test
-    public void streamShouldBeOpenInListener() {
+    public void streamShouldBeOpenInListener() throws Exception {
+        setUp();
         final Http2FrameStream stream2 = frameCodec.newStream();
         assertEquals(State.IDLE, stream2.state());
 
@@ -869,6 +887,7 @@ public class Http2FrameCodecTest {
 
     @Test
     public void upgradeEventNoRefCntError() throws Exception {
+        setUp();
         frameInboundWriter.writeInboundHeaders(Http2CodecUtil.HTTP_UPGRADE_STREAM_ID, request, 31, false);
         // Using reflect as the constructor is package-private and the class is final.
         Constructor<UpgradeEvent> constructor =
@@ -887,6 +906,7 @@ public class Http2FrameCodecTest {
 
     @Test
     public void upgradeWithoutFlowControlling() throws Exception {
+        setUp();
         channel.pipeline().addAfter(frameCodec.ctx.name(), null, new ChannelHandler() {
             @Override
             public void channelRead(final ChannelHandlerContext ctx, Object msg) {
@@ -926,6 +946,7 @@ public class Http2FrameCodecTest {
 
     @Test
     public void priorityForNonExistingStream() throws Exception {
+        setUp();
         writeHeaderAndAssert(1);
 
         frameInboundWriter.writeInboundPriority(3, 1, (short) 31, true);
@@ -933,6 +954,7 @@ public class Http2FrameCodecTest {
 
     @Test
     public void priorityForExistingStream() throws Exception {
+        setUp();
         writeHeaderAndAssert(1);
         writeHeaderAndAssert(3);
         frameInboundWriter.writeInboundPriority(3, 1, (short) 31, true);

--- a/common/src/main/java/io/netty5/util/concurrent/AbstractScheduledEventExecutor.java
+++ b/common/src/main/java/io/netty5/util/concurrent/AbstractScheduledEventExecutor.java
@@ -153,6 +153,9 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
             }
             if (polled.deadlineNanos() <= nanoTime) {
                 return polled;
+            } else {
+                // We didn't want this task after all.
+                scheduledTaskQueue.offer(polled);
             }
         }
         return null;

--- a/common/src/main/java/io/netty5/util/concurrent/AbstractScheduledEventExecutor.java
+++ b/common/src/main/java/io/netty5/util/concurrent/AbstractScheduledEventExecutor.java
@@ -38,7 +38,7 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
     private static final RunnableScheduledFutureNode<?>[]
             EMPTY_RUNNABLE_SCHEDULED_FUTURE_NODES = new RunnableScheduledFutureNode<?>[0];
 
-    private DefaultPriorityQueue<RunnableScheduledFutureNode<?>> scheduledTaskQueue;
+    private PriorityQueue<RunnableScheduledFutureNode<?>> scheduledTaskQueue;
 
     protected AbstractScheduledEventExecutor() {
     }
@@ -135,7 +135,7 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
     protected final RunnableScheduledFuture<?> pollScheduledTask(long nanoTime) {
         assert inEventLoop();
 
-        DefaultPriorityQueue<RunnableScheduledFutureNode<?>> scheduledTaskQueue = this.scheduledTaskQueue;
+        Queue<RunnableScheduledFutureNode<?>> scheduledTaskQueue = this.scheduledTaskQueue;
         if (scheduledTaskQueue == null) {
             return null;
         }
@@ -144,19 +144,8 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
             return null;
         }
         if (scheduledTask.deadlineNanos() <= nanoTime) {
-            RunnableScheduledFutureNode<?> polled = scheduledTaskQueue.poll();
-            if (polled == scheduledTask) {
-                return scheduledTask;
-            }
-            if (polled == null) {
-                return null;
-            }
-            if (polled.deadlineNanos() <= nanoTime) {
-                return polled;
-            } else {
-                // We didn't want this task after all.
-                scheduledTaskQueue.offer(polled);
-            }
+            scheduledTaskQueue.remove();
+            return scheduledTask;
         }
         return null;
     }

--- a/common/src/main/java/io/netty5/util/internal/DefaultPriorityQueue.java
+++ b/common/src/main/java/io/netty5/util/internal/DefaultPriorityQueue.java
@@ -19,7 +19,7 @@ import java.util.AbstractQueue;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Iterator;
-import java.util.concurrent.locks.StampedLock;
+import java.util.NoSuchElementException;
 
 import static io.netty5.util.internal.PriorityQueueNode.INDEX_NOT_IN_QUEUE;
 import static java.util.Objects.requireNonNull;
@@ -27,266 +27,213 @@ import static java.util.Objects.requireNonNull;
 /**
  * A priority queue which uses natural ordering of elements. Elements are also required to be of type
  * {@link PriorityQueueNode} for the purpose of maintaining the index in the priority queue.
- * <p>
- * This priority queue is thread-safe, and uses locking internally.
- *
  * @param <T> The object that is maintained in the queue.
  */
 public final class DefaultPriorityQueue<T extends PriorityQueueNode> extends AbstractQueue<T>
                                                                      implements PriorityQueue<T> {
     private static final PriorityQueueNode[] EMPTY_ARRAY = new PriorityQueueNode[0];
     private final Comparator<T> comparator;
-    private final StampedLock lock;
     private T[] queue;
     private int size;
 
-    @SuppressWarnings({"unchecked", "SuspiciousArrayCast"})
+    @SuppressWarnings("unchecked")
     public DefaultPriorityQueue(Comparator<T> comparator, int initialSize) {
         this.comparator = requireNonNull(comparator, "comparator");
-        lock = new StampedLock();
         queue = (T[]) (initialSize != 0 ? new PriorityQueueNode[initialSize] : EMPTY_ARRAY);
     }
 
     @Override
     public int size() {
-        long stamp = lock.readLock();
-        try {
-            return size;
-        } finally {
-            lock.unlockRead(stamp);
-        }
+        return size;
     }
 
     @Override
     public boolean isEmpty() {
-        long stamp = lock.readLock();
-        try {
-            return size == 0;
-        } finally {
-            lock.unlockRead(stamp);
-        }
+        return size == 0;
     }
 
     @Override
     public boolean contains(Object o) {
-        long stamp = lock.readLock();
-        try {
-            if (!(o instanceof PriorityQueueNode)) {
-                return false;
-            }
-            PriorityQueueNode node = (PriorityQueueNode) o;
-            return contains(node, node.priorityQueueIndex(this));
-        } finally {
-            lock.unlockRead(stamp);
+        if (!(o instanceof PriorityQueueNode)) {
+            return false;
         }
+        PriorityQueueNode node = (PriorityQueueNode) o;
+        return contains(node, node.priorityQueueIndex(this));
     }
 
     @Override
     public boolean containsTyped(T node) {
-        long stamp = lock.readLock();
-        try {
-            return contains(node, node.priorityQueueIndex(this));
-        } finally {
-            lock.unlockRead(stamp);
-        }
+        return contains(node, node.priorityQueueIndex(this));
     }
 
     @Override
     public void clear() {
-        long stamp = lock.writeLock();
-        try {
-            for (int i = 0; i < size; ++i) {
-                T node = queue[i];
-                if (node != null) {
-                    node.priorityQueueIndex(this, INDEX_NOT_IN_QUEUE);
-                    queue[i] = null;
-                }
+        for (int i = 0; i < size; ++i) {
+            T node = queue[i];
+            if (node != null) {
+                node.priorityQueueIndex(this, INDEX_NOT_IN_QUEUE);
+                queue[i] = null;
             }
-            size = 0;
-        } finally {
-            lock.unlockWrite(stamp);
         }
+        size = 0;
     }
 
     @Override
     public void clearIgnoringIndexes() {
-        long stamp = lock.writeLock();
-        try {
-            size = 0;
-        } finally {
-            lock.unlockWrite(stamp);
-        }
+        size = 0;
     }
 
     @Override
     public boolean offer(T e) {
-        long stamp = lock.writeLock();
-        try {
-            if (e.priorityQueueIndex(this) != INDEX_NOT_IN_QUEUE) {
-                throw new IllegalArgumentException("e.priorityQueueIndex(): " + e.priorityQueueIndex(this) +
-                        " (expected: " + INDEX_NOT_IN_QUEUE + ") + e: " + e);
-            }
-
-            // Check that the array capacity is enough to hold values by doubling capacity.
-            int length = queue.length;
-            if (size >= length) {
-                // Use a policy which allows for a 0 initial capacity. Same policy as JDK's priority queue, double when
-                // "small", then grow by 50% when "large".
-                queue = Arrays.copyOf(queue, length + (length < 64 ? length + 2 : length >>> 1));
-            }
-
-            bubbleUp(size++, e);
-            return true;
-        } finally {
-            lock.unlockWrite(stamp);
+        if (e.priorityQueueIndex(this) != INDEX_NOT_IN_QUEUE) {
+            throw new IllegalArgumentException("e.priorityQueueIndex(): " + e.priorityQueueIndex(this) +
+                    " (expected: " + INDEX_NOT_IN_QUEUE + ") + e: " + e);
         }
+
+        // Check that the array capacity is enough to hold values by doubling capacity.
+        if (size >= queue.length) {
+            // Use a policy which allows for a 0 initial capacity. Same policy as JDK's priority queue, double when
+            // "small", then grow by 50% when "large".
+            queue = Arrays.copyOf(queue, queue.length + ((queue.length < 64) ?
+                                                         (queue.length + 2) :
+                                                         (queue.length >>> 1)));
+        }
+
+        bubbleUp(size++, e);
+        return true;
     }
 
     @Override
     public T poll() {
-        long stamp = lock.writeLock();
-        try {
-            if (size == 0) {
-                return null;
-            }
-            T result = queue[0];
-            result.priorityQueueIndex(this, INDEX_NOT_IN_QUEUE);
-
-            T last = queue[--size];
-            queue[size] = null;
-            if (size != 0) { // Make sure we don't add the last element back.
-                bubbleDown(0, last);
-            }
-
-            return result;
-        } finally {
-            lock.unlockWrite(stamp);
+        if (size == 0) {
+            return null;
         }
+        T result = queue[0];
+        result.priorityQueueIndex(this, INDEX_NOT_IN_QUEUE);
+
+        T last = queue[--size];
+        queue[size] = null;
+        if (size != 0) { // Make sure we don't add the last element back.
+            bubbleDown(0, last);
+        }
+
+        return result;
     }
 
     @Override
     public T peek() {
-        long stamp = lock.readLock();
-        try {
-            return size == 0 ? null : queue[0];
-        } finally {
-            lock.unlockRead(stamp);
-        }
+        return (size == 0) ? null : queue[0];
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public boolean remove(Object o) {
-        long stamp = lock.writeLock();
+        final T node;
         try {
-            final T node;
-            try {
-                node = (T) o;
-            } catch (ClassCastException e) {
-                return false;
-            }
-            return removeTyped(node);
-        } finally {
-            lock.unlockWrite(stamp);
+            node = (T) o;
+        } catch (ClassCastException e) {
+            return false;
         }
+        return removeTyped(node);
     }
 
     @Override
     public boolean removeTyped(T node) {
-        long stamp = lock.writeLock();
-        try {
-            int i = node.priorityQueueIndex(this);
-            if (!contains(node, i)) {
-                return false;
-            }
-
-            node.priorityQueueIndex(this, INDEX_NOT_IN_QUEUE);
-            if (--size == 0 || size == i) {
-                // If there are no node left, or this is the last node in the array just remove and return.
-                queue[i] = null;
-                return true;
-            }
-
-            // Move the last element where node currently lives in the array.
-            T moved = queue[i] = queue[size];
-            queue[size] = null;
-            // priorityQueueIndex will be updated below in bubbleUp or bubbleDown
-
-            // Make sure the moved node still preserves the min-heap properties.
-            if (comparator.compare(node, moved) < 0) {
-                bubbleDown(i, moved);
-            } else {
-                bubbleUp(i, moved);
-            }
-            return true;
-        } finally {
-            lock.unlockWrite(stamp);
+        int i = node.priorityQueueIndex(this);
+        if (!contains(node, i)) {
+            return false;
         }
+
+        node.priorityQueueIndex(this, INDEX_NOT_IN_QUEUE);
+        if (--size == 0 || size == i) {
+            // If there are no node left, or this is the last node in the array just remove and return.
+            queue[i] = null;
+            return true;
+        }
+
+        // Move the last element where node currently lives in the array.
+        T moved = queue[i] = queue[size];
+        queue[size] = null;
+        // priorityQueueIndex will be updated below in bubbleUp or bubbleDown
+
+        // Make sure the moved node still preserves the min-heap properties.
+        if (comparator.compare(node, moved) < 0) {
+            bubbleDown(i, moved);
+        } else {
+            bubbleUp(i, moved);
+        }
+        return true;
     }
 
     @Override
     public void priorityChanged(T node) {
-        long stamp = lock.writeLock();
-        try {
-            int i = node.priorityQueueIndex(this);
-            if (!contains(node, i)) {
-                return;
-            }
+        int i = node.priorityQueueIndex(this);
+        if (!contains(node, i)) {
+            return;
+        }
 
-            // Preserve the min-heap property by comparing the new priority with parents/children in the heap.
-            if (i == 0) {
-                bubbleDown(i, node);
+        // Preserve the min-heap property by comparing the new priority with parents/children in the heap.
+        if (i == 0) {
+            bubbleDown(i, node);
+        } else {
+            // Get the parent to see if min-heap properties are violated.
+            int iParent = (i - 1) >>> 1;
+            T parent = queue[iParent];
+            if (comparator.compare(node, parent) < 0) {
+                bubbleUp(i, node);
             } else {
-                // Get the parent to see if min-heap properties are violated.
-                int iParent = i - 1 >>> 1;
-                T parent = queue[iParent];
-                if (comparator.compare(node, parent) < 0) {
-                    bubbleUp(i, node);
-                } else {
-                    bubbleDown(i, node);
-                }
+                bubbleDown(i, node);
             }
-        } finally {
-            lock.unlockWrite(stamp);
         }
     }
 
     @Override
     public Object[] toArray() {
-        long stamp = lock.readLock();
-        try {
-            return Arrays.copyOf(queue, size);
-        } finally {
-            lock.unlockRead(stamp);
-        }
+        return Arrays.copyOf(queue, size);
     }
 
-    @SuppressWarnings({"unchecked", "SuspiciousArrayCast", "SuspiciousSystemArraycopy"})
+    @SuppressWarnings("unchecked")
     @Override
     public <X> X[] toArray(X[] a) {
-        long stamp = lock.readLock();
-        try {
-            if (a.length < size) {
-                return (X[]) Arrays.copyOf(queue, size, a.getClass());
-            }
-            System.arraycopy(queue, 0, a, 0, size);
-            if (a.length > size) {
-                a[size] = null;
-            }
-            return a;
-        } finally {
-            lock.unlockRead(stamp);
+        if (a.length < size) {
+            return (X[]) Arrays.copyOf(queue, size, a.getClass());
         }
+        System.arraycopy(queue, 0, a, 0, size);
+        if (a.length > size) {
+            a[size] = null;
+        }
+        return a;
     }
 
     /**
-     * This priority queue does not support iteration.
-     *
-     * @throws UnsupportedOperationException iteration is not supported.
+     * This iterator does not return elements in any particular order.
      */
     @Override
     public Iterator<T> iterator() {
-        throw new UnsupportedOperationException();
+        return new PriorityQueueIterator();
+    }
+
+    private final class PriorityQueueIterator implements Iterator<T> {
+        private int index;
+
+        @Override
+        public boolean hasNext() {
+            return index < size;
+        }
+
+        @Override
+        public T next() {
+            if (index >= size) {
+                throw new NoSuchElementException();
+            }
+
+            return queue[index++];
+        }
+
+        @Override
+        public void remove() {
+            throw new UnsupportedOperationException("remove");
+        }
     }
 
     private boolean contains(PriorityQueueNode node, int i) {
@@ -326,7 +273,7 @@ public final class DefaultPriorityQueue<T extends PriorityQueueNode> extends Abs
 
     private void bubbleUp(int k, T node) {
         while (k > 0) {
-            int iParent = k - 1 >>> 1;
+            int iParent = (k - 1) >>> 1;
             T parent = queue[iParent];
 
             // If the bubbleUp node is less than the parent, then we have found a spot to insert and still maintain

--- a/common/src/main/java/io/netty5/util/internal/DefaultPriorityQueue.java
+++ b/common/src/main/java/io/netty5/util/internal/DefaultPriorityQueue.java
@@ -19,7 +19,7 @@ import java.util.AbstractQueue;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Iterator;
-import java.util.NoSuchElementException;
+import java.util.concurrent.locks.StampedLock;
 
 import static io.netty5.util.internal.PriorityQueueNode.INDEX_NOT_IN_QUEUE;
 import static java.util.Objects.requireNonNull;
@@ -27,213 +27,266 @@ import static java.util.Objects.requireNonNull;
 /**
  * A priority queue which uses natural ordering of elements. Elements are also required to be of type
  * {@link PriorityQueueNode} for the purpose of maintaining the index in the priority queue.
+ * <p>
+ * This priority queue is thread-safe, and uses locking internally.
+ *
  * @param <T> The object that is maintained in the queue.
  */
 public final class DefaultPriorityQueue<T extends PriorityQueueNode> extends AbstractQueue<T>
                                                                      implements PriorityQueue<T> {
     private static final PriorityQueueNode[] EMPTY_ARRAY = new PriorityQueueNode[0];
     private final Comparator<T> comparator;
+    private final StampedLock lock;
     private T[] queue;
     private int size;
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "SuspiciousArrayCast"})
     public DefaultPriorityQueue(Comparator<T> comparator, int initialSize) {
         this.comparator = requireNonNull(comparator, "comparator");
+        lock = new StampedLock();
         queue = (T[]) (initialSize != 0 ? new PriorityQueueNode[initialSize] : EMPTY_ARRAY);
     }
 
     @Override
     public int size() {
-        return size;
+        long stamp = lock.readLock();
+        try {
+            return size;
+        } finally {
+            lock.unlockRead(stamp);
+        }
     }
 
     @Override
     public boolean isEmpty() {
-        return size == 0;
+        long stamp = lock.readLock();
+        try {
+            return size == 0;
+        } finally {
+            lock.unlockRead(stamp);
+        }
     }
 
     @Override
     public boolean contains(Object o) {
-        if (!(o instanceof PriorityQueueNode)) {
-            return false;
+        long stamp = lock.readLock();
+        try {
+            if (!(o instanceof PriorityQueueNode)) {
+                return false;
+            }
+            PriorityQueueNode node = (PriorityQueueNode) o;
+            return contains(node, node.priorityQueueIndex(this));
+        } finally {
+            lock.unlockRead(stamp);
         }
-        PriorityQueueNode node = (PriorityQueueNode) o;
-        return contains(node, node.priorityQueueIndex(this));
     }
 
     @Override
     public boolean containsTyped(T node) {
-        return contains(node, node.priorityQueueIndex(this));
+        long stamp = lock.readLock();
+        try {
+            return contains(node, node.priorityQueueIndex(this));
+        } finally {
+            lock.unlockRead(stamp);
+        }
     }
 
     @Override
     public void clear() {
-        for (int i = 0; i < size; ++i) {
-            T node = queue[i];
-            if (node != null) {
-                node.priorityQueueIndex(this, INDEX_NOT_IN_QUEUE);
-                queue[i] = null;
+        long stamp = lock.writeLock();
+        try {
+            for (int i = 0; i < size; ++i) {
+                T node = queue[i];
+                if (node != null) {
+                    node.priorityQueueIndex(this, INDEX_NOT_IN_QUEUE);
+                    queue[i] = null;
+                }
             }
+            size = 0;
+        } finally {
+            lock.unlockWrite(stamp);
         }
-        size = 0;
     }
 
     @Override
     public void clearIgnoringIndexes() {
-        size = 0;
+        long stamp = lock.writeLock();
+        try {
+            size = 0;
+        } finally {
+            lock.unlockWrite(stamp);
+        }
     }
 
     @Override
     public boolean offer(T e) {
-        if (e.priorityQueueIndex(this) != INDEX_NOT_IN_QUEUE) {
-            throw new IllegalArgumentException("e.priorityQueueIndex(): " + e.priorityQueueIndex(this) +
-                    " (expected: " + INDEX_NOT_IN_QUEUE + ") + e: " + e);
-        }
+        long stamp = lock.writeLock();
+        try {
+            if (e.priorityQueueIndex(this) != INDEX_NOT_IN_QUEUE) {
+                throw new IllegalArgumentException("e.priorityQueueIndex(): " + e.priorityQueueIndex(this) +
+                        " (expected: " + INDEX_NOT_IN_QUEUE + ") + e: " + e);
+            }
 
-        // Check that the array capacity is enough to hold values by doubling capacity.
-        if (size >= queue.length) {
-            // Use a policy which allows for a 0 initial capacity. Same policy as JDK's priority queue, double when
-            // "small", then grow by 50% when "large".
-            queue = Arrays.copyOf(queue, queue.length + ((queue.length < 64) ?
-                                                         (queue.length + 2) :
-                                                         (queue.length >>> 1)));
-        }
+            // Check that the array capacity is enough to hold values by doubling capacity.
+            int length = queue.length;
+            if (size >= length) {
+                // Use a policy which allows for a 0 initial capacity. Same policy as JDK's priority queue, double when
+                // "small", then grow by 50% when "large".
+                queue = Arrays.copyOf(queue, length + (length < 64 ? length + 2 : length >>> 1));
+            }
 
-        bubbleUp(size++, e);
-        return true;
+            bubbleUp(size++, e);
+            return true;
+        } finally {
+            lock.unlockWrite(stamp);
+        }
     }
 
     @Override
     public T poll() {
-        if (size == 0) {
-            return null;
-        }
-        T result = queue[0];
-        result.priorityQueueIndex(this, INDEX_NOT_IN_QUEUE);
+        long stamp = lock.writeLock();
+        try {
+            if (size == 0) {
+                return null;
+            }
+            T result = queue[0];
+            result.priorityQueueIndex(this, INDEX_NOT_IN_QUEUE);
 
-        T last = queue[--size];
-        queue[size] = null;
-        if (size != 0) { // Make sure we don't add the last element back.
-            bubbleDown(0, last);
-        }
+            T last = queue[--size];
+            queue[size] = null;
+            if (size != 0) { // Make sure we don't add the last element back.
+                bubbleDown(0, last);
+            }
 
-        return result;
+            return result;
+        } finally {
+            lock.unlockWrite(stamp);
+        }
     }
 
     @Override
     public T peek() {
-        return (size == 0) ? null : queue[0];
+        long stamp = lock.readLock();
+        try {
+            return size == 0 ? null : queue[0];
+        } finally {
+            lock.unlockRead(stamp);
+        }
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public boolean remove(Object o) {
-        final T node;
+        long stamp = lock.writeLock();
         try {
-            node = (T) o;
-        } catch (ClassCastException e) {
-            return false;
+            final T node;
+            try {
+                node = (T) o;
+            } catch (ClassCastException e) {
+                return false;
+            }
+            return removeTyped(node);
+        } finally {
+            lock.unlockWrite(stamp);
         }
-        return removeTyped(node);
     }
 
     @Override
     public boolean removeTyped(T node) {
-        int i = node.priorityQueueIndex(this);
-        if (!contains(node, i)) {
-            return false;
-        }
+        long stamp = lock.writeLock();
+        try {
+            int i = node.priorityQueueIndex(this);
+            if (!contains(node, i)) {
+                return false;
+            }
 
-        node.priorityQueueIndex(this, INDEX_NOT_IN_QUEUE);
-        if (--size == 0 || size == i) {
-            // If there are no node left, or this is the last node in the array just remove and return.
-            queue[i] = null;
+            node.priorityQueueIndex(this, INDEX_NOT_IN_QUEUE);
+            if (--size == 0 || size == i) {
+                // If there are no node left, or this is the last node in the array just remove and return.
+                queue[i] = null;
+                return true;
+            }
+
+            // Move the last element where node currently lives in the array.
+            T moved = queue[i] = queue[size];
+            queue[size] = null;
+            // priorityQueueIndex will be updated below in bubbleUp or bubbleDown
+
+            // Make sure the moved node still preserves the min-heap properties.
+            if (comparator.compare(node, moved) < 0) {
+                bubbleDown(i, moved);
+            } else {
+                bubbleUp(i, moved);
+            }
             return true;
+        } finally {
+            lock.unlockWrite(stamp);
         }
-
-        // Move the last element where node currently lives in the array.
-        T moved = queue[i] = queue[size];
-        queue[size] = null;
-        // priorityQueueIndex will be updated below in bubbleUp or bubbleDown
-
-        // Make sure the moved node still preserves the min-heap properties.
-        if (comparator.compare(node, moved) < 0) {
-            bubbleDown(i, moved);
-        } else {
-            bubbleUp(i, moved);
-        }
-        return true;
     }
 
     @Override
     public void priorityChanged(T node) {
-        int i = node.priorityQueueIndex(this);
-        if (!contains(node, i)) {
-            return;
-        }
-
-        // Preserve the min-heap property by comparing the new priority with parents/children in the heap.
-        if (i == 0) {
-            bubbleDown(i, node);
-        } else {
-            // Get the parent to see if min-heap properties are violated.
-            int iParent = (i - 1) >>> 1;
-            T parent = queue[iParent];
-            if (comparator.compare(node, parent) < 0) {
-                bubbleUp(i, node);
-            } else {
-                bubbleDown(i, node);
+        long stamp = lock.writeLock();
+        try {
+            int i = node.priorityQueueIndex(this);
+            if (!contains(node, i)) {
+                return;
             }
+
+            // Preserve the min-heap property by comparing the new priority with parents/children in the heap.
+            if (i == 0) {
+                bubbleDown(i, node);
+            } else {
+                // Get the parent to see if min-heap properties are violated.
+                int iParent = i - 1 >>> 1;
+                T parent = queue[iParent];
+                if (comparator.compare(node, parent) < 0) {
+                    bubbleUp(i, node);
+                } else {
+                    bubbleDown(i, node);
+                }
+            }
+        } finally {
+            lock.unlockWrite(stamp);
         }
     }
 
     @Override
     public Object[] toArray() {
-        return Arrays.copyOf(queue, size);
+        long stamp = lock.readLock();
+        try {
+            return Arrays.copyOf(queue, size);
+        } finally {
+            lock.unlockRead(stamp);
+        }
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "SuspiciousArrayCast", "SuspiciousSystemArraycopy"})
     @Override
     public <X> X[] toArray(X[] a) {
-        if (a.length < size) {
-            return (X[]) Arrays.copyOf(queue, size, a.getClass());
+        long stamp = lock.readLock();
+        try {
+            if (a.length < size) {
+                return (X[]) Arrays.copyOf(queue, size, a.getClass());
+            }
+            System.arraycopy(queue, 0, a, 0, size);
+            if (a.length > size) {
+                a[size] = null;
+            }
+            return a;
+        } finally {
+            lock.unlockRead(stamp);
         }
-        System.arraycopy(queue, 0, a, 0, size);
-        if (a.length > size) {
-            a[size] = null;
-        }
-        return a;
     }
 
     /**
-     * This iterator does not return elements in any particular order.
+     * This priority queue does not support iteration.
+     *
+     * @throws UnsupportedOperationException iteration is not supported.
      */
     @Override
     public Iterator<T> iterator() {
-        return new PriorityQueueIterator();
-    }
-
-    private final class PriorityQueueIterator implements Iterator<T> {
-        private int index;
-
-        @Override
-        public boolean hasNext() {
-            return index < size;
-        }
-
-        @Override
-        public T next() {
-            if (index >= size) {
-                throw new NoSuchElementException();
-            }
-
-            return queue[index++];
-        }
-
-        @Override
-        public void remove() {
-            throw new UnsupportedOperationException("remove");
-        }
+        throw new UnsupportedOperationException();
     }
 
     private boolean contains(PriorityQueueNode node, int i) {
@@ -273,7 +326,7 @@ public final class DefaultPriorityQueue<T extends PriorityQueueNode> extends Abs
 
     private void bubbleUp(int k, T node) {
         while (k > 0) {
-            int iParent = (k - 1) >>> 1;
+            int iParent = k - 1 >>> 1;
             T parent = queue[iParent];
 
             // If the bubbleUp node is less than the parent, then we have found a spot to insert and still maintain

--- a/transport/src/main/java/io/netty5/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty5/channel/embedded/EmbeddedChannel.java
@@ -785,7 +785,7 @@ public class EmbeddedChannel extends AbstractChannel<Channel, SocketAddress, Soc
         @Override
         protected void runAfterTransportOperation() {
             super.runAfterTransportOperation();
-            if (!executor().inEventLoop()) {
+            if (!((EmbeddedEventLoop) executor()).isRunning()) {
                 runPendingTasks();
             }
         }

--- a/transport/src/main/java/io/netty5/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty5/channel/embedded/EmbeddedChannel.java
@@ -785,7 +785,7 @@ public class EmbeddedChannel extends AbstractChannel<Channel, SocketAddress, Soc
         @Override
         protected void runAfterTransportOperation() {
             super.runAfterTransportOperation();
-            if (!((EmbeddedEventLoop) executor()).running) {
+            if (!executor().inEventLoop()) {
                 runPendingTasks();
             }
         }

--- a/transport/src/main/java/io/netty5/channel/embedded/EmbeddedEventLoop.java
+++ b/transport/src/main/java/io/netty5/channel/embedded/EmbeddedEventLoop.java
@@ -182,6 +182,10 @@ final class EmbeddedEventLoop extends AbstractScheduledEventExecutor implements 
         }
     }
 
+    synchronized boolean isRunning() {
+        return running;
+    }
+
     @Override
     protected synchronized long getCurrentTimeNanos() {
         if (timeFrozen) {


### PR DESCRIPTION
Motivation:
Event loops and executors are expected to be thread-safe, and accessible from multiple threads.
Even though the EmbeddedEventLoop is _usually_ only used by one thread, it might not always be.
Especially as we're increasingly running our tests in parallel.

Modification:
Make all of the state-mutating methods of EmbeddedEventLoop synchronized.
The EmbeddedEventLoop extends the AbstractScheduledEventExecutor, which assumes that only one thread will be mutating its state - the event loop thread.
This is not the case with the EmbeddedEventLoop, as it has no dedicated thread but instead relies on external inputs driving its execution.
By making all state mutating methods synchronized, we not only protect the internals from concurrent modification, but also ensure safe publication of the internal state when it is accessed by multiple threads in a non-concurrent way.
Also fix an issue in Http2FrameCodecTest where we didn't wait for a future to complete before checking if it had succeeded or not.

Result:
The Http2FrameCodecTest, which was suffering data races in the AbstractScheduledEventExecutor and supporting classes, now runs more stably.