### PR TITLE
Fix buffer leak in DefaultCompositeBuffer#split

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/DefaultCompositeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/DefaultCompositeBuffer.java
@@ -893,7 +893,7 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
         int i = searchOffsets(splitOffset);
         int off = splitOffset - offsets[i];
         Buffer[] splits = Arrays.copyOf(bufs, off == 0? i : 1 + i);
-        bufs = Arrays.copyOfRange(bufs, off == bufs[i].capacity()? 1 + i : i, bufs.length);
+        bufs = Arrays.copyOfRange(bufs, off > 0 && off == bufs[i].capacity()? 1 + i : i, bufs.length);
         if (off > 0 && splits.length > 0 && off < splits[splits.length - 1].capacity()) {
             splits[splits.length - 1] = bufs[0].split(off);
         }

--- a/buffer/src/test/java/io/netty5/buffer/tests/BufferCompositionTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/tests/BufferCompositionTest.java
@@ -796,4 +796,28 @@ public class BufferCompositionTest extends BufferTestSupport {
             }
         }
     }
+
+    @Test
+    public void splitBufferLastBufferNoReadableBytes() {
+        try (BufferAllocator allocator = BufferAllocator.onHeapUnpooled()) {
+            Buffer buffer1 = allocator.allocate(8).writeLong(0x0102030405060708L);
+            buffer1.skipReadableBytes(4);
+
+            Buffer buffer2 = allocator.allocate(8).writeLong(0x0102030405060708L);
+            buffer2.skipReadableBytes(8);
+
+            try (CompositeBuffer composite = allocator.compose(asList(buffer1.send(), buffer2.send()));
+                 Buffer split = composite.split()) {
+
+                assertEquals(8, split.capacity());
+                assertEquals(4, split.readableBytes());
+                assertEquals(0, split.writableBytes());
+
+                assertEquals(1, composite.countComponents());
+                assertEquals(0, composite.capacity());
+                assertEquals(0, composite.readableBytes());
+                assertEquals(0, composite.writableBytes());
+            }
+        }
+    }
 }


### PR DESCRIPTION
Motivation:
Manually enabling leak detection reveals buffer leaks in `DefaultCompositeBuffer#split`. When splitting the buffers, some buffers might be left outside of `splits` and `bufs`.

Modification:
- Ensure `DefaultCompositeBuffer` splits the buffers so that they are either in `splits` or in `bufs`
- Add junit test

Result:
No more leaks in `DefaultCompositeBuffer#split`.