### PR TITLE
Pull the io_uring transport out of incubator and into core Netty 5

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -82,6 +82,18 @@
         </dependency>
         <dependency>
           <groupId>${project.groupId}</groupId>
+          <artifactId>netty5-transport-native-io_uring</artifactId>
+          <classifier>linux-x86_64</classifier>
+          <scope>runtime</scope>
+        </dependency>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>netty5-transport-native-io_uring</artifactId>
+          <classifier>linux-aarch_64</classifier>
+          <scope>runtime</scope>
+        </dependency>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
           <artifactId>netty5-transport-native-kqueue</artifactId>
           <classifier>osx-x86_64</classifier>
           <scope>runtime</scope>
@@ -107,7 +119,7 @@
       </dependencies>
     </profile>
 
-    <!-- The linux profile will only include the native jar for epoll to the all jar.
+    <!-- The linux profile will only include the native jar for epoll and io_uring to the all jar.
          If you want to also include the native jar for kqueue use -Puber.
     -->
     <profile>
@@ -118,6 +130,13 @@
         <dependency>
           <groupId>${project.groupId}</groupId>
           <artifactId>netty5-transport-native-epoll</artifactId>
+          <version>${project.version}</version>
+          <classifier>${jni.classifier}</classifier>
+          <scope>runtime</scope>
+        </dependency>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>netty5-transport-native-io_uring</artifactId>
           <version>${project.version}</version>
           <classifier>${jni.classifier}</classifier>
           <scope>runtime</scope>
@@ -268,6 +287,11 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty5-transport-classes-epoll</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty5-transport-classes-io_uring</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -220,6 +220,28 @@
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
+        <artifactId>netty5-transport-classes-io_uring</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty5-transport-native-io_uring</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty5-transport-native-io_uring</artifactId>
+        <version>${project.version}</version>
+        <classifier>linux-aarch_64</classifier>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty5-transport-native-io_uring</artifactId>
+        <version>${project.version}</version>
+        <classifier>linux-x86_64</classifier>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
         <artifactId>netty5-transport-classes-kqueue</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/license/LICENSE.liburing.txt
+++ b/license/LICENSE.liburing.txt
@@ -1,0 +1,7 @@
+Copyright 2020 Jens Axboe
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/pom.xml
+++ b/pom.xml
@@ -595,6 +595,8 @@
     <module>transport-native-unix-common</module>
     <module>transport-classes-epoll</module>
     <module>transport-native-epoll</module>
+    <module>transport-classes-io_uring</module>
+    <module>transport-native-io_uring</module>
     <module>transport-classes-kqueue</module>
     <module>transport-native-kqueue</module>
     <module>handler</module>

--- a/transport-classes-io_uring/pom.xml
+++ b/transport-classes-io_uring/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2014 The Netty Project
+  ~ Copyright 2021 The Netty Project
   ~
   ~ The Netty Project licenses this file to you under the Apache License,
   ~ version 2.0 (the "License"); you may not use this file except in compliance
@@ -21,13 +21,13 @@
     <artifactId>netty5-parent</artifactId>
     <version>5.0.0.Alpha6-SNAPSHOT</version>
   </parent>
-  <artifactId>netty5-transport-classes-epoll</artifactId>
+  <artifactId>netty5-transport-classes-io_uring</artifactId>
 
-  <name>Netty5/Transport/Classes/Epoll</name>
+  <name>Netty5/Transport/Classes/io_uring</name>
   <packaging>jar</packaging>
 
   <properties>
-    <javaModuleName>io.netty5.transport.classes.epoll</javaModuleName>
+    <javaModuleName>io.netty5.transport.classes.io_uring</javaModuleName>
   </properties>
 
   <dependencies>

--- a/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/AbstractIOUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/AbstractIOUringChannel.java
@@ -1,0 +1,812 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.buffer.Buffer;
+import io.netty5.buffer.BufferAllocator;
+import io.netty5.buffer.DefaultBufferAllocators;
+import io.netty5.buffer.StandardAllocationTypes;
+import io.netty5.channel.AbstractChannel;
+import io.netty5.channel.ChannelException;
+import io.netty5.channel.ChannelOption;
+import io.netty5.channel.ChannelShutdownDirection;
+import io.netty5.channel.EventLoop;
+import io.netty5.channel.ReadHandleFactory;
+import io.netty5.channel.WriteHandleFactory;
+import io.netty5.channel.socket.SocketProtocolFamily;
+import io.netty5.channel.unix.Errors;
+import io.netty5.channel.unix.FileDescriptor;
+import io.netty5.channel.unix.UnixChannel;
+import io.netty5.channel.unix.UnixChannelOption;
+import io.netty5.util.Resource;
+import io.netty5.util.collection.LongObjectHashMap;
+import io.netty5.util.collection.LongObjectMap;
+import io.netty5.util.concurrent.Future;
+import io.netty5.util.concurrent.FutureContextListener;
+import io.netty5.util.concurrent.Promise;
+import io.netty5.util.internal.SilentDispose;
+import io.netty5.util.internal.logging.InternalLogger;
+import io.netty5.util.internal.logging.InternalLoggerFactory;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.InetSocketAddress;
+import java.net.NetworkInterface;
+import java.net.NoRouteToHostException;
+import java.net.SocketAddress;
+import java.net.SocketException;
+import java.nio.channels.UnresolvedAddressException;
+import java.util.concurrent.Executor;
+import java.util.function.ObjLongConsumer;
+
+import static io.netty5.channel.unix.UnixChannelUtil.computeRemoteAddr;
+
+abstract class AbstractIOUringChannel<P extends UnixChannel>
+        extends AbstractChannel<P, SocketAddress, SocketAddress>
+        implements UnixChannel {
+    private static final InternalLogger LOGGER = InternalLoggerFactory.getInstance(AbstractIOUringChannel.class);
+    private static final int MAX_READ_AHEAD_PACKETS = 8;
+
+    static final FutureContextListener<Buffer, Void> CLOSE_BUFFER = (b, f) -> SilentDispose.dispose(b, LOGGER);
+
+    protected final LinuxSocket socket;
+    protected final ObjectRing<Object> readsPending;
+    protected final ObjectRing<Object> readsCompleted; // Either 'Failure', or a message (buffer, datagram, ...).
+    protected final LongObjectMap<Object> cancelledReads;
+
+    protected volatile boolean active;
+    protected volatile SocketAddress local;
+    protected volatile SocketAddress remote;
+
+    protected SubmissionQueue submissionQueue;
+    protected WriteSink writeSink;
+    protected int currentCompletionResult;
+    protected short currentCompletionData;
+
+    private final Promise<Executor> prepareClosePromise;
+    private final Runnable pendingRead;
+    private final Runnable rdHupRead;
+
+    private short lastReadId;
+    private boolean readPendingRegister;
+    private boolean readPendingConnect;
+    private Buffer connectRemoteAddressMem;
+    private boolean scheduledRdHup;
+    private boolean receivedRdHup;
+
+    protected AbstractIOUringChannel(P parent, EventLoop eventLoop, boolean supportingDisconnect,
+                                     ReadHandleFactory defaultReadHandleFactory,
+                                     WriteHandleFactory defaultWriteHandleFactory,
+                                     LinuxSocket socket, SocketAddress remote, boolean active) {
+        super(parent, eventLoop, supportingDisconnect, defaultReadHandleFactory, defaultWriteHandleFactory);
+        this.socket = socket;
+        this.active = active;
+        if (active) {
+            // Directly cache local and remote addresses.
+            local = socket.localAddress();
+            this.remote = remote == null ? socket.remoteAddress() : remote;
+        } else if (remote != null) {
+            this.remote = remote;
+        }
+        prepareClosePromise = eventLoop.newPromise();
+        pendingRead = this::submitReadForPending;
+        rdHupRead = this::submitReadForRdHup;
+        readsPending = new ObjectRing<>();
+        readsCompleted = new ObjectRing<>();
+        cancelledReads = new LongObjectHashMap<>(8);
+    }
+
+    @Override
+    protected SocketAddress localAddress0() {
+        return local;
+    }
+
+    @Override
+    protected SocketAddress remoteAddress0() {
+        return remote;
+    }
+
+    @Override
+    protected void doBind(SocketAddress localAddress) throws Exception {
+        if (local instanceof InetSocketAddress) {
+            checkResolvable((InetSocketAddress) local);
+        }
+        socket.bind(localAddress); // Bind immediately, as AbstractChannel expects it to be done after this method call.
+        if (fetchLocalAddress()) {
+            local = socket.localAddress();
+        } else {
+            local = localAddress;
+        }
+        cacheAddresses(local, remoteAddress());
+    }
+
+    protected static void checkResolvable(InetSocketAddress addr) {
+        if (addr.isUnresolved()) {
+            throw new UnresolvedAddressException();
+        }
+    }
+
+    protected final boolean fetchLocalAddress() {
+        return socket.protocolFamily() != SocketProtocolFamily.UNIX;
+    }
+
+    @Override
+    protected void doRead(boolean wasReadPendingAlready) throws Exception {
+        // Schedule a read operation. When completed, we'll get a callback to readComplete.
+        if (submissionQueue == null) {
+            readPendingRegister = true;
+            return;
+        }
+        if (!wasReadPendingAlready) {
+            submitRead();
+        }
+    }
+
+    private void submitRead() {
+        // Submit reads until read handle says stop, we fill the submission queue, or hit max limit
+        int maxPackets = Math.min(submissionQueue.remaining(), MAX_READ_AHEAD_PACKETS);
+        int sumPackets = 0;
+        int bufferSize = nextReadBufferSize();
+        boolean morePackets = bufferSize > 0;
+
+        while (morePackets) {
+            Buffer readBuffer = readBufferAllocator().allocate(bufferSize);
+            assert readBuffer.isDirect();
+            assert readBuffer.countWritableComponents() == 1;
+            sumPackets++;
+            morePackets = sumPackets < maxPackets && (bufferSize = nextReadBufferSize()) > 0;
+            submissionQueue.link(morePackets);
+            short readId = ++lastReadId;
+            submitReadForReadBuffer(readBuffer, readId, sumPackets > 1, readsPending);
+        }
+    }
+
+    private void submitNonBlockingRead() {
+        assert readsPending.isEmpty();
+        int bufferSize = nextReadBufferSize();
+        if (bufferSize == 0) {
+            return;
+        }
+        Buffer readBuffer = readBufferAllocator().allocate(bufferSize);
+        assert readBuffer.isDirect();
+        assert readBuffer.countWritableComponents() == 1;
+        short readId = ++lastReadId;
+        submitReadForReadBuffer(readBuffer, readId, true, readsPending);
+    }
+
+    private void submitReadForPending() {
+        if (active && readsPending.isEmpty()) {
+            submitRead();
+        }
+    }
+
+    private void submitReadForRdHup() {
+        if (active && readsPending.isEmpty()) {
+            submitNonBlockingRead();
+        }
+    }
+
+    protected int nextReadBufferSize() {
+        return readHandle().prepareRead();
+    }
+
+    protected void submitReadForReadBuffer(Buffer buffer, short readId, boolean nonBlocking,
+                                             ObjLongConsumer<Object> pendingConsumer) {
+        try (var itr = buffer.forEachComponent()) {
+            var cmp = itr.firstWritable();
+            assert cmp != null;
+            long address = cmp.writableNativeAddress();
+            int flags = nonBlocking ? Native.MSG_DONTWAIT : 0;
+            long udata = submissionQueue.addRecv(
+                    fd().intValue(), address, 0, cmp.writableBytes(), flags, readId);
+            pendingConsumer.accept(buffer, udata);
+        }
+    }
+
+    @Override
+    protected void doClearScheduledRead() {
+        // Using the lastReadId to differentiate our reads, means we avoid accidentally cancelling any future read.
+        while (readsPending.poll()) {
+            Object obj = readsPending.getPolledObject();
+            long udata = readsPending.getPolledStamp();
+            Resource.touch(obj, "read cancelled");
+            cancelledReads.put(udata, obj);
+            submissionQueue.addCancel(fd().intValue(), udata);
+        }
+    }
+
+    void readComplete(int res, long udata) {
+        assert executor().inEventLoop();
+        if (res == Native.ERRNO_ECANCELED_NEGATIVE || res == Errors.ERRNO_EAGAIN_NEGATIVE) {
+            Object obj = cancelledReads.remove(udata);
+            if (obj == null) {
+                obj = readsPending.remove(udata);
+            }
+            if (obj != null) {
+                SilentDispose.dispose(obj, logger());
+            }
+            return;
+        }
+
+        final Object obj;
+        if (readsPending.hasNextStamp(udata) && readsPending.poll()) {
+            obj = readsPending.getPolledObject();
+        } else {
+            // Out-of-order read completion? Weird. Should this ever happen?
+            obj = readsPending.remove(udata);
+        }
+        if (obj != null) {
+            if (res >= 0) {
+                Resource.touch(obj, "read completed");
+                readsCompleted.push(prepareCompletedRead(obj, res), udata);
+            } else {
+                SilentDispose.dispose(obj, logger());
+                readsCompleted.push(new Failure(res), udata);
+            }
+        }
+    }
+
+    protected Object prepareCompletedRead(Object obj, int result) {
+        ((Buffer) obj).skipWritableBytes(result);
+        return obj;
+    }
+
+    void ioLoopCompleted() {
+        if (!readsCompleted.isEmpty()) {
+            readNow(); // Will call back into doReadNow.
+        }
+        WriteSink writeSink = this.writeSink;
+        if (writeSink != null) {
+            writeSink.complete(0, 0, 0, false);
+            writeSink.writeLoopContinue();
+            writeSink.writeLoopEnd();
+            this.writeSink = null;
+        }
+    }
+
+    @Override
+    protected boolean doReadNow(ReadSink readSink) throws Exception {
+        while (readsCompleted.poll()) {
+            Object completion = readsCompleted.getPolledObject();
+            if (completion instanceof Failure) {
+                throw Errors.newIOException("channel.read", ((Failure) completion).result);
+            }
+            if (processRead(readSink, completion)) {
+                // Leave it to the sub-class to decide if this buffer is EOF or not.
+                return true;
+            }
+        }
+        // We have no more completed reads. Stop the read loop.
+        readSink.processRead(0, 0, null);
+        return false;
+    }
+
+    protected final BufferAllocator ioBufferAllocator() {
+        BufferAllocator allocator = bufferAllocator();
+        if (allocator.getAllocationType() == StandardAllocationTypes.OFF_HEAP) {
+            return allocator;
+        }
+        return DefaultBufferAllocators.offHeapAllocator();
+    }
+
+    @Override
+    protected final BufferAllocator readBufferAllocator() {
+        return ioBufferAllocator();
+    }
+
+    /**
+     * Process the given read.
+     *
+     * @return {@code true} if the channel should be closed, e.g. if a zero-readable buffer means EOF.
+     */
+    protected abstract boolean processRead(ReadSink readSink, Object read);
+
+    @Override
+    protected void readLoopComplete() {
+        super.readLoopComplete();
+        // If there are pending reads, or we received RDHUP (such that we want to drain inbound buffer),
+        // then schedule a read to run later, after other tasks.
+        // Those other tasks might issue their own reads, which we should not interferre with.
+        // Another reason we need to schedule these to run later, is that the read-loop will cancel any unprocessed
+        // reads after this method call.
+        if (isReadPending()) {
+            executor().execute(pendingRead);
+        } else if (receivedRdHup) {
+            executor().execute(rdHupRead);
+        }
+    }
+
+    @NotNull
+    protected Buffer intoDirectBuffer(Buffer buf, boolean dispose) {
+        BufferAllocator allocator = ioBufferAllocator();
+        Buffer copy = allocator.allocate(buf.readableBytes());
+        copy.writeBytes(buf);
+        if (dispose) {
+            buf.close();
+        }
+        return copy;
+    }
+
+    @Override
+    protected void writeLoop(WriteSink writeSink) {
+        this.writeSink = writeSink;
+        try {
+            writeSink.writeLoopStep();
+        } catch (Throwable e) {
+            handleWriteError(e);
+        }
+    }
+
+    @Override
+    protected void doWriteNow(WriteSink writeSink) {
+        submitAllWriteMessages(writeSink);
+        // We *MUST* submit all our messages, since we'll be releasing the outbound buffers after the doWriteNow call.
+        submissionQueue.submit();
+    }
+
+    protected abstract void submitAllWriteMessages(WriteSink writeSink);
+
+    abstract void writeComplete(int result, long udata);
+
+    /**
+     * Connect to the remote peer
+     */
+    @Override
+    protected boolean doConnect(SocketAddress remoteAddress, SocketAddress localAddress, Buffer initialData)
+            throws Exception {
+        if (localAddress instanceof InetSocketAddress) {
+            checkResolvable((InetSocketAddress) localAddress);
+        }
+
+        InetSocketAddress remoteSocketAddr = remoteAddress instanceof InetSocketAddress
+                ? (InetSocketAddress) remoteAddress : null;
+        if (remoteSocketAddr != null) {
+            checkResolvable(remoteSocketAddr);
+        }
+
+        if (localAddress != null) {
+            socket.bind(localAddress);
+        }
+
+        submitConnect(remoteSocketAddr, initialData);
+        return false;
+    }
+
+    protected void submitConnect(InetSocketAddress remoteSocketAddr, Buffer initialData) throws IOException {
+        Buffer addrBuf = ioBufferAllocator().allocate(Native.SIZEOF_SOCKADDR_STORAGE);
+        try (var itr = addrBuf.forEachComponent()) {
+            var cmp = itr.firstWritable();
+            SockaddrIn.write(socket.isIpv6(), cmp.writableNativeAddress(), remoteSocketAddr);
+            submissionQueue.addConnect(fd().intValue(), cmp.writableNativeAddress(),
+                    Native.SIZEOF_SOCKADDR_STORAGE, (short) 0);
+        }
+        connectRemoteAddressMem = addrBuf;
+    }
+
+    void connectComplete(int res, long udata) {
+        currentCompletionResult = res;
+        if (connectRemoteAddressMem != null) { // Can be null if we connected with TCP Fast Open.
+            SilentDispose.dispose(connectRemoteAddressMem, logger());
+            connectRemoteAddressMem = null;
+        }
+        finishConnect();
+    }
+
+    @Override
+    protected boolean doFinishConnect(SocketAddress requestedRemoteAddress) throws Exception {
+        int res = currentCompletionResult;
+        currentCompletionResult = 0;
+        currentCompletionData = 0;
+        if (res < 0) {
+            var nativeException = Errors.newIOException("connect", res);
+            if (res == Errors.ERROR_ECONNREFUSED_NEGATIVE) {
+                ConnectException refused = new ConnectException(nativeException.getMessage());
+                refused.initCause(nativeException);
+                throw refused;
+            }
+            if (res == Errors.ERROR_EHOSTUNREACH_NEGATIVE) { // EHOSTUNREACH: No route to host
+                NoRouteToHostException unreach = new NoRouteToHostException(nativeException.getMessage());
+                unreach.initCause(nativeException);
+                throw unreach;
+            }
+            SocketException exception = new SocketException(nativeException.getMessage());
+            exception.initCause(nativeException);
+            throw exception;
+        }
+        if (fetchLocalAddress()) {
+            local = socket.localAddress();
+        }
+        if (socket.finishConnect()) {
+            active = true;
+            if (requestedRemoteAddress instanceof InetSocketAddress) {
+                remote = computeRemoteAddr((InetSocketAddress) requestedRemoteAddress, socket.remoteAddress());
+            } else {
+                remote = requestedRemoteAddress;
+            }
+            submitPollRdHup();
+            if (readPendingConnect) {
+                submitRead();
+                readPendingConnect = false;
+            }
+            return true;
+        }
+        return false;
+    }
+
+    private void submitPollRdHup() {
+        submissionQueue.addPollRdHup(fd().intValue());
+        scheduledRdHup = true;
+    }
+
+    void completeRdHup(int res) {
+        if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
+            return;
+        }
+        receivedRdHup = true;
+        scheduledRdHup = false;
+        if (active && readsPending.isEmpty()) {
+            // Schedule a read to drain inbound buffer and notice the EOF.
+            submitNonBlockingRead();
+        }
+    }
+
+    void completeChannelRegister(SubmissionQueue submissionQueue) {
+        this.submissionQueue = submissionQueue;
+        if (active) {
+            submitPollRdHup();
+        }
+        if (readPendingRegister) {
+            readPendingRegister = false;
+            read();
+        }
+    }
+
+    @Override
+    protected void doDisconnect() throws Exception {
+        active = false;
+    }
+
+    @Override
+    protected Future<Executor> prepareToClose() {
+        // Prevent more operations from being submitted.
+        active = false;
+        // Cancel all pending reads.
+        doClearScheduledRead();
+        // Cancel any RDHUP poll
+        if (scheduledRdHup) {
+            submissionQueue.addPollRemove(fd().intValue(), Native.POLLRDHUP);
+        }
+        closeTransportNow(false);
+        return prepareClosePromise.asFuture();
+    }
+
+    @Override
+    protected void doClose() {
+        tryDisposeAll(readsPending);
+        tryDisposeAll(readsCompleted);
+        if (connectRemoteAddressMem != null) {
+            SilentDispose.trySilentDispose(connectRemoteAddressMem, logger());
+            connectRemoteAddressMem = null;
+        }
+    }
+
+    private void tryDisposeAll(ObjectRing<?> ring) {
+        while (ring.poll()) {
+            SilentDispose.trySilentDispose(ring.getPolledObject(), logger());
+        }
+    }
+
+    void closeTransportNow(boolean drainIO) {
+        submissionQueue.addClose(socket.intValue(), drainIO, (short) 0);
+    }
+
+    void closeComplete(int res, long udata) {
+        if (socket.markClosed()) {
+            prepareClosePromise.setSuccess(executor());
+        }
+    }
+
+    @Override
+    protected abstract void doShutdown(ChannelShutdownDirection direction) throws Exception;
+
+    @Override
+    public abstract boolean isShutdown(ChannelShutdownDirection direction);
+
+    @Override
+    public FileDescriptor fd() {
+        return socket;
+    }
+
+    @Override
+    public boolean isOpen() {
+        return socket.isOpen();
+    }
+
+    @Override
+    public boolean isActive() {
+        return active;
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "(fd: " + socket.intValue() + ')' + super.toString();
+    }
+
+    protected abstract InternalLogger logger();
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected <T> T getExtendedOption(ChannelOption<T> option) {
+        if (option == ChannelOption.SO_BROADCAST) {
+            return (T) Boolean.valueOf(isBroadcast());
+        }
+        if (option == ChannelOption.SO_RCVBUF) {
+            return (T) Integer.valueOf(getReceiveBufferSize());
+        }
+        if (option == ChannelOption.SO_SNDBUF) {
+            return (T) Integer.valueOf(getSendBufferSize());
+        }
+        if (option == ChannelOption.SO_LINGER) {
+            return (T) Integer.valueOf(getSoLinger());
+        }
+        if (option == ChannelOption.SO_REUSEADDR) {
+            return (T) Boolean.valueOf(isReuseAddress());
+        }
+        if (option == ChannelOption.IP_MULTICAST_LOOP_DISABLED) {
+            return (T) Boolean.valueOf(isLoopbackModeDisabled());
+        }
+        if (option == ChannelOption.IP_MULTICAST_IF) {
+            return (T) getNetworkInterface();
+        }
+        if (option == ChannelOption.IP_MULTICAST_TTL) {
+            return (T) Integer.valueOf(getTimeToLive());
+        }
+        if (option == ChannelOption.IP_TOS) {
+            return (T) Integer.valueOf(getTrafficClass());
+        }
+        if (option == UnixChannelOption.SO_REUSEPORT) {
+            return (T) Boolean.valueOf(isReusePort());
+        }
+        return super.getExtendedOption(option);
+    }
+
+    @Override
+    protected <T> void setExtendedOption(ChannelOption<T> option, T value) {
+        if (option == ChannelOption.SO_BROADCAST) {
+            setBroadcast((Boolean) value);
+        } else if (option == ChannelOption.SO_RCVBUF) {
+            setReceiveBufferSize((Integer) value);
+        } else if (option == ChannelOption.SO_SNDBUF) {
+            setSendBufferSize((Integer) value);
+        } else if (option == ChannelOption.SO_LINGER) {
+            setSoLinger((Integer) value);
+        } else if (option == ChannelOption.SO_REUSEADDR) {
+            setReuseAddress((Boolean) value);
+        } else if (option == ChannelOption.IP_MULTICAST_LOOP_DISABLED) {
+            setLoopbackModeDisabled((Boolean) value);
+        } else if (option == ChannelOption.IP_MULTICAST_IF) {
+            setNetworkInterface((NetworkInterface) value);
+        } else if (option == ChannelOption.IP_MULTICAST_TTL) {
+            setTimeToLive((Integer) value);
+        } else if (option == ChannelOption.IP_TOS) {
+            setTrafficClass((Integer) value);
+        } else if (option == UnixChannelOption.SO_REUSEPORT) {
+            setReusePort((Boolean) value);
+        } else {
+            super.setExtendedOption(option, value);
+        }
+    }
+
+    @Override
+    protected boolean isExtendedOptionSupported(ChannelOption<?> option) {
+        if (option == ChannelOption.SO_BROADCAST ||
+                option == ChannelOption.SO_RCVBUF ||
+                option == ChannelOption.SO_SNDBUF ||
+                option == ChannelOption.SO_LINGER ||
+                option == ChannelOption.SO_REUSEADDR ||
+                option == ChannelOption.IP_MULTICAST_LOOP_DISABLED ||
+                option == ChannelOption.IP_MULTICAST_IF ||
+                option == ChannelOption.IP_MULTICAST_TTL ||
+                option == ChannelOption.IP_TOS ||
+                option == UnixChannelOption.SO_REUSEPORT) {
+            return true;
+        }
+        return super.isExtendedOptionSupported(option);
+    }
+
+    private int getSendBufferSize() {
+        try {
+            return socket.getSendBufferSize();
+        } catch (IOException e) {
+            throw new ChannelException(e);
+        }
+    }
+
+    private void setSendBufferSize(int sendBufferSize) {
+        try {
+            socket.setSendBufferSize(sendBufferSize);
+        } catch (IOException e) {
+            throw new ChannelException(e);
+        }
+    }
+
+    private int getSoLinger() {
+        try {
+            return socket.getSoLinger();
+        } catch (IOException e) {
+            throw new ChannelException(e);
+        }
+    }
+
+    private void setSoLinger(int soLinger) {
+        try {
+            socket.setSoLinger(soLinger);
+        } catch (IOException e) {
+            throw new ChannelException(e);
+        }
+    }
+
+    private int getReceiveBufferSize() {
+        try {
+            return socket.getReceiveBufferSize();
+        } catch (IOException e) {
+            throw new ChannelException(e);
+        }
+    }
+
+    private void setReceiveBufferSize(int receiveBufferSize) {
+        try {
+            socket.setReceiveBufferSize(receiveBufferSize);
+        } catch (IOException e) {
+            throw new ChannelException(e);
+        }
+    }
+
+    private int getTrafficClass() {
+        try {
+            return socket.getTrafficClass();
+        } catch (IOException e) {
+            throw new ChannelException(e);
+        }
+    }
+
+    private void setTrafficClass(int trafficClass) {
+        try {
+            socket.setTrafficClass(trafficClass);
+        } catch (IOException e) {
+            throw new ChannelException(e);
+        }
+    }
+
+    private boolean isReuseAddress() {
+        try {
+            return socket.isReuseAddress();
+        } catch (IOException e) {
+            throw new ChannelException(e);
+        }
+    }
+
+    private void setReuseAddress(boolean reuseAddress) {
+        try {
+            socket.setReuseAddress(reuseAddress);
+        } catch (IOException e) {
+            throw new ChannelException(e);
+        }
+    }
+
+    private boolean isBroadcast() {
+        try {
+            return socket.isBroadcast();
+        } catch (IOException e) {
+            throw new ChannelException(e);
+        }
+    }
+
+    private void setBroadcast(boolean broadcast) {
+        try {
+            socket.setBroadcast(broadcast);
+        } catch (IOException e) {
+            throw new ChannelException(e);
+        }
+    }
+
+    private boolean isLoopbackModeDisabled() {
+        try {
+            return socket.isLoopbackModeDisabled();
+        } catch (IOException e) {
+            throw new ChannelException(e);
+        }
+    }
+
+    private void setLoopbackModeDisabled(boolean loopbackModeDisabled) {
+        try {
+            socket.setLoopbackModeDisabled(loopbackModeDisabled);
+        } catch (IOException e) {
+            throw new ChannelException(e);
+        }
+    }
+
+    private int getTimeToLive() {
+        try {
+            return socket.getTimeToLive();
+        } catch (IOException e) {
+            throw new ChannelException(e);
+        }
+    }
+
+    private void setTimeToLive(int ttl) {
+        try {
+            socket.setTimeToLive(ttl);
+        } catch (IOException e) {
+            throw new ChannelException(e);
+        }
+    }
+
+    protected NetworkInterface getNetworkInterface() {
+        try {
+            return socket.getNetworkInterface();
+        } catch (IOException e) {
+            throw new ChannelException(e);
+        }
+    }
+
+    private void setNetworkInterface(NetworkInterface networkInterface) {
+        try {
+            socket.setNetworkInterface(networkInterface);
+        } catch (IOException e) {
+            throw new ChannelException(e);
+        }
+    }
+
+    /**
+     * Returns {@code true} if the SO_REUSEPORT option is set.
+     */
+    private boolean isReusePort() {
+        try {
+            return socket.isReusePort();
+        } catch (IOException e) {
+            throw new ChannelException(e);
+        }
+    }
+
+    /**
+     * Set the SO_REUSEPORT option on the underlying Channel. This will allow to bind multiple
+     * {@link IOUringDatagramChannel}s to the same port and so accept connections with multiple threads.
+     * <p>
+     * Be aware this method needs be called before {@link IOUringDatagramChannel#bind(java.net.SocketAddress)} to have
+     * any affect.
+     */
+    private void setReusePort(boolean reusePort) {
+        try {
+            socket.setReusePort(reusePort);
+        } catch (IOException e) {
+            throw new ChannelException(e);
+        }
+    }
+
+    boolean isIpv6() {
+        return socket.isIpv6();
+    }
+
+    private static final class Failure {
+        final int result;
+
+        private Failure(int result) {
+            this.result = result;
+        }
+    }
+}

--- a/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/CmsgHdr.java
+++ b/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/CmsgHdr.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.util.internal.PlatformDependent;
+
+/**
+ * <pre>{@code
+ * struct cmsghdr {
+ *     socklen_t cmsg_len;    // data byte count, including header
+ *     int cmsg_level;  //originating protocol
+ *     int cmsg_type;   // protocol-specific type
+ *     // followed by unsigned char cmsg_data[];
+ * };
+ * }</pre>
+ */
+final class CmsgHdr {
+
+    private CmsgHdr() { }
+
+    static void write(long cmsghdrAddress, long cmsgHdrDataAddress,
+                      int cmsgLen, int cmsgLevel, int cmsgType, short segmentSize) {
+        if (Native.SIZEOF_SIZE_T == 4) {
+            PlatformDependent.putInt(cmsghdrAddress + Native.CMSG_OFFSETOF_CMSG_LEN, cmsgLen);
+        } else {
+            assert Native.SIZEOF_SIZE_T == 8;
+            PlatformDependent.putLong(cmsghdrAddress + Native.CMSG_OFFSETOF_CMSG_LEN, cmsgLen);
+        }
+        PlatformDependent.putInt(cmsghdrAddress + Native.CMSG_OFFSETOF_CMSG_LEVEL, cmsgLevel);
+        PlatformDependent.putInt(cmsghdrAddress + Native.CMSG_OFFSETOF_CMSG_TYPE, cmsgType);
+        PlatformDependent.putShort(cmsgHdrDataAddress, segmentSize);
+    }
+}

--- a/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/CompletionCallback.java
+++ b/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/CompletionCallback.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+interface CompletionCallback {
+    /**
+     * Called for a completion event that was put into the {@link CompletionQueue}.
+     */
+    void handle(int fd, int res, int flags, long udata);
+}

--- a/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/CompletionQueue.java
+++ b/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/CompletionQueue.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.util.internal.PlatformDependent;
+import io.netty5.util.internal.logging.InternalLogger;
+import io.netty5.util.internal.logging.InternalLoggerFactory;
+
+import java.util.StringJoiner;
+import java.util.function.IntSupplier;
+
+import static io.netty5.channel.uring.UserData.decode;
+
+/**
+ * Completion queue implementation for io_uring.
+ */
+final class CompletionQueue implements IntSupplier {
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(CompletionQueue.class);
+
+    //these offsets are used to access specific properties
+    //CQE (https://github.com/axboe/liburing/blob/master/src/include/liburing/io_uring.h#L162)
+    private static final int CQE_USER_DATA_FIELD = 0;
+    private static final int CQE_RES_FIELD = 8;
+    private static final int CQE_FLAGS_FIELD = 12;
+
+    private static final long CQE_SIZE = 16;
+
+    //these unsigned integer pointers(shared with the kernel) will be changed by the kernel
+    private final long kHeadAddress;
+    private final long kTailAddress;
+
+    private final long completionQueueArrayAddress;
+
+    final int ringSize;
+    final long ringAddress;
+    final int ringFd;
+
+    private final int ringEntries;
+    private final int ringMask;
+    private int ringHead;
+
+    CompletionQueue(long kHeadAddress, long kTailAddress, long kRingMaskAddress, long kRingEntriesAddress,
+                    long kOverflowAddress, long completionQueueArrayAddress, int ringSize, long ringAddress,
+                    int ringFd) {
+        this.kHeadAddress = kHeadAddress;
+        this.kTailAddress = kTailAddress;
+        this.completionQueueArrayAddress = completionQueueArrayAddress;
+        this.ringSize = ringSize;
+        this.ringAddress = ringAddress;
+        this.ringFd = ringFd;
+
+        this.ringEntries = PlatformDependent.getIntVolatile(kRingEntriesAddress);
+        this.ringMask = PlatformDependent.getIntVolatile(kRingMaskAddress);
+        this.ringHead = PlatformDependent.getIntVolatile(kHeadAddress);
+    }
+
+    /**
+     * Returns {@code true} if any completion event is ready to be processed by
+     * {@link #process(CompletionCallback)}, {@code false} otherwise.
+     */
+    boolean hasCompletions() {
+        return ringHead != PlatformDependent.getIntVolatile(kTailAddress);
+    }
+
+    @Override
+    public int getAsInt() {
+        return count();
+    }
+
+    int count() {
+        return PlatformDependent.getIntVolatile(kTailAddress) - ringHead;
+    }
+
+    /**
+     * Process the completion events in the {@link CompletionQueue} and return the number of processed
+     * events.
+     */
+    int process(CompletionCallback callback) {
+        int tail = PlatformDependent.getIntVolatile(kTailAddress);
+        int i = 0;
+        while (ringHead != tail) {
+            long cqeAddress = completionQueueArrayAddress + (ringHead & ringMask) * CQE_SIZE;
+
+            long udata = PlatformDependent.getLong(cqeAddress + CQE_USER_DATA_FIELD);
+            int res = PlatformDependent.getInt(cqeAddress + CQE_RES_FIELD);
+            int flags = PlatformDependent.getInt(cqeAddress + CQE_FLAGS_FIELD);
+
+            //Ensure that the kernel only sees the new value of the head index after the CQEs have been read.
+            ringHead++;
+            PlatformDependent.putIntOrdered(kHeadAddress, ringHead);
+
+            i++;
+
+            if (logger.isTraceEnabled()) {
+                logger.trace("completed(ring {}): {}(fd={}, res={})",
+                        ringFd, Native.opToStr(UserData.decodeOp(udata)), UserData.decodeFd(udata), res);
+            }
+            decode(res, flags, udata, callback);
+        }
+        return i;
+    }
+
+    @Override
+    public String toString() {
+        StringJoiner sb = new StringJoiner(", ", "CompletionQueue [", "]");
+        int tail = PlatformDependent.getIntVolatile(kTailAddress);
+        int head = ringHead;
+        while (head != tail) {
+            long cqeAddress = completionQueueArrayAddress + (ringHead & ringMask) * CQE_SIZE;
+            long udata = PlatformDependent.getLong(cqeAddress + CQE_USER_DATA_FIELD);
+            int res = PlatformDependent.getInt(cqeAddress + CQE_RES_FIELD);
+            sb.add(Native.opToStr(UserData.decodeOp(udata)) + "(fd=" + UserData.decodeFd(udata) + ",res=" + res + ')');
+            head++;
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Block until there is at least one completion ready to be processed.
+     */
+    void ioUringWaitCqe() {
+        int ret = Native.ioUringEnter(ringFd, 0, 1, Native.IORING_ENTER_GETEVENTS);
+        if (logger.isTraceEnabled()) {
+            logger.trace("completed(ring {}): {}", ringFd, toString());
+        }
+        if (ret < 0) {
+            throw new RuntimeException("ioUringEnter syscall returned " + ret);
+        }
+    }
+}

--- a/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/IOUring.java
+++ b/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/IOUring.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.channel.IoHandlerFactory;
+import io.netty5.util.internal.PlatformDependent;
+import io.netty5.util.internal.SystemPropertyUtil;
+import io.netty5.util.internal.logging.InternalLogger;
+import io.netty5.util.internal.logging.InternalLoggerFactory;
+
+public final class IOUring {
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(IOUring.class);
+    private static final Throwable UNAVAILABILITY_CAUSE;
+
+    static {
+        Throwable cause = null;
+        try {
+            if (SystemPropertyUtil.getBoolean("io.netty5.transport.noNative", false)) {
+                cause = new UnsupportedOperationException(
+                        "Native transport was explicit disabled with -Dio.netty5.transport.noNative=true");
+            } else {
+                String kernelVersion = Native.kernelVersion();
+                Native.checkKernelVersion(kernelVersion);
+                Throwable unsafeCause = PlatformDependent.getUnsafeUnavailabilityCause();
+                if (unsafeCause == null) {
+                    RingBuffer ringBuffer = null;
+                    try {
+                        ringBuffer = Native.createRingBuffer();
+                        Native.checkAllIOSupported(ringBuffer.fd());
+                    } finally {
+                        if (ringBuffer != null) {
+                            try {
+                                ringBuffer.close();
+                            } catch (Exception ignore) {
+                                // ignore
+                            }
+                        }
+                    }
+                } else {
+                    cause = new UnsupportedOperationException("Unsafe is not supported", unsafeCause);
+                }
+            }
+        } catch (Throwable t) {
+            cause = t;
+        }
+        if (cause != null) {
+            if (logger.isTraceEnabled()) {
+                logger.debug("io_uring integration unavailable: {}", cause.getMessage(), cause);
+            } else {
+                logger.debug("io_uring integration unavailable: {}", cause.getMessage());
+            }
+        }
+
+        UNAVAILABILITY_CAUSE = cause;
+    }
+
+    public static boolean isAvailable() {
+        return UNAVAILABILITY_CAUSE == null;
+    }
+
+    public static void ensureAvailability() {
+        if (UNAVAILABILITY_CAUSE != null) {
+            throw (Error) new UnsatisfiedLinkError(
+                    "failed to load the required native library").initCause(UNAVAILABILITY_CAUSE);
+        }
+    }
+
+    public static Throwable unavailabilityCause() {
+        return UNAVAILABILITY_CAUSE;
+    }
+
+    public static IoHandlerFactory newFactory() {
+        ensureAvailability();
+        return () -> {
+            RingBuffer ringBuffer = Native.createRingBuffer();
+            return new IOUringHandler(ringBuffer);
+        };
+    }
+
+    public static IoHandlerFactory newFactory(int ringSize) {
+        ensureAvailability();
+        return () -> {
+            RingBuffer ringBuffer = Native.createRingBuffer(ringSize);
+            return new IOUringHandler(ringBuffer);
+        };
+    }
+
+    public static IoHandlerFactory newFactory(int ringSize, int kernelWorkerOffloadThreshold) {
+        ensureAvailability();
+        return () -> {
+            RingBuffer ringBuffer = Native.createRingBuffer(ringSize, kernelWorkerOffloadThreshold);
+            return new IOUringHandler(ringBuffer);
+        };
+    }
+
+    private IOUring() {
+    }
+}

--- a/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/IOUringChannelOption.java
+++ b/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/IOUringChannelOption.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.channel.ChannelOption;
+import io.netty5.channel.unix.UnixChannelOption;
+
+import java.net.InetAddress;
+import java.util.Map;
+
+public class IOUringChannelOption<T> extends UnixChannelOption<T> {
+
+    public static final ChannelOption<Boolean> TCP_CORK = valueOf(IOUringChannelOption.class, "TCP_CORK");
+    public static final ChannelOption<Long> TCP_NOTSENT_LOWAT =
+            valueOf(IOUringChannelOption.class, "TCP_NOTSENT_LOWAT");
+    public static final ChannelOption<Integer> TCP_KEEPIDLE = valueOf(IOUringChannelOption.class, "TCP_KEEPIDLE");
+    public static final ChannelOption<Integer> TCP_KEEPINTVL = valueOf(IOUringChannelOption.class, "TCP_KEEPINTVL");
+    public static final ChannelOption<Integer> TCP_KEEPCNT = valueOf(IOUringChannelOption.class, "TCP_KEEPCNT");
+    public static final ChannelOption<Integer> TCP_USER_TIMEOUT =
+            valueOf(IOUringChannelOption.class, "TCP_USER_TIMEOUT");
+    public static final ChannelOption<Boolean> IP_FREEBIND = valueOf("IP_FREEBIND");
+    public static final ChannelOption<Boolean> IP_TRANSPARENT = valueOf("IP_TRANSPARENT");
+    public static final ChannelOption<Boolean> IP_RECVORIGDSTADDR = valueOf("IP_RECVORIGDSTADDR");
+    public static final ChannelOption<Integer> TCP_FASTOPEN = valueOf(IOUringChannelOption.class, "TCP_FASTOPEN");
+    public static final ChannelOption<Boolean> TCP_FASTOPEN_CONNECT =
+            valueOf(IOUringChannelOption.class, "TCP_FASTOPEN_CONNECT");
+    public static final ChannelOption<Integer> TCP_DEFER_ACCEPT =
+            ChannelOption.valueOf(IOUringChannelOption.class, "TCP_DEFER_ACCEPT");
+    public static final ChannelOption<Boolean> TCP_QUICKACK = valueOf(IOUringChannelOption.class, "TCP_QUICKACK");
+    public static final ChannelOption<Map<InetAddress, byte[]>> TCP_MD5SIG = valueOf("TCP_MD5SIG");
+
+    public static final ChannelOption<Integer> MAX_DATAGRAM_PAYLOAD_SIZE = valueOf("MAX_DATAGRAM_PAYLOAD_SIZE");
+    public static final ChannelOption<Boolean> UDP_GRO = valueOf("UDP_GRO");
+}

--- a/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/IOUringDatagramChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/IOUringDatagramChannel.java
@@ -1,0 +1,615 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.buffer.Buffer;
+import io.netty5.channel.AddressedEnvelope;
+import io.netty5.channel.ChannelException;
+import io.netty5.channel.ChannelOption;
+import io.netty5.channel.ChannelShutdownDirection;
+import io.netty5.channel.DefaultBufferAddressedEnvelope;
+import io.netty5.channel.EventLoop;
+import io.netty5.channel.FixedReadHandleFactory;
+import io.netty5.channel.MaxMessagesWriteHandleFactory;
+import io.netty5.channel.ReadHandleFactory;
+import io.netty5.channel.WriteHandleFactory;
+import io.netty5.channel.socket.DatagramChannel;
+import io.netty5.channel.socket.DatagramPacket;
+import io.netty5.channel.socket.DomainSocketAddress;
+import io.netty5.channel.socket.SocketProtocolFamily;
+import io.netty5.channel.unix.Errors;
+import io.netty5.channel.unix.SegmentedDatagramPacket;
+import io.netty5.channel.unix.UnixChannel;
+import io.netty5.channel.unix.UnixChannelUtil;
+import io.netty5.util.concurrent.Future;
+import io.netty5.util.concurrent.FutureListener;
+import io.netty5.util.concurrent.Promise;
+import io.netty5.util.internal.SilentDispose;
+import io.netty5.util.internal.StringUtil;
+import io.netty5.util.internal.logging.InternalLogger;
+import io.netty5.util.internal.logging.InternalLoggerFactory;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.NetworkInterface;
+import java.net.SocketAddress;
+import java.net.SocketException;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.function.ObjLongConsumer;
+
+import static java.util.Objects.requireNonNull;
+
+public final class IOUringDatagramChannel extends AbstractIOUringChannel<UnixChannel> implements DatagramChannel {
+    private static final InternalLogger LOGGER = InternalLoggerFactory.getInstance(IOUringDatagramChannel.class);
+    private static final String EXPECTED_TYPES =
+            " (expected: " + StringUtil.simpleClassName(DatagramPacket.class) + ", " +
+                    StringUtil.simpleClassName(AddressedEnvelope.class) + '<' +
+                    StringUtil.simpleClassName(Buffer.class) + ", " +
+                    StringUtil.simpleClassName(InetSocketAddress.class) + ">, " +
+                    StringUtil.simpleClassName(Buffer.class) + ')';
+
+    private static final String EXPECTED_TYPES_DOMAIN_SOCKET =
+            " (expected: " + StringUtil.simpleClassName(DatagramPacket.class) + ", " +
+                    StringUtil.simpleClassName(AddressedEnvelope.class) + '<' +
+                    StringUtil.simpleClassName(Buffer.class) + ", " +
+                    StringUtil.simpleClassName(DomainSocketAddress.class) + ">, " +
+                    StringUtil.simpleClassName(Buffer.class) + ')';
+
+    private final Deque<CachedMsgHdrMemory> msgHdrCache;
+    private final PendingData<Promise<Void>> pendingWrites;
+
+    // The maximum number of bytes for an InetAddress / Inet6Address
+    private final byte[] inet4AddressArray = new byte[SockaddrIn.IPV4_ADDRESS_LENGTH];
+    private final byte[] inet6AddressArray = new byte[SockaddrIn.IPV6_ADDRESS_LENGTH];
+
+    private volatile boolean activeOnOpen;
+    private volatile int maxDatagramSize;
+    private volatile boolean gro;
+    private volatile boolean connected;
+    private volatile boolean inputShutdown;
+    private volatile boolean outputShutdown;
+
+    public IOUringDatagramChannel(EventLoop eventLoop) {
+        this(null, eventLoop, true, new FixedReadHandleFactory(2048),
+                new MaxMessagesWriteHandleFactory(Integer.MAX_VALUE),
+                LinuxSocket.newSocketDgram(), false);
+    }
+
+    IOUringDatagramChannel(
+            UnixChannel parent, EventLoop eventLoop, boolean supportingDisconnect,
+            ReadHandleFactory defaultReadHandleFactory, WriteHandleFactory defaultWriteHandleFactory,
+            LinuxSocket socket, boolean active) {
+        super(parent, eventLoop, supportingDisconnect, defaultReadHandleFactory, defaultWriteHandleFactory,
+                socket, null, active);
+        msgHdrCache = new ArrayDeque<>();
+        pendingWrites = PendingData.newPendingData();
+    }
+
+    /**
+     * Returns {@code true} if the usage of {@link io.netty5.channel.unix.SegmentedDatagramPacket} is supported.
+     *
+     * @return {@code true} if supported, {@code false} otherwise.
+     */
+    public static boolean isSegmentedDatagramPacketSupported() {
+        return IOUring.isAvailable();
+    }
+
+    @Override
+    public boolean isActive() {
+        return isOpen() && (getActiveOnOpen() && isRegistered() || super.isActive());
+    }
+
+    @Override
+    protected InternalLogger logger() {
+        return LOGGER;
+    }
+
+    @Override
+    protected void doBind(SocketAddress localAddress) throws Exception {
+        super.doBind(localAddress);
+        active = true;
+    }
+
+    @Override
+    protected boolean doFinishConnect(SocketAddress requestedRemoteAddress) throws Exception {
+        if (currentCompletionResult >= 0) {
+            connected = true;
+        }
+        return super.doFinishConnect(requestedRemoteAddress);
+    }
+
+    @Override
+    public boolean isConnected() {
+        return connected;
+    }
+
+    private NetworkInterface networkInterface() throws SocketException {
+        NetworkInterface iface = getNetworkInterface();
+        if (iface == null) {
+            SocketAddress localAddress = localAddress();
+            if (localAddress instanceof InetSocketAddress) {
+                return NetworkInterface.getByInetAddress(((InetSocketAddress) localAddress()).getAddress());
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public Future<Void> joinGroup(InetAddress multicastAddress) {
+        try {
+            return joinGroup(multicastAddress, networkInterface(), null);
+        } catch (IOException | UnsupportedOperationException e) {
+            return newFailedFuture(e);
+        }
+    }
+
+    @Override
+    public Future<Void> joinGroup(
+            InetAddress multicastAddress, NetworkInterface networkInterface, InetAddress source) {
+        requireNonNull(multicastAddress, "multicastAddress");
+        requireNonNull(networkInterface, "networkInterface");
+
+        if (socket.protocolFamily() == SocketProtocolFamily.UNIX) {
+            return newFailedFuture(new UnsupportedOperationException("Multicast not supported"));
+        }
+
+        Promise<Void> promise = newPromise();
+        if (executor().inEventLoop()) {
+            joinGroup0(multicastAddress, networkInterface, source, promise);
+        } else {
+            executor().execute(() -> joinGroup0(multicastAddress, networkInterface, source, promise));
+        }
+        return promise.asFuture();
+    }
+
+    private void joinGroup0(InetAddress multicastAddress, NetworkInterface networkInterface,
+                            InetAddress source, Promise<Void> promise) {
+        assert executor().inEventLoop();
+
+        try {
+            socket.joinGroup(multicastAddress, networkInterface, source);
+        } catch (IOException e) {
+            promise.setFailure(e);
+            return;
+        }
+        promise.setSuccess(null);
+    }
+
+    @Override
+    public Future<Void> leaveGroup(InetAddress multicastAddress) {
+        try {
+            return leaveGroup(multicastAddress, networkInterface(), null);
+        } catch (IOException | UnsupportedOperationException e) {
+            return newFailedFuture(e);
+        }
+    }
+
+    @Override
+    public Future<Void> leaveGroup(
+            InetAddress multicastAddress, NetworkInterface networkInterface, InetAddress source) {
+        requireNonNull(multicastAddress, "multicastAddress");
+        requireNonNull(networkInterface, "networkInterface");
+
+        if (socket.protocolFamily() == SocketProtocolFamily.UNIX) {
+            return newFailedFuture(new UnsupportedOperationException("Multicast not supported"));
+        }
+
+        Promise<Void> promise = newPromise();
+        if (executor().inEventLoop()) {
+            leaveGroup0(multicastAddress, networkInterface, source, promise);
+        } else {
+            executor().execute(() -> leaveGroup0(multicastAddress, networkInterface, source, promise));
+        }
+        return promise.asFuture();
+    }
+
+    private void leaveGroup0(
+            final InetAddress multicastAddress, final NetworkInterface networkInterface, final InetAddress source,
+            final Promise<Void> promise) {
+        assert executor().inEventLoop();
+
+        try {
+            socket.leaveGroup(multicastAddress, networkInterface, source);
+        } catch (IOException e) {
+            promise.setFailure(e);
+            return;
+        }
+        promise.setSuccess(null);
+    }
+
+    @Override
+    public Future<Void> block(
+            InetAddress multicastAddress, NetworkInterface networkInterface,
+            InetAddress sourceToBlock) {
+        requireNonNull(multicastAddress, "multicastAddress");
+        requireNonNull(sourceToBlock, "sourceToBlock");
+        requireNonNull(networkInterface, "networkInterface");
+        return newFailedFuture(new UnsupportedOperationException("Multicast block not supported"));
+    }
+
+    @Override
+    public Future<Void> block(
+            InetAddress multicastAddress, InetAddress sourceToBlock) {
+        try {
+            return block(
+                    multicastAddress,
+                    networkInterface(),
+                    sourceToBlock);
+        } catch (IOException | UnsupportedOperationException e) {
+            return newFailedFuture(e);
+        }
+    }
+
+    @Override
+    protected int nextReadBufferSize() {
+        int expectedCapacity = readHandle().prepareRead();
+        if (expectedCapacity == 0) {
+            return 0;
+        }
+        int datagramSize = maxDatagramSize;
+        if (datagramSize == 0) {
+            return expectedCapacity;
+        }
+        return Math.min(datagramSize, expectedCapacity);
+    }
+
+    @Override
+    protected void submitReadForReadBuffer(Buffer buffer, short readId, boolean nonBlocking,
+                                           ObjLongConsumer<Object> pendingConsumer) {
+        try (var itr = buffer.forEachComponent()) {
+            var cmp = itr.firstWritable();
+            assert cmp != null;
+            long address = cmp.writableNativeAddress();
+            int writableBytes = cmp.writableBytes();
+            int flags = nonBlocking ? Native.MSG_DONTWAIT : 0;
+            if (connected) {
+                // Call recv(2) because we have a known peer.
+                long udata = submissionQueue.addRecv(fd().intValue(), address, 0, writableBytes, flags, readId);
+                pendingConsumer.accept(buffer, udata);
+                return;
+            }
+            // Call recvmsg(2) because we need the peer address for each packet.
+            short segmentSize = 0;
+            CachedMsgHdrMemory msgHdr = nextMsgHdr();
+            msgHdr.write(socket, null, address, writableBytes, segmentSize);
+            msgHdr.attachment = buffer;
+            long udata = submissionQueue.addRecvmsg(fd().intValue(), msgHdr.address(), readId);
+            pendingConsumer.accept(msgHdr, udata);
+        }
+    }
+
+    @Override
+    protected Object prepareCompletedRead(Object obj, int result) {
+        if (obj instanceof CachedMsgHdrMemory) {
+            try (CachedMsgHdrMemory msgHdr = (CachedMsgHdrMemory) obj) {
+                Buffer buffer = msgHdr.attachment;
+                msgHdr.attachment = null;
+                buffer.skipWritableBytes(result);
+                return msgHdr.read(this, buffer, result);
+            }
+        }
+        Buffer buffer = (Buffer) super.prepareCompletedRead(obj, result);
+        return new DatagramPacket(buffer, localAddress(), remoteAddress());
+    }
+
+    /**
+     * {@code byte[]} that can be used as temporary storage to encode the ipv4 address
+     */
+    byte[] inet4AddressArray() {
+        return inet4AddressArray;
+    }
+
+    /**
+     * {@code byte[]} that can be used as temporary storage to encode the ipv6 address
+     */
+    byte[] inet6AddressArray() {
+        return inet6AddressArray;
+    }
+
+    @Override
+    protected boolean processRead(ReadSink readSink, Object read) {
+        DatagramPacket packet = (DatagramPacket) read;
+        Buffer buffer = packet.content();
+        readSink.processRead(buffer.capacity(), buffer.readableBytes(), packet);
+        return false;
+    }
+
+    @Override
+    protected Object filterOutboundMessage(Object msg) {
+        if (socket.protocolFamily() == SocketProtocolFamily.UNIX) {
+            return filterOutboundMessage(msg, DomainSocketAddress.class, EXPECTED_TYPES_DOMAIN_SOCKET);
+        }
+        return filterOutboundMessage(msg, InetSocketAddress.class, EXPECTED_TYPES);
+    }
+
+    private Object filterOutboundMessage(Object msg, Class<? extends SocketAddress> recipientClass,
+                                          String expectedTypes) {
+        if (msg instanceof SegmentedDatagramPacket) {
+            SegmentedDatagramPacket packet = (SegmentedDatagramPacket) msg;
+            if (recipientClass.isInstance(packet.recipient())) {
+                Buffer content = packet.content();
+                return UnixChannelUtil.isBufferCopyNeededForWrite(content) ?
+                        packet.replace(intoDirectBuffer(content, true)) : msg;
+            }
+        } else if (msg instanceof DatagramPacket) {
+            DatagramPacket packet = (DatagramPacket) msg;
+            if (recipientClass.isInstance(packet.recipient())) {
+                Buffer content = packet.content();
+                return UnixChannelUtil.isBufferCopyNeededForWrite(content) ?
+                        packet.replace(intoDirectBuffer(content, true)) : msg;
+            }
+        } else if (msg instanceof Buffer) {
+            Buffer buf = (Buffer) msg;
+            return UnixChannelUtil.isBufferCopyNeededForWrite(buf)? intoDirectBuffer(buf, true) : buf;
+        } else if (msg instanceof AddressedEnvelope) {
+            @SuppressWarnings("unchecked")
+            AddressedEnvelope<Object, SocketAddress> e = (AddressedEnvelope<Object, SocketAddress>) msg;
+            if (recipientClass.isInstance(e.recipient())) {
+                InetSocketAddress recipient = (InetSocketAddress) e.recipient();
+                Object content = e.content();
+                if (content instanceof Buffer) {
+                    Buffer buf = (Buffer) content;
+                    if (UnixChannelUtil.isBufferCopyNeededForWrite(buf)) {
+                        try {
+                            return new DefaultBufferAddressedEnvelope<>(intoDirectBuffer(buf, true), recipient);
+                        } finally {
+                            SilentDispose.dispose(e, logger()); // Don't fail here, because we allocated a buffer.
+                        }
+                    }
+                    return e;
+                }
+            }
+        }
+
+        throw new UnsupportedOperationException(
+                "unsupported message type: " + StringUtil.simpleClassName(msg) + expectedTypes);
+    }
+
+    @Override
+    protected void submitAllWriteMessages(WriteSink writeSink) {
+        writeSink.consumeEachFlushedMessage(this::submiteWriteMessage);
+    }
+
+    private boolean submiteWriteMessage(Object msg, Promise<Void> promise) {
+        promise.asFuture().addListener(f -> updateWritabilityIfNeeded(true, true));
+        final Buffer data;
+        final SocketAddress remoteAddress;
+        final short segmentSize;
+        if (msg instanceof AddressedEnvelope) {
+            @SuppressWarnings("unchecked")
+            AddressedEnvelope<Buffer, SocketAddress> envelope = (AddressedEnvelope<Buffer, SocketAddress>) msg;
+            data = envelope.content();
+            remoteAddress = envelope.recipient();
+            if (msg instanceof SegmentedDatagramPacket) {
+                SegmentedDatagramPacket segMsg = (SegmentedDatagramPacket) msg;
+                // We only need to tell the kernel that we want to use UDP_SEGMENT if there are multiple
+                // segments in the packet.
+                segmentSize = (short) (segMsg.segmentSize() < data.readableBytes() ? segMsg.segmentSize() : 0);
+            } else {
+                segmentSize = 0;
+            }
+        } else {
+            data = (Buffer) msg;
+            remoteAddress = remoteAddress();
+            segmentSize = 0;
+        }
+
+        // Since we remove the messages from WriteSink/OutboundBuffer, it falls to us to close the buffer, and complete
+        // the promise.
+        promise.asFuture().addListener(data, CLOSE_BUFFER);
+        short pendingId = pendingWrites.addPending(promise);
+
+        try (var itr = data.forEachComponent()) {
+            var cmp = itr.firstReadable();
+            assert cmp != null;
+            int fd = fd().intValue();
+            if (connected) {
+                submissionQueue.addSend(fd, cmp.readableNativeAddress(), 0, cmp.readableBytes(), pendingId);
+            } else {
+                CachedMsgHdrMemory msgHdr = nextMsgHdr();
+                msgHdr.write(socket, remoteAddress, cmp.readableNativeAddress(), cmp.readableBytes(), segmentSize);
+                submissionQueue.addSendmsg(fd, msgHdr.address(), 0, pendingId);
+                promise.asFuture().addListener(msgHdr);
+            }
+        }
+        return writeHandle().lastWrite(data.readableBytes(), data.readableBytes(), 1);
+    }
+
+    @NotNull
+    private CachedMsgHdrMemory nextMsgHdr() {
+        CachedMsgHdrMemory msgHdr = msgHdrCache.pollFirst();
+        if (msgHdr == null) {
+            msgHdr = new CachedMsgHdrMemory(msgHdrCache);
+        }
+        return msgHdr;
+    }
+
+    @Override
+    void writeComplete(int result, long udata) {
+        Promise<Void> promise = pendingWrites.removePending(UserData.decodeData(udata));
+        if (result < 0) {
+            promise.setFailure(Errors.newIOException("send/sendmsg", result));
+        } else {
+            promise.setSuccess(null);
+        }
+    }
+
+    @Override
+    protected void doDisconnect() throws Exception {
+        super.doDisconnect();
+        connected = false;
+        cacheAddresses(local, null);
+        remote = null;
+    }
+
+    @Override
+    protected boolean doConnect(SocketAddress remoteAddress, SocketAddress localAddress, Buffer initialData)
+            throws Exception {
+        boolean connected = super.doConnect(remoteAddress, localAddress, initialData);
+        if (connected) {
+            this.connected = true;
+        }
+        return connected;
+    }
+
+    @Override
+    protected void doShutdown(ChannelShutdownDirection direction) {
+        switch (direction) {
+            case Inbound:
+                inputShutdown = true;
+                break;
+            case Outbound:
+                outputShutdown = true;
+                break;
+            default:
+                throw new AssertionError();
+        }
+    }
+
+    @Override
+    public boolean isShutdown(ChannelShutdownDirection direction) {
+        if (!isActive()) {
+            return true;
+        }
+        switch (direction) {
+            case Inbound:
+                return inputShutdown;
+            case Outbound:
+                return outputShutdown;
+            default:
+                throw new AssertionError();
+        }
+    }
+
+    @Override
+    protected void doClose() {
+        super.doClose();
+        CachedMsgHdrMemory msgHdr;
+        while ((msgHdr = msgHdrCache.pollFirst()) != null) {
+            msgHdr.release();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected <T> T getExtendedOption(ChannelOption<T> option) {
+        if (option == ChannelOption.DATAGRAM_CHANNEL_ACTIVE_ON_REGISTRATION) {
+            return (T) Boolean.valueOf(activeOnOpen);
+        }
+        if (option == IOUringChannelOption.MAX_DATAGRAM_PAYLOAD_SIZE) {
+            return (T) Integer.valueOf(getMaxDatagramSize());
+        }
+        if (option == IOUringChannelOption.UDP_GRO) {
+            return (T) Boolean.valueOf(isUdpGro());
+        }
+        return super.getExtendedOption(option);
+    }
+
+    @Override
+    protected <T> void setExtendedOption(ChannelOption<T> option, T value) {
+        if (option == ChannelOption.DATAGRAM_CHANNEL_ACTIVE_ON_REGISTRATION) {
+            setActiveOnOpen((Boolean) value);
+        } else if (option == IOUringChannelOption.MAX_DATAGRAM_PAYLOAD_SIZE) {
+            setMaxDatagramSize((Integer) value);
+        } else if (option == IOUringChannelOption.UDP_GRO) {
+            setUdpGro((Boolean) value);
+        } else {
+            super.setExtendedOption(option, value);
+        }
+    }
+
+    @Override
+    protected boolean isExtendedOptionSupported(ChannelOption<?> option) {
+        if (option == ChannelOption.DATAGRAM_CHANNEL_ACTIVE_ON_REGISTRATION ||
+                option == IOUringChannelOption.MAX_DATAGRAM_PAYLOAD_SIZE ||
+                option == IOUringChannelOption.UDP_GRO) {
+            return true;
+        }
+        return super.isExtendedOptionSupported(option);
+    }
+
+    private void setActiveOnOpen(boolean activeOnOpen) {
+        if (isRegistered()) {
+            throw new IllegalStateException("Can only be changed before channel was registered");
+        }
+        this.activeOnOpen = activeOnOpen;
+    }
+
+    boolean getActiveOnOpen() {
+        return activeOnOpen;
+    }
+
+    private int getMaxDatagramSize() {
+        return maxDatagramSize;
+    }
+
+    private void setMaxDatagramSize(int maxDatagramSize) {
+        this.maxDatagramSize = maxDatagramSize;
+    }
+
+    /**
+     * Enable / disable <a href="https://lwn.net/Articles/768995/">UDP_GRO</a>.
+     * @param gro {@code true} if {@code UDP_GRO} should be enabled, {@code false} otherwise.
+     */
+    private void setUdpGro(boolean gro) {
+        try {
+            socket.setUdpGro(gro);
+        } catch (IOException e) {
+            throw new ChannelException(e);
+        }
+        this.gro = gro;
+    }
+
+    /**
+     * Returns if {@code UDP_GRO} is enabled.
+     * @return {@code true} if enabled, {@code false} otherwise.
+     */
+    private boolean isUdpGro() {
+        // We don't do a syscall here but just return the cached value due a kernel bug:
+        // https://lore.kernel.org/netdev/20210325195614.800687-1-norman_maurer@apple.com/T/#u
+        return gro;
+    }
+
+    private static final class CachedMsgHdrMemory extends MsgHdrMemory
+            implements FutureListener<Void>, AutoCloseable {
+        private final Deque<CachedMsgHdrMemory> cache;
+        private Buffer attachment;
+
+        CachedMsgHdrMemory(Deque<CachedMsgHdrMemory> cache) {
+            this.cache = cache;
+        }
+
+        @Override
+        public void operationComplete(Future<? extends Void> future) {
+            close();
+        }
+
+        @Override
+        public void close() {
+            if (!cache.offerFirst(this)) {
+                release();
+            }
+        }
+
+        @Override
+        void release() {
+            super.release();
+        }
+    }
+}

--- a/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/IOUringHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/IOUringHandler.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.channel.IoExecutionContext;
+import io.netty5.channel.IoHandle;
+import io.netty5.channel.IoHandler;
+import io.netty5.channel.unix.FileDescriptor;
+import io.netty5.util.collection.IntObjectHashMap;
+import io.netty5.util.collection.IntObjectMap;
+import io.netty5.util.internal.PlatformDependent;
+import io.netty5.util.internal.StringUtil;
+import io.netty5.util.internal.logging.InternalLogger;
+import io.netty5.util.internal.logging.InternalLoggerFactory;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * {@link IoHandler} which is implemented in terms of the Linux-specific {@code io_uring} API.
+ */
+final class IOUringHandler implements IoHandler, CompletionCallback {
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(IOUringHandler.class);
+
+    private final RingBuffer ringBuffer;
+    private final IntObjectMap<AbstractIOUringChannel<?>> channels;
+    private final ArrayDeque<AbstractIOUringChannel<?>> touchedChannels;
+
+    private final AtomicBoolean eventfdAsyncNotify = new AtomicBoolean();
+    private final FileDescriptor eventfd;
+    private final long eventfdReadBuf;
+    private long eventfdReadSubmitted;
+
+    private volatile boolean shuttingDown;
+    private boolean closeCompleted;
+
+    IOUringHandler(RingBuffer ringBuffer) {
+        // Ensure that we load all native bits as otherwise it may fail when try to use native methods in IovArray
+        IOUring.ensureAvailability();
+        this.ringBuffer = requireNonNull(ringBuffer, "ringBuffer");
+        channels = new IntObjectHashMap<>();
+        touchedChannels = new ArrayDeque<>();
+        eventfd = Native.newBlockingEventFd();
+        eventfdReadBuf = PlatformDependent.allocateMemory(8);
+    }
+
+    @Override
+    public int run(IoExecutionContext context) {
+        SubmissionQueue submissionQueue = ringBuffer.ioUringSubmissionQueue();
+        CompletionQueue completionQueue = ringBuffer.ioUringCompletionQueue();
+        if (!completionQueue.hasCompletions() && context.canBlock()) {
+            if (eventfdReadSubmitted == 0) {
+                submitEventFdRead();
+            }
+            if (context.deadlineNanos() != -1) {
+                submitTimeout(context);
+            }
+            submissionQueue.submitAndWait();
+        } else {
+            submissionQueue.submit();
+        }
+        int completed = completionQueue.process(this);
+        notifyIoFinished();
+        return completed;
+    }
+
+    private void notifyIoFinished() {
+        AbstractIOUringChannel<?> ch;
+        while ((ch = touchedChannels.poll()) != null) {
+            ch.ioLoopCompleted();
+        }
+    }
+
+    @Override
+    public void handle(int fd, int res, int flags, long udata) {
+        if (fd == eventfd.intValue()) {
+            handleEventFdRead();
+            return;
+        }
+        byte op = UserData.decodeOp(udata);
+        if (fd == ringBuffer.fd()) {
+            if (op == Native.IORING_OP_NOP) {
+                completeRingClose();
+            }
+            return;
+        }
+        if (op == Native.IORING_OP_ASYNC_CANCEL) {
+            // We don't care about the result of async cancels; they are best effort.
+            return;
+        }
+        AbstractIOUringChannel<?> ch = channels.get(fd);
+        if (ch == null) {
+            logger.debug("ignoring {} completion for unknown channel (fd={}, res={})",
+                    Native.opToStr(op), fd, res);
+            return;
+        }
+        touchedChannels.offer(ch);
+        switch (op) {
+            case Native.IORING_OP_READ:
+            case Native.IORING_OP_RECV:
+            case Native.IORING_OP_ACCEPT:
+            case Native.IORING_OP_RECVMSG:
+                ch.readComplete(res, udata);
+                break;
+            case Native.IORING_OP_WRITE:
+            case Native.IORING_OP_SEND:
+            case Native.IORING_OP_WRITEV:
+            case Native.IORING_OP_SENDMSG:
+                ch.writeComplete(res, udata);
+                break;
+            case Native.IORING_OP_CONNECT:
+                ch.connectComplete(res, udata);
+                break;
+            case Native.IORING_OP_POLL_ADD:
+                if (UserData.decodeData(udata) == Native.POLLRDHUP) {
+                    ch.completeRdHup(res);
+                }
+                break;
+            case Native.IORING_OP_POLL_REMOVE:
+                // Ignore poll_removes.
+                break;
+            case Native.IORING_OP_CLOSE:
+                ch.closeComplete(res, udata);
+                break;
+            default:
+                logger.warn("Unknown {} completion: fd={}, res={}, udata={}.", Native.opToStr(op), fd, res, udata);
+        }
+    }
+
+    private void handleEventFdRead() {
+        eventfdReadSubmitted = 0;
+        eventfdAsyncNotify.set(false);
+        if (!shuttingDown) {
+            submitEventFdRead();
+        }
+    }
+
+    private void submitEventFdRead() {
+        SubmissionQueue submissionQueue = ringBuffer.ioUringSubmissionQueue();
+        eventfdReadSubmitted = submissionQueue.addEventFdRead(eventfd.intValue(), eventfdReadBuf, 0, 8, (short) 0);
+    }
+
+    private void submitTimeout(IoExecutionContext context) {
+        long delayNanos = context.delayNanos(System.nanoTime());
+        ringBuffer.ioUringSubmissionQueue().addTimeout(ringBuffer.fd(), delayNanos, (short) 0);
+    }
+
+    @Override
+    public void prepareToDestroy() {
+        shuttingDown = true;
+        CompletionQueue completionQueue = ringBuffer.ioUringCompletionQueue();
+        SubmissionQueue submissionQueue = ringBuffer.ioUringSubmissionQueue();
+        AbstractIOUringChannel<?>[] chs = channels.values().toArray(AbstractIOUringChannel[]::new);
+        boolean first = true; // Ensure all previously submitted IOs get to complete before closing all fds.
+        for (AbstractIOUringChannel<?> ch : chs) {
+            ch.closeTransportNow(first);
+            if (submissionQueue.count() > 0) {
+                submissionQueue.submit();
+            }
+            if (completionQueue.hasCompletions()) {
+                completionQueue.process(this);
+            }
+            first = false;
+        }
+    }
+
+    @Override
+    public void destroy() {
+        SubmissionQueue submissionQueue = ringBuffer.ioUringSubmissionQueue();
+        CompletionQueue completionQueue = ringBuffer.ioUringCompletionQueue();
+        if (eventfdReadSubmitted != 0) {
+            submissionQueue.addCancel(eventfd.intValue(), eventfdReadSubmitted);
+            eventfdReadSubmitted = 0;
+        }
+        if (submissionQueue.remaining() < 2) {
+            // We need to submit 2 linked operations. Since they are linked, we cannot allow a submit-call to
+            // separate them. We don't have enough room (< 2) in the queue, so we submit now to make more room.
+            submissionQueue.submit();
+        }
+        // Try to drain all the IO from the queue first...
+        submissionQueue.link(true);
+        submissionQueue.addNop(ringBuffer.fd(), Native.IOSQE_IO_DRAIN, (short) 0);
+        submissionQueue.link(false);
+        // ... but only wait for 200 milliseconds on this
+        submissionQueue.addLinkTimeout(ringBuffer.fd(), TimeUnit.MILLISECONDS.toNanos(200), (short) 0);
+        submissionQueue.submitAndWait();
+        completionQueue.process(this);
+        if (!closeCompleted) {
+            completeRingClose();
+        }
+    }
+
+    private void completeRingClose() {
+        closeCompleted = true;
+        ringBuffer.close();
+        try {
+            eventfd.close();
+        } catch (IOException e) {
+            logger.warn("Failed to close eventfd", e);
+        }
+        PlatformDependent.freeMemory(eventfdReadBuf);
+    }
+
+    @Override
+    public void register(IoHandle handle) throws Exception {
+        AbstractIOUringChannel<?> ch = cast(handle);
+        if (shuttingDown) {
+            throw new RejectedExecutionException("IoEventLoop is shutting down");
+        }
+        int fd = ch.fd().intValue();
+        logger.debug("Adding channel: {} (fd={})", ch.id(), fd);
+        ch.completeChannelRegister(ringBuffer.ioUringSubmissionQueue());
+        if (channels.put(fd, ch) == null) {
+            ringBuffer.ioUringSubmissionQueue().incrementHandledFds();
+        }
+    }
+
+    @Override
+    public void deregister(IoHandle handle) {
+        AbstractIOUringChannel<?> ch = cast(handle);
+        int fd = ch.fd().intValue();
+        logger.debug("Removing channel: {} (fd={})", ch.id(), fd);
+        AbstractIOUringChannel<?> existing = channels.remove(fd);
+        if (existing != null) {
+            ringBuffer.ioUringSubmissionQueue().decrementHandledFds();
+            if (existing != ch) {
+                // The Channel mapping was already replaced due FD reuse, put back the stored Channel.
+                channels.put(fd, existing);
+                // If we found another Channel in the map that is mapped to the same FD the given Channel MUST be
+                // closed.
+                assert !ch.isOpen();
+            }
+        }
+    }
+
+    @NotNull
+    private static AbstractIOUringChannel<?> cast(IoHandle handle) {
+        if (handle instanceof AbstractIOUringChannel) {
+            return (AbstractIOUringChannel<?>) handle;
+        }
+        String typeName = StringUtil.simpleClassName(handle);
+        throw new IllegalArgumentException("Channel of type " + typeName + " not supported");
+    }
+
+    @Override
+    public void wakeup(boolean inEventLoop) {
+        if (!inEventLoop && !eventfdAsyncNotify.getAndSet(true)) {
+            // write to the eventfd which will then trigger an eventfd read completion.
+            Native.eventFdWrite(eventfd.intValue(), 1L);
+        }
+    }
+
+    @Override
+    public boolean isCompatible(Class<? extends IoHandle> handleType) {
+        return AbstractIOUringChannel.class.isAssignableFrom(handleType);
+    }
+}

--- a/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/IOUringServerSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/IOUringServerSocketChannel.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.buffer.Buffer;
+import io.netty5.channel.AdaptiveReadHandleFactory;
+import io.netty5.channel.Channel;
+import io.netty5.channel.ChannelOption;
+import io.netty5.channel.ChannelShutdownDirection;
+import io.netty5.channel.EventLoop;
+import io.netty5.channel.EventLoopGroup;
+import io.netty5.channel.ServerChannelReadHandleFactory;
+import io.netty5.channel.ServerChannelWriteHandleFactory;
+import io.netty5.channel.socket.DomainSocketAddress;
+import io.netty5.channel.socket.ServerSocketChannel;
+import io.netty5.channel.socket.SocketChannelWriteHandleFactory;
+import io.netty5.channel.socket.SocketProtocolFamily;
+import io.netty5.channel.unix.Errors;
+import io.netty5.channel.unix.UnixChannel;
+import io.netty5.util.NetUtil;
+import io.netty5.util.internal.logging.InternalLogger;
+import io.netty5.util.internal.logging.InternalLoggerFactory;
+
+import java.io.IOException;
+import java.net.SocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static io.netty5.channel.unix.Buffer.allocateDirectWithNativeOrder;
+import static io.netty5.channel.unix.Buffer.free;
+import static io.netty5.channel.unix.Buffer.nativeAddressOf;
+import static io.netty5.channel.unix.Errors.ERRNO_EAGAIN_NEGATIVE;
+import static io.netty5.channel.unix.Errors.ERRNO_EWOULDBLOCK_NEGATIVE;
+import static io.netty5.channel.unix.Limits.SSIZE_MAX;
+import static io.netty5.util.internal.ObjectUtil.checkPositiveOrZero;
+
+public final class IOUringServerSocketChannel extends AbstractIOUringChannel<UnixChannel>
+        implements ServerSocketChannel {
+    private static final InternalLogger LOGGER = InternalLoggerFactory.getInstance(IOUringDatagramChannel.class);
+    private static final short IS_ACCEPT = 1;
+    private final ByteBuffer sockaddrMemory;
+    private final long sockaddrPtr;
+    private final long addrlenPtr;
+    private final EventLoopGroup childEventLoopGroup;
+
+    // The maximum number of bytes for an InetAddress / Inet6Address
+    private final byte[] inet4AddressArray = new byte[SockaddrIn.IPV4_ADDRESS_LENGTH];
+    private final byte[] inet6AddressArray = new byte[SockaddrIn.IPV6_ADDRESS_LENGTH];
+
+    private volatile int backlog = NetUtil.SOMAXCONN;
+
+    public IOUringServerSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup) {
+        super(null, eventLoop, false, new ServerChannelReadHandleFactory(), new ServerChannelWriteHandleFactory(),
+                LinuxSocket.newSocketStream(), null, false);
+        this.childEventLoopGroup = childEventLoopGroup;
+        sockaddrMemory = allocateDirectWithNativeOrder(Long.BYTES + Native.SIZEOF_SOCKADDR_STORAGE);
+        // Needs to be initialized to the size of acceptedAddressMemory.
+        // See https://man7.org/linux/man-pages/man2/accept.2.html
+        sockaddrMemory.putLong(0, Native.SIZEOF_SOCKADDR_STORAGE); // todo do this before enqueueing every accept?
+        addrlenPtr = nativeAddressOf(sockaddrMemory);
+        sockaddrPtr = addrlenPtr + Long.BYTES;
+    }
+
+    @Override
+    protected void doBind(SocketAddress localAddress) throws Exception {
+        super.doBind(localAddress);
+        socket.listen(getBacklog());
+        active = true;
+    }
+
+    @Override
+    protected void doRead(boolean wasReadPendingAlready) throws Exception {
+        if (!wasReadPendingAlready) {
+            submissionQueue.addAccept(fd().intValue(), sockaddrPtr, addrlenPtr, IS_ACCEPT);
+        }
+    }
+
+    @Override
+    void readComplete(int res, long udata) {
+        currentCompletionResult = res;
+        currentCompletionData = UserData.decodeData(udata);
+        readNow();
+    }
+
+    @Override
+    protected boolean doReadNow(ReadSink readSink) throws IOException {
+        int res = currentCompletionResult;
+        short data = currentCompletionData;
+        if (data != IS_ACCEPT) {
+            readSink.processRead(0, 0, null);
+            return false;
+        }
+        currentCompletionResult = 0;
+        currentCompletionData = 0;
+        if (res >= 0) {
+            Channel channel = newChildChannel(res);
+            readSink.processRead(1, 1, channel);
+        } else if (res == ERRNO_EAGAIN_NEGATIVE || res == ERRNO_EWOULDBLOCK_NEGATIVE) {
+            // Check if we failed because there was nothing to accept atm.
+            readSink.processRead(0, 0, null);
+        } else {
+            // Something bad happened. Convert to an exception.
+            throw Errors.newIOException("io_uring accept", res);
+        }
+        return false;
+    }
+
+    @Override
+    protected boolean processRead(ReadSink readSink, Object read) {
+        throw new UnsupportedOperationException();
+    }
+
+    private Channel newChildChannel(int fd) {
+        final SocketAddress peer;
+        if (socket.protocolFamily() == SocketProtocolFamily.UNIX) {
+            peer = null;
+        } else {
+            peer = buildAddress();
+        }
+        return new IOUringSocketChannel(
+                this, childEventLoopGroup().next(), false,
+                new AdaptiveReadHandleFactory(), new SocketChannelWriteHandleFactory(Integer.MAX_VALUE, SSIZE_MAX),
+                LinuxSocket.wrapBlocking(fd, socket.protocolFamily()), peer, true);
+    }
+
+    private SocketAddress buildAddress() {
+        if (socket.isIpv6()) {
+            return SockaddrIn.readIPv6(sockaddrPtr, inet6AddressArray, inet4AddressArray);
+        }
+        return SockaddrIn.readIPv4(sockaddrPtr, inet4AddressArray);
+    }
+
+    @Override
+    protected boolean doConnect(SocketAddress remoteAddress, SocketAddress localAddress, Buffer initialData) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected Object filterOutboundMessage(Object msg) throws Exception {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void submitAllWriteMessages(WriteSink writeSink) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    void writeComplete(int result, long udata) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void doShutdown(ChannelShutdownDirection direction) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isShutdown(ChannelShutdownDirection direction) {
+        return !isActive();
+    }
+
+    @Override
+    protected InternalLogger logger() {
+        return LOGGER;
+    }
+
+    @Override
+    protected void doClose() {
+        try {
+            super.doClose();
+        } finally {
+            free(sockaddrMemory);
+            if (socket.protocolFamily() == SocketProtocolFamily.UNIX) {
+                DomainSocketAddress local = (DomainSocketAddress) localAddress();
+                if (local != null) {
+                    try {
+                        if (!Files.deleteIfExists(Path.of(local.path()))) {
+                            logger().debug("Failed to delete domain socket file: {}", local.path());
+                        }
+                    } catch (IOException e) {
+                        logger().debug("Failed to delete domain socket file: {}", local.path(), e);
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public EventLoopGroup childEventLoopGroup() {
+        return childEventLoopGroup;
+    }
+
+    @Override
+    protected <T> T getExtendedOption(ChannelOption<T> option) {
+        if (option == ChannelOption.SO_BACKLOG) {
+            return (T) Integer.valueOf(getBacklog());
+        }
+        return super.getExtendedOption(option);
+    }
+
+    @Override
+    protected <T> void setExtendedOption(ChannelOption<T> option, T value) {
+        if (option == ChannelOption.SO_BACKLOG) {
+            setBacklog((Integer) value);
+        } else {
+            super.setExtendedOption(option, value);
+        }
+    }
+
+    @Override
+    protected boolean isExtendedOptionSupported(ChannelOption<?> option) {
+        if (option == ChannelOption.SO_BACKLOG) {
+            return true;
+        }
+        return super.isExtendedOptionSupported(option);
+    }
+
+    private int getBacklog() {
+        return backlog;
+    }
+
+    private void setBacklog(int backlog) {
+        checkPositiveOrZero(backlog, "backlog");
+        this.backlog = backlog;
+    }
+}

--- a/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/IOUringSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/IOUringSocketChannel.java
@@ -1,0 +1,404 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.buffer.Buffer;
+import io.netty5.channel.AbstractChannel;
+import io.netty5.channel.AdaptiveReadHandleFactory;
+import io.netty5.channel.ChannelOption;
+import io.netty5.channel.ChannelPipeline;
+import io.netty5.channel.ChannelShutdownDirection;
+import io.netty5.channel.EventLoop;
+import io.netty5.channel.FileRegion;
+import io.netty5.channel.ReadHandleFactory;
+import io.netty5.channel.WriteHandleFactory;
+import io.netty5.channel.socket.SocketChannel;
+import io.netty5.channel.socket.SocketChannelWriteHandleFactory;
+import io.netty5.channel.socket.SocketProtocolFamily;
+import io.netty5.channel.unix.Errors;
+import io.netty5.channel.unix.IovArray;
+import io.netty5.channel.unix.UnixChannelUtil;
+import io.netty5.util.concurrent.Future;
+import io.netty5.util.concurrent.FutureListener;
+import io.netty5.util.concurrent.Promise;
+import io.netty5.util.internal.StringUtil;
+import io.netty5.util.internal.logging.InternalLogger;
+import io.netty5.util.internal.logging.InternalLoggerFactory;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.NotYetConnectedException;
+import java.nio.channels.WritableByteChannel;
+
+import static io.netty5.channel.unix.Limits.IOV_MAX;
+import static io.netty5.channel.unix.Limits.SSIZE_MAX;
+import static java.util.Objects.requireNonNull;
+
+public final class IOUringSocketChannel extends AbstractIOUringChannel<IOUringServerSocketChannel>
+        implements SocketChannel {
+    private static final InternalLogger LOGGER = InternalLoggerFactory.getInstance(IOUringDatagramChannel.class);
+    private static final short IS_WRITE = 0;
+    private static final short IS_CONNECT = 1;
+
+    private final IovArray writeIovs;
+    private final ObjectRing<Promise<Void>> writePromises;
+
+    private Buffer connectInitalData;
+    private MsgHdrMemory connectMsgHdr;
+    private boolean writeInFlight;
+    private boolean moreWritesPending;
+
+    public IOUringSocketChannel(EventLoop eventLoop) {
+        this(null, eventLoop, true, new AdaptiveReadHandleFactory(),
+                new SocketChannelWriteHandleFactory(Integer.MAX_VALUE, SSIZE_MAX),
+                LinuxSocket.newSocketStream(), null, false);
+    }
+
+    IOUringSocketChannel(
+            IOUringServerSocketChannel parent, EventLoop eventLoop, boolean supportingDisconnect,
+            ReadHandleFactory defaultReadHandleFactory, WriteHandleFactory defaultWriteHandleFactory,
+            LinuxSocket socket, SocketAddress remote, boolean active) {
+        super(parent, eventLoop, supportingDisconnect, defaultReadHandleFactory, defaultWriteHandleFactory,
+                socket, remote, active);
+        writeIovs = new IovArray();
+        writePromises = new ObjectRing<>();
+    }
+
+    @Override
+    protected boolean processRead(ReadSink readSink, Object read) {
+        Buffer buffer = (Buffer) read;
+        if (buffer.readableBytes() == 0) {
+            // Reading zero bytes means we got EOF, and we should close the channel.
+            buffer.close();
+            return true;
+        }
+        readSink.processRead(buffer.capacity(), buffer.readableBytes(), buffer);
+        return false;
+    }
+
+    @Override
+    protected void submitConnect(InetSocketAddress remoteAddress, Buffer initialData) throws IOException {
+        if (initialData != null && initialData.isDirect() && supportsTcpFastOpen()) {
+            assert writePromises.isEmpty();
+            connectInitalData = initialData;
+            connectMsgHdr = new MsgHdrMemory();
+            try (var itr = initialData.forEachComponent()) {
+                var cmp = itr.firstReadable();
+                connectMsgHdr.write(socket, remoteAddress, cmp.readableNativeAddress(), cmp.readableBytes(), (short) 0);
+            }
+            submissionQueue.addSendmsg(fd().intValue(), connectMsgHdr.address(), Native.MSG_FASTOPEN, IS_CONNECT);
+            writeInFlight = true;
+            return;
+        }
+        super.submitConnect(remoteAddress, initialData);
+    }
+
+    private boolean supportsTcpFastOpen() throws IOException {
+        return Native.IS_SUPPORTING_TCP_FASTOPEN_CLIENT &&
+                socket.protocolFamily() != SocketProtocolFamily.UNIX &&
+                socket.isTcpFastOpenConnect();
+    }
+
+    @Override
+    protected Object filterOutboundMessage(Object msg) {
+        // todo file descriptors???
+//        if (socket.protocolFamily() == SocketProtocolFamily.UNIX && msg instanceof FileDescriptor) {
+//            return msg;
+//        }
+        if (msg instanceof Buffer) {
+            Buffer buf = (Buffer) msg;
+            if (UnixChannelUtil.isBufferCopyNeededForWrite(buf)) {
+                return intoDirectBuffer(buf, true);
+            }
+            return buf;
+        }
+
+        if (msg instanceof FileRegion) {
+            return msg;
+        }
+
+        if (msg instanceof RegionWriter) {
+            return msg;
+        }
+
+        throw new UnsupportedOperationException(
+                "unsupported message type: " + StringUtil.simpleClassName(msg));
+    }
+
+    @Override
+    protected void submitAllWriteMessages(WriteSink writeSink) {
+        // We need to submit all messages as a single IO, in order to ensure ordering.
+        // If we already have an outstanding write promise, we can't write anymore until it completes.
+        if (!writeInFlight) {
+            writeSink.consumeEachFlushedMessage(this::submitWriteMessage);
+            submissionQueue.addWritev(fd().intValue(), writeIovs.memoryAddress(0), writeIovs.count(), IS_WRITE);
+            writeInFlight = true;
+        }
+    }
+
+    private boolean submitWriteMessage(Object msg, Promise<Void> promise) {
+        if (msg instanceof Buffer) {
+            Buffer buf = (Buffer) msg;
+            if (buf.readableBytes() + writeIovs.size() < writeIovs.maxBytes() &&
+                    buf.countReadableComponents() + writeIovs.count() < IOV_MAX) {
+                writePromises.push(promise, buf.readableBytes());
+                writeIovs.addReadable(buf);
+            } else {
+                return false;
+            }
+        } else if (msg instanceof FileRegion) {
+            FileRegion region = (FileRegion) msg;
+            RegionWriter writer = new RegionWriter(region, promise);
+            writer.enqueueWrites();
+        } else if (msg instanceof RegionWriter) {
+            // Continuation of previous file region.
+            RegionWriter writer = (RegionWriter) msg;
+            writer.enqueueWrites();
+        } else {
+            // Should never reach here
+            throw new AssertionError("Unrecognized message: " + msg);
+        }
+        promise.asFuture().addListener(f -> updateWritabilityIfNeeded(true, true));
+        return true;
+    }
+
+    @Override
+    void writeComplete(int result, long udata) {
+        writeInFlight = false;
+        short data = UserData.decodeData(udata);
+        if (data == IS_CONNECT) {
+            assert connectInitalData != null;
+            if (result > 0) {
+                connectInitalData.skipReadableBytes(result);
+            }
+            connectComplete(0, (short) 0);
+            connectInitalData = null;
+            connectMsgHdr.release();
+            connectMsgHdr = null;
+            return;
+        }
+        assert data == IS_WRITE;
+        if (result < 0) {
+            var e = Errors.newIOException("write/flush", result);
+            writeIovs.clear();
+            while (writePromises.poll()) {
+                writePromises.getPolledObject().setFailure(e);
+            }
+            if (moreWritesPending) {
+                moreWritesPending = false;
+                writeFlushedNow();
+            }
+        } else {
+            int leftover = result;
+            while (leftover > 0 || writePromises.hasNextStamp(0)) {
+                writePromises.peek();
+                int size = (int) writePromises.getPolledStamp();
+                if (size <= leftover) {
+                    writePromises.getPolledObject().setSuccess(null);
+                    writePromises.poll();
+                    leftover -= size;
+                } else {
+                    writePromises.updatePeekedStamp(size - leftover);
+                    leftover = 0;
+                }
+            }
+            boolean completedAll = writeIovs.completeBytes(result);
+            if (moreWritesPending) {
+                moreWritesPending = false;
+                writeFlushedNow();
+            } else if (!completedAll) {
+                // We did not write everything. Submit another write IO for the remainder.
+                submissionQueue.addWritev(fd().intValue(),
+                        writeIovs.memoryAddress(0), writeIovs.count(), IS_WRITE);
+                writeInFlight = true;
+            }
+        }
+    }
+
+    @Override
+    protected void writeLoopComplete(boolean allWritten) {
+        // Don't schedule new write tasks automatically
+        if (!allWritten) {
+            moreWritesPending = true;
+        }
+    }
+
+    @Override
+    protected boolean isWriteFlushedScheduled() {
+        // Avoid queueing new write IOs if we already have a write IO scheduled.
+        // We only do one write at a time, because on TCP we have to do the writes in-order,
+        // and operations in io_uring can complete out-of-order.
+        moreWritesPending = true;
+        return !writePromises.isEmpty();
+    }
+
+    @Override
+    protected ChannelPipeline newChannelPipeline() {
+        return new IOUringSocketPipeline(this);
+    }
+
+    @Override
+    protected void doShutdown(ChannelShutdownDirection direction) throws Exception {
+        requireNonNull(direction, "direction");
+        switch (direction) {
+            case Inbound:
+                try {
+                    socket.shutdown(true, false);
+                } catch (NotYetConnectedException ignore) {
+                    // We attempted to shutdown and failed, which means the input has already effectively been
+                    // shutdown.
+                }
+                break;
+            case Outbound:
+                socket.shutdown(false, true);
+                break;
+            default:
+                throw new AssertionError("unhandled direction: " + direction);
+        }
+    }
+
+    @Override
+    public boolean isShutdown(ChannelShutdownDirection direction) {
+        requireNonNull(direction, "direction");
+        switch (direction) {
+            case Inbound:
+                return socket.isInputShutdown();
+            case Outbound:
+                return socket.isOutputShutdown();
+            default:
+                throw new AssertionError("unhandled direction: " + direction);
+        }
+    }
+
+    @Override
+    protected InternalLogger logger() {
+        return LOGGER;
+    }
+
+    @Override
+    protected void doClose() {
+        try {
+            super.doClose();
+        } finally {
+            writeIovs.release();
+        }
+    }
+
+    @Override
+    protected <T> T getExtendedOption(ChannelOption<T> option) {
+        if (option == ChannelOption.TCP_FASTOPEN_CONNECT) {
+            try {
+                return (T) Boolean.valueOf(socket.isTcpFastOpenConnect());
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+        return super.getExtendedOption(option);
+    }
+
+    @Override
+    protected <T> void setExtendedOption(ChannelOption<T> option, T value) {
+        if (option == ChannelOption.TCP_FASTOPEN_CONNECT) {
+            try {
+                socket.setTcpFastOpenConnect((Boolean) value);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        } else {
+            super.setExtendedOption(option, value);
+        }
+    }
+
+    @Override
+    protected boolean isExtendedOptionSupported(ChannelOption<?> option) {
+        return option == ChannelOption.TCP_FASTOPEN_CONNECT || super.isExtendedOptionSupported(option);
+    }
+
+    private final class RegionWriter implements WritableByteChannel, FutureListener<Void> {
+        private final FileRegion region;
+        private final Promise<Void> promise;
+        private long position;
+
+        RegionWriter(FileRegion region, Promise<Void> promise) {
+            this.region = region;
+            this.position = region.position();
+            this.promise = promise;
+        }
+
+        public void enqueueWrites() {
+            try {
+                region.transferTo(this, position);
+            } catch (IOException e) {
+                promise.setFailure(e);
+            }
+        }
+
+        @Override
+        public void operationComplete(Future<? extends Void> future) throws Exception {
+            if (future.isSuccess()) {
+                if (region.count() == region.transferred()) {
+                    region.release();
+                    promise.setSuccess(null);
+                } else {
+                    // Enqueue some more writes
+                    IOUringSocketPipeline pipeline = (IOUringSocketPipeline) pipeline();
+                    pipeline.writeTransportDirect(this, promise); // Do this to reuse the promise.
+                    executor().execute(pipeline::flush); // Schedule a flush to get the continuation going ASAP.
+                }
+            } else {
+                promise.tryFailure(new IOException("Write failures on channel", future.cause()));
+            }
+        }
+
+        @Override
+        public int write(ByteBuffer src) throws IOException {
+            if (src.remaining() + writeIovs.size() < writeIovs.maxBytes() && writeIovs.count() + 1 < IOV_MAX) {
+                Promise<Void> promise = newPromise();
+                Buffer buffer = ioBufferAllocator().copyOf(src);
+                promise.asFuture().addListener(buffer, CLOSE_BUFFER);
+                promise.asFuture().addListener(this);
+                writePromises.push(promise, buffer.readableBytes());
+                writeIovs.addReadable(buffer);
+                position += buffer.readableBytes();
+                return buffer.readableBytes();
+            }
+            return 0;
+        }
+
+        @Override
+        public boolean isOpen() {
+            return IOUringSocketChannel.this.isOpen();
+        }
+
+        @Override
+        public void close() throws IOException {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static final class IOUringSocketPipeline extends DefaultAbstractChannelPipeline {
+        IOUringSocketPipeline(AbstractChannel<?, ?, ?> channel) {
+            super(channel);
+        }
+
+        void writeTransportDirect(Object msg, Promise<Void> promise) {
+            writeTransport(msg, promise);
+        }
+    }
+}

--- a/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/IOUringTcpInfo.java
+++ b/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/IOUringTcpInfo.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+/**
+ * <pre>{@code
+ * struct tcp_info
+ * {
+ *      __u8    tcpi_state;
+ *      __u8    tcpi_ca_state;
+ *      __u8    tcpi_retransmits;
+ *      __u8    tcpi_probes;
+ *      __u8    tcpi_backoff;
+ *      __u8    tcpi_options;
+ *      __u8    tcpi_snd_wscale : 4, tcpi_rcv_wscale : 4;
+ *
+ *      __u32   tcpi_rto;
+ *      __u32   tcpi_ato;
+ *      __u32   tcpi_snd_mss;
+ *      __u32   tcpi_rcv_mss;
+ *
+ *      __u32   tcpi_unacked;
+ *      __u32   tcpi_sacked;
+ *      __u32   tcpi_lost;
+ *      __u32   tcpi_retrans;
+ *      __u32   tcpi_fackets;
+ *
+ *      __u32   tcpi_last_data_sent;
+ *      __u32   tcpi_last_ack_sent;
+ *      __u32   tcpi_last_data_recv;
+ *      __u32   tcpi_last_ack_recv;
+ *
+ *      __u32   tcpi_pmtu;
+ *      __u32   tcpi_rcv_ssthresh;
+ *      __u32   tcpi_rtt;
+ *      __u32   tcpi_rttvar;
+ *      __u32   tcpi_snd_ssthresh;
+ *      __u32   tcpi_snd_cwnd;
+ *      __u32   tcpi_advmss;
+ *      __u32   tcpi_reordering;
+ *
+ *      __u32   tcpi_rcv_rtt;
+ *      __u32   tcpi_rcv_space;
+ *
+ *      __u32   tcpi_total_retrans;
+ * };
+ * }</pre>
+ */
+public final class IOUringTcpInfo {
+
+    final long[] info = new long[32];
+
+    public int state() {
+        return (int) info[0];
+    }
+
+    public int caState() {
+        return (int) info[1];
+    }
+
+    public int retransmits() {
+        return (int) info[2];
+    }
+
+    public int probes() {
+        return (int) info[3];
+    }
+
+    public int backoff() {
+        return (int) info[4];
+    }
+
+    public int options() {
+        return (int) info[5];
+    }
+
+    public int sndWscale() {
+        return (int) info[6];
+    }
+
+    public int rcvWscale() {
+        return (int) info[7];
+    }
+
+    public long rto() {
+        return info[8];
+    }
+
+    public long ato() {
+        return info[9];
+    }
+
+    public long sndMss() {
+        return info[10];
+    }
+
+    public long rcvMss() {
+        return info[11];
+    }
+
+    public long unacked() {
+        return info[12];
+    }
+
+    public long sacked() {
+        return info[13];
+    }
+
+    public long lost() {
+        return info[14];
+    }
+
+    public long retrans() {
+        return info[15];
+    }
+
+    public long fackets() {
+        return info[16];
+    }
+
+    public long lastDataSent() {
+        return info[17];
+    }
+
+    public long lastAckSent() {
+        return info[18];
+    }
+
+    public long lastDataRecv() {
+        return info[19];
+    }
+
+    public long lastAckRecv() {
+        return info[20];
+    }
+
+    public long pmtu() {
+        return info[21];
+    }
+
+    public long rcvSsthresh() {
+        return info[22];
+    }
+
+    public long rtt() {
+        return info[23];
+    }
+
+    public long rttvar() {
+        return info[24];
+    }
+
+    public long sndSsthresh() {
+        return info[25];
+    }
+
+    public long sndCwnd() {
+        return info[26];
+    }
+
+    public long advmss() {
+        return info[27];
+    }
+
+    public long reordering() {
+        return info[28];
+    }
+
+    public long rcvRtt() {
+        return info[29];
+    }
+
+    public long rcvSpace() {
+        return info[30];
+    }
+
+    public long totalRetrans() {
+        return info[31];
+    }
+}

--- a/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/Iov.java
+++ b/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/Iov.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.util.internal.PlatformDependent;
+
+/**
+ * <pre>{@code
+ * struct iovec {
+ *     void  *iov_base;    // Starting address
+ *     size_t iov_len;     // Number of bytes to transfer
+ * };
+ * }</pre>
+ */
+final class Iov {
+
+    private Iov() { }
+
+    static void write(long iovAddress, long bufferAddress, int length) {
+        if (Native.SIZEOF_SIZE_T == 4) {
+            PlatformDependent.putInt(iovAddress + Native.IOVEC_OFFSETOF_IOV_BASE, (int) bufferAddress);
+            PlatformDependent.putInt(iovAddress + Native.IOVEC_OFFSETOF_IOV_LEN, length);
+        } else {
+            assert Native.SIZEOF_SIZE_T == 8;
+            PlatformDependent.putLong(iovAddress + Native.IOVEC_OFFSETOF_IOV_BASE, bufferAddress);
+            PlatformDependent.putLong(iovAddress + Native.IOVEC_OFFSETOF_IOV_LEN, length);
+        }
+    }
+
+    static long readBufferAddress(long iovAddress) {
+        if (Native.SIZEOF_SIZE_T == 4) {
+            return PlatformDependent.getInt(iovAddress + Native.IOVEC_OFFSETOF_IOV_BASE);
+        }
+        assert Native.SIZEOF_SIZE_T == 8;
+        return PlatformDependent.getLong(iovAddress + Native.IOVEC_OFFSETOF_IOV_BASE);
+    }
+
+    static int readBufferLength(long iovAddress) {
+        if (Native.SIZEOF_SIZE_T == 4) {
+            return PlatformDependent.getInt(iovAddress + Native.IOVEC_OFFSETOF_IOV_LEN);
+        }
+        assert Native.SIZEOF_SIZE_T == 8;
+        return (int) PlatformDependent.getLong(iovAddress + Native.IOVEC_OFFSETOF_IOV_LEN);
+    }
+
+    static long sumSize(long iovAddress, int length) {
+        long sum = 0;
+        for (int i = 0; i < length; i++) {
+            sum += readBufferLength(iovAddress);
+            iovAddress += 2L * Native.SIZEOF_SIZE_T;
+        }
+        return sum;
+    }
+}

--- a/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/LinuxSocket.java
+++ b/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/LinuxSocket.java
@@ -1,0 +1,433 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.channel.ChannelException;
+import io.netty5.channel.socket.SocketProtocolFamily;
+import io.netty5.channel.unix.Errors;
+import io.netty5.channel.unix.NativeInetAddress;
+import io.netty5.channel.unix.PeerCredentials;
+import io.netty5.channel.unix.Socket;
+import io.netty5.util.internal.PlatformDependent;
+import io.netty5.util.internal.SocketUtils;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.ProtocolFamily;
+import java.net.UnknownHostException;
+import java.util.Enumeration;
+
+/**
+ * A socket which provides access Linux native methods.
+ */
+final class LinuxSocket extends Socket {
+    static final InetAddress INET6_ANY = unsafeInetAddrByName("::");
+    private static final InetAddress INET_ANY = unsafeInetAddrByName("0.0.0.0");
+    private static final long MAX_UINT32_T = 0xFFFFFFFFL;
+
+    private LinuxSocket(int fd, SocketProtocolFamily family, boolean makeBlocking) {
+        super(fd, family);
+        if (makeBlocking) {
+            try {
+                makeBlocking();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+    }
+
+    @Override
+    public boolean markClosed() {
+        return super.markClosed();
+    }
+
+    void setTimeToLive(int ttl) throws IOException {
+        setTimeToLive(intValue(), ttl);
+    }
+
+    void setInterface(InetAddress address) throws IOException {
+        final NativeInetAddress a = NativeInetAddress.newInstance(address);
+        setInterface(intValue(), ipv6, a.address(), a.scopeId(), interfaceIndex(address));
+    }
+
+    void setNetworkInterface(NetworkInterface netInterface) throws IOException {
+        InetAddress address = deriveInetAddress(netInterface, protocolFamily() == SocketProtocolFamily.INET6);
+        if (address.equals(protocolFamily() == SocketProtocolFamily.INET ? INET_ANY : INET6_ANY)) {
+            throw new IOException("NetworkInterface does not support " + protocolFamily());
+        }
+        final NativeInetAddress nativeAddress = NativeInetAddress.newInstance(address);
+        setInterface(intValue(), ipv6, nativeAddress.address(), nativeAddress.scopeId(), interfaceIndex(netInterface));
+    }
+
+    InetAddress getInterface() throws IOException {
+        NetworkInterface inf = getNetworkInterface();
+        if (inf != null) {
+            Enumeration<InetAddress> addresses = SocketUtils.addressesFromNetworkInterface(inf);
+            if (addresses.hasMoreElements()) {
+                return addresses.nextElement();
+            }
+        }
+        return null;
+    }
+
+    NetworkInterface getNetworkInterface() throws IOException {
+        int ret = getInterface(intValue(), ipv6);
+        if (ipv6) {
+            return PlatformDependent.javaVersion() >= 7 ? NetworkInterface.getByIndex(ret) : null;
+        }
+        InetAddress address = inetAddress(ret);
+        return address != null ? NetworkInterface.getByInetAddress(address) : null;
+    }
+
+    private static InetAddress inetAddress(int value) {
+        byte[] var1 = {
+                (byte) (value >>> 24 & 255),
+                (byte) (value >>> 16 & 255),
+                (byte) (value >>> 8 & 255),
+                (byte) (value & 255)
+        };
+
+        try {
+            return InetAddress.getByAddress(var1);
+        } catch (UnknownHostException ignore) {
+            return null;
+        }
+    }
+
+    void joinGroup(InetAddress group, NetworkInterface netInterface, InetAddress source) throws IOException {
+        final NativeInetAddress g = NativeInetAddress.newInstance(group);
+        final boolean isIpv6 = group instanceof Inet6Address;
+        final NativeInetAddress i = NativeInetAddress.newInstance(deriveInetAddress(netInterface, isIpv6));
+        if (source != null) {
+            final NativeInetAddress s = NativeInetAddress.newInstance(source);
+            joinSsmGroup(intValue(), ipv6, g.address(), i.address(),
+                    g.scopeId(), interfaceIndex(netInterface), s.address());
+        } else {
+            joinGroup(intValue(), ipv6, g.address(), i.address(), g.scopeId(), interfaceIndex(netInterface));
+        }
+    }
+
+    void leaveGroup(InetAddress group, NetworkInterface netInterface, InetAddress source) throws IOException {
+        final NativeInetAddress g = NativeInetAddress.newInstance(group);
+        final boolean isIpv6 = group instanceof Inet6Address;
+        final NativeInetAddress i = NativeInetAddress.newInstance(deriveInetAddress(netInterface, isIpv6));
+        if (source != null) {
+            final NativeInetAddress s = NativeInetAddress.newInstance(source);
+            leaveSsmGroup(intValue(), ipv6, g.address(), i.address(),
+                    g.scopeId(), interfaceIndex(netInterface), s.address());
+        } else {
+            leaveGroup(intValue(), ipv6, g.address(), i.address(), g.scopeId(), interfaceIndex(netInterface));
+        }
+    }
+
+    private static int interfaceIndex(NetworkInterface networkInterface) {
+        return PlatformDependent.javaVersion() >= 7 ? networkInterface.getIndex() : -1;
+    }
+
+    private static int interfaceIndex(InetAddress address) throws IOException {
+        if (PlatformDependent.javaVersion() >= 7) {
+            NetworkInterface iface = NetworkInterface.getByInetAddress(address);
+            if (iface != null) {
+                return iface.getIndex();
+            }
+        }
+        return -1;
+    }
+
+    void setTcpDeferAccept(int deferAccept) throws IOException {
+        setTcpDeferAccept(intValue(), deferAccept);
+    }
+
+    void setTcpQuickAck(boolean quickAck) throws IOException {
+        setTcpQuickAck(intValue(), quickAck ? 1 : 0);
+    }
+
+    void setTcpCork(boolean tcpCork) throws IOException {
+        setTcpCork(intValue(), tcpCork ? 1 : 0);
+    }
+
+    void setSoBusyPoll(int loopMicros) throws IOException {
+        setSoBusyPoll(intValue(), loopMicros);
+    }
+
+    void setTcpNotSentLowAt(long tcpNotSentLowAt) throws IOException {
+        if (tcpNotSentLowAt < 0 || tcpNotSentLowAt > MAX_UINT32_T) {
+            throw new IllegalArgumentException("tcpNotSentLowAt must be a uint32_t");
+        }
+        setTcpNotSentLowAt(intValue(), (int) tcpNotSentLowAt);
+    }
+
+    void setTcpFastOpen(int tcpFastopenBacklog) throws IOException {
+        setTcpFastOpen(intValue(), tcpFastopenBacklog);
+    }
+
+    void setTcpFastOpenConnect(boolean tcpFastOpenConnect) throws IOException {
+        setTcpFastOpenConnect(intValue(), tcpFastOpenConnect ? 1 : 0);
+    }
+
+    boolean isTcpFastOpenConnect() throws IOException {
+        return isTcpFastOpenConnect(intValue()) != 0;
+    }
+
+    void setTcpKeepIdle(int seconds) throws IOException {
+        setTcpKeepIdle(intValue(), seconds);
+    }
+
+    void setTcpKeepIntvl(int seconds) throws IOException {
+        setTcpKeepIntvl(intValue(), seconds);
+    }
+
+    void setTcpKeepCnt(int probes) throws IOException {
+        setTcpKeepCnt(intValue(), probes);
+    }
+
+    void setTcpUserTimeout(int milliseconds) throws IOException {
+        setTcpUserTimeout(intValue(), milliseconds);
+    }
+
+    void setIpFreeBind(boolean enabled) throws IOException {
+        setIpFreeBind(intValue(), enabled ? 1 : 0);
+    }
+
+    void setIpTransparent(boolean enabled) throws IOException {
+        setIpTransparent(intValue(), enabled ? 1 : 0);
+    }
+
+    void setIpRecvOrigDestAddr(boolean enabled) throws IOException {
+        setIpRecvOrigDestAddr(intValue(), enabled ? 1 : 0);
+    }
+
+    int getTimeToLive() throws IOException {
+        return getTimeToLive(intValue());
+    }
+
+    void getTcpInfo(IOUringTcpInfo info) throws IOException {
+        getTcpInfo(intValue(), info.info);
+    }
+
+    void setTcpMd5Sig(InetAddress address, byte[] key) throws IOException {
+        final NativeInetAddress a = NativeInetAddress.newInstance(address);
+        setTcpMd5Sig(intValue(), ipv6, a.address(), a.scopeId(), key);
+    }
+
+    boolean isTcpCork() throws IOException  {
+        return isTcpCork(intValue()) != 0;
+    }
+
+    int getSoBusyPoll() throws IOException  {
+        return getSoBusyPoll(intValue());
+    }
+
+    int getTcpDeferAccept() throws IOException {
+        return getTcpDeferAccept(intValue());
+    }
+
+    boolean isTcpQuickAck() throws IOException {
+        return isTcpQuickAck(intValue()) != 0;
+    }
+
+    long getTcpNotSentLowAt() throws IOException {
+        return getTcpNotSentLowAt(intValue()) & MAX_UINT32_T;
+    }
+
+    int getTcpKeepIdle() throws IOException {
+        return getTcpKeepIdle(intValue());
+    }
+
+    int getTcpKeepIntvl() throws IOException {
+        return getTcpKeepIntvl(intValue());
+    }
+
+    int getTcpKeepCnt() throws IOException {
+        return getTcpKeepCnt(intValue());
+    }
+
+    int getTcpUserTimeout() throws IOException {
+        return getTcpUserTimeout(intValue());
+    }
+
+    boolean isIpFreeBind() throws IOException {
+        return isIpFreeBind(intValue()) != 0;
+    }
+
+    boolean isIpTransparent() throws IOException {
+        return isIpTransparent(intValue()) != 0;
+    }
+
+    boolean isIpRecvOrigDestAddr() throws IOException {
+        return isIpRecvOrigDestAddr(intValue()) != 0;
+    }
+
+    PeerCredentials getPeerCredentials() throws IOException {
+        return getPeerCredentials(intValue());
+    }
+
+    boolean isLoopbackModeDisabled() throws IOException {
+        return getIpMulticastLoop(intValue(), ipv6) == 0;
+    }
+
+    void setLoopbackModeDisabled(boolean loopbackModeDisabled) throws IOException {
+        setIpMulticastLoop(intValue(), ipv6, loopbackModeDisabled ? 0 : 1);
+    }
+
+    void setUdpGro(boolean gro) throws IOException {
+        setUdpGro(intValue(), gro ? 1 : 0);
+    }
+
+    void makeBlocking() throws IOException {
+        int result = makeBlocking(intValue());
+        if (result != 0) {
+            throw Errors.newIOException("makeBlocking", result);
+        }
+    }
+
+    private static InetAddress deriveInetAddress(NetworkInterface netInterface, boolean ipv6) {
+        final InetAddress ipAny = ipv6 ? INET6_ANY : INET_ANY;
+        if (netInterface != null) {
+            final Enumeration<InetAddress> ias = netInterface.getInetAddresses();
+            while (ias.hasMoreElements()) {
+                final InetAddress ia = ias.nextElement();
+                final boolean isV6 = ia instanceof Inet6Address;
+                if (isV6 == ipv6) {
+                    return ia;
+                }
+            }
+        }
+        return ipAny;
+    }
+
+    boolean isIpv6() {
+        return ipv6;
+    }
+
+    static LinuxSocket wrap(int fd, SocketProtocolFamily protocolFamily) {
+        return new LinuxSocket(fd, protocolFamily, true);
+    }
+
+    static LinuxSocket wrapBlocking(int fd, SocketProtocolFamily protocolFamily) {
+        return new LinuxSocket(fd, protocolFamily, false);
+    }
+
+    public static LinuxSocket newSocketStream(@Nullable ProtocolFamily protocolFamily) {
+        SocketProtocolFamily family = toSocketProtocolFamily(protocolFamily);
+        switch (family) {
+            case INET: return wrap(newSocketStream0(false), family);
+            case INET6: return wrap(newSocketStream0(true), family);
+            case UNIX: return wrap(newSocketDomain0(), family);
+            default: throw new IllegalArgumentException("Unsupported protocol family: " + family);
+        }
+    }
+
+    public static LinuxSocket newSocketDgram(@Nullable ProtocolFamily protocolFamily) {
+        SocketProtocolFamily family = toSocketProtocolFamily(protocolFamily);
+        switch (family) {
+            case INET: return wrap(newSocketDgram0(false), family);
+            case INET6: return wrap(newSocketDgram0(true), family);
+            case UNIX: return wrap(newSocketDomainDgram0(), family);
+            default: throw new IllegalArgumentException("Unsupported protocol family: " + family);
+        }
+    }
+
+    private static SocketProtocolFamily toSocketProtocolFamily(ProtocolFamily protocolFamily) {
+        if (protocolFamily == null) {
+            return isIPv6Preferred() ? SocketProtocolFamily.INET6 : SocketProtocolFamily.INET;
+        }
+        return SocketProtocolFamily.of(protocolFamily);
+    }
+
+    public static LinuxSocket newSocketStream(boolean ipv6) {
+        return wrap(newSocketStream0(ipv6), ipv6 ? SocketProtocolFamily.INET6 : SocketProtocolFamily.INET);
+    }
+
+    public static LinuxSocket newSocketStream() {
+        return newSocketStream(isIPv6Preferred() ? SocketProtocolFamily.INET6 : SocketProtocolFamily.INET);
+    }
+
+    public static LinuxSocket newSocketDgram(boolean ipv6) {
+        return wrap(newSocketDgram0(ipv6), ipv6 ? SocketProtocolFamily.INET6 : SocketProtocolFamily.INET);
+    }
+
+    public static LinuxSocket newSocketDgram() {
+        return newSocketDgram(isIPv6Preferred() ? SocketProtocolFamily.INET6 : SocketProtocolFamily.INET);
+    }
+
+    public static LinuxSocket newSocketDomain() {
+        return wrap(newSocketDomain0(), SocketProtocolFamily.UNIX);
+    }
+
+    private static InetAddress unsafeInetAddrByName(String inetName) {
+        try {
+            return InetAddress.getByName(inetName);
+        } catch (UnknownHostException uhe) {
+            throw new ChannelException(uhe);
+        }
+    }
+
+    private static native void joinGroup(int fd, boolean ipv6, byte[] group, byte[] interfaceAddress,
+                                         int scopeId, int interfaceIndex) throws IOException;
+    private static native void joinSsmGroup(int fd, boolean ipv6, byte[] group, byte[] interfaceAddress,
+                                            int scopeId, int interfaceIndex, byte[] source) throws IOException;
+    private static native void leaveGroup(int fd, boolean ipv6, byte[] group, byte[] interfaceAddress,
+                                          int scopeId, int interfaceIndex) throws IOException;
+    private static native void leaveSsmGroup(int fd, boolean ipv6, byte[] group, byte[] interfaceAddress,
+                                             int scopeId, int interfaceIndex, byte[] source) throws IOException;
+
+    private static native int getTcpDeferAccept(int fd) throws IOException;
+    private static native int isTcpQuickAck(int fd) throws IOException;
+    private static native int isTcpCork(int fd) throws IOException;
+    private static native int getSoBusyPoll(int fd) throws IOException;
+    private static native int getTcpNotSentLowAt(int fd) throws IOException;
+    private static native int getTcpKeepIdle(int fd) throws IOException;
+    private static native int getTcpKeepIntvl(int fd) throws IOException;
+    private static native int getTcpKeepCnt(int fd) throws IOException;
+    private static native int getTcpUserTimeout(int fd) throws IOException;
+    private static native int getTimeToLive(int fd) throws IOException;
+    private static native int isIpFreeBind(int fd) throws IOException;
+    private static native int isIpTransparent(int fd) throws IOException;
+    private static native int isIpRecvOrigDestAddr(int fd) throws IOException;
+    private static native void getTcpInfo(int fd, long[] array) throws IOException;
+    private static native PeerCredentials getPeerCredentials(int fd) throws IOException;
+    private static native int isTcpFastOpenConnect(int fd) throws IOException;
+
+    private static native void setTcpDeferAccept(int fd, int deferAccept) throws IOException;
+    private static native void setTcpQuickAck(int fd, int quickAck) throws IOException;
+    private static native void setTcpCork(int fd, int tcpCork) throws IOException;
+    private static native void setSoBusyPoll(int fd, int loopMicros) throws IOException;
+    private static native void setTcpNotSentLowAt(int fd, int tcpNotSentLowAt) throws IOException;
+    private static native void setTcpFastOpen(int fd, int tcpFastopenBacklog) throws IOException;
+    private static native void setTcpFastOpenConnect(int fd, int tcpFastOpenConnect) throws IOException;
+    private static native void setTcpKeepIdle(int fd, int seconds) throws IOException;
+    private static native void setTcpKeepIntvl(int fd, int seconds) throws IOException;
+    private static native void setTcpKeepCnt(int fd, int probes) throws IOException;
+    private static native void setTcpUserTimeout(int fd, int milliseconds)throws IOException;
+    private static native void setIpFreeBind(int fd, int freeBind) throws IOException;
+    private static native void setIpTransparent(int fd, int transparent) throws IOException;
+    private static native void setIpRecvOrigDestAddr(int fd, int transparent) throws IOException;
+    private static native void setTcpMd5Sig(
+            int fd, boolean ipv6, byte[] address, int scopeId, byte[] key) throws IOException;
+    private static native void setInterface(
+            int fd, boolean ipv6, byte[] interfaceAddress, int scopeId, int networkInterfaceIndex) throws IOException;
+    private static native int getInterface(int fd, boolean ipv6);
+    private static native int getIpMulticastLoop(int fd, boolean ipv6) throws IOException;
+    private static native void setIpMulticastLoop(int fd, boolean ipv6, int enabled) throws IOException;
+    private static native int makeBlocking(int fd) throws IOException;
+    private static native void setTimeToLive(int fd, int ttl) throws IOException;
+    private static native void setUdpGro(int fd, int gro) throws IOException;
+}

--- a/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/MsgHdr.java
+++ b/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/MsgHdr.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.util.internal.PlatformDependent;
+
+/**
+ * struct msghdr {
+ *     void         *msg_name;       // optional address
+ *     socklen_t    msg_namelen;     // size of address
+ *     struct       iovec*msg_iov;   // scatter/gather array
+ *     size_t       msg_iovlen;      // # elements in msg_iov
+ *     void*        msg_control;     // ancillary data, see below
+ *     size_t       msg_controllen;  // ancillary data buffer len
+ *     int          msg_flags;       // flags on received message
+ * };
+ */
+final class MsgHdr {
+
+    private MsgHdr() { }
+
+    static void write(long memoryAddress, long address, int addressSize,  long iovAddress, int iovLength,
+                      long msgControlAddr, long cmsgHdrDataAddress, short segmentSize) {
+        PlatformDependent.putInt(memoryAddress + Native.MSGHDR_OFFSETOF_MSG_NAMELEN, addressSize);
+
+        final int msgControlLen;
+        if (segmentSize > 0) {
+            msgControlLen = Native.CMSG_LEN;
+            CmsgHdr.write(msgControlAddr, cmsgHdrDataAddress, Native.CMSG_LEN, Native.SOL_UDP,
+                    Native.UDP_SEGMENT, segmentSize);
+        } else {
+            // Set to 0 if we not explicit requested GSO.
+            msgControlAddr = 0;
+            msgControlLen = 0;
+        }
+        if (Native.SIZEOF_SIZE_T == 4) {
+            PlatformDependent.putInt(memoryAddress + Native.MSGHDR_OFFSETOF_MSG_NAME, (int) address);
+            PlatformDependent.putInt(memoryAddress + Native.MSGHDR_OFFSETOF_MSG_IOV, (int) iovAddress);
+            PlatformDependent.putInt(memoryAddress + Native.MSGHDR_OFFSETOF_MSG_IOVLEN, iovLength);
+            PlatformDependent.putInt(memoryAddress + Native.MSGHDR_OFFSETOF_MSG_CONTROL, (int) msgControlAddr);
+            PlatformDependent.putInt(memoryAddress + Native.MSGHDR_OFFSETOF_MSG_CONTROLLEN, msgControlLen);
+        } else {
+            assert Native.SIZEOF_SIZE_T == 8;
+            PlatformDependent.putLong(memoryAddress + Native.MSGHDR_OFFSETOF_MSG_NAME, address);
+            PlatformDependent.putLong(memoryAddress + Native.MSGHDR_OFFSETOF_MSG_IOV, iovAddress);
+            PlatformDependent.putLong(memoryAddress + Native.MSGHDR_OFFSETOF_MSG_IOVLEN, iovLength);
+            PlatformDependent.putLong(memoryAddress + Native.MSGHDR_OFFSETOF_MSG_CONTROL, msgControlAddr);
+            PlatformDependent.putLong(memoryAddress + Native.MSGHDR_OFFSETOF_MSG_CONTROLLEN, msgControlLen);
+        }
+        // No flags (we assume the memory was memset before)
+    }
+}

--- a/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/MsgHdrMemory.java
+++ b/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/MsgHdrMemory.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.buffer.Buffer;
+import io.netty5.channel.socket.DatagramPacket;
+import io.netty5.util.internal.PlatformDependent;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+
+class MsgHdrMemory {
+    private final long memory;
+    private final long cmsgDataAddr;
+
+    MsgHdrMemory() {
+        int size = Native.SIZEOF_MSGHDR + Native.SIZEOF_SOCKADDR_STORAGE + Native.SIZEOF_IOVEC + Native.CMSG_SPACE;
+        memory = PlatformDependent.allocateMemory(size);
+        PlatformDependent.setMemory(memory, size, (byte) 0);
+
+        // We retrieve the address of the data once so we can just be JNI free after construction.
+        cmsgDataAddr = Native.cmsghdrData(memory + Native.SIZEOF_MSGHDR +
+                Native.SIZEOF_SOCKADDR_STORAGE + Native.SIZEOF_IOVEC);
+    }
+
+    void write(LinuxSocket socket, SocketAddress address, long bufferAddress, int length, short segmentSize) {
+        long sockAddress = memory + Native.SIZEOF_MSGHDR;
+        long iovAddress = sockAddress + Native.SIZEOF_SOCKADDR_STORAGE;
+        long cmsgAddr = iovAddress + Native.SIZEOF_IOVEC;
+        int addressLength;
+        if (address == null) {
+            addressLength = socket.isIpv6() ? Native.SIZEOF_SOCKADDR_IN6 : Native.SIZEOF_SOCKADDR_IN;
+            PlatformDependent.setMemory(sockAddress, Native.SIZEOF_SOCKADDR_STORAGE, (byte) 0);
+        } else { // todo handle domain socket addresses
+            addressLength = SockaddrIn.write(socket.isIpv6(), sockAddress, address);
+        }
+        Iov.write(iovAddress, bufferAddress, length);
+        MsgHdr.write(memory, sockAddress, addressLength, iovAddress, 1, cmsgAddr, cmsgDataAddr, segmentSize);
+    }
+
+    boolean hasPort(IOUringDatagramChannel channel) {
+        long sockAddress = memory + Native.SIZEOF_MSGHDR;
+        if (channel.isIpv6()) {
+            return SockaddrIn.hasPortIpv6(sockAddress);
+        }
+        return SockaddrIn.hasPortIpv4(sockAddress);
+    }
+
+    DatagramPacket read(IOUringDatagramChannel channel, Buffer buffer, int bytesRead) {
+        long sockAddress = memory + Native.SIZEOF_MSGHDR;
+        InetSocketAddress sender;
+        if (channel.isIpv6()) { // TODO handle domain socket addresses
+            byte[] ipv6Bytes = channel.inet6AddressArray();
+            byte[] ipv4bytes = channel.inet4AddressArray();
+
+            sender = SockaddrIn.readIPv6(sockAddress, ipv6Bytes, ipv4bytes);
+        } else {
+            byte[] bytes = channel.inet4AddressArray();
+            sender = SockaddrIn.readIPv4(sockAddress, bytes);
+        }
+        long iovAddress = memory + Native.SIZEOF_MSGHDR + Native.SIZEOF_SOCKADDR_STORAGE;
+        long bufferAddress = Iov.readBufferAddress(iovAddress);
+        int bufferLength = Iov.readBufferLength(iovAddress);
+        // reconstruct the reader index based on the memoryAddress of the buffer and the bufferAddress that was used
+        // in the iovec.
+        try (var itr = buffer.forEachComponent()) {
+            var cmp = itr.first();
+            assert cmp != null;
+            int readerOffset = (int) (bufferAddress - cmp.baseNativeAddress());
+            buffer.writerOffset(readerOffset + bytesRead);
+            buffer.readerOffset(readerOffset);
+        }
+
+        return new DatagramPacket(buffer, channel.localAddress(), sender);
+    }
+
+    long address() {
+        return memory;
+    }
+
+    void release() {
+        PlatformDependent.freeMemory(memory);
+    }
+}

--- a/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/Native.java
+++ b/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/Native.java
@@ -1,0 +1,409 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.channel.unix.FileDescriptor;
+import io.netty5.channel.unix.PeerCredentials;
+import io.netty5.channel.unix.Unix;
+import io.netty5.util.internal.ClassInitializerUtil;
+import io.netty5.util.internal.NativeLibraryLoader;
+import io.netty5.util.internal.PlatformDependent;
+import io.netty5.util.internal.SystemPropertyUtil;
+import io.netty5.util.internal.ThrowableUtil;
+import io.netty5.util.internal.logging.InternalLogger;
+import io.netty5.util.internal.logging.InternalLoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.channels.Selector;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Locale;
+
+final class Native {
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(Native.class);
+    static final int DEFAULT_RING_SIZE = Math.max(64, SystemPropertyUtil.getInt("io.netty.iouring.ringSize", 4096));
+    static final int DEFAULT_IOSEQ_ASYNC_THRESHOLD =
+            Math.max(0, SystemPropertyUtil.getInt("io.netty.iouring.iosqeAsyncThreshold", 25));
+
+    static {
+        Selector selector = null;
+        try {
+            // We call Selector.open() as this will under the hood cause IOUtil to be loaded.
+            // This is a workaround for a possible classloader deadlock that could happen otherwise:
+            //
+            // See https://github.com/netty/netty/issues/10187
+            selector = Selector.open();
+        } catch (IOException ignore) {
+            // Just ignore
+        }
+
+        // Preload all classes that will be used in the OnLoad(...) function of JNI to eliminate the possiblity of a
+        // class-loader deadlock. This is a workaround for https://github.com/netty/netty/issues/11209.
+
+        // This needs to match all the classes that are loaded via NETTY_JNI_UTIL_LOAD_CLASS or looked up via
+        // NETTY_JNI_UTIL_FIND_CLASS.
+        ClassInitializerUtil.tryLoadClasses(
+                Native.class,
+                // netty_io_uring_linuxsocket
+                PeerCredentials.class, java.io.FileDescriptor.class
+        );
+
+        File tmpDir = PlatformDependent.tmpdir();
+        Path tmpFile = tmpDir.toPath().resolve("netty_io_uring.tmp");
+        try {
+            // First, try calling a side-effect free JNI method to see if the library was already
+            // loaded by the application.
+            Native.createFile(tmpFile.toString());
+        } catch (UnsatisfiedLinkError ignore) {
+            // The library was not previously loaded, load it now.
+            loadNativeLibrary();
+        } finally {
+            tmpFile.toFile().delete();
+            try {
+                if (selector != null) {
+                    selector.close();
+                }
+            } catch (IOException ignore) {
+                // Just ignore
+            }
+        }
+        Unix.registerInternal(Native::registerUnix);
+    }
+
+    static final int SOCK_NONBLOCK = NativeStaticallyReferencedJniMethods.sockNonblock();
+    static final int SOCK_CLOEXEC = NativeStaticallyReferencedJniMethods.sockCloexec();
+    static final short AF_INET = (short) NativeStaticallyReferencedJniMethods.afInet();
+    static final short AF_INET6 = (short) NativeStaticallyReferencedJniMethods.afInet6();
+    static final int SIZEOF_SOCKADDR_STORAGE = NativeStaticallyReferencedJniMethods.sizeofSockaddrStorage();
+    static final int SIZEOF_SOCKADDR_IN = NativeStaticallyReferencedJniMethods.sizeofSockaddrIn();
+    static final int SIZEOF_SOCKADDR_IN6 = NativeStaticallyReferencedJniMethods.sizeofSockaddrIn6();
+    static final int SOCKADDR_IN_OFFSETOF_SIN_FAMILY =
+            NativeStaticallyReferencedJniMethods.sockaddrInOffsetofSinFamily();
+    static final int SOCKADDR_IN_OFFSETOF_SIN_PORT = NativeStaticallyReferencedJniMethods.sockaddrInOffsetofSinPort();
+    static final int SOCKADDR_IN_OFFSETOF_SIN_ADDR = NativeStaticallyReferencedJniMethods.sockaddrInOffsetofSinAddr();
+    static final int IN_ADDRESS_OFFSETOF_S_ADDR = NativeStaticallyReferencedJniMethods.inAddressOffsetofSAddr();
+    static final int SOCKADDR_IN6_OFFSETOF_SIN6_FAMILY =
+            NativeStaticallyReferencedJniMethods.sockaddrIn6OffsetofSin6Family();
+    static final int SOCKADDR_IN6_OFFSETOF_SIN6_PORT =
+            NativeStaticallyReferencedJniMethods.sockaddrIn6OffsetofSin6Port();
+    static final int SOCKADDR_IN6_OFFSETOF_SIN6_FLOWINFO =
+            NativeStaticallyReferencedJniMethods.sockaddrIn6OffsetofSin6Flowinfo();
+    static final int SOCKADDR_IN6_OFFSETOF_SIN6_ADDR =
+            NativeStaticallyReferencedJniMethods.sockaddrIn6OffsetofSin6Addr();
+    static final int SOCKADDR_IN6_OFFSETOF_SIN6_SCOPE_ID =
+            NativeStaticallyReferencedJniMethods.sockaddrIn6OffsetofSin6ScopeId();
+    static final int IN6_ADDRESS_OFFSETOF_S6_ADDR = NativeStaticallyReferencedJniMethods.in6AddressOffsetofS6Addr();
+    static final int SIZEOF_SIZE_T = NativeStaticallyReferencedJniMethods.sizeofSizeT();
+    static final int SIZEOF_IOVEC = NativeStaticallyReferencedJniMethods.sizeofIovec();
+    static final int CMSG_SPACE = NativeStaticallyReferencedJniMethods.cmsgSpace();
+    static final int CMSG_LEN = NativeStaticallyReferencedJniMethods.cmsgLen();
+    static final int CMSG_OFFSETOF_CMSG_LEN = NativeStaticallyReferencedJniMethods.cmsghdrOffsetofCmsgLen();
+    static final int CMSG_OFFSETOF_CMSG_LEVEL = NativeStaticallyReferencedJniMethods.cmsghdrOffsetofCmsgLevel();
+    static final int CMSG_OFFSETOF_CMSG_TYPE = NativeStaticallyReferencedJniMethods.cmsghdrOffsetofCmsgType();
+
+    static final int IOVEC_OFFSETOF_IOV_BASE = NativeStaticallyReferencedJniMethods.iovecOffsetofIovBase();
+    static final int IOVEC_OFFSETOF_IOV_LEN = NativeStaticallyReferencedJniMethods.iovecOffsetofIovLen();
+    static final int SIZEOF_MSGHDR = NativeStaticallyReferencedJniMethods.sizeofMsghdr();
+    static final int MSGHDR_OFFSETOF_MSG_NAME = NativeStaticallyReferencedJniMethods.msghdrOffsetofMsgName();
+    static final int MSGHDR_OFFSETOF_MSG_NAMELEN = NativeStaticallyReferencedJniMethods.msghdrOffsetofMsgNamelen();
+    static final int MSGHDR_OFFSETOF_MSG_IOV = NativeStaticallyReferencedJniMethods.msghdrOffsetofMsgIov();
+    static final int MSGHDR_OFFSETOF_MSG_IOVLEN = NativeStaticallyReferencedJniMethods.msghdrOffsetofMsgIovlen();
+    static final int MSGHDR_OFFSETOF_MSG_CONTROL = NativeStaticallyReferencedJniMethods.msghdrOffsetofMsgControl();
+    static final int MSGHDR_OFFSETOF_MSG_CONTROLLEN =
+            NativeStaticallyReferencedJniMethods.msghdrOffsetofMsgControllen();
+    static final int MSGHDR_OFFSETOF_MSG_FLAGS = NativeStaticallyReferencedJniMethods.msghdrOffsetofMsgFlags();
+    static final int POLLIN = NativeStaticallyReferencedJniMethods.pollin();
+    static final int POLLOUT = NativeStaticallyReferencedJniMethods.pollout();
+    static final int POLLRDHUP = NativeStaticallyReferencedJniMethods.pollrdhup();
+    static final int ERRNO_ECANCELED_NEGATIVE = -NativeStaticallyReferencedJniMethods.ecanceled();
+    static final int ERRNO_ETIME_NEGATIVE = -NativeStaticallyReferencedJniMethods.etime();
+
+    // These constants must be defined to have the same numeric value as their corresponding
+    // ordinal in the enum defined in the io_uring.h header file.
+    // DO NOT CHANGE THESE VALUES!
+    static final byte IORING_OP_NOP = 0; // Specified by IORING_OP_NOP in io_uring.h
+    static final byte IORING_OP_READV = 1; // Specified by IORING_OP_READV in io_uring.h
+    static final byte IORING_OP_WRITEV = 2; // Specified by IORING_OP_WRITEV in io_uring.h
+    static final byte IORING_OP_FSYNC = 3; // Specified by IORING_OP_FSYNC in io_uring.h
+    static final byte IORING_OP_READ_FIXED = 4; // Specified by IORING_OP_READ_FIXED in io_uring.h
+    static final byte IORING_OP_WRITE_FIXED = 5; // Specified by IORING_OP_WRITE_FIXED in io_uring.h
+    static final byte IORING_OP_POLL_ADD = 6; // Specified by IORING_OP_POLL_ADD in io_uring.h
+    static final byte IORING_OP_POLL_REMOVE = 7; // Specified by IORING_OP_POLL_REMOVE in io_uring.h
+    static final byte IORING_OP_SYNC_FILE_RANGE = 8; // Specified by IORING_OP_SYNC_FILE_RANGE in io_uring.h
+    static final byte IORING_OP_SENDMSG = 9; // Specified by IORING_OP_SENDMSG in io_uring.h
+    static final byte IORING_OP_RECVMSG = 10; // Specified by IORING_OP_RECVMSG in io_uring.h
+    static final byte IORING_OP_TIMEOUT = 11; // Specified by IORING_OP_TIMEOUT in io_uring.h
+    static final byte IORING_OP_TIMEOUT_REMOVE = 12; // Specified by IORING_OP_TIMEOUT_REMOVE in io_uring.h
+    static final byte IORING_OP_ACCEPT = 13; // Specified by IORING_OP_ACCEPT in io_uring.h
+    static final byte IORING_OP_ASYNC_CANCEL = 14; // Specified by IORING_OP_ASYNC_CANCEL in io_uring.h
+    static final byte IORING_OP_LINK_TIMEOUT = 15; // Specified by IORING_OP_LINK_TIMEOUT in io_uring.h
+    static final byte IORING_OP_CONNECT = 16; // Specified by IORING_OP_CONNECT in io_uring.h
+    static final byte IORING_OP_FALLOCATE = 17; // Specified by IORING_OP_FALLOCATE in io_uring.h
+    static final byte IORING_OP_OPENAT = 18; // Specified by IORING_OP_OPENAT in io_uring.h
+    static final byte IORING_OP_CLOSE = 19; // Specified by IORING_OP_CLOSE in io_uring.h
+    static final byte IORING_OP_FILES_UPDATE = 20; // Specified by IORING_OP_FILES_UPDATE in io_uring.h
+    static final byte IORING_OP_STATX = 21; // Specified by IORING_OP_STATX in io_uring.h
+    static final byte IORING_OP_READ = 22; // Specified by IORING_OP_READ in io_uring.h
+    static final byte IORING_OP_WRITE = 23; // Specified by IORING_OP_WRITE in io_uring.h
+    static final byte IORING_OP_FADVISE = 24; // Specified by IORING_OP_FADVISE in io_uring.h
+    static final byte IORING_OP_MADVISE = 25; // Specified by IORING_OP_MADVISE in io_uring.h
+    static final byte IORING_OP_SEND = 26; // Specified by IORING_OP_SEND in io_uring.h
+    static final byte IORING_OP_RECV = 27; // Specified by IORING_OP_RECV in io_uring.h
+    static final byte IORING_OP_OPENAT2 = 28; // Specified by IORING_OP_OPENAT2 in io_uring.h
+    static final byte IORING_OP_EPOLL_CTL = 29; // Specified by IORING_OP_EPOLL_CTL in io_uring.h
+    static final byte IORING_OP_SPLICE = 30; // Specified by IORING_OP_SPLICE in io_uring.h
+    static final byte IORING_OP_PROVIDE_BUFFERS = 31; // Specified by IORING_OP_PROVIDE_BUFFERS in io_uring.h
+    static final byte IORING_OP_REMOVE_BUFFERS = 32; // Specified by IORING_OP_REMOVE_BUFFERS in io_uring.h
+    static final byte IORING_OP_TEE = 33; // Specified by IORING_OP_TEE in io_uring.h
+    static final byte IORING_OP_SHUTDOWN = 34; // Specified by IORING_OP_SHUTDOWN in io_uring.h
+    static final byte IORING_OP_RENAMEAT = 35; // Specified by IORING_OP_RENAMEAT in io_uring.h
+    static final byte IORING_OP_UNLINKAT = 36; // Specified by IORING_OP_UNLINKAT in io_uring.h
+    static final byte IORING_OP_MKDIRAT = 37; // Specified by IORING_OP_MKDIRAT in io_uring.h
+    static final byte IORING_OP_SYMLINKAT = 38; // Specified by IORING_OP_SYMLINKAT in io_uring.h
+    static final byte IORING_OP_LINKAT = 39; // Specified by IORING_OP_LINKAT in io_uring.h
+
+    static String opToStr(byte op) {
+        switch (op) {
+            case IORING_OP_NOP: return "NOP";
+            case IORING_OP_READV: return "READV";
+            case IORING_OP_WRITEV: return "WRITEV";
+            case IORING_OP_FSYNC: return "FSYNC";
+            case IORING_OP_READ_FIXED: return "READ_FIXED";
+            case IORING_OP_WRITE_FIXED: return "WRITE_FIXED";
+            case IORING_OP_POLL_ADD: return "POLL_ADD";
+            case IORING_OP_POLL_REMOVE: return "POLL_REMOVE";
+            case IORING_OP_SYNC_FILE_RANGE: return "SYNC_FILE_RANGE";
+            case IORING_OP_SENDMSG: return "SENDMSG";
+            case IORING_OP_RECVMSG: return "RECVMSG";
+            case IORING_OP_TIMEOUT: return "TIMEOUT";
+            case IORING_OP_TIMEOUT_REMOVE: return "TIMEOUT_REMOVE";
+            case IORING_OP_ACCEPT: return "ACCEPT";
+            case IORING_OP_ASYNC_CANCEL: return "ASYNC_CANCEL";
+            case IORING_OP_LINK_TIMEOUT: return "LINK_TIMEOUT";
+            case IORING_OP_CONNECT: return "CONNECT";
+            case IORING_OP_FALLOCATE: return "FALLOCATE";
+            case IORING_OP_OPENAT: return "OPENAT";
+            case IORING_OP_CLOSE: return "CLOSE";
+            case IORING_OP_FILES_UPDATE: return "FILES_UPDATE";
+            case IORING_OP_STATX: return "STATX";
+            case IORING_OP_READ: return "READ";
+            case IORING_OP_WRITE: return "WRITE";
+            case IORING_OP_FADVISE: return "FADVISE";
+            case IORING_OP_MADVISE: return "MADVISE";
+            case IORING_OP_SEND: return "SEND";
+            case IORING_OP_RECV: return "RECV";
+            case IORING_OP_OPENAT2: return "OPENAT2";
+            case IORING_OP_EPOLL_CTL: return "EPOLL_CTL";
+            case IORING_OP_SPLICE: return "SPLICE";
+            case IORING_OP_PROVIDE_BUFFERS: return "PROVIDE_BUFFERS";
+            case IORING_OP_REMOVE_BUFFERS: return "REMOVE_BUFFERS";
+            case IORING_OP_TEE: return "TEE";
+            case IORING_OP_SHUTDOWN: return "SHUTDOWN";
+            case IORING_OP_RENAMEAT: return "RENAMEAT";
+            case IORING_OP_UNLINKAT: return "UNLINKAT";
+            case IORING_OP_MKDIRAT: return "MKDIRAT";
+            case IORING_OP_SYMLINKAT: return "SYMLINKAT";
+            case IORING_OP_LINKAT: return "LINKAT";
+            default: return "[OP CODE " + op + ']';
+        }
+    }
+
+    static final int IORING_ENTER_GETEVENTS = NativeStaticallyReferencedJniMethods.ioringEnterGetevents();
+    static final int IOSQE_ASYNC = NativeStaticallyReferencedJniMethods.iosqeAsync();
+    static final int IOSQE_LINK = NativeStaticallyReferencedJniMethods.iosqeLink();
+    static final int IOSQE_IO_DRAIN = NativeStaticallyReferencedJniMethods.iosqeDrain();
+    static final int MSG_DONTWAIT = NativeStaticallyReferencedJniMethods.msgDontwait();
+    static final int MSG_FASTOPEN = NativeStaticallyReferencedJniMethods.msgFastopen();
+    static final int SOL_UDP = NativeStaticallyReferencedJniMethods.solUdp();
+    static final int UDP_SEGMENT = NativeStaticallyReferencedJniMethods.udpSegment();
+    private static final int TFO_ENABLED_CLIENT_MASK = 0x1;
+    private static final int TFO_ENABLED_SERVER_MASK = 0x2;
+    private static final int TCP_FASTOPEN_MODE = NativeStaticallyReferencedJniMethods.tcpFastopenMode();
+    /**
+     * <a href ="https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt">tcp_fastopen</a> client mode enabled
+     * state.
+     */
+    static final boolean IS_SUPPORTING_TCP_FASTOPEN_CLIENT =
+            (TCP_FASTOPEN_MODE & TFO_ENABLED_CLIENT_MASK) == TFO_ENABLED_CLIENT_MASK;
+    /**
+     * <a href ="https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt">tcp_fastopen</a> server mode enabled
+     * state.
+     */
+    static final boolean IS_SUPPORTING_TCP_FASTOPEN_SERVER =
+            (TCP_FASTOPEN_MODE & TFO_ENABLED_SERVER_MASK) == TFO_ENABLED_SERVER_MASK;
+
+    private static final int[] REQUIRED_IORING_OPS = {
+            IORING_OP_POLL_ADD,
+            IORING_OP_TIMEOUT,
+            IORING_OP_ACCEPT,
+            IORING_OP_READ,
+            IORING_OP_WRITE,
+            IORING_OP_POLL_REMOVE,
+            IORING_OP_CONNECT,
+            IORING_OP_CLOSE,
+            IORING_OP_WRITEV,
+            IORING_OP_SENDMSG,
+            IORING_OP_RECVMSG
+    };
+
+    public static RingBuffer createRingBuffer() {
+        return createRingBuffer(DEFAULT_RING_SIZE);
+    }
+
+    static RingBuffer createRingBuffer(int ringSize) {
+        return createRingBuffer(ringSize, DEFAULT_IOSEQ_ASYNC_THRESHOLD);
+    }
+
+    static RingBuffer createRingBuffer(int ringSize, int iosqeAsyncThreshold) {
+        long[][] values = ioUringSetup(ringSize);
+        assert values.length == 2;
+        long[] completionQueueArgs = values[1];
+        assert completionQueueArgs.length == 9;
+        CompletionQueue completionQueue = new CompletionQueue(
+                completionQueueArgs[0],
+                completionQueueArgs[1],
+                completionQueueArgs[2],
+                completionQueueArgs[3],
+                completionQueueArgs[4],
+                completionQueueArgs[5],
+                (int) completionQueueArgs[6],
+                completionQueueArgs[7],
+                (int) completionQueueArgs[8]);
+        long[] submissionQueueArgs = values[0];
+        assert submissionQueueArgs.length == 11;
+        SubmissionQueue submissionQueue = new SubmissionQueue(
+                submissionQueueArgs[0],
+                submissionQueueArgs[1],
+                submissionQueueArgs[2],
+                submissionQueueArgs[3],
+                submissionQueueArgs[4],
+                submissionQueueArgs[5],
+                submissionQueueArgs[6],
+                submissionQueueArgs[7],
+                (int) submissionQueueArgs[8],
+                submissionQueueArgs[9],
+                (int) submissionQueueArgs[10],
+                iosqeAsyncThreshold,
+                completionQueue);
+        return new RingBuffer(submissionQueue, completionQueue);
+    }
+
+    static void checkAllIOSupported(int ringFd) {
+        if (!ioUringProbe(ringFd, REQUIRED_IORING_OPS)) {
+            throw new UnsupportedOperationException("Not all operations are supported: "
+                    + Arrays.toString(REQUIRED_IORING_OPS));
+        }
+    }
+
+    static void checkKernelVersion(String kernelVersion) {
+        boolean enforceKernelVersion = SystemPropertyUtil.getBoolean(
+                "io.netty.transport.iouring.enforceKernelVersion", true);
+        boolean kernelSupported = checkKernelVersion0(kernelVersion);
+        if (!kernelSupported) {
+            if (enforceKernelVersion) {
+                throw new UnsupportedOperationException(
+                        "you need at least kernel version 5.9, current kernel version: " + kernelVersion);
+            } else {
+                logger.debug("Detected kernel " + kernelVersion + " does not match minimum version of 5.9, " +
+                        "trying to use io_uring anyway");
+            }
+        }
+    }
+
+    private static boolean checkKernelVersion0(String kernelVersion) {
+        String[] versionComponents = kernelVersion.split("\\.");
+        if (versionComponents.length < 3) {
+            return false;
+        }
+
+        int major;
+        try {
+            major = Integer.parseInt(versionComponents[0]);
+        } catch (NumberFormatException e) {
+            return false;
+        }
+
+        if (major <= 4) {
+            return false;
+        }
+        if (major > 5) {
+            return true;
+        }
+
+        int minor;
+        try {
+            minor = Integer.parseInt(versionComponents[1]);
+        } catch (NumberFormatException e) {
+            return false;
+        }
+
+        return minor >= 9;
+    }
+
+    private static native boolean ioUringProbe(int ringFd, int[] ios);
+    private static native long[][] ioUringSetup(int entries);
+
+    static native int ioUringEnter(int ringFd, int toSubmit, int minComplete, int flags);
+
+    static native void eventFdWrite(int fd, long value);
+
+    static FileDescriptor newBlockingEventFd() {
+        return new FileDescriptor(blockingEventFd());
+    }
+
+    static native void ioUringExit(long submissionQueueArrayAddress, int submissionQueueRingEntries,
+                                          long submissionQueueRingAddress, int submissionQueueRingSize,
+                                          long completionQueueRingAddress, int completionQueueRingSize,
+                                          int ringFd);
+
+    private static native int blockingEventFd();
+
+    // for testing only!
+    static native int createFile(String name);
+
+    private static native int registerUnix();
+
+    static native long cmsghdrData(long hdrAddr);
+
+    static native String kernelVersion();
+
+    private Native() {
+        // utility
+    }
+
+    // From io_uring native library
+    private static void loadNativeLibrary() {
+        String name = PlatformDependent.normalizedOs().toLowerCase(Locale.ROOT).trim();
+        if (!name.startsWith("linux")) {
+            throw new IllegalStateException("Only supported on Linux");
+        }
+        String staticLibName = "netty5_transport_native_io_uring";
+        String sharedLibName = staticLibName + '_' + PlatformDependent.normalizedArch();
+        ClassLoader cl = PlatformDependent.getClassLoader(Native.class);
+        try {
+            NativeLibraryLoader.load(sharedLibName, cl);
+        } catch (UnsatisfiedLinkError e1) {
+            try {
+                NativeLibraryLoader.load(staticLibName, cl);
+                logger.info("Failed to load io_uring");
+            } catch (UnsatisfiedLinkError e2) {
+                ThrowableUtil.addSuppressed(e1, e2);
+                throw e1;
+            }
+        }
+    }
+}

--- a/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/NativeStaticallyReferencedJniMethods.java
+++ b/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/NativeStaticallyReferencedJniMethods.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+/**
+ * This class is necessary to break the following cyclic dependency:
+ * <ol>
+ * <li>JNI_OnLoad</li>
+ * <li>JNI Calls FindClass because RegisterNatives (used to register JNI methods) requires a class</li>
+ * <li>FindClass loads the class, but static members variables of that class attempt to call a JNI method which has not
+ * yet been registered.</li>
+ * <li>java.lang.UnsatisfiedLinkError is thrown because native method has not yet been registered.</li>
+ * </ol>
+ * Static members which call JNI methods must not be declared in this class!
+ */
+final class NativeStaticallyReferencedJniMethods {
+
+    private NativeStaticallyReferencedJniMethods() { }
+
+    static native int sockNonblock();
+    static native int sockCloexec();
+    static native int afInet();
+    static native int afInet6();
+    static native int sizeofSockaddrIn();
+    static native int sizeofSockaddrIn6();
+    static native int sockaddrInOffsetofSinFamily();
+    static native int sockaddrInOffsetofSinPort();
+    static native int sockaddrInOffsetofSinAddr();
+    static native int inAddressOffsetofSAddr();
+    static native int sockaddrIn6OffsetofSin6Family();
+    static native int sockaddrIn6OffsetofSin6Port();
+    static native int sockaddrIn6OffsetofSin6Flowinfo();
+    static native int sockaddrIn6OffsetofSin6Addr();
+    static native int sockaddrIn6OffsetofSin6ScopeId();
+    static native int in6AddressOffsetofS6Addr();
+    static native int sizeofSockaddrStorage();
+    static native int sizeofSizeT();
+    static native int sizeofIovec();
+    static native int iovecOffsetofIovBase();
+    static native int iovecOffsetofIovLen();
+    static native int sizeofMsghdr();
+    static native int msghdrOffsetofMsgName();
+    static native int msghdrOffsetofMsgNamelen();
+    static native int msghdrOffsetofMsgIov();
+    static native int msghdrOffsetofMsgIovlen();
+    static native int msghdrOffsetofMsgControl();
+    static native int msghdrOffsetofMsgControllen();
+    static native int msghdrOffsetofMsgFlags();
+    static native int etime();
+    static native int ecanceled();
+    static native int pollin();
+    static native int pollout();
+    static native int pollrdhup();
+    static native int ioringEnterGetevents();
+    static native int iosqeAsync();
+    static native int iosqeLink();
+    static native int iosqeDrain();
+    static native int msgDontwait();
+    static native int msgFastopen();
+    static native int cmsgSpace();
+    static native int cmsgLen();
+    static native int solUdp();
+    static native int udpSegment();
+    static native int cmsghdrOffsetofCmsgLen();
+    static native int cmsghdrOffsetofCmsgLevel();
+    static native int cmsghdrOffsetofCmsgType();
+    static native int tcpFastopenMode();
+}

--- a/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/ObjectRing.java
+++ b/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/ObjectRing.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.function.ObjLongConsumer;
+
+final class ObjectRing<T> implements ObjLongConsumer<T> {
+    private Object[] objs;
+    private long[] stamps;
+    private int head; // next push index
+    private int tail; // next poll index, unless same as head
+    private Object polledObject;
+    private long polledStamp;
+
+    ObjectRing() {
+        objs = new Object[16];
+        stamps = new long[16];
+    }
+
+    @Override
+    public void accept(T obj, long value) {
+        push(obj, value);
+    }
+
+    void push(@NotNull T obj, long stamp) {
+        int nextHead = next(head);
+        if (nextHead == tail) {
+            expand();
+            nextHead = next(head);
+        }
+        objs[head] = obj;
+        stamps[head] = stamp;
+        head = nextHead;
+    }
+
+    boolean isEmpty() {
+        return tail == head;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Nullable T remove(long stamp) {
+        if (isEmpty()) {
+            return null;
+        }
+        if (stamps[tail] == stamp) {
+            Object obj = objs[tail];
+            objs[tail] = null;
+            stamps[tail] = 0;
+            tail = next(tail);
+            return (T) obj;
+        }
+        // iterate and do internal remove
+        int index = tail;
+        while (index != head) {
+            if (stamps[index] == stamp) {
+                Object obj = objs[index];
+                // Found the obj; move prior entries up.
+                int i = tail;
+                Object prevObj = objs[tail];
+                long prevStamp = stamps[tail];
+                do {
+                    i = next(i);
+                    Object tmpObj = objs[i];
+                    long tmpStamp = stamps[i];
+                    objs[i] = prevObj;
+                    stamps[i] = prevStamp;
+                    prevObj = tmpObj;
+                    prevStamp = tmpStamp;
+                } while (i != index);
+                tail = next(tail);
+                return (T) obj;
+            }
+            index = next(index);
+        }
+        return null;
+    }
+
+    boolean poll() {
+        if (isEmpty()) {
+            return false;
+        }
+        polledObject = objs[tail];
+        polledStamp = stamps[tail];
+        objs[tail] = null;
+        stamps[tail] = 0;
+        tail = next(tail);
+        return true;
+    }
+
+    boolean peek() {
+        if (isEmpty()) {
+            return false;
+        }
+        polledObject = objs[tail];
+        polledStamp = stamps[tail];
+        return true;
+    }
+
+    void updatePeekedStamp(long stamp) {
+        if (isEmpty()) {
+            throw new IllegalStateException("No peeked stamp");
+        }
+        stamps[tail] = stamp;
+    }
+
+    boolean hasNextStamp(long stamp) {
+        return !isEmpty() && stamps[tail] == stamp;
+    }
+
+    @SuppressWarnings("unchecked")
+    T getPolledObject() {
+        T object = (T) polledObject;
+        polledObject = null;
+        return object;
+    }
+
+    long getPolledStamp() {
+        long id = polledStamp;
+        polledStamp = 0;
+        return id;
+    }
+
+    private void expand() {
+        Object[] nextBufs = new Object[objs.length << 1];
+        long[] nextStamps = new long[stamps.length << 1];
+        int index = 0;
+        while (head != tail) {
+            nextBufs[index] = objs[tail];
+            nextStamps[index] = stamps[tail];
+            index++;
+            tail = next(tail);
+        }
+        objs = nextBufs;
+        stamps = nextStamps;
+        tail = 0;
+        head = index;
+    }
+
+    private int next(int index) {
+        if (index + 1 == objs.length) {
+            return 0;
+        }
+        return index + 1;
+    }
+}

--- a/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/PendingData.java
+++ b/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/PendingData.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.util.collection.ShortObjectHashMap;
+
+import java.util.function.BiConsumer;
+
+interface PendingData<D> {
+    static <V> PendingData<V> newPendingData() {
+        final class PendingDataMap<D> extends ShortObjectHashMap<D> implements PendingData<D> {
+            private int counter;
+
+            @Override
+            public short addPending(D data) {
+                short id = nextPendingId();
+                put(id, data);
+                return id;
+            }
+
+            @Override
+            public D removePending(short id) {
+                return remove(id);
+            }
+
+            private short nextPendingId() {
+                if (size() > Short.MAX_VALUE) {
+                    throw new IllegalStateException("Too many pending objects: " + size());
+                }
+                short candidate;
+                do {
+                    candidate = (short) ++counter;
+                } while (candidate == 0 || containsKey(candidate)); // Avoid using 0 for id; it can cause type confusion
+                return candidate;
+            }
+
+            @Override
+            public void forEach(BiConsumer<? super Short, ? super D> action) {
+                super.forEach(action);
+            }
+        }
+        return new PendingDataMap<>();
+    }
+
+    short addPending(D data);
+
+    D removePending(short id);
+
+    boolean isEmpty();
+
+    void forEach(BiConsumer<? super Short, ? super D> consumer);
+}

--- a/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/RingBuffer.java
+++ b/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/RingBuffer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+final class RingBuffer {
+    private final SubmissionQueue submissionQueue;
+    private final CompletionQueue completionQueue;
+
+    RingBuffer(SubmissionQueue submissionQueue, CompletionQueue completionQueue) {
+        this.submissionQueue = submissionQueue;
+        this.completionQueue = completionQueue;
+    }
+
+    int fd() {
+        return completionQueue.ringFd;
+    }
+
+    SubmissionQueue ioUringSubmissionQueue() {
+        return this.submissionQueue;
+    }
+
+    CompletionQueue ioUringCompletionQueue() {
+        return this.completionQueue;
+    }
+
+    void close() {
+        Native.ioUringExit(
+                submissionQueue.submissionQueueArrayAddress,
+                submissionQueue.ringEntries,
+                submissionQueue.ringAddress,
+                submissionQueue.ringSize,
+                completionQueue.ringAddress,
+                completionQueue.ringSize,
+                completionQueue.ringFd);
+        submissionQueue.release();
+    }
+}

--- a/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/SockaddrIn.java
+++ b/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/SockaddrIn.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.channel.socket.DomainSocketAddress;
+import io.netty5.util.internal.PlatformDependent;
+
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.net.UnknownHostException;
+
+import static io.netty5.util.internal.PlatformDependent.BIG_ENDIAN_NATIVE_ORDER;
+
+final class SockaddrIn {
+    static final byte[] IPV4_MAPPED_IPV6_PREFIX = {
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, (byte) 0xff, (byte) 0xff };
+    static final int IPV4_ADDRESS_LENGTH = 4;
+    static final int IPV6_ADDRESS_LENGTH = 16;
+
+    private SockaddrIn() { }
+
+    static int write(boolean ipv6, long memory, SocketAddress address) {
+        if (address instanceof InetSocketAddress) {
+            InetSocketAddress inet = (InetSocketAddress) address;
+            if (ipv6) {
+                return writeIPv6(memory, inet.getAddress(), inet.getPort());
+            } else {
+                return writeIPv4(memory, inet.getAddress(), inet.getPort());
+            }
+        } else if (address instanceof DomainSocketAddress) {
+            // todo
+            throw new UnsupportedOperationException("Unknown socket address type: " + address);
+        } else {
+            throw new UnsupportedOperationException("Unknown socket address type: " + address);
+        }
+    }
+
+    /**
+     * <pre>{@code
+     * struct sockaddr_in {
+     *      sa_family_t    sin_family; // address family: AF_INET
+     *      in_port_t      sin_port;   // port in network byte order
+     *      struct in_addr sin_addr;   // internet address
+     * };
+     *
+     * // Internet address.
+     * struct in_addr {
+     *     uint32_t       s_addr;     // address in network byte order
+     * };
+     * }</pre>
+     */
+    static int writeIPv4(long memory, InetAddress address, int port) {
+        PlatformDependent.setMemory(memory, Native.SIZEOF_SOCKADDR_IN, (byte) 0);
+
+        PlatformDependent.putShort(memory + Native.SOCKADDR_IN_OFFSETOF_SIN_FAMILY, Native.AF_INET);
+        PlatformDependent.putShort(memory + Native.SOCKADDR_IN_OFFSETOF_SIN_PORT, handleNetworkOrder((short) port));
+        byte[] bytes = address.getAddress();
+        int offset = 0;
+        if (bytes.length == IPV6_ADDRESS_LENGTH) {
+            // IPV6 mapped IPV4 address, we only need the last 4 bytes.
+            offset = IPV4_MAPPED_IPV6_PREFIX.length;
+        }
+        assert bytes.length == offset + 4;
+        PlatformDependent.copyMemory(bytes, offset,
+                memory + Native.SOCKADDR_IN_OFFSETOF_SIN_ADDR + Native.IN_ADDRESS_OFFSETOF_S_ADDR, 4);
+        return Native.SIZEOF_SOCKADDR_IN;
+    }
+
+    /**
+     * <pre>{@code
+     * struct sockaddr_in6 {
+     *     sa_family_t     sin6_family;   // AF_INET6
+     *     in_port_t       sin6_port;     // port number
+     *     uint32_t        sin6_flowinfo; // IPv6 flow information
+     *     struct in6_addr sin6_addr;     // IPv6 address
+     *     uint32_t        sin6_scope_id; /* Scope ID (new in 2.4)
+     * };
+     *
+     * struct in6_addr {
+     *     unsigned char s6_addr[16];   // IPv6 address
+     * };
+     * }</pre>
+     */
+    static int writeIPv6(long memory, InetAddress address, int port) {
+        PlatformDependent.setMemory(memory, Native.SIZEOF_SOCKADDR_IN6, (byte) 0);
+        PlatformDependent.putShort(memory + Native.SOCKADDR_IN6_OFFSETOF_SIN6_FAMILY, Native.AF_INET6);
+        PlatformDependent.putShort(memory + Native.SOCKADDR_IN6_OFFSETOF_SIN6_PORT, handleNetworkOrder((short) port));
+        // Skip sin6_flowinfo as we did memset before
+        byte[] bytes = address.getAddress();
+        if  (bytes.length == IPV4_ADDRESS_LENGTH) {
+            int offset = Native.SOCKADDR_IN6_OFFSETOF_SIN6_ADDR + Native.IN6_ADDRESS_OFFSETOF_S6_ADDR;
+            PlatformDependent.copyMemory(IPV4_MAPPED_IPV6_PREFIX, 0, memory + offset, IPV4_MAPPED_IPV6_PREFIX.length);
+            PlatformDependent.copyMemory(bytes, 0,
+                    memory + offset + IPV4_MAPPED_IPV6_PREFIX.length, IPV4_ADDRESS_LENGTH);
+            // Skip sin6_scope_id as we did memset before
+        } else {
+            PlatformDependent.copyMemory(
+                    bytes, 0, memory + Native.SOCKADDR_IN6_OFFSETOF_SIN6_ADDR + Native.IN6_ADDRESS_OFFSETOF_S6_ADDR,
+                    IPV6_ADDRESS_LENGTH);
+            PlatformDependent.putInt(
+                    memory + Native.SOCKADDR_IN6_OFFSETOF_SIN6_SCOPE_ID, ((Inet6Address) address).getScopeId());
+        }
+        return Native.SIZEOF_SOCKADDR_IN6;
+    }
+
+    static InetSocketAddress readIPv4(long memory, byte[] tmpArray) {
+        assert tmpArray.length == IPV4_ADDRESS_LENGTH;
+        int port = handleNetworkOrder(PlatformDependent.getShort(
+                memory + Native.SOCKADDR_IN_OFFSETOF_SIN_PORT)) & 0xFFFF;
+        PlatformDependent.copyMemory(memory + Native.SOCKADDR_IN_OFFSETOF_SIN_ADDR + Native.IN_ADDRESS_OFFSETOF_S_ADDR,
+                tmpArray, 0, IPV4_ADDRESS_LENGTH);
+        try {
+            return new InetSocketAddress(InetAddress.getByAddress(tmpArray), port);
+        } catch (UnknownHostException ignore) {
+            return null;
+        }
+    }
+
+    static InetSocketAddress readIPv6(long memory, byte[] ipv6Array, byte[] ipv4Array) {
+        assert ipv6Array.length == IPV6_ADDRESS_LENGTH;
+        assert ipv4Array.length == IPV4_ADDRESS_LENGTH;
+
+        int port = handleNetworkOrder(PlatformDependent.getShort(
+                memory + Native.SOCKADDR_IN6_OFFSETOF_SIN6_PORT)) & 0xFFFF;
+        PlatformDependent.copyMemory(
+                memory + Native.SOCKADDR_IN6_OFFSETOF_SIN6_ADDR + Native.IN6_ADDRESS_OFFSETOF_S6_ADDR,
+                ipv6Array, 0, IPV6_ADDRESS_LENGTH);
+        if (PlatformDependent.equals(
+                ipv6Array, 0, IPV4_MAPPED_IPV6_PREFIX, 0, IPV4_MAPPED_IPV6_PREFIX.length)) {
+            System.arraycopy(ipv6Array, IPV4_MAPPED_IPV6_PREFIX.length, ipv4Array, 0, IPV4_ADDRESS_LENGTH);
+            try {
+                return new InetSocketAddress(Inet4Address.getByAddress(ipv4Array), port);
+            } catch (UnknownHostException ignore) {
+                return null;
+            }
+        } else {
+            int scopeId = PlatformDependent.getInt(memory + Native.SOCKADDR_IN6_OFFSETOF_SIN6_SCOPE_ID);
+            try {
+                return new InetSocketAddress(Inet6Address.getByAddress(null, ipv6Array, scopeId), port);
+            } catch (UnknownHostException ignore) {
+                return null;
+            }
+        }
+    }
+
+    static boolean hasPortIpv4(long memory) {
+        int port = handleNetworkOrder(PlatformDependent.getShort(
+                memory + Native.SOCKADDR_IN_OFFSETOF_SIN_PORT)) & 0xFFFF;
+        return port > 0;
+    }
+
+    static boolean hasPortIpv6(long memory) {
+        int port = handleNetworkOrder(PlatformDependent.getShort(
+                memory + Native.SOCKADDR_IN6_OFFSETOF_SIN6_PORT)) & 0xFFFF;
+        return port > 0;
+    }
+
+    private static short handleNetworkOrder(short v) {
+        return BIG_ENDIAN_NATIVE_ORDER ? v : Short.reverseBytes(v);
+    }
+}

--- a/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/SubmissionQueue.java
+++ b/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/SubmissionQueue.java
@@ -1,0 +1,327 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.util.internal.PlatformDependent;
+import io.netty5.util.internal.logging.InternalLogger;
+import io.netty5.util.internal.logging.InternalLoggerFactory;
+
+import java.util.StringJoiner;
+import java.util.function.IntSupplier;
+
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+
+final class SubmissionQueue {
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(SubmissionQueue.class);
+
+    private static final long SQE_SIZE = 64;
+    private static final int INT_SIZE = Integer.BYTES; //no 32 Bit support?
+    private static final int KERNEL_TIMESPEC_SIZE = 16; //__kernel_timespec
+
+    //these offsets are used to access specific properties
+    //SQE https://github.com/axboe/liburing/blob/master/src/include/liburing/io_uring.h#L21
+    private static final int SQE_OP_CODE_FIELD = 0;
+    private static final int SQE_FLAGS_FIELD = 1;
+    private static final int SQE_IOPRIO_FIELD = 2; // u16
+    private static final int SQE_FD_FIELD = 4; // s32
+    private static final int SQE_OFFSET_FIELD = 8;
+    private static final int SQE_ADDRESS_FIELD = 16;
+    private static final int SQE_LEN_FIELD = 24;
+    private static final int SQE_RW_FLAGS_FIELD = 28;
+    private static final int SQE_USER_DATA_FIELD = 32;
+    private static final int SQE_PAD_FIELD = 40;
+
+    private static final int KERNEL_TIMESPEC_TV_SEC_FIELD = 0;
+    private static final int KERNEL_TIMESPEC_TV_NSEC_FIELD = 8;
+
+    //these unsigned integer pointers(shared with the kernel) will be changed by the kernel
+    private final long kHeadAddress;
+    private final long kTailAddress;
+    private final long kFlagsAddress;
+    private final long kDroppedAddress;
+    private final long kArrayAddress;
+    final long submissionQueueArrayAddress;
+
+    final int ringEntries;
+    private final int ringMask; // = ringEntries - 1
+
+    final int ringSize;
+    final long ringAddress;
+    final int ringFd;
+    private final long timeoutMemoryAddress;
+    private final int iosqeAsyncThreshold;
+    private final IntSupplier completionCount;
+    private int numHandledFds;
+    private boolean link;
+    private int head;
+    private int tail;
+
+    SubmissionQueue(long kHeadAddress, long kTailAddress, long kRingMaskAddress, long kRingEntriesAddress,
+                    long kFlagsAddress, long kDroppedAddress, long kArrayAddress,
+                    long submissionQueueArrayAddress, int ringSize, long ringAddress, int ringFd,
+                    int iosqeAsyncThreshold, IntSupplier completionCount) {
+        this.kHeadAddress = kHeadAddress;
+        this.kTailAddress = kTailAddress;
+        this.kFlagsAddress = kFlagsAddress;
+        this.kDroppedAddress = kDroppedAddress;
+        this.kArrayAddress = kArrayAddress;
+        this.submissionQueueArrayAddress = submissionQueueArrayAddress;
+        this.ringSize = ringSize;
+        this.ringAddress = ringAddress;
+        this.ringFd = ringFd;
+        this.ringEntries = PlatformDependent.getIntVolatile(kRingEntriesAddress);
+        this.ringMask = PlatformDependent.getIntVolatile(kRingMaskAddress);
+        this.head = PlatformDependent.getIntVolatile(kHeadAddress);
+        this.tail = PlatformDependent.getIntVolatile(kTailAddress);
+
+        this.timeoutMemoryAddress = PlatformDependent.allocateMemory(KERNEL_TIMESPEC_SIZE);
+        this.iosqeAsyncThreshold = iosqeAsyncThreshold;
+        this.completionCount = completionCount;
+
+        // Zero the whole SQE array first
+        PlatformDependent.setMemory(submissionQueueArrayAddress, ringEntries * SQE_SIZE, (byte) 0);
+
+        // Fill SQ array indices (1-1 with SQE array) and set nonzero constant SQE fields
+        long address = kArrayAddress;
+        for (int i = 0; i < ringEntries; i++, address += INT_SIZE) {
+            PlatformDependent.putInt(address, i);
+        }
+    }
+
+    void incrementHandledFds() {
+        numHandledFds++;
+    }
+
+    void decrementHandledFds() {
+        numHandledFds--;
+        assert numHandledFds >= 0;
+    }
+
+    void link(boolean link) {
+        this.link = link;
+    }
+
+    private int flags() {
+        return (numHandledFds < iosqeAsyncThreshold ? 0 : Native.IOSQE_ASYNC) | (link ? Native.IOSQE_LINK : 0);
+    }
+
+    private long enqueueSqe(byte op, int flags, int rwFlags, int fd,
+                               long bufferAddress, int length, long offset, short data) {
+        int pending = tail - head;
+        if (pending == ringEntries) {
+            int submitted = submit();
+            if (submitted == 0) {
+                // We have a problem, could not submit to make more room in the ring
+                throw new RuntimeException("SQ ring full and no submissions accepted");
+            }
+        }
+        long sqe = submissionQueueArrayAddress + (tail++ & ringMask) * SQE_SIZE;
+        return setData(sqe, op, flags, rwFlags, fd, bufferAddress, length, offset, data);
+    }
+
+    private long setData(long sqe, byte op, int flags, int rwFlags, int fd, long bufferAddress, int length,
+                         long offset, short data) {
+        //set sqe(submission queue) properties
+
+        PlatformDependent.putByte(sqe + SQE_OP_CODE_FIELD, op);
+        PlatformDependent.putByte(sqe + SQE_FLAGS_FIELD, (byte) flags);
+        // This constant is set up-front
+        //PlatformDependent.putShort(sqe + SQE_IOPRIO_FIELD, (short) 0);
+        PlatformDependent.putInt(sqe + SQE_FD_FIELD, fd);
+        PlatformDependent.putLong(sqe + SQE_OFFSET_FIELD, offset);
+        PlatformDependent.putLong(sqe + SQE_ADDRESS_FIELD, bufferAddress);
+        PlatformDependent.putInt(sqe + SQE_LEN_FIELD, length);
+        PlatformDependent.putInt(sqe + SQE_RW_FLAGS_FIELD, rwFlags);
+        long userData = UserData.encode(fd, op, data);
+        PlatformDependent.putLong(sqe + SQE_USER_DATA_FIELD, userData);
+
+        if (logger.isTraceEnabled()) {
+            if (op == Native.IORING_OP_WRITEV || op == Native.IORING_OP_READV) {
+                logger.trace("add(ring {}): {}(fd={}, len={} ({} bytes), off={}, data={})",
+                        ringFd, Native.opToStr(op), fd, length, Iov.sumSize(bufferAddress, length), offset, data);
+            } else {
+                logger.trace("add(ring {}): {}(fd={}, len={}, off={}, data={})",
+                        ringFd, Native.opToStr(op), fd, length, offset, data);
+            }
+        }
+        return userData;
+    }
+
+    @Override
+    public String toString() {
+        StringJoiner sb = new StringJoiner(", ", "SubmissionQueue [", "]");
+        int pending = tail - head;
+        for (int i = 0; i < pending; i++) {
+            long sqe = submissionQueueArrayAddress + (head + i & ringMask) * SQE_SIZE;
+            sb.add(Native.opToStr(PlatformDependent.getByte(sqe + SQE_OP_CODE_FIELD)) +
+                    "(fd=" + PlatformDependent.getInt(sqe + SQE_FD_FIELD) + ')');
+        }
+        return sb.toString();
+    }
+
+    long addNop(int fd, int flags, short data) {
+        return enqueueSqe(Native.IORING_OP_NOP, flags, 0, fd, 0, 0, 0, data);
+    }
+
+    long addTimeout(int fd, long nanoSeconds, short extraData) {
+        setTimeout(nanoSeconds);
+        return enqueueSqe(Native.IORING_OP_TIMEOUT, 0, 0, fd, timeoutMemoryAddress, 1, 0, extraData);
+    }
+
+    long addLinkTimeout(int fd, long nanoSeconds, short extraData) {
+        setTimeout(nanoSeconds);
+        return enqueueSqe(Native.IORING_OP_LINK_TIMEOUT, 0, 0, fd, timeoutMemoryAddress, 1, 0, extraData);
+    }
+
+    long addPollIn(int fd) {
+        return addPoll(fd, Native.POLLIN);
+    }
+
+    long addPollRdHup(int fd) {
+        return addPoll(fd, Native.POLLRDHUP);
+    }
+
+    long addPollOut(int fd) {
+        return addPoll(fd, Native.POLLOUT);
+    }
+
+    private long addPoll(int fd, int pollMask) {
+        return enqueueSqe(Native.IORING_OP_POLL_ADD, 0, pollMask, fd, 0, 0, 0, (short) pollMask);
+    }
+
+    long addRecvmsg(int fd, long msgHdr, short extraData) {
+        // Use Native.MSG_DONTWAIT due a io_uring bug which did have it not respect non-blocking fds.
+        // See https://lore.kernel.org/io-uring/371592A7-A199-4F5C-A906-226FFC6CEED9@googlemail.com/T/#u
+        return enqueueSqe(Native.IORING_OP_RECVMSG, flags(), 0 /*Native.MSG_DONTWAIT*/, fd, msgHdr, 1, 0, extraData);
+    }
+
+    long addSendmsg(int fd, long msgHdr, int flags, short extraData) {
+        return enqueueSqe(Native.IORING_OP_SENDMSG, flags(), flags, fd, msgHdr, 1, 0, extraData);
+    }
+
+    long addRead(int fd, long bufferAddress, int pos, int limit, short extraData) {
+        return enqueueSqe(Native.IORING_OP_READ, flags(), 0, fd, bufferAddress + pos, limit - pos, 0, extraData);
+    }
+
+    long addRecv(int fd, long bufferAddress, int pos, int limit, int flags, short extraData) {
+        return enqueueSqe(Native.IORING_OP_RECV, flags(), flags, fd, bufferAddress + pos, limit - pos, 0, extraData);
+    }
+
+    long addEventFdRead(int fd, long bufferAddress, int pos, int limit, short extraData) {
+        return enqueueSqe(Native.IORING_OP_READ, 0, 0, fd, bufferAddress + pos, limit - pos, 0, extraData);
+    }
+
+    long addSend(int fd, long bufferAddress, int pos, int limit, short extraData) {
+        return enqueueSqe(Native.IORING_OP_SEND, flags(), 0, fd, bufferAddress + pos, limit - pos, 0, extraData);
+    }
+
+    long addWrite(int fd, long bufferAddress, int pos, int limit, short extraData) {
+        return enqueueSqe(Native.IORING_OP_WRITE, flags(), 0, fd, bufferAddress + pos, limit - pos, 0, extraData);
+    }
+
+    long addAccept(int fd, long address, long addressLength, short extraData) {
+        return enqueueSqe(Native.IORING_OP_ACCEPT, flags(), /*Native.SOCK_NONBLOCK |*/ Native.SOCK_CLOEXEC, fd,
+                address, 0, addressLength, extraData);
+    }
+
+    //fill the address which is associated with server poll link user_data
+    long addPollRemove(int fd, int pollMask) {
+        assert pollMask <= Short.MAX_VALUE && pollMask >= Short.MIN_VALUE;
+        return enqueueSqe(Native.IORING_OP_POLL_REMOVE, 0, 0, fd,
+                          UserData.encode(fd, Native.IORING_OP_POLL_ADD, (short) pollMask), 0, 0, (short) pollMask);
+    }
+
+    long addConnect(int fd, long socketAddress, long socketAddressLength, short extraData) {
+        return enqueueSqe(Native.IORING_OP_CONNECT, flags(), 0, fd, socketAddress, 0, socketAddressLength, extraData);
+    }
+
+    long addWritev(int fd, long iovecArrayAddress, int length, short extraData) {
+        return enqueueSqe(Native.IORING_OP_WRITEV, flags(), 0, fd, iovecArrayAddress, length, 0, extraData);
+    }
+
+    long addClose(int fd, boolean drain, short extraData) {
+        int flags = flags() | (drain ? Native.IOSQE_IO_DRAIN : 0);
+        return enqueueSqe(Native.IORING_OP_CLOSE, flags, 0, fd, 0, 0, 0, extraData);
+    }
+
+    long addCancel(int fd, long sqeToCancel) {
+        return enqueueSqe(Native.IORING_OP_ASYNC_CANCEL, flags(), 0, fd, sqeToCancel, 0, 0, (short) 0);
+    }
+
+    int submit() {
+        int submit = tail - head;
+        return submit > 0 ? submit(submit, 0, 0) : 0;
+    }
+
+    int submitAndWait() {
+        int submit = tail - head;
+        if (submit > 0) {
+            return submit(submit, 1, Native.IORING_ENTER_GETEVENTS);
+        }
+        assert submit == 0;
+        int ret = Native.ioUringEnter(ringFd, 0, 1, Native.IORING_ENTER_GETEVENTS);
+        if (ret < 0) {
+            throw new RuntimeException("ioUringEnter syscall returned " + ret);
+        }
+        return ret; // should be 0
+    }
+
+    private int submit(int toSubmit, int minComplete, int flags) {
+        if (logger.isTraceEnabled()) {
+            logger.trace("submit(ring {}): {}", ringFd, toString());
+        }
+        PlatformDependent.putIntOrdered(kTailAddress, tail); // release memory barrier
+        int ret = Native.ioUringEnter(ringFd, toSubmit, minComplete, flags);
+        head = PlatformDependent.getIntVolatile(kHeadAddress); // acquire memory barrier
+        if (ret != toSubmit) {
+            if (ret < 0) {
+                throw new RuntimeException("ioUringEnter syscall returned " + ret);
+            }
+            logger.warn("Not all submissions succeeded. Only {} of {} SQEs were submitted, " +
+                    "while there are {} pending completions.", ret, toSubmit, completionCount.getAsInt());
+        }
+        return ret;
+    }
+
+    private void setTimeout(long timeoutNanoSeconds) {
+        long seconds, nanoSeconds;
+
+        if (timeoutNanoSeconds == 0) {
+            seconds = 0;
+            nanoSeconds = 0;
+        } else {
+            seconds = (int) min(timeoutNanoSeconds / 1000000000L, Integer.MAX_VALUE);
+            nanoSeconds = (int) max(timeoutNanoSeconds - seconds * 1000000000L, 0);
+        }
+
+        PlatformDependent.putLong(timeoutMemoryAddress + KERNEL_TIMESPEC_TV_SEC_FIELD, seconds);
+        PlatformDependent.putLong(timeoutMemoryAddress + KERNEL_TIMESPEC_TV_NSEC_FIELD, nanoSeconds);
+    }
+
+    public int count() {
+        return tail - head;
+    }
+
+    public int remaining() {
+        return ringEntries - count();
+    }
+
+    //delete memory
+    public void release() {
+        PlatformDependent.freeMemory(timeoutMemoryAddress);
+    }
+}

--- a/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/UserData.java
+++ b/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/UserData.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+final class UserData {
+    private UserData() {
+    }
+
+    static long encode(int fd, byte op, short data) {
+        return ((long) data << 48) | ((op & 0xFFL)  << 32) | fd & 0xFFFFFFFFL;
+    }
+
+    static void decode(int res, int flags, long udata, CompletionCallback callback) {
+        int fd = decodeFd(udata);
+        callback.handle(fd, res, flags, udata);
+    }
+
+    static int decodeFd(long udata) {
+        return (int) (udata & 0xFFFFFFFFL);
+    }
+
+    static byte decodeOp(long udata) {
+        return (byte) ((udata >>> 32) & 0xFFL);
+    }
+
+    static short decodeData(long udata) {
+        return (short) (udata >>> 48);
+    }
+}

--- a/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/package-info.java
+++ b/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * io_uring is a high I/O performance scalable interface for fully
+ * asynchronous Linux syscalls <a href="https://kernel.dk/io_uring.pdf">io_uring doc</a>
+ */
+package io.netty5.channel.uring;

--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -418,7 +418,6 @@
     </dependency>
   </dependencies>
 
-
   <build>
     <plugins>
       <!-- Also include c files in source jar -->

--- a/transport-native-io_uring/README.md
+++ b/transport-native-io_uring/README.md
@@ -1,0 +1,62 @@
+# Netty io_uring
+
+The new io_uring interface added to the Linux Kernel 5.1 is a high I/O performance scalable interface for fully asynchronous Linux syscalls
+
+## Requirements:
+
+- x86-64 / aarch64 processor
+- at least 5.9 (but at least 5.14 is recommended)
+- to run the tests, you have to increase memlock(default 64K)
+
+
+See [our wiki page](https://netty.io/wiki/native-transports.html).
+
+## How to include the dependency
+
+To include the dependency you need to ensure you also specify the right classifier. At the moment we only support linux
+ x86_64 and aarch_64 but this may change. 
+ 
+As an example this is how you would include the dependency in maven for x86_64:
+```
+<dependency>
+    <groupId>io.netty</groupId>
+    <artifactId>netty-transport-native-io_uring</artifactId>
+    <version>${netty.version}</version>
+    <classifier>linux-x86_64</classifier>
+</dependency>
+```
+
+And in gradle:
+```
+dependencies {
+    implementation 'io.netty:netty-transport-native-io_uring:${netty.version}:linux-x86_64'
+}
+```
+
+## FAQ
+
+### I tried to use io_uring but got `java.lang.RuntimeException: failed to create io_uring ring fd Cannot allocate memory`
+
+When you tried to use io_uring but saw an exception that looked like this please try to encreate the [memlock limit](https://access.redhat.com/solutions/61334) for the user that tries to use io_uring:
+
+
+```
+Exception in thread "main" java.lang.UnsatisfiedLinkError: failed to load the required native library
+	at io.netty.channel.uring.IOUring.ensureAvailability(IOUring.java:63)
+        ...
+        ...
+Caused by: java.lang.RuntimeException: failed to create io_uring ring fd Cannot allocate memory
+	at io.netty.channel.uring.Native.ioUringSetup(Native Method)
+	at io.netty.channel.uring.Native.createRingBuffer(Native.java:141)
+	at io.netty.channel.uring.Native.createRingBuffer(Native.java:174)
+	at io.netty.channel.uring.IOUring.<clinit>(IOUring.java:36)
+	... 17 more
+```
+
+
+You can check your current memlock settings by
+
+```
+$ ulimit -l
+65536
+```

--- a/transport-native-io_uring/pom.xml
+++ b/transport-native-io_uring/pom.xml
@@ -1,0 +1,409 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2021 The Netty Project
+  ~
+  ~ The Netty Project licenses this file to you under the Apache License,
+  ~ version 2.0 (the "License"); you may not use this file except in compliance
+  ~ with the License. You may obtain a copy of the License at:
+  ~
+  ~   https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.netty</groupId>
+    <artifactId>netty5-parent</artifactId>
+    <version>5.0.0.Alpha6-SNAPSHOT</version>
+  </parent>
+  <artifactId>netty5-transport-native-io_uring</artifactId>
+
+  <name>Netty5/Transport/Native/io_uring</name>
+  <packaging>jar</packaging>
+
+  <properties>
+    <javaModuleNameClassifier>${os.detected.name}.${os.detected.arch}</javaModuleNameClassifier>
+    <javaModuleName>io.netty5.transport.io_uring</javaModuleName>
+    <unix.common.lib.name>netty-unix-common</unix.common.lib.name>
+    <unix.common.lib.dir>${project.build.directory}/unix-common-lib</unix.common.lib.dir>
+    <unix.common.lib.unpacked.dir>${unix.common.lib.dir}/META-INF/native/lib</unix.common.lib.unpacked.dir>
+    <unix.common.include.unpacked.dir>${unix.common.lib.dir}/META-INF/native/include</unix.common.include.unpacked.dir>
+    <jni.compiler.args.cflags>CFLAGS=-O3 -Werror -fno-omit-frame-pointer -Wunused-variable -fvisibility=hidden -I${unix.common.include.unpacked.dir}</jni.compiler.args.cflags>
+    <jni.compiler.args.ldflags>LDFLAGS=-L${unix.common.lib.unpacked.dir} -Wl,--no-as-needed -lrt -ldl -Wl,--whole-archive -l${unix.common.lib.name} -Wl,--no-whole-archive</jni.compiler.args.ldflags>
+    <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
+    <skipTests>true</skipTests>
+    <jniArch>${os.detected.arch}</jniArch>
+    <jni.classifier>${os.detected.name}-${jniArch}</jni.classifier>
+    <jniLibName>netty5_transport_native_io_uring_${jniArch}</jniLibName>
+    <nativeLibOnlyDir>${project.build.directory}/native-lib-only</nativeLibOnlyDir>
+    <extraConfigureArg />
+    <extraConfigureArg2 />
+    <test.argLine>-D_</test.argLine>
+  </properties>
+
+  <profiles>
+    <profile>
+      <id>linux</id>
+      <activation>
+        <os>
+          <family>linux</family>
+        </os>
+      </activation>
+      <properties>
+        <skipTests>false</skipTests>
+      </properties>
+
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <!-- Copy the native lib that was generated -->
+              <execution>
+                <id>copy-native-lib</id>
+                <phase>process-test-resources</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
+
+                    <copy todir="${project.build.outputDirectory}" includeEmptyDirs="false">
+                      <zipfileset dir="${nativeLibOnlyDir}/META-INF/native" />
+                      <regexpmapper handledirsep="yes" from="^(?:[^/]+/)*([^/]+)$" to="META-INF/native/\1" />
+                    </copy>
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <!-- unpack the unix-common static library and include files -->
+              <execution>
+                <id>unpack</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>unpack-dependencies</goal>
+                </goals>
+                <configuration>
+                  <includeGroupIds>${project.groupId}</includeGroupIds>
+                  <includeArtifactIds>netty5-transport-native-unix-common</includeArtifactIds>
+                  <classifier>${jni.classifier}</classifier>
+                  <outputDirectory>${unix.common.lib.dir}</outputDirectory>
+                  <includes>META-INF/native/**</includes>
+                  <overWriteReleases>false</overWriteReleases>
+                  <overWriteSnapshots>true</overWriteSnapshots>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>org.fusesource.hawtjni</groupId>
+            <artifactId>hawtjni-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>build-native-lib</id>
+                <configuration>
+                  <name>${jniLibName}</name>
+                  <nativeSourceDirectory>${nativeSourceDirectory}</nativeSourceDirectory>
+                  <libDirectory>${nativeLibOnlyDir}</libDirectory>
+                  <configureArgs>
+                    <arg>${jni.compiler.args.ldflags}</arg>
+                    <arg>${jni.compiler.args.cflags}</arg>
+                    <configureArg>--libdir=${project.build.directory}/native-build/target/lib</configureArg>
+                    <configureArg>${extraConfigureArg}</configureArg>
+                    <configureArg>${extraConfigureArg2}</configureArg>
+                  </configureArgs>
+                </configuration>
+                <goals>
+                  <goal>generate</goal>
+                  <goal>build</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <artifactId>maven-jar-plugin</artifactId>
+            <executions>
+              <!-- Generate the JAR that contains the native library in it. -->
+              <execution>
+                <id>native-jar</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+                <configuration>
+                  <archive>
+                    <manifest>
+                      <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                    </manifest>
+                    <manifestEntries>
+                      <Bundle-NativeCode>META-INF/native/libnetty5_transport_native_io_uring_${os.detected.arch}.so; osname=Linux; processor=${os.detected.arch},*</Bundle-NativeCode>
+                      <Fragment-Host>io.netty5.transport-classes-io_uring</Fragment-Host>
+                      <Automatic-Module-Name>${javaModuleName}</Automatic-Module-Name>
+                    </manifestEntries>
+                    <index>true</index>
+                    <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                  </archive>
+                  <classifier>${jni.classifier}</classifier>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>io_uring-epoll-combination</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <includes>
+                    <include>**/CombinationOfIOUringAndEpollTest.java</include>
+                  </includes>
+                  <reuseForks>false</reuseForks>
+                </configuration>
+              </execution>
+              <execution>
+                <id>epoll-io_uring-combination</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <includes>
+                    <include>**/CombinationOfEpollAndIOUringTest.java</include>
+                  </includes>
+                  <runOrder>random</runOrder>
+                  <systemPropertyVariables>
+                    <logback.configurationFile>src/test/resources/logback-test.xml</logback.configurationFile>
+                    <logLevel>debug</logLevel>
+                  </systemPropertyVariables>
+                  <properties>
+                    <property>
+                      <name>listener</name>
+                      <value>io.netty.build.junit.TimedOutTestsListener</value>
+                    </property>
+                  </properties>
+                  <!-- Ensure the whole stacktrace is preserved when an exception is thrown. See https://issues.apache.org/jira/browse/SUREFIRE-1457 -->
+                  <trimStackTrace>false</trimStackTrace>
+                  <argLine>${test.argLine}</argLine>
+                  <!-- Ensure a new JVM is used -->
+                  <forkCount>1</forkCount>
+                  <reuseForks>false</reuseForks>
+                </configuration>
+              </execution>
+              <execution>
+                <id>default-test</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <includes>
+                    <include>**/*Test*.java</include>
+                  </includes>
+                  <excludes>
+                    <exclude>**/Abstract*</exclude>
+                    <exclude>**/CombinationOf*</exclude>
+                  </excludes>
+                  <runOrder>random</runOrder>
+                  <systemPropertyVariables>
+                    <logback.configurationFile>src/test/resources/logback-test.xml</logback.configurationFile>
+                    <logLevel>debug</logLevel>
+                  </systemPropertyVariables>
+                  <properties>
+                    <property>
+                      <name>listener</name>
+                      <value>io.netty.build.junit.TimedOutTestsListener</value>
+                    </property>
+                  </properties>
+                  <!-- Ensure the whole stacktrace is preserved when an exception is thrown. See https://issues.apache.org/jira/browse/SUREFIRE-1457 -->
+                  <trimStackTrace>false</trimStackTrace>
+                  <argLine>${test.argLine}</argLine>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+
+      <dependencies>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty5-transport-native-unix-common</artifactId>
+          <version>${project.version}</version>
+          <classifier>${jni.classifier}</classifier>
+          <!--
+            The unix-common with classifier dependency is optional because it is not a runtime dependency, but a build time
+            dependency to get the static library which is built directly into the shared library generated by this project.
+          -->
+          <optional>true</optional>
+        </dependency>
+
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty5-transport-native-epoll</artifactId>
+          <version>${project.version}</version>
+          <scope>test</scope>
+          <classifier>${jni.classifier}</classifier>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>linux-aarch64</id>
+      <properties>
+        <!-- use aarch_64 as this is also what os.detected.arch will use on an aarch64 system -->
+        <jniArch>aarch_64</jniArch>
+        <!-- As we cross-compile just skip the tests because we could not load this lib on the system anyway -->
+        <skipTests>true</skipTests>
+        <extraConfigureArg>--host=aarch64-linux-gnu</extraConfigureArg>
+        <extraConfigureArg2>CC=aarch64-none-linux-gnu-gcc</extraConfigureArg2>
+      </properties>
+    </profile>
+    <profile>
+      <id>linux-aarch64-native</id>
+      <properties>
+        <!-- use aarch_64 as this is also what os.detected.arch will use on an aarch64 system -->
+        <jniArch>aarch_64</jniArch>
+        <extraConfigureArg>--host=aarch64-linux-gnu</extraConfigureArg>
+      </properties>
+    </profile>
+    <profile>
+      <id>leak</id>
+      <properties>
+        <test.argLine>-Dio.netty5.leakDetectionLevel=paranoid -Dio.netty5.leakDetection.targetRecords=32 -Dio.netty5.buffer.lifecycleTracingEnabled=true</test.argLine>
+      </properties>
+    </profile>
+  </profiles>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty5-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty5-buffer</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty5-transport</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty5-transport-native-unix-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty5-transport-classes-io_uring</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty5-testsuite</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty5-transport-native-unix-common-tests</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty5-transport-classes-epoll</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk18on</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <!-- Also include c files in source jar -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${nativeSourceDirectory}</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <!-- Generate the fallback JAR that does not contain the native library. -->
+          <execution>
+            <id>default-jar</id>
+            <configuration>
+              <excludes>
+                <exclude>META-INF/native/**</exclude>
+              </excludes>
+              <archive>
+                <manifest>
+                  <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                </manifest>
+                <manifestEntries>
+                  <Automatic-Module-Name>${javaModuleName}</Automatic-Module-Name>
+                </manifestEntries>
+                <index>true</index>
+                <manifestFile>${project.build.directory}/manifests/MANIFEST.MF</manifestFile>
+              </archive>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <!-- Copy the manifest file that we populated so far so we can use it as a starting point when generating the jars and adding more things to it. -->
+          <execution>
+            <id>copy-manifest</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <copy file="${project.build.outputDirectory}/META-INF/MANIFEST.MF" tofile="${project.build.directory}/manifests/MANIFEST.MF" />
+                <copy file="${project.build.outputDirectory}/META-INF/MANIFEST.MF" tofile="${project.build.directory}/manifests/MANIFEST-native.MF" />
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/transport-native-io_uring/src/main/c/io_uring.h
+++ b/transport-native-io_uring/src/main/c/io_uring.h
@@ -1,0 +1,361 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/* SPDX-License-Identifier: (GPL-2.0 WITH Linux-syscall-note) OR MIT */
+/*
+ * Header file for the io_uring interface.
+ *
+ * Copyright (C) 2019 Jens Axboe
+ * Copyright (C) 2019 Christoph Hellwig
+ */
+#ifndef LINUX_IO_URING_H
+#define LINUX_IO_URING_H
+
+#include <linux/fs.h>
+#include <linux/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * IO submission data structure (Submission Queue Entry)
+ */
+struct io_uring_sqe {
+	__u8	opcode;		/* type of operation for this sqe */
+	__u8	flags;		/* IOSQE_ flags */
+	__u16	ioprio;		/* ioprio for the request */
+	__s32	fd;		/* file descriptor to do IO on */
+	union {
+		__u64	off;	/* offset into file */
+		__u64	addr2;
+	};
+	union {
+		__u64	addr;	/* pointer to buffer or iovecs */
+		__u64	splice_off_in;
+	};
+	__u32	len;		/* buffer size or number of iovecs */
+	union {
+		// IMPORTANT:
+		// We explicit use 'int __bitwise' here and not ' __kernel_rwf_t' as this may not be present in the
+		// kernel headers that are used on the system.
+		int __bitwise	rw_flags;
+		__u32		fsync_flags;
+		__u16		poll_events;	/* compatibility */
+		__u32		poll32_events;	/* word-reversed for BE */
+		__u32		sync_range_flags;
+		__u32		msg_flags;
+		__u32		timeout_flags;
+		__u32		accept_flags;
+		__u32		cancel_flags;
+		__u32		open_flags;
+		__u32		statx_flags;
+		__u32		fadvise_advice;
+		__u32		splice_flags;
+	};
+	__u64	user_data;	/* data to be passed back at completion time */
+	union {
+		struct {
+			/* pack this to avoid bogus arm OABI complaints */
+			union {
+				/* index into fixed buffers, if used */
+				__u16	buf_index;
+				/* for grouped buffer selection */
+				__u16	buf_group;
+			} __attribute__((packed));
+			/* personality to use, if used */
+			__u16	personality;
+			__s32	splice_fd_in;
+		};
+		__u64	__pad2[3];
+	};
+};
+
+enum {
+	IOSQE_FIXED_FILE_BIT,
+	IOSQE_IO_DRAIN_BIT,
+	IOSQE_IO_LINK_BIT,
+	IOSQE_IO_HARDLINK_BIT,
+	IOSQE_ASYNC_BIT,
+	IOSQE_BUFFER_SELECT_BIT,
+};
+
+/*
+ * sqe->flags
+ */
+/* use fixed fileset */
+#define IOSQE_FIXED_FILE	(1U << IOSQE_FIXED_FILE_BIT)
+/* issue after inflight IO */
+#define IOSQE_IO_DRAIN		(1U << IOSQE_IO_DRAIN_BIT)
+/* links next sqe */
+#define IOSQE_IO_LINK		(1U << IOSQE_IO_LINK_BIT)
+/* like LINK, but stronger */
+#define IOSQE_IO_HARDLINK	(1U << IOSQE_IO_HARDLINK_BIT)
+/* always go async */
+#define IOSQE_ASYNC		(1U << IOSQE_ASYNC_BIT)
+/* select buffer from sqe->buf_group */
+#define IOSQE_BUFFER_SELECT	(1U << IOSQE_BUFFER_SELECT_BIT)
+
+/*
+ * io_uring_setup() flags
+ */
+#define IORING_SETUP_IOPOLL	(1U << 0)	/* io_context is polled */
+#define IORING_SETUP_SQPOLL	(1U << 1)	/* SQ poll thread */
+#define IORING_SETUP_SQ_AFF	(1U << 2)	/* sq_thread_cpu is valid */
+#define IORING_SETUP_CQSIZE	(1U << 3)	/* app defines CQ size */
+#define IORING_SETUP_CLAMP	(1U << 4)	/* clamp SQ/CQ ring sizes */
+#define IORING_SETUP_ATTACH_WQ	(1U << 5)	/* attach to existing wq */
+#define IORING_SETUP_R_DISABLED	(1U << 6)	/* start with ring disabled */
+
+enum {
+	IORING_OP_NOP,
+	IORING_OP_READV,
+	IORING_OP_WRITEV,
+	IORING_OP_FSYNC,
+	IORING_OP_READ_FIXED,
+	IORING_OP_WRITE_FIXED,
+	IORING_OP_POLL_ADD,
+	IORING_OP_POLL_REMOVE,
+	IORING_OP_SYNC_FILE_RANGE,
+	IORING_OP_SENDMSG,
+	IORING_OP_RECVMSG,
+	IORING_OP_TIMEOUT,
+	IORING_OP_TIMEOUT_REMOVE,
+	IORING_OP_ACCEPT,
+	IORING_OP_ASYNC_CANCEL,
+	IORING_OP_LINK_TIMEOUT,
+	IORING_OP_CONNECT,
+	IORING_OP_FALLOCATE,
+	IORING_OP_OPENAT,
+	IORING_OP_CLOSE,
+	IORING_OP_FILES_UPDATE,
+	IORING_OP_STATX,
+	IORING_OP_READ,
+	IORING_OP_WRITE,
+	IORING_OP_FADVISE,
+	IORING_OP_MADVISE,
+	IORING_OP_SEND,
+	IORING_OP_RECV,
+	IORING_OP_OPENAT2,
+	IORING_OP_EPOLL_CTL,
+	IORING_OP_SPLICE,
+	IORING_OP_PROVIDE_BUFFERS,
+	IORING_OP_REMOVE_BUFFERS,
+	IORING_OP_TEE,
+	IORING_OP_SHUTDOWN,
+
+	/* this goes last, obviously */
+	IORING_OP_LAST,
+};
+
+/*
+ * sqe->fsync_flags
+ */
+#define IORING_FSYNC_DATASYNC	(1U << 0)
+
+/*
+ * sqe->timeout_flags
+ */
+#define IORING_TIMEOUT_ABS	(1U << 0)
+
+/*
+ * sqe->splice_flags
+ * extends splice(2) flags
+ */
+#define SPLICE_F_FD_IN_FIXED	(1U << 31) /* the last bit of __u32 */
+
+/*
+ * IO completion data structure (Completion Queue Entry)
+ */
+struct io_uring_cqe {
+	__u64	user_data;	/* sqe->data submission passed back */
+	__s32	res;		/* result code for this event */
+	__u32	flags;
+};
+
+/*
+ * cqe->flags
+ *
+ * IORING_CQE_F_BUFFER	If set, the upper 16 bits are the buffer ID
+ */
+#define IORING_CQE_F_BUFFER		(1U << 0)
+
+enum {
+	IORING_CQE_BUFFER_SHIFT		= 16,
+};
+
+/*
+ * Magic offsets for the application to mmap the data it needs
+ */
+#define IORING_OFF_SQ_RING		0ULL
+#define IORING_OFF_CQ_RING		0x8000000ULL
+#define IORING_OFF_SQES			0x10000000ULL
+
+/*
+ * Filled with the offset for mmap(2)
+ */
+struct io_sqring_offsets {
+	__u32 head;
+	__u32 tail;
+	__u32 ring_mask;
+	__u32 ring_entries;
+	__u32 flags;
+	__u32 dropped;
+	__u32 array;
+	__u32 resv1;
+	__u64 resv2;
+};
+
+/*
+ * sq_ring->flags
+ */
+#define IORING_SQ_NEED_WAKEUP	(1U << 0) /* needs io_uring_enter wakeup */
+#define IORING_SQ_CQ_OVERFLOW	(1U << 1) /* CQ ring is overflown */
+
+struct io_cqring_offsets {
+	__u32 head;
+	__u32 tail;
+	__u32 ring_mask;
+	__u32 ring_entries;
+	__u32 overflow;
+	__u32 cqes;
+	__u32 flags;
+	__u32 resv1;
+	__u64 resv2;
+};
+
+/*
+ * cq_ring->flags
+ */
+
+/* disable eventfd notifications */
+#define IORING_CQ_EVENTFD_DISABLED	(1U << 0)
+
+/*
+ * io_uring_enter(2) flags
+ */
+#define IORING_ENTER_GETEVENTS	(1U << 0)
+#define IORING_ENTER_SQ_WAKEUP	(1U << 1)
+#define IORING_ENTER_SQ_WAIT	(1U << 2)
+
+/*
+ * Passed in for io_uring_setup(2). Copied back with updated info on success
+ */
+struct io_uring_params {
+	__u32 sq_entries;
+	__u32 cq_entries;
+	__u32 flags;
+	__u32 sq_thread_cpu;
+	__u32 sq_thread_idle;
+	__u32 features;
+	__u32 wq_fd;
+	__u32 resv[3];
+	struct io_sqring_offsets sq_off;
+	struct io_cqring_offsets cq_off;
+};
+
+/*
+ * io_uring_params->features flags
+ */
+#define IORING_FEAT_SINGLE_MMAP		(1U << 0)
+#define IORING_FEAT_NODROP		(1U << 1)
+#define IORING_FEAT_SUBMIT_STABLE	(1U << 2)
+#define IORING_FEAT_RW_CUR_POS		(1U << 3)
+#define IORING_FEAT_CUR_PERSONALITY	(1U << 4)
+#define IORING_FEAT_FAST_POLL		(1U << 5)
+#define IORING_FEAT_POLL_32BITS 	(1U << 6)
+#define IORING_FEAT_SQPOLL_NONFIXED	(1U << 7)
+
+/*
+ * io_uring_register(2) opcodes and arguments
+ */
+enum {
+	IORING_REGISTER_BUFFERS			= 0,
+	IORING_UNREGISTER_BUFFERS		= 1,
+	IORING_REGISTER_FILES			= 2,
+	IORING_UNREGISTER_FILES			= 3,
+	IORING_REGISTER_EVENTFD			= 4,
+	IORING_UNREGISTER_EVENTFD		= 5,
+	IORING_REGISTER_FILES_UPDATE		= 6,
+	IORING_REGISTER_EVENTFD_ASYNC		= 7,
+	IORING_REGISTER_PROBE			= 8,
+	IORING_REGISTER_PERSONALITY		= 9,
+	IORING_UNREGISTER_PERSONALITY		= 10,
+	IORING_REGISTER_RESTRICTIONS		= 11,
+	IORING_REGISTER_ENABLE_RINGS		= 12,
+
+	/* this goes last */
+	IORING_REGISTER_LAST
+};
+
+struct io_uring_files_update {
+	__u32 offset;
+	__u32 resv;
+	__aligned_u64 /* __s32 * */ fds;
+};
+
+#define IO_URING_OP_SUPPORTED	(1U << 0)
+
+struct io_uring_probe_op {
+	__u8 op;
+	__u8 resv;
+	__u16 flags;	/* IO_URING_OP_* flags */
+	__u32 resv2;
+};
+
+struct io_uring_probe {
+	__u8 last_op;	/* last opcode supported */
+	__u8 ops_len;	/* length of ops[] array below */
+	__u16 resv;
+	__u32 resv2[3];
+	struct io_uring_probe_op ops[0];
+};
+
+struct io_uring_restriction {
+	__u16 opcode;
+	union {
+		__u8 register_op; /* IORING_RESTRICTION_REGISTER_OP */
+		__u8 sqe_op;      /* IORING_RESTRICTION_SQE_OP */
+		__u8 sqe_flags;   /* IORING_RESTRICTION_SQE_FLAGS_* */
+	};
+	__u8 resv;
+	__u32 resv2[3];
+};
+
+/*
+ * io_uring_restriction->opcode values
+ */
+enum {
+	/* Allow an io_uring_register(2) opcode */
+	IORING_RESTRICTION_REGISTER_OP		= 0,
+
+	/* Allow an sqe opcode */
+	IORING_RESTRICTION_SQE_OP		= 1,
+
+	/* Allow sqe flags */
+	IORING_RESTRICTION_SQE_FLAGS_ALLOWED	= 2,
+
+	/* Require sqe flags (these flags must be set on each submission) */
+	IORING_RESTRICTION_SQE_FLAGS_REQUIRED	= 3,
+
+	IORING_RESTRICTION_LAST
+};
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/transport-native-io_uring/src/main/c/netty5_io_uring.h
+++ b/transport-native-io_uring/src/main/c/netty5_io_uring.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include "io_uring.h"
+#include "netty5_unix_buffer.h"
+#include "netty5_unix_errors.h"
+#include "netty5_unix_filedescriptor.h"
+#include "netty5_unix_jni.h"
+#include "netty5_unix_limits.h"
+#include "netty5_unix_socket.h"
+#include "netty5_unix_util.h"
+#include "netty5_unix.h"
+
+#ifndef NETTY5_IO_URING
+#define NETTY5_IO_URING
+
+struct io_uring_sq {
+    unsigned *khead;
+    unsigned *ktail;
+    unsigned *kring_mask;
+    unsigned *kring_entries;
+    unsigned *kflags;
+    unsigned *kdropped;
+    unsigned *array;
+    struct io_uring_sqe *sqes;
+
+    size_t ring_sz;
+    void *ring_ptr;
+};
+
+struct io_uring_cq {
+    unsigned *khead;
+    unsigned *ktail;
+    unsigned *kring_mask;
+    unsigned *kring_entries;
+    unsigned *koverflow;
+    struct io_uring_cqe *cqes;
+
+    size_t ring_sz;
+    void *ring_ptr;
+};
+
+struct io_uring {
+    struct io_uring_sq sq;
+    struct io_uring_cq cq;
+    unsigned flags;
+    int ring_fd;
+};
+
+#endif

--- a/transport-native-io_uring/src/main/c/netty5_io_uring_linuxsocket.c
+++ b/transport-native-io_uring/src/main/c/netty5_io_uring_linuxsocket.c
@@ -1,0 +1,758 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Since glibc 2.8, the _GNU_SOURCE feature test macro must be defined
+ * (before including any header files) in order to obtain the
+ * definition of the ucred structure. See <a href=https://linux.die.net/man/7/unix>
+ */
+#define _GNU_SOURCE
+
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <netinet/in.h>
+#include <netinet/udp.h> // SOL_UDP
+#include <linux/tcp.h> // TCP_NOTSENT_LOWAT is a linux specific define
+#include <fcntl.h>
+
+#include "netty5_io_uring_linuxsocket.h"
+#include "netty5_unix_errors.h"
+#include "netty5_unix_filedescriptor.h"
+#include "netty5_unix_jni.h"
+#include "netty5_unix_socket.h"
+#include "netty5_unix_util.h"
+
+#define LINUXSOCKET_CLASSNAME "io/netty5/channel/uring/LinuxSocket"
+
+// TCP_FASTOPEN is defined in linux 3.7. We define this here so older kernels can compile.
+#ifndef TCP_FASTOPEN
+#define TCP_FASTOPEN 23
+#endif
+
+// TCP_FASTOPEN_CONNECT is defined in linux 4.11. We define this here so older kernels can compile.
+#ifndef TCP_FASTOPEN_CONNECT
+#define TCP_FASTOPEN_CONNECT 30
+#endif
+
+// TCP_NOTSENT_LOWAT is defined in linux 3.12. We define this here so older kernels can compile.
+#ifndef TCP_NOTSENT_LOWAT
+#define TCP_NOTSENT_LOWAT 25
+#endif
+
+// SO_BUSY_POLL is defined in linux 3.11. We define this here so older kernels can compile.
+#ifndef SO_BUSY_POLL
+#define SO_BUSY_POLL 46
+#endif
+
+static jclass peerCredentialsClass = NULL;
+static jmethodID peerCredentialsMethodId = NULL;
+
+// JNI Registered Methods Begin
+static void netty5_io_uring_linuxsocket_setTimeToLive(JNIEnv* env, jclass clazz, jint fd, jint optval) {
+    netty5_unix_socket_setOption(env, fd, IPPROTO_IP, IP_TTL, &optval, sizeof(optval));
+}
+
+static void netty5_io_uring_linuxsocket_setIpMulticastLoop(JNIEnv* env, jclass clazz, jint fd, jboolean ipv6, jint optval) {
+    if (ipv6 == JNI_TRUE) {
+        u_int val = (u_int) optval;
+        netty5_unix_socket_setOption(env, fd, IPPROTO_IPV6, IPV6_MULTICAST_LOOP, &val, sizeof(val));
+    } else {
+        u_char val = (u_char) optval;
+        netty5_unix_socket_setOption(env, fd, IPPROTO_IP, IP_MULTICAST_LOOP, &val, sizeof(val));
+    }
+}
+
+static int netty5_io_uring_linuxsocket_makeBlocking(JNIEnv* env, jclass clazz, jint fd) {
+    int flags;
+    if ((flags = fcntl(fd, F_GETFL, 0)) < 0 ||
+        fcntl(fd, F_SETFL, flags & (~O_NONBLOCK)) < 0) {
+        return -errno;
+    }
+    return 0;
+}
+
+static void netty5_io_uring_linuxsocket_setInterface(JNIEnv* env, jclass clazz, jint fd, jboolean ipv6, jbyteArray interfaceAddress, jint scopeId, jint interfaceIndex) {
+    struct sockaddr_storage interfaceAddr;
+    socklen_t interfaceAddrSize;
+    struct sockaddr_in* interfaceIpAddr;
+
+    memset(&interfaceAddr, 0, sizeof(interfaceAddr));
+
+    if (ipv6 == JNI_TRUE) {
+        if (interfaceIndex == -1) {
+           netty5_unix_errors_throwIOException(env, "Unable to find network index");
+           return;
+        }
+        netty5_unix_socket_setOption(env, fd, IPPROTO_IPV6, IPV6_MULTICAST_IF, &interfaceIndex, sizeof(interfaceIndex));
+    } else {
+        if (netty5_unix_socket_initSockaddr(env, ipv6, interfaceAddress, scopeId, 0, &interfaceAddr, &interfaceAddrSize) == -1) {
+            netty5_unix_errors_throwIOException(env, "Could not init sockaddr");
+            return;
+        }
+
+        interfaceIpAddr = (struct sockaddr_in*) &interfaceAddr;
+        netty5_unix_socket_setOption(env, fd, IPPROTO_IP, IP_MULTICAST_IF, &interfaceIpAddr->sin_addr, sizeof(interfaceIpAddr->sin_addr));
+    }
+}
+
+static void netty5_io_uring_linuxsocket_setTcpCork(JNIEnv* env, jclass clazz, jint fd, jint optval) {
+    netty5_unix_socket_setOption(env, fd, IPPROTO_TCP, TCP_CORK, &optval, sizeof(optval));
+}
+
+static void netty5_io_uring_linuxsocket_setTcpQuickAck(JNIEnv* env, jclass clazz, jint fd, jint optval) {
+    netty5_unix_socket_setOption(env, fd, IPPROTO_TCP, TCP_QUICKACK, &optval, sizeof(optval));
+}
+
+static void netty5_io_uring_linuxsocket_setTcpDeferAccept(JNIEnv* env, jclass clazz, jint fd, jint optval) {
+    netty5_unix_socket_setOption(env, fd, IPPROTO_TCP, TCP_DEFER_ACCEPT, &optval, sizeof(optval));
+}
+
+static void netty5_io_uring_linuxsocket_setTcpNotSentLowAt(JNIEnv* env, jclass clazz, jint fd, jint optval) {
+    netty5_unix_socket_setOption(env, fd, IPPROTO_TCP, TCP_NOTSENT_LOWAT, &optval, sizeof(optval));
+}
+
+static void netty5_io_uring_linuxsocket_setTcpFastOpen(JNIEnv* env, jclass clazz, jint fd, jint optval) {
+    netty5_unix_socket_setOption(env, fd, IPPROTO_TCP, TCP_FASTOPEN, &optval, sizeof(optval));
+}
+
+static void netty5_io_uring_linuxsocket_setTcpFastOpenConnect(JNIEnv* env, jclass clazz, jint fd, jint optval) {
+    netty5_unix_socket_setOption(env, fd, IPPROTO_TCP, TCP_FASTOPEN_CONNECT, &optval, sizeof(optval));
+}
+
+static void netty5_io_uring_linuxsocket_setTcpKeepIdle(JNIEnv* env, jclass clazz, jint fd, jint optval) {
+    netty5_unix_socket_setOption(env, fd, IPPROTO_TCP, TCP_KEEPIDLE, &optval, sizeof(optval));
+}
+
+static void netty5_io_uring_linuxsocket_setTcpKeepIntvl(JNIEnv* env, jclass clazz, jint fd, jint optval) {
+    netty5_unix_socket_setOption(env, fd, IPPROTO_TCP, TCP_KEEPINTVL, &optval, sizeof(optval));
+}
+
+static void netty5_io_uring_linuxsocket_setTcpKeepCnt(JNIEnv* env, jclass clazz, jint fd, jint optval) {
+    netty5_unix_socket_setOption(env, fd, IPPROTO_TCP, TCP_KEEPCNT, &optval, sizeof(optval));
+}
+
+static void netty5_io_uring_linuxsocket_setTcpUserTimeout(JNIEnv* env, jclass clazz, jint fd, jint optval) {
+    netty5_unix_socket_setOption(env, fd, IPPROTO_TCP, TCP_USER_TIMEOUT, &optval, sizeof(optval));
+}
+
+static void netty5_io_uring_linuxsocket_setIpFreeBind(JNIEnv* env, jclass clazz, jint fd, jint optval) {
+    netty5_unix_socket_setOption(env, fd, IPPROTO_IP, IP_FREEBIND, &optval, sizeof(optval));
+}
+
+static void netty5_io_uring_linuxsocket_setIpTransparent(JNIEnv* env, jclass clazz, jint fd, jint optval) {
+    netty5_unix_socket_setOption(env, fd, SOL_IP, IP_TRANSPARENT, &optval, sizeof(optval));
+}
+
+static void netty5_io_uring_linuxsocket_setIpRecvOrigDestAddr(JNIEnv* env, jclass clazz, jint fd, jint optval) {
+    netty5_unix_socket_setOption(env, fd, IPPROTO_IP, IP_RECVORIGDSTADDR, &optval, sizeof(optval));
+}
+
+static void netty5_io_uring_linuxsocket_setSoBusyPoll(JNIEnv* env, jclass clazz, jint fd, jint optval) {
+    netty5_unix_socket_setOption(env, fd, SOL_SOCKET, SO_BUSY_POLL, &optval, sizeof(optval));
+}
+
+static void netty5_io_uring_linuxsocket_joinGroup(JNIEnv* env, jclass clazz, jint fd, jboolean ipv6, jbyteArray groupAddress, jbyteArray interfaceAddress, jint scopeId, jint interfaceIndex) {
+    struct sockaddr_storage groupAddr;
+    socklen_t groupAddrSize;
+    struct sockaddr_storage interfaceAddr;
+    socklen_t interfaceAddrSize;
+    struct sockaddr_in* groupIpAddr;
+    struct sockaddr_in* interfaceIpAddr;
+    struct ip_mreq mreq;
+
+    struct sockaddr_in6* groupIp6Addr;
+    struct ipv6_mreq mreq6;
+
+    memset(&groupAddr, 0, sizeof(groupAddr));
+    memset(&interfaceAddr, 0, sizeof(interfaceAddr));
+
+    if (netty5_unix_socket_initSockaddr(env, ipv6, groupAddress, scopeId, 0, &groupAddr, &groupAddrSize) == -1) {
+        netty5_unix_errors_throwIOException(env, "Could not init sockaddr for groupAddress");
+        return;
+    }
+
+    switch (groupAddr.ss_family) {
+    case AF_INET:
+        if (netty5_unix_socket_initSockaddr(env, ipv6, interfaceAddress, scopeId, 0, &interfaceAddr, &interfaceAddrSize) == -1) {
+            netty5_unix_errors_throwIOException(env, "Could not init sockaddr for interfaceAddr");
+            return;
+        }
+
+        interfaceIpAddr = (struct sockaddr_in*) &interfaceAddr;
+        groupIpAddr = (struct sockaddr_in*) &groupAddr;
+
+        memcpy(&mreq.imr_multiaddr, &groupIpAddr->sin_addr, sizeof(groupIpAddr->sin_addr));
+        memcpy(&mreq.imr_interface, &interfaceIpAddr->sin_addr, sizeof(interfaceIpAddr->sin_addr));
+        netty5_unix_socket_setOption(env, fd, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mreq, sizeof(mreq));
+        break;
+    case AF_INET6:
+        if (interfaceIndex == -1) {
+            netty5_unix_errors_throwIOException(env, "Unable to find network index");
+            return;
+        }
+        mreq6.ipv6mr_interface = interfaceIndex;
+
+        groupIp6Addr = (struct sockaddr_in6*) &groupAddr;
+        memcpy(&mreq6.ipv6mr_multiaddr, &groupIp6Addr->sin6_addr, sizeof(groupIp6Addr->sin6_addr));
+        netty5_unix_socket_setOption(env, fd, IPPROTO_IPV6, IPV6_JOIN_GROUP, &mreq6, sizeof(mreq6));
+        break;
+    default:
+        netty5_unix_errors_throwIOException(env, "Address family not supported");
+        break;
+    }
+}
+
+static void netty5_io_uring_linuxsocket_joinSsmGroup(JNIEnv* env, jclass clazz, jint fd, jboolean ipv6, jbyteArray groupAddress, jbyteArray interfaceAddress, jint scopeId, jint interfaceIndex, jbyteArray sourceAddress) {
+    struct sockaddr_storage groupAddr;
+    socklen_t groupAddrSize;
+    struct sockaddr_storage interfaceAddr;
+    socklen_t interfaceAddrSize;
+    struct sockaddr_storage sourceAddr;
+    socklen_t sourceAddrSize;
+    struct sockaddr_in* groupIpAddr;
+    struct sockaddr_in* interfaceIpAddr;
+    struct sockaddr_in* sourceIpAddr;
+    struct ip_mreq_source mreq;
+
+    struct group_source_req mreq6;
+
+    memset(&groupAddr, 0, sizeof(groupAddr));
+    memset(&sourceAddr, 0, sizeof(sourceAddr));
+    memset(&interfaceAddr, 0, sizeof(interfaceAddr));
+
+    if (netty5_unix_socket_initSockaddr(env, ipv6, groupAddress, scopeId, 0, &groupAddr, &groupAddrSize) == -1) {
+        netty5_unix_errors_throwIOException(env, "Could not init sockaddr for groupAddress");
+        return;
+    }
+
+    if (netty5_unix_socket_initSockaddr(env, ipv6, sourceAddress, scopeId, 0, &sourceAddr, &sourceAddrSize) == -1) {
+        netty5_unix_errors_throwIOException(env, "Could not init sockaddr for sourceAddress");
+        return;
+    }
+
+    switch (groupAddr.ss_family) {
+    case AF_INET:
+        if (netty5_unix_socket_initSockaddr(env, ipv6, interfaceAddress, scopeId, 0, &interfaceAddr, &interfaceAddrSize) == -1) {
+            netty5_unix_errors_throwIOException(env, "Could not init sockaddr for interfaceAddress");
+            return;
+        }
+        interfaceIpAddr = (struct sockaddr_in*) &interfaceAddr;
+        groupIpAddr = (struct sockaddr_in*) &groupAddr;
+        sourceIpAddr = (struct sockaddr_in*) &sourceAddr;
+        memcpy(&mreq.imr_multiaddr, &groupIpAddr->sin_addr, sizeof(groupIpAddr->sin_addr));
+        memcpy(&mreq.imr_interface, &interfaceIpAddr->sin_addr, sizeof(interfaceIpAddr->sin_addr));
+        memcpy(&mreq.imr_sourceaddr, &sourceIpAddr->sin_addr, sizeof(sourceIpAddr->sin_addr));
+        netty5_unix_socket_setOption(env, fd, IPPROTO_IP, IP_ADD_SOURCE_MEMBERSHIP, &mreq, sizeof(mreq));
+        break;
+    case AF_INET6:
+        if (interfaceIndex == -1) {
+            netty5_unix_errors_throwIOException(env, "Unable to find network index");
+            return;
+        }
+        mreq6.gsr_group = groupAddr;
+        mreq6.gsr_interface = interfaceIndex;
+        mreq6.gsr_source = sourceAddr;
+        netty5_unix_socket_setOption(env, fd, IPPROTO_IPV6, MCAST_JOIN_SOURCE_GROUP, &mreq6, sizeof(mreq6));
+        break;
+    default:
+        netty5_unix_errors_throwIOException(env, "Address family not supported");
+        break;
+    }
+}
+
+static void netty5_io_uring_linuxsocket_leaveGroup(JNIEnv* env, jclass clazz, jint fd, jboolean ipv6, jbyteArray groupAddress, jbyteArray interfaceAddress, jint scopeId, jint interfaceIndex) {
+    struct sockaddr_storage groupAddr;
+    socklen_t groupAddrSize;
+
+    struct sockaddr_storage interfaceAddr;
+    socklen_t interfaceAddrSize;
+    struct sockaddr_in* groupIpAddr;
+    struct sockaddr_in* interfaceIpAddr;
+    struct ip_mreq mreq;
+
+    struct sockaddr_in6* groupIp6Addr;
+    struct ipv6_mreq mreq6;
+
+    memset(&groupAddr, 0, sizeof(groupAddr));
+    memset(&interfaceAddr, 0, sizeof(interfaceAddr));
+
+    if (netty5_unix_socket_initSockaddr(env, ipv6, groupAddress, scopeId, 0, &groupAddr, &groupAddrSize) == -1) {
+        netty5_unix_errors_throwIOException(env, "Could not init sockaddr for groupAddress");
+        return;
+    }
+
+    switch (groupAddr.ss_family) {
+    case AF_INET:
+        if (netty5_unix_socket_initSockaddr(env, ipv6, interfaceAddress, scopeId, 0, &interfaceAddr, &interfaceAddrSize) == -1) {
+            netty5_unix_errors_throwIOException(env, "Could not init sockaddr for interfaceAddress");
+            return;
+        }
+        interfaceIpAddr = (struct sockaddr_in*) &interfaceAddr;
+        groupIpAddr = (struct sockaddr_in*) &groupAddr;
+
+        memcpy(&mreq.imr_multiaddr, &groupIpAddr->sin_addr, sizeof(groupIpAddr->sin_addr));
+        memcpy(&mreq.imr_interface, &interfaceIpAddr->sin_addr, sizeof(interfaceIpAddr->sin_addr));
+        netty5_unix_socket_setOption(env, fd, IPPROTO_IP, IP_DROP_MEMBERSHIP, &mreq, sizeof(mreq));
+        break;
+    case AF_INET6:
+        if (interfaceIndex == -1) {
+            netty5_unix_errors_throwIOException(env, "Unable to find network index");
+            return;
+        }
+        mreq6.ipv6mr_interface = interfaceIndex;
+
+        groupIp6Addr = (struct sockaddr_in6*) &groupAddr;
+        memcpy(&mreq6.ipv6mr_multiaddr, &groupIp6Addr->sin6_addr, sizeof(groupIp6Addr->sin6_addr));
+        netty5_unix_socket_setOption(env, fd, IPPROTO_IPV6, IPV6_LEAVE_GROUP, &mreq6, sizeof(mreq6));
+        break;
+    default:
+        netty5_unix_errors_throwIOException(env, "Address family not supported");
+        break;
+    }
+}
+
+static void netty5_io_uring_linuxsocket_leaveSsmGroup(JNIEnv* env, jclass clazz, jint fd, jboolean ipv6, jbyteArray groupAddress, jbyteArray interfaceAddress, jint scopeId, jint interfaceIndex, jbyteArray sourceAddress) {
+    struct sockaddr_storage groupAddr;
+    socklen_t groupAddrSize;
+    struct sockaddr_storage interfaceAddr;
+    socklen_t interfaceAddrSize;
+    struct sockaddr_storage sourceAddr;
+    socklen_t sourceAddrSize;
+    struct sockaddr_in* groupIpAddr;
+    struct sockaddr_in* interfaceIpAddr;
+    struct sockaddr_in* sourceIpAddr;
+
+    struct ip_mreq_source mreq;
+    struct group_source_req mreq6;
+
+    memset(&groupAddr, 0, sizeof(groupAddr));
+    memset(&sourceAddr, 0, sizeof(sourceAddr));
+    memset(&interfaceAddr, 0, sizeof(interfaceAddr));
+
+
+    if (netty5_unix_socket_initSockaddr(env, ipv6, groupAddress, scopeId, 0, &groupAddr, &groupAddrSize) == -1) {
+        netty5_unix_errors_throwIOException(env, "Could not init sockaddr for groupAddress");
+        return;
+    }
+
+    if (netty5_unix_socket_initSockaddr(env, ipv6, sourceAddress, scopeId, 0, &sourceAddr, &sourceAddrSize) == -1) {
+        netty5_unix_errors_throwIOException(env, "Could not init sockaddr for sourceAddress");
+        return;
+    }
+
+    switch (groupAddr.ss_family) {
+    case AF_INET:
+        if (netty5_unix_socket_initSockaddr(env, ipv6, interfaceAddress, scopeId, 0, &interfaceAddr, &interfaceAddrSize) == -1) {
+            netty5_unix_errors_throwIOException(env, "Could not init sockaddr for interfaceAddress");
+            return;
+        }
+        interfaceIpAddr = (struct sockaddr_in*) &interfaceAddr;
+
+        groupIpAddr = (struct sockaddr_in*) &groupAddr;
+        sourceIpAddr = (struct sockaddr_in*) &sourceAddr;
+        memcpy(&mreq.imr_multiaddr, &groupIpAddr->sin_addr, sizeof(groupIpAddr->sin_addr));
+        memcpy(&mreq.imr_interface, &interfaceIpAddr->sin_addr, sizeof(interfaceIpAddr->sin_addr));
+        memcpy(&mreq.imr_sourceaddr, &sourceIpAddr->sin_addr, sizeof(sourceIpAddr->sin_addr));
+        netty5_unix_socket_setOption(env, fd, IPPROTO_IP, IP_DROP_SOURCE_MEMBERSHIP, &mreq, sizeof(mreq));
+        break;
+    case AF_INET6:
+        if (interfaceIndex == -1) {
+            netty5_unix_errors_throwIOException(env, "Unable to find network index");
+            return;
+        }
+
+        mreq6.gsr_group = groupAddr;
+        mreq6.gsr_interface = interfaceIndex;
+        mreq6.gsr_source = sourceAddr;
+        netty5_unix_socket_setOption(env, fd, IPPROTO_IPV6, MCAST_LEAVE_SOURCE_GROUP, &mreq6, sizeof(mreq6));
+        break;
+    default:
+        netty5_unix_errors_throwIOException(env, "Address family not supported");
+        break;
+    }
+}
+
+static void netty5_io_uring_linuxsocket_setTcpMd5Sig(JNIEnv* env, jclass clazz, jint fd, jboolean ipv6, jbyteArray address, jint scopeId, jbyteArray key) {
+    struct sockaddr_storage addr;
+    socklen_t addrSize;
+
+    memset(&addr, 0, sizeof(addr));
+
+    if (netty5_unix_socket_initSockaddr(env, ipv6, address, scopeId, 0, &addr, &addrSize) == -1) {
+        netty5_unix_errors_throwIOException(env, "Could not init sockaddr");
+        return;
+    }
+
+    struct tcp_md5sig md5sig;
+    memset(&md5sig, 0, sizeof(md5sig));
+    md5sig.tcpm_addr.ss_family = addr.ss_family;
+
+    struct sockaddr_in* ipaddr;
+    struct sockaddr_in6* ip6addr;
+
+    switch (addr.ss_family) {
+    case AF_INET:
+        ipaddr = (struct sockaddr_in*) &addr;
+        memcpy(&((struct sockaddr_in *) &md5sig.tcpm_addr)->sin_addr, &ipaddr->sin_addr, sizeof(ipaddr->sin_addr));
+        break;
+    case AF_INET6:
+        ip6addr = (struct sockaddr_in6*) &addr;
+        memcpy(&((struct sockaddr_in6 *) &md5sig.tcpm_addr)->sin6_addr, &ip6addr->sin6_addr, sizeof(ip6addr->sin6_addr));
+        break;
+    }
+
+    if (key != NULL) {
+        md5sig.tcpm_keylen = (*env)->GetArrayLength(env, key);
+        (*env)->GetByteArrayRegion(env, key, 0, md5sig.tcpm_keylen, (void *) &md5sig.tcpm_key);
+        if ((*env)->ExceptionCheck(env) == JNI_TRUE) {
+            return;
+        }
+    }
+
+    if (setsockopt(fd, IPPROTO_TCP, TCP_MD5SIG, &md5sig, sizeof(md5sig)) < 0) {
+        netty5_unix_errors_throwIOExceptionErrorNo(env, "setsockopt() failed: ", errno);
+    }
+}
+
+static int netty5_io_uring_linuxsocket_getInterface(JNIEnv* env, jclass clazz, jint fd, jboolean ipv6) {
+    if (ipv6 == JNI_TRUE) {
+        int optval;
+        if (netty5_unix_socket_getOption(env, fd, IPPROTO_IPV6, IPV6_MULTICAST_IF, &optval, sizeof(optval)) == -1) {
+            return -1;
+        }
+        return optval;
+    } else {
+        struct in_addr optval;
+        if (netty5_unix_socket_getOption(env, fd, IPPROTO_IP, IP_MULTICAST_IF, &optval, sizeof(optval)) == -1) {
+            return -1;
+        }
+
+        return ntohl(optval.s_addr);
+    }
+}
+
+static jint netty5_io_uring_linuxsocket_getTimeToLive(JNIEnv* env, jclass clazz, jint fd) {
+    int optval;
+    if (netty5_unix_socket_getOption(env, fd, IPPROTO_IP, IP_TTL, &optval, sizeof(optval)) == -1) {
+        return -1;
+    }
+    return optval;
+}
+
+
+static jint netty5_io_uring_linuxsocket_getIpMulticastLoop(JNIEnv* env, jclass clazz, jint fd, jboolean ipv6) {
+    if (ipv6 == JNI_TRUE) {
+        u_int optval;
+        if (netty5_unix_socket_getOption(env, fd, IPPROTO_IPV6, IPV6_MULTICAST_LOOP, &optval, sizeof(optval)) == -1) {
+            return -1;
+        }
+        return (jint) optval;
+    } else {
+        u_char optval;
+        if (netty5_unix_socket_getOption(env, fd, IPPROTO_IP, IP_MULTICAST_LOOP, &optval, sizeof(optval)) == -1) {
+            return -1;
+        }
+        return (jint) optval;
+    }
+}
+
+static jint netty5_io_uring_linuxsocket_getTcpKeepIdle(JNIEnv* env, jclass clazz, jint fd) {
+    int optval;
+    if (netty5_unix_socket_getOption(env, fd, IPPROTO_TCP, TCP_KEEPIDLE, &optval, sizeof(optval)) == -1) {
+        return -1;
+    }
+    return optval;
+}
+
+static jint netty5_io_uring_linuxsocket_getTcpKeepIntvl(JNIEnv* env, jclass clazz, jint fd) {
+    int optval;
+    if (netty5_unix_socket_getOption(env, fd, IPPROTO_TCP, TCP_KEEPINTVL, &optval, sizeof(optval)) == -1) {
+        return -1;
+    }
+    return optval;
+}
+
+static jint netty5_io_uring_linuxsocket_getTcpKeepCnt(JNIEnv* env, jclass clazz, jint fd) {
+     int optval;
+     if (netty5_unix_socket_getOption(env, fd, IPPROTO_TCP, TCP_KEEPCNT, &optval, sizeof(optval)) == -1) {
+         return -1;
+     }
+     return optval;
+}
+
+static jint netty5_io_uring_linuxsocket_getTcpUserTimeout(JNIEnv* env, jclass clazz, jint fd) {
+     int optval;
+     if (netty5_unix_socket_getOption(env, fd, IPPROTO_TCP, TCP_USER_TIMEOUT, &optval, sizeof(optval)) == -1) {
+         return -1;
+     }
+     return optval;
+}
+
+static jint netty5_io_uring_linuxsocket_isIpFreeBind(JNIEnv* env, jclass clazz, jint fd) {
+     int optval;
+     if (netty5_unix_socket_getOption(env, fd, IPPROTO_IP, IP_FREEBIND, &optval, sizeof(optval)) == -1) {
+         return -1;
+     }
+     return optval;
+}
+
+static jint netty5_io_uring_linuxsocket_isIpTransparent(JNIEnv* env, jclass clazz, jint fd) {
+     int optval;
+     if (netty5_unix_socket_getOption(env, fd, SOL_IP, IP_TRANSPARENT, &optval, sizeof(optval)) == -1) {
+         return -1;
+     }
+     return optval;
+}
+
+static jint netty5_io_uring_linuxsocket_isIpRecvOrigDestAddr(JNIEnv* env, jclass clazz, jint fd) {
+     int optval;
+     if (netty5_unix_socket_getOption(env, fd, IPPROTO_IP, IP_RECVORIGDSTADDR, &optval, sizeof(optval)) == -1) {
+         return -1;
+     }
+     return optval;
+}
+
+static void netty5_io_uring_linuxsocket_getTcpInfo(JNIEnv* env, jclass clazz, jint fd, jlongArray array) {
+     struct tcp_info tcp_info;
+     if (netty5_unix_socket_getOption(env, fd, IPPROTO_TCP, TCP_INFO, &tcp_info, sizeof(tcp_info)) == -1) {
+         return;
+     }
+     jlong cArray[32];
+     // Expand to 64 bits, then cast away unsigned-ness.
+     cArray[0] = (jlong) (uint64_t) tcp_info.tcpi_state;
+     cArray[1] = (jlong) (uint64_t) tcp_info.tcpi_ca_state;
+     cArray[2] = (jlong) (uint64_t) tcp_info.tcpi_retransmits;
+     cArray[3] = (jlong) (uint64_t) tcp_info.tcpi_probes;
+     cArray[4] = (jlong) (uint64_t) tcp_info.tcpi_backoff;
+     cArray[5] = (jlong) (uint64_t) tcp_info.tcpi_options;
+     cArray[6] = (jlong) (uint64_t) tcp_info.tcpi_snd_wscale;
+     cArray[7] = (jlong) (uint64_t) tcp_info.tcpi_rcv_wscale;
+     cArray[8] = (jlong) (uint64_t) tcp_info.tcpi_rto;
+     cArray[9] = (jlong) (uint64_t) tcp_info.tcpi_ato;
+     cArray[10] = (jlong) (uint64_t) tcp_info.tcpi_snd_mss;
+     cArray[11] = (jlong) (uint64_t) tcp_info.tcpi_rcv_mss;
+     cArray[12] = (jlong) (uint64_t) tcp_info.tcpi_unacked;
+     cArray[13] = (jlong) (uint64_t) tcp_info.tcpi_sacked;
+     cArray[14] = (jlong) (uint64_t) tcp_info.tcpi_lost;
+     cArray[15] = (jlong) (uint64_t) tcp_info.tcpi_retrans;
+     cArray[16] = (jlong) (uint64_t) tcp_info.tcpi_fackets;
+     cArray[17] = (jlong) (uint64_t) tcp_info.tcpi_last_data_sent;
+     cArray[18] = (jlong) (uint64_t) tcp_info.tcpi_last_ack_sent;
+     cArray[19] = (jlong) (uint64_t) tcp_info.tcpi_last_data_recv;
+     cArray[20] = (jlong) (uint64_t) tcp_info.tcpi_last_ack_recv;
+     cArray[21] = (jlong) (uint64_t) tcp_info.tcpi_pmtu;
+     cArray[22] = (jlong) (uint64_t) tcp_info.tcpi_rcv_ssthresh;
+     cArray[23] = (jlong) (uint64_t) tcp_info.tcpi_rtt;
+     cArray[24] = (jlong) (uint64_t) tcp_info.tcpi_rttvar;
+     cArray[25] = (jlong) (uint64_t) tcp_info.tcpi_snd_ssthresh;
+     cArray[26] = (jlong) (uint64_t) tcp_info.tcpi_snd_cwnd;
+     cArray[27] = (jlong) (uint64_t) tcp_info.tcpi_advmss;
+     cArray[28] = (jlong) (uint64_t) tcp_info.tcpi_reordering;
+     cArray[29] = (jlong) (uint64_t) tcp_info.tcpi_rcv_rtt;
+     cArray[30] = (jlong) (uint64_t) tcp_info.tcpi_rcv_space;
+     cArray[31] = (jlong) (uint64_t) tcp_info.tcpi_total_retrans;
+
+     (*env)->SetLongArrayRegion(env, array, 0, 32, cArray);
+}
+
+static jint netty5_io_uring_linuxsocket_isTcpCork(JNIEnv* env, jclass clazz, jint fd) {
+    int optval;
+    if (netty5_unix_socket_getOption(env, fd, IPPROTO_TCP, TCP_CORK, &optval, sizeof(optval)) == -1) {
+        return -1;
+    }
+    return optval;
+}
+
+static jint netty5_io_uring_linuxsocket_getSoBusyPoll(JNIEnv* env, jclass clazz, jint fd) {
+    int optval;
+    if (netty5_unix_socket_getOption(env, fd, SOL_SOCKET, SO_BUSY_POLL, &optval, sizeof(optval)) == -1) {
+        return -1;
+    }
+    return optval;
+}
+
+static jint netty5_io_uring_linuxsocket_getTcpDeferAccept(JNIEnv* env, jclass clazz, jint fd) {
+    int optval;
+    if (netty5_unix_socket_getOption(env, fd, IPPROTO_TCP, TCP_DEFER_ACCEPT, &optval, sizeof(optval)) == -1) {
+        return -1;
+    }
+    return optval;
+}
+
+static jint netty5_io_uring_linuxsocket_isTcpQuickAck(JNIEnv* env, jclass clazz, jint fd) {
+    int optval;
+    if (netty5_unix_socket_getOption(env, fd, IPPROTO_TCP, TCP_QUICKACK, &optval, sizeof(optval)) == -1) {
+        return -1;
+    }
+    return optval;
+}
+
+static jint netty5_io_uring_linuxsocket_isTcpFastOpenConnect(JNIEnv* env, jclass clazz, jint fd) {
+    int optval;
+    // We call netty5_unix_socket_getOption0 directly so we can handle ENOPROTOOPT by ourself.
+    if (netty5_unix_socket_getOption0(fd, IPPROTO_TCP, TCP_FASTOPEN_CONNECT, &optval, sizeof(optval)) == -1) {
+        if (errno == ENOPROTOOPT) {
+            // Not supported by the system, so just return 0.
+            return 0;
+        }
+        netty5_unix_socket_getOptionHandleError(env, errno);
+        return -1;
+    }
+    return optval;
+}
+
+static jint netty5_io_uring_linuxsocket_getTcpNotSentLowAt(JNIEnv* env, jclass clazz, jint fd) {
+    int optval;
+    if (netty5_unix_socket_getOption(env, fd, IPPROTO_TCP, TCP_NOTSENT_LOWAT, &optval, sizeof(optval)) == -1) {
+        return -1;
+    }
+    return optval;
+}
+
+static jobject netty5_io_uring_linuxsocket_getPeerCredentials(JNIEnv *env, jclass clazz, jint fd) {
+     struct ucred credentials;
+     if(netty5_unix_socket_getOption(env,fd, SOL_SOCKET, SO_PEERCRED, &credentials, sizeof (credentials)) == -1) {
+         return NULL;
+     }
+     jintArray gids = (*env)->NewIntArray(env, 1);
+     (*env)->SetIntArrayRegion(env, gids, 0, 1, (jint*) &credentials.gid);
+     return (*env)->NewObject(env, peerCredentialsClass, peerCredentialsMethodId, credentials.pid, credentials.uid, gids);
+}
+
+static void netty5_epoll_linuxsocket_setUdpGro(JNIEnv* env, jclass clazz, jint fd, jint optval) {
+    netty5_unix_socket_setOption(env, fd, SOL_UDP, UDP_GRO, &optval, sizeof(optval));
+}
+// JNI Registered Methods End
+
+// JNI Method Registration Table Begin
+static const JNINativeMethod fixed_method_table[] = {
+  { "setTimeToLive", "(II)V", (void *) netty5_io_uring_linuxsocket_setTimeToLive },
+  { "getTimeToLive", "(I)I", (void *) netty5_io_uring_linuxsocket_getTimeToLive },
+  { "setInterface", "(IZ[BII)V", (void *) netty5_io_uring_linuxsocket_setInterface },
+  { "getInterface", "(IZ)I", (void *) netty5_io_uring_linuxsocket_getInterface },
+  { "setIpMulticastLoop", "(IZI)V", (void * ) netty5_io_uring_linuxsocket_setIpMulticastLoop },
+  { "getIpMulticastLoop", "(IZ)I", (void * ) netty5_io_uring_linuxsocket_getIpMulticastLoop },
+  { "makeBlocking", "(I)I", (void * ) netty5_io_uring_linuxsocket_makeBlocking },
+  { "setTcpCork", "(II)V", (void *) netty5_io_uring_linuxsocket_setTcpCork },
+  { "setSoBusyPoll", "(II)V", (void *) netty5_io_uring_linuxsocket_setSoBusyPoll },
+  { "setTcpQuickAck", "(II)V", (void *) netty5_io_uring_linuxsocket_setTcpQuickAck },
+  { "setTcpDeferAccept", "(II)V", (void *) netty5_io_uring_linuxsocket_setTcpDeferAccept },
+  { "setTcpNotSentLowAt", "(II)V", (void *) netty5_io_uring_linuxsocket_setTcpNotSentLowAt },
+  { "isTcpCork", "(I)I", (void *) netty5_io_uring_linuxsocket_isTcpCork },
+  { "getSoBusyPoll", "(I)I", (void *) netty5_io_uring_linuxsocket_getSoBusyPoll },
+  { "getTcpDeferAccept", "(I)I", (void *) netty5_io_uring_linuxsocket_getTcpDeferAccept },
+  { "getTcpNotSentLowAt", "(I)I", (void *) netty5_io_uring_linuxsocket_getTcpNotSentLowAt },
+  { "isTcpQuickAck", "(I)I", (void *) netty5_io_uring_linuxsocket_isTcpQuickAck },
+  { "setTcpFastOpen", "(II)V", (void *) netty5_io_uring_linuxsocket_setTcpFastOpen },
+  { "setTcpFastOpenConnect", "(II)V", (void *) netty5_io_uring_linuxsocket_setTcpFastOpenConnect },
+  { "isTcpFastOpenConnect", "(I)I", (void *) netty5_io_uring_linuxsocket_isTcpFastOpenConnect },
+  { "setTcpKeepIdle", "(II)V", (void *) netty5_io_uring_linuxsocket_setTcpKeepIdle },
+  { "setTcpKeepIntvl", "(II)V", (void *) netty5_io_uring_linuxsocket_setTcpKeepIntvl },
+  { "setTcpKeepCnt", "(II)V", (void *) netty5_io_uring_linuxsocket_setTcpKeepCnt },
+  { "setTcpUserTimeout", "(II)V", (void *) netty5_io_uring_linuxsocket_setTcpUserTimeout },
+  { "setIpFreeBind", "(II)V", (void *) netty5_io_uring_linuxsocket_setIpFreeBind },
+  { "setIpTransparent", "(II)V", (void *) netty5_io_uring_linuxsocket_setIpTransparent },
+  { "setIpRecvOrigDestAddr", "(II)V", (void *) netty5_io_uring_linuxsocket_setIpRecvOrigDestAddr },
+  { "getTcpKeepIdle", "(I)I", (void *) netty5_io_uring_linuxsocket_getTcpKeepIdle },
+  { "getTcpKeepIntvl", "(I)I", (void *) netty5_io_uring_linuxsocket_getTcpKeepIntvl },
+  { "getTcpKeepCnt", "(I)I", (void *) netty5_io_uring_linuxsocket_getTcpKeepCnt },
+  { "getTcpUserTimeout", "(I)I", (void *) netty5_io_uring_linuxsocket_getTcpUserTimeout },
+  { "isIpFreeBind", "(I)I", (void *) netty5_io_uring_linuxsocket_isIpFreeBind },
+  { "isIpTransparent", "(I)I", (void *) netty5_io_uring_linuxsocket_isIpTransparent },
+  { "isIpRecvOrigDestAddr", "(I)I", (void *) netty5_io_uring_linuxsocket_isIpRecvOrigDestAddr },
+  { "getTcpInfo", "(I[J)V", (void *) netty5_io_uring_linuxsocket_getTcpInfo },
+  { "setTcpMd5Sig", "(IZ[BI[B)V", (void *) netty5_io_uring_linuxsocket_setTcpMd5Sig },
+  { "joinGroup", "(IZ[B[BII)V", (void *) netty5_io_uring_linuxsocket_joinGroup },
+  { "joinSsmGroup", "(IZ[B[BII[B)V", (void *) netty5_io_uring_linuxsocket_joinSsmGroup },
+  { "leaveGroup", "(IZ[B[BII)V", (void *) netty5_io_uring_linuxsocket_leaveGroup },
+  { "leaveSsmGroup", "(IZ[B[BII[B)V", (void *) netty5_io_uring_linuxsocket_leaveSsmGroup },
+  { "setUdpGro", "(II)V", (void *) netty5_epoll_linuxsocket_setUdpGro }
+};
+
+static const jint fixed_method_table_size = sizeof(fixed_method_table) / sizeof(fixed_method_table[0]);
+
+static jint dynamicMethodsTableSize() {
+    return fixed_method_table_size + 1; // 1 is for the dynamic method signatures.
+}
+
+static JNINativeMethod* createDynamicMethodsTable(const char* packagePrefix) {
+    char* dynamicTypeName = NULL;
+    size_t size = sizeof(JNINativeMethod) * dynamicMethodsTableSize();
+    JNINativeMethod* dynamicMethods = malloc(size);
+    if (dynamicMethods == NULL) {
+        return NULL;
+    }
+    memset(dynamicMethods, 0, size);
+    memcpy(dynamicMethods, fixed_method_table, sizeof(fixed_method_table));
+
+    JNINativeMethod* dynamicMethod = &dynamicMethods[fixed_method_table_size];
+    NETTY_JNI_UTIL_PREPEND(packagePrefix, "io/netty5/channel/unix/PeerCredentials;", dynamicTypeName, error);
+    NETTY_JNI_UTIL_PREPEND("(I)L", dynamicTypeName,  dynamicMethod->signature, error);
+    dynamicMethod->name = "getPeerCredentials";
+    dynamicMethod->fnPtr = (void *) netty5_io_uring_linuxsocket_getPeerCredentials;
+    netty_jni_util_free_dynamic_name(&dynamicTypeName);
+    return dynamicMethods;
+error:
+    free(dynamicTypeName);
+    netty_jni_util_free_dynamic_methods_table(dynamicMethods, fixed_method_table_size, dynamicMethodsTableSize());
+    return NULL;
+}
+
+// JNI Method Registration Table End
+
+jint netty5_io_uring_linuxsocket_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
+    int ret = JNI_ERR;
+    char* nettyClassName = NULL;
+    int linuxSocketRegistered = 0;
+
+    // Register the methods which are not referenced by static member variables
+    JNINativeMethod* dynamicMethods = createDynamicMethodsTable(packagePrefix);
+    if (dynamicMethods == NULL) {
+        goto done;
+    }
+    if (netty_jni_util_register_natives(env,
+            packagePrefix,
+            LINUXSOCKET_CLASSNAME,
+            dynamicMethods,
+            dynamicMethodsTableSize()) != 0) {
+        goto done;
+    }
+    linuxSocketRegistered = 1;
+
+    NETTY_JNI_UTIL_PREPEND(packagePrefix, "io/netty5/channel/unix/PeerCredentials", nettyClassName, done);
+    NETTY_JNI_UTIL_LOAD_CLASS(env, peerCredentialsClass, nettyClassName, done);
+    netty_jni_util_free_dynamic_name(&nettyClassName);
+
+    NETTY_JNI_UTIL_GET_METHOD(env, peerCredentialsClass, peerCredentialsMethodId, "<init>", "(II[I)V", done);
+
+    ret = NETTY_JNI_UTIL_JNI_VERSION;
+done:
+    if (ret == JNI_ERR) {
+        if (linuxSocketRegistered == 1) {
+            netty_jni_util_unregister_natives(env, packagePrefix, LINUXSOCKET_CLASSNAME);
+        }
+    }
+    netty_jni_util_free_dynamic_methods_table(dynamicMethods, fixed_method_table_size, dynamicMethodsTableSize());
+    free(nettyClassName);
+
+    return ret;
+}
+
+void netty5_io_uring_linuxsocket_JNI_OnUnLoad(JNIEnv* env, const char* packagePrefix) {
+    netty_jni_util_unregister_natives(env, packagePrefix, LINUXSOCKET_CLASSNAME);
+    NETTY_JNI_UTIL_UNLOAD_CLASS(env, peerCredentialsClass);
+}

--- a/transport-native-io_uring/src/main/c/netty5_io_uring_linuxsocket.h
+++ b/transport-native-io_uring/src/main/c/netty5_io_uring_linuxsocket.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef NETTY5_IO_URING_LINUXSOCKET_H_
+#define NETTY5_IO_URING_LINUXSOCKET_H_
+
+#include <jni.h>
+
+// JNI initialization hooks. Users of this file are responsible for calling these in the JNI_OnLoad and JNI_OnUnload methods.
+jint netty5_io_uring_linuxsocket_JNI_OnLoad(JNIEnv* env, const char* packagePrefix);
+void netty5_io_uring_linuxsocket_JNI_OnUnLoad(JNIEnv* env, const char* packagePrefix);
+
+#endif

--- a/transport-native-io_uring/src/main/c/netty5_io_uring_native.c
+++ b/transport-native-io_uring/src/main/c/netty5_io_uring_native.c
@@ -1,0 +1,691 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+#define _GNU_SOURCE // RTLD_DEFAULT
+#include "netty5_io_uring.h"
+#include <dlfcn.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <jni.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "syscall.h"
+#include "netty5_io_uring_linuxsocket.h"
+#include <syscall.h>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+
+#include <sys/eventfd.h>
+#include <poll.h>
+// Needed for UDP_SEGMENT
+#include <netinet/udp.h>
+#include <sys/utsname.h>
+
+// Allow to compile on systems with older kernels.
+#ifndef UDP_SEGMENT
+#define UDP_SEGMENT 103
+#endif
+
+// Add define if NETTY5_IO_URING_BUILD_STATIC is defined so it is picked up in netty5_jni_util.c
+#ifdef NETTY5_IO_URING_BUILD_STATIC
+#define NETTY5_JNI_UTIL_BUILD_STATIC
+#endif
+
+// Allow to compile on systems with older kernels
+#ifndef MSG_FASTOPEN
+#define MSG_FASTOPEN 0x20000000
+#endif
+
+#define NATIVE_CLASSNAME "io/netty5/channel/uring/Native"
+#define STATICALLY_CLASSNAME "io/netty5/channel/uring/NativeStaticallyReferencedJniMethods"
+#define LIBRARYNAME "netty5_transport_native_io_uring"
+
+static jclass longArrayClass = NULL;
+static char* staticPackagePrefix = NULL;
+static int register_unix_called = 0;
+
+static void netty5_io_uring_native_JNI_OnUnLoad(JNIEnv* env, const char* packagePrefix) {
+    netty5_unix_limits_JNI_OnUnLoad(env, packagePrefix);
+    netty5_unix_errors_JNI_OnUnLoad(env, packagePrefix);
+    netty5_unix_filedescriptor_JNI_OnUnLoad(env, packagePrefix);
+    netty5_unix_socket_JNI_OnUnLoad(env, packagePrefix);
+    netty5_unix_buffer_JNI_OnUnLoad(env, packagePrefix);
+
+    NETTY_JNI_UTIL_UNLOAD_CLASS(env, longArrayClass);
+}
+
+static void io_uring_unmap_rings(struct io_uring_sq *sq, struct io_uring_cq *cq) {
+    munmap(sq->ring_ptr, sq->ring_sz);
+    if (cq->ring_ptr && cq->ring_ptr != sq->ring_ptr) {
+        munmap(cq->ring_ptr, cq->ring_sz);
+  }
+}
+
+static int io_uring_mmap(int fd, struct io_uring_params *p, struct io_uring_sq *sq, struct io_uring_cq *cq) {
+    size_t size;
+    int ret;
+
+    sq->ring_sz = p->sq_off.array + p->sq_entries * sizeof(unsigned);
+    cq->ring_sz = p->cq_off.cqes + p->cq_entries * sizeof(struct io_uring_cqe);
+
+    if ((p->features & IORING_FEAT_SINGLE_MMAP) == 1) {
+        if (cq->ring_sz > sq->ring_sz) {
+            sq->ring_sz = cq->ring_sz;
+        }
+        cq->ring_sz = sq->ring_sz;
+    }
+    sq->ring_ptr = mmap(0, sq->ring_sz, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_POPULATE, fd, IORING_OFF_SQ_RING);
+    if (sq->ring_ptr == MAP_FAILED) {
+        return -errno;
+    }
+
+    if ((p->features & IORING_FEAT_SINGLE_MMAP) == 1) {
+        cq->ring_ptr = sq->ring_ptr;
+    } else {
+        cq->ring_ptr = mmap(0, cq->ring_sz, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_POPULATE, fd, IORING_OFF_CQ_RING);
+        if (cq->ring_ptr == MAP_FAILED) {
+            cq->ring_ptr = NULL;
+            ret = -errno;
+            goto err;
+        }
+    }
+
+    sq->khead = sq->ring_ptr + p->sq_off.head;
+    sq->ktail = sq->ring_ptr + p->sq_off.tail;
+    sq->kring_mask = sq->ring_ptr + p->sq_off.ring_mask;
+    sq->kring_entries = sq->ring_ptr + p->sq_off.ring_entries;
+    sq->kflags = sq->ring_ptr + p->sq_off.flags;
+    sq->kdropped = sq->ring_ptr + p->sq_off.dropped;
+    sq->array = sq->ring_ptr + p->sq_off.array;
+
+    size = p->sq_entries * sizeof(struct io_uring_sqe);
+    sq->sqes = mmap(0, size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_POPULATE, fd, IORING_OFF_SQES);
+    if (sq->sqes == MAP_FAILED) {
+        ret = -errno;
+        goto err;
+    }
+
+    cq->khead = cq->ring_ptr + p->cq_off.head;
+    cq->ktail = cq->ring_ptr + p->cq_off.tail;
+    cq->kring_mask = cq->ring_ptr + p->cq_off.ring_mask;
+    cq->kring_entries = cq->ring_ptr + p->cq_off.ring_entries;
+    cq->koverflow = cq->ring_ptr + p->cq_off.overflow;
+    cq->cqes = cq->ring_ptr + p->cq_off.cqes;
+
+    return 0;
+err:
+    io_uring_unmap_rings(sq, cq);
+    return ret;
+}
+
+static int setup_io_uring(int ring_fd, struct io_uring *io_uring_ring,
+                    struct io_uring_params *p) {
+    return io_uring_mmap(ring_fd, p, &io_uring_ring->sq, &io_uring_ring->cq);
+}
+
+static jint netty5_io_uring_enter(JNIEnv *env, jclass class1, jint ring_fd, jint to_submit,
+                                 jint min_complete, jint flags) {
+    int result;
+    int err;
+    do {
+        result = sys_io_uring_enter(ring_fd, to_submit, min_complete, flags, NULL);
+        if (result >= 0) {
+            return result;
+        }
+    } while ((err = errno) == EINTR);
+    return -err;
+}
+
+static jstring netty5_io_uring_kernel_version(JNIEnv* env, jclass clazz) {
+    struct utsname u;
+    uname(&u);
+
+    jstring result = (*env)->NewStringUTF(env, u.release);
+    return result;
+}
+
+static jint netty5_epoll_native_blocking_event_fd(JNIEnv* env, jclass clazz) {
+    // We use a blocking fd with io_uring FAST_POLL read
+    jint eventFD = eventfd(0, EFD_CLOEXEC);
+
+    if (eventFD < 0) {
+        netty5_unix_errors_throwChannelExceptionErrorNo(env, "eventfd() failed: ", errno);
+    }
+    return eventFD;
+}
+
+static void netty5_io_uring_eventFdWrite(JNIEnv* env, jclass clazz, jint fd, jlong value) {
+    int result;
+    int err;
+    do {
+        result = eventfd_write(fd, (eventfd_t) value);
+        if (result >= 0) {
+            return;
+        }
+    } while ((err = errno) == EINTR);
+    netty5_unix_errors_throwChannelExceptionErrorNo(env, "eventfd_write(...) failed: ", err);
+}
+
+static void netty5_io_uring_ring_buffer_exit(JNIEnv *env, jclass clazz,
+        jlong submissionQueueArrayAddress, jint submissionQueueRingEntries, jlong submissionQueueRingAddress, jint submissionQueueRingSize,
+        jlong completionQueueRingAddress, jint completionQueueRingSize, jint ringFd) {
+    munmap((struct io_uring_sqe*) submissionQueueArrayAddress, submissionQueueRingEntries * sizeof(struct io_uring_sqe));
+    munmap((void*) submissionQueueRingAddress, submissionQueueRingSize);
+
+    if (((void *) completionQueueRingAddress) && ((void *) completionQueueRingAddress) != ((void *) submissionQueueRingAddress)) {
+        munmap((void *)completionQueueRingAddress, completionQueueRingSize);
+    }
+    close(ringFd);
+}
+
+static jboolean netty5_io_uring_probe(JNIEnv *env, jclass clazz, jint ring_fd, jintArray ops) {
+    jboolean supported = JNI_FALSE;
+    struct io_uring_probe *probe;
+    size_t mallocLen = sizeof(*probe) + 256 * sizeof(struct io_uring_probe_op);
+    probe = malloc(mallocLen);
+    memset(probe, 0, mallocLen);
+
+    if (sys_io_uring_register(ring_fd, IORING_REGISTER_PROBE, probe, 256) < 0) {
+        netty5_unix_errors_throwRuntimeExceptionErrorNo(env, "failed to probe via sys_io_uring_register(....) ", errno);
+        goto done;
+    }
+
+    jsize opsLen = (*env)->GetArrayLength(env, ops);
+    jint *opsElements = (*env)->GetIntArrayElements(env, ops, 0);
+    int i;
+    for (i = 0; i < opsLen; i++) {
+        int op = opsElements[i];
+        if (op > probe->last_op || (probe->ops[op].flags & IO_URING_OP_SUPPORTED) == 0) {
+            goto done;
+        }
+    }
+    // all supported
+    supported = JNI_TRUE;
+done:
+    free(probe);
+    return supported;
+}
+
+
+static jobjectArray netty5_io_uring_setup(JNIEnv *env, jclass clazz, jint entries) {
+    struct io_uring_params p;
+    memset(&p, 0, sizeof(p));
+
+#ifdef IORING_SETUP_SUBMIT_ALL
+    p.flags = IORING_SETUP_SUBMIT_ALL;
+#endif
+
+    jobjectArray array = (*env)->NewObjectArray(env, 2, longArrayClass, NULL);
+    if (array == NULL) {
+        // This will put an OOME on the stack
+        return NULL;
+    }
+    jlongArray submissionArray = (*env)->NewLongArray(env, 11);
+    if (submissionArray == NULL) {
+        // This will put an OOME on the stack
+        return NULL;
+
+    }
+    jlongArray completionArray = (*env)->NewLongArray(env, 9);
+    if (completionArray == NULL) {
+        // This will put an OOME on the stack
+        return NULL;
+    }
+
+    int ring_fd = sys_io_uring_setup((int)entries, &p);
+
+    if (ring_fd < 0) {
+        if (errno == ENOMEM) {
+            netty5_unix_errors_throwRuntimeExceptionErrorNo(env,
+                "failed to allocate memory for io_uring ring; "
+                "try raising memlock limit (see getrlimit(RLIMIT_MEMLOCK, ...) or ulimit -l): ", errno);
+        } else {
+            netty5_unix_errors_throwRuntimeExceptionErrorNo(env, "failed to create io_uring ring fd: ", errno);
+        }
+        return NULL;
+    }
+    struct io_uring io_uring_ring;
+    int ret = setup_io_uring(ring_fd, &io_uring_ring, &p);
+
+    if (ret != 0) {
+        netty5_unix_errors_throwRuntimeExceptionErrorNo(env, "failed to mmap io_uring ring buffer: ", ret);
+        return NULL;
+    }
+
+    jlong submissionArrayElements[] = {
+        (jlong)io_uring_ring.sq.khead,
+        (jlong)io_uring_ring.sq.ktail,
+        (jlong)io_uring_ring.sq.kring_mask,
+        (jlong)io_uring_ring.sq.kring_entries,
+        (jlong)io_uring_ring.sq.kflags,
+        (jlong)io_uring_ring.sq.kdropped,
+        (jlong)io_uring_ring.sq.array,
+        (jlong)io_uring_ring.sq.sqes,
+        (jlong)io_uring_ring.sq.ring_sz,
+        (jlong)io_uring_ring.sq.ring_ptr,
+        (jlong)ring_fd
+    };
+    (*env)->SetLongArrayRegion(env, submissionArray, 0, 11, submissionArrayElements);
+
+    jlong completionArrayElements[] = {
+        (jlong)io_uring_ring.cq.khead,
+        (jlong)io_uring_ring.cq.ktail,
+        (jlong)io_uring_ring.cq.kring_mask,
+        (jlong)io_uring_ring.cq.kring_entries,
+        (jlong)io_uring_ring.cq.koverflow,
+        (jlong)io_uring_ring.cq.cqes,
+        (jlong)io_uring_ring.cq.ring_sz,
+        (jlong)io_uring_ring.cq.ring_ptr,
+        (jlong)ring_fd
+    };
+    (*env)->SetLongArrayRegion(env, completionArray, 0, 9, completionArrayElements);
+
+    (*env)->SetObjectArrayElement(env, array, 0, submissionArray);
+    (*env)->SetObjectArrayElement(env, array, 1, completionArray);
+    return array;
+}
+
+static jint netty5_create_file(JNIEnv *env, jclass class, jstring filename) {
+    const char *file = (*env)->GetStringUTFChars(env, filename, 0);
+
+    int fd =  open(file, O_RDWR | O_TRUNC | O_CREAT, 0644);
+    (*env)->ReleaseStringUTFChars(env, filename, file);
+    return fd;
+}
+
+
+static jint netty5_io_uring_registerUnix(JNIEnv* env, jclass clazz) {
+    register_unix_called = 1;
+    return netty5_unix_register(env, staticPackagePrefix);
+}
+
+static jint netty5_io_uring_sockNonblock(JNIEnv* env, jclass clazz) {
+    return SOCK_NONBLOCK;
+}
+
+static jint netty5_io_uring_sockCloexec(JNIEnv* env, jclass clazz) {
+    return SOCK_CLOEXEC;
+}
+
+static jint netty5_io_uring_afInet(JNIEnv* env, jclass clazz) {
+    return AF_INET;
+}
+
+static jint netty5_io_uring_afInet6(JNIEnv* env, jclass clazz) {
+    return AF_INET6;
+}
+
+static jint netty5_io_uring_sizeofSockaddrIn(JNIEnv* env, jclass clazz) {
+    return sizeof(struct sockaddr_in);
+}
+
+static jint netty5_io_uring_sizeofSockaddrIn6(JNIEnv* env, jclass clazz) {
+    return sizeof(struct sockaddr_in6);
+}
+
+static jint netty5_io_uring_sockaddrInOffsetofSinFamily(JNIEnv* env, jclass clazz) {
+    return offsetof(struct sockaddr_in, sin_family);
+}
+
+static jint netty5_io_uring_sockaddrInOffsetofSinPort(JNIEnv* env, jclass clazz) {
+    return offsetof(struct sockaddr_in, sin_port);
+}
+
+static jint netty5_io_uring_sockaddrInOffsetofSinAddr(JNIEnv* env, jclass clazz) {
+    return offsetof(struct sockaddr_in, sin_addr);
+}
+
+static jint netty5_io_uring_inAddressOffsetofSAddr(JNIEnv* env, jclass clazz) {
+    return offsetof(struct in_addr, s_addr);
+}
+
+static jint netty5_io_uring_sockaddrIn6OffsetofSin6Family(JNIEnv* env, jclass clazz) {
+    return offsetof(struct sockaddr_in6, sin6_family);
+}
+
+static jint netty5_io_uring_sockaddrIn6OffsetofSin6Port(JNIEnv* env, jclass clazz) {
+    return offsetof(struct sockaddr_in6, sin6_port);
+}
+
+static jint netty5_io_uring_sockaddrIn6OffsetofSin6Flowinfo(JNIEnv* env, jclass clazz) {
+    return offsetof(struct sockaddr_in6, sin6_flowinfo);
+}
+
+static jint netty5_io_uring_sockaddrIn6OffsetofSin6Addr(JNIEnv* env, jclass clazz) {
+    return offsetof(struct sockaddr_in6, sin6_addr);
+}
+
+static jint netty5_io_uring_sockaddrIn6OffsetofSin6ScopeId(JNIEnv* env, jclass clazz) {
+    return offsetof(struct sockaddr_in6, sin6_scope_id);
+}
+
+static jint netty5_io_uring_in6AddressOffsetofS6Addr(JNIEnv* env, jclass clazz) {
+    return offsetof(struct in6_addr, s6_addr);
+}
+
+static jint netty5_io_uring_sizeofSockaddrStorage(JNIEnv* env, jclass clazz) {
+    return sizeof(struct sockaddr_storage);
+}
+
+static jint netty5_io_uring_sizeofSizeT(JNIEnv* env, jclass clazz) {
+    return sizeof(size_t);
+}
+
+static jint netty5_io_uring_sizeofIovec(JNIEnv* env, jclass clazz) {
+    return sizeof(struct iovec);
+}
+
+static jint netty5_io_uring_iovecOffsetofIovBase(JNIEnv* env, jclass clazz) {
+    return offsetof(struct iovec, iov_base);
+}
+
+static jint netty5_io_uring_iovecOffsetofIovLen(JNIEnv* env, jclass clazz) {
+    return offsetof(struct iovec, iov_len);
+}
+
+static jint netty5_io_uring_sizeofMsghdr(JNIEnv* env, jclass clazz) {
+    return sizeof(struct msghdr);
+}
+
+static jint netty5_io_uring_msghdrOffsetofMsgName(JNIEnv* env, jclass clazz) {
+    return offsetof(struct msghdr, msg_name);
+}
+
+static jint netty5_io_uring_msghdrOffsetofMsgNamelen(JNIEnv* env, jclass clazz) {
+    return offsetof(struct msghdr, msg_namelen);
+}
+static jint netty5_io_uring_msghdrOffsetofMsgIov(JNIEnv* env, jclass clazz) {
+    return offsetof(struct msghdr, msg_iov);
+}
+static jint netty5_io_uring_msghdrOffsetofMsgIovlen(JNIEnv* env, jclass clazz) {
+    return offsetof(struct msghdr, msg_iovlen);
+}
+
+static jint netty5_io_uring_msghdrOffsetofMsgControl(JNIEnv* env, jclass clazz) {
+    return offsetof(struct msghdr, msg_control);
+}
+
+static jint netty5_io_uring_msghdrOffsetofMsgControllen(JNIEnv* env, jclass clazz) {
+    return offsetof(struct msghdr, msg_controllen);
+}
+
+static jint netty5_io_uring_msghdrOffsetofMsgFlags(JNIEnv* env, jclass clazz) {
+    return offsetof(struct msghdr, msg_flags);
+}
+
+static jint netty5_io_uring_cmsghdrOffsetofCmsgLen(JNIEnv* env, jclass clazz) {
+    return offsetof(struct cmsghdr, cmsg_len);
+}
+
+static jint netty5_io_uring_cmsghdrOffsetofCmsgLevel(JNIEnv* env, jclass clazz) {
+    return offsetof(struct cmsghdr, cmsg_level);
+}
+
+static jint netty5_io_uring_cmsghdrOffsetofCmsgType(JNIEnv* env, jclass clazz) {
+    return offsetof(struct cmsghdr, cmsg_type);
+}
+
+static jlong netty5_io_uring_cmsghdrData(JNIEnv* env, jclass clazz, jlong cmsghdrAddr) {
+    return (jlong) CMSG_DATA((struct cmsghdr*) cmsghdrAddr);
+}
+
+static int getSysctlValue(const char * property, int* returnValue) {
+    int rc = -1;
+    FILE *fd=fopen(property, "r");
+    if (fd != NULL) {
+      char buf[32] = {0x0};
+      if (fgets(buf, 32, fd) != NULL) {
+        *returnValue = atoi(buf);
+        rc = 0;
+      }
+      fclose(fd);
+    }
+    return rc;
+}
+
+static jint netty5_io_uring_tcpFastopenMode(JNIEnv* env, jclass clazz) {
+    int fastopen = 0;
+    getSysctlValue("/proc/sys/net/ipv4/tcp_fastopen", &fastopen);
+    return fastopen;
+}
+
+static jint netty5_io_uring_etime(JNIEnv* env, jclass clazz) {
+    return ETIME;
+}
+
+static jint netty5_io_uring_ecanceled(JNIEnv* env, jclass clazz) {
+    return ECANCELED;
+}
+
+static jint netty5_io_uring_pollin(JNIEnv* env, jclass clazz) {
+    return POLLIN;
+}
+
+static jint netty5_io_uring_pollout(JNIEnv* env, jclass clazz) {
+    return POLLOUT;
+}
+
+static jint netty5_io_uring_pollrdhup(JNIEnv* env, jclass clazz) {
+    return POLLRDHUP;
+}
+
+static jint netty5_io_uring_ioringEnterGetevents(JNIEnv* env, jclass clazz) {
+    return IORING_ENTER_GETEVENTS;
+}
+
+static jint netty5_io_uring_iosqeAsync(JNIEnv* env, jclass clazz) {
+    return IOSQE_ASYNC;
+}
+
+static jint netty5_io_uring_iosqeLink(JNIEnv* env, jclass clazz) {
+    return IOSQE_IO_LINK;
+}
+
+static jint netty5_io_uring_iosqeDrain(JNIEnv* env, jclass clazz) {
+    return IOSQE_IO_DRAIN;
+}
+
+static jint netty5_io_uring_msgDontwait(JNIEnv* env, jclass clazz) {
+    return MSG_DONTWAIT;
+}
+
+static jint netty5_io_uring_msgFastopen(JNIEnv* env, jclass clazz) {
+    return MSG_FASTOPEN;
+}
+
+static jint netty5_io_uring_cmsgSpace(JNIEnv* env, jclass clazz) {
+    return CMSG_SPACE(sizeof(uint16_t));
+}
+
+static jint netty5_io_uring_cmsgLen(JNIEnv* env, jclass clazz) {
+    return CMSG_LEN(sizeof(uint16_t));
+}
+
+static jint netty5_io_uring_solUdp(JNIEnv* env, jclass clazz) {
+    return SOL_UDP;
+}
+
+static jint netty5_io_uring_udpSegment(JNIEnv* env, jclass clazz) {
+    return UDP_SEGMENT;
+}
+
+// JNI Method Registration Table Begin
+static const JNINativeMethod statically_referenced_fixed_method_table[] = {
+  { "sockNonblock", "()I", (void *) netty5_io_uring_sockNonblock },
+  { "sockCloexec", "()I", (void *) netty5_io_uring_sockCloexec },
+  { "afInet", "()I", (void *) netty5_io_uring_afInet },
+  { "afInet6", "()I", (void *) netty5_io_uring_afInet6 },
+  { "sizeofSockaddrIn", "()I", (void *) netty5_io_uring_sizeofSockaddrIn },
+  { "sizeofSockaddrIn6", "()I", (void *) netty5_io_uring_sizeofSockaddrIn6 },
+  { "sockaddrInOffsetofSinFamily", "()I", (void *) netty5_io_uring_sockaddrInOffsetofSinFamily },
+  { "sockaddrInOffsetofSinPort", "()I", (void *) netty5_io_uring_sockaddrInOffsetofSinPort },
+  { "sockaddrInOffsetofSinAddr", "()I", (void *) netty5_io_uring_sockaddrInOffsetofSinAddr },
+  { "inAddressOffsetofSAddr", "()I", (void *) netty5_io_uring_inAddressOffsetofSAddr },
+  { "sockaddrIn6OffsetofSin6Family", "()I", (void *) netty5_io_uring_sockaddrIn6OffsetofSin6Family },
+  { "sockaddrIn6OffsetofSin6Port", "()I", (void *) netty5_io_uring_sockaddrIn6OffsetofSin6Port },
+  { "sockaddrIn6OffsetofSin6Flowinfo", "()I", (void *) netty5_io_uring_sockaddrIn6OffsetofSin6Flowinfo },
+  { "sockaddrIn6OffsetofSin6Addr", "()I", (void *) netty5_io_uring_sockaddrIn6OffsetofSin6Addr },
+  { "sockaddrIn6OffsetofSin6ScopeId", "()I", (void *) netty5_io_uring_sockaddrIn6OffsetofSin6ScopeId },
+  { "in6AddressOffsetofS6Addr", "()I", (void *) netty5_io_uring_in6AddressOffsetofS6Addr },
+  { "sizeofSockaddrStorage", "()I", (void *) netty5_io_uring_sizeofSockaddrStorage },
+  { "sizeofSizeT", "()I", (void *) netty5_io_uring_sizeofSizeT },
+  { "sizeofIovec", "()I", (void *) netty5_io_uring_sizeofIovec },
+  { "cmsgSpace", "()I", (void *) netty5_io_uring_cmsgSpace},
+  { "cmsgLen", "()I", (void *) netty5_io_uring_cmsgLen},
+  { "iovecOffsetofIovBase", "()I", (void *) netty5_io_uring_iovecOffsetofIovBase },
+  { "iovecOffsetofIovLen", "()I", (void *) netty5_io_uring_iovecOffsetofIovLen },
+  { "sizeofMsghdr", "()I", (void *) netty5_io_uring_sizeofMsghdr },
+  { "msghdrOffsetofMsgName", "()I", (void *) netty5_io_uring_msghdrOffsetofMsgName },
+  { "msghdrOffsetofMsgNamelen", "()I", (void *) netty5_io_uring_msghdrOffsetofMsgNamelen },
+  { "msghdrOffsetofMsgIov", "()I", (void *) netty5_io_uring_msghdrOffsetofMsgIov },
+  { "msghdrOffsetofMsgIovlen", "()I", (void *) netty5_io_uring_msghdrOffsetofMsgIovlen },
+  { "msghdrOffsetofMsgControl", "()I", (void *) netty5_io_uring_msghdrOffsetofMsgControl },
+  { "msghdrOffsetofMsgControllen", "()I", (void *) netty5_io_uring_msghdrOffsetofMsgControllen },
+  { "msghdrOffsetofMsgFlags", "()I", (void *) netty5_io_uring_msghdrOffsetofMsgFlags },
+  { "etime", "()I", (void *) netty5_io_uring_etime },
+  { "ecanceled", "()I", (void *) netty5_io_uring_ecanceled },
+  { "pollin", "()I", (void *) netty5_io_uring_pollin },
+  { "pollout", "()I", (void *) netty5_io_uring_pollout },
+  { "pollrdhup", "()I", (void *) netty5_io_uring_pollrdhup },
+  { "ioringEnterGetevents", "()I", (void *) netty5_io_uring_ioringEnterGetevents },
+  { "iosqeAsync", "()I", (void *) netty5_io_uring_iosqeAsync },
+  { "iosqeLink", "()I", (void *) netty5_io_uring_iosqeLink },
+  { "iosqeDrain", "()I", (void *) netty5_io_uring_iosqeDrain },
+  { "msgDontwait", "()I", (void *) netty5_io_uring_msgDontwait },
+  { "msgFastopen", "()I", (void *) netty5_io_uring_msgFastopen },
+  { "solUdp", "()I", (void *) netty5_io_uring_solUdp },
+  { "udpSegment", "()I", (void *) netty5_io_uring_udpSegment },
+  { "cmsghdrOffsetofCmsgLen", "()I", (void *) netty5_io_uring_cmsghdrOffsetofCmsgLen },
+  { "cmsghdrOffsetofCmsgLevel", "()I", (void *) netty5_io_uring_cmsghdrOffsetofCmsgLevel },
+  { "cmsghdrOffsetofCmsgType", "()I", (void *) netty5_io_uring_cmsghdrOffsetofCmsgType },
+  { "tcpFastopenMode", "()I", (void *) netty5_io_uring_tcpFastopenMode },
+};
+static const jint statically_referenced_fixed_method_table_size = sizeof(statically_referenced_fixed_method_table) / sizeof(statically_referenced_fixed_method_table[0]);
+
+static const JNINativeMethod method_table[] = {
+    {"ioUringSetup", "(I)[[J", (void *) netty5_io_uring_setup},
+    {"ioUringProbe", "(I[I)Z", (void *) netty5_io_uring_probe},
+    {"ioUringExit", "(JIJIJII)V", (void *) netty5_io_uring_ring_buffer_exit},
+    {"createFile", "(Ljava/lang/String;)I", (void *) netty5_create_file},
+    {"ioUringEnter", "(IIII)I", (void *) netty5_io_uring_enter},
+    {"blockingEventFd", "()I", (void *) netty5_epoll_native_blocking_event_fd},
+    {"eventFdWrite", "(IJ)V", (void *) netty5_io_uring_eventFdWrite },
+    {"registerUnix", "()I", (void *) netty5_io_uring_registerUnix },
+    {"cmsghdrData", "(J)J", (void *) netty5_io_uring_cmsghdrData},
+    {"kernelVersion", "()Ljava/lang/String;", (void *) netty5_io_uring_kernel_version },
+};
+static const jint method_table_size =
+    sizeof(method_table) / sizeof(method_table[0]);
+// JNI Method Registration Table End
+
+static jint netty5_iouring_native_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
+    int ret = JNI_ERR;
+    int nativeRegistered = 0;
+    int staticallyRegistered = 0;
+    int linuxsocketOnLoadCalled = 0;
+
+    // We must register the statically referenced methods first!
+    if (netty_jni_util_register_natives(env,
+            packagePrefix,
+            STATICALLY_CLASSNAME,
+            statically_referenced_fixed_method_table,
+            statically_referenced_fixed_method_table_size) != 0) {
+        goto done;
+    }
+    nativeRegistered = 1;
+
+    if (netty_jni_util_register_natives(env, packagePrefix,
+                                       NATIVE_CLASSNAME,
+                                       method_table, method_table_size) != 0) {
+        goto done;
+    }
+    staticallyRegistered = 1;
+
+    if (netty5_io_uring_linuxsocket_JNI_OnLoad(env, packagePrefix) == JNI_ERR) {
+        goto done;
+    }
+    linuxsocketOnLoadCalled = 1;
+
+    NETTY_JNI_UTIL_LOAD_CLASS(env, longArrayClass, "[J", done);
+
+    if (packagePrefix != NULL) {
+        staticPackagePrefix = strdup(packagePrefix);
+    }
+    ret = NETTY_JNI_UTIL_JNI_VERSION;
+done:
+    if (ret == JNI_ERR) {
+        if (nativeRegistered == 1) {
+            netty_jni_util_unregister_natives(env, packagePrefix, NATIVE_CLASSNAME);
+        }
+        if (staticallyRegistered == 1) {
+            netty_jni_util_unregister_natives(env, packagePrefix, STATICALLY_CLASSNAME);
+        }
+        if (linuxsocketOnLoadCalled == 1) {
+            netty5_io_uring_linuxsocket_JNI_OnUnLoad(env, packagePrefix);
+        }
+    }
+    return ret;
+}
+
+static void netty5_iouring_native_JNI_OnUnload(JNIEnv* env) {
+    netty_jni_util_unregister_natives(env, staticPackagePrefix, NATIVE_CLASSNAME);
+    netty_jni_util_unregister_natives(env, staticPackagePrefix, STATICALLY_CLASSNAME);
+    netty5_io_uring_native_JNI_OnUnLoad(env, staticPackagePrefix);
+
+    if (register_unix_called == 1) {
+        register_unix_called = 0;
+        netty5_unix_unregister(env, staticPackagePrefix);
+    }
+    if (staticPackagePrefix != NULL) {
+        free((void *) staticPackagePrefix);
+        staticPackagePrefix = NULL;
+    }
+}
+
+// Invoked by the JVM when statically linked
+JNIEXPORT jint JNI_OnLoad_netty5_transport_native_io_uring(JavaVM* vm, void* reserved) {
+    jint ret = netty_jni_util_JNI_OnLoad(vm, reserved, LIBRARYNAME, netty5_iouring_native_JNI_OnLoad);
+    return ret;
+}
+
+// Invoked by the JVM when statically linked
+JNIEXPORT void JNI_OnUnload_netty5_transport_native_io_uring(JavaVM* vm, void* reserved) {
+    netty_jni_util_JNI_OnUnload(vm, reserved, netty5_iouring_native_JNI_OnUnload);
+}
+
+#ifndef NETTY5_IO_URING_BUILD_STATIC
+JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *reserved) {
+    return netty_jni_util_JNI_OnLoad(vm, reserved, LIBRARYNAME, netty5_iouring_native_JNI_OnLoad);
+}
+
+JNIEXPORT void JNI_OnUnload(JavaVM* vm, void* reserved) {
+    netty_jni_util_JNI_OnUnload(vm, reserved, netty5_iouring_native_JNI_OnUnload);
+}
+#endif /* NETTY5_IO_URING_BUILD_STATIC */
+

--- a/transport-native-io_uring/src/main/c/syscall.c
+++ b/transport-native-io_uring/src/main/c/syscall.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+  /* SPDX-License-Identifier: MIT */
+#include "syscall.h"
+#include <signal.h>
+#include <sys/syscall.h>
+#include <sys/uio.h>
+#include <unistd.h>
+
+// Define syscall numbers if not exists as these are "stable".
+#ifndef __NR_io_uring_setup
+#define __NR_io_uring_setup		425
+#endif
+#ifndef __NR_io_uring_enter
+#define __NR_io_uring_enter		426
+#endif
+#ifndef __NR_io_uring_register
+#define __NR_io_uring_register	427
+#endif
+
+int sys_io_uring_setup(unsigned entries, struct io_uring_params *p) {
+    return syscall(__NR_io_uring_setup, entries, p);
+}
+
+int sys_io_uring_enter(int fd, unsigned to_submit, unsigned min_complete,
+                       unsigned flags, sigset_t *sig) {
+    return syscall(__NR_io_uring_enter, fd, to_submit, min_complete, flags, sig,
+                 _NSIG / 8);
+}
+
+int sys_io_uring_register(int fd, unsigned opcode, const void *arg, unsigned nr_args) {
+    return syscall(__NR_io_uring_register, fd, opcode, arg, nr_args);
+}

--- a/transport-native-io_uring/src/main/c/syscall.h
+++ b/transport-native-io_uring/src/main/c/syscall.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+ /* SPDX-License-Identifier: MIT */
+#include <signal.h>
+#include "io_uring.h"
+#ifndef LIBURING_SYSCALL_H
+#define LIBURING_SYSCALL_H
+
+/*
+ * System calls
+ */
+extern int sys_io_uring_setup(unsigned entries, struct io_uring_params *p);
+extern int sys_io_uring_enter(int fd, unsigned to_submit, unsigned min_complete,
+                              unsigned flags, sigset_t *sig);
+extern int sys_io_uring_register(int fd, unsigned int opcode, const void *arg, unsigned int nr_args);
+#endif

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/CombinationOfEpollAndIOUringTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/CombinationOfEpollAndIOUringTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.channel.epoll.Epoll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class CombinationOfEpollAndIOUringTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        // Epoll must be usable.
+        Epoll.ensureAvailability();
+        assumeTrue(IOUring.isAvailable());
+    }
+
+    @Test
+    public void testEpollAndIOUringCanBothBeLoaded() {
+        Epoll.ensureAvailability();
+        IOUring.ensureAvailability();
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/CombinationOfIOUringAndEpollTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/CombinationOfIOUringAndEpollTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.channel.epoll.Epoll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class CombinationOfIOUringAndEpollTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+        // Epoll must be usable.
+        Epoll.ensureAvailability();
+    }
+
+    @Test
+    public void testIOUringAndEpollCanBothBeLoaded() {
+        IOUring.ensureAvailability();
+        Epoll.ensureAvailability();
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringCompositeBufferGatheringWriteTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringCompositeBufferGatheringWriteTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.testsuite.transport.TestsuitePermutation;
+import io.netty5.testsuite.transport.socket.CompositeBufferGatheringWriteTest;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IOUringCompositeBufferGatheringWriteTest extends CompositeBufferGatheringWriteTest  {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.socket();
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringDatagramConnectNotExistsTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringDatagramConnectNotExistsTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.testsuite.transport.TestsuitePermutation;
+import io.netty5.testsuite.transport.socket.DatagramConnectNotExistsTest;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IOUringDatagramConnectNotExistsTest extends DatagramConnectNotExistsTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.datagramSocket();
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringDatagramMulticastIPv6Test.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringDatagramMulticastIPv6Test.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.testsuite.transport.TestsuitePermutation;
+import io.netty5.testsuite.transport.socket.DatagramMulticastIPv6Test;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IOUringDatagramMulticastIPv6Test extends DatagramMulticastIPv6Test {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<Bootstrap, Bootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.datagram(protocolFamily());
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringDatagramMulticastTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringDatagramMulticastTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.testsuite.transport.TestsuitePermutation;
+import io.netty5.testsuite.transport.socket.DatagramMulticastTest;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IOUringDatagramMulticastTest extends DatagramMulticastTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<Bootstrap, Bootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.datagram(protocolFamily());
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringDatagramUnicastIPv6MappedTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringDatagramUnicastIPv6MappedTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.testsuite.transport.TestsuitePermutation.BootstrapComboFactory;
+import io.netty5.testsuite.transport.socket.DatagramUnicastIPv6MappedTest;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IOUringDatagramUnicastIPv6MappedTest extends DatagramUnicastIPv6MappedTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
+    @Override
+    protected List<BootstrapComboFactory<Bootstrap, Bootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.datagram(protocolFamily());
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringDatagramUnicastIPv6Test.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringDatagramUnicastIPv6Test.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.testsuite.transport.TestsuitePermutation;
+import io.netty5.testsuite.transport.socket.DatagramUnicastIPv6Test;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IOUringDatagramUnicastIPv6Test extends DatagramUnicastIPv6Test {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<Bootstrap, Bootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.datagram(protocolFamily());
+    }
+
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringDatagramUnicastTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringDatagramUnicastTest.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.buffer.Buffer;
+import io.netty5.channel.Channel;
+import io.netty5.channel.ChannelHandlerAdapter;
+import io.netty5.channel.ChannelHandlerContext;
+import io.netty5.channel.ChannelOption;
+import io.netty5.channel.FixedReadHandleFactory;
+import io.netty5.channel.SimpleChannelInboundHandler;
+import io.netty5.channel.socket.DatagramPacket;
+import io.netty5.channel.socket.SocketProtocolFamily;
+import io.netty5.channel.unix.SegmentedDatagramPacket;
+import io.netty5.testsuite.transport.TestsuitePermutation;
+import io.netty5.testsuite.transport.socket.DatagramUnicastInetTest;
+import io.netty5.util.ReferenceCountUtil;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import static io.netty5.buffer.DefaultBufferAllocators.offHeapAllocator;
+import static java.util.Arrays.stream;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IOUringDatagramUnicastTest extends DatagramUnicastInetTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<Bootstrap, Bootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.datagram(SocketProtocolFamily.INET);
+    }
+
+    @Test
+    @Timeout(8)
+    public void testRecvMsgDontBlock(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testRecvMsgDontBlock);
+    }
+
+    public void testRecvMsgDontBlock(Bootstrap sb, Bootstrap cb) throws Throwable {
+        Channel sc = null;
+        Channel cc = null;
+
+        try {
+            cb.handler(new SimpleChannelInboundHandler<>() {
+                @Override
+                protected void messageReceived(ChannelHandlerContext ctx, Object msg) {
+                    // NOOP.
+                }
+            });
+            cc = cb.bind(newSocketAddress()).asStage().get();
+
+            CountDownLatch readLatch = new CountDownLatch(1);
+            CountDownLatch readCompleteLatch = new CountDownLatch(1);
+            sc = sb.handler(new ChannelHandlerAdapter() {
+                @Override
+                public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                    readLatch.countDown();
+                    ReferenceCountUtil.release(msg);
+                }
+
+                @Override
+                public void channelReadComplete(ChannelHandlerContext ctx) {
+                    readCompleteLatch.countDown();
+                }
+            }).option(ChannelOption.READ_HANDLE_FACTORY, new FixedReadHandleFactory(2048))
+                    .bind(newSocketAddress()).asStage().get();
+            InetSocketAddress addr = sendToAddress((InetSocketAddress) sc.localAddress());
+            cc.writeAndFlush(new DatagramPacket(offHeapAllocator().copyOf(new byte[512]), addr)).asStage().sync();
+
+            readLatch.await();
+            readCompleteLatch.await();
+        } finally {
+            if (cc != null) {
+                cc.close().asStage().sync();
+            }
+            if (sc != null) {
+                sc.close().asStage().sync();
+            }
+        }
+    }
+
+    @Test
+    public void testSendSegmentedDatagramPacket(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testSendSegmentedDatagramPacket);
+    }
+
+    public void testSendSegmentedDatagramPacket(Bootstrap sb, Bootstrap cb) throws Throwable {
+        testSegmentedDatagramPacket(sb, cb, false, false);
+    }
+
+    @Disabled("Loopback does not support packet segmentation.")
+    @Test
+    public void testSendSegmentedDatagramPacketComposite(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testSendSegmentedDatagramPacketComposite);
+    }
+
+    public void testSendSegmentedDatagramPacketComposite(Bootstrap sb, Bootstrap cb) throws Throwable {
+        testSegmentedDatagramPacket(sb, cb, true, false);
+    }
+
+    @Disabled("Loopback does not support packet segmentation.")
+    @Test
+    public void testSendAndReceiveSegmentedDatagramPacket(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testSendAndReceiveSegmentedDatagramPacket);
+    }
+
+    public void testSendAndReceiveSegmentedDatagramPacket(Bootstrap sb, Bootstrap cb) throws Throwable {
+        testSegmentedDatagramPacket(sb, cb, false, true);
+    }
+
+    @Disabled("Loopback does not support packet segmentation.")
+    @Test
+    public void testSendAndReceiveSegmentedDatagramPacketComposite(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testSendAndReceiveSegmentedDatagramPacketComposite);
+    }
+
+    public void testSendAndReceiveSegmentedDatagramPacketComposite(Bootstrap sb, Bootstrap cb) throws Throwable {
+        testSegmentedDatagramPacket(sb, cb, true, true);
+    }
+
+    private void testSegmentedDatagramPacket(Bootstrap sb, Bootstrap cb, boolean composite, boolean gro)
+            throws Throwable {
+        assumeTrue(IOUringDatagramChannel.isSegmentedDatagramPacketSupported());
+        Channel sc = null;
+        Channel cc = null;
+
+        try {
+            cb.handler(new SimpleChannelInboundHandler<>() {
+                @Override
+                public void messageReceived(ChannelHandlerContext ctx, Object msgs) {
+                    // Nothing will be sent.
+                }
+            });
+
+            cc = cb.bind(newSocketAddress()).asStage().get();
+            if (!(cc instanceof IOUringDatagramChannel)) {
+                // Only supported for the native io_uring transport.
+                return;
+            }
+            final int numBuffers = 16;
+            final int segmentSize = 512;
+            int bufferCapacity = numBuffers * segmentSize;
+            final CountDownLatch latch = new CountDownLatch(numBuffers);
+            AtomicReference<Throwable> errorRef = new AtomicReference<>();
+            if (gro) {
+                // Enable GRO and also ensure we can read everything with one read as otherwise
+                // we will drop things on the floor.
+                sb.option(IOUringChannelOption.UDP_GRO, true);
+                sb.option(ChannelOption.READ_HANDLE_FACTORY, new FixedReadHandleFactory(bufferCapacity));
+            }
+            sc = sb.handler(new SimpleChannelInboundHandler<>() {
+                @Override
+                public void messageReceived(ChannelHandlerContext ctx, Object msg) {
+                    if (msg instanceof DatagramPacket) {
+                        DatagramPacket packet = (DatagramPacket) msg;
+                        int packetSize = packet.content().readableBytes();
+                        assertEquals(segmentSize, packetSize, "Unexpected datagram packet size");
+                        latch.countDown();
+                    } else {
+                        fail("Unexpected message of type " + msg.getClass() + ": " + msg);
+                    }
+                }
+
+                @Override
+                public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+                    do {
+                        Throwable throwable = errorRef.get();
+                        if (throwable != null) {
+                            if (throwable != cause) {
+                                throwable.addSuppressed(cause);
+                            }
+                            break;
+                        }
+                    } while (!errorRef.compareAndSet(null, cause));
+                    super.channelExceptionCaught(ctx, cause);
+                }
+            }).bind(newSocketAddress()).asStage().get();
+
+            if (gro && !(sc instanceof IOUringDatagramChannel)) {
+                // Only supported for the native io_uring transport.
+                return;
+            }
+            if (sc instanceof IOUringDatagramChannel) {
+                assertEquals(gro, sc.getOption(IOUringChannelOption.UDP_GRO));
+            }
+            InetSocketAddress addr = sendToAddress((InetSocketAddress) sc.localAddress());
+            final Buffer buffer;
+            if (composite) {
+                Buffer[] components = new Buffer[numBuffers];
+                for (int i = 0; i < numBuffers; i++) {
+                    components[i] = offHeapAllocator().allocate(segmentSize);
+                    components[i].fill((byte) 0);
+                    components[i].skipWritableBytes(segmentSize);
+                }
+                buffer = offHeapAllocator().compose(stream(components).map(Buffer::send).collect(Collectors.toList()));
+            } else {
+                buffer = offHeapAllocator().allocate(bufferCapacity);
+                buffer.fill((byte) 0);
+                buffer.skipWritableBytes(bufferCapacity);
+            }
+            cc.writeAndFlush(new SegmentedDatagramPacket(buffer, segmentSize, addr)).asStage().sync();
+
+            if (!latch.await(10, TimeUnit.SECONDS)) {
+                Throwable error = errorRef.get();
+                if (error != null) {
+                    throw error;
+                }
+                fail();
+            }
+        } finally {
+            if (cc != null) {
+                cc.close().asStage().sync();
+            }
+            if (sc != null) {
+                sc.close().asStage().sync();
+            }
+        }
+    }
+
+    @Override
+    protected boolean supportDisconnect() {
+        return false;
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringDetectPeerCloseWithReadTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringDetectPeerCloseWithReadTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.channel.Channel;
+import io.netty5.channel.EventLoopGroup;
+import io.netty5.channel.MultithreadEventLoopGroup;
+import io.netty5.channel.ServerChannel;
+import io.netty5.channel.unix.tests.DetectPeerCloseWithoutReadTest;
+import org.junit.jupiter.api.BeforeAll;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IOUringDetectPeerCloseWithReadTest extends DetectPeerCloseWithoutReadTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
+    @Override
+    protected EventLoopGroup newGroup() {
+        return new MultithreadEventLoopGroup(2, IOUring.newFactory());
+    }
+
+    @Override
+    protected Class<? extends ServerChannel> serverChannel() {
+        return IOUringServerSocketChannel.class;
+    }
+
+    @Override
+    protected Class<? extends Channel> clientChannel() {
+        return IOUringSocketChannel.class;
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringEventLoopTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringEventLoopTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.channel.EventLoop;
+import io.netty5.channel.EventLoopGroup;
+import io.netty5.channel.IoHandlerFactory;
+import io.netty5.channel.MultithreadEventLoopGroup;
+import io.netty5.channel.ServerChannel;
+import io.netty5.testsuite.transport.AbstractSingleThreadEventLoopTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IOUringEventLoopTest extends AbstractSingleThreadEventLoopTest {
+
+    public static final Runnable EMPTY_RUNNABLE = () -> {
+    };
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
+    @Override
+    protected IoHandlerFactory newIoHandlerFactory() {
+        return IOUring.newFactory();
+    }
+
+    @Override
+    protected Class<? extends ServerChannel> serverChannelClass() {
+        return IOUringServerSocketChannel.class;
+    }
+
+    @Test
+    public void testSubmitMultipleTasksAndEnsureTheseAreExecuted() throws Exception {
+        EventLoopGroup group =  new MultithreadEventLoopGroup(1, newIoHandlerFactory());
+        try {
+            EventLoop loop = group.next();
+            loop.submit(EMPTY_RUNNABLE).asStage().sync();
+            loop.submit(EMPTY_RUNNABLE).asStage().sync();
+            loop.submit(EMPTY_RUNNABLE).asStage().sync();
+            loop.submit(EMPTY_RUNNABLE).asStage().sync();
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+
+    @Test
+    public void testSchedule() throws Exception {
+        EventLoopGroup group = new MultithreadEventLoopGroup(1, IOUring.newFactory());
+        try {
+            EventLoop loop = group.next();
+            loop.schedule(EMPTY_RUNNABLE, 1, TimeUnit.SECONDS).asStage().sync();
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringRemoteIpTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringRemoteIpTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.channel.Channel;
+import io.netty5.channel.ChannelHandlerAdapter;
+import io.netty5.channel.ChannelHandlerContext;
+import io.netty5.channel.EventLoopGroup;
+import io.netty5.channel.MultithreadEventLoopGroup;
+import io.netty5.util.NetUtil;
+import io.netty5.util.concurrent.Future;
+import io.netty5.util.concurrent.ImmediateEventExecutor;
+import io.netty5.util.concurrent.Promise;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.opentest4j.TestAbortedException;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.SocketException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class IOUringRemoteIpTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        Assumptions.assumeTrue(IOUring.isAvailable());
+    }
+
+    @Test
+    public void testRemoteAddressIpv4() throws Exception {
+        testRemoteAddress(NetUtil.LOCALHOST4, NetUtil.LOCALHOST4);
+    }
+
+    @Test
+    public void testRemoteAddressIpv6() throws Exception {
+        testRemoteAddress(NetUtil.LOCALHOST6, NetUtil.LOCALHOST6);
+    }
+
+    @Test
+    public void testRemoteAddressIpv4AndServerAutoDetect() throws Exception {
+        testRemoteAddress(null, NetUtil.LOCALHOST4);
+    }
+
+    @Test
+    public void testRemoteAddressIpv6ServerAutoDetect() throws Exception {
+        testRemoteAddress(null, NetUtil.LOCALHOST6);
+    }
+
+    private static void testRemoteAddress(InetAddress server, InetAddress client) throws Exception {
+        final Promise<SocketAddress> promise = ImmediateEventExecutor.INSTANCE.newPromise();
+        EventLoopGroup bossGroup = new MultithreadEventLoopGroup(1, IOUring.newFactory());
+        Socket socket = new Socket();
+        try {
+            ServerBootstrap b = new ServerBootstrap();
+            b.group(bossGroup)
+                    .channel(IOUringServerSocketChannel.class)
+                    .childHandler(new ChannelHandlerAdapter() {
+                        @Override
+                        public void channelActive(ChannelHandlerContext ctx) {
+                            promise.setSuccess(ctx.channel().remoteAddress());
+                            ctx.close();
+                        }
+                    });
+
+            // Start the server.
+            Future<Channel> f;
+            InetSocketAddress connectAddress;
+            if (server == null) {
+                f = b.bind(0).asStage().sync().future();
+                connectAddress = new InetSocketAddress(client,
+                        ((InetSocketAddress) f.getNow().localAddress()).getPort());
+            } else {
+                try {
+                    f = b.bind(server, 0).asStage().sync().future();
+                } catch (Throwable cause) {
+                    throw new TestAbortedException("Bind failed, address family not supported ?", cause);
+                }
+                connectAddress = (InetSocketAddress) f.getNow().localAddress();
+            }
+
+            try {
+                socket.bind(new InetSocketAddress(client, 0));
+            } catch (SocketException e) {
+                throw new TestAbortedException("Bind failed, address family not supported ?", e);
+            }
+            socket.connect(connectAddress);
+
+            InetSocketAddress addr = (InetSocketAddress) promise.asFuture().asStage().get();
+            assertEquals(socket.getLocalSocketAddress(), addr);
+            f.getNow().close().asStage().sync();
+        } finally {
+            // Shut down all event loops to terminate all threads.
+            bossGroup.shutdownGracefully();
+
+            socket.close();
+        }
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketAutoReadTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketAutoReadTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.testsuite.transport.TestsuitePermutation;
+import io.netty5.testsuite.transport.socket.SocketAutoReadTest;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IOUringSocketAutoReadTest extends SocketAutoReadTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.socket();
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketChannelNotYetConnectedTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketChannelNotYetConnectedTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.testsuite.transport.TestsuitePermutation;
+import io.netty5.testsuite.transport.socket.SocketChannelNotYetConnectedTest;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IOUringSocketChannelNotYetConnectedTest extends SocketChannelNotYetConnectedTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.clientSocket();
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketConditionalWritabilityTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketConditionalWritabilityTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.testsuite.transport.TestsuitePermutation;
+import io.netty5.testsuite.transport.socket.SocketConditionalWritabilityTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IOUringSocketConditionalWritabilityTest extends SocketConditionalWritabilityTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.socket();
+    }
+
+    @Test
+    @Override
+    public void testConditionalWritability(TestInfo testInfo) throws Throwable {
+        // Ignore as it does not pass on QEMU atm
+        // super.testConditionalWritability();
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketConnectTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketConnectTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.testsuite.transport.TestsuitePermutation;
+import io.netty5.testsuite.transport.socket.SocketConnectTest;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IOUringSocketConnectTest extends SocketConnectTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.socket();
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketConnectionAttemptTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketConnectionAttemptTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.testsuite.transport.TestsuitePermutation;
+import io.netty5.testsuite.transport.socket.SocketConnectionAttemptTest;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IOUringSocketConnectionAttemptTest extends SocketConnectionAttemptTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.clientSocket();
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketDataReadInitialStateTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketDataReadInitialStateTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.testsuite.transport.TestsuitePermutation;
+import io.netty5.testsuite.transport.socket.SocketDataReadInitialStateTest;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IOUringSocketDataReadInitialStateTest extends SocketDataReadInitialStateTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.socket();
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketEchoTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketEchoTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.testsuite.transport.TestsuitePermutation.BootstrapComboFactory;
+import io.netty5.testsuite.transport.socket.SocketEchoTest;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IOUringSocketEchoTest extends SocketEchoTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
+    @Override
+    protected List<BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.socket();
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketExceptionHandlingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketExceptionHandlingTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.testsuite.transport.TestsuitePermutation;
+import io.netty5.testsuite.transport.socket.SocketExceptionHandlingTest;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IOUringSocketExceptionHandlingTest extends SocketExceptionHandlingTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.socket();
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketFixedLengthEchoTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketFixedLengthEchoTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.testsuite.transport.TestsuitePermutation;
+import io.netty5.testsuite.transport.socket.SocketFixedLengthEchoTest;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IOUringSocketFixedLengthEchoTest extends SocketFixedLengthEchoTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.socket();
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketGatheringWriteTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketGatheringWriteTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.testsuite.transport.TestsuitePermutation;
+import io.netty5.testsuite.transport.socket.SocketGatheringWriteTest;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IOUringSocketGatheringWriteTest extends SocketGatheringWriteTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.socket();
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketHalfClosedTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketHalfClosedTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.testsuite.transport.TestsuitePermutation;
+import io.netty5.testsuite.transport.socket.SocketHalfClosedTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IOUringSocketHalfClosedTest extends SocketHalfClosedTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.socket();
+    }
+
+    @Override
+    @Disabled // TODO was disabled in 4.1 code as well... figure out why?
+    @Test
+    public void testAutoCloseFalseDoesShutdownOutput(TestInfo testInfo) throws Throwable {
+        super.testAutoCloseFalseDoesShutdownOutput(testInfo);
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketMultipleConnectTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketMultipleConnectTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.channel.EventLoopGroup;
+import io.netty5.channel.nio.AbstractNioChannel;
+import io.netty5.testsuite.transport.TestsuitePermutation;
+import io.netty5.testsuite.transport.socket.SocketMultipleConnectTest;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IOUringSocketMultipleConnectTest extends SocketMultipleConnectTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> factories = new ArrayList<>();
+        for (var comboFactory : IOUringSocketTestPermutation.INSTANCE.socket()) {
+            EventLoopGroup group = comboFactory.newClientInstance().config().group();
+            if (group.isCompatible(AbstractNioChannel.class) || group.isCompatible(AbstractIOUringChannel.class)) {
+                factories.add(comboFactory);
+            }
+        }
+        return factories;
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketReadPendingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketReadPendingTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.testsuite.transport.TestsuitePermutation;
+import io.netty5.testsuite.transport.socket.SocketReadPendingTest;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IOUringSocketReadPendingTest extends SocketReadPendingTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.socket();
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketRstTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketRstTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.channel.Channel;
+import io.netty5.channel.unix.Errors;
+import io.netty5.testsuite.transport.TestsuitePermutation;
+import io.netty5.testsuite.transport.socket.SocketRstTest;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IOUringSocketRstTest extends SocketRstTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.socket();
+    }
+
+    @Override
+    protected void assertRstOnCloseException(IOException cause, Channel clientChannel) {
+        if (!AbstractIOUringChannel.class.isInstance(clientChannel)) {
+            super.assertRstOnCloseException(cause, clientChannel);
+            return;
+        }
+
+        assertTrue(cause instanceof Errors.NativeIoException,
+                "actual [type, message]: [" + cause.getClass() + ", " + cause.getMessage() + ']');
+        assertEquals(Errors.ERRNO_ECONNRESET_NEGATIVE, ((Errors.NativeIoException) cause).expectedErr());
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketShutdownOutputByPeerTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketShutdownOutputByPeerTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.testsuite.transport.TestsuitePermutation;
+import io.netty5.testsuite.transport.socket.SocketShutdownOutputByPeerTest;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IOUringSocketShutdownOutputByPeerTest extends SocketShutdownOutputByPeerTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapFactory<ServerBootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.serverSocket();
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketShutdownOutputBySelfTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketShutdownOutputBySelfTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.testsuite.transport.TestsuitePermutation;
+import io.netty5.testsuite.transport.socket.SocketShutdownOutputBySelfTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IOUringSocketShutdownOutputBySelfTest extends SocketShutdownOutputBySelfTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.clientSocket();
+    }
+
+    @Test
+    @Override
+    public void testWriteAfterShutdownOutputNoWritabilityChange(TestInfo testInfo) throws Throwable {
+        // TODO Ignore as it does not pass on QEMU atm
+        // super.testWriteAfterShutdownOutputNoWritabilityChange();
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketSslClientRenegotiateTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketSslClientRenegotiateTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.testsuite.transport.TestsuitePermutation;
+import io.netty5.testsuite.transport.socket.SocketSslClientRenegotiateTest;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IOUringSocketSslClientRenegotiateTest extends SocketSslClientRenegotiateTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.socket();
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketSslEchoTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketSslEchoTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.testsuite.transport.TestsuitePermutation;
+import io.netty5.testsuite.transport.socket.SocketSslEchoTest;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IOUringSocketSslEchoTest extends SocketSslEchoTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.socket();
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketSslGreetingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketSslGreetingTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.testsuite.transport.TestsuitePermutation;
+import io.netty5.testsuite.transport.socket.SocketSslGreetingTest;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IOUringSocketSslGreetingTest extends SocketSslGreetingTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.socket();
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketSslSessionReuseTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketSslSessionReuseTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.testsuite.transport.TestsuitePermutation;
+import io.netty5.testsuite.transport.socket.SocketSslSessionReuseTest;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IOUringSocketSslSessionReuseTest extends SocketSslSessionReuseTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.socket();
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketStartTlsTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketStartTlsTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.testsuite.transport.TestsuitePermutation;
+import io.netty5.testsuite.transport.socket.SocketStartTlsTest;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IOUringSocketStartTlsTest extends SocketStartTlsTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.socket();
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketStringEchoTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketStringEchoTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.testsuite.transport.TestsuitePermutation;
+import io.netty5.testsuite.transport.socket.SocketStringEchoTest;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IOUringSocketStringEchoTest extends SocketStringEchoTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.socket();
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.channel.unix.Socket;
+import io.netty5.channel.unix.tests.SocketTest;
+import org.junit.jupiter.api.BeforeAll;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IOUringSocketTest extends SocketTest<Socket> {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
+    @Override
+    protected Socket newSocket() {
+        return Socket.newSocketStream();
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketTestPermutation.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketTestPermutation.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.channel.AdaptiveReadHandleFactory;
+import io.netty5.channel.Channel;
+import io.netty5.channel.ChannelFactory;
+import io.netty5.channel.EventLoop;
+import io.netty5.channel.EventLoopGroup;
+import io.netty5.channel.MultithreadEventLoopGroup;
+import io.netty5.channel.socket.SocketChannelWriteHandleFactory;
+import io.netty5.channel.socket.nio.NioDatagramChannel;
+import io.netty5.channel.socket.nio.NioServerSocketChannel;
+import io.netty5.channel.socket.nio.NioSocketChannel;
+import io.netty5.testsuite.transport.TestsuitePermutation;
+import io.netty5.testsuite.transport.TestsuitePermutation.BootstrapComboFactory;
+import io.netty5.testsuite.transport.TestsuitePermutation.BootstrapFactory;
+import io.netty5.testsuite.transport.socket.SocketTestPermutation;
+import io.netty5.util.concurrent.DefaultThreadFactory;
+import io.netty5.util.internal.logging.InternalLogger;
+import io.netty5.util.internal.logging.InternalLoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.net.ProtocolFamily;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static io.netty5.channel.unix.Limits.SSIZE_MAX;
+
+public class IOUringSocketTestPermutation extends SocketTestPermutation {
+
+    static final IOUringSocketTestPermutation INSTANCE = new IOUringSocketTestPermutation();
+
+    static final EventLoopGroup IO_URING_BOSS_GROUP = new MultithreadEventLoopGroup(
+            BOSSES, new DefaultThreadFactory("testsuite-io_uring-boss", true), IOUring.newFactory());
+    static final EventLoopGroup IO_URING_WORKER_GROUP = new MultithreadEventLoopGroup(
+            WORKERS, new DefaultThreadFactory("testsuite-io_uring-worker", true), IOUring.newFactory());
+
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(IOUringSocketTestPermutation.class);
+
+    @Override
+    public List<BootstrapComboFactory<ServerBootstrap, Bootstrap>> socket() {
+
+        List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> list =
+                combo(serverSocket(), clientSocket());
+
+        list.remove(list.size() - 1); // Exclude NIO x NIO test
+
+        return list;
+    }
+
+    @Override
+    public List<BootstrapFactory<ServerBootstrap>> serverSocket() {
+        List<BootstrapFactory<ServerBootstrap>> toReturn = new ArrayList<>();
+        toReturn.add(serverIouBootstrapBase());
+        if (isServerFastOpen()) {
+            toReturn.add(() -> {
+                ServerBootstrap serverBootstrap = new ServerBootstrap().group(IO_URING_BOSS_GROUP,
+                                                                              IO_URING_WORKER_GROUP)
+                                                                       .channel(IOUringServerSocketChannel.class);
+                serverBootstrap.option(IOUringChannelOption.TCP_FASTOPEN, 5);
+                return serverBootstrap;
+            });
+        }
+        toReturn.add(serverNioBootstrapBase());
+
+        return toReturn;
+    }
+
+    private BootstrapFactory<ServerBootstrap> serverNioBootstrapBase() {
+        return () -> new ServerBootstrap().group(nioBossGroup, nioWorkerGroup)
+                .channel(NioServerSocketChannel.class);
+    }
+
+    private BootstrapFactory<ServerBootstrap> serverIouBootstrapBase() {
+        return () -> new ServerBootstrap().group(IO_URING_BOSS_GROUP, IO_URING_WORKER_GROUP)
+                .channel(IOUringServerSocketChannel.class);
+    }
+
+    @Override
+    public List<BootstrapFactory<Bootstrap>> clientSocket() {
+        return Arrays.asList(
+                clientIouBootstrapBase(),
+                clientNioBoostrapBase()
+        );
+    }
+
+    private BootstrapFactory<Bootstrap> clientIouBootstrapBase() {
+        return () -> new Bootstrap().group(IO_URING_WORKER_GROUP).channel(IOUringSocketChannel.class);
+    }
+
+    private BootstrapFactory<Bootstrap> clientNioBoostrapBase() {
+        return () -> new Bootstrap().group(nioWorkerGroup).channel(NioSocketChannel.class);
+    }
+
+    @Override
+    public List<TestsuitePermutation.BootstrapComboFactory<Bootstrap, Bootstrap>> datagram(
+            final ProtocolFamily family) {
+        // Make the list of Bootstrap factories.
+        List<BootstrapFactory<Bootstrap>> bfs = Arrays.asList(
+                () -> new Bootstrap()
+                        .group(IO_URING_WORKER_GROUP)
+                        .channelFactory(new ChannelFactory<>() {
+                    @Override
+                    public Channel newChannel(EventLoop eventLoop) {
+                        return new IOUringDatagramChannel(
+                                null, eventLoop, true,
+                                new AdaptiveReadHandleFactory(),
+                                new SocketChannelWriteHandleFactory(Integer.MAX_VALUE, SSIZE_MAX),
+                                LinuxSocket.newSocketDgram(family), false);
+                    }
+
+                    @Override
+                    public String toString() {
+                        return ProtocolFamily.class.getSimpleName() + ".class";
+                    }
+                }),
+                () -> new Bootstrap().group(nioWorkerGroup).channelFactory(new ChannelFactory<>() {
+                    @Override
+                    public Channel newChannel(EventLoop eventLoop) {
+                        return new NioDatagramChannel(eventLoop, family);
+                    }
+
+                    @Override
+                    public String toString() {
+                        return NioDatagramChannel.class.getSimpleName() + ".class";
+                    }
+                })
+        );
+
+        return combo(bfs, bfs);
+    }
+
+    public boolean isServerFastOpen() {
+        int fastopen = 0;
+        File file = new File("/proc/sys/net/ipv4/tcp_fastopen");
+        if (file.exists()) {
+            BufferedReader in = null;
+            try {
+                in = new BufferedReader(new FileReader(file));
+                fastopen = Integer.parseInt(in.readLine());
+                if (logger.isDebugEnabled()) {
+                    logger.debug("{}: {}", file, fastopen);
+                }
+            } catch (Exception e) {
+                logger.debug("Failed to get TCP_FASTOPEN from: {}", file, e);
+            } finally {
+                if (in != null) {
+                    try {
+                        in.close();
+                    } catch (Exception e) {
+                        // Ignored.
+                    }
+                }
+            }
+        } else {
+            if (logger.isDebugEnabled()) {
+                logger.debug("{}: {} (non-existent)", file, fastopen);
+            }
+        }
+        return fastopen == 3;
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringWriteBeforeRegisteredTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringWriteBeforeRegisteredTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.testsuite.transport.TestsuitePermutation;
+import io.netty5.testsuite.transport.socket.WriteBeforeRegisteredTest;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IOUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.clientSocket();
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/NativeTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/NativeTest.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.buffer.Buffer;
+import io.netty5.buffer.BufferAllocator;
+import io.netty5.buffer.DefaultBufferAllocators;
+import io.netty5.channel.unix.FileDescriptor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class NativeTest {
+    private ExecutorService executor;
+
+    @BeforeEach
+    void createExecutor() {
+        executor = Executors.newCachedThreadPool();
+    }
+
+    @AfterEach
+    void shutDownExecutor() {
+        executor.shutdown();
+    }
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
+    @Test
+    public void canWriteFile(@TempDir Path tmpDir) {
+        BufferAllocator allocator = DefaultBufferAllocators.offHeapAllocator();
+        final Buffer writeEventBuf = allocator.allocate(100);
+        final String inputString = "Hello World!";
+        writeEventBuf.writeCharSequence(inputString, StandardCharsets.UTF_8);
+
+        Path file = tmpDir.resolve("io_uring.tmp");
+        int fd = Native.createFile(file.toString());
+
+        RingBuffer ringBuffer = Native.createRingBuffer(32);
+        SubmissionQueue submissionQueue = ringBuffer.ioUringSubmissionQueue();
+        CompletionQueue completionQueue = ringBuffer.ioUringCompletionQueue();
+
+        assertNotNull(ringBuffer);
+        assertNotNull(submissionQueue);
+        assertNotNull(completionQueue);
+
+        try (var itr = writeEventBuf.forEachComponent()) {
+            var cmp = itr.firstReadable();
+            assertNotNull(cmp);
+            submissionQueue.addWrite(fd, cmp.readableNativeAddress(), 0, cmp.readableBytes(), (short) 0);
+            submissionQueue.submit();
+        }
+
+        completionQueue.ioUringWaitCqe();
+        assertEquals(1, completionQueue.process((fd1, res, flags, udata) -> {
+            assertEquals(inputString.length(), res);
+            writeEventBuf.close();
+        }));
+
+        final Buffer readEventBuf = allocator.allocate(100);
+        try (var itr = readEventBuf.forEachComponent()) {
+            var cmp = itr.firstWritable();
+            submissionQueue.addRead(fd, cmp.writableNativeAddress(), 0, cmp.writableBytes(), (short) 0);
+            submissionQueue.submit();
+        }
+
+        completionQueue.ioUringWaitCqe();
+        assertEquals(1, completionQueue.process((fd12, res, flags, udata) -> {
+            assertEquals(inputString.length(), res);
+            readEventBuf.skipWritableBytes(res);
+        }));
+        byte[] dataRead = new byte[inputString.length()];
+        readEventBuf.readBytes(dataRead, 0, inputString.length());
+
+        assertArrayEquals(inputString.getBytes(), dataRead);
+        readEventBuf.close();
+
+        ringBuffer.close();
+        file.toFile().delete();
+    }
+
+    @Test
+    public void timeoutTest() throws Exception {
+
+        RingBuffer ringBuffer = Native.createRingBuffer(32);
+        SubmissionQueue submissionQueue = ringBuffer.ioUringSubmissionQueue();
+        final CompletionQueue completionQueue = ringBuffer.ioUringCompletionQueue();
+
+        assertNotNull(ringBuffer);
+        assertNotNull(submissionQueue);
+        assertNotNull(completionQueue);
+
+        var future = executor.submit(() -> {
+            completionQueue.ioUringWaitCqe();
+            completionQueue.process((fd, res, flags, udata) -> assertEquals(-62, res));
+            return null;
+        });
+
+        try {
+            Thread.sleep(80);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        submissionQueue.addTimeout(-1, 0, (short) 0);
+        submissionQueue.submit();
+
+        future.get();
+        ringBuffer.close();
+    }
+
+    //Todo clean
+    @Test
+    public void eventfdTest() throws Exception {
+        RingBuffer ringBuffer = Native.createRingBuffer(32);
+        SubmissionQueue submissionQueue = ringBuffer.ioUringSubmissionQueue();
+        final CompletionQueue completionQueue = ringBuffer.ioUringCompletionQueue();
+
+        assertNotNull(ringBuffer);
+        assertNotNull(submissionQueue);
+        assertNotNull(completionQueue);
+
+        final FileDescriptor eventFd = Native.newBlockingEventFd();
+        submissionQueue.addPollIn(eventFd.intValue());
+        submissionQueue.submit();
+
+        executor.submit(() -> Native.eventFdWrite(eventFd.intValue(), 1L));
+
+        completionQueue.ioUringWaitCqe();
+        assertEquals(1, completionQueue.process((fd, res, flags, udata) -> assertEquals(1, res)));
+        try {
+            eventFd.close();
+        } finally {
+            ringBuffer.close();
+        }
+    }
+
+    //Todo clean
+    //eventfd signal doesnt work when ioUringWaitCqe and eventFdWrite are executed in a thread
+    //created this test to reproduce this "weird" bug
+    @Test
+    @Timeout(8)
+    public void eventfdNoSignal() throws Exception {
+
+        RingBuffer ringBuffer = Native.createRingBuffer(32);
+        SubmissionQueue submissionQueue = ringBuffer.ioUringSubmissionQueue();
+        final CompletionQueue completionQueue = ringBuffer.ioUringCompletionQueue();
+
+        assertNotNull(ringBuffer);
+        assertNotNull(submissionQueue);
+        assertNotNull(completionQueue);
+
+        var waitingCqe = executor.submit(() -> {
+            completionQueue.ioUringWaitCqe();
+            assertEquals(1, completionQueue.process((fd, res, flags, udata) -> assertEquals(1, res)));
+        });
+        final FileDescriptor eventFd = Native.newBlockingEventFd();
+        submissionQueue.addPollIn(eventFd.intValue());
+        submissionQueue.submit();
+
+        executor.submit(() -> Native.eventFdWrite(eventFd.intValue(), 1L));
+
+        try {
+            waitingCqe.get();
+        } finally {
+            ringBuffer.close();
+        }
+    }
+
+    @Test
+    public void ioUringExitTest() {
+        RingBuffer ringBuffer = Native.createRingBuffer();
+        ringBuffer.close();
+    }
+
+    @Test
+    public void ioUringPollRemoveTest() throws Exception {
+        RingBuffer ringBuffer = Native.createRingBuffer(32);
+        SubmissionQueue submissionQueue = ringBuffer.ioUringSubmissionQueue();
+        final CompletionQueue completionQueue = ringBuffer.ioUringCompletionQueue();
+
+        FileDescriptor eventFd = Native.newBlockingEventFd();
+        submissionQueue.addPollIn(eventFd.intValue());
+        submissionQueue.submit();
+        submissionQueue.addPollRemove(eventFd.intValue(), Native.POLLIN);
+        submissionQueue.submit();
+
+        final CountDownLatch latch = new CountDownLatch(2);
+        CompletionCallback verifyCallback = (fd, res, flags, udata) -> {
+            byte op = UserData.decodeOp(udata);
+            if (op == Native.IORING_OP_POLL_ADD) {
+                assertEquals(Native.ERRNO_ECANCELED_NEGATIVE, res);
+                latch.countDown();
+            } else if (op == Native.IORING_OP_POLL_REMOVE) {
+                assertEquals(0, res);
+                latch.countDown();
+            } else {
+                fail("op " + op);
+            }
+        };
+        var waitingCqe = executor.submit(() -> {
+            completionQueue.ioUringWaitCqe();
+            assertEquals(2, completionQueue.process(verifyCallback));
+        });
+        try {
+            waitingCqe.get();
+            latch.await();
+            eventFd.close();
+        } finally {
+            ringBuffer.close();
+        }
+    }
+
+    @Test
+    public void testUserData() {
+        RingBuffer ringBuffer = Native.createRingBuffer(32);
+        SubmissionQueue submissionQueue = ringBuffer.ioUringSubmissionQueue();
+        final CompletionQueue completionQueue = ringBuffer.ioUringCompletionQueue();
+
+        try {
+            // Ensure userdata works with negative and positive values
+            for (int i = Short.MIN_VALUE; i <= Short.MAX_VALUE; i++) {
+                submissionQueue.addWrite(-1, -1, -1, -1, (short) i);
+                assertEquals(1, submissionQueue.submitAndWait());
+                final int expectedData = i;
+                assertEquals(1, completionQueue.process((fd, res, flags, udata) -> {
+                    byte op = UserData.decodeOp(udata);
+                    short data = UserData.decodeData(udata);
+                    assertEquals(-1, fd);
+                    assertTrue(res < 0);
+                    assertEquals(Native.IORING_OP_WRITE, op);
+                    assertEquals(expectedData, data);
+                }));
+            }
+        } finally {
+            ringBuffer.close();
+        }
+    }
+
+    @Test
+    public void parsingKernelVersionTest() {
+        Native.checkKernelVersion("10.11.123");
+        assertThrows(UnsupportedOperationException.class, () -> Native.checkKernelVersion("5.8.1-23"));
+
+        Native.checkKernelVersion("5.100.1-1");
+        Native.checkKernelVersion("5.9.1-1");
+        Native.checkKernelVersion("5.9.100-1");
+
+        assertThrows(UnsupportedOperationException.class, () -> Native.checkKernelVersion("5.5.67"));
+        assertThrows(UnsupportedOperationException.class, () -> Native.checkKernelVersion("5.5.32"));
+        assertThrows(UnsupportedOperationException.class, () -> Native.checkKernelVersion("4.16.20"));
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/ObjectRingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/ObjectRingTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ObjectRingTest {
+    @Test
+    void mustBeInitiallyEmpty() {
+        ObjectRing<String> ring = new ObjectRing<>();
+        assertTrue(ring.isEmpty());
+        assertFalse(ring.poll());
+    }
+
+    @Test
+    void mustNotBeEmptyAfterPush() {
+        ObjectRing<String> ring = new ObjectRing<>();
+        ring.push("a", 1);
+        assertFalse(ring.isEmpty());
+        assertTrue(ring.poll());
+    }
+
+    @Test
+    void pushAndPullAreFirstInFirstOut() {
+        ObjectRing<String> ring = new ObjectRing<>();
+        ring.push("a", 1);
+        assertTrue(ring.poll());
+        assertThat(ring.getPolledObject()).isEqualTo("a");
+        assertThat(ring.getPolledStamp()).isOne();
+        assertTrue(ring.isEmpty());
+        assertFalse(ring.poll());
+
+        ring.push("b", 2);
+        ring.push("c", 3);
+
+        assertTrue(ring.poll());
+        assertThat(ring.getPolledObject()).isEqualTo("b");
+        assertThat(ring.getPolledStamp()).isEqualTo(2);
+        assertFalse(ring.isEmpty());
+
+        assertTrue(ring.poll());
+        assertThat(ring.getPolledObject()).isEqualTo("c");
+        assertThat(ring.getPolledStamp()).isEqualTo(3);
+        assertTrue(ring.isEmpty());
+        assertFalse(ring.poll());
+    }
+
+    @Test
+    void mustAutomaticallyExpandRing() {
+        ObjectRing<Integer> ring = new ObjectRing<>();
+        for (int i = 0; i < 1000; i++) {
+            ring.push(i, i);
+        }
+        for (int i = 0; i < 1000; i++) {
+            assertTrue(ring.poll());
+            assertThat(ring.getPolledObject()).isEqualTo(i);
+            assertThat(ring.getPolledStamp()).isEqualTo(i);
+        }
+        assertTrue(ring.isEmpty());
+        assertFalse(ring.poll());
+    }
+
+    @Test
+    void polledItemsAreClearedAfterReading() {
+        ObjectRing<String> ring = new ObjectRing<>();
+        ring.push("a", 1);
+        ring.push("b", 2);
+        assertTrue(ring.poll());
+        assertThat(ring.getPolledObject()).isEqualTo("a");
+        assertThat(ring.getPolledStamp()).isEqualTo(1L);
+        assertThat(ring.getPolledObject()).isNull();
+        assertThat(ring.getPolledStamp()).isZero();
+
+        assertTrue(ring.poll());
+        assertThat(ring.getPolledObject()).isEqualTo("b");
+        assertThat(ring.getPolledStamp()).isEqualTo(2L);
+        assertThat(ring.getPolledObject()).isNull();
+        assertThat(ring.getPolledStamp()).isZero();
+    }
+
+    @Test
+    void peekOfEmptyRingReturnsFalse() {
+        ObjectRing<Integer> ring = new ObjectRing<>();
+        assertFalse(ring.peek());
+    }
+
+    @Test
+    void peekedItemsAreClearedAfterReading() {
+        ObjectRing<String> ring = new ObjectRing<>();
+        ring.push("a", 1);
+        ring.push("b", 2);
+        assertTrue(ring.peek());
+        assertThat(ring.getPolledObject()).isEqualTo("a");
+        assertThat(ring.getPolledStamp()).isEqualTo(1L);
+        assertThat(ring.getPolledObject()).isNull();
+        assertThat(ring.getPolledStamp()).isZero();
+
+        assertTrue(ring.peek());
+        assertThat(ring.getPolledObject()).isEqualTo("a");
+        assertThat(ring.getPolledStamp()).isEqualTo(1L);
+        assertThat(ring.getPolledObject()).isNull();
+        assertThat(ring.getPolledStamp()).isZero();
+
+        assertTrue(ring.poll());
+        assertThat(ring.getPolledObject()).isEqualTo("a");
+        assertThat(ring.getPolledStamp()).isEqualTo(1L);
+        assertThat(ring.getPolledObject()).isNull();
+        assertThat(ring.getPolledStamp()).isZero();
+
+        assertTrue(ring.peek());
+        assertThat(ring.getPolledObject()).isEqualTo("b");
+        assertThat(ring.getPolledStamp()).isEqualTo(2L);
+        assertThat(ring.getPolledObject()).isNull();
+        assertThat(ring.getPolledStamp()).isZero();
+
+        assertTrue(ring.peek());
+        assertThat(ring.getPolledObject()).isEqualTo("b");
+        assertThat(ring.getPolledStamp()).isEqualTo(2L);
+        assertThat(ring.getPolledObject()).isNull();
+        assertThat(ring.getPolledStamp()).isZero();
+
+        assertTrue(ring.poll());
+        assertThat(ring.getPolledObject()).isEqualTo("b");
+        assertThat(ring.getPolledStamp()).isEqualTo(2L);
+        assertThat(ring.getPolledObject()).isNull();
+        assertThat(ring.getPolledStamp()).isZero();
+
+        assertFalse(ring.peek());
+    }
+
+    @Test
+    void updatingPeekedStampMustBeReflectedInPoll() {
+        ObjectRing<String> ring = new ObjectRing<>();
+        ring.push("a", 1);
+        ring.push("b", 2);
+
+        assertTrue(ring.peek());
+        ring.updatePeekedStamp(10 + ring.getPolledStamp());
+
+        assertTrue(ring.poll());
+        assertThat(ring.getPolledObject()).isEqualTo("a");
+        assertThat(ring.getPolledStamp()).isEqualTo(11);
+
+        assertTrue(ring.peek());
+        ring.updatePeekedStamp(10 + ring.getPolledStamp());
+
+        assertTrue(ring.poll());
+        assertThat(ring.getPolledObject()).isEqualTo("b");
+        assertThat(ring.getPolledStamp()).isEqualTo(12);
+    }
+
+    @Test
+    void outOfOrderRemove() {
+        ObjectRing<String> ring = new ObjectRing<>();
+        ring.push("a", 1);
+        ring.push("b", 2);
+        ring.push("c", 3);
+        ring.push("d", 1);
+
+        // Remove unknown item
+        assertThat(ring.remove(10)).isNull();
+
+        // Remove first
+        assertThat(ring.remove(1)).isEqualTo("a");
+
+        // Remove middle item
+        assertThat(ring.remove(3)).isEqualTo("c");
+
+        // Remove end item
+        assertThat(ring.remove(1)).isEqualTo("d");
+
+        // Remove previously removed item
+        assertThat(ring.remove(1)).isNull();
+
+        // Remove last item
+        assertThat(ring.remove(2)).isEqualTo("b");
+
+        // Remove when empty
+        assertThat(ring.remove(1)).isNull();
+    }
+
+    @Test
+    void hasNextItemIsFalseWhenEmpty() {
+        ObjectRing<String> ring = new ObjectRing<>();
+        assertFalse(ring.hasNextStamp(1));
+    }
+
+    @Test
+    void hasNextItemIsFalseWhenStampNotMatching() {
+        ObjectRing<String> ring = new ObjectRing<>();
+        ring.push("a", 1);
+        assertFalse(ring.hasNextStamp(2));
+    }
+
+    @Test
+    void hasNextItemIsTrueWhenNextStampMatches() {
+        ObjectRing<String> ring = new ObjectRing<>();
+        ring.push("a", 1);
+        ring.push("b", 2);
+        assertTrue(ring.hasNextStamp(1));
+        assertTrue(ring.poll());
+        assertTrue(ring.hasNextStamp(2));
+        assertTrue(ring.poll());
+        assertFalse(ring.hasNextStamp(1));
+        assertFalse(ring.hasNextStamp(2));
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/PollRemoveTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/PollRemoveTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.channel.Channel;
+import io.netty5.channel.ChannelInitializer;
+import io.netty5.channel.EventLoopGroup;
+import io.netty5.channel.MultithreadEventLoopGroup;
+import io.netty5.channel.socket.ServerSocketChannel;
+import io.netty5.channel.socket.SocketChannel;
+import io.netty5.handler.logging.LogLevel;
+import io.netty5.handler.logging.LoggingHandler;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class PollRemoveTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
+    private static void ioUringTest() throws Exception {
+        Class<? extends ServerSocketChannel> clazz = IOUringServerSocketChannel.class;
+        final EventLoopGroup bossGroup = new MultithreadEventLoopGroup(1, IOUring.newFactory());
+
+        try {
+            ServerBootstrap b = new ServerBootstrap();
+            b.group(bossGroup)
+                    .channel(clazz)
+                    .handler(new LoggingHandler(LogLevel.TRACE))
+                    .childHandler(new ChannelInitializer<SocketChannel>() {
+                        @Override
+                        public void initChannel(SocketChannel ch) { }
+                    });
+
+            Channel sc = b.bind(2020).asStage().get();
+
+            // close ServerChannel
+            sc.close().asStage().sync();
+        } finally {
+            bossGroup.shutdownGracefully().asStage().sync();
+        }
+    }
+
+    @Test
+    @Timeout(10)
+    public void test() throws Exception {
+        ioUringTest();
+        ioUringTest();
+    }
+}
+

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/SockaddrInTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/SockaddrInTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+
+import static io.netty5.channel.unix.Buffer.allocateDirectWithNativeOrder;
+import static io.netty5.channel.unix.Buffer.free;
+import static io.netty5.channel.unix.Buffer.nativeAddressOf;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class SockaddrInTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
+    @Test
+    public void testIp4() throws Exception {
+        ByteBuffer buffer = allocateDirectWithNativeOrder(64);
+        try {
+            long memoryAddress = nativeAddressOf(buffer);
+            InetAddress address = InetAddress.getByAddress(new byte[] { 10, 10, 10, 10 });
+            int port = 45678;
+            assertEquals(Native.SIZEOF_SOCKADDR_IN, SockaddrIn.writeIPv4(memoryAddress, address, port));
+            byte[] bytes = new byte[4];
+            InetSocketAddress sockAddr = SockaddrIn.readIPv4(memoryAddress, bytes);
+            assertArrayEquals(address.getAddress(), sockAddr.getAddress().getAddress());
+            assertEquals(port, sockAddr.getPort());
+        } finally {
+            free(buffer);
+        }
+    }
+
+    @Test
+    public void testIp6() throws Exception {
+        ByteBuffer buffer = allocateDirectWithNativeOrder(64);
+        try {
+            long memoryAddress = nativeAddressOf(buffer);
+            Inet6Address address = Inet6Address.getByAddress(
+                    null, new byte[] { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 }, 12345);
+            int port = 45678;
+            assertEquals(Native.SIZEOF_SOCKADDR_IN6, SockaddrIn.writeIPv6(memoryAddress, address, port));
+            byte[] ipv6Bytes = new byte[16];
+            byte[] ipv4Bytes = new byte[4];
+
+            InetSocketAddress sockAddr = SockaddrIn.readIPv6(memoryAddress, ipv6Bytes, ipv4Bytes);
+            Inet6Address inet6Address = (Inet6Address) sockAddr.getAddress();
+            assertArrayEquals(address.getAddress(), inet6Address.getAddress());
+            assertEquals(address.getScopeId(), inet6Address.getScopeId());
+            assertEquals(port, sockAddr.getPort());
+        } finally {
+            free(buffer);
+        }
+    }
+
+    @Test
+    public void testWriteIp4ReadIpv6Mapped() throws Exception {
+        ByteBuffer buffer = allocateDirectWithNativeOrder(64);
+        try {
+            long memoryAddress = nativeAddressOf(buffer);
+            InetAddress address = InetAddress.getByAddress(new byte[] { 10, 10, 10, 10 });
+            int port = 45678;
+            assertEquals(Native.SIZEOF_SOCKADDR_IN6, SockaddrIn.writeIPv6(memoryAddress, address, port));
+            byte[] ipv6Bytes = new byte[16];
+            byte[] ipv4Bytes = new byte[4];
+
+            InetSocketAddress sockAddr = SockaddrIn.readIPv6(memoryAddress, ipv6Bytes, ipv4Bytes);
+            Inet4Address ipv4Address = (Inet4Address) sockAddr.getAddress();
+
+            System.arraycopy(SockaddrIn.IPV4_MAPPED_IPV6_PREFIX, 0, ipv6Bytes, 0,
+                    SockaddrIn.IPV4_MAPPED_IPV6_PREFIX.length);
+            assertArrayEquals(ipv4Bytes, ipv4Address.getAddress());
+            assertEquals(port, sockAddr.getPort());
+        } finally {
+            free(buffer);
+        }
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/SubmissionQueueTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/SubmissionQueueTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class SubmissionQueueTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
+    @Test
+    public void sqeFullTest() {
+        RingBuffer ringBuffer = Native.createRingBuffer(8);
+        try {
+            SubmissionQueue submissionQueue = ringBuffer.ioUringSubmissionQueue();
+            final CompletionQueue completionQueue = ringBuffer.ioUringCompletionQueue();
+
+            assertNotNull(ringBuffer);
+            assertNotNull(submissionQueue);
+            assertNotNull(completionQueue);
+
+            int counter = 0;
+            while (submissionQueue.remaining() > 0) {
+                assertThat(submissionQueue.addNop(0, 0, (short) 1)).isNotZero();
+                counter++;
+            }
+            assertEquals(8, counter);
+            assertEquals(8, submissionQueue.count());
+            assertThat(submissionQueue.addNop(0, 0, (short) 1)).isNotZero();
+            assertEquals(1, submissionQueue.count());
+            submissionQueue.submitAndWait();
+            assertEquals(9, completionQueue.count());
+            assertEquals(9, completionQueue.getAsInt());
+        } finally {
+            ringBuffer.close();
+        }
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/UserDataTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/UserDataTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class UserDataTest {
+    @Test
+    public void testUserData() {
+        // Ensure userdata works with negative and positive values
+        for (int fd : new int[] { -10, -1, 0, 1, 10, Short.MAX_VALUE, Integer.MAX_VALUE }) {
+            for (byte op = 0; op < 20; op++) {
+                for (int data = Short.MIN_VALUE; data <= Short.MAX_VALUE; data++) {
+                    final int expectedFd = fd;
+                    final byte expectedOp = op;
+                    final short expectedData = (short) data;
+                    long udata = UserData.encode(expectedFd, expectedOp, expectedData);
+                    UserData.decode(0, 0, udata, (actualFd, res, flags, ud) -> {
+                        assertEquals(expectedFd, actualFd);
+                        assertEquals(expectedOp, UserData.decodeOp(ud));
+                        assertEquals(expectedData, UserData.decodeData(ud));
+                        assertEquals(udata, ud);
+                    });
+                }
+            }
+        }
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/example/EchoIOUringServer.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/example/EchoIOUringServer.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring.example;
+
+import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.channel.ChannelInitializer;
+import io.netty5.channel.ChannelPipeline;
+import io.netty5.channel.EventLoopGroup;
+import io.netty5.channel.MultithreadEventLoopGroup;
+import io.netty5.channel.socket.SocketChannel;
+import io.netty5.channel.uring.IOUring;
+import io.netty5.channel.uring.IOUringServerSocketChannel;
+import io.netty5.handler.logging.LogLevel;
+import io.netty5.handler.logging.LoggingHandler;
+
+//temporary prototype example
+public class EchoIOUringServer {
+    private static final int PORT = Integer.parseInt(System.getProperty("port", "8080"));
+
+    public static void main(String []args) throws Exception {
+        EventLoopGroup bossGroup = new MultithreadEventLoopGroup(1, IOUring.newFactory());
+        EventLoopGroup workerGroup = new MultithreadEventLoopGroup(1, IOUring.newFactory());
+        final EchoIOUringServerHandler serverHandler = new EchoIOUringServerHandler();
+        try {
+            ServerBootstrap b = new ServerBootstrap();
+            b.group(bossGroup, workerGroup)
+                    .channel(IOUringServerSocketChannel.class)
+                    .handler(new LoggingHandler(LogLevel.INFO))
+                    .childHandler(new ChannelInitializer<SocketChannel>() {
+                        @Override
+                        public void initChannel(SocketChannel ch) throws Exception {
+                            ChannelPipeline p = ch.pipeline();
+                            //p.addLast(new LoggingHandler(LogLevel.INFO));
+                            p.addLast(serverHandler);
+                        }
+                    });
+
+            // Start the server.
+            var ch = b.bind(PORT).asStage().get();
+
+            // Wait until the server socket is closed.
+            ch.closeFuture().asStage().sync();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        } finally {
+            // Shut down all event loops to terminate all threads.
+            bossGroup.shutdownGracefully();
+            workerGroup.shutdownGracefully();
+        }
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/example/EchoIOUringServerHandler.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/example/EchoIOUringServerHandler.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.uring.example;
+
+import io.netty5.channel.ChannelHandlerAdapter;
+import io.netty5.channel.ChannelHandlerContext;
+
+//temporary prototype example
+public class EchoIOUringServerHandler extends ChannelHandlerAdapter {
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) {
+        ctx.write(msg);
+    }
+
+    @Override
+    public void channelReadComplete(ChannelHandlerContext ctx) {
+        ctx.flush();
+    }
+
+    @Override
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        // Close the connection when an exception is raised.
+        cause.printStackTrace();
+        ctx.close();
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
+    }
+}

--- a/transport-native-io_uring/src/test/resources/junit-platform.properties
+++ b/transport-native-io_uring/src/test/resources/junit-platform.properties
@@ -1,0 +1,19 @@
+# Copyright 2022 The Netty Project
+#
+# The Netty Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+#junit.jupiter.execution.timeout.default=60s
+junit.jupiter.execution.timeout.mode=disabled_on_debug
+#junit.jupiter.execution.parallel.enabled = true
+#junit.jupiter.execution.parallel.mode.default = concurrent
+#junit.jupiter.execution.parallel.config.dynamic.factor=4

--- a/transport-native-io_uring/src/test/resources/log4j2-test.xml
+++ b/transport-native-io_uring/src/test/resources/log4j2-test.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="[%.20t] %-5level %logger{1.} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <AsyncRoot level="debug">
+            <AppenderRef ref="Console"/>
+        </AsyncRoot>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
Motivation:
For Netty 5 we want io_uring to be a fully featured, and fully supported transport.

Modification:
This copies the `netty5` branch of our incubator io_uring transport into Netty. There are still some missing pieces (domain sockets, better read-loop handling, etc), but this is the first step.

Result:
The io_uring integration has landed in Netty 5
