### PR TITLE
fix init allocateUninitializedArray

### DIFF
--- a/common/src/main/java/io/netty5/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty5/util/internal/PlatformDependent0.java
@@ -331,7 +331,7 @@ final class PlatformDependent0 {
                     try {
                         return MethodHandles.lookup().findVirtual(finalInternalUnsafe.getClass(),
                                 "allocateUninitializedArray",
-                                MethodType.methodType(byte[].class, Class.class, int.class))
+                                MethodType.methodType(Object.class, Class.class, int.class))
                                 .bindTo(finalInternalUnsafe);
                     } catch (NoSuchMethodException | SecurityException | IllegalAccessException e) {
                         return e;
@@ -341,7 +341,7 @@ final class PlatformDependent0 {
                 if (maybeException instanceof MethodHandle) {
                     try {
                         MethodHandle m = (MethodHandle) maybeException;
-                        byte[] bytes = (byte[]) m.invoke(finalInternalUnsafe, byte.class, 8);
+                        byte[] bytes = (byte[]) m.invoke(byte.class, 8);
                         assert bytes.length == 8;
                         allocateArrayHandle = m;
                     } catch (Throwable e) {


### PR DESCRIPTION
**Motivation**:
<details>
  <summary>Non-fatal exception while netty initialization:</summary>
 
  ```
08:55:22.083 [main] DEBUG i.n.util.internal.PlatformDependent0     - jdk.internal.misc.Unsafe.allocateUninitializedArray(int): unavailable
java.lang.NoSuchMethodException: no such method: jdk.internal.misc.Unsafe.allocateUninitializedArray(Class,int)byte[]/invokeVirtual
        at java.base@19.0.1/java.lang.invoke.MemberName.makeAccessException(MemberName.java:976)
        at java.base@19.0.1/java.lang.invoke.MemberName$Factory.resolveOrFail(MemberName.java:1117)
        at java.base@19.0.1/java.lang.invoke.MethodHandles$Lookup.resolveOrFail(MethodHandles.java:3664)
        at java.base@19.0.1/java.lang.invoke.MethodHandles$Lookup.findVirtual(MethodHandles.java:2690)
        at io.netty5.util.internal.PlatformDependent0.lambda$static$7(PlatformDependent0.java:373)
        at java.base@19.0.1/java.security.AccessController.executePrivileged(AccessController.java:168)
        at java.base@19.0.1/java.security.AccessController.doPrivileged(AccessController.java:318)
        at io.netty5.util.internal.PlatformDependent0.<clinit>(PlatformDependent0.java:371)
        at io.netty5.util.internal.PlatformDependent.isAndroid(PlatformDependent.java:291)
        at io.netty5.util.internal.PlatformDependent.<clinit>(PlatformDependent.java:84)
        at io.netty5.channel.nio.NioHandler.lambda$openSelector$2(NioHandler.java:175)
        at java.base@19.0.1/java.security.AccessController.executePrivileged(AccessController.java:168)
        at java.base@19.0.1/java.security.AccessController.doPrivileged(AccessController.java:318)
        at io.netty5.channel.nio.NioHandler.openSelector(NioHandler.java:170)
        at io.netty5.channel.nio.NioHandler.<init>(NioHandler.java:120)
        at io.netty5.channel.nio.NioHandler.<init>(NioHandler.java:115)
        at io.netty5.channel.MultithreadEventLoopGroup.newChild(MultithreadEventLoopGroup.java:293)
        at io.netty5.channel.MultithreadEventLoopGroup.newChild(MultithreadEventLoopGroup.java:39)
        at io.netty5.util.concurrent.MultithreadEventExecutorGroup.<init>(MultithreadEventExecutorGroup.java:131)
        at io.netty5.channel.MultithreadEventLoopGroup.<init>(MultithreadEventLoopGroup.java:236)
        at io.netty5.channel.MultithreadEventLoopGroup.<init>(MultithreadEventLoopGroup.java:190)
        at io.netty5.channel.MultithreadEventLoopGroup.<init>(MultithreadEventLoopGroup.java:88)
        at io.netty5.channel.MultithreadEventLoopGroup.<init>(MultithreadEventLoopGroup.java:62)
        at mega.legacy.client.Main$package$.main(Main.scala:41)
        at mega.legacy.client.main.main(Main.scala:23)
  ```

</details>

**Modification**:

Fixed incorrect initialization of `allocateUninitializedArray`.

1. `Unsafe.allocateUninitializedArray` returns `Object` not `byte[]`, `findVirtual` cannot find it with the wrong signature.
2. Don't pass reference to `Unsafe` into `invoke`, because it already was binded by `.bindTo(finalInternalUnsafe)`

**Result**:

Before:
```
Benchmark                                                 (size)  Mode  Cnt     Score      Error  Units
UnitializedArrayBenchmark.allocateUninitializedByteArray   10000  avgt    6   708.495 ± 1034.006  ns/op
UnitializedArrayBenchmark.allocateUninitializedByteArray  100000  avgt    6  6282.405 ± 8777.465  ns/op
```

After:
```
Benchmark                                                 (size)  Mode  Cnt   Score   Error  Units
UnitializedArrayBenchmark.allocateUninitializedByteArray   10000  avgt    6  31.925 ± 1.955  ns/op
UnitializedArrayBenchmark.allocateUninitializedByteArray  100000  avgt    6  59.238 ± 4.599  ns/op
```