### PR TITLE
Attach lifecycle traces to Send.receive exceptions

### DIFF
--- a/docker/Dockerfile.centos6
+++ b/docker/Dockerfile.centos6
@@ -26,7 +26,7 @@ RUN mkdir -p /var/cache/yum/x86_64/6/centos-sclo-rh/ && \
     yum install devtoolset-7 -y
 
 # Downloading and installing SDKMAN!
-RUN curl -s "https://get.sdkman.io" | bash
+RUN curl -s  "https://get.sdkman.io" | bash
 
 ARG java_version=11.0.12-zulu
 ENV JAVA_VERSION $java_version


### PR DESCRIPTION
Motivation:
A Send can only be received once. Any subsequent call to receive will throw an exception. It will be helpful for debugging such exceptions, if they include a lifecycle trace for the received object, which may include the point where the object was first received.

Modification:
Make SendFromOwned remember the received object and, if not null (e.g. via a race), use it to attach traces to any gate exceptions it throws.

Result:
Exceptions from Send.receive are now easier to debug.