### PR TITLE
Make it possible for AbstractChannel subclasses to drive the write-loop

### DIFF
--- a/transport/src/main/java/io/netty5/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty5/channel/AbstractChannel.java
@@ -1138,7 +1138,7 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
         close(newPromise(), t, newClosedChannelException(t, "writeFlushed()"));
     }
 
-    private void handleWriteError(Throwable t) {
+    protected void handleWriteError(Throwable t) {
         assertEventLoop();
 
         if (t instanceof IOException && isAutoClose()) {

--- a/transport/src/main/java/io/netty5/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty5/channel/AbstractChannel.java
@@ -595,7 +595,7 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
         close(promise, closedChannelException, closedChannelException);
     }
 
-    private void updateWritabilityIfNeeded(boolean notify, boolean notifyLater) {
+    protected void updateWritabilityIfNeeded(boolean notify, boolean notifyLater) {
         long totalPending = totalPending();
 
         if (totalPending > writeBufferWaterMark.high()) {

--- a/transport/src/main/java/io/netty5/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty5/channel/AbstractChannel.java
@@ -595,7 +595,7 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
         close(promise, closedChannelException, closedChannelException);
     }
 
-    protected void updateWritabilityIfNeeded(boolean notify, boolean notifyLater) {
+    protected final void updateWritabilityIfNeeded(boolean notify, boolean notifyLater) {
         long totalPending = totalPending();
 
         if (totalPending > writeBufferWaterMark.high()) {

--- a/transport/src/main/java/io/netty5/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty5/channel/AbstractChannel.java
@@ -1104,6 +1104,8 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
             do {
                 writeSink.writeLoopStep();
             } while (writeSink.writeLoopContinue());
+        } catch (Throwable throwable) {
+            handleWriteError(throwable);
         } finally {
             writeSink.writeLoopEnd();
         }
@@ -2144,13 +2146,8 @@ public abstract class AbstractChannel<P extends Channel, L extends SocketAddress
          * or {@link #complete(long, Throwable, boolean)}, after which the loop driver can call
          * {@link #writeLoopContinue()} to check if more loop iterations are needed.
          */
-        public void writeLoopStep() {
-            try {
-                doWriteNow(this);
-
-            } catch (Throwable t) {
-                handleWriteError(t);
-            }
+        public void writeLoopStep() throws Throwable {
+            doWriteNow(this);
         }
 
         /**


### PR DESCRIPTION
Motivation:
For asynchronous transports, we need to be able to drive the write-loop on our own schedule.

Modification:
Pull the write-loop out of `WriteSink` into a protected method on `AbstractChannel`, and offer methods to step and end the write-loop.

Result:
Asynchronous transports can now drive the write-loop forward in response to IO completions.