### PR TITLE
Remove calls to ThreadGroup.destroy and isDestroyed

### DIFF
--- a/common/src/test/java/io/netty/util/concurrent/DefaultThreadFactoryTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/DefaultThreadFactoryTest.java
@@ -274,7 +274,6 @@ public class DefaultThreadFactoryTest {
         final AtomicReference<ThreadGroup> firstCaptured = new AtomicReference<ThreadGroup>();
 
         final ThreadGroup group = new ThreadGroup("first");
-        assertFalse(group.isDestroyed());
         final Thread first = new Thread(group, new Runnable() {
             @Override
             public void run() {
@@ -285,9 +284,6 @@ public class DefaultThreadFactoryTest {
         });
         first.start();
         first.join();
-        // Destroy the group now
-        group.destroy();
-        assertTrue(group.isDestroyed());
         assertEquals(group, firstCaptured.get());
 
         ThreadGroup currentThreadGroup = Thread.currentThread().getThreadGroup();


### PR DESCRIPTION
Motivation:
These methods have been deprecated for removal since Java 16.

Modification:
We can trivially remove these calls from the one test that use them, because they are not important for what's being tested.

Result:
Test pass on Java 19, where these methods no longer work.

Fixes build error seen in #12949