### PR TITLE
Turn ReadHandle.estimatedBufferCapacity into prepareRead

### DIFF
--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/TestChannelInitializer.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/TestChannelInitializer.java
@@ -56,7 +56,7 @@ public class TestChannelInitializer extends ChannelInitializer<Channel> {
                 private int totalNumMessagesRead;
 
                 @Override
-                public int estimatedBufferCapacity() {
+                public int prepareRead() {
                     return 1; // only ever allocate buffers of size 1 to ensure the number of reads is controlled.
                 }
 

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketAutoReadTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketAutoReadTest.java
@@ -19,13 +19,13 @@ import io.netty5.bootstrap.Bootstrap;
 import io.netty5.bootstrap.ServerBootstrap;
 import io.netty5.buffer.BufferAllocator;
 import io.netty5.buffer.DefaultBufferAllocators;
-import io.netty5.util.Resource;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelInitializer;
 import io.netty5.channel.ChannelOption;
 import io.netty5.channel.ReadHandleFactory;
+import io.netty5.util.Resource;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
@@ -168,7 +168,7 @@ public class SocketAutoReadTest extends AbstractSocketTest {
             return new ReadHandle() {
 
                 @Override
-                public int estimatedBufferCapacity() {
+                public int prepareRead() {
                     return 1; // only ever allocate buffers of size 1 to ensure the number of reads is controlled.
                 }
 

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketReadPendingTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketReadPendingTest.java
@@ -17,13 +17,13 @@ package io.netty5.testsuite.transport.socket;
 
 import io.netty5.bootstrap.Bootstrap;
 import io.netty5.bootstrap.ServerBootstrap;
-import io.netty5.util.Resource;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelInitializer;
 import io.netty5.channel.ChannelOption;
 import io.netty5.channel.ReadHandleFactory;
+import io.netty5.util.Resource;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
@@ -142,22 +142,25 @@ public class SocketReadPendingTest extends AbstractSocketTest {
         public ReadHandle newHandle(Channel channel) {
             return new ReadHandle() {
                 private int totalNumMessagesRead;
+                private int totalNumMessagesPrep;
 
                 @Override
-                public int estimatedBufferCapacity() {
-                    return 1; // only ever allocate buffers of size 1 to ensure the number of reads is controlled.
+                public int prepareRead() {
+                    // only ever allocate buffers of size 1 to ensure the number of reads is controlled.
+                    return totalNumMessagesPrep++ < numReads ? 1 : 0;
                 }
 
                 @Override
                 public boolean lastRead(int attemptedBytesRead, int actualBytesRead, int numMessagesRead) {
                     if (numMessagesRead > 0) {
-                        this.totalNumMessagesRead += numMessagesRead;
+                        totalNumMessagesRead += numMessagesRead;
                     }
                     return totalNumMessagesRead < numReads;
                 }
 
                 @Override
                 public void readComplete() {
+                    totalNumMessagesPrep = 0;
                     totalNumMessagesRead = 0;
                 }
             };

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueReadHandleFactory.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueReadHandleFactory.java
@@ -46,9 +46,9 @@ public final class KQueueReadHandleFactory extends MaxMessagesReadHandleFactory 
         }
 
         @Override
-        public int estimatedBufferCapacity() {
+        public int prepareRead() {
             // bufferCapacity(...) is called with what KQueue tells us.
-            return capacity;
+            return capacity * super.prepareRead();
         }
     }
 }

--- a/transport/src/main/java/io/netty5/channel/AdaptiveReadHandleFactory.java
+++ b/transport/src/main/java/io/netty5/channel/AdaptiveReadHandleFactory.java
@@ -119,8 +119,8 @@ public class AdaptiveReadHandleFactory extends MaxMessagesReadHandleFactory {
         }
 
         @Override
-        public int estimatedBufferCapacity() {
-            return nextReceiveBufferSize;
+        public int prepareRead() {
+            return nextReceiveBufferSize * super.prepareRead();
         }
 
         private void record(int actualReadBytes) {

--- a/transport/src/main/java/io/netty5/channel/FixedReadHandleFactory.java
+++ b/transport/src/main/java/io/netty5/channel/FixedReadHandleFactory.java
@@ -33,8 +33,8 @@ public class FixedReadHandleFactory extends MaxMessagesReadHandleFactory {
         }
 
         @Override
-        public int estimatedBufferCapacity() {
-            return bufferSize;
+        public int prepareRead() {
+            return bufferSize * super.prepareRead();
         }
     }
 

--- a/transport/src/main/java/io/netty5/channel/MaxMessagesReadHandleFactory.java
+++ b/transport/src/main/java/io/netty5/channel/MaxMessagesReadHandleFactory.java
@@ -49,23 +49,34 @@ public abstract class MaxMessagesReadHandleFactory implements ReadHandleFactory 
      */
     protected abstract static class MaxMessageReadHandle implements ReadHandle {
         private final int maxMessagesPerRead;
-        private int totalMessages;
+        private int messagesPrepared;
+        private int messagesCompleted;
 
         protected MaxMessageReadHandle(int maxMessagesPerRead) {
             this.maxMessagesPerRead = checkPositive(maxMessagesPerRead, "maxMessagesPerRead");
         }
 
+        /**
+         * @return 1 if more messages can be prepared,
+         * or 0 if the maximum number of messages have already been prepared.
+         */
+        @Override
+        public int prepareRead() {
+            return messagesPrepared++ < maxMessagesPerRead? 1 : 0;
+        }
+
         @Override
         public boolean lastRead(int attemptedBytesRead, int actualBytesRead, int numMessagesRead) {
             if (numMessagesRead > 0) {
-                totalMessages += numMessagesRead;
+                messagesCompleted += numMessagesRead;
             }
-            return totalMessages < maxMessagesPerRead;
+            return messagesCompleted < maxMessagesPerRead;
         }
 
         @Override
         public void readComplete() {
-            totalMessages = 0;
+            messagesPrepared = 0;
+            messagesCompleted = 0;
         }
     }
 }

--- a/transport/src/main/java/io/netty5/channel/ReadHandleFactory.java
+++ b/transport/src/main/java/io/netty5/channel/ReadHandleFactory.java
@@ -34,8 +34,14 @@ public interface ReadHandleFactory {
         /**
          * Guess the capacity for the next receive buffer that is probably large enough to read all inbound data and
          * small enough not to waste its space.
+         * <p>
+         * This also assumes that the given read is about to happen, and may later be paired with a
+         * {@link #lastRead(int, int, int)} call.
+         * <p>
+         * The implementation can return zero, if no reads should be prepared until after the next
+         * {@link #readComplete()} call.
          */
-        int estimatedBufferCapacity();
+        int prepareRead();
 
         /**
          * Notify the {@link ReadHandle} of the last read operation and its result.

--- a/transport/src/main/java/io/netty5/channel/ServerChannelReadHandleFactory.java
+++ b/transport/src/main/java/io/netty5/channel/ServerChannelReadHandleFactory.java
@@ -31,8 +31,8 @@ public final class ServerChannelReadHandleFactory extends MaxMessagesReadHandleF
     public MaxMessageReadHandle newMaxMessageHandle(int maxMessagesPerRead) {
         return new MaxMessageReadHandle(maxMessagesPerRead) {
             @Override
-            public int estimatedBufferCapacity() {
-                return 128;
+            public int prepareRead() {
+                return 128 * super.prepareRead();
             }
         };
     }

--- a/transport/src/test/java/io/netty5/channel/MaxMessagesReadHandleFactoryTest.java
+++ b/transport/src/test/java/io/netty5/channel/MaxMessagesReadHandleFactoryTest.java
@@ -29,10 +29,6 @@ public class MaxMessagesReadHandleFactoryTest {
             @Override
             public MaxMessageReadHandle newMaxMessageHandle(int maxMessagesPerRead) {
                 return new MaxMessageReadHandle(maxMessagesPerRead) {
-                    @Override
-                    public int estimatedBufferCapacity() {
-                        return 0;
-                    }
                 };
             }
         };

--- a/transport/src/test/java/io/netty5/channel/local/LocalChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/local/LocalChannelTest.java
@@ -25,10 +25,10 @@ import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelInitializer;
 import io.netty5.channel.ChannelOption;
-import io.netty5.channel.MaxMessagesReadHandleFactory;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.EventLoopGroup;
 import io.netty5.channel.IoHandler;
+import io.netty5.channel.MaxMessagesReadHandleFactory;
 import io.netty5.channel.MultithreadEventLoopGroup;
 import io.netty5.channel.ServerChannelReadHandleFactory;
 import io.netty5.channel.SimpleChannelInboundHandler;
@@ -1251,8 +1251,8 @@ public class LocalChannelTest {
         public MaxMessageReadHandle newMaxMessageHandle(int maxMessagesPerRead) {
             return new MaxMessageReadHandle(maxMessagesPerRead) {
                 @Override
-                public int estimatedBufferCapacity() {
-                    return 128;
+                public int prepareRead() {
+                    return 128 * super.prepareRead();
                 }
 
                 @Override


### PR DESCRIPTION
Motivation:
For asynchronous transport implementations we need to know a priori how many messages we can receive in one event-loop iteration for a channel. To do this we need a slight change to how ReadHandle works.

Modification:
Change the ReadHandle.estimatedBufferCapacity method into a prepareRead method. The prepareRead may change state of the handle, and may limit the number of buffers that can be prepared at any one time. For instance, handles derived from the MaxMessagesReadHandleFactory will refuse to prepare more than the max-messages number of buffers.

Result:
Asynchronous transports can now prepare the correct number of read operations, following the instructions of the ReadHandle.