### PR TITLE
Remove deprecated/unused goal definitions which will break maven 4

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -74,9 +74,6 @@
         <groupId>com.commsen.maven</groupId>
         <artifactId>bom-helper-maven-plugin</artifactId>
         <version>0.4.0</version>
-        <goals>
-          <goal>resolve</goal>
-        </goals>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Motivation:

The netty BOM includes a deprecated element in the POM which will be removed in Maven 4. This causes the following exception when trying to import it:
```
Caused by: org.apache.maven.model.building.ModelBuildingException: 1 problem was encountered while building the effective model for /Users/gnodet/work/git/camel/parent/pom.xml
[FATAL] Unrecognised tag: 'goals' (position: START_TAG seen ...</version>\n        <goals>... @77:16)  @ io.netty:netty-bom:4.1.84.Final, /Users/gnodet/.m2/repository/io/netty/netty-bom/4.1.84.Final/netty-bom-4.1.84.Final.pom, line 77, column 16

	at org.apache.maven.model.building.DefaultModelProblemCollector.newModelBuildingException(DefaultModelProblemCollector.java:197)
	at org.apache.maven.model.building.DefaultModelBuilder.build(DefaultModelBuilder.java:772)
	at org.apache.maven.model.building.DefaultModelBuilder.build(DefaultModelBuilder.java:460)
	at org.apache.maven.model.building.DefaultModelBuilder.build(DefaultModelBuilder.java:439)
	at org.codehaus.mojo.flatten.ModelBuilderThreadSafetyWorkaround.build(ModelBuilderThreadSafetyWorkaround.java:130)
	at org.codehaus.mojo.flatten.FlattenMojo.createEffectivePom(FlattenMojo.java:902)
	... 19 common frames omitted
```
The `build > plugins > plugin > goals` element has been deprecated since a long time and it not actually used by recent maven versions.

Modification:

Remove the undesired xml element.

Result:

BOM can be parsed with maven 4.
