### PR TITLE
[Feature] Add OCSP Validation for Server Certificate

### DIFF
--- a/handler-ssl-ocsp/pom.xml
+++ b/handler-ssl-ocsp/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2022 The Netty Project
+  ~
+  ~ The Netty Project licenses this file to you under the Apache License,
+  ~ version 2.0 (the "License"); you may not use this file except in compliance
+  ~ with the License. You may obtain a copy of the License at:
+  ~
+  ~   https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.netty</groupId>
+    <artifactId>netty-parent</artifactId>
+    <version>4.1.85.Final-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>netty-handler-ssl-ocsp</artifactId>
+  <packaging>jar</packaging>
+
+  <properties>
+    <javaModuleName>io.netty.handler.ssl.ocsp</javaModuleName>
+  </properties>
+
+  <name>Netty/Handler/Ssl/Ocsp</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-http</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-resolver-dns</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/IoTransport.java
+++ b/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/IoTransport.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl.ocsp;
+
+import io.netty.channel.ChannelFactory;
+import io.netty.channel.EventLoop;
+import io.netty.channel.nio.NioEventLoop;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.DatagramChannel;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioDatagramChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
+/**
+ * {@link IoTransport} holds {@link EventLoop}, {@link SocketChannel}
+ * and {@link DatagramChannel} for DNS I/O.
+ */
+public final class IoTransport {
+    private final EventLoop eventLoop;
+    private final ChannelFactory<SocketChannel> socketChannel;
+    private final ChannelFactory<DatagramChannel> datagramChannel;
+
+    /**
+     * Default {@link IoTransport} which uses {@link NioEventLoop}, {@link NioSocketChannel}
+     * and {@link NioDatagramChannel}.
+     */
+    public static final IoTransport DEFAULT = new IoTransport(new NioEventLoopGroup(1).next(),
+            new ChannelFactory<SocketChannel>() {
+                @Override
+                public SocketChannel newChannel() {
+                    return new NioSocketChannel();
+                }
+            },
+            new ChannelFactory<DatagramChannel>() {
+                @Override
+                public DatagramChannel newChannel() {
+                    return new NioDatagramChannel();
+                }
+            });
+
+    /**
+     * Create a new {@link IoTransport} instance
+     *
+     * @param eventLoop       {@link EventLoop} to use for I/O
+     * @param socketChannel   {@link SocketChannel} for TCP DNS lookup and OCSP query
+     * @param datagramChannel {@link DatagramChannel} for UDP DNS lookup
+     * @return {@link NullPointerException} if any parameter is {@code null}
+     */
+    public static IoTransport create(EventLoop eventLoop, ChannelFactory<SocketChannel> socketChannel,
+                                     ChannelFactory<DatagramChannel> datagramChannel) {
+        return new IoTransport(eventLoop, socketChannel, datagramChannel);
+    }
+
+    private IoTransport(EventLoop eventLoop, ChannelFactory<SocketChannel> socketChannel,
+                        ChannelFactory<DatagramChannel> datagramChannel) {
+        this.eventLoop = checkNotNull(eventLoop, "EventLoop");
+        this.socketChannel = checkNotNull(socketChannel, "SocketChannel");
+        this.datagramChannel = checkNotNull(datagramChannel, "DatagramChannel");
+    }
+
+    public EventLoop eventLoop() {
+        return eventLoop;
+    }
+
+    public ChannelFactory<SocketChannel> socketChannel() {
+        return socketChannel;
+    }
+
+    public ChannelFactory<DatagramChannel> datagramChannel() {
+        return datagramChannel;
+    }
+}

