### PR TITLE
Avoid ignoring interrupts in testsuite

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/sctp/SctpEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/sctp/SctpEchoTest.java
@@ -119,11 +119,7 @@ public class SctpEchoTest extends AbstractSctpTest {
                 break;
             }
 
-            try {
-                Thread.sleep(50);
-            } catch (InterruptedException e) {
-                // Ignore.
-            }
+            Thread.sleep(50);
         }
 
         while (sh.counter < data.length) {
@@ -134,11 +130,7 @@ public class SctpEchoTest extends AbstractSctpTest {
                 break;
             }
 
-            try {
-                Thread.sleep(50);
-            } catch (InterruptedException e) {
-                // Ignore.
-            }
+            Thread.sleep(50);
         }
 
         sh.channel.close().sync();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketCancelWriteTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketCancelWriteTest.java
@@ -77,11 +77,7 @@ public class SocketCancelWriteTest extends AbstractSocketTest {
             if (ch.exception.get() != null) {
                 break;
             }
-            try {
-                Thread.sleep(50);
-            } catch (InterruptedException ignore) {
-                // Ignore.
-            }
+            Thread.sleep(50);
         }
         sh.channel.close().sync();
         ch.channel.close().sync();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketEchoTest.java
@@ -219,11 +219,7 @@ public class SocketEchoTest extends AbstractSocketTest {
                 break;
             }
 
-            try {
-                Thread.sleep(50);
-            } catch (InterruptedException e) {
-                // Ignore.
-            }
+            Thread.sleep(50);
         }
 
         while (sh.counter < data.length) {
@@ -234,11 +230,7 @@ public class SocketEchoTest extends AbstractSocketTest {
                 break;
             }
 
-            try {
-                Thread.sleep(50);
-            } catch (InterruptedException e) {
-                // Ignore.
-            }
+            Thread.sleep(50);
         }
 
         sh.channel.close().sync();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFileRegionTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFileRegionTest.java
@@ -243,11 +243,7 @@ public class SocketFileRegionTest extends AbstractSocketTest {
                 break;
             }
 
-            try {
-                Thread.sleep(50);
-            } catch (InterruptedException e) {
-                // Ignore.
-            }
+            Thread.sleep(50);
         }
 
         sh.channel.close().sync();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFixedLengthEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFixedLengthEchoTest.java
@@ -109,11 +109,7 @@ public class SocketFixedLengthEchoTest extends AbstractSocketTest {
                 break;
             }
 
-            try {
-                Thread.sleep(50);
-            } catch (InterruptedException e) {
-                // Ignore.
-            }
+            Thread.sleep(50);
         }
 
         while (sh.counter < data.length) {
@@ -124,11 +120,7 @@ public class SocketFixedLengthEchoTest extends AbstractSocketTest {
                 break;
             }
 
-            try {
-                Thread.sleep(50);
-            } catch (InterruptedException e) {
-                // Ignore.
-            }
+            Thread.sleep(50);
         }
 
         sh.channel.close().sync();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketObjectEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketObjectEchoTest.java
@@ -120,11 +120,7 @@ public class SocketObjectEchoTest extends AbstractSocketTest {
                 break;
             }
 
-            try {
-                Thread.sleep(50);
-            } catch (InterruptedException e) {
-                // Ignore.
-            }
+            Thread.sleep(50);
         }
 
         while (sh.counter < data.length) {
@@ -135,11 +131,7 @@ public class SocketObjectEchoTest extends AbstractSocketTest {
                 break;
             }
 
-            try {
-                Thread.sleep(50);
-            } catch (InterruptedException e) {
-                // Ignore.
-            }
+            Thread.sleep(50);
         }
 
         sh.channel.close().sync();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSpdyEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSpdyEchoTest.java
@@ -220,11 +220,7 @@ public class SocketSpdyEchoTest extends AbstractSocketTest {
                 break;
             }
 
-            try {
-                Thread.sleep(50);
-            } catch (InterruptedException e) {
-                // Ignore.
-            }
+            Thread.sleep(50);
         }
 
         if (sh.exception.get() != null && !(sh.exception.get() instanceof IOException)) {

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSpliceTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSpliceTest.java
@@ -150,11 +150,7 @@ public class EpollSpliceTest {
                 break;
             }
 
-            try {
-                Thread.sleep(50);
-            } catch (InterruptedException e) {
-                // Ignore.
-            }
+            Thread.sleep(50);
         }
 
         while (sh.counter < data.length) {
@@ -165,11 +161,7 @@ public class EpollSpliceTest {
                 break;
             }
 
-            try {
-                Thread.sleep(50);
-            } catch (InterruptedException e) {
-                // Ignore.
-            }
+            Thread.sleep(50);
         }
 
         sh.channel.close().sync();
@@ -223,11 +215,7 @@ public class EpollSpliceTest {
             if (sh.exception.get() != null) {
                 break;
             }
-            try {
-                Thread.sleep(50);
-            } catch (InterruptedException e) {
-                // Ignore.
-            }
+            Thread.sleep(50);
         }
 
         sc.close().sync();


### PR DESCRIPTION
Motivation:
JUnit relies on interrupts to communicate test timeouts. When we silently swallow interrupts, we break this mechanism.

Modification:
Make the loops in the testsuite throw their interrupts instead of silently swallowing them.

Result:
The tests now responds to timeouts.
