### PR TITLE
fix(sec): upgrade com.google.protobuf:protobuf-java to 3.16.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,7 @@
   ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
   ~ License for the specific language governing permissions and limitations
   ~ under the License.
-  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
@@ -178,7 +177,7 @@
       <properties>
         <skipNativeImageTestsuite>false</skipNativeImageTestsuite>
         <forbiddenapis.skip>true</forbiddenapis.skip>
-        <testJvm />
+        <testJvm/>
       </properties>
     </profile>
     <profile>
@@ -188,8 +187,8 @@
       </activation>
       <properties>
         <!-- Not use alpn agent as Java11+ supports alpn out of the box -->
-        <argLine.alpnAgent />
-        <argLine.java9.extras />
+        <argLine.alpnAgent/>
+        <argLine.java9.extras/>
         <!-- Export some stuff which is used during our tests -->
         <argLine.java9>--illegal-access=deny ${argLine.java9.extras}</argLine.java9>
         <forbiddenapis.skip>true</forbiddenapis.skip>
@@ -210,8 +209,8 @@
       </activation>
       <properties>
         <!-- Not use alpn agent as Java11+ supports alpn out of the box -->
-        <argLine.alpnAgent />
-        <argLine.java9.extras />
+        <argLine.alpnAgent/>
+        <argLine.java9.extras/>
         <!-- Export some stuff which is used during our tests -->
         <argLine.java9>--illegal-access=deny ${argLine.java9.extras}</argLine.java9>
         <forbiddenapis.skip>true</forbiddenapis.skip>
@@ -233,8 +232,8 @@
       </activation>
       <properties>
         <!-- Not use alpn agent as Java11+ supports alpn out of the box -->
-        <argLine.alpnAgent />
-        <argLine.java9.extras />
+        <argLine.alpnAgent/>
+        <argLine.java9.extras/>
         <!-- Export some stuff which is used during our tests -->
         <argLine.java9>--illegal-access=deny ${argLine.java9.extras}</argLine.java9>
         <forbiddenapis.skip>true</forbiddenapis.skip>
@@ -255,11 +254,11 @@
         <jdk>15</jdk>
       </activation>
       <properties>
-        <argLine.java9.extras />
+        <argLine.java9.extras/>
         <!-- Export some stuff which is used during our tests -->
         <argLine.java9>--illegal-access=deny ${argLine.java9.extras}</argLine.java9>
         <!-- Not use alpn agent as Java11+ supports alpn out of the box -->
-        <argLine.alpnAgent />
+        <argLine.alpnAgent/>
         <forbiddenapis.skip>true</forbiddenapis.skip>
         <!-- 1.4.x does not work in Java10+ -->
         <jboss.marshalling.version>2.0.5.Final</jboss.marshalling.version>
@@ -277,11 +276,11 @@
         <jdk>14</jdk>
       </activation>
       <properties>
-        <argLine.java9.extras />
+        <argLine.java9.extras/>
         <!-- Export some stuff which is used during our tests -->
         <argLine.java9>--illegal-access=deny ${argLine.java9.extras}</argLine.java9>
         <!-- Not use alpn agent as Java11+ supports alpn out of the box -->
-        <argLine.alpnAgent />
+        <argLine.alpnAgent/>
         <forbiddenapis.skip>true</forbiddenapis.skip>
         <!-- 1.4.x does not work in Java10+ -->
         <jboss.marshalling.version>2.0.5.Final</jboss.marshalling.version>
@@ -299,11 +298,11 @@
         <jdk>13</jdk>
       </activation>
       <properties>
-        <argLine.java9.extras />
+        <argLine.java9.extras/>
         <!-- Export some stuff which is used during our tests -->
         <argLine.java9>--illegal-access=deny ${argLine.java9.extras}</argLine.java9>
         <!-- Not use alpn agent as Java11+ supports alpn out of the box -->
-        <argLine.alpnAgent />
+        <argLine.alpnAgent/>
         <forbiddenapis.skip>true</forbiddenapis.skip>
         <!-- 1.4.x does not work in Java10+ -->
         <jboss.marshalling.version>2.0.5.Final</jboss.marshalling.version>
@@ -322,11 +321,11 @@
         <jdk>12</jdk>
       </activation>
       <properties>
