### PR TITLE
Move validation of connection headers in HTTP/2 back to `HpackDecoder`

### DIFF
--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/headers/DefaultHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/headers/DefaultHttp2Headers.java
@@ -18,7 +18,6 @@ package io.netty5.handler.codec.http2.headers;
 import io.netty5.handler.codec.http.headers.DefaultHttpHeaders;
 import io.netty5.handler.codec.http.headers.HeaderValidationException;
 import io.netty5.handler.codec.http.headers.HttpCookiePair;
-import io.netty5.handler.codec.http.headers.HttpHeaderValidationUtil;
 import io.netty5.handler.codec.http.headers.HttpHeaders;
 import io.netty5.handler.codec.http.headers.HttpSetCookie;
 import io.netty5.handler.codec.http.headers.MultiMap;
@@ -93,22 +92,9 @@ public class DefaultHttp2Headers extends DefaultHttpHeaders implements Http2Head
                         }
                     }
                 }
-                if (HttpHeaderValidationUtil.isConnectionHeader(name, true)) {
-                    throw new HeaderValidationException(
-                            "Illegal connection-specific header '" + name + "' encountered.");
-                }
             }
         }
         return name;
-    }
-
-    @Override
-    protected CharSequence validateValue(CharSequence key, CharSequence value) {
-        if (validateValues && HttpHeaderValidationUtil.isTeNotTrailers(key, value)) {
-            throw new HeaderValidationException(
-                    "Illegal value specified for the 'TE' header (only 'trailers' is allowed).");
-        }
-        return super.validateValue(key, value);
     }
 
     @Override

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/DefaultHttp2HeadersTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/DefaultHttp2HeadersTest.java
@@ -21,6 +21,8 @@ import io.netty5.handler.codec.http2.headers.Http2Headers.PseudoHeaderName;
 import io.netty5.util.internal.StringUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import java.util.Map.Entry;
 
@@ -189,6 +191,15 @@ public class DefaultHttp2HeadersTest {
         assertEquals(of("101"), headers.status());
         assertEquals(of("github.com"), headers.authority());
         assertEquals(of("http"), headers.scheme());
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] name={0} value={1}")
+    @CsvSource(value = {"upgrade,protocol1", "connection,close", "keep-alive,timeout=5", "proxy-connection,close",
+            "transfer-encoding,chunked", "te,something-else"})
+    void possibleToAddConnectionHeaders(String name, String value) {
+        Http2Headers headers = newHeaders();
+        headers.add(name, value);
+        assertTrue(headers.contains(name, value));
     }
 
     private static void verifyAllPseudoHeadersPresent(Http2Headers headers) {


### PR DESCRIPTION
Motivation:

#12755 added validation for presence of connection-related headers while `HpackDecoder` decodes the incoming frame. Then #12832 moved this validation from `HpackDecoder` to `DefaultHttp2Headers`. As the result, existing use-case that could use `DefaultHttp2Headers` for HTTP/2 and HTTP/1.X broke when users add  any of the mentioned prohibited headers. The HTTP/1.X to HTTP/2 translation logic usually has sanitization process that removes connection-related headers. It's enough to run this validation only for incoming messages and we should preserve backward compatibility for 4.1.

Modifications:

- Move `isConnectionHeader` and `te` validations from `DefaultHttp2Headers` back to `HpackDecoder`;
- Add tests to verify `HpackDecoder` fails incoming headers as expected;
- Add tests to verify mentioned headers can be added to `DefaultHttp2Headers`;

Result:

Backward compatibility is preserved, while validation for connection-related headers is done in `HpackDecoder`.

Backport of #12975.