### PR TITLE
Deprecate ObjectEncoder/ObjectDecoder

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/serialization/ClassResolver.java
+++ b/codec/src/main/java/io/netty/handler/codec/serialization/ClassResolver.java
@@ -17,7 +17,18 @@ package io.netty.handler.codec.serialization;
 
 /**
  * please use {@link ClassResolvers} as instance factory
+ * <p>
+ * <strong>Security:</strong> serialization can be a security liability,
+ * and should not be used without defining a list of classes that are
+ * allowed to be desirialized. Such a list can be specified with the
+ * <tt>jdk.serialFilter</tt> system property, for instance.
+ * See the <a href="https://docs.oracle.com/en/java/javase/17/core/serialization-filtering1.html">
+ * serialization filtering</a> article for more information.
+ *
+ * @deprecated This class has been deprecated with no replacement,
+ * because serialization can be a security liability
  */
+@Deprecated
 public interface ClassResolver {
 
     Class<?> resolve(String className) throws ClassNotFoundException;

--- a/codec/src/main/java/io/netty/handler/codec/serialization/ClassResolvers.java
+++ b/codec/src/main/java/io/netty/handler/codec/serialization/ClassResolvers.java
@@ -20,6 +20,20 @@ import io.netty.util.internal.PlatformDependent;
 import java.lang.ref.Reference;
 import java.util.HashMap;
 
+/**
+ * Factory methods for creating {@link ClassResolver} instances.
+ * <p>
+ * <strong>Security:</strong> serialization can be a security liability,
+ * and should not be used without defining a list of classes that are
+ * allowed to be desirialized. Such a list can be specified with the
+ * <tt>jdk.serialFilter</tt> system property, for instance.
+ * See the <a href="https://docs.oracle.com/en/java/javase/17/core/serialization-filtering1.html">
+ * serialization filtering</a> article for more information.
+ *
+ * @deprecated This class has been deprecated with no replacement,
+ * because serialization can be a security liability
+ */
+@Deprecated
 public final class ClassResolvers {
 
     /**

--- a/codec/src/main/java/io/netty/handler/codec/serialization/CompatibleObjectEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/serialization/CompatibleObjectEncoder.java
@@ -33,7 +33,18 @@ import java.io.Serializable;
  * <p>
  * This encoder is interoperable with the standard Java object streams such as
  * {@link ObjectInputStream} and {@link ObjectOutputStream}.
+ * <p>
+ * <strong>Security:</strong> serialization can be a security liability,
+ * and should not be used without defining a list of classes that are
+ * allowed to be desirialized. Such a list can be specified with the
+ * <tt>jdk.serialFilter</tt> system property, for instance.
+ * See the <a href="https://docs.oracle.com/en/java/javase/17/core/serialization-filtering1.html">
+ * serialization filtering</a> article for more information.
+ *
+ * @deprecated This class has been deprecated with no replacement,
+ * because serialization can be a security liability
  */
+@Deprecated
 public class CompatibleObjectEncoder extends MessageToByteEncoder<Serializable> {
     private final int resetInterval;
     private int writtenObjects;

--- a/codec/src/main/java/io/netty/handler/codec/serialization/ObjectDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/serialization/ObjectDecoder.java
@@ -32,7 +32,18 @@ import java.io.StreamCorruptedException;
  * compatible with the standard {@link ObjectOutputStream}.  Please use
  * {@link ObjectEncoder} or {@link ObjectEncoderOutputStream} to ensure the
  * interoperability with this decoder.
+ * <p>
+ * <strong>Security:</strong> serialization can be a security liability,
+ * and should not be used without defining a list of classes that are
+ * allowed to be desirialized. Such a list can be specified with the
+ * <tt>jdk.serialFilter</tt> system property, for instance.
+ * See the <a href="https://docs.oracle.com/en/java/javase/17/core/serialization-filtering1.html">
+ * serialization filtering</a> article for more information.
+ *
+ * @deprecated This class has been deprecated with no replacement,
+ * because serialization can be a security liability
  */
+@Deprecated
 public class ObjectDecoder extends LengthFieldBasedFrameDecoder {
 
     private final ClassResolver classResolver;

--- a/codec/src/main/java/io/netty/handler/codec/serialization/ObjectDecoderInputStream.java
+++ b/codec/src/main/java/io/netty/handler/codec/serialization/ObjectDecoderInputStream.java
@@ -27,7 +27,18 @@ import java.io.StreamCorruptedException;
 /**
  * An {@link ObjectInput} which is interoperable with {@link ObjectEncoder}
  * and {@link ObjectEncoderOutputStream}.
+ * <p>
+ * <strong>Security:</strong> serialization can be a security liability,
+ * and should not be used without defining a list of classes that are
+ * allowed to be desirialized. Such a list can be specified with the
+ * <tt>jdk.serialFilter</tt> system property, for instance.
+ * See the <a href="https://docs.oracle.com/en/java/javase/17/core/serialization-filtering1.html">
+ * serialization filtering</a> article for more information.
+ *
+ * @deprecated This class has been deprecated with no replacement,
+ * because serialization can be a security liability
  */
+@Deprecated
 public class ObjectDecoderInputStream extends InputStream implements
         ObjectInput {
 

--- a/codec/src/main/java/io/netty/handler/codec/serialization/ObjectEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/serialization/ObjectEncoder.java
@@ -32,7 +32,18 @@ import java.io.Serializable;
  * compatible with the standard {@link ObjectInputStream}.  Please use
  * {@link ObjectDecoder} or {@link ObjectDecoderInputStream} to ensure the
  * interoperability with this encoder.
+ * <p>
+ * <strong>Security:</strong> serialization can be a security liability,
+ * and should not be used without defining a list of classes that are
+ * allowed to be desirialized. Such a list can be specified with the
+ * <tt>jdk.serialFilter</tt> system property, for instance.
+ * See the <a href="https://docs.oracle.com/en/java/javase/17/core/serialization-filtering1.html">
+ * serialization filtering</a> article for more information.
+ *
+ * @deprecated This class has been deprecated with no replacement,
+ * because serialization can be a security liability
  */
+@Deprecated
 @Sharable
 public class ObjectEncoder extends MessageToByteEncoder<Serializable> {
     private static final byte[] LENGTH_PLACEHOLDER = new byte[4];

--- a/codec/src/main/java/io/netty/handler/codec/serialization/ObjectEncoderOutputStream.java
+++ b/codec/src/main/java/io/netty/handler/codec/serialization/ObjectEncoderOutputStream.java
@@ -29,7 +29,18 @@ import java.io.OutputStream;
 /**
  * An {@link ObjectOutput} which is interoperable with {@link ObjectDecoder}
  * and {@link ObjectDecoderInputStream}.
+ * <p>
+ * <strong>Security:</strong> serialization can be a security liability,
+ * and should not be used without defining a list of classes that are
+ * allowed to be desirialized. Such a list can be specified with the
+ * <tt>jdk.serialFilter</tt> system property, for instance.
+ * See the <a href="https://docs.oracle.com/en/java/javase/17/core/serialization-filtering1.html">
+ * serialization filtering</a> article for more information.
+ *
+ * @deprecated This class has been deprecated with no replacement,
+ * because serialization can be a security liability
  */
+@Deprecated
 public class ObjectEncoderOutputStream extends OutputStream implements
         ObjectOutput {
 

--- a/codec/src/main/java/io/netty/handler/codec/serialization/package-info.java
+++ b/codec/src/main/java/io/netty/handler/codec/serialization/package-info.java
@@ -18,5 +18,16 @@
  * Encoder, decoder and their compatibility stream implementations which
  * transform a {@link java.io.Serializable} object into a byte buffer and
  * vice versa.
+ * <p>
+ * <strong>Security:</strong> serialization can be a security liability,
+ * and should not be used without defining a list of classes that are
+ * allowed to be desirialized. Such a list can be specified with the
+ * <tt>jdk.serialFilter</tt> system property, for instance.
+ * See the <a href="https://docs.oracle.com/en/java/javase/17/core/serialization-filtering1.html">
+ * serialization filtering</a> article for more information.
+ *
+ * @deprecated This package has been deprecated with no replacement,
+ * because serialization can be a security liability
  */
+@Deprecated
 package io.netty.handler.codec.serialization;


### PR DESCRIPTION
Motivation:
Serialization has proven itself to be a security liability, and one that cannot easily be fixed: new gadgets are created and found regularly, as are filter-bypasses.

Modification:
Deprecate all of `io.netty.handler.codec.serialization` to discourage its use.

Result:
Use of object serialization is now discouraged.

Thank you to Oriya Yavnieli of the JFrog Security Research team for bringing this to our attention.