--- a/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspClient.java
+++ b/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspClient.java
@@ -1,0 +1,341 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl.ocsp;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFactory;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoop;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpClientCodec;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.resolver.AddressResolver;
+import io.netty.resolver.AddressResolverGroup;
+import io.netty.resolver.InetSocketAddressResolver;
+import io.netty.resolver.dns.DnsNameResolver;
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.FutureListener;
+import io.netty.util.concurrent.GenericFutureListener;
+import io.netty.util.concurrent.Promise;
+import io.netty.util.internal.SystemPropertyUtil;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+import org.bouncycastle.asn1.DEROctetString;
+import org.bouncycastle.asn1.x509.AccessDescription;
+import org.bouncycastle.asn1.x509.AuthorityInformationAccess;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.Extensions;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateHolder;
+import org.bouncycastle.cert.ocsp.BasicOCSPResp;
+import org.bouncycastle.cert.ocsp.CertificateID;
+import org.bouncycastle.cert.ocsp.OCSPException;
+import org.bouncycastle.cert.ocsp.OCSPReqBuilder;
+import org.bouncycastle.cert.ocsp.OCSPResp;
+import org.bouncycastle.operator.ContentVerifierProvider;
+import org.bouncycastle.operator.OperatorCreationException;
+import org.bouncycastle.operator.jcajce.JcaContentVerifierProviderBuilder;
+import org.bouncycastle.operator.jcajce.JcaDigestCalculatorProviderBuilder;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.net.URL;
+import java.security.SecureRandom;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
+
+import static io.netty.handler.codec.http.HttpMethod.POST;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+import static io.netty.handler.ssl.ocsp.OcspHttpHandler.OCSP_REQUEST_TYPE;
+import static io.netty.handler.ssl.ocsp.OcspHttpHandler.OCSP_RESPONSE_TYPE;
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import static org.bouncycastle.asn1.ocsp.OCSPObjectIdentifiers.id_pkix_ocsp_nonce;
+import static org.bouncycastle.asn1.x509.X509ObjectIdentifiers.id_ad_ocsp;
+import static org.bouncycastle.cert.ocsp.CertificateID.HASH_SHA1;
+
+final class OcspClient {
+
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(OcspClient.class);
+
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+    private static final int OCSP_RESPONSE_MAX_SIZE = SystemPropertyUtil.getInt(
+            "io.netty.ocsp.responseSize", 1024 * 10);
+
+    static {
+        logger.debug("-Dio.netty.ocsp.responseSize: {} bytes", OCSP_RESPONSE_MAX_SIZE);
+    }
+
+    /**
+     * Query the certificate status using OCSP
+     *
+     * @param x509Certificate       Client {@link X509Certificate} to validate
+     * @param issuer                {@link X509Certificate} issuer of client certificate
+     * @param validateResponseNonce Set to {@code true} to enable OCSP response validation
+     * @param ioTransport           {@link IoTransport} to use
+     * @return {@link Promise} of {@link BasicOCSPResp}
+     */
+    static Promise<BasicOCSPResp> query(final X509Certificate x509Certificate,
+                                        final X509Certificate issuer, final boolean validateResponseNonce,
+                                        final IoTransport ioTransport, final DnsNameResolver dnsNameResolver) {
+        final EventLoop eventLoop = ioTransport.eventLoop();
+        final Promise<BasicOCSPResp> responsePromise = eventLoop.newPromise();
+        eventLoop.execute(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    CertificateID certificateID = new CertificateID(new JcaDigestCalculatorProviderBuilder()
+                            .build().get(HASH_SHA1), new JcaX509CertificateHolder(issuer),
+                            x509Certificate.getSerialNumber());
+
+                    // Initialize OCSP Request Builder and add CertificateID into it.
+                    OCSPReqBuilder builder = new OCSPReqBuilder();
+                    builder.addRequest(certificateID);
+
+                    // Generate 16-bytes (octets) of nonce and add it into OCSP Request builder.
+                    // Because as per RFC-8954#2.1:
+                    //
+                    //   OCSP responders MUST accept lengths of at least
+                    //   16 octets and MAY choose to ignore the Nonce extension for requests
+                    //   where the length of the nonce is less than 16 octets.
+                    byte[] nonce = new byte[16];
+                    SECURE_RANDOM.nextBytes(nonce);
+                    final DEROctetString derNonce = new DEROctetString(nonce);
+                    builder.setRequestExtensions(new Extensions(new Extension(id_pkix_ocsp_nonce, false, derNonce)));
+
+                    // Get OCSP URL from Certificate and query it.
+                    URL uri = new URL(parseOcspUrlFromCertificate(x509Certificate));
+
+                    // Find port
+                    int port = uri.getPort();
+                    if (port == -1) {
+                        port = uri.getDefaultPort();
+                    }
+
+                    // Configure path
+                    String path = uri.getPath();
+                    if (path.isEmpty()) {
+                        path = "/";
+                    } else {
+                        if (uri.getQuery() != null) {
+                            path = path + "?" + uri.getQuery();
+                        }
+                    }
+
+                    Promise<OCSPResp> ocspResponsePromise = query(eventLoop,
+                            Unpooled.wrappedBuffer(builder.build().getEncoded()),
+                            uri.getHost(), port, path, ioTransport, dnsNameResolver);
+
+                    // Validate OCSP response
+                    ocspResponsePromise.addListener(new GenericFutureListener<Future<OCSPResp>>() {
+                        @Override
+                        public void operationComplete(Future<OCSPResp> future) throws Exception {
+                            // If Future was successful then we have received OCSP response
+                            // We will now validate it.
+                            if (future.isSuccess()) {
+                                BasicOCSPResp resp = (BasicOCSPResp) future.get().getResponseObject();
+                                validateResponse(responsePromise, resp, derNonce, issuer, validateResponseNonce);
+                            } else {
+                                responsePromise.tryFailure(future.cause());
+                            }
+                        }
+                    });
+
+                } catch (Exception ex) {
+                    responsePromise.tryFailure(ex);
+                }
+            }
+        });
+        return responsePromise;
+    }
+
+    /**
+     * Query the OCSP responder for certificate status using HTTP/1.1
+     *
+     * @param eventLoop   {@link EventLoop} for HTTP request execution
+     * @param ocspRequest {@link ByteBuf} containing OCSP request data
+     * @param host        OCSP responder hostname
+     * @param port        OCSP responder port
+     * @param path        OCSP responder path
+     * @param ioTransport {@link IoTransport} to use
+     * @return Returns {@link Promise} containing {@link OCSPResp}
+     */
+    private static Promise<OCSPResp> query(final EventLoop eventLoop, final ByteBuf ocspRequest,
+                                           final String host, final int port, final String path,
+                                           final IoTransport ioTransport, final DnsNameResolver dnsNameResolver) {
+        final Promise<OCSPResp> responsePromise = eventLoop.newPromise();
+
+        try {
+            final Bootstrap bootstrap = new Bootstrap()
+                    .group(ioTransport.eventLoop())
+                    .option(ChannelOption.TCP_NODELAY, true)
+                    .channelFactory(ioTransport.socketChannel())
+                    .handler(new Initializer(responsePromise));
+
+            dnsNameResolver.resolve(host).addListener(new FutureListener<InetAddress>() {
+                @Override
+                public void operationComplete(Future<InetAddress> future) throws Exception {
+
+                    // If Future was successful then we have successfully resolved OCSP server address.
+                    // If not, mark 'responsePromise' as failure.
+                    if (future.isSuccess()) {
+                        // Get the resolved InetAddress
+                        InetAddress hostAddress = future.get();
+                        final ChannelFuture channelFuture = bootstrap.connect(hostAddress, port);
+                        channelFuture.addListener(new ChannelFutureListener() {
+                            @Override
+                            public void operationComplete(ChannelFuture future) {
+                                // If Future was successful then connection to OCSP responder was successful.
+                                // We will send a OCSP request now
+                                if (future.isSuccess()) {
+                                    FullHttpRequest request = new DefaultFullHttpRequest(HTTP_1_1, POST, path,
+                                            ocspRequest);
+                                    request.headers().add(HttpHeaderNames.HOST, host);
+                                    request.headers().add(HttpHeaderNames.USER_AGENT, "Netty OCSP Client");
+                                    request.headers().add(HttpHeaderNames.CONTENT_TYPE, OCSP_REQUEST_TYPE);
+                                    request.headers().add(HttpHeaderNames.ACCEPT_ENCODING, OCSP_RESPONSE_TYPE);
+                                    request.headers().add(HttpHeaderNames.CONTENT_LENGTH, ocspRequest.readableBytes());
+
+                                    // Send the OCSP HTTP Request
+                                    channelFuture.channel().writeAndFlush(request);
+                                } else {
+                                    responsePromise.tryFailure(new IllegalStateException(
+                                            "Connection to OCSP Responder Failed", future.cause()));
+                                }
+                            }
+                        });
+                    } else {
+                        responsePromise.tryFailure(future.cause());
+                    }
+                }
+            });
+        } catch (Exception ex) {
+            responsePromise.tryFailure(ex);
+        }
+
+        return responsePromise;
+    }
+
+    private static void validateResponse(Promise<BasicOCSPResp> responsePromise, BasicOCSPResp basicResponse,
+                                         DEROctetString derNonce, X509Certificate issuer, boolean validateNonce) {
+        try {
+            // Validate number of responses. We only requested for 1 certificate
+            // so number of responses must be 1. If not, we will throw an error.
+            int responses = basicResponse.getResponses().length;
+            if (responses != 1) {
+                throw new IllegalArgumentException("Expected number of responses was 1 but got: " + responses);
+            }
+
+            if (validateNonce) {
+                validateNonce(basicResponse, derNonce);
+            }
+            validateSignature(basicResponse, issuer);
+            responsePromise.trySuccess(basicResponse);
+        } catch (Exception ex) {
+            responsePromise.tryFailure(ex);
+        }
+    }
+
+    /**
+     * Validate OCSP response nonce
+     */
+    private static void validateNonce(BasicOCSPResp basicResponse, DEROctetString encodedNonce) throws OCSPException {
+        Extension nonceExt = basicResponse.getExtension(id_pkix_ocsp_nonce);
+        if (nonceExt != null) {
+            DEROctetString responseNonceString = (DEROctetString) nonceExt.getExtnValue();
+            if (!responseNonceString.equals(encodedNonce)) {
+                throw new OCSPException("Nonce does not match");
+            }
+        } else {
+            throw new IllegalArgumentException("Nonce is not present");
+        }
+    }
+
+    /**
+     * Validate OCSP response signature
+     */
+    private static void validateSignature(BasicOCSPResp resp, X509Certificate certificate) throws OCSPException {
+        try {
+            ContentVerifierProvider verifier = new JcaContentVerifierProviderBuilder().build(certificate);
+            if (!resp.isSignatureValid(verifier)) {
+                throw new OCSPException("OCSP signature is not valid");
+            }
+        } catch (OperatorCreationException e) {
+            throw new OCSPException("Error validating OCSP-Signature", e);
+        }
+    }
+
+    /**
+     * Parse OCSP endpoint URL from Certificate
+     *
+     * @param cert Certificate to be parsed
+     * @return OCSP endpoint URL
+     * @throws NullPointerException     If we couldn't locate OCSP responder URL
+     * @throws IllegalArgumentException If we couldn't parse X509Certificate into JcaX509CertificateHolder
+     */
+    private static String parseOcspUrlFromCertificate(X509Certificate cert) {
+        X509CertificateHolder holder;
+        try {
+            holder = new JcaX509CertificateHolder(cert);
+        } catch (CertificateEncodingException e) {
+            // Though this should never happen
+            throw new IllegalArgumentException("Error while parsing X509Certificate into JcaX509CertificateHolder", e);
+        }
+
+        AuthorityInformationAccess aiaExtension = AuthorityInformationAccess.fromExtensions(holder.getExtensions());
+
+        // Lookup for OCSP responder url
+        for (AccessDescription accessDescription : aiaExtension.getAccessDescriptions()) {
+            if (accessDescription.getAccessMethod().equals(id_ad_ocsp)) {
+                return accessDescription.getAccessLocation().getName().toASN1Primitive().toString();
+            }
+        }
+
+        throw new NullPointerException("Unable to find OCSP responder URL in Certificate");
+    }
+
+    static final class Initializer extends ChannelInitializer<SocketChannel> {
+
+        private final Promise<OCSPResp> responsePromise;
+
+        Initializer(Promise<OCSPResp> responsePromise) {
+            this.responsePromise = checkNotNull(responsePromise, "ResponsePromise");
+        }
+
+        @Override
+        protected void initChannel(SocketChannel socketChannel) {
+            ChannelPipeline pipeline = socketChannel.pipeline();
+            pipeline.addLast(new HttpClientCodec());
+            pipeline.addLast(new HttpObjectAggregator(OCSP_RESPONSE_MAX_SIZE));
+            pipeline.addLast(new OcspHttpHandler(responsePromise));
+        }
+    }
+
+    private OcspClient() {
+        // Prevent outside initialization
+    }
+}

