### PR TITLE
Don't write zeros to newly allocated array

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolSubpage.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolSubpage.java
@@ -73,10 +73,6 @@ final class PoolSubpage<T> implements PoolSubpageMetric {
             if ((maxNumElems & 63) != 0) {
                 bitmapLength ++;
             }
-
-            for (int i = 0; i < bitmapLength; i ++) {
-                bitmap[i] = 0;
-            }
         }
         addToPool(head);
     }


### PR DESCRIPTION
Motivation:
Java guarantees that primitive int arrays are initialized to zero, so writing zeros to a newly allocated array is pointless.

Modification:
Remove loop that writes zeros to a newly allocated array in PoolSubpage.

Result:
Less wasted work.