### PR TITLE
Apply 'VisibleForTesting', 'TestOnly' annotations

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -246,3 +246,11 @@ reactive web services, which can be obtained at:
     * license/LICENSE.servicetalk.txt (Apache License 2.0)
   * HOMEPAGE:
     * https://github.com/apple/servicetalk
+
+This product optionally depends on 'annotations', A set of Java annotations which can be used in JVM-based
+languages written by JetBrains, which can be obtained at:
+
+  * LICENSE:
+    * license/LICENSE.annotations.txt (Apache License 2.0)
+  * HOMEPAGE:
+    * https://github.com/JetBrains/java-annotations

--- a/buffer/pom.xml
+++ b/buffer/pom.xml
@@ -38,6 +38,12 @@
       <artifactId>netty5-common</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!-- Annotations for IDE integration and analysis -->
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>

--- a/buffer/src/main/java/io/netty5/buffer/BufferInputStream.java
+++ b/buffer/src/main/java/io/netty5/buffer/BufferInputStream.java
@@ -17,6 +17,7 @@ package io.netty5.buffer;
 
 import io.netty5.util.Send;
 import io.netty5.util.internal.StringUtil;
+import org.jetbrains.annotations.TestOnly;
 
 import java.io.DataInput;
 import java.io.DataInputStream;
