### PR TITLE
remove Recycler deprecated methods

### DIFF
--- a/common/src/main/java/io/netty5/util/Recycler.java
+++ b/common/src/main/java/io/netty5/util/Recycler.java
@@ -116,38 +116,6 @@ public abstract class Recycler<T> {
         this(maxCapacityPerThread, RATIO, DEFAULT_QUEUE_CHUNK_SIZE_PER_THREAD);
     }
 
-    /**
-     * @deprecated Use one of the following instead:
-     * {@link #Recycler()}, {@link #Recycler(int)}, {@link #Recycler(int, int, int)}.
-     */
-    @Deprecated
-    @SuppressWarnings("unused") // Parameters we can't remove due to compatibility.
-    protected Recycler(int maxCapacityPerThread, int maxSharedCapacityFactor) {
-        this(maxCapacityPerThread, RATIO, DEFAULT_QUEUE_CHUNK_SIZE_PER_THREAD);
-    }
-
-    /**
-     * @deprecated Use one of the following instead:
-     * {@link #Recycler()}, {@link #Recycler(int)}, {@link #Recycler(int, int, int)}.
-     */
-    @Deprecated
-    @SuppressWarnings("unused") // Parameters we can't remove due to compatibility.
-    protected Recycler(int maxCapacityPerThread, int maxSharedCapacityFactor,
-                       int ratio, int maxDelayedQueuesPerThread) {
-        this(maxCapacityPerThread, ratio, DEFAULT_QUEUE_CHUNK_SIZE_PER_THREAD);
-    }
-
-    /**
-     * @deprecated Use one of the following instead:
-     * {@link #Recycler()}, {@link #Recycler(int)}, {@link #Recycler(int, int, int)}.
-     */
-    @Deprecated
-    @SuppressWarnings("unused") // Parameters we can't remove due to compatibility.
-    protected Recycler(int maxCapacityPerThread, int maxSharedCapacityFactor,
-                       int ratio, int maxDelayedQueuesPerThread, int delayedQueueRatio) {
-        this(maxCapacityPerThread, ratio, DEFAULT_QUEUE_CHUNK_SIZE_PER_THREAD);
-    }
-
     protected Recycler(int maxCapacityPerThread, int ratio, int chunkSize) {
         interval = max(0, ratio);
         if (maxCapacityPerThread <= 0) {
@@ -180,19 +148,6 @@ public abstract class Recycler<T> {
         }
 
         return obj;
-    }
-
-    /**
-     * @deprecated use {@link Handle#recycle(Object)}.
-     */
-    @Deprecated
-    public final boolean recycle(T o, Handle<T> handle) {
-        if (handle == NOOP_HANDLE) {
-            return false;
-        }
-
-        handle.recycle(o);
-        return true;
     }
 
     final int threadLocalSize() {


### PR DESCRIPTION
Motivation:

Some methods in `Recycler` have been marked deprecated since [#11858](https://github.com/netty/netty/pull/11858). Now they are not used any more. Maybe it's a good time to drop them in Netty 5.

Modification:

Remove some unused deprecated methods in `Recycler`.

Result:

Clean up work
