### PR TITLE
Transport to close channel if read detects closure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1098,6 +1098,10 @@
                     <match>/org\.openjdk\.jmh\..*/</match>
                   </item>
                   <item>
+                    <matcher>java-package</matcher>
+                    <match>/.*\.testsuite\..*/</match>
+                  </item>
+                  <item>
                     <matcher>java</matcher>
                     <match>@io.netty.util.internal.UnstableApi ^*;</match>
                   </item>
@@ -1131,18 +1135,6 @@
                   <regex>true</regex>
                   <package>io\.netty\..*</package>
                   <justification>They're not "external classes" if they're from a Netty package.</justification>
-                </item>
-                <item>
-                  <ignore>true</ignore>
-                  <code>java.field.removed</code>
-                  <classQualifiedName>io.netty.util.internal.InternalThreadLocalMap</classQualifiedName>
-                  <justification>Ignore cache padding.</justification>
-                </item>
-                <item>
-                  <ignore>true</ignore>
-                  <code>java.method.removed</code>
-                  <old>method java.lang.String io.netty.testsuite.util.TestUtils::testMethodName(org.junit.rules.TestName)</old>
-                  <justification>This should be test-only, and we're removing support for JUnit 4.</justification>
                 </item>
                 <!-- Necessary changes to fix #12627 -->
                 <item>

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/AbstractSocketShutdownOutputByPeerTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/AbstractSocketShutdownOutputByPeerTest.java
@@ -72,11 +72,14 @@ public abstract class AbstractSocketShutdownOutputByPeerTest<Socket> extends Abs
             shutdownOutput(s);
 
             h.halfClosure.await();
+            // Transport/protocols do not support half closure on the wire, shutting down output will send a FIN
+            // on the wire and trigger closure/cleanup.
+            h.ch.closeFuture().await();
 
-            assertTrue(h.ch.isOpen());
-            assertTrue(h.ch.isActive());
+            assertFalse(h.ch.isOpen());
+            assertFalse(h.ch.isActive());
             assertTrue(h.ch.isInputShutdown());
