### PR TITLE
Make Handler-Ssl-Ocsp releasable

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -298,6 +298,11 @@
       <artifactId>netty-handler-proxy</artifactId>
       <scope>compile</scope>
     </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-handler-ssl-ocsp</artifactId>
+        <scope>compile</scope>
+      </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-resolver</artifactId>

--- a/all/pom.xml
+++ b/all/pom.xml
@@ -298,11 +298,11 @@
       <artifactId>netty-handler-proxy</artifactId>
       <scope>compile</scope>
     </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-handler-ssl-ocsp</artifactId>
-        <scope>compile</scope>
-      </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-handler-ssl-ocsp</artifactId>
+      <scope>compile</scope>
+    </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-resolver</artifactId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -167,6 +167,11 @@
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
+        <artifactId>netty-handler-ssl-ocsp</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
         <artifactId>netty-resolver</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/handler-ssl-ocsp/pom.xml
+++ b/handler-ssl-ocsp/pom.xml
@@ -37,6 +37,7 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>

--- a/handler-ssl-ocsp/pom.xml
+++ b/handler-ssl-ocsp/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.85.Final-SNAPSHOT</version>
+    <version>4.1.86.Final-SNAPSHOT</version>
   </parent>
 
   <artifactId>netty-handler-ssl-ocsp</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -760,8 +760,6 @@
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcpkix-jdk15on</artifactId>
         <version>1.69</version>
-        <scope>compile</scope>
-        <optional>true</optional>
       </dependency>
 
       <!--
@@ -772,8 +770,6 @@
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcprov-jdk15on</artifactId>
         <version>1.69</version>
-        <scope>compile</scope>
-        <optional>true</optional>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -760,6 +760,8 @@
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcpkix-jdk15on</artifactId>
         <version>1.69</version>
+        <scope>compile</scope>
+        <optional>true</optional>
       </dependency>
 
       <!--
@@ -770,6 +772,8 @@
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcprov-jdk15on</artifactId>
         <version>1.69</version>
+        <scope>compile</scope>
+        <optional>true</optional>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Motivation:
We should make Handler-Ssl-Ocsp releasable.

Modification:
Added handler-ssl-ocsp into `bom` and `all` modules.

Result:
Fixes #13003 . 