--- a/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspHttpHandler.java
+++ b/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspHttpHandler.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl.ocsp;
+
+import io.netty.buffer.ByteBufUtil;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.util.concurrent.Promise;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+import org.bouncycastle.cert.ocsp.OCSPException;
+import org.bouncycastle.cert.ocsp.OCSPResp;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
+final class OcspHttpHandler extends SimpleChannelInboundHandler<FullHttpResponse> {
+
+    private static final InternalLogger LOGGER = InternalLoggerFactory.getInstance(OcspHttpHandler.class);
+    private final Promise<OCSPResp> responseFuture;
+
+    public static final String OCSP_REQUEST_TYPE = "application/ocsp-request";
+    public static final String OCSP_RESPONSE_TYPE = "application/ocsp-response";
+
+    /**
+     * Create new {@link OcspHttpHandler} instance
+     *
+     * @param responsePromise {@link Promise} of {@link OCSPResp}
+     */
+    OcspHttpHandler(Promise<OCSPResp> responsePromise) {
+        this.responseFuture = checkNotNull(responsePromise, "ResponsePromise");
+    }
+
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx, FullHttpResponse response) throws Exception {
+        try {
+            // If DEBUG is enabled then log the response
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Received OCSP HTTP Response: {}", response);
+            }
+
+            // Response headers must contain 'Content-Type'
+            String contentType = response.headers().get(HttpHeaderNames.CONTENT_TYPE);
+            if (contentType == null) {
+                throw new OCSPException("HTTP Response does not contain 'CONTENT-TYPE' header");
+            }
+
+            // Response headers must contain 'application/ocsp-response'
+            if (!contentType.equalsIgnoreCase(OCSP_RESPONSE_TYPE)) {
+                throw new OCSPException("Response Content-Type was: " + contentType +
+                        "; Expected: " + OCSP_RESPONSE_TYPE);
+            }
+
+            // Status must be OK for successful lookup
+            if (response.status() != OK) {
+                throw new IllegalArgumentException("HTTP Response Code was: " + response.status().code() +
+                        "; Expected: 200");
+            }
+
+            responseFuture.trySuccess(new OCSPResp(ByteBufUtil.getBytes(response.content())));
+        } finally {
+            ctx.channel().close();
+        }
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        responseFuture.tryFailure(cause);
+    }
+}

