### PR TITLE
Fix scalability issue of ByteToMessageDecoder sub-classes that also i…

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
@@ -20,6 +20,7 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelConfig;
+import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.socket.ChannelInputShutdownEvent;
@@ -73,7 +74,7 @@ import static java.lang.Integer.MAX_VALUE;
  * is not released or added to the <tt>out</tt> {@link List}. Use derived buffers like {@link ByteBuf#readSlice(int)}
  * to avoid leaking memory.
  */
-public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter {
+public abstract class ByteToMessageDecoder extends ChannelDuplexHandler {
 
     /**
      * Cumulate {@link ByteBuf}s by merge them into one {@link ByteBuf}'s, using memory copies.

--- a/pom.xml
+++ b/pom.xml
@@ -1175,7 +1175,7 @@
                   <justification>Acceptable incompatibility for required change</justification>
                 </item>
 
-
+                <!-- Necessary changes to fix Scalability problems of SslHandler related to false-sharing within the JDK -->
                 <item>
                   <ignore>true</ignore>
                   <code>java.class.nonFinalClassInheritsFromNewClass</code>
@@ -1342,6 +1342,366 @@
                   <code>java.class.nonFinalClassInheritsFromNewClass</code>
                   <old>class io.netty.handler.codec.xml.XmlFrameDecoder</old>
                   <new>class io.netty.handler.codec.xml.XmlFrameDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.haproxy.HAProxyMessageDecoder</old>
+                  <new>class io.netty.handler.codec.haproxy.HAProxyMessageDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.ssl.AbstractSniHandler&lt;T&gt;</old>
+                  <new>class io.netty.handler.ssl.AbstractSniHandler&lt;T&gt;</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.ssl.OptionalSslHandler</old>
+                  <new>class io.netty.handler.ssl.OptionalSslHandler</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.ssl.SniHandler</old>
+                  <new>class io.netty.handler.ssl.SniHandler</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.ssl.SslClientHelloHandler&lt;T&gt;</old>
+                  <new>class io.netty.handler.ssl.SslClientHelloHandler&lt;T&gt;</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.ssl.SslHandler</old>
+                  <new>class io.netty.handler.ssl.SslHandler</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.http.HttpObjectDecoder</old>
+                  <new>class io.netty.handler.codec.http.HttpObjectDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.http.HttpRequestDecoder</old>
+                  <new>class io.netty.handler.codec.http.HttpRequestDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.http.HttpResponseDecoder</old>
+                  <new>class io.netty.handler.codec.http.HttpResponseDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.http.websocketx.WebSocket00FrameDecoder</old>
+                  <new>class io.netty.handler.codec.http.websocketx.WebSocket00FrameDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.http.websocketx.WebSocket07FrameDecoder</old>
+                  <new>class io.netty.handler.codec.http.websocketx.WebSocket07FrameDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.http.websocketx.WebSocket08FrameDecoder</old>
+                  <new>class io.netty.handler.codec.http.websocketx.WebSocket08FrameDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.http.websocketx.WebSocket13FrameDecoder</old>
+                  <new>class io.netty.handler.codec.http.websocketx.WebSocket13FrameDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.rtsp.RtspDecoder</old>
+                  <new>class io.netty.handler.codec.rtsp.RtspDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.rtsp.RtspObjectDecoder</old>
+                  <new>class io.netty.handler.codec.rtsp.RtspObjectDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.rtsp.RtspRequestDecoder</old>
+                  <new>class io.netty.handler.codec.rtsp.RtspRequestDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.rtsp.RtspResponseDecoder</old>
+                  <new>class io.netty.handler.codec.rtsp.RtspResponseDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.spdy.SpdyFrameCodec</old>
+                  <new>class io.netty.handler.codec.spdy.SpdyFrameCodec</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.http2.Http2ConnectionHandler</old>
+                  <new>class io.netty.handler.codec.http2.Http2ConnectionHandler</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.http2.Http2FrameCodec</old>
+                  <new>class io.netty.handler.codec.http2.Http2FrameCodec</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.http2.Http2MultiplexCodec</old>
+                  <new>class io.netty.handler.codec.http2.Http2MultiplexCodec</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.http2.HttpToHttp2ConnectionHandler</old>
+                  <new>class io.netty.handler.codec.http2.HttpToHttp2ConnectionHandler</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.memcache.AbstractMemcacheObjectDecoder</old>
+                  <new>class io.netty.handler.codec.memcache.AbstractMemcacheObjectDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.memcache.binary.AbstractBinaryMemcacheDecoder&lt;M extends io.netty.handler.codec.memcache.binary.BinaryMemcacheMessage&gt;</old>
+                  <new>class io.netty.handler.codec.memcache.binary.AbstractBinaryMemcacheDecoder&lt;M extends io.netty.handler.codec.memcache.binary.BinaryMemcacheMessage&gt;</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.memcache.binary.BinaryMemcacheRequestDecoder</old>
+                  <new>class io.netty.handler.codec.memcache.binary.BinaryMemcacheRequestDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.memcache.binary.BinaryMemcacheResponseDecoder</old>
+                  <new>class io.netty.handler.codec.memcache.binary.BinaryMemcacheResponseDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.socks.SocksAuthRequestDecoder</old>
+                  <new>class io.netty.handler.codec.socks.SocksAuthRequestDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.socks.SocksAuthResponseDecoder</old>
+                  <new>class io.netty.handler.codec.socks.SocksAuthResponseDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.socks.SocksCmdRequestDecoder</old>
+                  <new>class io.netty.handler.codec.socks.SocksCmdRequestDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.socks.SocksCmdResponseDecoder</old>
+                  <new>class io.netty.handler.codec.socks.SocksCmdResponseDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.socks.SocksInitRequestDecoder</old>
+                  <new>class io.netty.handler.codec.socks.SocksInitRequestDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.socks.SocksInitResponseDecoder</old>
+                  <new>class io.netty.handler.codec.socks.SocksInitResponseDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.socksx.SocksPortUnificationServerHandler</old>
+                  <new>class io.netty.handler.codec.socksx.SocksPortUnificationServerHandler</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.socksx.v4.Socks4ClientDecoder</old>
+                  <new>class io.netty.handler.codec.socksx.v4.Socks4ClientDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.socksx.v4.Socks4ServerDecoder</old>
+                  <new>class io.netty.handler.codec.socksx.v4.Socks4ServerDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.socksx.v5.Socks5CommandRequestDecoder</old>
+                  <new>class io.netty.handler.codec.socksx.v5.Socks5CommandRequestDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.socksx.v5.Socks5CommandResponseDecoder</old>
+                  <new>class io.netty.handler.codec.socksx.v5.Socks5CommandResponseDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.socksx.v5.Socks5InitialRequestDecoder</old>
+                  <new>class io.netty.handler.codec.socksx.v5.Socks5InitialRequestDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.socksx.v5.Socks5InitialResponseDecoder</old>
+                  <new>class io.netty.handler.codec.socksx.v5.Socks5InitialResponseDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.socksx.v5.Socks5PasswordAuthRequestDecoder</old>
+                  <new>class io.netty.handler.codec.socksx.v5.Socks5PasswordAuthRequestDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.socksx.v5.Socks5PasswordAuthResponseDecoder</old>
+                  <new>class io.netty.handler.codec.socksx.v5.Socks5PasswordAuthResponseDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.stomp.StompSubframeDecoder</old>
+                  <new>class io.netty.handler.codec.stomp.StompSubframeDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.xml.XmlDecoder</old>
+                  <new>class io.netty.handler.codec.xml.XmlDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.example.factorial.BigIntegerDecoder</old>
+                  <new>class io.netty.example.factorial.BigIntegerDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.example.portunification.PortUnificationServerHandler</old>
+                  <new>class io.netty.example.portunification.PortUnificationServerHandler</new>
                   <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
                   <justification>Acceptable incompatibility with very low risk which improves performance</justification>
                 </item>

--- a/pom.xml
+++ b/pom.xml
@@ -1174,11 +1174,176 @@
                   <superClass>io.netty.handler.codec.http.multipart.AbstractMixedHttpData&lt;io.netty.handler.codec.http.multipart.Attribute&gt;</superClass>
                   <justification>Acceptable incompatibility for required change</justification>
                 </item>
+
+
                 <item>
                   <ignore>true</ignore>
                   <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.ByteToMessageDecoder</old>
+                  <new>class io.netty.handler.codec.ByteToMessageDecoder</new>
                   <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
-                  <justification>Acceptable incompatibility for required change</justification>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.DelimiterBasedFrameDecoder</old>
+                  <new>class io.netty.handler.codec.DelimiterBasedFrameDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.FixedLengthFrameDecoder</old>
+                  <new>class io.netty.handler.codec.FixedLengthFrameDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.LengthFieldBasedFrameDecoder</old>
+                  <new>class io.netty.handler.codec.LengthFieldBasedFrameDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.LineBasedFrameDecoder</old>
+                  <new>class io.netty.handler.codec.LineBasedFrameDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.ReplayingDecoder&lt;S&gt;</old>
+                  <new>class io.netty.handler.codec.ReplayingDecoder&lt;S&gt;</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.compression.Bzip2Decoder</old>
+                  <new>class io.netty.handler.codec.compression.Bzip2Decoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.compression.FastLzFrameDecoder</old>
+                  <new>class io.netty.handler.codec.compression.FastLzFrameDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.compression.JZlibDecoder</old>
+                  <new>class io.netty.handler.codec.compression.JZlibDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.compression.JdkZlibDecoder</old>
+                  <new>class io.netty.handler.codec.compression.JdkZlibDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.compression.Lz4FrameDecoder</old>
+                  <new>class io.netty.handler.codec.compression.Lz4FrameDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.compression.LzfDecoder</old>
+                  <new>class io.netty.handler.codec.compression.LzfDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.compression.SnappyFrameDecoder</old>
+                  <new>class io.netty.handler.codec.compression.SnappyFrameDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.compression.SnappyFramedDecoder</old>
+                  <new>class io.netty.handler.codec.compression.SnappyFramedDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.compression.ZlibDecoder</old>
+                  <new>class io.netty.handler.codec.compression.ZlibDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>ADD YOUR EXPLANATION FOR THE NECESSITY OF THIS CHANGE</justification>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.json.JsonObjectDecoder</old>
+                  <new>class io.netty.handler.codec.json.JsonObjectDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.marshalling.CompatibleMarshallingDecoder</old>
+                  <new>class io.netty.handler.codec.marshalling.CompatibleMarshallingDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.marshalling.MarshallingDecoder</old>
+                  <new>class io.netty.handler.codec.marshalling.MarshallingDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.protobuf.ProtobufVarint32FrameDecoder</old>
+                  <new>class io.netty.handler.codec.protobuf.ProtobufVarint32FrameDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.serialization.ObjectDecoder</old>
+                  <new>class io.netty.handler.codec.serialization.ObjectDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <old>class io.netty.handler.codec.xml.XmlFrameDecoder</old>
+                  <new>class io.netty.handler.codec.xml.XmlFrameDecoder</new>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
+                  <justification>Acceptable incompatibility with very low risk which improves performance</justification>
                 </item>
               </differences>
             </revapi.differences>

--- a/pom.xml
+++ b/pom.xml
@@ -1085,6 +1085,7 @@
           </dependency>
         </dependencies>
         <configuration>
+          <ignoreSuggestionsFormat>xml</ignoreSuggestionsFormat>
           <analysisConfiguration>
             <revapi.filter>
               <elements>
@@ -1171,6 +1172,12 @@
                   <old>class io.netty.handler.codec.http.multipart.MixedAttribute</old>
                   <new>class io.netty.handler.codec.http.multipart.MixedAttribute</new>
                   <superClass>io.netty.handler.codec.http.multipart.AbstractMixedHttpData&lt;io.netty.handler.codec.http.multipart.Attribute&gt;</superClass>
+                  <justification>Acceptable incompatibility for required change</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <superClass>io.netty.channel.ChannelDuplexHandler</superClass>
                   <justification>Acceptable incompatibility for required change</justification>
                 </item>
               </differences>


### PR DESCRIPTION
…mplement ChannelOutboundHandler

Motivation:

There is some scalability issue with ChannelHandler implementations that implement ChannelInboundHandler and ChannelOutboundHandler at the same time. This can be fixed by usually extending ChannelDuplexHandler. Unfortunally this is not possible when the ChannelHandler in question already extend ByteToMessageDecoder, which is the case for SslHandler which is a very popular handler. To fix this let's just have ByteToMessageDecoder extend ChannelDuplexHandler. This will not hurt in general as we will still skip execution of the outbound methods if te sub-class is not overriding these while also ensure that we not get into trouble of scalability issues.

Modifications:

Let ByteToMessageDecoder extend ChannelDuplexHandler

Result:

Workaround scalability issue of SslHandler.
