### PR TITLE
WebSocketClientHandshaker: add public accessors for parameters

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker13.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker13.java
@@ -306,4 +306,15 @@ public class WebSocketClientHandshaker13 extends WebSocketClientHandshaker {
         return this;
     }
 
+    public boolean isAllowExtensions() {
+        return allowExtensions;
+    }
+
+    public boolean isPerformMasking() {
+        return performMasking;
+    }
+
+    public boolean isAllowMaskMismatch() {
+        return allowMaskMismatch;
+    }
 }


### PR DESCRIPTION
Motivation:

WebSocket client & server handshakers may be extended with custom frame encoder / decoder, however client handshaker parameters are private so cant be passed to custom frame encoder / decoder.

Modifications:

WebSocketClientHandshaker13: add public accessors for parameters.

Result:

Custom frame encoder / decoder may be provided with WebSocket client handshaker parameters.