--- a/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspResponse.java
+++ b/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspResponse.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl.ocsp;
+
+import java.util.Date;
+
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
+public class OcspResponse {
+    private final Status status;
+    private final Date thisUpdate;
+    private final Date nextUpdate;
+
+    public OcspResponse(Status status, Date thisUpdate, Date nextUpdate) {
+        this.status = checkNotNull(status, "Status");
+        this.thisUpdate = checkNotNull(thisUpdate, "ThisUpdate");
+        this.nextUpdate = checkNotNull(nextUpdate, "NextUpdate");
+    }
+
+    public Status status() {
+        return status;
+    }
+
+    public Date thisUpdate() {
+        return thisUpdate;
+    }
+
+    public Date nextUpdate() {
+        return nextUpdate;
+    }
+
+    @Override
+    public String toString() {
+        return "OcspResponse{" +
+                "status=" + status +
+                ", thisUpdate=" + thisUpdate +
+                ", nextUpdate=" + nextUpdate +
+                '}';
+    }
+
+    public enum Status {
+        /**
+         * Certificate is valid
+         */
+        VALID,
+
+        /**
+         * Certificate is revoked
+         */
+        REVOKED,
+
+        /**
+         * Certificate status is unknown
+         */
+        UNKNOWN
+    }
+}

