### PR TITLE
Avoid high contention on Cleaner registration/cleanup

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/internal/CleanerDrop.java
+++ b/buffer/src/main/java/io/netty5/buffer/internal/CleanerDrop.java
@@ -56,7 +56,7 @@ public final class CleanerDrop<T extends Buffer> implements Drop<T> {
             Drop<T> drop, MemoryManager manager, boolean detectLeaks) {
         CleanerDrop<T> cleanerDrop = new CleanerDrop<>();
         GatedRunner<T> runner = new GatedRunner<>(drop, manager, detectLeaks);
-        cleanerDrop.cleanable = InternalBufferUtils.nextCleaner().register(cleanerDrop, runner);
+        cleanerDrop.cleanable = InternalBufferUtils.getCleaner().register(cleanerDrop, runner);
         cleanerDrop.runner = runner;
         return cleanerDrop;
     }

--- a/buffer/src/main/java/io/netty5/buffer/internal/CleanerDrop.java
+++ b/buffer/src/main/java/io/netty5/buffer/internal/CleanerDrop.java
@@ -56,7 +56,7 @@ public final class CleanerDrop<T extends Buffer> implements Drop<T> {
             Drop<T> drop, MemoryManager manager, boolean detectLeaks) {
         CleanerDrop<T> cleanerDrop = new CleanerDrop<>();
         GatedRunner<T> runner = new GatedRunner<>(drop, manager, detectLeaks);
-        cleanerDrop.cleanable = InternalBufferUtils.CLEANER.register(cleanerDrop, runner);
+        cleanerDrop.cleanable = InternalBufferUtils.nextCleaner().register(cleanerDrop, runner);
         cleanerDrop.runner = runner;
         return cleanerDrop;
     }