-            assertFalse(h.ch.isOutputShutdown());
+            assertTrue(h.ch.isOutputShutdown());
 
             while (h.closure.getCount() != 1 && h.halfClosureCount.intValue() != 1) {
                 Thread.sleep(100);

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -227,7 +227,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
             throws Throwable {
         final int totalServerBytesWritten = 1024 * 16;
         final int numReadsPerReadLoop = 2;
-        final AtomicReference<Channel> serverConnectedChannelRef = new AtomicReference<>();
+        final AtomicReference<Channel> serverConnectedChannelRef = new AtomicReference<Channel>();
         final CountDownLatch serverChannelLatch = new CountDownLatch(1);
         final CountDownLatch serverInitializedLatch = new CountDownLatch(1);
         final CountDownLatch clientReadAllDataLatch = new CountDownLatch(1);

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -212,7 +212,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] autoRead={0} serverForceClose={1}")
     @CsvSource(value = {"true,true", "true,false", "false, true", "false,false"})
-    public void testAllDataReadAfterHalfClosure(boolean autoRead, boolean serverForceClose,
+    public void testAllDataReadAfterHalfClosure(final boolean autoRead, final boolean serverForceClose,
                                                 TestInfo testInfo) throws Throwable {
         run(testInfo, new Runner<ServerBootstrap, Bootstrap>() {
             @Override
@@ -223,7 +223,8 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
     }
 
     private void testAllDataReadAfterHalfClosure(ServerBootstrap sb, Bootstrap cb,
-                                                 boolean autoRead, boolean serverForceClose) throws Throwable {
+                                                 final boolean autoRead, final boolean serverForceClose)
+            throws Throwable {
         final int totalServerBytesWritten = 1024 * 16;
         final int numReadsPerReadLoop = 2;
         final AtomicReference<Channel> serverConnectedChannelRef = new AtomicReference<>();
@@ -252,7 +253,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                     serverChannelLatch.countDown();
                     ch.pipeline().addLast(new ChannelInboundHandlerAdapter() {
                         @Override
-                        public void channelActive(ChannelHandlerContext ctx) throws Exception {
+                        public void channelActive(final ChannelHandlerContext ctx) throws Exception {
                             ByteBuf buf = ctx.alloc().buffer(totalServerBytesWritten);
                             buf.writerIndex(buf.capacity());
                             ctx.writeAndFlush(buf).addListener(new ChannelFutureListener() {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -347,7 +347,8 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
             assertTrue(totalServerBytesWritten > clientReadCompletes.get(),
                 "too many read complete events: " + clientReadCompletes.get());
             assertTrue(clientZeroDataReadCompletes.get() <= 1, // 1 is OK to detect close.
-                "too many readComplete with no data: " + clientReadCompletes.get());
+                "too many readComplete with no data: " + clientZeroDataReadCompletes.get() + " readComplete: " +
+                        clientReadCompletes.get());
 
             serverChannelLatch.await();
             Channel serverConnectedChannel = serverConnectedChannelRef.get();

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
@@ -504,9 +504,11 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
                 if (isAllowHalfClosure(config())) {
                     try {
                         socket.shutdown(true, false);
-                    } catch (IOException | NotYetConnectedException ignored) {
+                    } catch (IOException ignored) {
                         // We attempted to shutdown and failed, which means the input has already effectively been
                         // shutdown.
+                    } catch (NotYetConnectedException ignored) {
+                        // same as above...
                     }
                     clearEpollIn0();
                     pipeline().fireUserEventTriggered(ChannelInputShutdownEvent.INSTANCE);

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
@@ -730,7 +730,7 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
             // If oom will close the read event, release connection.
             // See https://github.com/netty/netty/issues/10434
             if (close || cause instanceof OutOfMemoryError || cause instanceof IOException) {
-                shutdownInput(false);
+                transportInputShutdown();
             }
         }
 
@@ -765,7 +765,7 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
                             boolean spliceInResult = spliceTask.spliceIn(allocHandle);
 
                             if (allocHandle.isReceivedRdHup()) {
-                                shutdownInput(true);
+                                transportInputShutdown();
                             }
                             if (spliceInResult) {
                                 // We need to check if it is still active as if not we removed all SpliceTasks in
@@ -820,7 +820,7 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
                 pipeline.fireChannelReadComplete();
 
                 if (close) {
-                    shutdownInput(false);
+                    transportInputShutdown();
                 }
             } catch (Throwable t) {
                 handleReadException(pipeline, byteBuf, t, close, allocHandle);

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
@@ -447,9 +447,11 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
                 if (isAllowHalfClosure(config())) {
                     try {
                         socket.shutdown(true, false);
-                    } catch (IOException | NotYetConnectedException ignored) {
+                    } catch (IOException ignored) {
                         // We attempted to shutdown and failed, which means the input has already effectively been
                         // shutdown.
+                    } catch (NotYetConnectedException ignored) {
+                        // same as above...
                     }
                     clearReadFilter0();
                     pipeline().fireUserEventTriggered(ChannelInputShutdownEvent.INSTANCE);

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueStreamChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueStreamChannel.java
@@ -564,7 +564,7 @@ public abstract class AbstractKQueueStreamChannel extends AbstractKQueueChannel 
                 pipeline.fireChannelReadComplete();
 
                 if (close) {
-                    shutdownInput(false);
+                    transportInputShutdown();
                 }
             } catch (Throwable t) {
                 handleReadException(pipeline, byteBuf, t, close, allocHandle);
@@ -591,7 +591,7 @@ public abstract class AbstractKQueueStreamChannel extends AbstractKQueueChannel 
                 // If oom will close the read event, release connection.
                 // See https://github.com/netty/netty/issues/10434
                 if (close || cause instanceof OutOfMemoryError || cause instanceof IOException) {
-                    shutdownInput(false);
+                    transportInputShutdown();
                 }
             }
         }

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollETSocketHalfClosed.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollETSocketHalfClosed.java
@@ -18,12 +18,18 @@ package io.netty.channel.epoll;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.Channel;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketHalfClosedTest;
 
 import java.util.List;
 
 public class EpollETSocketHalfClosed extends SocketHalfClosedTest {
+    @Override
+    protected boolean needReadToDetectClosure(Channel channel) {
+        return !(channel.eventLoop() instanceof EpollEventLoop);
+    }
+
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return EpollSocketTestPermutation.INSTANCE.socketWithoutFastOpen();

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollLTSocketHalfClosed.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollLTSocketHalfClosed.java
@@ -18,12 +18,18 @@ package io.netty.channel.epoll;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.Channel;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketHalfClosedTest;
 
 import java.util.List;
 
 public class EpollLTSocketHalfClosed extends SocketHalfClosedTest {
+    @Override
+    protected boolean needReadToDetectClosure(Channel channel) {
+        return !(channel.eventLoop() instanceof EpollEventLoop);
+    }
+
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return EpollSocketTestPermutation.INSTANCE.socketWithoutFastOpen();

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueETSocketHalfClosedTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueETSocketHalfClosedTest.java
@@ -17,12 +17,18 @@ package io.netty.channel.kqueue;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketHalfClosedTest;
 
 import java.util.List;
 
 public class KQueueETSocketHalfClosedTest extends SocketHalfClosedTest {
+    @Override
+    protected boolean needReadToDetectClosure(Channel channel) {
+        return !(channel.eventLoop() instanceof KQueueEventLoop);
+    }
+
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return KQueueSocketTestPermutation.INSTANCE.socket();

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioByteChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioByteChannel.java
@@ -100,6 +100,7 @@ public abstract class AbstractNioByteChannel extends AbstractNioChannel {
             if (!isInputShutdown0()) {
                 if (isAllowHalfClosure(config())) {
                     shutdownInput();
+                    clearReadPending();
                     pipeline.fireUserEventTriggered(ChannelInputShutdownEvent.INSTANCE);
                 }
             }


### PR DESCRIPTION
Motivation:
Protocols powered by the ByteStream transport classes (TCP, UDS) do not have independent state for input/output shutdown. If we read the transport is shut down then future writes are not expected to succeed, but today we leave the channel in an unusable state and expect the next write to detect the failure and trigger a close.

Modifications:
- Instead of waiting for the write to detect the channel is closed the transport should just close the channel when it detects it is closed.