--- a/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspServerCertificateValidator.java
+++ b/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspServerCertificateValidator.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl.ocsp;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.ssl.SslHandler;
+import io.netty.handler.ssl.SslHandshakeCompletionEvent;
+import io.netty.resolver.dns.DnsNameResolver;
+import io.netty.resolver.dns.DnsNameResolverBuilder;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GenericFutureListener;
+import io.netty.util.concurrent.Promise;
+import org.bouncycastle.cert.ocsp.BasicOCSPResp;
+import org.bouncycastle.cert.ocsp.OCSPException;
+import org.bouncycastle.cert.ocsp.RevokedStatus;
+import org.bouncycastle.cert.ocsp.SingleResp;
+
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.Date;
+
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
+/**
+ * {@link OcspServerCertificateValidator} validates incoming server's certificate
+ * using OCSP. Once TLS handshake is completed, {@link SslHandshakeCompletionEvent#SUCCESS} is fired, validator
+ * will perform certificate validation using OCSP over HTTP/1.1 with the server's certificate issuer OCSP responder.
+ */
+public class OcspServerCertificateValidator extends ChannelInboundHandlerAdapter {
+
+    private final boolean closeAndThrowIfNotValid;
+    private final boolean validateNonce;
+    private final IoTransport ioTransport;
+    private final DnsNameResolver dnsNameResolver;
+
+    /**
+     * Create a new {@link OcspServerCertificateValidator} instance without nonce validation
+     * on OCSP response, using default {@link IoTransport#DEFAULT} instance,
+     * default {@link DnsNameResolver} implementation and with {@link #closeAndThrowIfNotValid}
+     * set to {@code true}
+     */
+    public OcspServerCertificateValidator() {
+        this(false);
+    }
+
+    /**
+     * Create a new {@link OcspServerCertificateValidator} instance with
+     * default {@link IoTransport#DEFAULT} instance and default {@link DnsNameResolver} implementation
+     * and {@link #closeAndThrowIfNotValid} set to {@code true}.
+     *
+     * @param validateNonce Set to {@code true} if we should force nonce validation on
+     *                      OCSP response else set to {@code false}
+     */
+    public OcspServerCertificateValidator(boolean validateNonce) {
+        this(validateNonce, IoTransport.DEFAULT);
+    }
+
+    /**
+     * Create a new {@link OcspServerCertificateValidator} instance
+     *
+     * @param validateNonce Set to {@code true} if we should force nonce validation on
+     *                      OCSP response else set to {@code false}
+     * @param ioTransport   {@link IoTransport} to use
+     */
+    public OcspServerCertificateValidator(boolean validateNonce, IoTransport ioTransport) {
+        this(validateNonce, ioTransport, createDefaultResolver(ioTransport));
+    }
+
+    /**
+     * Create a new {@link IoTransport} instance with {@link #closeAndThrowIfNotValid} set to {@code true}
+     *
+     * @param validateNonce   Set to {@code true} if we should force nonce validation on
+     *                        OCSP response else set to {@code false}
+     * @param ioTransport     {@link IoTransport} to use
+     * @param dnsNameResolver {@link DnsNameResolver} implementation to use
+     */
+    public OcspServerCertificateValidator(boolean validateNonce, IoTransport ioTransport,
+                                          DnsNameResolver dnsNameResolver) {
+        this(true, validateNonce, ioTransport, dnsNameResolver);
+    }
+
+    /**
+     * Create a new {@link IoTransport} instance
+     *
+     * @param closeAndThrowIfNotValid If set to {@code true} then we will close the channel and throw an exception
+     *                                when certificate is not {@link OcspResponse.Status#VALID}.
+     *                                If set to {@code false} then we will simply pass the {@link OcspValidationEvent}
+     *                                to the next handler in pipeline and let it decide what to do.
+     * @param validateNonce           Set to {@code true} if we should force nonce validation on
+     *                                OCSP response else set to {@code false}
+     * @param ioTransport             {@link IoTransport} to use
+     * @param dnsNameResolver         {@link DnsNameResolver} implementation to use
+     */
+    public OcspServerCertificateValidator(boolean closeAndThrowIfNotValid, boolean validateNonce,
+                                          IoTransport ioTransport, DnsNameResolver dnsNameResolver) {
+        this.closeAndThrowIfNotValid = closeAndThrowIfNotValid;
+        this.validateNonce = validateNonce;
+        this.ioTransport = checkNotNull(ioTransport, "IoTransport");
+        this.dnsNameResolver = checkNotNull(dnsNameResolver, "DnsNameResolver");
+    }
+
+    protected static DnsNameResolver createDefaultResolver(final IoTransport ioTransport) {
+        return new DnsNameResolverBuilder()
+                .eventLoop(ioTransport.eventLoop())
+                .channelFactory(ioTransport.datagramChannel())
+                .socketChannelFactory(ioTransport.socketChannel())
+                .build();
+    }
+
+    @Override
+    public void userEventTriggered(final ChannelHandlerContext ctx, final Object evt) throws Exception {
+        ctx.fireUserEventTriggered(evt);
+
+        if (evt instanceof SslHandshakeCompletionEvent) {
+            SslHandshakeCompletionEvent sslHandshakeCompletionEvent = (SslHandshakeCompletionEvent) evt;
+
+            // If TLS handshake was successful then only we will perform OCSP certificate validation.
+            // If not, then just forward the event to next handler in pipeline and remove ourselves from pipeline.
+            if (sslHandshakeCompletionEvent.isSuccess()) {
+                Certificate[] certificates = ctx.pipeline().get(SslHandler.class)
+                        .engine()
+                        .getSession()
+                        .getPeerCertificates();
+
+                assert certificates.length <= 2 : "There must an end-entity certificate and issuer certificate";
+
+                Promise<BasicOCSPResp> ocspRespPromise = OcspClient.query((X509Certificate) certificates[0],
+                        (X509Certificate) certificates[1], validateNonce, ioTransport, dnsNameResolver);
+
+                ocspRespPromise.addListener(new GenericFutureListener<Future<BasicOCSPResp>>() {
+                    @Override
+                    public void operationComplete(Future<BasicOCSPResp> future) throws Exception {
+                        // If Future is success then we have successfully received OCSP response
+                        // from OCSP responder. We will validate it now and process.
+                        if (future.isSuccess()) {
+                            SingleResp response = future.get().getResponses()[0];
+
+                            Date current = new Date();
+                            if (!(current.after(response.getThisUpdate()) &&
+                                    current.before(response.getNextUpdate()))) {
+                                ctx.fireExceptionCaught(new IllegalStateException("OCSP Response is out-of-date"));
+                            }
+
+                            OcspResponse.Status status;
+                            if (response.getCertStatus() == null) {
+                                // 'null' means certificate is valid
+                                status = OcspResponse.Status.VALID;
+                            } else if (response.getCertStatus() instanceof RevokedStatus) {
+                                status = OcspResponse.Status.REVOKED;
+                            } else {
+                                status = OcspResponse.Status.UNKNOWN;
+                            }
+
+                            ctx.fireUserEventTriggered(new OcspValidationEvent(
+                                    new OcspResponse(status, response.getThisUpdate(), response.getNextUpdate())));
+
+                            // If Certificate is not VALID and 'closeAndThrowIfNotValid' is set
+                            // to 'true' then close the channel and throw an exception.
+                            if (status != OcspResponse.Status.VALID && closeAndThrowIfNotValid) {
+                                ctx.channel().close();
+                                // Certificate is not valid. Throw
+                                ctx.fireExceptionCaught(new OCSPException(
+                                        "Certificate not valid. Status: " + status));
+                            }
+                        } else {
+                            ctx.fireExceptionCaught(future.cause());
+                        }
+                    }
+                });
+            }
+            // Lets remove ourselves from the pipeline because we are done processing validation.
+            ctx.pipeline().remove(this);
+        }
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        ctx.channel().close();
+    }
+}