-        <argLine.java9.extras />
+        <argLine.java9.extras/>
         <!-- Export some stuff which is used during our tests -->
         <argLine.java9>--illegal-access=deny ${argLine.java9.extras}</argLine.java9>
         <!-- Not use alpn agent as Java11+ supports alpn out of the box -->
-        <argLine.alpnAgent />
+        <argLine.alpnAgent/>
         <forbiddenapis.skip>true</forbiddenapis.skip>
         <!-- 1.4.x does not work in Java10+ -->
         <jboss.marshalling.version>2.0.5.Final</jboss.marshalling.version>
@@ -345,11 +344,11 @@
         <jdk>11</jdk>
       </activation>
       <properties>
-        <argLine.java9.extras />
+        <argLine.java9.extras/>
         <!-- Export some stuff which is used during our tests -->
         <argLine.java9>--illegal-access=deny ${argLine.java9.extras}</argLine.java9>
         <!-- Not use alpn agent as Java11+ supports alpn out of the box -->
-        <argLine.alpnAgent />
+        <argLine.alpnAgent/>
         <forbiddenapis.skip>true</forbiddenapis.skip>
         <!-- 1.4.x does not work in Java10+ -->
         <jboss.marshalling.version>2.0.5.Final</jboss.marshalling.version>
@@ -365,11 +364,11 @@
         <jdk>10</jdk>
       </activation>
       <properties>
-        <argLine.java9.extras />
+        <argLine.java9.extras/>
         <!-- Export some stuff which is used during our tests -->
         <argLine.java9>--illegal-access=deny --add-modules java.xml.bind ${argLine.java9.extras}</argLine.java9>
         <!-- Not use alpn agent as Java10 supports alpn out of the box -->
-        <argLine.alpnAgent />
+        <argLine.alpnAgent/>
         <forbiddenapis.skip>true</forbiddenapis.skip>
         <!-- Needed because of https://issues.apache.org/jira/browse/MENFORCER-275 -->
         <enforcer.plugin.version>3.0.0-M3</enforcer.plugin.version>
@@ -382,11 +381,11 @@
     <profile>
       <id>java9</id>
       <properties>
-        <argLine.java9.extras />
+        <argLine.java9.extras/>
         <!-- Export some stuff which is used during our tests -->
         <argLine.java9>--illegal-access=deny --add-modules java.xml.bind ${argLine.java9.extras}</argLine.java9>
         <!-- Not use alpn agent as Java9 supports alpn out of the box -->
-        <argLine.alpnAgent />
+        <argLine.alpnAgent/>
         <!-- Skip as maven plugin not works with Java9 yet -->
         <forbiddenapis.skip>true</forbiddenapis.skip>
         <!-- Needed because of https://issues.apache.org/jira/browse/MENFORCER-275 -->
@@ -411,7 +410,7 @@
       </activation>
       <properties>
         <tcnative.artifactId>netty-tcnative-boringssl-static</tcnative.artifactId>
-        <tcnative.classifier />
+        <tcnative.classifier/>
       </properties>
     </profile>
     <profile>
@@ -428,7 +427,7 @@
       </activation>
       <properties>
         <tcnative.artifactId>netty-tcnative-boringssl-static</tcnative.artifactId>
-        <tcnative.classifier />
+        <tcnative.classifier/>
       </properties>
     </profile>
     <profile>
@@ -444,7 +443,7 @@
       </activation>
       <properties>
         <tcnative.artifactId>netty-tcnative-boringssl-static</tcnative.artifactId>
-        <tcnative.classifier />
+        <tcnative.classifier/>
       </properties>
     </profile>
     <profile>
@@ -558,7 +557,7 @@
     <argLine.noUnsafe>-D_</argLine.noUnsafe> <!-- Overridden when 'noUnsafe' profile is active -->
     <argLine.coverage>-D_</argLine.coverage> <!-- Overridden when 'coverage' profile is active -->
     <argLine.printGC>-XX:+PrintGCDetails</argLine.printGC>
-    <argLine.java9 /> <!-- Overridden when 'java9' profile is active -->
+    <argLine.java9/> <!-- Overridden when 'java9' profile is active -->
     <argLine.javaProperties>-D_</argLine.javaProperties>
     <!-- Configure the os-maven-plugin extension to expand the classifier on                  -->
     <!-- Fedora-"like" systems. This is currently only used for the netty-tcnative dependency -->
