### PR TITLE
HPACK dynamic table size update must happen at the beginning of the h…

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackDecoder.java
@@ -79,15 +79,14 @@ final class HpackDecoder {
             Http2Exception.newStatic(COMPRESSION_ERROR, "HPACK - max dynamic table size change required",
                     Http2Exception.ShutdownHint.HARD_SHUTDOWN, HpackDecoder.class, "decode(..)");
     private static final byte READ_HEADER_REPRESENTATION = 0;
-    private static final byte READ_MAX_DYNAMIC_TABLE_SIZE = 1;
-    private static final byte READ_INDEXED_HEADER = 2;
-    private static final byte READ_INDEXED_HEADER_NAME = 3;
-    private static final byte READ_LITERAL_HEADER_NAME_LENGTH_PREFIX = 4;
-    private static final byte READ_LITERAL_HEADER_NAME_LENGTH = 5;
-    private static final byte READ_LITERAL_HEADER_NAME = 6;
-    private static final byte READ_LITERAL_HEADER_VALUE_LENGTH_PREFIX = 7;
-    private static final byte READ_LITERAL_HEADER_VALUE_LENGTH = 8;
-    private static final byte READ_LITERAL_HEADER_VALUE = 9;
+    private static final byte READ_INDEXED_HEADER = 1;
+    private static final byte READ_INDEXED_HEADER_NAME = 2;
+    private static final byte READ_LITERAL_HEADER_NAME_LENGTH_PREFIX = 3;
+    private static final byte READ_LITERAL_HEADER_NAME_LENGTH = 4;
+    private static final byte READ_LITERAL_HEADER_NAME = 5;
+    private static final byte READ_LITERAL_HEADER_VALUE_LENGTH_PREFIX = 6;
+    private static final byte READ_LITERAL_HEADER_VALUE_LENGTH = 7;
+    private static final byte READ_LITERAL_HEADER_VALUE = 8;
 
     private final HpackHuffmanDecoder huffmanDecoder = new HpackHuffmanDecoder();
     private final HpackDynamicTable hpackDynamicTable;
@@ -127,11 +126,25 @@ final class HpackDecoder {
     void decode(int streamId, ByteBuf in, Http2Headers headers, boolean validateHeaders) throws Http2Exception {
         Http2HeadersSink sink = new Http2HeadersSink(
                 streamId, headers, maxHeaderListSize, validateHeaders);
+        decodeDynamicTableSizeUpdates(in);
         decode(in, sink);
 
         // Now that we've read all of our headers we can perform the validation steps. We must
         // delay throwing until this point to prevent dynamic table corruption.
         sink.finish();
+    }
+
+    private void decodeDynamicTableSizeUpdates(ByteBuf in) throws Http2Exception {
+        byte b;
+        while (in.isReadable() && ((b = in.getByte(in.readerIndex())) & 0x20) == 0x20 && ((b & 0xC0) == 0x00)) {
+            in.readByte();
+            int index = b & 0x1F;
+            if (index == 0x1F) {
+                setDynamicTableSize(decodeULE128(in, (long) index));
+            } else {
+                setDynamicTableSize(index);
+            }
+        }
     }
 
     private void decode(ByteBuf in, Http2HeadersSink sink) throws Http2Exception {
@@ -184,13 +197,8 @@ final class HpackDecoder {
                         }
                     } else if ((b & 0x20) == 0x20) {
                         // Dynamic Table Size Update
-                        index = b & 0x1F;
-                        if (index == 0x1F) {
-                            state = READ_MAX_DYNAMIC_TABLE_SIZE;
-                        } else {
-                            setDynamicTableSize(index);
-                            state = READ_HEADER_REPRESENTATION;
-                        }
+                        throw connectionError(COMPRESSION_ERROR, "Dynamic table size update must happen " +
+                            "at the beginning of the header block");
                     } else {
                         // Literal Header Field without Indexing / never Indexed
                         indexType = (b & 0x10) == 0x10 ? IndexType.NEVER : IndexType.NONE;
@@ -209,11 +217,6 @@ final class HpackDecoder {
                                 state = READ_LITERAL_HEADER_VALUE_LENGTH_PREFIX;
                         }
                     }
-                    break;
-
-                case READ_MAX_DYNAMIC_TABLE_SIZE:
-                    setDynamicTableSize(decodeULE128(in, (long) index));
-                    state = READ_HEADER_REPRESENTATION;
                     break;
 
                 case READ_INDEXED_HEADER:

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackDecoder.java
@@ -126,6 +126,8 @@ final class HpackDecoder {
     void decode(int streamId, ByteBuf in, Http2Headers headers, boolean validateHeaders) throws Http2Exception {
         Http2HeadersSink sink = new Http2HeadersSink(
                 streamId, headers, maxHeaderListSize, validateHeaders);
+        // Check for dynamic table size updates, which must occur at the beginning:
+        // https://www.rfc-editor.org/rfc/rfc7541.html#section-4.2
         decodeDynamicTableSizeUpdates(in);
         decode(in, sink);
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackDecoder.java
@@ -199,6 +199,7 @@ final class HpackDecoder {
                         }
                     } else if ((b & 0x20) == 0x20) {
                         // Dynamic Table Size Update
+                        // See https://www.rfc-editor.org/rfc/rfc7541.html#section-4.2
                         throw connectionError(COMPRESSION_ERROR, "Dynamic table size update must happen " +
                             "at the beginning of the header block");
                     } else {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackDecoderTest.java
@@ -404,6 +404,22 @@ public class HpackDecoderTest {
     }
 
     @Test
+    public void testDynamicTableSizeUpdateAfterTheBeginingOfTheBlock() throws Http2Exception {
+        assertThrows(Http2Exception.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                decode("8120");
+            }
+        });
+        assertThrows(Http2Exception.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                decode("813FE11F");
+            }
+        });
+    }
+
+    @Test
     public void testLiteralWithIncrementalIndexingWithEmptyName() throws Http2Exception {
         decode("400005" + hex("value"));
         verify(mockHeaders, times(1)).add(EMPTY_STRING, of("value"));


### PR DESCRIPTION
…eader block

Motivation:

HpackDecoder accepts dynamic table size updates at any stage of a header block. Such modification should always happen before the table is modified as per RFC 7541.

Modifications:

Check the header block first for dynamic table size updates in a separate method. Then reject any table size update when processing unpacking the rest of the block. Dynamic table size update could have been done with the current switch/case but it requires to keep track of the modifications which is not hard but introduces complexity in the loop (a simple boolean that must be switched for any modification but the table size update). Instead a table size update is achieved first in a simpler loop and then any table size update is rejected.

Result:

Fixes #12981