--- a/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspValidationEvent.java
+++ b/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspValidationEvent.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl.ocsp;
+
+public final class OcspValidationEvent {
+
+    private final OcspResponse response;
+
+    public OcspValidationEvent(OcspResponse response) {
+        this.response = response;
+    }
+
+    public OcspResponse response() {
+        return response;
+    }
+
+    @Override
+    public String toString() {
+        return "OcspValidationEvent{" +
+                "response=" + response +
+                '}';
+    }
+}

--- a/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/package-info.java
+++ b/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * Certificate validation using OCSP
+ */
+package io.netty.handler.ssl.ocsp;

--- a/handler-ssl-ocsp/src/test/java/io/netty/handler/ssl/ocsp/OcspClientTest.java
+++ b/handler-ssl-ocsp/src/test/java/io/netty/handler/ssl/ocsp/OcspClientTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl.ocsp;
+
+import io.netty.util.concurrent.Promise;
+import org.bouncycastle.cert.ocsp.BasicOCSPResp;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.HttpsURLConnection;
+import java.io.IOException;
+import java.net.URL;
+import java.security.cert.X509Certificate;
+import java.util.concurrent.ExecutionException;
+
+import static io.netty.handler.ssl.ocsp.OcspServerCertificateValidator.createDefaultResolver;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class OcspClientTest {
+
+    @Test
+    void simpleOcspQueryTest() throws IOException, ExecutionException, InterruptedException {
+        HttpsURLConnection httpsConnection = null;
+        try {
+            URL url = new URL("https://netty.io");
+            httpsConnection = (HttpsURLConnection) url.openConnection();
+            httpsConnection.connect();
+
+            // Pull server certificates for validation
+            X509Certificate[] certs = (X509Certificate[]) httpsConnection.getServerCertificates();
+            X509Certificate serverCert = certs[0];
+            X509Certificate certIssuer = certs[1];
+
+            Promise<BasicOCSPResp> promise = OcspClient.query(serverCert, certIssuer, false,
+                    IoTransport.DEFAULT, createDefaultResolver(IoTransport.DEFAULT));
+            BasicOCSPResp basicOCSPResp = promise.get();
+
+            // 'null' means certificate is valid
+            assertNull(basicOCSPResp.getResponses()[0].getCertStatus());
+        } finally {
+            if (httpsConnection != null) {
+                httpsConnection.disconnect();
+            }
+        }
+    }
+}

