### PR TITLE
Make 'cache = null' to help PoolThreadCache GC finalizer in PoolByteBuf.

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
@@ -176,6 +176,7 @@ abstract class PooledByteBuf<T> extends AbstractReferenceCountedByteBuf {
             chunk.arena.free(chunk, tmpNioBuf, handle, maxLength, cache);
             tmpNioBuf = null;
             chunk = null;
+            cache = null;
             recycle();
         }
     }


### PR DESCRIPTION
Motivation:
PoolByteBuf deallocate not make `cache = null`, and recycle PoolByteBuf, so the PollThreadCache is always reachable by GC root. It is reachable until the cache is overridden at the next init.


