### PR TITLE
WebSocket frame decoding: replace byte array[4] frame mask with int. …

### DIFF
--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocket13FrameEncoder.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocket13FrameEncoder.java
@@ -174,14 +174,13 @@ public class WebSocket13FrameEncoder extends MessageToMessageEncoder<WebSocketFr
                 int mask = ThreadLocalRandom.current().nextInt(Integer.MAX_VALUE);
                 buf.writeInt(mask);
 
-                int counter = 0;
                 int i = data.readerOffset();
                 int end = data.writerOffset();
 
                 int maskOffset = 0;
                 for (; i < end; i++) {
                     byte byteData = data.getByte(i);
-                    buf.writeByte((byte) (byteData ^ byteAtIndex(mask, maskOffset++ & 3)));
+                    buf.writeByte((byte) (byteData ^ WebSocketUtil.byteAtIndex(mask, maskOffset++ & 3)));
                 }
                 out.add(buf);
             } else {
@@ -200,9 +199,5 @@ public class WebSocket13FrameEncoder extends MessageToMessageEncoder<WebSocketFr
             }
             throw t;
         }
-    }
-
-    private static int byteAtIndex(int mask, int index) {
-        return (mask >> 8 * (3 - index)) & 0xFF;
     }
 }

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketUtil.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketUtil.java
@@ -86,6 +86,10 @@ final class WebSocketUtil {
         return base64(sha1);
     }
 
+    static int byteAtIndex(int mask, int index) {
+        return (mask >> 8 * (3 - index)) & 0xFF;
+    }
+
     private WebSocketUtil() {
     }
 }


### PR DESCRIPTION
…(#12989)

Motivation:

Make implementation consistent with recent changes on WebSocket08FrameEncoder https://github.com/netty/netty/pull/12969.

Modifications:

WebSocket08FrameDecoder: replace frame mask byte array[4] with int.

Result:

Simpler implementation consistent with WebSocket08FrameEncoder.