--- a/handler-ssl-ocsp/src/test/java/io/netty/handler/ssl/ocsp/OcspServerCertificateValidatorTest.java
+++ b/handler-ssl-ocsp/src/test/java/io/netty/handler/ssl/ocsp/OcspServerCertificateValidatorTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl.ocsp;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OcspServerCertificateValidatorTest {
+
+    @Test
+    void connectUsingHttpAndValidateCertificateUsingOcspTest() throws Exception {
+        final AtomicBoolean ocspStatus = new AtomicBoolean();
+        EventLoopGroup eventLoopGroup = new NioEventLoopGroup();
+
+        try {
+            final CountDownLatch latch = new CountDownLatch(1);
+            final SslContext sslContext = SslContextBuilder.forClient()
+                    .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                    .build();
+
+            Bootstrap bootstrap = new Bootstrap()
+                    .group(eventLoopGroup)
+                    .channel(NioSocketChannel.class)
+                    .option(ChannelOption.TCP_NODELAY, true)
+                    .handler(new ChannelInitializer<SocketChannel>() {
+                        @Override
+                        protected void initChannel(SocketChannel ch) {
+                            ChannelPipeline pipeline = ch.pipeline();
+                            pipeline.addLast(sslContext.newHandler(ch.alloc(), "netty.io", 443));
+                            pipeline.addLast(new OcspServerCertificateValidator(false));
+                            pipeline.addLast(new SimpleChannelInboundHandler<Object>() {
+                                @Override
+                                protected void channelRead0(ChannelHandlerContext ctx, Object msg) {
+                                    // NOOP
+                                }
+
+                                @Override
+                                public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                                    if (evt instanceof OcspValidationEvent) {
+                                        OcspValidationEvent event = (OcspValidationEvent) evt;
+
+                                        ocspStatus.set(event.response().status() == OcspResponse.Status.VALID);
+                                        ctx.channel().close();
+                                        latch.countDown();
+                                    }
+                                }
+                            });
+                        }
+                    });
+
+            ChannelFuture channelFuture = bootstrap.connect("netty.io", 443);
+            channelFuture.sync();
+
+            // Wait for maximum of 1 minute for Ocsp validation to happen
+            latch.await(1, TimeUnit.MINUTES);
+            assertTrue(ocspStatus.get());
+
+            // Wait for Channel to be closed
+            channelFuture.channel().closeFuture().sync();
+        } finally {
+            eventLoopGroup.shutdownGracefully();
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -650,6 +650,7 @@
     <module>transport-udt</module>
     <module>handler</module>
     <module>handler-proxy</module>
+    <module>handler-ssl-ocsp</module>
     <module>example</module>
     <module>testsuite</module>
     <module>testsuite-autobahn</module>


### PR DESCRIPTION
Motivation:
Validating server certificate status is an integral part of building a secure application. To make this process fast and efficient, we should use OCSP. However, performing OCSP operations is complex. This PR aims to simplify that process by adding a handler in the pipeline.

```java
@Override
protected void initChannel(SocketChannel ch) {
    ChannelPipeline pipeline = ch.pipeline();
    pipeline.addLast(sslContext.newHandler(ch.alloc(), "netty.io", 443));
    pipeline.addLast(new OcspServerCertificateValidator(false)); // Adding OCSP validator handler
    pipeline.addLast(new HttpClientCodec());
    pipeline.addLast(new HttpObjectAggregator(1024));
    pipeline.addLast(new MyHandler());
}
```

Modification:
Create a new module `Netty/Handler/Ssl/Ocsp` which implements OCSP validation using HTTP/1.1.

Result:
Easier validation of server certificate status
