### PR TITLE
Optimize methods: FastThreadLocal.remove() and FastThreadLocal.initialize(...)

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/FastThreadLocal.java
+++ b/common/src/main/java/io/netty/util/concurrent/FastThreadLocal.java
@@ -175,6 +175,9 @@ public class FastThreadLocal<V> {
         V v = null;
         try {
             v = initialValue();
+            if (v == InternalThreadLocalMap.UNSET) {
+                throw new IllegalArgumentException("InternalThreadLocalMap.UNSET can not be initial value.");
+            }
         } catch (Exception e) {
             PlatformDependent.throwException(e);
         }
@@ -250,9 +253,8 @@ public class FastThreadLocal<V> {
         }
 
         Object v = threadLocalMap.removeIndexedVariable(index);
-        removeFromVariablesToRemove(threadLocalMap, this);
-
         if (v != InternalThreadLocalMap.UNSET) {
+            removeFromVariablesToRemove(threadLocalMap, this);
             try {
                 onRemoval((V) v);
             } catch (Exception e) {

--- a/common/src/main/java/io/netty/util/internal/InternalThreadLocalMap.java
+++ b/common/src/main/java/io/netty/util/internal/InternalThreadLocalMap.java
@@ -57,7 +57,7 @@ public final class InternalThreadLocalMap extends UnpaddedInternalThreadLocalMap
     private static final int STRING_BUILDER_MAX_SIZE;
 
     private static final InternalLogger logger;
-
+    /** Internal use only. */
     public static final Object UNSET = new Object();
 
     /** Used by {@link FastThreadLocal} */

--- a/common/src/test/java/io/netty/util/concurrent/FastThreadLocalTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/FastThreadLocalTest.java
@@ -335,4 +335,29 @@ public class FastThreadLocalTest {
         FastThreadLocal.removeAll();
         assertEquals(0, FastThreadLocal.size());
     }
+
+    @Test
+    public void testFastThreadLocalInitialValueWithUnset() throws Exception {
+        final AtomicReference<Throwable> throwable = new AtomicReference<Throwable>();
+        final FastThreadLocal fst = new FastThreadLocal() {
+            @Override
+            protected Object initialValue() throws Exception {
+                return InternalThreadLocalMap.UNSET;
+            }
+        };
+        Runnable runnable = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    fst.get();
+                } catch (Throwable t) {
+                    throwable.set(t);
+                }
+            }
+        };
+        FastThreadLocalThread fastThreadLocalThread = new FastThreadLocalThread(runnable);
+        fastThreadLocalThread.start();
+        fastThreadLocalThread.join();
+        assertThat(throwable.get(), is(instanceOf(IllegalArgumentException.class)));
+    }
 }


### PR DESCRIPTION
Motivation:
1. When call the method `FastThreadLocal.remove()`,  if the `FastThreadLocal` instance has not been `set/initialized` or has already been `removed`, then there is no need to call the `removeFromVariablesToRemove(...)` method, which will trigger a `hash-find` and hurt performance. 
Code example:
```
import io.netty.util.concurrent.FastThreadLocal;

public class TestFtlRemove {

    public static void main(String[] args) {
        
        // Assume we already created some FastThreadLocals:
        for (int i = 1 ; i<= 99; i++) {
            new FastThreadLocal<Integer>().set(1);
        }

        // then come to fst_100.
        FastThreadLocal<Integer> fst_100 = new FastThreadLocal<Integer>();

        // Now we execute fst_100.remove():
        fst_100.remove();
        // fst_100.remove() will trigger:
        // FastThreadLocal.removeFromVariablesToRemove(...) --> IdentityHashMap.remove(key) method,
        // which need to do hash-find to locate the key to remove,
        // this is not necessary for fst_100 and hurt performance.

    }
}
```
2. For method `FastThreadLocal.initialize(...)`, the return value of `initialValue()` should not be `InternalThreadLocalMap.UNSET`, which means the following code should not be allowed and need to rise an `Exception` when call `get()`:
```
FastThreadLocal<Object> fst = new FastThreadLocal<Object>(){
    @Override
    protected Object initialValue() throws Exception {
        return InternalThreadLocalMap.UNSET; // This should not be allowed.
    }
};
fst.get(); // Need to rise an Exception.
```

Modification:

1. Add checkpoint in method `removeFromVariablesToRemove(...)`, avoid call `FastThreadLocal.removeFromVariablesToRemove(...)` when the `FastThreadLocal` instance has not been `set/initialized` or has already been `removed`.
2. Add checkpoint in method `initialize(...)`, and rise an `Exception` if the check not passed.

Result:
Resolve problems described above.
