### PR TITLE
Move validation of connection headers in HTTP/2 back to `HpackDecoder`

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
@@ -172,6 +172,12 @@ public class DefaultHttp2Headers
     }
 
     @Override
+    protected void validateValue(ValueValidator<CharSequence> validator, CharSequence name, CharSequence value) {
+        // This method has a noop override for backward compatibility, see https://github.com/netty/netty/pull/12975
+        super.validateValue(validator, name, value);
+    }
+
+    @Override
     public Http2Headers clear() {
         firstNonPseudo = head;
         return super.clear();

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
@@ -79,9 +79,6 @@ public class DefaultHttp2Headers
                     PlatformDependent.throwException(connectionError(
                             PROTOCOL_ERROR, "Invalid HTTP/2 pseudo-header '%s' encountered.", name));
                 }
-            } else if (HttpHeaderValidationUtil.isConnectionHeader(name, true)) {
-                PlatformDependent.throwException(connectionError(
-                        PROTOCOL_ERROR, "Illegal connection-specific header '%s' encountered.", name));
             }
         }
     };
@@ -172,17 +169,6 @@ public class DefaultHttp2Headers
                         PROTOCOL_ERROR, "Duplicate HTTP/2 pseudo-header '%s' encountered.", name));
             }
         }
-    }
-
-    @Override
-    protected void validateValue(ValueValidator<CharSequence> validator, CharSequence name, CharSequence value) {
-        if (nameValidator() == HTTP2_NAME_VALIDATOR) {
-            if (HttpHeaderValidationUtil.isTeNotTrailers(name, value)) {
-                PlatformDependent.throwException(connectionError(PROTOCOL_ERROR,
-                        "Illegal value specified for the 'TE' header (only 'trailers' is allowed)."));
-            }
-        }
-        super.validateValue(validator, name, value);
     }
 
     @Override

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersTest.java
@@ -20,6 +20,8 @@ import io.netty.handler.codec.http2.Http2Headers.PseudoHeaderName;
 import io.netty.util.internal.StringUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import java.util.Map.Entry;
 
@@ -188,6 +190,15 @@ public class DefaultHttp2HeadersTest {
         assertEquals(of("101"), headers.status());
         assertEquals(of("github.com"), headers.authority());
         assertEquals(of("http"), headers.scheme());
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] name={0} value={1}")
+    @CsvSource(value = {"upgrade,protocol1", "connection,close", "keep-alive,timeout=5", "proxy-connection,close",
+            "transfer-encoding,chunked", "te,something-else"})
+    void possibleToAddConnectionHeaders(String name, String value) {
+        Http2Headers headers = newHeaders();
+        headers.add(name, value);
+        assertTrue(headers.contains(name, value));
     }
 
     private static void verifyAllPseudoHeadersPresent(Http2Headers headers) {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackDecoderTest.java
@@ -37,12 +37,15 @@ import io.netty.util.internal.StringUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.MockingDetails;
 import org.mockito.invocation.Invocation;
 
 import java.lang.reflect.Method;
 
 import static io.netty.handler.codec.http2.HpackDecoder.decodeULE128;
+import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
 import static io.netty.handler.codec.http2.Http2HeadersEncoder.NEVER_SENSITIVE;
 import static io.netty.util.AsciiString.EMPTY_STRING;
 import static io.netty.util.AsciiString.of;
@@ -765,12 +768,42 @@ public class HpackDecoderTest {
 
             final Http2Headers decoded = new DefaultHttp2Headers();
 
-            assertThrows(Http2Exception.StreamException.class, new Executable() {
+            Http2Exception.StreamException e = assertThrows(Http2Exception.StreamException.class, new Executable() {
                 @Override
                 public void execute() throws Throwable {
-                    hpackDecoder.decode(1, in, decoded, true);
+                    hpackDecoder.decode(3, in, decoded, true);
                 }
             });
+            assertThat(e.streamId(), is(3));
+            assertThat(e.error(), is(PROTOCOL_ERROR));
+        } finally {
+            in.release();
+        }
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] name={0} value={1}")
+    @CsvSource(value = {"upgrade,protocol1", "connection,close", "keep-alive,timeout=5", "proxy-connection,close",
+            "transfer-encoding,chunked", "te,something-else"})
+    public void receivedConnectionHeader(String name, String value) throws Exception {
+        final ByteBuf in = Unpooled.buffer(200);
+        try {
+            HpackEncoder hpackEncoder = new HpackEncoder(true);
+
+            Http2Headers toEncode = new InOrderHttp2Headers();
+            toEncode.add(":method", "GET");
+            toEncode.add(name, value);
+            hpackEncoder.encodeHeaders(1, in, toEncode, NEVER_SENSITIVE);
+
+            final Http2Headers decoded = new DefaultHttp2Headers();
+
+            Http2Exception.StreamException e = assertThrows(Http2Exception.StreamException.class, new Executable() {
+                @Override
+                public void execute() throws Throwable {
+                    hpackDecoder.decode(3, in, decoded, true);
+                }
+            });
+            assertThat(e.streamId(), is(3));
+            assertThat(e.error(), is(PROTOCOL_ERROR));
         } finally {
             in.release();
         }


### PR DESCRIPTION
Motivation:

#12755 added validation for presence of connection-related headers while `HpackDecoder` decodes the incoming frame. Then #12760 moved this validation from `HpackDecoder` to `DefaultHttp2Headers`. As the result, existing use-case that could use `DefaultHttp2Headers` for HTTP/2 and HTTP/1.X broke when users add  any of the mentioned prohibited headers. The HTTP/1.X to HTTP/2 translation logic usually has sanitization process that removes connection-related headers. It's enough to run this validation only for incoming messages and we should preserve backward compatibility for 4.1.

Modifications:

- Move `isConnectionHeader` and `te` validations from `DefaultHttp2Headers` back to `HpackDecoder`;
- Add tests to verify `HpackDecoder` fails incoming headers as expected;
- Add tests to verify mentioned headers can be added to `DefaultHttp2Headers`;

Result:

Backward compatibility is preserved, while validation for connection-related headers is done in `HpackDecoder`.