### PR TITLE
Optimize method: io.netty.util.Recycler.threadLocalSize()

### DIFF
--- a/common/src/main/java/io/netty/util/Recycler.java
+++ b/common/src/main/java/io/netty/util/Recycler.java
@@ -196,7 +196,8 @@ public abstract class Recycler<T> {
     }
 
     final int threadLocalSize() {
-        return threadLocal.get().pooledHandles.size();
+        LocalPool<T> localPool = threadLocal.getIfExists();
+        return localPool == null ? 0 : localPool.pooledHandles.size();
     }
 
     protected abstract T newObject(Handle<T> handle);


### PR DESCRIPTION
Motivation:

If we call method `Recycler.threadLocalSize()` after `FastThreadLocal.remove()` / `FastThreadLocal.removeAll()` , then the `threadLocal` will init again and create a new `pooledHandles` queue, which is not necessary.

Modification:

Firstly check the `threadLocal`'s value, return 0 if it is `null`.

Result:

When we call method `Recycler.threadLocalSize()`, avoid initializing `threadLocal`  while `threadLocal`'s value is `null`.
