### PR TITLE
Extend DNS address supplier interface to provide feedback

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
@@ -482,7 +482,7 @@ abstract class DnsResolveContext<T> {
                         if (isFeedbackAddressStream) {
                             final DnsServerResponseFeedbackAddressStream feedbackNameServerAddrStream =
                                     (DnsServerResponseFeedbackAddressStream) nameServerAddrStream;
-                            feedbackNameServerAddrStream.feedbackFailure(nameServerAddr,
+                            feedbackNameServerAddrStream.feedbackFailure(nameServerAddr, queryCause,
                                     System.nanoTime() - queryStartTimeNanos);
                         }
                         queryLifecycleObserver.queryFailed(queryCause);

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
@@ -433,10 +433,13 @@ abstract class DnsResolveContext<T> {
                 parent.ch.eventLoop().newPromise();
 
         final long queryStartTimeNanos;
+        final boolean isFeedbackAddressStream;
         if (nameServerAddrStream instanceof DnsServerResponseFeedbackAddressStream) {
             queryStartTimeNanos = System.nanoTime();
+            isFeedbackAddressStream = true;
         } else {
             queryStartTimeNanos = -1;
+            isFeedbackAddressStream = false;
         }
 
         final Future<AddressedEnvelope<DnsResponse, InetSocketAddress>> f =
@@ -466,7 +469,7 @@ abstract class DnsResolveContext<T> {
                 final Throwable queryCause = future.cause();
                 try {
                     if (queryCause == null) {
-                        if (queryStartTimeNanos >= 0) {
+                        if (isFeedbackAddressStream) {
                             final DnsServerResponseFeedbackAddressStream feedbackNameServerAddrStream =
                                     (DnsServerResponseFeedbackAddressStream) nameServerAddrStream;
                             feedbackNameServerAddrStream.feedbackSuccess(nameServerAddr,
@@ -476,7 +479,7 @@ abstract class DnsResolveContext<T> {
                                    queryLifecycleObserver, promise);
                     } else {
                         // Server did not respond or I/O error occurred; try again.
-                        if (queryStartTimeNanos >= 0) {
+                        if (isFeedbackAddressStream) {
                             final DnsServerResponseFeedbackAddressStream feedbackNameServerAddrStream =
                                     (DnsServerResponseFeedbackAddressStream) nameServerAddrStream;
                             feedbackNameServerAddrStream.feedbackFailure(nameServerAddr);

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
@@ -450,12 +450,6 @@ abstract class DnsResolveContext<T> {
             @Override
             public void operationComplete(Future<AddressedEnvelope<DnsResponse, InetSocketAddress>> future) {
                 queriesInProgress.remove(future);
-                if (queryStartTimeNanos >= 0) {
-                    final DnsServerResponseTimeFeedbackAddressStream feedbackNameServerAddrStream =
-                            (DnsServerResponseTimeFeedbackAddressStream) nameServerAddrStream;
-                    feedbackNameServerAddrStream.feedbackResponseTime(nameServerAddr,
-                            System.nanoTime() - queryStartTimeNanos);
-                }
 
                 if (promise.isDone() || future.isCancelled()) {
                     queryLifecycleObserver.queryCancelled(allowedQueries);
@@ -481,6 +475,12 @@ abstract class DnsResolveContext<T> {
                               newDnsQueryLifecycleObserver(question), true, promise, queryCause);
                     }
                 } finally {
+                    if (queryStartTimeNanos >= 0) {
+                        final DnsServerResponseTimeFeedbackAddressStream feedbackNameServerAddrStream =
+                                (DnsServerResponseTimeFeedbackAddressStream) nameServerAddrStream;
+                        feedbackNameServerAddrStream.feedbackResponseTime(nameServerAddr,
+                                System.nanoTime() - queryStartTimeNanos);
+                    }
                     tryToFinishResolve(nameServerAddrStream, nameServerAddrStreamIndex, question,
                                        // queryLifecycleObserver has already been terminated at this point so we must
                                        // not allow it to be terminated again by tryToFinishResolve.

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
@@ -482,7 +482,8 @@ abstract class DnsResolveContext<T> {
                         if (isFeedbackAddressStream) {
                             final DnsServerResponseFeedbackAddressStream feedbackNameServerAddrStream =
                                     (DnsServerResponseFeedbackAddressStream) nameServerAddrStream;
-                            feedbackNameServerAddrStream.feedbackFailure(nameServerAddr);
+                            feedbackNameServerAddrStream.feedbackFailure(nameServerAddr,
+                                    System.nanoTime() - queryStartTimeNanos);
                         }
                         queryLifecycleObserver.queryFailed(queryCause);
                         query(nameServerAddrStream, nameServerAddrStreamIndex + 1, question,

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerResponseFeedbackAddressStream.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerResponseFeedbackAddressStream.java
@@ -19,15 +19,27 @@ import java.net.InetSocketAddress;
 
 /**
  * An infinite stream of DNS server addresses, that requests feedback to be returned to it.
+ *
+ * If query is successful timing information is provided, else a failure notification is given.
  */
-public interface DnsServerResponseTimeFeedbackAddressStream extends DnsServerAddressStream {
+public interface DnsServerResponseFeedbackAddressStream extends DnsServerAddressStream {
 
     /**
-     * A way to provide timing feedback to the {@link DnsServerAddressStream} so that {@link #next()} can be tuned
+     * A way to provide timing feedback to {@link DnsServerAddressStream} so that {@link #next()} can be tuned
      * to return the best performing DNS server address
+     *
+     * NOTE: This is called regardless of the RCode returned by the DNS server
      *
      * @param address The address returned by {@link #next()} that feedback needs to be applied to
      * @param queryResponseTimeNanos The response time of a query against the given DNS server
      */
-    void feedbackResponseTime(InetSocketAddress address, long queryResponseTimeNanos);
+    void feedbackSuccess(InetSocketAddress address, long queryResponseTimeNanos);
+
+    /**
+     * A way to provide failure feedback to {@link DnsServerAddressStream} so that {@link #next()} cab be tuned
+     * to return the best performing DNS server address
+     *
+     * @param address The address returned by {@link #next()} that feedback needs to be applied to
+     */
+    void feedbackFailure(InetSocketAddress address);
 }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerResponseFeedbackAddressStream.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerResponseFeedbackAddressStream.java
@@ -40,7 +40,8 @@ public interface DnsServerResponseFeedbackAddressStream extends DnsServerAddress
      * to return the best performing DNS server address
      *
      * @param address The address returned by {@link #next()} that feedback needs to be applied to
+     * @param failureCause The reason the DNS query failed, can be used to penalize failures differently
      * @param queryResponseTimeNanos The response time of a query against the given DNS server
      */
-    void feedbackFailure(InetSocketAddress address, long queryResponseTimeNanos);
+    void feedbackFailure(InetSocketAddress address, Throwable failureCause, long queryResponseTimeNanos);
 }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerResponseFeedbackAddressStream.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerResponseFeedbackAddressStream.java
@@ -25,7 +25,7 @@ import java.net.InetSocketAddress;
 public interface DnsServerResponseFeedbackAddressStream extends DnsServerAddressStream {
 
     /**
-     * A way to provide timing feedback to {@link DnsServerAddressStream} so that {@link #next()} can be tuned
+     * A way to provide success feedback to {@link DnsServerAddressStream} so that {@link #next()} can be tuned
      * to return the best performing DNS server address
      *
      * NOTE: This is called regardless of the RCode returned by the DNS server
@@ -40,6 +40,7 @@ public interface DnsServerResponseFeedbackAddressStream extends DnsServerAddress
      * to return the best performing DNS server address
      *
      * @param address The address returned by {@link #next()} that feedback needs to be applied to
+     * @param queryResponseTimeNanos The response time of a query against the given DNS server
      */
-    void feedbackFailure(InetSocketAddress address);
+    void feedbackFailure(InetSocketAddress address, long queryResponseTimeNanos);
 }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerResponseTimeFeedbackAddressStream.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerResponseTimeFeedbackAddressStream.java
@@ -1,0 +1,18 @@
+package io.netty.resolver.dns;
+
+import java.net.InetSocketAddress;
+
+/**
+ * An infinite stream of DNS server addresses, that requests feedback to be returned to it.
+ */
+public interface DnsServerResponseTimeFeedbackAddressStream extends DnsServerAddressStream {
+
+    /**
+     * A way to provide timing feedback to the {@link DnsServerAddressStream} so that {@link #next()} can be tuned
+     * to return the best performing DNS server address
+     *
+     * @param address The address returned by {@link #next()} that feedback needs to be applied to
+     * @param queryResponseTimeNanos The response time of a query against the given DNS server
+     */
+    void feedbackResponseTime(InetSocketAddress address, long queryResponseTimeNanos);
+}

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerResponseTimeFeedbackAddressStream.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerResponseTimeFeedbackAddressStream.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package io.netty.resolver.dns;
 
 import java.net.InetSocketAddress;

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -123,6 +123,7 @@ import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -3675,11 +3676,16 @@ public class DnsNameResolverTest {
                 return new DnsServerResponseFeedbackAddressStream() {
                     @Override
                     public void feedbackSuccess(InetSocketAddress address, long queryResponseTimeNanos) {
+                        assertThat(queryResponseTimeNanos, greaterThanOrEqualTo(0L));
                         successCalled.set(true);
                     }
 
                     @Override
-                    public void feedbackFailure(InetSocketAddress address, long queryResponseTimeNanos) {
+                    public void feedbackFailure(InetSocketAddress address,
+                                                Throwable failureCause,
+                                                long queryResponseTimeNanos) {
+                        assertThat(queryResponseTimeNanos, greaterThanOrEqualTo(0L));
+                        assertNotNull(failureCause);
                         failureCalled.set(true);
                     }
 

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -3663,4 +3663,78 @@ public class DnsNameResolverTest {
             datagramSocket.close();
         }
     }
+
+    @Test
+    public void testResponseFeedbackStream() {
+        final AtomicBoolean successCalled = new AtomicBoolean();
+        final AtomicBoolean failureCalled = new AtomicBoolean();
+        final AtomicBoolean returnSuccess = new AtomicBoolean(false);
+        final DnsNameResolver resolver = newResolver(true, new DnsServerAddressStreamProvider() {
+            @Override
+            public DnsServerAddressStream nameServerAddressStream(String hostname) {
+                return new DnsServerResponseFeedbackAddressStream() {
+                    @Override
+                    public void feedbackSuccess(InetSocketAddress address, long queryResponseTimeNanos) {
+                        successCalled.set(true);
+                    }
+
+                    @Override
+                    public void feedbackFailure(InetSocketAddress address) {
+                        failureCalled.set(true);
+                    }
+
+                    @Override
+                    public InetSocketAddress next() {
+                        if (returnSuccess.get()) {
+                            return dnsServer.localAddress();
+                        }
+                        try {
+                            return new InetSocketAddress(InetAddress.getByAddress("foo.com",
+                                    new byte[] {(byte) 169, (byte) 254, 12, 34 }), 53);
+                        } catch (UnknownHostException e) {
+                            throw new Error(e);
+                        }
+                    }
+
+                    @Override
+                    public int size() {
+                        return 1;
+                    }
+
+                    @Override
+                    public DnsServerAddressStream duplicate() {
+                        return this;
+                    }
+                };
+            }
+        }).build();
+        try {
+            // setup call to be successful and verify
+            returnSuccess.set(true);
+            resolver.resolve("google.com").syncUninterruptibly().getNow();
+            assertTrue(successCalled.get());
+            assertFalse(failureCalled.get());
+
+            // reset state for next query
+            successCalled.set(false);
+            failureCalled.set(false);
+
+            // setup call to fail and verify
+            returnSuccess.set(false);
+            try {
+                resolver.resolve("yahoo.com").syncUninterruptibly().getNow();
+                fail();
+            } catch (Exception e) {
+                // expected
+                assertThat(e, is(instanceOf(UnknownHostException.class)));
+            } finally {
+                assertFalse(successCalled.get());
+                assertTrue(failureCalled.get());
+            }
+        } finally {
+            if (resolver != null) {
+                resolver.close();
+            }
+        }
+    }
 }

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -3679,7 +3679,7 @@ public class DnsNameResolverTest {
                     }
 
                     @Override
-                    public void feedbackFailure(InetSocketAddress address) {
+                    public void feedbackFailure(InetSocketAddress address, long queryResponseTimeNanos) {
                         failureCalled.set(true);
                     }
 


### PR DESCRIPTION
Motivation:

This change allows the start of building out a resolver that is more performant. Most standalone DNS resolvers have some mechanism to find and prioritize nameservers that are giving the best service (either lower error rate or faster response times)

E.g. https://unbound.docs.nlnetlabs.nl/en/latest/reference/history/info-timeout-server-selection.html

Modification:

Added a new interface that extends DnsServerAddressStream to provide a mechanism for DnsResolverContext to provide feedback back to the class that is providing DNS servers in the form of InetSocketAddress

Result:

The DnsServerAddressStream is now able to know the response times of queries for each InetSocketAddress that it returned, or that the InetSocketAddress had a failure when used
