### PR TITLE
Pool Thread Cache support memory leak check.

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolThreadCache.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolThreadCache.java
@@ -236,15 +236,15 @@ final class PoolThreadCache {
                 heapArena.numThreadCaches.getAndDecrement();
             }
         } else {
-            //see https://github.com/netty/netty/issues/12749
-            checkCacheIsLeak(smallSubPageDirectCaches, "SmallSubPageDirectCaches");
-            checkCacheIsLeak(normalDirectCaches, "NormalDirectCaches");
-            checkCacheIsLeak(smallSubPageHeapCaches, "SmallSubPageHeapCaches");
-            checkCacheIsLeak(normalHeapCaches, "NormalHeapCaches");
+            // See https://github.com/netty/netty/issues/12749
+            checkCacheMayLeak(smallSubPageDirectCaches, "SmallSubPageDirectCaches");
+            checkCacheMayLeak(normalDirectCaches, "NormalDirectCaches");
+            checkCacheMayLeak(smallSubPageHeapCaches, "SmallSubPageHeapCaches");
+            checkCacheMayLeak(normalHeapCaches, "NormalHeapCaches");
         }
     }
 
-    private void checkCacheIsLeak(MemoryRegionCache<?>[] caches, String type) {
+    private static void checkCacheMayLeak(MemoryRegionCache<?>[] caches, String type) {
         for (MemoryRegionCache<?> cache : caches) {
             if (cache.queue.size() > 0) {
                 logger.debug("{} memory may leak.", type);

--- a/buffer/src/main/java/io/netty/buffer/PoolThreadCache.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolThreadCache.java
@@ -247,7 +247,8 @@ final class PoolThreadCache {
     private void checkCacheIsLeak(MemoryRegionCache<?>[] caches, String type) {
         for (MemoryRegionCache<?> cache : caches) {
             if (cache.queue.size() > 0) {
-                logger.warn("[] memory may leak.", type);
+                logger.debug("{} memory may leak.", type);
+                return;
             }
         }
     }

--- a/buffer/src/main/java/io/netty/buffer/PoolThreadCache.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolThreadCache.java
@@ -236,6 +236,7 @@ final class PoolThreadCache {
                 heapArena.numThreadCaches.getAndDecrement();
             }
         } else {
+            //see https://github.com/netty/netty/issues/12749
             checkCacheIsLeak(smallSubPageDirectCaches, "SmallSubPageDirectCaches");
             checkCacheIsLeak(normalDirectCaches, "NormalDirectCaches");
             checkCacheIsLeak(smallSubPageHeapCaches, "SmallSubPageHeapCaches");

--- a/buffer/src/main/java/io/netty/buffer/PoolThreadCache.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolThreadCache.java
@@ -179,12 +179,12 @@ final class PoolThreadCache {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     boolean add(PoolArena<?> area, PoolChunk chunk, ByteBuffer nioBuffer,
                 long handle, int normCapacity, SizeClass sizeClass) {
-        if (freed.get()) {
-            return false;
-        }
         int sizeIdx = area.size2SizeIdx(normCapacity);
         MemoryRegionCache<?> cache = cache(area, sizeIdx, sizeClass);
         if (cache == null) {
+            return false;
+        }
+        if (freed.get()) {
             return false;
         }
         return cache.add(chunk, nioBuffer, handle, normCapacity);


### PR DESCRIPTION
Motivation:
Fixes-#12749

1. If the PoolThreadCache is already freed, didn't add the ByteBuf to the cache, free it to PoolChunk directly.
2. If the PoolThreadCache leak, print warns log.