### PR TITLE
Stop producing compressed heap dumps in SocketGatheringWriteTest

### DIFF
--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketGatheringWriteTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketGatheringWriteTest.java
@@ -31,7 +31,6 @@ import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.ImmediateEventExecutor;
 import io.netty5.util.concurrent.Promise;
 import io.netty5.util.internal.StringUtil;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
@@ -54,11 +53,6 @@ public class SocketGatheringWriteTest extends AbstractSocketTest {
 
     static {
         random.nextBytes(data);
-    }
-
-    @AfterAll
-    public static void compressHeapDumps() throws Exception {
-        TestUtils.compressHeapDumps();
     }
 
     @Test


### PR DESCRIPTION
Motivation:
This operation takes a while to complete, and was added 6 years ago. Whatever we were trying to debug back then, is probably not relevant anymore.

Modification:
Stop producing XZ compressed heap dumps after running all of the SocketGatheringWriteTests.

Result:
The test runs much faster.