@@ -257,6 +258,7 @@ public final class BufferInputStream extends InputStream implements DataInput {
      *
      * @return The internal buffer instance.
      */
+    @TestOnly
     Buffer buffer() {
         return buffer;
     }

--- a/codec-dns/pom.xml
+++ b/codec-dns/pom.xml
@@ -53,6 +53,12 @@
       <artifactId>netty5-codec</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!-- Annotations for IDE integration and analysis -->
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.directory.server</groupId>

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/DefaultDnsRecordEncoder.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/DefaultDnsRecordEncoder.java
@@ -20,6 +20,7 @@ import io.netty5.channel.socket.SocketProtocolFamily;
 import io.netty5.handler.codec.UnsupportedMessageTypeException;
 import io.netty5.util.internal.StringUtil;
 import io.netty5.util.internal.UnstableApi;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import static io.netty5.handler.codec.dns.DnsCodecUtil.addressNumber;
 
@@ -129,6 +130,7 @@ public class DefaultDnsRecordEncoder implements DnsRecordEncoder {
     }
 
     // Package-Private for testing
+    @VisibleForTesting
     static int calculateEcsAddressLength(int sourcePrefixLength, int lowOrderBitsToPreserve) {
         return (sourcePrefixLength >>> 3) + (lowOrderBitsToPreserve != 0 ? 1 : 0);
     }

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientHandshaker.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientHandshaker.java
@@ -38,6 +38,7 @@ import io.netty5.util.NetUtil;
 import io.netty5.util.ReferenceCountUtil;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.Promise;
+import org.jetbrains.annotations.TestOnly;
 
 import java.net.URI;
 import java.nio.channels.ClosedChannelException;
@@ -59,7 +60,7 @@ public abstract class WebSocketClientHandshaker {
 
     private volatile boolean handshakeComplete;
 
-    private volatile long forceCloseTimeoutMillis = DEFAULT_FORCE_CLOSE_TIMEOUT_MILLIS;
+    private volatile long forceCloseTimeoutMillis;
 
     private volatile int forceCloseInit;
 
@@ -212,7 +213,8 @@ public abstract class WebSocketClientHandshaker {
      * Flag to indicate if the closing handshake was initiated because of timeout.
      * For testing only.
      */
-    protected boolean isForceCloseComplete() {
+    @TestOnly
+    boolean isForceCloseComplete() {
         return forceCloseComplete;
     }
 

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientProtocolHandshakeHandler.java
@@ -20,6 +20,7 @@ import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.http.FullHttpResponse;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.Promise;
+import org.jetbrains.annotations.TestOnly;
 
 import java.util.concurrent.TimeUnit;
 
@@ -119,6 +120,7 @@ class WebSocketClientProtocolHandshakeHandler implements ChannelHandler {
      *
      * @return current handshake future
      */
+    @TestOnly
     Future<Void> getHandshakeFuture() {
         return handshakePromise.asFuture();
     }

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/DefaultHttp2HeadersDecoder.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/DefaultHttp2HeadersDecoder.java
@@ -17,6 +17,7 @@ package io.netty5.handler.codec.http2;
 import io.netty5.buffer.Buffer;
 import io.netty5.handler.codec.http2.headers.Http2Headers;
 import io.netty5.util.internal.UnstableApi;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import static io.netty5.handler.codec.http2.Http2CodecUtil.DEFAULT_HEADER_LIST_SIZE;
 import static io.netty5.handler.codec.http2.Http2Error.COMPRESSION_ERROR;
@@ -95,6 +96,7 @@ public class DefaultHttp2HeadersDecoder implements Http2HeadersDecoder, Http2Hea
      * Exposed for testing only! Default values used in the initial settings frame are overridden intentionally
      * for testing but violate the RFC if used outside the scope of testing.
      */
+    @VisibleForTesting
     DefaultHttp2HeadersDecoder(boolean validateHeaders, boolean validateHeaderValues, HpackDecoder hpackDecoder) {
         this.hpackDecoder = requireNonNull(hpackDecoder, "hpackDecoder");
         this.validateHeaders = validateHeaders;

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/DefaultHttp2HeadersEncoder.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/DefaultHttp2HeadersEncoder.java
@@ -19,6 +19,7 @@ import io.netty5.buffer.Buffer;
 import io.netty5.buffer.BufferAllocator;
 import io.netty5.handler.codec.http2.headers.Http2Headers;
 import io.netty5.util.internal.UnstableApi;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import static io.netty5.handler.codec.http2.Http2Error.COMPRESSION_ERROR;
 import static io.netty5.handler.codec.http2.Http2Exception.connectionError;
@@ -57,6 +58,7 @@ public class DefaultHttp2HeadersEncoder implements Http2HeadersEncoder, Http2Hea
      * Exposed Used for testing only! Default values used in the initial settings frame are overridden intentionally
      * for testing but violate the RFC if used outside the scope of testing.
      */
+    @VisibleForTesting
     DefaultHttp2HeadersEncoder(SensitivityDetector sensitivityDetector, HpackEncoder hpackEncoder) {
         this.sensitivityDetector = requireNonNull(sensitivityDetector, "sensitiveDetector");
         this.hpackEncoder = requireNonNull(hpackEncoder, "hpackEncoder");

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/HpackDecoder.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/HpackDecoder.java
@@ -36,6 +36,8 @@ import io.netty5.handler.codec.http.headers.HeaderValidationException;
 import io.netty5.handler.codec.http2.HpackUtil.IndexType;
 import io.netty5.handler.codec.http2.headers.Http2Headers;
 import io.netty5.util.AsciiString;
+import org.jetbrains.annotations.TestOnly;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import static io.netty5.handler.codec.http2.Http2CodecUtil.DEFAULT_HEADER_TABLE_SIZE;
 import static io.netty5.handler.codec.http2.Http2CodecUtil.MAX_HEADER_LIST_SIZE;
@@ -112,6 +114,7 @@ final class HpackDecoder {
      * Exposed Used for testing only! Default values used in the initial settings frame are overridden intentionally
      * for testing but violate the RFC if used outside the scope of testing.
      */
+    @VisibleForTesting
     HpackDecoder(long maxHeaderListSize, int maxHeaderTableSize) {
         this.maxHeaderListSize = checkPositive(maxHeaderListSize, "maxHeaderListSize");
 
@@ -350,6 +353,7 @@ final class HpackDecoder {
     /**
      * Return the number of header fields in the dynamic table. Exposed for testing.
      */
+    @TestOnly
     int length() {
         return hpackDynamicTable.length();
     }
@@ -357,6 +361,7 @@ final class HpackDecoder {
     /**
      * Return the size of the dynamic table. Exposed for testing.
      */
+    @TestOnly
     long size() {
         return hpackDynamicTable.size();
     }
@@ -364,6 +369,7 @@ final class HpackDecoder {
     /**
      * Return the header field at the given index. Exposed for testing.
      */
+    @TestOnly
     HpackHeaderField getHeaderField(int index) {
         return hpackDynamicTable.getEntry(index + 1);
     }
@@ -434,6 +440,7 @@ final class HpackDecoder {
      * <p>
      * Visible for testing only!
      */
+    @VisibleForTesting
     static int decodeULE128(Buffer in, int result) throws Http2Exception {
         final int readerIndex = in.readerOffset();
         final long v = decodeULE128(in, (long) result);
@@ -454,6 +461,7 @@ final class HpackDecoder {
      * <p>
      * Visible for testing only!
      */
+    @VisibleForTesting
     static long decodeULE128(Buffer in, long result) throws Http2Exception {
         assert result <= 0x7f && result >= 0;
         final boolean resultStartedAtZero = result == 0;

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/HpackEncoder.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/HpackEncoder.java
@@ -36,6 +36,8 @@ import io.netty5.handler.codec.http2.HpackUtil.IndexType;
 import io.netty5.handler.codec.http2.Http2HeadersEncoder.SensitivityDetector;
 import io.netty5.handler.codec.http2.headers.Http2Headers;
 import io.netty5.util.AsciiString;
+import org.jetbrains.annotations.TestOnly;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -335,6 +337,7 @@ final class HpackEncoder {
     /**
      * Return the number of header fields in the dynamic table. Exposed for testing.
      */
+    @VisibleForTesting
     int length() {
         return size == 0 ? 0 : head.after.index - head.before.index + 1;
     }
@@ -342,6 +345,7 @@ final class HpackEncoder {
     /**
      * Return the size of the dynamic table. Exposed for testing.
      */
+    @TestOnly
     long size() {
         return size;
     }
@@ -349,6 +353,7 @@ final class HpackEncoder {
     /**
      * Return the header field at the given index. Exposed for testing.
      */
+    @TestOnly
     HpackHeaderField getHeaderField(int index) {
         HeaderEntry entry = head;
         while (index-- >= 0) {

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2EmptyDataFrameConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2EmptyDataFrameConnectionDecoder.java
@@ -15,6 +15,7 @@
 package io.netty5.handler.codec.http2;
 
 import io.netty5.util.internal.ObjectUtil;
+import org.jetbrains.annotations.VisibleForTesting;
 
 /**
  * Enforce a limit on the maximum number of consecutive empty DATA frames (without end_of_stream flag) that are allowed
@@ -50,6 +51,7 @@ final class Http2EmptyDataFrameConnectionDecoder extends DecoratingHttp2Connecti
     }
 
     // Package-private for testing
+    @VisibleForTesting
     Http2FrameListener frameListener0() {
         return super.frameListener();
     }

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2FrameCodec.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2FrameCodec.java
@@ -35,6 +35,7 @@ import io.netty5.util.concurrent.Promise;
 import io.netty5.util.internal.UnstableApi;
 import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
+import org.jetbrains.annotations.TestOnly;
 
 import static io.netty5.handler.codec.http2.Http2CodecUtil.HTTP_UPGRADE_STREAM_ID;
 import static io.netty5.handler.codec.http2.Http2CodecUtil.isStreamIdValid;
@@ -207,6 +208,7 @@ public class Http2FrameCodec extends Http2ConnectionHandler {
      * <p>
      * This is package-private for testing only.
      */
+    @TestOnly
     int numInitializingStreams() {
         return frameStreamToInitializeMap.size();
     }

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2FrameCodecBuilder.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2FrameCodecBuilder.java
@@ -16,6 +16,7 @@
 package io.netty5.handler.codec.http2;
 
 import io.netty5.util.internal.UnstableApi;
+import org.jetbrains.annotations.TestOnly;
 
 import static java.util.Objects.requireNonNull;
 
@@ -61,6 +62,7 @@ public class Http2FrameCodecBuilder extends
     }
 
     // For testing only.
+    @TestOnly
     Http2FrameCodecBuilder frameWriter(Http2FrameWriter frameWriter) {
         this.frameWriter = requireNonNull(frameWriter, "frameWriter");
         return this;

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/HttpConversionUtil.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/HttpConversionUtil.java
@@ -36,6 +36,7 @@ import io.netty5.handler.codec.http2.headers.Http2Headers;
 import io.netty5.util.AsciiString;
 import io.netty5.util.internal.StringUtil;
 import io.netty5.util.internal.UnstableApi;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import java.net.URI;
 import java.util.Iterator;
@@ -579,6 +580,7 @@ public final class HttpConversionUtil {
     }
 
     // package-private for testing only
+    @VisibleForTesting
     static void setHttp2Authority(CharSequence authority, Http2Headers out) {
         // The authority MUST NOT include the deprecated "userinfo" subcomponent
         if (authority != null) {

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/WeightedFairQueueByteDistributor.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/WeightedFairQueueByteDistributor.java
@@ -23,6 +23,8 @@ import io.netty5.util.internal.PriorityQueue;
 import io.netty5.util.internal.PriorityQueueNode;
 import io.netty5.util.internal.SystemPropertyUtil;
 import io.netty5.util.internal.UnstableApi;
+import org.jetbrains.annotations.TestOnly;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -65,6 +67,7 @@ public final class WeightedFairQueueByteDistributor implements StreamByteDistrib
      *
      * Visible only for testing!
      */
+    @VisibleForTesting
     static final int INITIAL_CHILDREN_MAP_SIZE =
             max(1, SystemPropertyUtil.getInt("io.netty5.http2.childrenMapSize", 2));
     /**
@@ -353,6 +356,7 @@ public final class WeightedFairQueueByteDistributor implements StreamByteDistrib
     /**
      * For testing only!
      */
+    @TestOnly
     boolean isChild(int childId, int parentId, short weight) {
         State parent = state(parentId);
         State child;
@@ -363,6 +367,7 @@ public final class WeightedFairQueueByteDistributor implements StreamByteDistrib
     /**
      * For testing only!
      */
+    @TestOnly
     int numChildren(int streamId) {
         State state = state(streamId);
         return state == null ? 0 : state.children.size();

--- a/codec/pom.xml
+++ b/codec/pom.xml
@@ -48,6 +48,12 @@
       <artifactId>netty5-transport</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!-- Annotations for IDE integration and analysis -->
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>com.ning</groupId>
       <artifactId>compress-lzf</artifactId>

--- a/codec/src/main/java/io/netty5/handler/codec/base64/Base64.java
+++ b/codec/src/main/java/io/netty5/handler/codec/base64/Base64.java
@@ -22,6 +22,7 @@ package io.netty5.handler.codec.base64;
 import io.netty5.buffer.Buffer;
 import io.netty5.buffer.BufferAllocator;
 import io.netty5.util.ByteProcessor;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import static io.netty5.buffer.DefaultBufferAllocators.offHeapAllocator;
 import static io.netty5.buffer.DefaultBufferAllocators.onHeapAllocator;
@@ -169,6 +170,7 @@ public final class Base64 {
     }
 
     // package-private for testing
+    @VisibleForTesting
     static int encodedBufferSize(int len, boolean breakLines) {
         // Cast len to long to prevent overflow
         long len43 = ((long) len << 2) / 3;
@@ -255,6 +257,7 @@ public final class Base64 {
     }
 
     // package-private for testing
+    @VisibleForTesting
     static int decodedBufferSize(int len) {
         return len - (len >>> 2);
     }

--- a/common/src/main/java/io/netty5/util/NetUtil.java
+++ b/common/src/main/java/io/netty5/util/NetUtil.java
@@ -21,6 +21,7 @@ import io.netty5.util.internal.StringUtil;
 import io.netty5.util.internal.SystemPropertyUtil;
 import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -357,6 +358,7 @@ public final class NetUtil {
     }
 
     // visible for tests
+    @VisibleForTesting
     static byte[] validIpV4ToBytes(String ip) {
         int i;
         return new byte[] {
@@ -705,6 +707,7 @@ public final class NetUtil {
      * @return byte array representation of the {@code ip} or {@code null} if not a valid IP address.
      */
      // visible for test
+    @VisibleForTesting
     static byte[] getIPv6ByName(CharSequence ip, boolean ipv4Mapped) {
         final byte[] bytes = new byte[IPV6_BYTE_COUNT];
         final int ipLength = ip.length();

--- a/common/src/main/java/io/netty5/util/concurrent/GlobalEventExecutor.java
+++ b/common/src/main/java/io/netty5/util/concurrent/GlobalEventExecutor.java
@@ -20,6 +20,7 @@ import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
 import org.jetbrains.annotations.Async.Execute;
 import org.jetbrains.annotations.Async.Schedule;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -58,6 +59,7 @@ public final class GlobalEventExecutor extends AbstractScheduledEventExecutor im
     // can trigger the creation of a thread from arbitrary thread groups; for this reason, the thread factory must not
     // be sticky about its thread group
     // visible for testing
+    @VisibleForTesting
     final ThreadFactory threadFactory;
     private final TaskRunner taskRunner = new TaskRunner();
     private final AtomicBoolean started = new AtomicBoolean();

--- a/common/src/main/java/io/netty5/util/concurrent/UnorderedThreadPoolEventExecutor.java
+++ b/common/src/main/java/io/netty5/util/concurrent/UnorderedThreadPoolEventExecutor.java
@@ -17,6 +17,7 @@ package io.netty5.util.concurrent;
 
 import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
+import org.jetbrains.annotations.TestOnly;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
@@ -162,6 +163,7 @@ public final class UnorderedThreadPoolEventExecutor implements EventExecutor {
      *
      * @return The task queue of this executor.
      */
+    @TestOnly
     BlockingQueue<Runnable> getQueue() {
         return executor.getQueue();
     }

--- a/common/src/main/java/io/netty5/util/internal/MacAddressUtil.java
+++ b/common/src/main/java/io/netty5/util/internal/MacAddressUtil.java
@@ -19,6 +19,7 @@ package io.netty5.util.internal;
 import io.netty5.util.NetUtil;
 import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import java.net.InetAddress;
 import java.net.NetworkInterface;
@@ -207,6 +208,7 @@ public final class MacAddressUtil {
      * @return positive - current is better, 0 - cannot tell from MAC addr, negative - candidate is better.
      */
     // visible for testing
+    @VisibleForTesting
     static int compareAddresses(byte[] current, byte[] candidate) {
         if (candidate == null || candidate.length < EUI48_MAC_ADDRESS_LENGTH) {
             return 1;

--- a/common/src/main/java/io/netty5/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty5/util/internal/PlatformDependent.java
@@ -27,6 +27,7 @@ import org.jctools.queues.atomic.SpscLinkedAtomicQueue;
 import org.jctools.queues.unpadded.SpscLinkedUnpaddedQueue;
 import org.jctools.util.Pow2;
 import org.jctools.util.UnsafeAccess;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -197,7 +198,7 @@ public final class PlatformDependent {
         LINUX_OS_CLASSIFIERS = Collections.unmodifiableSet(availableClassifiers);
     }
 
-    static void addFilesystemOsClassifiers(final Set<String> allowedClassifiers,
+    private static void addFilesystemOsClassifiers(final Set<String> allowedClassifiers,
                                            final Set<String> availableClassifiers) {
         for (final String osReleaseFileName : OS_RELEASE_FILES) {
             final File file = new File(osReleaseFileName);
@@ -240,6 +241,10 @@ public final class PlatformDependent {
         }
     }
 
+    /**
+     * Package private for testing purposes only!
+     */
+    @VisibleForTesting
     static boolean addPropertyOsClassifiers(Set<String> allowedClassifiers, Set<String> availableClassifiers) {
         // empty: -Dio.netty.osClassifiers (no distro specific classifiers for native libs)
         // single ID: -Dio.netty.osClassifiers=ubuntu
@@ -1388,6 +1393,7 @@ public final class PlatformDependent {
     /**
      * Package private for testing purposes only!
      */
+    @VisibleForTesting
     static int hashCodeAsciiSafe(byte[] bytes, int startPos, int length) {
         int hash = HASH_CODE_ASCII_SEED;
         final int remainingBytes = length & 7;

--- a/common/src/main/java/io/netty5/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty5/util/internal/PlatformDependent0.java
@@ -17,6 +17,7 @@ package io.netty5.util.internal;
 
 import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
+import org.jetbrains.annotations.VisibleForTesting;
 import sun.misc.Unsafe;
 
 import java.lang.invoke.MethodHandle;
@@ -870,11 +871,13 @@ final class PlatformDependent0 {
     }
 
     // Package-private for testing only
+    @VisibleForTesting
     static int majorVersionFromJavaSpecificationVersion() {
         return majorVersion(SystemPropertyUtil.get("java.specification.version", "11"));
     }
 
     // Package-private for testing only
+    @VisibleForTesting
     static int majorVersion(final String javaSpecVersion) {
         final String[] components = javaSpecVersion.split("\\.");
         final int[] version = new int[components.length];

--- a/common/src/main/java/io/netty5/util/internal/logging/Slf4JLoggerFactory.java
+++ b/common/src/main/java/io/netty5/util/internal/logging/Slf4JLoggerFactory.java
@@ -16,6 +16,7 @@
 package io.netty5.util.internal.logging;
 
 
+import org.jetbrains.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.helpers.NOPLoggerFactory;
@@ -50,6 +51,7 @@ public class Slf4JLoggerFactory extends InternalLoggerFactory {
     }
 
     // package-private for testing.
+    @VisibleForTesting
     static InternalLogger wrapLogger(Logger logger) {
         return logger instanceof LocationAwareLogger ?
                 new LocationAwareSlf4JLogger((LocationAwareLogger) logger) : new Slf4JLogger(logger);

--- a/handler/pom.xml
+++ b/handler/pom.xml
@@ -74,6 +74,12 @@
       <classifier>${tcnative.classifier}</classifier>
       <optional>true</optional>
     </dependency>
+    <!-- Annotations for IDE integration and analysis -->
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk18on</artifactId>

--- a/handler/src/main/java/io/netty5/handler/ssl/CipherSuiteConverter.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/CipherSuiteConverter.java
@@ -18,6 +18,7 @@ package io.netty5.handler.ssl;
 import io.netty5.util.internal.UnstableApi;
 import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
+import org.jetbrains.annotations.TestOnly;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -122,6 +123,7 @@ public final class CipherSuiteConverter {
     /**
      * Clears the cache for testing purpose.
      */
+    @TestOnly
     static void clearCache() {
         j2o.clear();
         o2j.clear();

--- a/handler/src/main/java/io/netty5/handler/ssl/OpenSslPrivateKey.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/OpenSslPrivateKey.java
@@ -19,6 +19,7 @@ import io.netty.internal.tcnative.SSL;
 import io.netty5.util.AbstractReferenceCounted;
 import io.netty5.util.IllegalReferenceCountException;
 import io.netty5.util.internal.EmptyArrays;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import javax.security.auth.Destroyable;
 import java.security.PrivateKey;
@@ -119,9 +120,11 @@ final class OpenSslPrivateKey extends AbstractReferenceCounted implements Privat
     }
 
     // Package-private for unit-test only
+    @VisibleForTesting
     final class OpenSslPrivateKeyMaterial extends AbstractReferenceCounted implements OpenSslKeyMaterial {
 
         // Package-private for unit-test only
+        @VisibleForTesting
         long certificateChain;
         private final X509Certificate[] x509CertificateChain;
 

--- a/handler/src/main/java/io/netty5/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -34,6 +34,8 @@ import io.netty5.util.internal.StringUtil;
 import io.netty5.util.internal.UnstableApi;
 import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
+import org.jetbrains.annotations.TestOnly;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import javax.crypto.spec.SecretKeySpec;
 import javax.net.ssl.ExtendedSSLSession;
@@ -612,6 +614,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine
     /**
      * Visible only for testing!
      */
+    @TestOnly
     final synchronized int maxWrapOverhead() {
         return maxWrapOverhead;
     }
@@ -619,6 +622,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine
     /**
      * Visible only for testing!
      */
+    @VisibleForTesting
     final synchronized int maxEncryptedPacketLength() {
         return maxEncryptedPacketLength0();
     }

--- a/handler/src/main/java/io/netty5/handler/ssl/util/InsecureTrustManagerFactory.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/util/InsecureTrustManagerFactory.java
@@ -18,6 +18,7 @@ package io.netty5.handler.ssl.util;
 import io.netty5.util.internal.EmptyArrays;
 import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
+import org.jetbrains.annotations.TestOnly;
 
 import javax.net.ssl.ManagerFactoryParameters;
 import javax.net.ssl.TrustManager;
@@ -34,6 +35,7 @@ import java.security.cert.X509Certificate;
  * It is purely for testing purposes, and thus it is very insecure.
  * </p>
  */
+@TestOnly
 public final class InsecureTrustManagerFactory extends SimpleTrustManagerFactory {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(InsecureTrustManagerFactory.class);

--- a/handler/src/main/java/io/netty5/handler/ssl/util/SelfSignedCertificate.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/util/SelfSignedCertificate.java
@@ -21,6 +21,7 @@ import io.netty5.util.internal.PlatformDependent;
 import io.netty5.util.internal.SystemPropertyUtil;
 import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
+import org.jetbrains.annotations.TestOnly;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -57,6 +58,7 @@ import static java.nio.charset.StandardCharsets.US_ASCII;
  * <em>optional</em> dependency of Netty.
  * </p>
  */
+@TestOnly
 public final class SelfSignedCertificate {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(SelfSignedCertificate.class);

--- a/handler/src/main/java/io/netty5/handler/timeout/IdleStateHandler.java
+++ b/handler/src/main/java/io/netty5/handler/timeout/IdleStateHandler.java
@@ -22,6 +22,7 @@ import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelInitializer;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.FutureListener;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import java.util.concurrent.TimeUnit;
 
@@ -308,6 +309,7 @@ public class IdleStateHandler implements ChannelHandler {
     /**
      * This method is visible for testing!
      */
+    @VisibleForTesting
     long ticksInNanos() {
         return System.nanoTime();
     }
@@ -315,6 +317,7 @@ public class IdleStateHandler implements ChannelHandler {
     /**
      * This method is visible for testing!
      */
+    @VisibleForTesting
     Future<?> schedule(ChannelHandlerContext ctx, Runnable task, long delay, TimeUnit unit) {
         return ctx.executor().schedule(task, delay, unit);
     }

--- a/license/LICENSE.annotations.txt
+++ b/license/LICENSE.annotations.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/resolver-dns/pom.xml
+++ b/resolver-dns/pom.xml
@@ -68,6 +68,12 @@
       <artifactId>netty5-handler</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!-- Annotations for IDE integration and analysis -->
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>org.apache.directory.server</groupId>
       <artifactId>apacheds-protocol-dns</artifactId>

--- a/resolver-dns/src/main/java/io/netty5/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty5/resolver/dns/DnsResolveContext.java
@@ -40,6 +40,7 @@ import io.netty5.util.internal.StringUtil;
 import io.netty5.util.internal.ThrowableUtil;
 import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -281,6 +282,7 @@ abstract class DnsResolveContext<T> {
     // guards against loops in the cache but early return once a loop is detected.
     //
     // Visible for testing only
+    @VisibleForTesting
     static String cnameResolveFromCache(DnsCnameCache cnameCache, String name) throws UnknownHostException {
         String first = cnameCache.get(hostnameWithDot(name));
         if (first == null) {

--- a/resolver/pom.xml
+++ b/resolver/pom.xml
@@ -38,6 +38,12 @@
       <artifactId>netty5-common</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!-- Annotations for IDE integration and analysis -->
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>

--- a/resolver/src/main/java/io/netty5/resolver/DefaultHostsFileEntriesResolver.java
+++ b/resolver/src/main/java/io/netty5/resolver/DefaultHostsFileEntriesResolver.java
@@ -20,6 +20,7 @@ import io.netty5.util.internal.PlatformDependent;
 import io.netty5.util.internal.SystemPropertyUtil;
 import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import java.net.InetAddress;
 import java.nio.charset.Charset;
@@ -59,6 +60,7 @@ public final class DefaultHostsFileEntriesResolver implements HostsFileEntriesRe
     }
 
     // for testing purpose only
+    @VisibleForTesting
     DefaultHostsFileEntriesResolver(HostsFileEntriesProvider.Parser hostsFileParser, long refreshInterval) {
         this.hostsFileParser = hostsFileParser;
         this.refreshInterval = ObjectUtil.checkPositiveOrZero(refreshInterval, "refreshInterval");
@@ -119,6 +121,7 @@ public final class DefaultHostsFileEntriesResolver implements HostsFileEntriesRe
     }
 
     // package-private for testing purposes
+    @VisibleForTesting
     String normalize(String inetHost) {
         return inetHost.toLowerCase(Locale.ENGLISH);
     }

--- a/transport-classes-epoll/pom.xml
+++ b/transport-classes-epoll/pom.xml
@@ -51,6 +51,12 @@
       <artifactId>netty5-transport-native-unix-common</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!-- Annotations for IDE integration and analysis -->
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
 

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollHandler.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollHandler.java
@@ -31,6 +31,7 @@ import io.netty5.util.internal.StringUtil;
 import io.netty5.util.internal.SystemPropertyUtil;
 import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -104,6 +105,7 @@ public class EpollHandler implements IoHandler {
     }
 
     // Package-private for tests.
+    @VisibleForTesting
     EpollHandler(int maxEvents, SelectStrategy strategy) {
         selectStrategy = strategy;
         if (maxEvents == 0) {
@@ -387,6 +389,7 @@ public class EpollHandler implements IoHandler {
     /**
      * Visible only for testing!
      */
+    @VisibleForTesting
     void handleLoopException(Throwable t) {
         logger.warn("Unexpected exception in the selector loop.", t);
 


### PR DESCRIPTION
Motivation:

Start to use `@VisibleForTesting` in Netty 5 to make it easier to users to understand what to expect.

Modification:

Applied `@VisibleForTesting`

Added Notice

Result:

Better code readability & IDE support