### PR TITLE
Don't unnecessarily reorder http headers

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -673,7 +673,11 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
             contentLength = HttpUtil.normalizeAndGetContentLength(contentLengthFields,
                     isHttp10OrEarlier, allowDuplicateContentLengths);
             if (contentLength != -1) {
-                headers.set(HttpHeaderNames.CONTENT_LENGTH, contentLength);
+                String lengthValue = contentLengthFields.get(0).trim();
+                if (contentLengthFields.size() > 1 || // don't unnecessarily re-order headers
+                        !lengthValue.equals(Long.toString(contentLength))) {
+                    headers.set(HttpHeaderNames.CONTENT_LENGTH, contentLength);
+                }
             }
         }
 


### PR DESCRIPTION
Motivation:

The guard against multiple Content-Length headers would unconditionally replace the Content-Length header(s), this means that the Content-Length header would always be placed last. Changing the order of headers can have significant impact on code that for example does cryptographic signing of the headers and should be avoided if possible.

Modification:

Before re-assigning the Content-Length header, check if the current header is good enough and avoid the (re-)assigning in that case.

Result:

If there is only a single Content-Length header, it will remain in the same order among the headers.