### PR TITLE
Remove duplicate declaration of gson

### DIFF
--- a/codec-http2/pom.xml
+++ b/codec-http2/pom.xml
@@ -120,10 +120,6 @@
       <artifactId>reflections</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-    </dependency>
-    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty5-transport</artifactId>
       <version>${project.version}</version>
@@ -132,4 +128,3 @@
     </dependency>
   </dependencies>
 </project>
-


### PR DESCRIPTION
Some problems were encountered while building the effective model for io.netty:netty5-codec-http2:jar:5.0.0.Alpha6-SNAPSHOT
'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: com.google.code.gson:gson:jar -> duplicate declaration of version (?) @ line 122, column 17
It is highly recommended to fix these problems because they threaten the stability of your build.
For this reason, future Maven versions might no longer support building such malformed projects.
