### PR TITLE
Add error code for EHOSTUNREACH

### DIFF
--- a/transport-native-unix-common/src/main/c/netty5_unix_errors.c
+++ b/transport-native-unix-common/src/main/c/netty5_unix_errors.c
@@ -188,6 +188,10 @@ static jint netty5_unix_errors_errorENETUNREACH(JNIEnv* env, jclass clazz) {
     return ENETUNREACH;
 }
 
+static jint netty5_unix_errors_errorEHOSTUNREACH(JNIEnv* env, jclass clazz) {
+    return EHOSTUNREACH;
+}
+
 static jstring netty5_unix_errors_strError(JNIEnv* env, jclass clazz, jint error) {
     return (*env)->NewStringUTF(env, strerror(error));
 }
@@ -207,6 +211,7 @@ static const JNINativeMethod statically_referenced_fixed_method_table[] = {
   { "errorEISCONN", "()I", (void *) netty5_unix_errors_errorEISCONN },
   { "errorEALREADY", "()I", (void *) netty5_unix_errors_errorEALREADY },
   { "errorENETUNREACH", "()I", (void *) netty5_unix_errors_errorENETUNREACH },
+  { "errorEHOSTUNREACH", "()I", (void *) netty5_unix_errors_errorEHOSTUNREACH },
   { "strError", "(I)Ljava/lang/String;", (void *) netty5_unix_errors_strError }
 };
 static const jint statically_referenced_fixed_method_table_size = sizeof(statically_referenced_fixed_method_table) / sizeof(statically_referenced_fixed_method_table[0]);

--- a/transport-native-unix-common/src/main/java/io/netty5/channel/unix/Errors.java
+++ b/transport-native-unix-common/src/main/java/io/netty5/channel/unix/Errors.java
@@ -23,7 +23,6 @@ import java.net.ConnectException;
 import java.net.NoRouteToHostException;
 import java.nio.channels.AlreadyConnectedException;
 import java.nio.channels.ClosedChannelException;
-import java.nio.channels.ConnectionPendingException;
 import java.nio.channels.NotYetConnectedException;
 
 import static io.netty5.channel.unix.ErrorsStaticallyReferencedJniMethods.errnoEAGAIN;
@@ -36,6 +35,7 @@ import static io.netty5.channel.unix.ErrorsStaticallyReferencedJniMethods.errnoE
 import static io.netty5.channel.unix.ErrorsStaticallyReferencedJniMethods.errnoEWOULDBLOCK;
 import static io.netty5.channel.unix.ErrorsStaticallyReferencedJniMethods.errorEALREADY;
 import static io.netty5.channel.unix.ErrorsStaticallyReferencedJniMethods.errorECONNREFUSED;
+import static io.netty5.channel.unix.ErrorsStaticallyReferencedJniMethods.errorEHOSTUNREACH;
 import static io.netty5.channel.unix.ErrorsStaticallyReferencedJniMethods.errorEISCONN;
 import static io.netty5.channel.unix.ErrorsStaticallyReferencedJniMethods.errorENETUNREACH;
 import static io.netty5.channel.unix.ErrorsStaticallyReferencedJniMethods.strError;
@@ -58,12 +58,13 @@ public final class Errors {
     public static final int ERROR_EISCONN_NEGATIVE = -errorEISCONN();
     public static final int ERROR_EALREADY_NEGATIVE = -errorEALREADY();
     public static final int ERROR_ENETUNREACH_NEGATIVE = -errorENETUNREACH();
+    public static final int ERROR_EHOSTUNREACH_NEGATIVE = -errorEHOSTUNREACH();
 
     /**
      * Holds the mappings for errno codes to String messages.
      * This eliminates the need to call back into JNI to get the right String message on an exception
      * and thus is faster.
-     *
+     * <p>
      * The array length of 512 should be more then enough because errno.h only holds < 200 codes.
      */
     private static final String[] ERRORS = new String[512];

--- a/transport-native-unix-common/src/main/java/io/netty5/channel/unix/ErrorsStaticallyReferencedJniMethods.java
+++ b/transport-native-unix-common/src/main/java/io/netty5/channel/unix/ErrorsStaticallyReferencedJniMethods.java
@@ -42,5 +42,6 @@ final class ErrorsStaticallyReferencedJniMethods {
     static native int errorEISCONN();
     static native int errorEALREADY();
     static native int errorENETUNREACH();
+    static native int errorEHOSTUNREACH();
     static native String strError(int err);
 }


### PR DESCRIPTION
Motivation:
We might see this error code when we do our own system calls to `connect(2)`.

Modification:
Add Errors constant, and JNI function for reading the value of EHOSTUNREACH.

Result:
We can now look for this error code when doing our own `connect(2)` system calls.