### PR TITLE
Fix bug in method io.netty.util.internal.InternalThreadLocalMap.size()

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/FastThreadLocal.java
+++ b/common/src/main/java/io/netty/util/concurrent/FastThreadLocal.java
@@ -22,6 +22,8 @@ import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Set;
 
+import static io.netty.util.internal.InternalThreadLocalMap.VARIABLES_TO_REMOVE_INDEX;
+
 /**
  * A special variant of {@link ThreadLocal} that yields higher access performance when accessed from a
  * {@link FastThreadLocalThread}.
@@ -43,8 +45,6 @@ import java.util.Set;
  */
 public class FastThreadLocal<V> {
 
-    private static final int variablesToRemoveIndex = InternalThreadLocalMap.nextVariableIndex();
-
     /**
      * Removes all {@link FastThreadLocal} variables bound to the current thread.  This operation is useful when you
      * are in a container environment, and you don't want to leave the thread local variables in the threads you do not
@@ -57,7 +57,7 @@ public class FastThreadLocal<V> {
         }
 
         try {
-            Object v = threadLocalMap.indexedVariable(variablesToRemoveIndex);
+            Object v = threadLocalMap.indexedVariable(VARIABLES_TO_REMOVE_INDEX);
             if (v != null && v != InternalThreadLocalMap.UNSET) {
                 @SuppressWarnings("unchecked")
                 Set<FastThreadLocal<?>> variablesToRemove = (Set<FastThreadLocal<?>>) v;
@@ -96,11 +96,11 @@ public class FastThreadLocal<V> {
 
     @SuppressWarnings("unchecked")
     private static void addToVariablesToRemove(InternalThreadLocalMap threadLocalMap, FastThreadLocal<?> variable) {
-        Object v = threadLocalMap.indexedVariable(variablesToRemoveIndex);
+        Object v = threadLocalMap.indexedVariable(VARIABLES_TO_REMOVE_INDEX);
         Set<FastThreadLocal<?>> variablesToRemove;
         if (v == InternalThreadLocalMap.UNSET || v == null) {
             variablesToRemove = Collections.newSetFromMap(new IdentityHashMap<FastThreadLocal<?>, Boolean>());
-            threadLocalMap.setIndexedVariable(variablesToRemoveIndex, variablesToRemove);
+            threadLocalMap.setIndexedVariable(VARIABLES_TO_REMOVE_INDEX, variablesToRemove);
         } else {
             variablesToRemove = (Set<FastThreadLocal<?>>) v;
         }
@@ -111,7 +111,7 @@ public class FastThreadLocal<V> {
     private static void removeFromVariablesToRemove(
             InternalThreadLocalMap threadLocalMap, FastThreadLocal<?> variable) {
 
-        Object v = threadLocalMap.indexedVariable(variablesToRemoveIndex);
+        Object v = threadLocalMap.indexedVariable(VARIABLES_TO_REMOVE_INDEX);
 
         if (v == InternalThreadLocalMap.UNSET || v == null) {
             return;

--- a/common/src/main/java/io/netty/util/internal/InternalThreadLocalMap.java
+++ b/common/src/main/java/io/netty/util/internal/InternalThreadLocalMap.java
@@ -44,6 +44,7 @@ public final class InternalThreadLocalMap extends UnpaddedInternalThreadLocalMap
     private static final ThreadLocal<InternalThreadLocalMap> slowThreadLocalMap =
             new ThreadLocal<InternalThreadLocalMap>();
     private static final AtomicInteger nextIndex = new AtomicInteger();
+    // Internal use only.
     public static final int VARIABLES_TO_REMOVE_INDEX = nextVariableIndex();
 
     private static final int DEFAULT_ARRAY_LIST_INITIAL_CAPACITY = 8;

--- a/common/src/main/java/io/netty/util/internal/InternalThreadLocalMap.java
+++ b/common/src/main/java/io/netty/util/internal/InternalThreadLocalMap.java
@@ -29,6 +29,7 @@ import java.util.Arrays;
 import java.util.BitSet;
 import java.util.IdentityHashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -43,6 +44,7 @@ public final class InternalThreadLocalMap extends UnpaddedInternalThreadLocalMap
     private static final ThreadLocal<InternalThreadLocalMap> slowThreadLocalMap =
             new ThreadLocal<InternalThreadLocalMap>();
     private static final AtomicInteger nextIndex = new AtomicInteger();
+    public static final int VARIABLES_TO_REMOVE_INDEX = nextVariableIndex();
 
     private static final int DEFAULT_ARRAY_LIST_INITIAL_CAPACITY = 8;
     private static final int ARRAY_LIST_CAPACITY_EXPAND_THRESHOLD = 1 << 30;
@@ -196,15 +198,14 @@ public final class InternalThreadLocalMap extends UnpaddedInternalThreadLocalMap
             count ++;
         }
 
-        for (Object o: indexedVariables) {
-            if (o != UNSET) {
-                count ++;
-            }
+        Object v = indexedVariable(VARIABLES_TO_REMOVE_INDEX);
+        if (v != null && v != InternalThreadLocalMap.UNSET) {
+            @SuppressWarnings("unchecked")
+            Set<FastThreadLocal<?>> variablesToRemove = (Set<FastThreadLocal<?>>) v;
+            count += variablesToRemove.size();
         }
 
-        // We should subtract 1 from the count because the first element in 'indexedVariables' is reserved
-        // by 'FastThreadLocal' to keep the list of 'FastThreadLocal's to remove on 'FastThreadLocal.removeAll()'.
-        return count - 1;
+        return count;
     }
 
     public StringBuilder stringBuilder() {

--- a/common/src/test/java/io/netty/util/concurrent/FastThreadLocalTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/FastThreadLocalTest.java
@@ -253,6 +253,7 @@ public class FastThreadLocalTest {
         nextIndexField.setAccessible(true);
         AtomicInteger nextIndex = (AtomicInteger) nextIndexField.get(AtomicInteger.class);
         int nextIndex_before = nextIndex.get();
+        final AtomicReference<Throwable> throwable = new AtomicReference<Throwable>();
         try {
             while (nextIndex.get() < ARRAY_LIST_CAPACITY_MAX_SIZE) {
                 new FastThreadLocal<Boolean>();
@@ -261,13 +262,16 @@ public class FastThreadLocalTest {
             try {
                 new FastThreadLocal<Boolean>();
             } catch (Throwable t) {
-                // assert the max index cannot greater than (ARRAY_LIST_CAPACITY_MAX_SIZE - 1)
-                assertThat(t, is(instanceOf(IllegalStateException.class)));
+                throwable.set(t);
+            } finally {
+                // Assert the max index cannot greater than (ARRAY_LIST_CAPACITY_MAX_SIZE - 1).
+                assertThat(throwable.get(), is(instanceOf(IllegalStateException.class)));
+                // Assert the index was reset to ARRAY_LIST_CAPACITY_MAX_SIZE
+                // after it reaches ARRAY_LIST_CAPACITY_MAX_SIZE.
+                assertEquals(ARRAY_LIST_CAPACITY_MAX_SIZE - 1, InternalThreadLocalMap.lastVariableIndex());
             }
-            // assert the index was reset to ARRAY_LIST_CAPACITY_MAX_SIZE after it reaches ARRAY_LIST_CAPACITY_MAX_SIZE
-            assertEquals(ARRAY_LIST_CAPACITY_MAX_SIZE - 1, InternalThreadLocalMap.lastVariableIndex());
         } finally {
-            // restore the index
+            // Restore the index.
             nextIndex.set(nextIndex_before);
         }
     }
@@ -297,5 +301,38 @@ public class FastThreadLocalTest {
         fastThreadLocalThread.join();
         // assert the expanded size is not overflowed to negative value
         assertThat(throwable.get(), is(not(instanceOf(NegativeArraySizeException.class))));
+    }
+
+    @Test
+    public void testFastThreadLocalSize() throws Exception {
+        int originSize = FastThreadLocal.size();
+        assertTrue(originSize >= 0);
+
+        InternalThreadLocalMap.get();
+        assertEquals(originSize, FastThreadLocal.size());
+
+        new FastThreadLocal<Boolean>();
+        assertEquals(originSize, FastThreadLocal.size());
+
+        FastThreadLocal<Boolean> fst2 = new FastThreadLocal<Boolean>();
+        fst2.get();
+        assertEquals(1 + originSize, FastThreadLocal.size());
+
+        FastThreadLocal<Boolean> fst3 = new FastThreadLocal<Boolean>();
+        fst3.set(null);
+        assertEquals(2 + originSize, FastThreadLocal.size());
+
+        FastThreadLocal<Boolean> fst4 = new FastThreadLocal<Boolean>();
+        fst4.set(Boolean.TRUE);
+        assertEquals(3 + originSize, FastThreadLocal.size());
+
+        fst4.set(Boolean.TRUE);
+        assertEquals(3 + originSize, FastThreadLocal.size());
+
+        fst4.remove();
+        assertEquals(2 + originSize, FastThreadLocal.size());
+
+        FastThreadLocal.removeAll();
+        assertEquals(originSize, FastThreadLocal.size());
     }
 }

--- a/common/src/test/java/io/netty/util/concurrent/FastThreadLocalTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/FastThreadLocalTest.java
@@ -333,6 +333,6 @@ public class FastThreadLocalTest {
         assertEquals(2 + originSize, FastThreadLocal.size());
 
         FastThreadLocal.removeAll();
-        assertEquals(originSize, FastThreadLocal.size());
+        assertEquals(0, FastThreadLocal.size());
     }
 }


### PR DESCRIPTION
Motivation:

1. Seems there is a bug in method `InternalThreadLocalMap.size()`.  The code example below prints `-1`, which is not correct:
```
import io.netty.util.concurrent.FastThreadLocal;
import io.netty.util.internal.InternalThreadLocalMap;

public class TestFtlSize {
    public static void main(String[] args) {
        InternalThreadLocalMap.get();
        System.out.println(FastThreadLocal.size()); // Prints -1.
    }
}
```
2. Change the calculation logic from looping the `indexedVariables` array to rely on `IdentityHashMap.size()`, which will improve performance.

Modification:

Change the calculation logic in method `InternalThreadLocalMap.size()`.

Result:

Prints `0` in above code example.