--- a/buffer/src/main/java/io/netty5/buffer/internal/CleanerPool.java
+++ b/buffer/src/main/java/io/netty5/buffer/internal/CleanerPool.java
@@ -172,13 +172,13 @@ final class CleanerPool {
 
         @Override
         protected Cleaner initialValue() {
-            if (! EVENT_LOOP_USE_POOL && ThreadExecutorMap.currentExecutor() != null) {
+            if (!EVENT_LOOP_USE_POOL && ThreadExecutorMap.currentExecutor() != null) {
                 // Allocate one dedicated cleaner for the caller event-loop thread
                 return createCleaner();
-            } else {
-                // Return one of the shared cleaners from the shared cleaner pool.
-                return CleanersPool.cleaners[(counter.getAndIncrement() & 0x7F_FF_FF_FF) % POOL_SIZE];
             }
+
+            // Return one of the shared cleaners from the shared cleaner pool.
+            return CleanersPool.cleaners[(counter.getAndIncrement() & 0x7F_FF_FF_FF) % POOL_SIZE];
         }
     }
 

--- a/buffer/src/main/java/io/netty5/buffer/internal/CleanerPool.java
+++ b/buffer/src/main/java/io/netty5/buffer/internal/CleanerPool.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.buffer.internal;
+
+import io.netty5.util.concurrent.FastThreadLocal;
+import io.netty5.util.internal.SystemPropertyUtil;
+import io.netty5.util.internal.logging.InternalLogger;
+import io.netty5.util.internal.logging.InternalLoggerFactory;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.ref.Cleaner;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+/**
+ * Helper class used to maintain a set of configurable Cleaner instances that can then be mapped to Event Loop threads.
+ */
+final class CleanerPool {
+    /**
+     * Our logger.
+     */
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(CleanerPool.class);
+
+    /**
+     * System property name used to configure Cleaner pool size (default=0 for all available processors)
+     */
+    private static final String CNF_POOL_SIZE = "io.netty5.cleanerpool.size";
+
+    /**
+     * Number of cleaners used to track phantom resources.
+     * 0 means size will match number of available processors (default value=0)
+     */
+    private static final int POOL_SIZE = getPoolSize();
+
+    /**
+     * System property used to configure whether virtual threads should be used as cleaner daemon threads
+     * (default=false)
+     * if this property is set to true, and if the platform supports loom, then the Cleaners
+     * will be created using virtual ThreadFactory obtained from Thread.ofVirtual().factory() method.
+     * Threadfactory will be created using MethodHandles (if the platform version is >= 19).
+     */
+    private static final String CNF_USE_VTHREAD = "io.netty5.cleanerpool.vthread";
+
+    /**
+     * If platform supports loom, then use virtual threads for cleaner daemon threads.
+     * false by default.
+     */
+    private static final boolean USE_VTHREAD = SystemPropertyUtil.getBoolean(CNF_USE_VTHREAD, false);
+
+    /**
+     * Method handle used to optionally load Virtual ThreadFactory if the current platform is supporting Loom.
+     */
+    private static final MethodHandles.Lookup publicLookup = MethodHandles.publicLookup();
+
+    /**
+     * Method handle for Thread.ofVirtual() method. Null in case jvm version is < 19
+     */
+    private static final MethodHandle mhOfVirtual;
+
+    /**
+     * Method handle for java.lang.Thread.Builder.OfVirtual.factory() method. Null in case jvm version is < 19
+     */
+    private static final MethodHandle mhFactory;
+
+    /**
+     * Cleaner instances shared by all event loops.
+     */
+    private final Cleaner[] cleaners = IntStream.range(0, POOL_SIZE).mapToObj(i -> createCleaner())
+            .toArray(Cleaner[]::new);
+
+    /**
+     * A FastThreadLocal which allows to map a random cleaner to each thread calling the nextCleaner method.
+     * Cleaners are distributed in round robin, and the same EventLoop will get the same Cleaner for every
+     * nextCleaner method invocations.
+     */
+    private final CleanerThreadLocal threadLocalCleaner = new CleanerThreadLocal(cleaners);
+
+    /**
+     * Static initializer used to setup Method Handles that are used to obtain loom virtual Threadfactory
+     * (if the platform supports it).
+     */
+    static {
+        MethodHandle mhOfVirtualTmp = null;
+        MethodHandle mhFactoryTmp = null;
+
+        if (USE_VTHREAD) {
+            try {
+                Class<?> clzOfVirtual = Class.forName("java.lang.Thread$Builder$OfVirtual");
+                mhOfVirtualTmp = publicLookup.findStatic(Thread.class, "ofVirtual",
+                        MethodType.methodType(clzOfVirtual));
+                mhFactoryTmp = publicLookup.findVirtual(clzOfVirtual, "factory",
+                        MethodType.methodType(ThreadFactory.class));
+            } catch (ClassNotFoundException e) {
+                logger.debug("Loom not supported, Cleaner will use default cleaner daemon threads.");
+            } catch (Throwable t) {
+                logger.warn("Could not create virtual thread factory, will use default cleaner daemon threads.", t);
+            }
+        }
+
+        mhOfVirtual = mhOfVirtualTmp;
+        mhFactory = mhFactoryTmp;
+    }
+
+    /**
+     * The singleton for the CleanerPool.
+     */
+    public static final CleanerPool INSTANCE = new CleanerPool();
+
+    /**
+     * The FastThreadLocal used to map a Cleaner instance to Event Loop threads.
+     */
+    private static class CleanerThreadLocal extends FastThreadLocal<Cleaner> {
+        private final Cleaner[] cleaners;
+        private static final AtomicInteger counter = new AtomicInteger();
+
+        CleanerThreadLocal(Cleaner[] cleaners) {
+            this.cleaners = cleaners;
+        }
+
+        @Override
+        protected Cleaner initialValue() {
+            return cleaners[counter.getAndIncrement() % POOL_SIZE];
+        }
+    }
+
+    private CleanerPool() {
+        logger.info("Instantiating CleanerPool: {}={}, {}={}, using vthreads={}",
+                        CNF_POOL_SIZE, POOL_SIZE,
+                        CNF_USE_VTHREAD, USE_VTHREAD,
+                        mhFactory != null);
+    }
+
+    /**
+     * Returns the next available cleaner to the calling thread.
+     * The same thread will get the same cleaner for every nextCleaner method calls.
+     */
+    Cleaner nextCleaner() {
+        return threadLocalCleaner.get();
+    }
+
+    private static int getPoolSize() {
+        int poolSize = SystemPropertyUtil.getInt(CNF_POOL_SIZE, 0);
+        if (poolSize < 0) {
+            throw new IllegalArgumentException(CNF_POOL_SIZE + " is negative: " + poolSize);
+        }
+        return poolSize == 0 ? Runtime.getRuntime().availableProcessors() : poolSize;
+    }
+
+    /**
+     * Creates a cleaner initialized with a virtual ThreadFactory if the platform supports loom,
+     * else creates an usual Cleaner with default cleaner daemon thread.
+     */
+    private Cleaner createCleaner() {
+        ThreadFactory virtualThreadFactory = getVirtualThreadFactory();
+        if (logger.isDebugEnabled()) {
+            if (virtualThreadFactory != null) {
+                logger.debug("Creating cleaner with virtual thread factory");
+            } else {
+                logger.debug("Creating cleaner with default cleaner daemon thread");
+            }
+        }
+        return virtualThreadFactory == null ? Cleaner.create() : Cleaner.create(virtualThreadFactory);
+    }
+
+    /**
+     * Returns a Virtual Thread Factory in case Loom is supported, else null
+     * (meaning that default Cleaner threads will be used).
+     *
+     * @return a Virtual Thread Factory in case Loom is supported, else null
+     */
+    private ThreadFactory getVirtualThreadFactory() {
+        if (!USE_VTHREAD || mhOfVirtual == null) {
+            return null;
+        }
+
+        try {
+            ThreadFactory threadFactory = (ThreadFactory) mhFactory.invoke(mhOfVirtual.invoke());
+            return threadFactory;
+        } catch (Throwable t) {
+            logger.warn("Could not create virtual thread factory, will use default cleaner daemon threads.", t);
+            return null;
+        }
+    }
+}

--- a/buffer/src/main/java/io/netty5/buffer/internal/CleanerPool.java
+++ b/buffer/src/main/java/io/netty5/buffer/internal/CleanerPool.java
@@ -17,6 +17,7 @@ package io.netty5.buffer.internal;
 
 import io.netty5.util.concurrent.FastThreadLocal;
 import io.netty5.util.internal.SystemPropertyUtil;
+import io.netty5.util.internal.ThreadExecutorMap;
 import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
 
@@ -24,12 +25,34 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.ref.Cleaner;
+import java.util.Optional;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 
 /**
- * Helper class used to maintain a set of configurable Cleaner instances that can then be mapped to Event Loop threads.
+ * Cleaner allocation strategy used to assign cleaners to event-loop and external threads.
+ * The default policy is used:
+ * <ul>
+ *     <li>for event-loop threads, by default a fast-thread-local shared-nothing Cleaner instance is allocated and used
+ *         for each event-loop thread.</li>
+ *     <li>for external threads, a shared Cleaner pool is used to distribute and map Cleaners to each external threads
+ *     in a round-robin way using fast-thread-local. This pool is allocated lazily, just if some external threads need
+ *     it</li>
+ * </ul>
+ *
+ * <p>System property configuration:</p>
+ * <ul>
+ *     <li>-Dio.netty5.cleanerpool.size: integer value (default=1). Size of the shared Cleaner pool. This pool is
+ *     used for external (non-event-loop) threads. "0" means all available processors are used as the pool size.</li>
+ *     <li>-Dio.netty5.cleanerpool.eventloop.usepool: boolean (default=false). If set to true, all event-loop threads
+ *     will use the shared threadpool, like external threads. This can be useful if we need to revert to a singleton
+ *     Cleaner to be used by all event-loop/external threads (using io.netty5.cleanerpool.eventloop.usepool=true and
+ *     io.netty5.cleanerpool.size=1). if set to false, it means all event-loop threads will be assigned to a dedicated
+ *     Cleaner instance, so the pool won't be used in this case.</li>
+ *     <li>-Dio.netty5.cleanerpool.vthread: boolean (default=false). If "true", and if the platform supports loom,
+ *     then the Cleaners will be allocated using a ThreadFactory that returns virtual threads.</li>
+ * </ul>
  */
 final class CleanerPool {
     /**
@@ -38,28 +61,43 @@ final class CleanerPool {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(CleanerPool.class);
 
     /**
-     * System property name used to configure Cleaner pool size (default=0 for all available processors)
+     * System property name used to configure the shared Cleaner pool size. External (non-event-loop) threads
+     * will always use the shared cleaner pool. The shared cleaner pool is instantiated lazily (only if it is
+     * needed).
+     * default=1.
+     * 0 means size will be set with the number of available processors.
      */
     private static final String CNF_POOL_SIZE = "io.netty5.cleanerpool.size";
 
     /**
-     * Number of cleaners used to track phantom resources.
-     * 0 means size will match number of available processors (default value=0)
+     * System property name used to configure whether event-loop threads must use the shared cleaner pool.
+     * default=false, meaning that each event-loop thread will use its own cleaner instance
      */
-    private static final int POOL_SIZE = getPoolSize();
+    private static final String CNF_EVENT_LOOP_USE_POOL = "io.netty5.cleanerpool.eventloop.usepool";
+
+    /**
+     * Size of the shared Cleaner pool used by external threads, and optionally by event-loop threads.
+     * @see #CNF_POOL_SIZE
+     */
+    private static final int POOL_SIZE = getPoolSize(1);
+
+    /**
+     * Flag to configure whether event-loop threads must use the shared cleaner pool (default=false).
+     * @see #CNF_EVENT_LOOP_USE_POOL
+     */
+    private static final boolean EVENT_LOOP_USE_POOL = SystemPropertyUtil.getBoolean(CNF_EVENT_LOOP_USE_POOL, false);
 
     /**
      * System property used to configure whether virtual threads should be used as cleaner daemon threads
      * (default=false)
      * if this property is set to true, and if the platform supports loom, then the Cleaners
      * will be created using virtual ThreadFactory obtained from Thread.ofVirtual().factory() method.
-     * Threadfactory will be created using MethodHandles (if the platform version is >= 19).
      */
     private static final String CNF_USE_VTHREAD = "io.netty5.cleanerpool.vthread";
 
     /**
      * If platform supports loom, then use virtual threads for cleaner daemon threads.
-     * false by default.
+     * @see #CNF_USE_VTHREAD
      */
     private static final boolean USE_VTHREAD = SystemPropertyUtil.getBoolean(CNF_USE_VTHREAD, false);
 
@@ -79,21 +117,25 @@ final class CleanerPool {
     private static final MethodHandle mhFactory;
 
     /**
-     * Cleaner instances shared by all event loops.
+     * Cleaner instances shared by all external threads, and optionally by event-loop threads
+     * These cleaners are wrapped in a static inner class for lazy initialization purpose.
      */
-    private final Cleaner[] cleaners = IntStream.range(0, POOL_SIZE).mapToObj(i -> createCleaner())
-            .toArray(Cleaner[]::new);
+    private static class CleanersPool {
+        static final Cleaner[] cleaners = IntStream.range(0, POOL_SIZE)
+                .mapToObj(i -> createCleaner()).toArray(Cleaner[]::new);
+    }
 
     /**
-     * A FastThreadLocal which allows to map a random cleaner to each thread calling the nextCleaner method.
-     * Cleaners are distributed in round robin, and the same EventLoop will get the same Cleaner for every
-     * nextCleaner method invocations.
+     * A FastThreadLocal that returns a Cleaner to the caller thread.
+     * For event-loop threads, by default a dedicated cleaner instance is allocated and mapped to the
+     * caller thread, but by configuration, event-loop threads can use the shared cleaner pool if this is
+     * necessary.
+     * For external threads, a cleaner is always returned from the shared fixed cleaner pool in a round-robin way.
      */
-    private final CleanerThreadLocal threadLocalCleaner = new CleanerThreadLocal(cleaners);
+    private final CleanerThreadLocal threadLocalCleaner = new CleanerThreadLocal();
 
     /**
-     * Static initializer used to setup Method Handles that are used to obtain loom virtual Threadfactory
-     * (if the platform supports it).
+     * Setup Method Handles that are used to obtain loom virtual ThreadFactory (if the platform supports it).
      */
     static {
         MethodHandle mhOfVirtualTmp = null;
@@ -126,36 +168,38 @@ final class CleanerPool {
      * The FastThreadLocal used to map a Cleaner instance to Event Loop threads.
      */
     private static class CleanerThreadLocal extends FastThreadLocal<Cleaner> {
-        private final Cleaner[] cleaners;
         private static final AtomicInteger counter = new AtomicInteger();
-
-        CleanerThreadLocal(Cleaner[] cleaners) {
-            this.cleaners = cleaners;
-        }
 
         @Override
         protected Cleaner initialValue() {
-            return cleaners[counter.getAndIncrement() % POOL_SIZE];
+            if (! EVENT_LOOP_USE_POOL && ThreadExecutorMap.currentExecutor() != null) {
+                // Allocate one dedicated cleaner for the caller event-loop thread
+                return createCleaner();
+            } else {
+                // Return one of the shared cleaners from the shared cleaner pool.
+                return CleanersPool.cleaners[(counter.getAndIncrement() & 0x7F_FF_FF_FF) % POOL_SIZE];
+            }
         }
     }
 
     private CleanerPool() {
-        logger.info("Instantiating CleanerPool: {}={}, {}={}, using vthreads={}",
-                        CNF_POOL_SIZE, POOL_SIZE,
-                        CNF_USE_VTHREAD, USE_VTHREAD,
-                        mhFactory != null);
+        logger.debug("Instantiating CleanerPool: {}={}, {}={}, {}={}, using vthreads={}",
+                CNF_EVENT_LOOP_USE_POOL, EVENT_LOOP_USE_POOL,
+                CNF_POOL_SIZE, POOL_SIZE,
+                CNF_USE_VTHREAD, USE_VTHREAD,
+                mhFactory != null);
     }
 
     /**
-     * Returns the next available cleaner to the calling thread.
-     * The same thread will get the same cleaner for every nextCleaner method calls.
+     * Returns a Cleaner to the calling thread.
+     * The same thread will get the same cleaner for every getCleaner method calls.
      */
-    Cleaner nextCleaner() {
+    Cleaner getCleaner() {
         return threadLocalCleaner.get();
     }
 
-    private static int getPoolSize() {
-        int poolSize = SystemPropertyUtil.getInt(CNF_POOL_SIZE, 0);
+    private static int getPoolSize(int defSize) {
+        int poolSize = SystemPropertyUtil.getInt(CNF_POOL_SIZE, defSize);
         if (poolSize < 0) {
             throw new IllegalArgumentException(CNF_POOL_SIZE + " is negative: " + poolSize);
         }
@@ -164,37 +208,37 @@ final class CleanerPool {
 
     /**
      * Creates a cleaner initialized with a virtual ThreadFactory if the platform supports loom,
-     * else creates an usual Cleaner with default cleaner daemon thread.
+     * else creates a normal Cleaner with default cleaner daemon thread.
      */
-    private Cleaner createCleaner() {
-        ThreadFactory virtualThreadFactory = getVirtualThreadFactory();
+    private static Cleaner createCleaner() {
+        Optional<ThreadFactory> virtualThreadFactory = getVirtualThreadFactory();
+
         if (logger.isDebugEnabled()) {
-            if (virtualThreadFactory != null) {
-                logger.debug("Creating cleaner with virtual thread factory");
-            } else {
-                logger.debug("Creating cleaner with default cleaner daemon thread");
-            }
+            virtualThreadFactory.ifPresentOrElse(
+                    threadFactory -> logger.debug("Creating cleaner with virtual thread factory"),
+                    () -> logger.debug("Creating cleaner with default cleaner daemon thread"));
         }
-        return virtualThreadFactory == null ? Cleaner.create() : Cleaner.create(virtualThreadFactory);
+
+        // If Loom is supported, return a cleaner based on virtual threads, else
+        // return a normal cleaner that will use a default daemon thread.
+        Optional<Cleaner> virtualCleaner = virtualThreadFactory.map(Cleaner::create);
+        return virtualCleaner.orElse(Cleaner.create());
     }
 
     /**
-     * Returns a Virtual Thread Factory in case Loom is supported, else null
-     * (meaning that default Cleaner threads will be used).
-     *
-     * @return a Virtual Thread Factory in case Loom is supported, else null
+     * Returns an optional Virtual Thread Factory in case Loom is supported.
      */
-    private ThreadFactory getVirtualThreadFactory() {
+    private static Optional<ThreadFactory> getVirtualThreadFactory() {
         if (!USE_VTHREAD || mhOfVirtual == null) {
-            return null;
+            return Optional.empty();
         }
 
         try {
             ThreadFactory threadFactory = (ThreadFactory) mhFactory.invoke(mhOfVirtual.invoke());
-            return threadFactory;
+            return Optional.of(threadFactory);
         } catch (Throwable t) {
             logger.warn("Could not create virtual thread factory, will use default cleaner daemon threads.", t);
-            return null;
+            return Optional.empty();
         }
     }
 }

--- a/buffer/src/main/java/io/netty5/buffer/internal/InternalBufferUtils.java
+++ b/buffer/src/main/java/io/netty5/buffer/internal/InternalBufferUtils.java
@@ -43,8 +43,8 @@ import static java.util.Objects.requireNonNull;
 public interface InternalBufferUtils {
     LongAdder MEM_USAGE_NATIVE = new LongAdder();
 
-    static Cleaner nextCleaner() {
-        return CleanerPool.INSTANCE.nextCleaner();
+    static Cleaner getCleaner() {
+        return CleanerPool.INSTANCE.getCleaner();
     }
 
     Drop<Buffer> NO_OP_DROP = new Drop<>() {

--- a/buffer/src/main/java/io/netty5/buffer/internal/InternalBufferUtils.java
+++ b/buffer/src/main/java/io/netty5/buffer/internal/InternalBufferUtils.java
@@ -42,7 +42,11 @@ import static java.util.Objects.requireNonNull;
 
 public interface InternalBufferUtils {
     LongAdder MEM_USAGE_NATIVE = new LongAdder();
-    Cleaner CLEANER = Cleaner.create();
+
+    static Cleaner nextCleaner() {
+        return CleanerPool.INSTANCE.nextCleaner();
+    }
+
     Drop<Buffer> NO_OP_DROP = new Drop<>() {
         @Override
         public void drop(Buffer obj) {

--- a/buffer/src/main/java/io/netty5/buffer/unsafe/UnsafeMemoryManager.java
+++ b/buffer/src/main/java/io/netty5/buffer/unsafe/UnsafeMemoryManager.java
@@ -65,7 +65,7 @@ public final class UnsafeMemoryManager implements MemoryManager {
         final long address;
         final UnsafeMemory memory;
         final int size32 = Math.toIntExact(size);
-        Cleaner cleaner = InternalBufferUtils.nextCleaner();
+        Cleaner cleaner = InternalBufferUtils.getCleaner();
         Drop<Buffer> drop = InternalBufferUtils.NO_OP_DROP;
         if (allocationType == StandardAllocationTypes.OFF_HEAP) {
             base = null;

--- a/buffer/src/main/java/io/netty5/buffer/unsafe/UnsafeMemoryManager.java
+++ b/buffer/src/main/java/io/netty5/buffer/unsafe/UnsafeMemoryManager.java
@@ -65,7 +65,7 @@ public final class UnsafeMemoryManager implements MemoryManager {
         final long address;
         final UnsafeMemory memory;
         final int size32 = Math.toIntExact(size);
-        Cleaner cleaner = InternalBufferUtils.CLEANER;
+        Cleaner cleaner = InternalBufferUtils.nextCleaner();
         Drop<Buffer> drop = InternalBufferUtils.NO_OP_DROP;
         if (allocationType == StandardAllocationTypes.OFF_HEAP) {
             base = null;

--- a/microbench/src/main/java/io/netty5/microbench/buffer/MTAllocateBenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/buffer/MTAllocateBenchmark.java
@@ -63,8 +63,6 @@ public class MTAllocateBenchmark extends AbstractMicrobenchmark {
                 "-Dio.netty5.leakDetection.level=disabled",
                 "-Dio.netty5.buffer.leakDetectionEnabled=false",
                 "-Dio.netty5.buffer.lifecycleTracingEnabled=false",
-                // in case java19+ and loom is used
-                "--enable-preview",
                 // size of the shared cleaner pool used only by external threads (0=number of available processors)
                 "-Dio.netty5.cleanerpool.size=0",
         };

--- a/microbench/src/main/java/io/netty5/microbench/buffer/MTAllocateBenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/buffer/MTAllocateBenchmark.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.microbench.buffer;
+
+import io.netty5.buffer.Buffer;
+import io.netty5.buffer.DefaultBufferAllocators;
+import io.netty5.microbench.util.AbstractMicrobenchmark;
+import io.netty5.util.concurrent.SingleThreadEventExecutor;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+/**
+ * This scenario performs a benchmark which simulates multiple threads doing many buffer allocations/releases.
+ */
+@Warmup(iterations = 1, time = 10)
+@Measurement(iterations = 4, time = 5)
+@Fork(value = 1)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class MTAllocateBenchmark extends AbstractMicrobenchmark {
+
+    /**
+     * These executors are used to perform buffer intensitive allocations/releases from event-loop threads
+     * (see testAllocateEventLoopThread method)
+     */
+    private SingleThreadEventExecutor[] execs;
+
+    /**
+     * JVM arguments.
+     */
+    @Override
+    protected String[] jvmArgs() {
+        return new String[] {
+                "-XX:+UnlockDiagnosticVMOptions",
+                "-XX:+DebugNonSafepoints",
+                "-Dio.netty5.leakDetection.level=disabled",
+                "-Dio.netty5.buffer.leakDetectionEnabled=false",
+                "-Dio.netty5.buffer.lifecycleTracingEnabled=false",
+                // in case java19+ and loom is used
+                "--enable-preview",
+                // size of the shared cleaner pool used only by external threads (0=number of available processors)
+                "-Dio.netty5.cleanerpool.size=0",
+        };
+    }
+
+    /**
+     * Creates event-loop threads with number of available processors)
+     */
+    @Setup
+    public void setup() {
+        execs = IntStream.range(0, Runtime.getRuntime().availableProcessors())
+                .mapToObj(i -> new SingleThreadEventExecutor())
+                .toArray(SingleThreadEventExecutor[]::new);
+    }
+
+    /**
+     * Shutdown event-loop threads
+     */
+    @TearDown
+    public void tearDown() {
+        Stream.of(execs).forEach(eventExecutors -> eventExecutors.shutdownGracefully());
+    }
+
+    /**
+     * Many external threads are allocating/dropping buffers concurrently.
+     * The shared fixed-size cleaner pool will be used to distribute cleaners among
+     * threads.
+     */
+    @Benchmark
+    @Threads(Threads.MAX) // available processors
+    @BenchmarkMode(Mode.Throughput)
+    public void testAllocateExternalThread(Blackhole bh) {
+        int size = ThreadLocalRandom.current().nextInt(1, 1024);
+        try (Buffer buf = DefaultBufferAllocators.onHeapAllocator().allocate(size)) {
+            bh.consume(buf);
+        }
+    }
+
+    /**
+     * Many event-loop threads are allocating/dropping many buffers concurrently.
+     * There will be one Cleaner instance mapped to each event-loop thread.
+     * Notice that using -Dio.netty5.cleanerpool.eventloop.usepool=true will
+     * force event-loop threads to use the shared cleaner pool, but by default
+     * this property is set to false.
+     * @param bh
+     * @throws InterruptedException
+     */
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    public void testAllocateEventLoopThread(Blackhole bh) throws InterruptedException {
+        int cpus = Runtime.getRuntime().availableProcessors();
+        final CountDownLatch latch = new CountDownLatch(cpus);
+
+        Runnable task = () -> {
+            for (int j = 0; j < 100000; j ++) {
+                int size = ThreadLocalRandom.current().nextInt(1, 1024);
+                try (Buffer buf = DefaultBufferAllocators.onHeapAllocator().allocate(size)) {
+                    bh.consume(buf);
+                }
+            }
+            latch.countDown();
+        };
+
+        IntStream.range(0, cpus).forEach(i -> execs[i].execute(task));
+        latch.await();
+    }
+}


### PR DESCRIPTION
Motivation:

Netty5 buffer API is now using the JDK _Cleaner_ tool, in order to process the phantom reachable buffers and to invoke cleaning actions (memory release and buffer leak detection).

Now, when calling the _Cleaner.register()_ method, or _Cleanable.clean()_ methods, the caller threads may contend on some synchronized methods, [see this method](https://github.com/openjdk/jdk/blob/jdk-19+36/src/java.base/share/classes/jdk/internal/ref/PhantomCleanable.java#L87) which is called by _Cleaner.register()_ as well as [this method](https://github.com/openjdk/jdk/blob/jdk-19+36/src/java.base/share/classes/jdk/internal/ref/PhantomCleanable.java#L102) which is called when invoking _Cleanable.clean()_ method.

So, with some scenarios, this may considerably affect performance, especially under heavy load and when Event Loop threads are allocating/dropping buffers very often (each event loop thread are waiting for each other, fighting in order to obtain the synchronized lock on the _Cleaner_ object).

For example, using Reactor-Netty based on netty5, we have a scenario where an H2C client can send/receive around 132k of requests per seconds, but with a lot of idle CPUS (**30% idle**), and using the proposed patch, the rate of received response is considerably increased, up to **380k** instead of **132k**).

In order to reproduce the issue, I have attached a [JMH reproducer](https://github.com/netty/netty/files/9965221/test.benchmark.netty.buffer.alloc.tgz) scenario project. On my machine with 10 cpus, and with jdk19, I'm getting the following results, with around **68% of idle CPUs**:

```
Benchmark                          Mode  Cnt     Score    Error   Units
AllocationBenchmark.testAllocate  thrpt    4  2995.474 ± 94.552  ops/ms
```
and using the proposed patch, I'm then getting the following with only **1,32% of idle CPU:**
```
Benchmark                          Mode  Cnt      Score      Error   Units
AllocationBenchmark.testAllocate  thrpt    4  50095.795 ± 1377.148  ops/ms
```

Modification:

The _InternalBufferUtils.CLEANER_ singleton is not used anymore and has been replaced by the new _CleanerPool_ class which maintains a pool of cleaners that are mapped to each Event Loops (using FastThreadLocal).
By default, the number of Cleaner instances maintained by the CleanerPool corresponds to the number of available processors, but you can take control on the number of cleaners allocated by the pool, using this system property:

```
-Dio.netty5.cleanerpool.size=<number>  (0 by default, meaning the number of available processors are used as the number of created Cleaners)
```

It may be frightening to create many Cleaners because there is a daemon thread that is created for each _Cleaner_ instance, but using multiple Cleaners almost eliminate the EventLoop thread contention on the Cleaner register/unregister.
Also, on a bug free system, without any memory leaks, then the daemon threads are normally staying idle and won't be waken up by phantom references.

In addition to this, in case java19+ is used, the _CleanerPool_ can optionally use Loom _virtual ThreadFactory_ for _Cleaner_ daemon threads. The _virtual ThreadFactory_ are instantiated using MethodHandles in order to avoid locking to Loom API.
If you are using java19+, you can configure this system property:
```
-Dio.netty5.cleanerpool.vthread=true (false by default)
```
This will allow to configure the Cleaners with virtual threads, something like (but using Method Handles):
```
Cleaner cleaner = Cleaner.create(Threads.ofVirtual().factory()) 
```

Honestly, I did the test using Cleaners + Virtual Threads, but the results are similar, even a bit slower.
I think maybe it's because _synchronized_ is still pinning the carrier thread (maybe ...).

That's why the io.netty5.cleanerpool.vthread is set to false by default. But it may be useful to have all in place in order to be able to switch to vthreads in case they fix the _synchronized_ issue.

Result:

The proposed patch reduces and almost eliminates the contention between event loops and the Cleaner, at the cost of allocating more Cleaner instances, but this is normally not a problem for systems which don't have any memory leaks , because the Cleaner daemon threads should sday idle in this case. And optionally, all is in place in order to use Loom virtual threads as Cleaner daemons (if java19+ is used).

