### PR TITLE
Optimize method 'io.netty.util.Recycler.DefaultHandle.availableToClaim()'

### DIFF
--- a/common/src/main/java/io/netty/util/Recycler.java
+++ b/common/src/main/java/io/netty/util/Recycler.java
@@ -68,7 +68,7 @@ public abstract class Recycler<T> {
         DEFAULT_MAX_CAPACITY_PER_THREAD = maxCapacityPerThread;
         DEFAULT_QUEUE_CHUNK_SIZE_PER_THREAD = SystemPropertyUtil.getInt("io.netty.recycler.chunkSize", 32);
 
-        // By default we allow one push to a Recycler for each 8th try on handles that were never recycled before.
+        // By default, we allow one push to a Recycler for each 8th try on handles that were never recycled before.
         // This should help to slowly increase the capacity of the recycler while not be too sensitive to allocation
         // bursts.
         RATIO = max(0, SystemPropertyUtil.getInt("io.netty.recycler.ratio", 8));
@@ -214,7 +214,6 @@ public abstract class Recycler<T> {
             STATE_UPDATER = (AtomicIntegerFieldUpdater<DefaultHandle<?>>) updater;
         }
 
-        @SuppressWarnings({"FieldMayBeFinal", "unused"}) // Updated by STATE_UPDATER.
         private volatile int state; // State is initialised to STATE_CLAIMED (aka. 0) so they can be released.
         private final LocalPool<T> localPool;
         private T value;
@@ -242,8 +241,10 @@ public abstract class Recycler<T> {
         boolean availableToClaim() {
             if (state != STATE_AVAILABLE) {
                 return false;
+            } else {
+                state = STATE_CLAIMED;
+                return true;
             }
-            return STATE_UPDATER.compareAndSet(this, STATE_AVAILABLE, STATE_CLAIMED);
         }
 
         void toAvailable() {


### PR DESCRIPTION
Motivation:

The method `io.netty.util.Recycler.DefaultHandle.availableToClaim()` is in the scope of `ThreadLocal`, seems there is no race condition, IMHO we can assign value to `state` directly, instead of using `STATE_UPDATER`.

Modification:

Assign value directly to `state`.

Result:

Assign value directly to `state`.
