### PR TITLE
HttpConnectionHandler should send a GO_AWAY frame with PROTOCOL_ERROR…

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -738,7 +738,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
 
         if (stream == null) {
             if (!outbound || connection().local().mayHaveCreatedStream(streamId)) {
-                resetUnknownStream(ctx, streamId, http2Ex.error().code(), ctx.newPromise());
+                onError(ctx, outbound, connectionError(PROTOCOL_ERROR, "Unknown stream"));
             }
         } else {
             resetStream(ctx, stream, http2Ex.error().code(), ctx.newPromise());

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -738,6 +738,10 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
 
         if (stream == null) {
             if (!outbound || connection().local().mayHaveCreatedStream(streamId)) {
+                // See https://datatracker.ietf.org/doc/html/rfc7540#section-5.1.1:
+                //
+                // An endpoint that receives an unexpected stream identifier MUST respond with a connection error
+                // of type PROTOCOL_ERROR.
                 onError(ctx, outbound, connectionError(PROTOCOL_ERROR, "Unknown stream"));
             }
         } else {


### PR DESCRIPTION
… when it receives an unknown stream instead of resetting the stream.

Motivation:

When an HTTP/2 connection process an unnkown stream it should throw a GO_AWAY frame and close the connection as per RFC 7540. The current implementation instead sends a RST frame.

Modifications:

Change the HttpConnectionHandler behavior to throw an error instead of writing a rst frame, the error will trigger a GO_AWAY frame to be sent and then close the connection appropriately.

Result:

HttpConnectionHandler should send a GO_AWAY frame with PROTOCOL_ERROR when it receives an unknown stream and fix #12974
