### PR TITLE
Enable SocketHalfClosedTest for epoll

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -339,7 +339,6 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
     }
 
     @Test
-    @Timeout(30)
     public void testAutoCloseFalseDoesShutdownOutput(TestInfo testInfo) throws Throwable {
         // This test only works on Linux / BSD / MacOS as we assume some semantics that are not true for Windows.
         assumeFalse(PlatformDependent.isWindows());

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -339,6 +339,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
     }
 
     @Test
+    @Timeout(30)
     public void testAutoCloseFalseDoesShutdownOutput(TestInfo testInfo) throws Throwable {
         // This test only works on Linux / BSD / MacOS as we assume some semantics that are not true for Windows.
         assumeFalse(PlatformDependent.isWindows());
@@ -363,7 +364,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                                                              Bootstrap cb) throws InterruptedException {
         final int expectedBytes = 100;
         final CountDownLatch serverReadExpectedLatch = new CountDownLatch(1);
-        final CountDownLatch doneLatch = new CountDownLatch(1);
+        final CountDownLatch doneLatch = new CountDownLatch(2);
         final AtomicReference<Throwable> causeRef = new AtomicReference<Throwable>();
         Channel serverChannel = null;
         Channel clientChannel = null;
@@ -375,9 +376,9 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                     .childOption(ChannelOption.AUTO_CLOSE, false)
                     .childOption(ChannelOption.SO_LINGER, 0);
 
-            final SimpleChannelInboundHandler<ByteBuf> leaderHandler = new AutoCloseFalseLeader(expectedBytes,
+            final AutoCloseFalseLeader leaderHandler = new AutoCloseFalseLeader(expectedBytes,
                     serverReadExpectedLatch, doneLatch, causeRef);
-            final SimpleChannelInboundHandler<ByteBuf> followerHandler = new AutoCloseFalseFollower(expectedBytes,
+            final AutoCloseFalseFollower followerHandler = new AutoCloseFalseFollower(expectedBytes,
                     serverReadExpectedLatch, doneLatch, causeRef);
             sb.childHandler(new ChannelInitializer<Channel>() {
                 @Override
@@ -398,6 +399,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
 
             doneLatch.await();
             assertNull(causeRef.get());
+            assertTrue(leaderHandler.seenOutputShutdown);
         } finally {
             if (clientChannel != null) {
                 clientChannel.close().sync();
@@ -479,7 +481,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
         private final CountDownLatch doneLatch;
         private final AtomicReference<Throwable> causeRef;
         private int bytesRead;
-        private boolean seenOutputShutdown;
+        boolean seenOutputShutdown;
 
         AutoCloseFalseLeader(int expectedBytes, CountDownLatch followerCloseLatch, CountDownLatch doneLatch,
                              AtomicReference<Throwable> causeRef) {
@@ -515,10 +517,6 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
         protected void channelRead0(ChannelHandlerContext ctx, ByteBuf msg) throws Exception {
             bytesRead += msg.readableBytes();
             if (bytesRead >= expectedBytes) {
-                if (!seenOutputShutdown) {
-                    causeRef.set(new IllegalStateException(
-                            ChannelOutputShutdownEvent.class.getSimpleName() + " event was not seen"));
-                }
                 doneLatch.countDown();
             }
         }
@@ -527,6 +525,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
         public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
             if (evt instanceof ChannelOutputShutdownEvent) {
                 seenOutputShutdown = true;
+                doneLatch.countDown();
             }
         }
 

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollETSocketHalfClosedTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollETSocketHalfClosedTest.java
@@ -23,12 +23,7 @@ import io.netty.testsuite.transport.socket.SocketHalfClosedTest;
 
 import java.util.List;
 
-public class EpollETSocketHalfClosed extends SocketHalfClosedTest {
-    @Override
-    public int maxReadCompleteWithNoDataAfterInputShutdown() {
-        return 1;
-    }
-
+public class EpollETSocketHalfClosedTest extends SocketHalfClosedTest {
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return EpollSocketTestPermutation.INSTANCE.socketWithoutFastOpen();

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollLTSocketHalfClosedTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollLTSocketHalfClosedTest.java
@@ -23,12 +23,7 @@ import io.netty.testsuite.transport.socket.SocketHalfClosedTest;
 
 import java.util.List;
 
-public class EpollLTSocketHalfClosed extends SocketHalfClosedTest {
-    @Override
-    public int maxReadCompleteWithNoDataAfterInputShutdown() {
-        return 1;
-    }
-
+public class EpollLTSocketHalfClosedTest extends SocketHalfClosedTest {
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return EpollSocketTestPermutation.INSTANCE.socketWithoutFastOpen();

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueETSocketHalfClosedTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueETSocketHalfClosedTest.java
@@ -24,11 +24,6 @@ import java.util.List;
 
 public class KQueueETSocketHalfClosedTest extends SocketHalfClosedTest {
     @Override
-    public int maxReadCompleteWithNoDataAfterInputShutdown() {
-        return 1;
-    }
-
-    @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return KQueueSocketTestPermutation.INSTANCE.socket();
     }


### PR DESCRIPTION
Motivation:
These tests were not being run for epoll because the classes did not have the Test suffix. We also aren't regularly running these tests for kqueue because we don't have a MacOS CI build. It turns out that all transports now behave consistently with regards to read-completes after input shutdown, so the tests don't need to change their assertions for epoll/kqueue vs. NIO.

Modification:
Enable the SocketHalfClosedTest for epoll, both edge and level triggered. Remove test parameter adjustments for epoll and kqueue.

Result:
SocketHalfClosedTest tests now run, and pass, for epoll.

This is a back port of #12993