### PR TITLE
Remove deprecated/unused goal definitions which will break maven 4

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -74,9 +74,6 @@
         <groupId>com.commsen.maven</groupId>
         <artifactId>bom-helper-maven-plugin</artifactId>
         <version>0.4.0</version>
-        <goals>
-          <goal>resolve</goal>
-        </goals>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Same as #12911 but for `main` branch.