### PR TITLE
Add entry for creating temporary files for BlockHound configuration

### DIFF
--- a/common/src/main/java/io/netty/util/internal/Hidden.java
+++ b/common/src/main/java/io/netty/util/internal/Hidden.java
@@ -162,6 +162,7 @@ class Hidden {
                     "io.netty.util.NetUtil$SoMaxConnAction",
                     "run");
 
+            builder.allowBlockingCallsInside("io.netty.util.internal.PlatformDependent", "createTempFile");
             builder.nonBlockingThreadPredicate(new Function<Predicate<Thread>, Predicate<Thread>>() {
                 @Override
                 public Predicate<Thread> apply(final Predicate<Thread> p) {


### PR DESCRIPTION
Motivation:

We sometimes need to create temporary files which might trigger BlockHound.

Modifications:

Add extra config to allow these calls

Result:

Fixes https://github.com/netty/netty/issues/12908