### PR TITLE
Fix native library packaging when cross-compile on m1 for intel

### DIFF
--- a/resolver-dns-native-macos/pom.xml
+++ b/resolver-dns-native-macos/pom.xml
@@ -324,7 +324,7 @@
                     </manifest>
                     <manifestEntries>
                       <Bundle-NativeCode>META-INF/native/libnetty_resolver_dns_native_macos_x86_64.jnilib; osname=MacOSX; processor=x86_64</Bundle-NativeCode>
-                      <Fragment-Host>io.netty.resolver-dns-classes-macos</Fragment-Host>
+                      <Fragment-Host>io.netty5.resolver-dns-classes-macos</Fragment-Host>
                       <Automatic-Module-Name>${javaModuleName}</Automatic-Module-Name>
                     </manifestEntries>
                     <index>true</index>

--- a/resolver-dns-native-macos/pom.xml
+++ b/resolver-dns-native-macos/pom.xml
@@ -286,7 +286,7 @@
               <execution>
                 <id>build-native-lib</id>
                 <configuration>
-                  <name>netty_resolver_dns_native_macos_x86_64</name>
+                  <name>netty5_resolver_dns_native_macos_x86_64</name>
                   <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
                   <libDirectory>${project.build.outputDirectory}</libDirectory>
                   <!-- We use Maven's artifact classifier instead.

--- a/resolver-dns-native-macos/pom.xml
+++ b/resolver-dns-native-macos/pom.xml
@@ -323,7 +323,7 @@
                       <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                     </manifest>
                     <manifestEntries>
-                      <Bundle-NativeCode>META-INF/native/libnetty_resolver_dns_native_macos_x86_64.jnilib; osname=MacOSX; processor=x86_64</Bundle-NativeCode>
+                      <Bundle-NativeCode>META-INF/native/libnetty5_resolver_dns_native_macos_x86_64.jnilib; osname=MacOSX; processor=x86_64</Bundle-NativeCode>
                       <Fragment-Host>io.netty5.resolver-dns-classes-macos</Fragment-Host>
                       <Automatic-Module-Name>${javaModuleName}</Automatic-Module-Name>
                     </manifestEntries>

--- a/transport-native-kqueue/pom.xml
+++ b/transport-native-kqueue/pom.xml
@@ -325,8 +325,8 @@
                       <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                     </manifest>
                     <manifestEntries>
-                      <Bundle-NativeCode>META-INF/native/libnetty_transport_native_kqueue_x86_64.jnilib; osname=MacOSX; processor=x86_64</Bundle-NativeCode>
-                      <Fragment-Host>io.netty.transport-classes-kqueue</Fragment-Host>
+                      <Bundle-NativeCode>META-INF/native/libnetty5_transport_native_kqueue_x86_64.jnilib; osname=MacOSX; processor=x86_64</Bundle-NativeCode>
+                      <Fragment-Host>io.netty5.transport-classes-kqueue</Fragment-Host>
                       <Automatic-Module-Name>${javaModuleName}</Automatic-Module-Name>
                     </manifestEntries>
                     <index>true</index>

--- a/transport-native-kqueue/pom.xml
+++ b/transport-native-kqueue/pom.xml
@@ -287,7 +287,7 @@
               <execution>
                 <id>build-native-lib</id>
                 <configuration>
-                  <name>netty_transport_native_kqueue_aarch_64</name>
+                  <name>netty5_transport_native_kqueue_x86_64</name>
                   <nativeSourceDirectory>${nativeSourceDirectory}</nativeSourceDirectory>
                   <libDirectory>${project.build.outputDirectory}</libDirectory>
                   <!-- We use Maven's artifact classifier instead.
@@ -325,7 +325,7 @@
                       <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                     </manifest>
                     <manifestEntries>
-                      <Bundle-NativeCode>META-INF/native/libnetty_transport_native_kqueue_aarch_64.jnilib; osname=MacOSX; processor=aarch64</Bundle-NativeCode>
+                      <Bundle-NativeCode>META-INF/native/libnetty_transport_native_kqueue_x86_64.jnilib; osname=MacOSX; processor=x86_64</Bundle-NativeCode>
                       <Fragment-Host>io.netty.transport-classes-kqueue</Fragment-Host>
                       <Automatic-Module-Name>${javaModuleName}</Automatic-Module-Name>
                     </manifestEntries>


### PR DESCRIPTION
Motivation:

We did have a few build configuration problems when cross-compile which resulted in un-usable native libraries.

Modifications:

- Fix native lib naming
- Fix OSGI config

Result:

Fixes https://github.com/netty/netty/issues/12861