@@ -572,7 +571,7 @@
     <conscrypt.groupId>org.conscrypt</conscrypt.groupId>
     <conscrypt.artifactId>conscrypt-openjdk-uber</conscrypt.artifactId>
     <conscrypt.version>2.5.2</conscrypt.version>
-    <conscrypt.classifier />
+    <conscrypt.classifier/>
     <jni.classifier>${os.detected.name}-${os.detected.arch}</jni.classifier>
     <logging.config>${project.basedir}/../common/src/test/resources/logback-test.xml</logging.config>
     <logging.logLevel>debug</logging.logLevel>
@@ -691,7 +690,7 @@
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>
-        <version>2.6.1</version>
+        <version>3.16.1</version>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf.nano</groupId>
@@ -1582,39 +1581,39 @@
             </goals>
             <configuration>
               <target>
-                <taskdef resource="net/sf/antcontrib/antlib.xml" />
+                <taskdef resource="net/sf/antcontrib/antlib.xml"/>
 
                 <!-- Get the information about the latest commit -->
                 <exec executable="git" outputproperty="gitOutput.lastCommit" resultproperty="gitExitCode.lastCommit" failonerror="false" failifexecutionfails="false">
-                  <arg value="log" />
-                  <arg value="-1" />
-                  <arg value="--format=format:%h %H %cd" />
-                  <arg value="--date=iso" />
+                  <arg value="log"/>
+                  <arg value="-1"/>
+                  <arg value="--format=format:%h %H %cd"/>
+                  <arg value="--date=iso"/>
                 </exec>
-                <propertyregex property="shortCommitHash" input="${gitOutput.lastCommit}" regexp="^([0-9a-f]+) .*$" select="\1" casesensitive="true" defaultValue="0" />
-                <propertyregex property="longCommitHash" input="${gitOutput.lastCommit}" regexp="^[0-9a-f]+ ([0-9a-f]{40}) .*$" select="\1" casesensitive="true" defaultValue="0000000000000000000000000000000000000000" />
-                <propertyregex property="commitDate" input="${gitOutput.lastCommit}" regexp="^[0-9a-f]+ [0-9a-f]{40} (.*)$" select="\1" casesensitive="true" defaultValue="1970-01-01 00:00:00 +0000" />
+                <propertyregex property="shortCommitHash" input="${gitOutput.lastCommit}" regexp="^([0-9a-f]+) .*$" select="\1" casesensitive="true" defaultValue="0"/>
+                <propertyregex property="longCommitHash" input="${gitOutput.lastCommit}" regexp="^[0-9a-f]+ ([0-9a-f]{40}) .*$" select="\1" casesensitive="true" defaultValue="0000000000000000000000000000000000000000"/>
+                <propertyregex property="commitDate" input="${gitOutput.lastCommit}" regexp="^[0-9a-f]+ [0-9a-f]{40} (.*)$" select="\1" casesensitive="true" defaultValue="1970-01-01 00:00:00 +0000"/>
 
                 <!-- Get the information abount whether the repository is clean or dirty -->
                 <exec executable="git" outputproperty="gitOutput.repoStatus" resultproperty="gitExitCode.repoStatus" failonerror="false" failifexecutionfails="false">
-                  <arg value="status" />
-                  <arg value="--porcelain" />
+                  <arg value="status"/>
+                  <arg value="--porcelain"/>
                 </exec>
                 <if>
-                  <equals arg2="0" arg1="${gitExitCode.repoStatus}" />
+                  <equals arg2="0" arg1="${gitExitCode.repoStatus}"/>
                   <then>
                     <if>
-                      <equals arg2="" arg1="${gitOutput.repoStatus}" />
+                      <equals arg2="" arg1="${gitOutput.repoStatus}"/>
                       <then>
-                        <property name="repoStatus" value="clean" />
+                        <property name="repoStatus" value="clean"/>
                       </then>
                       <else>
-                        <property name="repoStatus" value="dirty" />
+                        <property name="repoStatus" value="dirty"/>
                       </else>
                     </if>
                   </then>
                   <else>
-                    <property name="repoStatus" value="unknown" />
+                    <property name="repoStatus" value="unknown"/>
                   </else>
                 </if>
 
