### PR TITLE
Implement Early hints response status, do not poll the encoding with HTTP 1xx codes

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientCodec.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientCodec.java
@@ -266,8 +266,10 @@ public final class HttpClientCodec extends CombinedChannelDuplexHandler<HttpResp
             // request / response pairs in sync.
             HttpMethod method = queue.poll();
 
-            final int statusCode = ((HttpResponse) msg).status().code();
-            if (statusCode >= 100 && statusCode < 200) {
+            final HttpResponseStatus status = ((HttpResponse) msg).status();
+            final HttpStatusClass statusClass = status.codeClass();
+            final int statusCode = status.code();
+            if (statusClass == HttpStatusClass.INFORMATIONAL) {
                 // An informational response should be excluded from paired comparison.
                 // Just delegate to super method which has all the needed handling.
                 return super.isContentAlwaysEmpty(msg);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentEncoder.java
@@ -63,7 +63,6 @@ public abstract class HttpContentEncoder extends MessageToMessageCodec<HttpReque
 
     private static final CharSequence ZERO_LENGTH_HEAD = "HEAD";
     private static final CharSequence ZERO_LENGTH_CONNECT = "CONNECT";
-    private static final int CONTINUE_CODE = HttpResponseStatus.CONTINUE.code();
 
     private final Queue<CharSequence> acceptEncodingQueue = new ArrayDeque<CharSequence>();
     private EmbeddedChannel encoder;
@@ -113,9 +112,9 @@ public abstract class HttpContentEncoder extends MessageToMessageCodec<HttpReque
                 final HttpResponse res = (HttpResponse) msg;
                 final int code = res.status().code();
                 final CharSequence acceptEncoding;
-                if (code == CONTINUE_CODE) {
-                    // We need to not poll the encoding when response with CONTINUE as another response will follow
-                    // for the issued request. See https://github.com/netty/netty/issues/4079
+                if (code >= 100 && code < 200) {
+                    // We need to not poll the encoding when response with 1xx codes as another response will follow
+                    // for the issued request. See https://github.com/netty/netty/issues/12904 and https://github.com/netty/netty/issues/4079
                     acceptEncoding = null;
                 } else {
                     // Get the list of encodings accepted by the peer.

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentEncoder.java
@@ -111,8 +111,9 @@ public abstract class HttpContentEncoder extends MessageToMessageCodec<HttpReque
 
                 final HttpResponse res = (HttpResponse) msg;
                 final int code = res.status().code();
+                final HttpStatusClass codeClass = res.status().codeClass();
                 final CharSequence acceptEncoding;
-                if (code >= 100 && code < 200) {
+                if (codeClass == HttpStatusClass.INFORMATIONAL) {
                     // We need to not poll the encoding when response with 1xx codes as another response will follow
                     // for the issued request.
                     // See https://github.com/netty/netty/issues/12904 and https://github.com/netty/netty/issues/4079

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentEncoder.java
@@ -114,7 +114,8 @@ public abstract class HttpContentEncoder extends MessageToMessageCodec<HttpReque
                 final CharSequence acceptEncoding;
                 if (code >= 100 && code < 200) {
                     // We need to not poll the encoding when response with 1xx codes as another response will follow
-                    // for the issued request. See https://github.com/netty/netty/issues/12904 and https://github.com/netty/netty/issues/4079
+                    // for the issued request.
+                    // See https://github.com/netty/netty/issues/12904 and https://github.com/netty/netty/issues/4079
                     acceptEncoding = null;
                 } else {
                     // Get the list of encodings accepted by the peer.

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -522,14 +522,16 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
     protected boolean isContentAlwaysEmpty(HttpMessage msg) {
         if (msg instanceof HttpResponse) {
             HttpResponse res = (HttpResponse) msg;
-            int code = res.status().code();
+            final HttpResponseStatus status = res.status();
+            final int code = status.code();
+            final HttpStatusClass statusClass = status.codeClass();
 
             // Correctly handle return codes of 1xx.
             //
             // See:
             //     - https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html Section 4.4
             //     - https://github.com/netty/netty/issues/222
-            if (code >= 100 && code < 200) {
+            if (statusClass == HttpStatusClass.INFORMATIONAL) {
                 // One exception: Hixie 76 websocket handshake response
                 return !(code == 101 && !res.headers().contains(HttpHeaderNames.SEC_WEBSOCKET_ACCEPT)
                          && res.headers().contains(HttpHeaderNames.UPGRADE, HttpHeaderValues.WEBSOCKET, true));

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseStatus.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseStatus.java
@@ -49,6 +49,11 @@ public class HttpResponseStatus implements Comparable<HttpResponseStatus> {
     public static final HttpResponseStatus PROCESSING = newStatus(102, "Processing");
 
     /**
+     * 103 Early Hints (RFC 8297)
+     */
+    public static final HttpResponseStatus EARLY_HINTS = newStatus(103, "Early Hints");
+
+    /**
      * 200 OK
      */
     public static final HttpResponseStatus OK = newStatus(200, "OK");
@@ -344,6 +349,8 @@ public class HttpResponseStatus implements Comparable<HttpResponseStatus> {
             return SWITCHING_PROTOCOLS;
         case 102:
             return PROCESSING;
+        case 103:
+            return EARLY_HINTS;
         case 200:
             return OK;
         case 201:

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentCompressorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentCompressorTest.java
@@ -604,6 +604,57 @@ public class HttpContentCompressorTest {
     }
 
     @Test
+    public void test1xxInformationalResponse() throws Exception {
+        FullHttpRequest request = newRequest();
+        HttpUtil.set100ContinueExpected(request, true);
+
+        EmbeddedChannel ch = new EmbeddedChannel(new HttpContentCompressor());
+        ch.writeInbound(request);
+
+        FullHttpResponse continueResponse = new DefaultFullHttpResponse(
+            HttpVersion.HTTP_1_1, HttpResponseStatus.CONTINUE, Unpooled.EMPTY_BUFFER);
+        ch.writeOutbound(continueResponse);
+
+        FullHttpResponse earlyHintsResponse = new DefaultFullHttpResponse(
+            HttpVersion.HTTP_1_1, HttpResponseStatus.EARLY_HINTS, Unpooled.EMPTY_BUFFER);
+        earlyHintsResponse.trailingHeaders().set(of("X-Test"), of("Netty"));
+        ch.writeOutbound(earlyHintsResponse);
+
+        FullHttpResponse res = new DefaultFullHttpResponse(
+            HttpVersion.HTTP_1_1, HttpResponseStatus.OK, Unpooled.EMPTY_BUFFER);
+        res.trailingHeaders().set(of("X-Test"), of("Netty"));
+        ch.writeOutbound(res);
+
+        Object o = ch.readOutbound();
+        assertThat(o, is(instanceOf(FullHttpResponse.class)));
+
+        res = (FullHttpResponse) o;
+        assertSame(continueResponse, res);
+        res.release();
+
+        o = ch.readOutbound();
+        assertThat(o, is(instanceOf(FullHttpResponse.class)));
+
+        res = (FullHttpResponse) o;
+        assertSame(earlyHintsResponse, res);
+        res.release();
+
+        o = ch.readOutbound();
+        assertThat(o, is(instanceOf(FullHttpResponse.class)));
+
+        res = (FullHttpResponse) o;
+        assertThat(res.headers().get(HttpHeaderNames.TRANSFER_ENCODING), is(nullValue()));
+
+        // Content encoding shouldn't be modified.
+        assertThat(res.headers().get(HttpHeaderNames.CONTENT_ENCODING), is(nullValue()));
+        assertThat(res.content().readableBytes(), is(0));
+        assertThat(res.content().toString(CharsetUtil.US_ASCII), is(""));
+        assertEquals("Netty", res.trailingHeaders().get(of("X-Test")));
+        assertEquals(DecoderResult.SUCCESS, res.decoderResult());
+        assertThat(ch.readOutbound(), is(nullValue()));
+    }
+
+    @Test
     public void testTooManyResponses() throws Exception {
         FullHttpRequest request = newRequest();
         EmbeddedChannel ch = new EmbeddedChannel(new HttpContentCompressor());

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamFrameToHttpObjectCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamFrameToHttpObjectCodec.java
@@ -91,9 +91,9 @@ public class Http2StreamFrameToHttpObjectCodec extends MessageToMessageCodec<Htt
 
             final CharSequence status = headers.status();
 
-            // 100-continue response is a special case where Http2HeadersFrame#isEndStream=false
+            // 1xx response (excluding 101) is a special case where Http2HeadersFrame#isEndStream=false
             // but we need to decode it as a FullHttpResponse to play nice with HttpObjectAggregator.
-            if (null != status && HttpResponseStatus.CONTINUE.codeAsText().contentEquals(status)) {
+            if (null != status && isInformationalResponseHeaderFrame(status)) {
                 final FullHttpMessage fullMsg = newFullMessage(id, headers, ctx.alloc());
                 out.add(fullMsg);
                 return;
@@ -151,18 +151,18 @@ public class Http2StreamFrameToHttpObjectCodec extends MessageToMessageCodec<Htt
      */
     @Override
     protected void encode(ChannelHandlerContext ctx, HttpObject obj, List<Object> out) throws Exception {
-        // 100-continue is typically a FullHttpResponse, but the decoded
+        // 1xx (excluding 101) is typically a FullHttpResponse, but the decoded
         // Http2HeadersFrame should not be marked as endStream=true
         if (obj instanceof HttpResponse) {
             final HttpResponse res = (HttpResponse) obj;
-            if (res.status().equals(HttpResponseStatus.CONTINUE)) {
+            if (isInformationalResponseHeaderFrame(res.status().code())) {
                 if (res instanceof FullHttpResponse) {
                     final Http2Headers headers = toHttp2Headers(ctx, res);
                     out.add(new DefaultHttp2HeadersFrame(headers, false));
                     return;
                 } else {
                     throw new EncoderException(
-                            HttpResponseStatus.CONTINUE + " must be a FullHttpResponse");
+                            res.status() + " must be a FullHttpResponse");
                 }
             }
         }
@@ -246,5 +246,29 @@ public class Http2StreamFrameToHttpObjectCodec extends MessageToMessageCodec<Htt
     private static Channel connectionChannel(ChannelHandlerContext ctx) {
         final Channel ch = ctx.channel();
         return ch instanceof Http2StreamChannel ? ch.parent() : ch;
+    }
+
+    /**
+     *    An informational response using a 1xx status code other than 101 is
+     *    transmitted as a HEADERS frame
+     */
+    private static boolean isInformationalResponseHeaderFrame(CharSequence status) {
+        if (status.length() == 3) {
+            char char0 = status.charAt(0);
+            char char1 = status.charAt(1);
+            char char2 = status.charAt(2);
+            return char0 == '1'
+                && char1 >= '0' && char1 <= '9'
+                && char2 >= '0' && char2 <= '9' && char2 != '1';
+        }
+        return false;
+    }
+
+    /**
+     *    An informational response using a 1xx status code other than 101 is
+     *    transmitted as a HEADERS frame
+     */
+    private static boolean isInformationalResponseHeaderFrame(int status) {
+        return status >= 100 && status < 200 && status != 101;
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamFrameToHttpObjectCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamFrameToHttpObjectCodec.java
@@ -167,8 +167,7 @@ public class Http2StreamFrameToHttpObjectCodec extends MessageToMessageCodec<Htt
                     out.add(new DefaultHttp2HeadersFrame(headers, false));
                     return;
                 } else {
-                    throw new EncoderException(
-                            status + " must be a FullHttpResponse");
+                    throw new EncoderException(status + " must be a FullHttpResponse");
                 }
             }
         }


### PR DESCRIPTION
Motivation:

- 103 Early Hints response status is missing
- Http 1xx codes should expect another response next

Modifications:

- Add 103 Early Hints response status
- Replace `code == 100` with `code == 1xx`

Result:

Fixes https://github.com/netty/netty/issues/12904 and https://github.com/eclipse-vertx/vert.x/pull/4508

