### PR TITLE
Add toString methods to allocators to aid in debugging

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/ManagedBufferAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/ManagedBufferAllocator.java
@@ -87,4 +87,9 @@ class ManagedBufferAllocator implements BufferAllocator, AllocatorControl {
     public BufferAllocator getAllocator() {
         return this;
     }
+
+    @Override
+    public String toString() {
+        return "BufferAllocator(" + allocationType + (closed ? ", closed)" : ")");
+    }
 }

--- a/buffer/src/main/java/io/netty5/buffer/internal/WrappingAllocation.java
+++ b/buffer/src/main/java/io/netty5/buffer/internal/WrappingAllocation.java
@@ -38,4 +38,9 @@ public final class WrappingAllocation implements AllocationType {
     public boolean isDirect() {
         return false;
     }
+
+    @Override
+    public String toString() {
+        return "WrappingAllocation(byte[" + array.length + "])";
+    }
 }

--- a/buffer/src/main/java/io/netty5/buffer/pool/PooledBufferAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/pool/PooledBufferAllocator.java
@@ -616,4 +616,10 @@ public class PooledBufferAllocator implements BufferAllocator, BufferAllocatorMe
 
         return buf.toString();
     }
+
+    @Override
+    public String toString() {
+        return "PooledBufferAllocator@" + Integer.toHexString(System.identityHashCode(this)) +
+                "(" + allocationType + (closed ? ", closed)" : ")");
+    }
 }


### PR DESCRIPTION
Motivation:
Many transport tests are parameterized over different allocator implementations, so having proper toString methods on the allocators is useful for identifying what parameters a given test run is using.

Modification:
Add toString implementations on ManagedBufferAllocator, PooledBufferAllocator, and WrappingAllocation (an allocation type).

Result:
Allocators now have nicer toString implementations that produce meaningful output.