### PR TITLE
Replace LinkedList with ArrayList

### DIFF
--- a/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlElement.java
+++ b/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlElement.java
@@ -15,7 +15,7 @@
  */
 package io.netty.handler.codec.xml;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 /**

--- a/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlElement.java
+++ b/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlElement.java
@@ -28,7 +28,7 @@ public abstract class XmlElement {
     private final String namespace;
     private final String prefix;
 
-    private final List<XmlNamespace> namespaces = new LinkedList<XmlNamespace>();
+    private final List<XmlNamespace> namespaces = new ArrayList<XmlNamespace>();
 
     protected XmlElement(String name, String namespace, String prefix) {
         this.name = name;

--- a/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlElementStart.java
+++ b/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlElementStart.java
@@ -15,7 +15,7 @@
  */
 package io.netty.handler.codec.xml;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 /**

--- a/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlElementStart.java
+++ b/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlElementStart.java
@@ -23,7 +23,7 @@ import java.util.List;
  */
 public class XmlElementStart extends XmlElement {
 
-    private final List<XmlAttribute> attributes = new LinkedList<XmlAttribute>();
+    private final List<XmlAttribute> attributes = new ArrayList<XmlAttribute>();
 
     public XmlElementStart(String name, String namespace, String prefix) {
         super(name, namespace, prefix);


### PR DESCRIPTION
Motivation:

ArrayList is more efficient than LinkedList in the space cost.
ArrayList is almost as efficient as LinkedList in the time cost of tail insertion, which are the practical use cases of the two lists I modified.

Modification:

Replace LinkedList with ArrayList.

Result:

Less space cost.
