### PR TITLE
Fix test flakiness of Http2FrameCodecTest

### DIFF
--- a/common/src/main/java/io/netty5/util/concurrent/ImmediateEventExecutor.java
+++ b/common/src/main/java/io/netty5/util/concurrent/ImmediateEventExecutor.java
@@ -65,6 +65,14 @@ public final class ImmediateEventExecutor extends AbstractEventExecutor {
     }
 
     @Override
+    public <V> Future<V> newSucceededFuture(V result) {
+        // Always return a new future instance, instead of using the shared one from AbstractEventExecutor.
+        // We do not know how widely shared the ImmediateEventExecutor instance is, and we cannot know if,
+        // in tests for instance, our callers can tolerate running each other's listeners.
+        return DefaultPromise.newSuccessfulPromise(this, result).asFuture();
+    }
+
+    @Override
     public Future<Void> shutdownGracefully(long quietPeriod, long timeout, TimeUnit unit) {
         return terminationFuture();
     }


### PR DESCRIPTION
Motivation:
Tests that fail randomly for no obvious reason are a drain on our progress.

Modification:

1.
Make the Http2FrameCodecTest only run its setup once. This simplifies debugging and makes the test run faster by an imperceptible amount.

2.
Finally, fix a test isolation failure identified in the ImmediateEventExecutor. It turns out the AbstractEventExecutor has a single, cached, instance of a successful future. Normally not an issue, but when listeners are added to it, they are actually added, and _then_ all listeners are notified on the future. For the immediate event executor, of which there is only a single instance, it means that all tests that use it, and run concurrently, can end up notifying listeners for each other. And some of these listeners can end up calling back into their EmbeddedEventLoops, thereby causing concurrent access to a single-threaded data structure. To fix this, the ImmediateEventExecutor now always returns a new instance whenever it is asked for a successful future. Doing so fixes the test isolation failures, without compromising the performance benefits intended by the abstractEventExecutor.

Result:
The Http2FrameCodecTest, and likely a number of other tests, now run more stably.