### PR TITLE
Avoid ignoring interrupts in SocketStartTlsTest and SocketSslEchoTest

### DIFF
--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslEchoTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslEchoTest.java
@@ -353,11 +353,7 @@ public class SocketSslEchoTest extends AbstractSocketTest {
                 break;
             }
 
-            try {
-                Thread.sleep(50);
-            } catch (InterruptedException e) {
-                // Ignore.
-            }
+            Thread.sleep(50);
         }
 
         while (serverRecvCounter.get() < data.length) {
@@ -368,11 +364,7 @@ public class SocketSslEchoTest extends AbstractSocketTest {
                 break;
             }
 
-            try {
-                Thread.sleep(50);
-            } catch (InterruptedException e) {
-                // Ignore.
-            }
+            Thread.sleep(50);
         }
 
         // Wait until renegotiation is done.

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketStartTlsTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketStartTlsTest.java
@@ -172,11 +172,7 @@ public class SocketStartTlsTest extends AbstractSocketTest {
                 break;
             }
 
-            try {
-                Thread.sleep(50);
-            } catch (InterruptedException e) {
-                // Ignore.
-            }
+            Thread.sleep(50);
         }
 
         while (sh.channel.isActive()) {
@@ -187,11 +183,7 @@ public class SocketStartTlsTest extends AbstractSocketTest {
                 break;
             }
 
-            try {
-                Thread.sleep(50);
-            } catch (InterruptedException e) {
-                // Ignore.
-            }
+            Thread.sleep(50);
         }
 
         sh.channel.close().asStage().await();


### PR DESCRIPTION
Motivation:
JUnit relies on interrupts to communicate test timeouts.
When we silently swallow interrupts, we break this mechanism.

Modification:
Make the loops in SocketStartTlsTest and SocketSslEchoTest throw their interrupts instead of silently swallowing them.

Result:
The tests now responds to timeouts.