### PR TITLE
Allow Buffer reuse in ByteToMessageDecoder.Cumulator

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
@@ -81,6 +81,11 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
     public static final Cumulator MERGE_CUMULATOR = new Cumulator() {
         @Override
         public ByteBuf cumulate(ByteBufAllocator alloc, ByteBuf cumulation, ByteBuf in) {
+            if (cumulation == in) {
+                // when the in buffer is the same as the cumulation it is doubly retained, release it once
+                in.release();
+                return cumulation;
+            }
             if (!cumulation.isReadable() && in.isContiguous()) {
                 // If cumulation is empty and input buffer is contiguous, use it directly
                 cumulation.release();
@@ -116,6 +121,11 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
     public static final Cumulator COMPOSITE_CUMULATOR = new Cumulator() {
         @Override
         public ByteBuf cumulate(ByteBufAllocator alloc, ByteBuf cumulation, ByteBuf in) {
+            if (cumulation == in) {
+                // when the in buffer is the same as the cumulation it is doubly retained, release it once
+                in.release();
+                return cumulation;
+            }
             if (!cumulation.isReadable()) {
                 cumulation.release();
                 return in;


### PR DESCRIPTION
Motivation:

In systems where data is streamed it is common to see partially received data. In these cases it can be advantageous to use a receive buffer allocator that re-uses the same buffer as long as it has space left to read more data. This ensures higher utilization of buffers and lowers buffer allocation pressure. In netty up until 4.1.44 this strategy was supported by the Cumulators in ByteToMessageDecoder (although possibly not by design). Since the cumulation buffer starts out as being the input buffer, and only (re)allocated if more space is needed, such a strategy of re-using buffers mean that the Cumulator will be passed the very same buffer as both input and cumulation. In earlier versions this would just work by virtue of both readerIndex and writerIndex being updated when copying data from the input buffer to the cumulation buffer. Although it would waste buffer space unnecessarily when doing so. In more recent versions when the cumulation was changed to avoid extra bounds checking on the expected-to-be-discarded input buffer, the readerIndex was not updated until after copying all data, which results in the data from the buffer (which is both input and cumulation) being duplicated (either in the same buffer or in a newly allocated larger cumulation buffer).

Modification:

This is solved by letting the Cumulator implementations explicitly handle the case when the input buffer and the cumulation buffer are the same.