@@ -1625,18 +1624,18 @@
                 <!--
                 <property name="metaInfDir" value="${project.basedir}/src/main/resources/META-INF" />
                 -->
-                <property name="metaInfDir" value="${project.build.outputDirectory}/META-INF" />
-                <property name="versionPropFile" value="${metaInfDir}/${project.groupId}.versions.properties" />
-                <mkdir dir="${metaInfDir}" />
-                <delete file="${versionPropFile}" quiet="true" />
+                <property name="metaInfDir" value="${project.build.outputDirectory}/META-INF"/>
+                <property name="versionPropFile" value="${metaInfDir}/${project.groupId}.versions.properties"/>
+                <mkdir dir="${metaInfDir}"/>
+                <delete file="${versionPropFile}" quiet="true"/>
 
                 <propertyfile file="${versionPropFile}" comment="Generated by netty-parent/pom.xml">
-                  <entry key="${project.artifactId}.version" value="${project.version}" />
-                  <entry key="${project.artifactId}.buildDate" type="date" value="now" pattern="yyyy-MM-dd HH:mm:ss Z" />
-                  <entry key="${project.artifactId}.commitDate" value="${commitDate}" />
-                  <entry key="${project.artifactId}.shortCommitHash" value="${shortCommitHash}" />
-                  <entry key="${project.artifactId}.longCommitHash" value="${longCommitHash}" />
-                  <entry key="${project.artifactId}.repoStatus" value="${repoStatus}" />
+                  <entry key="${project.artifactId}.version" value="${project.version}"/>
+                  <entry key="${project.artifactId}.buildDate" type="date" value="now" pattern="yyyy-MM-dd HH:mm:ss Z"/>
+                  <entry key="${project.artifactId}.commitDate" value="${commitDate}"/>
+                  <entry key="${project.artifactId}.shortCommitHash" value="${shortCommitHash}"/>
+                  <entry key="${project.artifactId}.longCommitHash" value="${longCommitHash}"/>
+                  <entry key="${project.artifactId}.repoStatus" value="${repoStatus}"/>
                 </propertyfile>
               </target>
             </configuration>
@@ -1829,7 +1828,7 @@
                     </goals>
                   </pluginExecutionFilter>
                   <action>
-                    <ignore />
+                    <ignore/>
                   </action>
                 </pluginExecution>
                 <pluginExecution>
@@ -1842,7 +1841,7 @@
                     </goals>
                   </pluginExecutionFilter>
                   <action>
-                    <ignore />
+                    <ignore/>
                   </action>
                 </pluginExecution>
                 <pluginExecution>
@@ -1855,7 +1854,7 @@
                     </goals>
                   </pluginExecutionFilter>
                   <action>
-                    <ignore />
+                    <ignore/>
                   </action>
                 </pluginExecution>
                 <pluginExecution>
@@ -1868,7 +1867,7 @@
                     </goals>
                   </pluginExecutionFilter>
                   <action>
-                    <ignore />
+                    <ignore/>
                   </action>
                 </pluginExecution>
                 <pluginExecution>
@@ -1881,7 +1880,7 @@
                     </goals>
                   </pluginExecutionFilter>
                   <action>
-                    <ignore />
+                    <ignore/>
                   </action>
                 </pluginExecution>
                 <pluginExecution>
@@ -1895,7 +1894,7 @@
                     </goals>
                   </pluginExecutionFilter>
                   <action>
-                    <ignore />
+                    <ignore/>
                   </action>
                 </pluginExecution>
                 <pluginExecution>
@@ -1910,7 +1909,7 @@
                     </goals>
                   </pluginExecutionFilter>
                   <action>
-                    <ignore />
+                    <ignore/>
                   </action>
                 </pluginExecution>
               </pluginExecutions>


### PR DESCRIPTION
### What happened？
There are 2 security vulnerabilities found in com.google.protobuf:protobuf-java 2.6.1
- [CVE-2015-5237](https://www.oscs1024.com/hd/CVE-2015-5237)
- [CVE-2021-22569](https://www.oscs1024.com/hd/CVE-2021-22569)


### What did I do？
Upgrade com.google.protobuf:protobuf-java from 2.6.1 to 3.16.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS