### PR TITLE
Remove the LoggerFactories' public constructors

### DIFF
--- a/common/src/main/java/io/netty5/util/internal/logging/JdkLoggerFactory.java
+++ b/common/src/main/java/io/netty5/util/internal/logging/JdkLoggerFactory.java
@@ -23,15 +23,11 @@ import java.util.logging.Logger;
  * <a href="https://docs.oracle.com/javase/7/docs/technotes/guides/logging/">java.util.logging</a>
  * logger.
  */
-public class JdkLoggerFactory extends InternalLoggerFactory {
+public final class JdkLoggerFactory extends InternalLoggerFactory {
 
     public static final InternalLoggerFactory INSTANCE = new JdkLoggerFactory();
 
-    /**
-     * @deprecated Use {@link #INSTANCE} instead.
-     */
-    @Deprecated
-    public JdkLoggerFactory() {
+    private JdkLoggerFactory() {
     }
 
     @Override

--- a/common/src/main/java/io/netty5/util/internal/logging/Log4J2LoggerFactory.java
+++ b/common/src/main/java/io/netty5/util/internal/logging/Log4J2LoggerFactory.java
@@ -21,11 +21,7 @@ public final class Log4J2LoggerFactory extends InternalLoggerFactory {
 
     public static final InternalLoggerFactory INSTANCE = new Log4J2LoggerFactory();
 
-    /**
-     * @deprecated Use {@link #INSTANCE} instead.
-     */
-    @Deprecated
-    public Log4J2LoggerFactory() {
+    private Log4J2LoggerFactory() {
     }
 
     @Override

--- a/common/src/main/java/io/netty5/util/internal/logging/Slf4JLoggerFactory.java
+++ b/common/src/main/java/io/netty5/util/internal/logging/Slf4JLoggerFactory.java
@@ -26,19 +26,14 @@ import org.slf4j.spi.LocationAwareLogger;
  * Logger factory which creates a <a href="https://www.slf4j.org/">SLF4J</a>
  * logger.
  */
-public class Slf4JLoggerFactory extends InternalLoggerFactory {
+public final class Slf4JLoggerFactory extends InternalLoggerFactory {
 
-    @SuppressWarnings("deprecation")
     public static final InternalLoggerFactory INSTANCE = new Slf4JLoggerFactory();
 
-    /**
-     * @deprecated Use {@link #INSTANCE} instead.
-     */
-    @Deprecated
-    public Slf4JLoggerFactory() {
+    private Slf4JLoggerFactory() {
     }
 
-    Slf4JLoggerFactory(boolean failIfNOP) {
+    private Slf4JLoggerFactory(boolean failIfNOP) {
         assert failIfNOP; // Should be always called with true.
         if (LoggerFactory.getILoggerFactory() instanceof NOPLoggerFactory) {
             throw new NoClassDefFoundError("NOPLoggerFactory not supported");


### PR DESCRIPTION
Motivation:

The public constructors in LoggerFactories were deprecated since 2016. (discussions #5047)

Now is good time to remove deprecated public constructors

Modification:

Removed deprecated public constructors

Result:

Cleanup