### PR TITLE
Close EmbeddedChannel and release all buffers once test completes

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentCompressorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentCompressorTest.java
@@ -652,6 +652,8 @@ public class HttpContentCompressorTest {
         assertEquals("Netty", res.trailingHeaders().get(of("X-Test")));
         assertEquals(DecoderResult.SUCCESS, res.decoderResult());
         assertThat(ch.readOutbound(), is(nullValue()));
+
+        assertTrue(ch.finishAndReleaseAll());
     }
 
     @Test
@@ -691,6 +693,8 @@ public class HttpContentCompressorTest {
         assertEquals("Netty", res.trailingHeaders().get(of("X-Test")));
         assertEquals(DecoderResult.SUCCESS, res.decoderResult());
         assertThat(ch.readOutbound(), is(nullValue()));
+
+        assertTrue(ch.finishAndReleaseAll());
     }
 
     @Test


### PR DESCRIPTION
Motivation:

de8a7efd054d1eedc833303b1c2c8c76e519d5e1 added some new tests but missed to close the EmbeddedChannel and release the still buffered data once done. This results in a leak.

Modifications:

Call finishAndReleaseAll() once test completes

Result:

No more leaks
