### PR TITLE
Fix bug in partially consuming ChannelOutboundBuffer

### DIFF
--- a/transport/src/main/java/io/netty5/channel/ChannelOutboundBuffer.java
+++ b/transport/src/main/java/io/netty5/channel/ChannelOutboundBuffer.java
@@ -376,16 +376,17 @@ final class ChannelOutboundBuffer {
             return;
         }
 
-        boolean keepGoing = true;
         do {
             if (!entry.cancelled) {
                 Promise<Void> promise = entry.promise;
+                if (!processor.test(entry.msg, promise)) {
+                    return;
+                }
                 promise.asFuture().addListener(new DecrementPendingBytes(this, entry.pendingSize));
-                keepGoing = processor.test(entry.msg, promise);
             }
             removeEntry(entry);
             entry = entry.recycleAndGetNext();
-        } while (keepGoing && isFlushedEntry(entry));
+        } while (isFlushedEntry(entry));
     }
 
     private boolean isFlushedEntry(Entry e) {


### PR DESCRIPTION
Motivation:
If the callback to ChannelOutboundBuffer.consumeEachFlushedMessage returned `false` to halt the iteration early, the message that caused the halt will then be considered to have been consumed. That's a bug. The message should instead remain flushed in the outbound buffer.

Modification:
Fix the loop logic so we avoid removing any message that causes the loop to break early.

Result:
The callback to ChannelOutboundBuffer.consumeEachFlushedMessage can now break the loop early, if it can't process the given message, without loosing any data.