### PR TITLE
Try to fix test timeout of CloseNotifyTest

### DIFF
--- a/handler/src/test/java/io/netty5/handler/ssl/CloseNotifyTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/CloseNotifyTest.java
@@ -32,7 +32,6 @@ import java.util.Collection;
 import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
 
 import static io.netty5.buffer.BufferUtil.writeAscii;
 import static io.netty5.buffer.DefaultBufferAllocators.offHeapAllocator;
@@ -68,7 +67,7 @@ public class CloseNotifyTest {
     }
 
     @ParameterizedTest(name = "{index}: provider={0}, protocol={1}")
-    @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
+    @Timeout(30)
     @MethodSource("data")
     public void eventsOrder(SslProvider provider, String protocol) throws Exception {
         assumeTrue(provider != SslProvider.OPENSSL || OpenSsl.isAvailable(), "OpenSSL is not available");


### PR DESCRIPTION
Motivation:
We sometimes observe the CloseNotifyTest fail with stack traces like this:

```
[ERROR] eventsOrder{SslProvider, String}[1]  Time elapsed: 0.01 s  <<< ERROR!
java.util.concurrent.TimeoutException: eventsOrder(io.netty5.handler.ssl.SslProvider, java.lang.String) timed out after 5000 milliseconds
	at org.junit.jupiter.engine.extension.TimeoutExceptionFactory.create(TimeoutExceptionFactory.java:29)
	at org.junit.jupiter.engine.extension.SameThreadTimeoutInvocation.proceed(SameThreadTimeoutInvocation.java:58)
	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:156)
```

Because the attached stack trace is from the JUnit 5 `TimeoutExceptionFactory`, we can actually tell that the test timed out before the preemptible test thread even started running! This means the CI instance is very overloaded and needs much more time to start threads. It is not unusual for very busy virtual machines in the cloud to take several seconds to start a thread.

Modification:
Increase the test timeout from 5 seconds to 30.

Result:
This should reduce the likelyhood of the test timing out on busy CI machines; at least before they get to even begin running the test thread.