### PR TITLE
Initialize InternalLogger as last field in InternalThreadLocalMap to …

### DIFF
--- a/common/src/main/java/io/netty/util/internal/InternalThreadLocalMap.java
+++ b/common/src/main/java/io/netty/util/internal/InternalThreadLocalMap.java
@@ -39,8 +39,6 @@ import java.util.concurrent.atomic.AtomicInteger;
  * unless you know what you are doing.
  */
 public final class InternalThreadLocalMap extends UnpaddedInternalThreadLocalMap {
-
-    private static final InternalLogger logger = InternalLoggerFactory.getInstance(InternalThreadLocalMap.class);
     private static final ThreadLocal<InternalThreadLocalMap> slowThreadLocalMap =
             new ThreadLocal<InternalThreadLocalMap>();
     private static final AtomicInteger nextIndex = new AtomicInteger();
@@ -51,10 +49,14 @@ public final class InternalThreadLocalMap extends UnpaddedInternalThreadLocalMap
     private static final int ARRAY_LIST_CAPACITY_EXPAND_THRESHOLD = 1 << 30;
     // Reference: https://hg.openjdk.java.net/jdk8/jdk8/jdk/file/tip/src/share/classes/java/util/ArrayList.java#l229
     private static final int ARRAY_LIST_CAPACITY_MAX_SIZE = Integer.MAX_VALUE - 8;
-    private static final int STRING_BUILDER_INITIAL_SIZE;
-    private static final int STRING_BUILDER_MAX_SIZE;
+
     private static final int HANDLER_SHARABLE_CACHE_INITIAL_CAPACITY = 4;
     private static final int INDEXED_VARIABLE_TABLE_INITIAL_SIZE = 32;
+
+    private static final int STRING_BUILDER_INITIAL_SIZE;
+    private static final int STRING_BUILDER_MAX_SIZE;
+
+    private static final InternalLogger logger;
 
     public static final Object UNSET = new Object();
 
@@ -86,9 +88,16 @@ public final class InternalThreadLocalMap extends UnpaddedInternalThreadLocalMap
     static {
         STRING_BUILDER_INITIAL_SIZE =
                 SystemPropertyUtil.getInt("io.netty.threadLocalMap.stringBuilder.initialSize", 1024);
-        logger.debug("-Dio.netty.threadLocalMap.stringBuilder.initialSize: {}", STRING_BUILDER_INITIAL_SIZE);
+        STRING_BUILDER_MAX_SIZE =
+                SystemPropertyUtil.getInt("io.netty.threadLocalMap.stringBuilder.maxSize", 1024 * 4);
 
-        STRING_BUILDER_MAX_SIZE = SystemPropertyUtil.getInt("io.netty.threadLocalMap.stringBuilder.maxSize", 1024 * 4);
+        // Ensure the InternalLogger is initialized as last field in this class as InternalThreadLocalMap might be used
+        // by the InternalLogger itself. For this its important that all the other static fields are correctly
+        // initialized.
+        //
+        // See https://github.com/netty/netty/issues/12931.
+        logger = InternalLoggerFactory.getInstance(InternalThreadLocalMap.class);
+        logger.debug("-Dio.netty.threadLocalMap.stringBuilder.initialSize: {}", STRING_BUILDER_INITIAL_SIZE);
         logger.debug("-Dio.netty.threadLocalMap.stringBuilder.maxSize: {}", STRING_BUILDER_MAX_SIZE);
     }
 


### PR DESCRIPTION
…fix possible NPE

Motivation:

InternalLogger implementations might use FastThreadLocal and so InternalThradLocalMap. Because of this its important that we init the field that holds the InternalLogger as last.

Modifications:

Ensure field is init as last

Result:

Fix possible NPE, see https://github.com/netty/netty/issues/12931
