### PR TITLE
Correctly handle unresolvable InetSocketAddress when using DatagramCh…

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
@@ -255,6 +255,10 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
     }
 
     public void testSendToUnresolvableAddress(Bootstrap sb, Bootstrap cb) throws Throwable {
+        SocketAddress serverAddress = newSocketAddress();
+        if (!(serverAddress instanceof InetSocketAddress)) {
+            return;
+        }
         Channel sc = sb.handler(new ChannelInitializer<Channel>() {
             @Override
             protected void initChannel(Channel ch) throws Exception {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
@@ -22,18 +22,19 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.DatagramPacket;
+import io.netty.util.CharsetUtil;
 import io.netty.util.NetUtil;
 import io.netty.util.internal.EmptyArrays;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.opentest4j.TestAbortedException;
 
-import java.io.IOException;
 import java.net.BindException;
 import java.net.DatagramSocket;
 import java.net.Inet6Address;
@@ -42,6 +43,7 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.SocketException;
 import java.nio.channels.NotYetConnectedException;
+import java.nio.channels.UnresolvedAddressException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -51,6 +53,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -238,6 +241,58 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
                 throw new TestAbortedException("JDK sockets do not support binding to these addresses.", e);
             }
             semaphore.acquire();
+        }
+    }
+
+    @Test
+    public void testSendToUnresolvableAddress(TestInfo testInfo) throws Throwable {
+        run(testInfo, new Runner<Bootstrap, Bootstrap>() {
+            @Override
+            public void run(Bootstrap bootstrap, Bootstrap bootstrap2) throws Throwable {
+                testSendToUnresolvableAddress(bootstrap, bootstrap2);
+            }
+        });
+    }
+
+    public void testSendToUnresolvableAddress(Bootstrap sb, Bootstrap cb) throws Throwable {
+        Channel sc = sb.handler(new ChannelInitializer<Channel>() {
+            @Override
+            protected void initChannel(Channel ch) throws Exception {
+                ch.pipeline().addLast(new SimpleChannelInboundHandler<DatagramPacket>() {
+                    @Override
+                    protected void channelRead0(ChannelHandlerContext ctx, DatagramPacket msg) {
+                        // Just drop
+                    }
+                });
+            }
+        }).bind(newSocketAddress()).sync().channel();
+
+        Channel cc = cb.handler(new ChannelInboundHandlerAdapter()).bind(newSocketAddress()).sync().channel();
+        try {
+            InetSocketAddress goodHost = (InetSocketAddress) sc.localAddress();
+            InetSocketAddress unresolvedHost = new InetSocketAddress("NOT_A_REAL_ADDRESS", goodHost.getPort());
+
+            assertFalse(goodHost.isUnresolved());
+            assertTrue(unresolvedHost.isUnresolved());
+
+            String message = "hello world!";
+            assertTrue(cc.writeAndFlush(new DatagramPacket(
+                    Unpooled.copiedBuffer(message, CharsetUtil.US_ASCII), goodHost)).await().isSuccess());
+            assertInstanceOf(UnresolvedAddressException.class, cc.writeAndFlush(new DatagramPacket(
+                    Unpooled.copiedBuffer(message, CharsetUtil.US_ASCII), unresolvedHost)).await().cause());
+
+            // DatagramChannel should still be open after sending to unresolved address
+            assertTrue(cc.isOpen());
+
+            // DatagramChannel should still be able to send messages outbound
+            assertTrue(cc.writeAndFlush(new DatagramPacket(
+                    Unpooled.copiedBuffer(message, CharsetUtil.US_ASCII), goodHost)).await().isSuccess());
+            assertInstanceOf(UnresolvedAddressException.class, cc.writeAndFlush(new DatagramPacket(
+                    Unpooled.copiedBuffer(message, CharsetUtil.US_ASCII), unresolvedHost)).await().cause());
+            assertTrue(cc.isOpen());
+        } finally {
+            closeChannel(cc);
+            closeChannel(sc);
         }
     }
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
@@ -269,12 +269,12 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
                     }
                 });
             }
-        }).bind(newSocketAddress()).sync().channel();
+        }).bind(serverAddress).sync().channel();
 
         Channel cc = cb.option(ChannelOption.DATAGRAM_CHANNEL_ACTIVE_ON_REGISTRATION, true).
                 handler(new ChannelInboundHandlerAdapter()).register().sync().channel();
         try {
-            InetSocketAddress goodHost = (InetSocketAddress) sc.localAddress();
+            InetSocketAddress goodHost = sendToAddress((InetSocketAddress) sc.localAddress());
             InetSocketAddress unresolvedHost = new InetSocketAddress("NOT_A_REAL_ADDRESS", goodHost.getPort());
 
             assertFalse(goodHost.isUnresolved());

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -45,6 +45,7 @@ import java.net.NetworkInterface;
 import java.net.PortUnreachableException;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
+import java.nio.channels.UnresolvedAddressException;
 
 import static io.netty.channel.epoll.LinuxSocket.newSocketDgram;
 
@@ -417,6 +418,13 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
         return doWriteOrSendBytes(data, remoteAddress, false) > 0;
     }
 
+    private static void checkUnresolved(AddressedEnvelope<?, ?> envelope) {
+        if (envelope.recipient() instanceof InetSocketAddress
+                && (((InetSocketAddress) envelope.recipient()).isUnresolved())) {
+            throw new UnresolvedAddressException();
+        }
+    }
+
     @Override
     protected Object filterOutboundMessage(Object msg) {
         if (msg instanceof io.netty.channel.unix.SegmentedDatagramPacket) {
@@ -425,12 +433,16 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
                         "unsupported message type: " + StringUtil.simpleClassName(msg) + EXPECTED_TYPES);
             }
             io.netty.channel.unix.SegmentedDatagramPacket packet = (io.netty.channel.unix.SegmentedDatagramPacket) msg;
+            checkUnresolved(packet);
+
             ByteBuf content = packet.content();
             return UnixChannelUtil.isBufferCopyNeededForWrite(content) ?
                     packet.replace(newDirectBuffer(packet, content)) : msg;
         }
         if (msg instanceof DatagramPacket) {
             DatagramPacket packet = (DatagramPacket) msg;
+            checkUnresolved(packet);
+
             ByteBuf content = packet.content();
             return UnixChannelUtil.isBufferCopyNeededForWrite(content) ?
                     new DatagramPacket(newDirectBuffer(packet, content), packet.recipient()) : msg;
@@ -444,6 +456,8 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
         if (msg instanceof AddressedEnvelope) {
             @SuppressWarnings("unchecked")
             AddressedEnvelope<Object, SocketAddress> e = (AddressedEnvelope<Object, SocketAddress>) msg;
+            checkUnresolved(e);
+
             if (e.content() instanceof ByteBuf &&
                 (e.recipient() == null || e.recipient() instanceof InetSocketAddress)) {
 

--- a/transport/src/main/java/io/netty/channel/socket/oio/OioDatagramChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/OioDatagramChannel.java
@@ -45,6 +45,7 @@ import java.net.SocketAddress;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.nio.channels.NotYetConnectedException;
+import java.nio.channels.UnresolvedAddressException;
 import java.util.List;
 import java.util.Locale;
 
@@ -292,15 +293,28 @@ public class OioDatagramChannel extends AbstractOioMessageChannel
         }
     }
 
+    private static void checkUnresolved(AddressedEnvelope<?, ?> envelope) {
+        if (envelope.recipient() instanceof InetSocketAddress
+                && (((InetSocketAddress) envelope.recipient()).isUnresolved())) {
+            throw new UnresolvedAddressException();
+        }
+    }
+
     @Override
     protected Object filterOutboundMessage(Object msg) {
-        if (msg instanceof DatagramPacket || msg instanceof ByteBuf) {
+        if (msg instanceof DatagramPacket) {
+            checkUnresolved((DatagramPacket) msg);
+            return msg;
+        }
+
+        if (msg instanceof ByteBuf) {
             return msg;
         }
 
         if (msg instanceof AddressedEnvelope) {
             @SuppressWarnings("unchecked")
             AddressedEnvelope<Object, SocketAddress> e = (AddressedEnvelope<Object, SocketAddress>) msg;
+            checkUnresolved(e);
             if (e.content() instanceof ByteBuf) {
                 return msg;
             }


### PR DESCRIPTION
…annel

Motivation:

We should consistent handle the case when a DatagramPacket was send to an unresolvable InetSocketAddress.

Modifications:

Consistently fail in the case of unresolvable InetSocketAddress

Result:

Fixes https://github.com/netty/netty/issues/13015
