### PR TITLE
Optimize FastThreadLocal

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/FastThreadLocal.java
+++ b/common/src/main/java/io/netty/util/concurrent/FastThreadLocal.java
@@ -122,7 +122,7 @@ public class FastThreadLocal<V> {
         variablesToRemove.remove(variable);
     }
 
-    private int index = 0; // Init with 0.
+    private int index; // Init with 0.
 
     public FastThreadLocal() { }
 


### PR DESCRIPTION
Motivation:

The object array's `index` of `FastThreadLocal` was application scope, so the increment of `index` within one thread will affect all the other threads. 

For example:

If one thread's threadLocal stores more than 32(the initial table size) elements, then the second thread will do the table expansion even it only needs store just 1 element, this will cause the object array expansion more frequently and eat more memory. 

Code example:
```
public static void main(String[] args) throws InterruptedException {
        Thread t1 = new Thread(new Runnable() {
            @Override
            public void run() {
                for (int i = 0; i < 31; i++) {
                    FastThreadLocal<Integer> fst = new FastThreadLocal<Integer>();
                    fst.set(i);
                }
            }
        });
        t1.start();
        t1.join();
        // After t1 thread finished, the main thread create a FastThreadLocal fst2.
        FastThreadLocal<Integer> fst2 = new FastThreadLocal();
        // The object table of 'fst2' will do expansion, even it only needs store just ONE element.
        fst2.set(2);
    }
```

Modification:

1. Change the index of threadLocal array scope from global scope to thread scope.
2. Postpone the generation of the `index` value from `FastThreadLocal`'s construction method to get()/set() method.

Result:

Save memory space and lower the table expansion overhead.

(Partly)Fixes: #11937. 
