### PR TITLE
Subclasses of FastThreadLocalThread can selectively permit blocking calls

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/FastThreadLocalThread.java
+++ b/common/src/main/java/io/netty/util/concurrent/FastThreadLocalThread.java
@@ -111,4 +111,18 @@ public class FastThreadLocalThread extends Thread {
         return thread instanceof FastThreadLocalThread &&
                 ((FastThreadLocalThread) thread).willCleanupFastThreadLocals();
     }
+
+    /**
+     * Query whether this thread is allowed to perform blocking calls or not.
+     * {@link FastThreadLocalThread}s are often used in event-loops, where blocking calls are forbidden in order to
+     * prevent event-loop stalls, so this method returns {@code false} by default.
+     * <p>
+     * Subclasses of {@link FastThreadLocalThread} can override this method if they are not meant to be used for
+     * running event-loops.
+     *
+     * @return {@code false}, unless overriden by a subclass.
+     */
+    public boolean permitBlockingCalls() {
+        return false;
+    }
 }

--- a/common/src/main/java/io/netty/util/internal/Hidden.java
+++ b/common/src/main/java/io/netty/util/internal/Hidden.java
@@ -170,7 +170,9 @@ class Hidden {
                         @Override
                         @SuppressJava6Requirement(reason = "Predicate#test")
                         public boolean test(Thread thread) {
-                            return p.test(thread) || thread instanceof FastThreadLocalThread;
+                            return p.test(thread) ||
+                                    thread instanceof FastThreadLocalThread &&
+                                            !((FastThreadLocalThread) thread).permitBlockingCalls();
                         }
                     };
                 }

--- a/transport-blockhound-tests/src/test/java/io/netty/util/internal/NettyBlockHoundIntegrationTest.java
+++ b/transport-blockhound-tests/src/test/java/io/netty/util/internal/NettyBlockHoundIntegrationTest.java
@@ -190,6 +190,23 @@ public class NettyBlockHoundIntegrationTest {
     }
 
     @Test
+    void permittingBlockingCallsInFastThreadLocalThreadSubclass() throws Exception {
+        final FutureTask<Void> future = new FutureTask<>(() -> {
+            Thread.sleep(0);
+            return null;
+        });
+        FastThreadLocalThread thread = new FastThreadLocalThread(future) {
+            @Override
+            public boolean permitBlockingCalls() {
+                return true; // The Thread.sleep(0) call should not be flagged because we allow blocking calls.
+            }
+        };
+        thread.start();
+        future.get(5, TimeUnit.SECONDS);
+        thread.join();
+    }
+
+    @Test
     @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
     public void testHashedWheelTimerStartStop() throws Exception {
         HashedWheelTimer timer = new HashedWheelTimer();


### PR DESCRIPTION
Motivation:
People sometimes make use of FastThreadLocalThreads outside of event-loops, e.g. for task-offload, or to make ues of Netty's thread-locals. Our Blockhound integration is currently preventing these threads from performing blocking calls, which is overly restrictive.

Modification:
Add an escape hatch for subclasses of FastThreadLocalThread to permit blocking calls.

Result:
It is now possible to use FastThreadLocalThreads outside of event-loops, make use of blocking calls, and not be flagged by Blockhound.

Fixes #12959