### PR TITLE
Optimize method: io.netty.util.Recycler.LocalPool.release(...)

### DIFF
--- a/common/src/main/java/io/netty/util/Recycler.java
+++ b/common/src/main/java/io/netty/util/Recycler.java
@@ -283,8 +283,8 @@ public abstract class Recycler<T> {
         }
 
         void release(DefaultHandle<T> handle) {
-            MessagePassingQueue<DefaultHandle<T>> handles = pooledHandles;
             handle.toAvailable();
+            MessagePassingQueue<DefaultHandle<T>> handles = pooledHandles;
             if (handles != null) {
                 handles.relaxedOffer(handle);
             }


### PR DESCRIPTION
Motivation:

1. There is a chance that `handle.toAvailable()` throws an exception, then there is no need to use the reference of `pooledHandles`, so it's better to move `handles = pooledHandles` after `handle.toAvailable()`.
2. The `pooledHandles` may becomes `null` after `handle.toAvailable()`, so move it after  `handle.toAvailable()` will lower the chance of executing `handles.relaxedOffer(handle)` which may leads to a synchronized `offer(e)` method.

Modification:

Move `handles = pooledHandles` after `handle.toAvailable()`.

Result:

Improve the performance in above cases.
