### PR TITLE
Avoid long stacktrace when netty-resolver-dns-native-macos native library is missing

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddressStreamProviders.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddressStreamProviders.java
@@ -71,9 +71,17 @@ public final class DnsServerAddressStreamProviders {
                         + "incorrect DNS resolutions on MacOS. Check whether you have a dependency on "
                         + "'io.netty:netty-resolver-dns-native-macos'", MACOS_PROVIDER_CLASS_NAME);
             } catch (Throwable cause) {
-                LOGGER.error("Unable to load {}, fallback to system defaults. This may result in "
-                        + "incorrect DNS resolutions on MacOS. Check whether you have a dependency on "
-                        + "'io.netty:netty-resolver-dns-native-macos'", MACOS_PROVIDER_CLASS_NAME, cause);
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("Unable to load {}, fallback to system defaults. This may result in "
+                            + "incorrect DNS resolutions on MacOS. Check whether you have a dependency on "
+                            + "'io.netty:netty-resolver-dns-native-macos'", MACOS_PROVIDER_CLASS_NAME, cause);
+                } else {
+                    LOGGER.error("Unable to load {}, fallback to system defaults. This may result in "
+                            + "incorrect DNS resolutions on MacOS. Check whether you have a dependency on "
+                            + "'io.netty:netty-resolver-dns-native-macos'. Use DEBUG level to see the full stack: {}",
+                            MACOS_PROVIDER_CLASS_NAME,
+                            cause.getCause() != null ? cause.getCause().toString() : cause.toString());
+                }
                 constructor = null;
             }
         }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddressStreamProviders.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddressStreamProviders.java
@@ -72,7 +72,7 @@ public final class DnsServerAddressStreamProviders {
                         + "'io.netty:netty-resolver-dns-native-macos'", MACOS_PROVIDER_CLASS_NAME);
             } catch (Throwable cause) {
                 if (LOGGER.isDebugEnabled()) {
-                    LOGGER.debug("Unable to load {}, fallback to system defaults. This may result in "
+                    LOGGER.error("Unable to load {}, fallback to system defaults. This may result in "
                             + "incorrect DNS resolutions on MacOS. Check whether you have a dependency on "
                             + "'io.netty:netty-resolver-dns-native-macos'", MACOS_PROVIDER_CLASS_NAME, cause);
                 } else {


### PR DESCRIPTION
Motivation:
When `netty-resolver-dns-native-macos` java classes are on the classpath but the native library is missing, the long stacktrace below is printed in the logs. In the log message it is already recommended that a missing dependency may cause the issue, adding this dependency in most cases should fix the issue. This PR proposes changes in the information that is provided for this issue depending on the log level:
- When on DEBUG log level the recommendation for checking the dependency and the full stacktrace can be seen
- Otherwise the recommendation for checking the dependency and the cause message can be seen

```
[Test worker] ERROR i.n.r.d.DnsServerAddressStreamProviders - Unable to load io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider, fallback to system defaults. This may result in incorrect DNS resolutions on MacOS. Check whether you have a dependency on 'io.netty:netty-resolver-dns-native-macos'
java.lang.reflect.InvocationTargetException: null
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at io.netty.resolver.dns.DnsServerAddressStreamProviders.<clinit>(DnsServerAddressStreamProviders.java:64)
        ...
Caused by: java.lang.UnsatisfiedLinkError: failed to load the required native library
	at io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider.ensureAvailability(MacOSDnsServerAddressStreamProvider.java:110)
	at io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider.<init>(MacOSDnsServerAddressStreamProvider.java:120)
	...
Caused by: java.lang.UnsatisfiedLinkError: could not load a native library: netty_resolver_dns_native_macos_x86_64
	at io.netty.util.internal.NativeLibraryLoader.load(NativeLibraryLoader.java:239)
	at io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider.loadNativeLibrary(MacOSDnsServerAddressStreamProvider.java:92)
	at io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider.<clinit>(MacOSDnsServerAddressStreamProvider.java:77)
	...
	Suppressed: java.lang.UnsatisfiedLinkError: could not load a native library: netty_resolver_dns_native_macos
		at io.netty.util.internal.NativeLibraryLoader.load(NativeLibraryLoader.java:239)
		at io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider.loadNativeLibrary(MacOSDnsServerAddressStreamProvider.java:95)
		...
	Caused by: java.io.FileNotFoundException: META-INF/native/libnetty_resolver_dns_native_macos.jnilib
		at io.netty.util.internal.NativeLibraryLoader.load(NativeLibraryLoader.java:181)
		...
		Suppressed: java.lang.UnsatisfiedLinkError: no netty_resolver_dns_native_macos in java.library.path
			at java.lang.ClassLoader.loadLibrary(ClassLoader.java:1860)
			at java.lang.Runtime.loadLibrary0(Runtime.java:871)
			at java.lang.System.loadLibrary(System.java:1122)
			at io.netty.util.internal.NativeLibraryUtil.loadLibrary(NativeLibraryUtil.java:38)
			at io.netty.util.internal.NativeLibraryLoader.loadLibrary(NativeLibraryLoader.java:391)
			at io.netty.util.internal.NativeLibraryLoader.load(NativeLibraryLoader.java:161)
			...
			Suppressed: java.lang.UnsatisfiedLinkError: no netty_resolver_dns_native_macos in java.library.path
				at java.lang.ClassLoader.loadLibrary(ClassLoader.java:1860)
				at java.lang.Runtime.loadLibrary0(Runtime.java:871)
				at java.lang.System.loadLibrary(System.java:1122)
				at io.netty.util.internal.NativeLibraryUtil.loadLibrary(NativeLibraryUtil.java:38)
				...
Caused by: java.io.FileNotFoundException: META-INF/native/libnetty_resolver_dns_native_macos_x86_64.jnilib
	at io.netty.util.internal.NativeLibraryLoader.load(NativeLibraryLoader.java:181)
	...
	Suppressed: java.lang.UnsatisfiedLinkError: no netty_resolver_dns_native_macos_x86_64 in java.library.path
		at java.lang.ClassLoader.loadLibrary(ClassLoader.java:1860)
		at java.lang.Runtime.loadLibrary0(Runtime.java:871)
		at java.lang.System.loadLibrary(System.java:1122)
		at io.netty.util.internal.NativeLibraryUtil.loadLibrary(NativeLibraryUtil.java:38)
		...
		Suppressed: java.lang.UnsatisfiedLinkError: no netty_resolver_dns_native_macos_x86_64 in java.library.path
			at java.lang.ClassLoader.loadLibrary(ClassLoader.java:1860)
			at java.lang.Runtime.loadLibrary0(Runtime.java:871)
			at java.lang.System.loadLibrary(System.java:1122)
			at io.netty.util.internal.NativeLibraryUtil.loadLibrary(NativeLibraryUtil.java:38)
			...
```

Modification:
- When `DnsServerAddressStreamProviders` tries to load `MacOSDnsServerAddressStreamProvider` but the needed native library is not available:
  - If the log level is DEBUG log level,  a recommendation for checking the dependency and the full stacktrace can be seen
  - Otherwise, a recommendation for checking the dependency and only the cause message can be seen

Result:
The log file is less verbose when on log level different than DEBUG, but when on DEBUG level, the full information will be available
