### PR TITLE
Add docs for methods:io.netty.util.internal.ObjectPool.ObjectCreator#newObject and io.netty.util.Recycler#newObject

### DIFF
--- a/common/src/main/java/io/netty/util/Recycler.java
+++ b/common/src/main/java/io/netty/util/Recycler.java
@@ -199,6 +199,9 @@ public abstract class Recycler<T> {
         return threadLocal.get().pooledHandles.size();
     }
 
+    /**
+     * @param handle can NOT be null.
+     */
     protected abstract T newObject(Handle<T> handle);
 
     @SuppressWarnings("ClassNameSameAsAncestorName") // Can't change this due to compatibility.

--- a/common/src/main/java/io/netty/util/internal/ObjectPool.java
+++ b/common/src/main/java/io/netty/util/internal/ObjectPool.java
@@ -55,6 +55,8 @@ public abstract class ObjectPool<T> {
         /**
          * Creates an returns a new {@link Object} that can be used and later recycled via
          * {@link Handle#recycle(Object)}.
+         *
+         * @param handle can NOT be null.
          */
         T newObject(Handle<T> handle);
     }


### PR DESCRIPTION
Motivation:

When constructing `ObjectPool` or `Recycler`, we need to pass the `handle` param, if it is `null`,
then executing the `recycle` method will cause `NullPointerException`.

Code example:

```
import io.netty.util.Recycler;

public class TestDemo {

    Recycler.Handle handle;

    TestDemo(Recycler.Handle handle) {
        this.handle = handle;
    }

    public static void main(String[] args) {
        Recycler<TestDemo> recycler = new Recycler() {
            @Override
            protected Object newObject(Recycler.Handle handle) {
                return new TestDemo(null);
            }
        };
        TestDemo obj = recycler.get();
        obj.handle.recycle(obj); // Throws NullPointerException.
    }
}
```
For compatibility, there seems not much we can do now, so just added some docs. 

IMHO, maybe we can create an `Recyclable`  interface in the next major release(netty5?), then let all the recyclable object class implement it, this can help to do the `handle` check and also let people easily see whether it is a recyclable object or not, also we can add some API like: `recycle(...)` to the `Recyclable` interface.

Modification:

Add docs for the `handle` param, indicates it can not be null.

Result:

Add docs for the `handle` param, indicates it can not be null.

