### PR TITLE
Introduce Netty Security

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -315,6 +315,11 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>netty-security</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>netty-transport</artifactId>
       <scope>compile</scope>
     </dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -182,6 +182,11 @@
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
+        <artifactId>netty-security</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
         <artifactId>netty-transport</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker13.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker13.java
@@ -346,4 +346,15 @@ public class WebSocketClientHandshaker13 extends WebSocketClientHandshaker {
         return this;
     }
 
+    public boolean isAllowExtensions() {
+        return allowExtensions;
+    }
+
+    public boolean isPerformMasking() {
+        return performMasking;
+    }
+
+    public boolean isAllowMaskMismatch() {
+        return allowMaskMismatch;
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -638,6 +638,7 @@
     <module>resolver-dns</module>
     <module>resolver-dns-classes-macos</module>
     <module>resolver-dns-native-macos</module>
+    <module>security</module>
     <module>transport</module>
     <module>transport-native-unix-common-tests</module>
     <module>transport-native-unix-common</module>

--- a/security/pom.xml
+++ b/security/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2022 The Netty Project
+  ~
+  ~ The Netty Project licenses this file to you under the Apache License,
+  ~ version 2.0 (the "License"); you may not use this file except in compliance
+  ~ with the License. You may obtain a copy of the License at:
+  ~
+  ~   https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>netty-parent</artifactId>
+    <groupId>io.netty</groupId>
+    <version>4.1.86.Final-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>netty-security</artifactId>
+  <packaging>jar</packaging>
+
+  <properties>
+    <javaModuleName>io.netty.security</javaModuleName>
+  </properties>
+
+  <name>Netty/Security</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-handler</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.github.seancfoley</groupId>
+      <artifactId>ipaddress</artifactId>
+      <version>5.3.4</version>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/security/pom.xml
+++ b/security/pom.xml
@@ -16,7 +16,7 @@
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <artifactId>netty-parent</artifactId>
     <groupId>io.netty</groupId>

--- a/security/src/main/java/io/netty/security/core/Action.java
+++ b/security/src/main/java/io/netty/security/core/Action.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.security.core;
+
+/**
+ * Actions to be taken
+ */
+public enum Action {
+
+    /**
+     * Accept the request and pass it to next handler.
+     */
+    ACCEPT,
+
+    /**
+     * Drop the request without closing the connection.
+     */
+    DROP,
+
+    /**
+     * Drop the request and close the connection.
+     */
+    REJECT
+}

--- a/security/src/main/java/io/netty/security/core/Address.java
+++ b/security/src/main/java/io/netty/security/core/Address.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.security.core;
+
+import java.math.BigInteger;
+import java.net.InetAddress;
+
+/**
+ * Address is a context holder which holds {@link InetAddress}, IPv4 Address as {@link Integer},
+ * IPv4 Address Subnet Mask as {@link Integer}, IPv6 Address as {@link BigInteger},
+ * IPv6 Address Subnet Mask as {@link BigInteger}, and {@link Version} of IP address.
+ */
+public interface Address extends Comparable<Address> {
+
+    /**
+     * Accept any Address
+     */
+    Address ANY_ADDRESS = new Address() {
+        @Override
+        public InetAddress address() {
+            return null;
+        }
+
+        @Override
+        public int v4AddressAsInt() {
+            return 0;
+        }
+
+        @Override
+        public int v4SubnetMaskAsInt() {
+            return 0;
+        }
+
+        @Override
+        public BigInteger v6NetworkAddressAsBigInt() {
+            return null;
+        }
+
+        @Override
+        public BigInteger v6SubnetMaskAsBigInt() {
+            return null;
+        }
+
+        @Override
+        public Version version() {
+            return Version.v4;
+        }
+
+        @Override
+        public int compareTo(Address address) {
+            return 0;
+        }
+
+        @Override
+        public int hashCode() {
+            return super.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return getClass() == o.getClass();
+        }
+    };
+
+    /**
+     * Return {@link InetAddress} of this Address
+     */
+    InetAddress address();
+
+    /**
+     * Return {@link Integer} address of this Address
+     * <p>
+     * Call {@link #version()} to determine if this address is present or not
+     */
+    int v4AddressAsInt();
+
+    /**
+     * Subnet mask of this Address
+     * <p>
+     * Call {@link #version()} to determine if this address is present or not
+     */
+    int v4SubnetMaskAsInt();
+
+    /**
+     * Return {@link BigInteger} address of this Address
+     * <p>
+     * Call {@link #version()} to determine if this address is present or not
+     */
+    BigInteger v6NetworkAddressAsBigInt();
+
+    /**
+     * Subnet mask of this Address
+     * <p>
+     * Call {@link #version()} to determine if this address is present or not
+     */
+    BigInteger v6SubnetMaskAsBigInt();
+
+    /**
+     * Return {@link Version} of this Address
+     */
+    Version version();
+
+    /**
+     * Try to match an {@link Address} with this {@link IpAddress}
+     *
+     * @param address {@link Address} to match
+     * @return {@code true} if match was successful else {@code false}
+     */
+    @Override
+    int compareTo(Address address);
+
+    /**
+     * IP address version
+     */
+    enum Version {
+
+        /**
+         * IPv4 address
+         */
+        v4,
+
+        /**
+         * IPv6 address
+         */
+        v6
+    }
+}

--- a/security/src/main/java/io/netty/security/core/BasicFilter.java
+++ b/security/src/main/java/io/netty/security/core/BasicFilter.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.security.core;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.AddressedEnvelope;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.socket.DatagramPacket;
+
+/**
+ * Filters takes decision for an incoming {@link FiveTuple},
+ * {@link AddressedEnvelope} or {@link ByteBuf}.
+ */
+public interface BasicFilter extends Filter {
+
+    /**
+     * Evaluate a {@link ChannelHandlerContext#fireChannelActive()}
+     * and return appropriate {@link Action}
+     *
+     * @param fiveTuple {@link FiveTuple} instance
+     * @return Appropriate {@link Action}
+     */
+    @Override
+    Action validateChannelActive(FiveTuple fiveTuple);
+
+    @Override
+    Action validateObject(Object msg, FiveTuple fiveTuple);
+
+    /**
+     * Evaluate a {@link AddressedEnvelope} and return appropriate {@link Action}
+     *
+     * @param datagramPacket {@link DatagramPacket} to evaluate
+     * @param fiveTuple      {@link FiveTuple} instance
+     * @return Appropriate {@link Action}
+     */
+    Action validateDatagramPacket(DatagramPacket datagramPacket, FiveTuple fiveTuple);
+
+    /**
+     * Evaluate a {@link Channel} and {@link ByteBuf} and
+     * return appropriate {@link Action}
+     *
+     * @param buffer    {@link ByteBuf} to evaluate
+     * @param fiveTuple {@link FiveTuple} instance
+     * @return Appropriate {@link Action}
+     */
+    Action validateBuffer(ByteBuf buffer, FiveTuple fiveTuple);
+}

--- a/security/src/main/java/io/netty/security/core/Filter.java
+++ b/security/src/main/java/io/netty/security/core/Filter.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.security.core;
+
+import io.netty.channel.ChannelHandlerContext;
+
+/**
+ * {@link Filter} takes {@link Action} decision for an incoming
+ * {@link Object} and {@link FiveTuple}.
+ */
+public interface Filter {
+
+    /**
+     * Evaluate a {@link ChannelHandlerContext#fireChannelActive()} and
+     * return appropriate {@link Action}
+     *
+     * @param fiveTuple {@link FiveTuple} instance
+     * @return Appropriate {@link Action}
+     */
+    Action validateChannelActive(FiveTuple fiveTuple);
+
+    /**
+     * Evaluate a {@link Object} message and return appropriate {@link Action}
+     *
+     * @param fiveTuple {@link FiveTuple} instance
+     * @return Appropriate {@link Action}
+     */
+    Action validateObject(Object msg, FiveTuple fiveTuple);
+}

--- a/security/src/main/java/io/netty/security/core/FiveTuple.java
+++ b/security/src/main/java/io/netty/security/core/FiveTuple.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.security.core;
+
+/**
+ * FiveTuple stores 5 elements of a network connection.
+ * <p>
+ * <ol>
+ *     <li> Protocol (TCP/UDP) </li>
+ *     <li> Source Port </li>
+ *     <li> Destination Port </li>
+ *     <li> Source IP Address </li>
+ *     <li> Destination IP Address </li>
+ * </ol>
+ */
+public interface FiveTuple extends Comparable<FiveTuple> {
+
+    /**
+     * Tuple {@link Protocol}
+     */
+    Protocol protocol();
+
+    /**
+     * Tuple Source Port
+     */
+    int sourcePort();
+
+    /**
+     * Tuple Destination Port
+     */
+    int destinationPort();
+
+    /**
+     * Tuple Source {@link Address}
+     */
+    Address sourceIpAddress();
+
+    /**
+     * Source Destination {@link Address}
+     */
+    Address destinationIpAddress();
+
+    @Override
+    int compareTo(FiveTuple o);
+}

--- a/security/src/main/java/io/netty/security/core/InternalBufferUtils.java
+++ b/security/src/main/java/io/netty/security/core/InternalBufferUtils.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.security.core;
+
+import io.netty.buffer.ByteBuf;
+
+/**
+ * Backward port of Netty5's InternalBufferUtils
+ */
+public final class InternalBufferUtils {
+
+    private InternalBufferUtils() {
+        // Prevent outside initialization
+    }
+
+    public interface UncheckedLoadByte {
+        byte load(ByteBuf buffer, int offset);
+    }
+
+    public static final UncheckedLoadByte UNCHECKED_LOAD_BYTE_BUFFER = new UncheckedLoadByte() {
+        @Override
+        public byte load(ByteBuf buffer, int offset) {
+            return buffer.getByte(offset);
+        }
+    };
+
+    private static boolean equalsInner(ByteBuf a, int aStartIndex, ByteBuf b, int bStartIndex, int length) {
+        final int longCount = length >>> 3;
+        final int byteCount = length & 7;
+
+        for (int i = longCount; i > 0; i--) {
+            if (a.getLong(aStartIndex) != b.getLong(bStartIndex)) {
+                return false;
+            }
+            aStartIndex += 8;
+            bStartIndex += 8;
+        }
+
+        for (int i = byteCount; i > 0; i--) {
+            if (a.getByte(aStartIndex) != b.getByte(bStartIndex)) {
+                return false;
+            }
+            aStartIndex++;
+            bStartIndex++;
+        }
+
+        return true;
+    }
+
+    public static int bytesBefore(ByteBuf haystack, UncheckedLoadByte hl, ByteBuf needle, UncheckedLoadByte nl) {
+        if (haystack.refCnt() == 0) {
+            throw new IllegalStateException("Haystack is not accessible");
+        }
+        if (needle.refCnt() == 0) {
+            throw new IllegalStateException("Needle is not accessible");
+        }
+
+        if (needle.readableBytes() > haystack.readableBytes()) {
+            return -1;
+        }
+
+        if (hl == null) {
+            hl = UNCHECKED_LOAD_BYTE_BUFFER;
+        }
+
+        if (nl == null) {
+            nl = UNCHECKED_LOAD_BYTE_BUFFER;
+        }
+
+        int haystackLen = haystack.readableBytes();
+        int needleLen = needle.readableBytes();
+        if (needleLen == 0) {
+            return 0;
+        }
+
+        // When the needle has only one byte that can be read,
+        // the Buffer.bytesBefore() method can be used
+        if (needleLen == 1) {
+            return haystack.bytesBefore(needle.getByte(needle.readerIndex()));
+        }
+
+        int needleStart = needle.readerIndex();
+        int haystackStart = haystack.readerIndex();
+        long suffixes = maxFixes(needle, nl, needleLen, needleStart, true);
+        long prefixes = maxFixes(needle, nl, needleLen, needleStart, false);
+        int maxSuffix = Math.max((int) (suffixes >> 32), (int) (prefixes >> 32));
+        int period = Math.max((int) suffixes, (int) prefixes);
+        int length = Math.min(needleLen - period, maxSuffix + 1);
+
+        if (equalsInner(needle, needleStart, needle, needleStart + period, length)) {
+            return bytesBeforeInnerPeriodic(
+                    haystack, hl, needle, nl, haystackLen, needleLen, needleStart, haystackStart, maxSuffix, period);
+        }
+        return bytesBeforeInnerNonPeriodic(
+                haystack, hl, needle, nl, haystackLen, needleLen, needleStart, haystackStart, maxSuffix);
+    }
+
+    private static int bytesBeforeInnerPeriodic(ByteBuf haystack, UncheckedLoadByte hl,
+                                                ByteBuf needle, UncheckedLoadByte nl,
+                                                int haystackLen, int needleLen, int needleStart, int haystackStart,
+                                                int maxSuffix, int period) {
+        int j = 0;
+        int memory = -1;
+        while (j <= haystackLen - needleLen) {
+            int i = Math.max(maxSuffix, memory) + 1;
+            while (i < needleLen && nl.load(needle, i + needleStart) == hl.load(haystack, i + j + haystackStart)) {
+                ++i;
+            }
+            if (i > haystackLen) {
+                return -1;
+            }
+            if (i >= needleLen) {
+                i = maxSuffix;
+                while (i > memory && nl.load(needle, i + needleStart) == hl.load(haystack, i + j + haystackStart)) {
+                    --i;
+                }
+                if (i <= memory) {
+                    return j;
+                }
+                j += period;
+                memory = needleLen - period - 1;
+            } else {
+                j += i - maxSuffix;
+                memory = -1;
+            }
+        }
+        return -1;
+    }
+
+    private static int bytesBeforeInnerNonPeriodic(ByteBuf haystack, UncheckedLoadByte hl,
+                                                   ByteBuf needle, UncheckedLoadByte nl,
+                                                   int haystackLen, int needleLen, int needleStart, int haystackStart,
+                                                   int maxSuffix) {
+        int j = 0;
+        int period = Math.max(maxSuffix + 1, needleLen - maxSuffix - 1) + 1;
+        while (j <= haystackLen - needleLen) {
+            int i = maxSuffix + 1;
+            while (i < needleLen && nl.load(needle, i + needleStart) == hl.load(haystack, i + j + haystackStart)) {
+                ++i;
+            }
+            if (i > haystackLen) {
+                return -1;
+            }
+            if (i >= needleLen) {
+                i = maxSuffix;
+                while (i >= 0 && nl.load(needle, i + needleStart) == hl.load(haystack, i + j + haystackStart)) {
+                    --i;
+                }
+                if (i < 0) {
+                    return j;
+                }
+                j += period;
+            } else {
+                j += i - maxSuffix;
+            }
+        }
+        return -1;
+    }
+
+    private static long maxFixes(ByteBuf needle, UncheckedLoadByte nl, int needleLen, int start, boolean isSuffix) {
+        int period = 1;
+        int maxSuffix = -1;
+        int lastRest = start;
+        int k = 1;
+        while (lastRest + k < needleLen) {
+            byte a = nl.load(needle, lastRest + k);
+            byte b = nl.load(needle, maxSuffix + k);
+            boolean suffix = isSuffix ? a < b : a > b;
+            if (suffix) {
+                lastRest += k;
+                k = 1;
+                period = lastRest - maxSuffix;
+            } else if (a == b) {
+                if (k != period) {
+                    ++k;
+                } else {
+                    lastRest += period;
+                    k = 1;
+                }
+            } else {
+                maxSuffix = lastRest;
+                lastRest = maxSuffix + 1;
+                k = period = 1;
+            }
+        }
+        return ((long) maxSuffix << 32) + period;
+    }
+}

--- a/security/src/main/java/io/netty/security/core/IpAddress.java
+++ b/security/src/main/java/io/netty/security/core/IpAddress.java
@@ -152,7 +152,7 @@ public final class IpAddress implements Address {
 
         assert blocks.length > 0 : "There must be at least one block";
 
-        List<IpAddress> ipAddresses = new ArrayList<>();
+        List<IpAddress> ipAddresses = new ArrayList<IpAddress>();
         for (IPAddress ipAddress : blocks) {
             ipAddresses.add(new IpAddress(ipAddress.toInetAddress(), ipAddress.getPrefixLength()));
         }

--- a/security/src/main/java/io/netty/security/core/IpAddress.java
+++ b/security/src/main/java/io/netty/security/core/IpAddress.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.security.core;
+
+import inet.ipaddr.IPAddress;
+import inet.ipaddr.IPAddressString;
+import inet.ipaddr.format.IPAddressRange;
+import io.netty.util.NetUtil;
+import io.netty.util.internal.ObjectUtil;
+
+import java.math.BigInteger;
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.netty.security.core.Util.compareIntegers;
+import static io.netty.security.core.Util.hash;
+
+/**
+ * {@link IpAddress} contains IPv4 or IPv6 address and Subnet Mask of them.
+ */
+public final class IpAddress implements Address {
+    private final InetAddress inetAddress;
+    private final Version version;
+    private int v4NetworkAddress = -1;
+    private int v4SubnetMask = -1;
+    private BigInteger v6NetworkAddress;
+    private BigInteger v6SubnetMask;
+
+    private IpAddress(InetAddress inetAddress, int subnetMask) {
+        this.inetAddress = ObjectUtil.checkNotNull(inetAddress, "InetAddress");
+
+        if (inetAddress instanceof Inet4Address) {
+            version = Version.v4;
+            v4SubnetMask = Util.prefixToSubnetMaskV4(ObjectUtil.checkInRange(subnetMask, 0, 32, "SubnetMask"));
+            v4NetworkAddress = NetUtil.ipv4AddressToInt((Inet4Address) inetAddress) & v4SubnetMask;
+        } else if (inetAddress instanceof Inet6Address) {
+            version = Version.v6;
+            v6SubnetMask = Util.prefixToSubnetMaskV6(ObjectUtil.checkInRange(subnetMask, 0, 128, "SubnetMask"));
+            v6NetworkAddress = new BigInteger(inetAddress.getAddress()).add(v6SubnetMask);
+        } else {
+            throw new IllegalArgumentException("Invalid InetAddress");
+        }
+    }
+
+    /**
+     * Create a new {@link IpAddress} instance with /32 or /128 subnet mask
+     *
+     * @param ipAddress IP address
+     * @return {@link IpAddress} instance
+     * @throws AssertionError If IP address is invalid
+     */
+    public static IpAddress of(String ipAddress) {
+        InetAddress address = NetUtil.createInetAddressFromIpAddressString(ipAddress);
+        assert address != null : "Invalid IP Address"; // Guard against invalid IP address
+        return new IpAddress(address, address instanceof Inet4Address ? 32 : 128);
+    }
+
+    /**
+     * Create a new {@link IpAddress} instance with /32 or /128 subnet mask
+     *
+     * @param inetAddress InetAddress
+     * @return {@link IpAddress} instance
+     * @throws AssertionError If IP address is invalid
+     */
+    public static IpAddress of(InetAddress inetAddress) {
+        InetAddress address = NetUtil.createInetAddressFromIpAddressString(inetAddress.getHostAddress());
+        assert address != null : "Invalid IP Address"; // Guard against invalid IP address
+        return new IpAddress(address, address instanceof Inet4Address ? 32 : 128);
+    }
+
+    /**
+     * Create a new {@link IpAddress} instance with specified subnet mask
+     *
+     * @param ipAddress  IP address
+     * @param subnetMask Subnet mask
+     * @return {@link IpAddress} instance
+     * @throws AssertionError If IP address is invalid
+     */
+    public static IpAddress of(String ipAddress, int subnetMask) {
+        InetAddress inetAddress = NetUtil.createInetAddressFromIpAddressString(ipAddress);
+        assert inetAddress != null : "Invalid IP Address"; // Guard against invalid IP address
+        return new IpAddress(inetAddress, subnetMask);
+    }
+
+    /**
+     * Create a new {@link IpAddress} instance with specified subnet mask
+     *
+     * @param inetAddress InetAddress
+     * @param subnetMask  Subnet mask
+     * @return {@link IpAddress} instance
+     * @throws AssertionError If IP address is invalid
+     */
+    public static IpAddress of(InetAddress inetAddress, int subnetMask) {
+        InetAddress address = NetUtil.createInetAddressFromIpAddressString(inetAddress.getHostAddress());
+        assert address != null : "Invalid IP Address"; // Guard against invalid IP address
+        return new IpAddress(address, subnetMask);
+    }
+
+    /**
+     * Create a new {@link IpAddress} instance with /32 or /128 subnet mask
+     *
+     * @param ipAddress IP address byte array
+     * @return {@link IpAddress} instance
+     * @throws UnknownHostException If IP address is invalid
+     */
+    public static IpAddress of(byte[] ipAddress) throws UnknownHostException {
+        InetAddress address = InetAddress.getByAddress(ipAddress);
+        return new IpAddress(address, address instanceof Inet4Address ? 32 : 128);
+    }
+
+    /**
+     * Create a new {@link IpAddress} instance with specified subnet mask
+     *
+     * @param ipAddress  IP address byte array
+     * @param subnetMask Subnet mask
+     * @return {@link IpAddress} instance
+     * @throws UnknownHostException If IP address is invalid
+     */
+    public static IpAddress of(byte[] ipAddress, int subnetMask) throws UnknownHostException {
+        return new IpAddress(InetAddress.getByAddress(ipAddress), subnetMask);
+    }
+
+    /**
+     * Create a new {@link IpAddress} instances with specified IP range
+     *
+     * @param ipStart Start of IP range
+     * @param ipEnd   End of IP range
+     * @return {@link List} containing {@link IpAddress} instances
+     */
+    public static List<IpAddress> from(String ipStart, String ipEnd) {
+        IPAddress address1 = new IPAddressString(ipStart).getAddress();
+        IPAddress address2 = new IPAddressString(ipEnd).getAddress();
+        IPAddressRange range = address1.spanWithRange(address2);
+        IPAddress[] blocks = range.spanWithPrefixBlocks();
+
+        assert blocks.length > 0 : "There must be at least one block";
+
+        List<IpAddress> ipAddresses = new ArrayList<>();
+        for (IPAddress ipAddress : blocks) {
+            ipAddresses.add(new IpAddress(ipAddress.toInetAddress(), ipAddress.getPrefixLength()));
+        }
+
+        return ipAddresses;
+    }
+
+    @Override
+    public InetAddress address() {
+        return inetAddress;
+    }
+
+    @Override
+    public int v4AddressAsInt() {
+        return v4NetworkAddress;
+    }
+
+    @Override
+    public int v4SubnetMaskAsInt() {
+        return v4SubnetMask;
+    }
+
+    @Override
+    public BigInteger v6NetworkAddressAsBigInt() {
+        return v6NetworkAddress;
+    }
+
+    @Override
+    public BigInteger v6SubnetMaskAsBigInt() {
+        return v6SubnetMask;
+    }
+
+    /**
+     * Returns {@link Version} of this IP address
+     */
+    @Override
+    public Version version() {
+        return version;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        IpAddress ipAddress = (IpAddress) o;
+        return hashCode() == ipAddress.hashCode();
+    }
+
+    @Override
+    public int compareTo(Address address) {
+        if (address.version() == Version.v4) {
+            return compareIntegers(address.v4AddressAsInt() & v4SubnetMaskAsInt(), v4AddressAsInt());
+        } else if (address.version() == Version.v6) {
+            return v6NetworkAddressAsBigInt().and(v6SubnetMaskAsBigInt()).compareTo(address.v6NetworkAddressAsBigInt());
+        } else {
+            // Unsupported IP version. So let's return -1
+            // because we have no idea at all about it.
+            return -1;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return hash(inetAddress, version);
+    }
+
+    @Override
+    public String toString() {
+        return "IpAddress{address=" + inetAddress + ", version=" + version + '}';
+    }
+}

--- a/security/src/main/java/io/netty/security/core/IpAddressLookup.java
+++ b/security/src/main/java/io/netty/security/core/IpAddressLookup.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.security.core;
+
+/**
+ * This interface handles lookup of {@link Address}.
+ */
+public interface IpAddressLookup {
+
+    /**
+     * Perform lookup for an {@link Address} in database
+     *
+     * @return Index at which {@link Address} is located inside
+     * {@link IpAddresses}. Whole number is returned when lookup
+     * was successful else negative number if lookup was not successful.
+     */
+    int lookup(Address address);
+
+    /**
+     * Perform lookup for an {@link Address} in database
+     *
+     * @return {@code true} if {@link Address} was found in the
+     * database or else {@code false}
+     */
+    boolean lookupAddress(Address address);
+}

--- a/security/src/main/java/io/netty/security/core/IpAddresses.java
+++ b/security/src/main/java/io/netty/security/core/IpAddresses.java
@@ -155,7 +155,7 @@ public class IpAddresses extends SafeListController<Address> implements IpAddres
         public List<Address> process(List<Address> list) {
             Collections.sort(list);
             Iterator<Address> iterator = list.iterator();
-            List<Address> toKeep = new ArrayList<>();
+            List<Address> toKeep = new ArrayList<Address>();
 
             Address parentRule = iterator.hasNext() ? iterator.next() : null;
             if (parentRule != null) {

--- a/security/src/main/java/io/netty/security/core/IpAddresses.java
+++ b/security/src/main/java/io/netty/security/core/IpAddresses.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.security.core;
+
+import io.netty.util.internal.ObjectUtil;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * {@link IpAddresses} contains multiple {@link IpAddress} and provide lookup of
+ * using {@link IpAddressLookup}.
+ * Note: this class has a natural ordering that is inconsistent with equals.
+ */
+public class IpAddresses extends SafeListController<Address> implements IpAddressLookup, Comparable<IpAddresses> {
+
+    public static final class AcceptAnyIpAddresses extends IpAddresses {
+        public static final AcceptAnyIpAddresses INSTANCE = new AcceptAnyIpAddresses();
+
+        private AcceptAnyIpAddresses() {
+            super(Collections.singletonList(Address.ANY_ADDRESS));
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return getClass() == o.getClass();
+        }
+
+        @Override
+        public int lookup(Address address) {
+            return 0;
+        }
+
+        @Override
+        public boolean lookupAddress(Address address) {
+            return true;
+        }
+
+        @Override
+        public int compareTo(IpAddresses ipAddresses) {
+            return 0;
+        }
+
+        @Override
+        public int hashCode() {
+            return super.hashCode();
+        }
+    }
+
+    private IpAddresses(List<Address> addresses) {
+        super(new SortAndFilterImpl());
+        ObjectUtil.checkNotNull(addresses, "List");
+        MAIN_LIST.addAll(addresses);
+        unlockAndLock();
+    }
+
+    /**
+     * Create a new {@link IpAddresses} instance with specified {@link List} of {@link Address}
+     *
+     * @param ipAddresses {@link List} of {@link Address}
+     * @return {@link IpAddresses} new instance
+     */
+    public static IpAddresses create(List<Address> ipAddresses) {
+        return new IpAddresses(ipAddresses);
+    }
+
+    /**
+     * Create a new {@link IpAddresses} instance with specified {@link List} of {@link Address}
+     *
+     * @param ipAddresses {@link IpAddress}s
+     * @return {@link IpAddresses} new instance
+     */
+    public static IpAddresses create(Address... ipAddresses) {
+        return new IpAddresses(Arrays.asList(ipAddresses));
+    }
+
+    /**
+     * Create a new {@link IpAddresses} instance without any {@link Address}
+     *
+     * @return {@link IpAddresses} new instance
+     */
+    public static IpAddresses create() {
+        return new IpAddresses(Collections.<Address>emptyList());
+    }
+
+    @Override
+    public int lookup(Address address) {
+        // Perform lookup using Binary Search.
+        // If return index is zero or higher, return true else false.
+        return Collections.binarySearch(MAIN_LIST, address);
+    }
+
+    @Override
+    public boolean lookupAddress(Address address) {
+        // If return is whole number then lookup was successful.
+        // If return is negative number then lookup was unsuccessful.
+        return lookup(address) >= 0;
+    }
+
+    @Override
+    public String toString() {
+        return "IpAddresses{List=" + MAIN_LIST + '}';
+    }
+
+    @Override
+    public int compareTo(IpAddresses ipAddresses) {
+        // If current list size is bigger than comparator list size then return 1;
+        // If current list size is smaller than comparator list size then return -1;
+        if (MAIN_LIST.size() > ipAddresses.MAIN_LIST.size()) {
+            return 1;
+        }
+        if (MAIN_LIST.size() < ipAddresses.MAIN_LIST.size()) {
+            return -1;
+        }
+
+        // Iterate over current list and comparator list at the same time
+        // and compare Ip Address.
+        for (int i = 0; i < MAIN_LIST.size(); i++) {
+            int compare = ipAddresses.MAIN_LIST.get(i).compareTo(MAIN_LIST.get(i));
+            if (compare != 0) {
+                return compare;
+            }
+        }
+
+        return 0;
+    }
+
+    private static final class SortAndFilterImpl implements SortAndFilter<Address> {
+
+        /**
+         * <ol>
+         *     <li> Sort the list </li>
+         *     <li> Remove over-lapping subnet </li>
+         *     <li> Sort the list again </li>
+         * </ol>
+         */
+        @SuppressWarnings("ConstantConditions")
+        @Override
+        public List<Address> process(List<Address> list) {
+            Collections.sort(list);
+            Iterator<Address> iterator = list.iterator();
+            List<Address> toKeep = new ArrayList<>();
+
+            Address parentRule = iterator.hasNext() ? iterator.next() : null;
+            if (parentRule != null) {
+                toKeep.add(parentRule);
+            }
+
+            while (iterator.hasNext()) {
+
+                // Grab a potential child rule.
+                Address childRule = iterator.next();
+
+                // If parentRule matches childRule, then there's no need to keep the child rule.
+                // Otherwise, the rules are distinct, and we need both.
+                //
+                // parentRule can never be null.
+                if (parentRule.compareTo(childRule) == 0) {
+                    toKeep.add(childRule);
+                    // Then we'll keep the child rule around as the parent for the next round.
+                    parentRule = childRule;
+                }
+            }
+
+            Collections.sort(toKeep);
+            return toKeep;
+        }
+    }
+}

--- a/security/src/main/java/io/netty/security/core/LockMechanism.java
+++ b/security/src/main/java/io/netty/security/core/LockMechanism.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.security.core;
+
+/**
+ * {@link LockMechanism} provides locking mechanism to ensure data consistency.
+ */
+public interface LockMechanism {
+
+    /**
+     * Lock a {@link SafeListController} instance to prevent it from being modified
+     *
+     * @throws IllegalStateException If Instance is already unlocked
+     */
+    void lock();
+
+    /**
+     * Unlock a {@link SafeListController} instance for modification
+     *
+     * @throws IllegalStateException If Instance is already unlocked
+     */
+    void unlock();
+
+    /**
+     * Returns {@code true} if this class is locked else {@code false}
+     */
+    boolean isLocked();
+}

--- a/security/src/main/java/io/netty/security/core/PortLookup.java
+++ b/security/src/main/java/io/netty/security/core/PortLookup.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.security.core;
+
+public interface PortLookup {
+
+    /**
+     * Perform lookup of port
+     *
+     * @param port Port to lookup
+     * @return Zero (0) if lookup was successful else 1 or -1.
+     */
+    int lookup(int port);
+
+    /**
+     * Perform lookup of port
+     *
+     * @param port Port to lookup
+     * @return {@code true} if lookup was successful else {@code false}.
+     */
+    boolean lookupPort(int port);
+}

--- a/security/src/main/java/io/netty/security/core/Ports.java
+++ b/security/src/main/java/io/netty/security/core/Ports.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.security.core;
+
+public interface Ports extends PortLookup, Comparable<Ports> {
+
+    /**
+     * Accept any port number
+     */
+    Ports ANY_PORT = new Ports() {
+        @Override
+        public boolean equals(Object o) {
+            return getClass() == o.getClass();
+        }
+
+        @Override
+        public int hashCode() {
+            return super.hashCode();
+        }
+
+        @Override
+        public int start() {
+            return 1;
+        }
+
+        @Override
+        public int end() {
+            return 65_535;
+        }
+
+        @Override
+        public int compareTo(Ports ports) {
+            return 0;
+        }
+
+        @Override
+        public int lookup(int port) {
+            return 0;
+        }
+
+        @Override
+        public boolean lookupPort(int port) {
+            return true;
+        }
+    };
+
+    /**
+     * Start of Port range
+     */
+    int start();
+
+    /**
+     * End of Port range
+     */
+    int end();
+
+    @Override
+    int compareTo(Ports ports);
+}

--- a/security/src/main/java/io/netty/security/core/Ports.java
+++ b/security/src/main/java/io/netty/security/core/Ports.java
@@ -20,7 +20,7 @@ public interface Ports extends PortLookup, Comparable<Ports> {
     /**
      * Accept any port number
      */
-    Ports ANY_PORT = new Ports() {
+    Ports ANYPORT = new Ports() {
         @Override
         public boolean equals(Object o) {
             return getClass() == o.getClass();

--- a/security/src/main/java/io/netty/security/core/Protocol.java
+++ b/security/src/main/java/io/netty/security/core/Protocol.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.security.core;
+
+/**
+ * Protocol type
+ */
+public enum Protocol {
+
+    /**
+     * TCP (Transmission Control Protocol)
+     */
+    TCP,
+
+    /**
+     * UDP (User Datagram Protocol)
+     */
+    UDP
+}

--- a/security/src/main/java/io/netty/security/core/Rule.java
+++ b/security/src/main/java/io/netty/security/core/Rule.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.security.core;
+
+import io.netty.security.core.payload.Payload;
+import io.netty.security.core.payload.PayloadMatcher;
+
+import java.util.List;
+
+public interface Rule extends Comparable<Rule> {
+
+    /**
+     * Tuple {@link Protocol}
+     */
+    Protocol protocol();
+
+    /**
+     * Source Ports
+     */
+    Ports sourcePorts();
+
+    /**
+     * Destination Ports
+     */
+    Ports destinationPorts();
+
+    /**
+     * Rule Source {@link IpAddresses}
+     */
+    IpAddresses sourceIpAddresses();
+
+    /**
+     * Rule Destination {@link IpAddresses}
+     */
+    IpAddresses destinationIpAddresses();
+
+    /**
+     * {@link List} of {@link Payload}
+     */
+    List<? extends Payload<?>> payloads();
+
+    /**
+     * Rule {@link PayloadMatcher}
+     */
+    PayloadMatcher<Object, Object> payloadMatcher();
+
+    /**
+     * Rule {@link Action}
+     */
+    Action action();
+
+    @Override
+    int compareTo(Rule rule);
+}

--- a/security/src/main/java/io/netty/security/core/RuleLookup.java
+++ b/security/src/main/java/io/netty/security/core/RuleLookup.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.security.core;
+
+@FunctionalInterface
+public interface RuleLookup {
+
+    /**
+     * Perform lookup for a {@link Rule} in database
+     *
+     * @param fiveTuple {@link FiveTuple} implementation instance
+     * @return {@link Rule} instance if rules was found else {@code null}
+     */
+    Rule lookup(FiveTuple fiveTuple);
+}

--- a/security/src/main/java/io/netty/security/core/SafeListController.java
+++ b/security/src/main/java/io/netty/security/core/SafeListController.java
@@ -39,11 +39,11 @@ public abstract class SafeListController<T> implements LockMechanism {
 
     // Main List should be accessible from Parent class
     // because Parent class will use it for operations.
-    protected final List<T> MAIN_LIST = new ArrayList<>();
+    protected final List<T> MAIN_LIST = new ArrayList<T>();
 
     // Copy List should be private because it is internally
     // used for copying elements from Main List and vice-versa.
-    private final List<T> COPY_LIST = new ArrayList<>();
+    private final List<T> COPY_LIST = new ArrayList<T>();
 
     // SortAndFilter can be null if there is no need
     // of sorting and filtering.

--- a/security/src/main/java/io/netty/security/core/SafeListController.java
+++ b/security/src/main/java/io/netty/security/core/SafeListController.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.security.core;
+
+import io.netty.util.internal.ObjectUtil;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * <p> This class provides safe mechanism for adding or remove for class
+ * extending {@link SafeListController}. </p>
+ *
+ * <p>
+ * To add elements into this, you must unlock this class first.
+ * Call {@link #unlock()} and then call {@link #add(Object)}.
+ * Once you're done adding elements, lock this class using {@link #lock()}.
+ * This will trigger update process and elements will be sorted and filtered
+ * if necessary.
+ * </p>
+ *
+ * @param <T> Element type
+ */
+public abstract class SafeListController<T> implements LockMechanism {
+
+    // Main List should be accessible from Parent class
+    // because Parent class will use it for operations.
+    protected final List<T> MAIN_LIST = new ArrayList<>();
+
+    // Copy List should be private because it is internally
+    // used for copying elements from Main List and vice-versa.
+    private final List<T> COPY_LIST = new ArrayList<>();
+
+    // SortAndFilter can be null if there is no need
+    // of sorting and filtering.
+    private final SortAndFilter<T> sortAndFilter;
+
+    /**
+     * When lock is set to true then directly modifying the {@link List}
+     * will result in an exception.
+     */
+    private boolean isLocked = true;
+
+    protected SafeListController() {
+        this(null);
+    }
+
+    protected SafeListController(SortAndFilter<T> sortAndFilter) {
+        this.sortAndFilter = sortAndFilter;
+    }
+
+    /**
+     * Lock {@link SafeListController} so no more modification can take place
+     *
+     * @throws IllegalStateException If Instance is already locked
+     */
+    @Override
+    public synchronized void lock() {
+        if (isLocked) {
+            throw new IllegalStateException("Instance is already locked");
+        }
+        isLocked = true;
+
+        // Reload
+        List<T> tempHolderList;
+
+        // Sort and Filter if required.
+        if (sortAndFilter != null) {
+            tempHolderList = sortAndFilter.process(COPY_LIST);
+        } else {
+            tempHolderList = COPY_LIST;
+        }
+
+        // Clear Main List before adding all elements of
+        // Copy List.
+        MAIN_LIST.clear();
+        MAIN_LIST.addAll(tempHolderList);
+
+        // Clear both temporary Lists
+        COPY_LIST.clear();
+        tempHolderList.clear();
+    }
+
+    /**
+     * Unlock {@link SafeListController} for modification
+     *
+     * @throws IllegalStateException If Instance is already unlocked
+     */
+    @Override
+    public synchronized void unlock() {
+        if (!isLocked) {
+            throw new IllegalStateException("Instance is already unlocked");
+        }
+        isLocked = false;
+
+        // Add all items from Main List to Copy List
+        COPY_LIST.addAll(MAIN_LIST);
+    }
+
+    /**
+     * Unlock and lock for modification and finalization
+     *
+     * @throws IllegalStateException If Instance is already unlocked
+     */
+    public synchronized void unlockAndLock() {
+        if (!isLocked) {
+            throw new IllegalStateException("Instance is already unlocked");
+        }
+
+        // Unlock for modification
+        unlock();
+
+        // Lock to sort and finalize
+        lock();
+    }
+
+    /**
+     * Add an element
+     *
+     * @param element Element to add
+     * @return true
+     * @throws IllegalStateException Cannot add element when instance is locked
+     */
+    public synchronized boolean add(T element) {
+        if (isLocked) {
+            throw new IllegalStateException("Cannot add element when instance is locked." +
+                    " Call #unlock before adding element.");
+        }
+        ObjectUtil.checkNotNull(element, element.getClass().getSimpleName());
+        return COPY_LIST.add(element);
+    }
+
+    /**
+     * Remove an element
+     *
+     * @param element Element to remove
+     * @return true if remove was successful else false
+     * @throws IllegalStateException Cannot remove element when instance is locked
+     */
+    public synchronized boolean remove(T element) {
+        if (isLocked) {
+            throw new IllegalStateException("Cannot remove element when instance is locked." +
+                    " Call #unlock before removing element.");
+        }
+        ObjectUtil.checkNotNull(element, element.getClass().getSimpleName());
+        return COPY_LIST.remove(element);
+    }
+
+    /**
+     * Return an unmodifiable {@link List} of Main List.
+     */
+    public List<T> copy() {
+        return Collections.unmodifiableList(MAIN_LIST);
+    }
+
+    /**
+     * Returns {@code true} if this class is locked else {@code false}
+     */
+    @Override
+    public boolean isLocked() {
+        return isLocked;
+    }
+
+    /**
+     * Functions that need to sort elements in {@link List} should
+     * implement this interface.
+     *
+     * @param <T> Element type
+     */
+    public interface SortAndFilter<T> {
+
+        /**
+         * Sort and Filter
+         *
+         * @param list {@link List} containing elements to be sorted and filter.
+         * @return {@link List} containing element that are sorted and filtered.
+         */
+        List<T> process(List<T> list);
+    }
+}

--- a/security/src/main/java/io/netty/security/core/StaticIpAddress.java
+++ b/security/src/main/java/io/netty/security/core/StaticIpAddress.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.security.core;
+
+import io.netty.util.NetUtil;
+import io.netty.util.internal.ObjectUtil;
+
+import java.math.BigInteger;
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import static io.netty.security.core.Util.compareIntegers;
+import static io.netty.security.core.Util.hash;
+
+/**
+ * This is a simple implementation handle of {@link Address} which cache
+ * 32-bit {@link Integer} IPv4 address or 128-bit {@link BigInteger} IPv6 Address.
+ */
+public final class StaticIpAddress implements Address {
+    private static final int subnetMaskV4 = Util.prefixToSubnetMaskV4(32);
+    private static final BigInteger subnetMaskV6 = Util.prefixToSubnetMaskV6(128);
+
+    private final InetAddress address;
+    private int addressV4 = -1;
+    private BigInteger addressV6;
+
+    private StaticIpAddress(InetAddress address) {
+        this.address = ObjectUtil.checkNotNull(address, "InetAddress");
+
+        if (address instanceof Inet4Address) {
+            addressV4 = NetUtil.ipv4AddressToInt((Inet4Address) address);
+        } else if (address instanceof Inet6Address) {
+            addressV6 = new BigInteger(address.getAddress());
+        } else {
+            throw new IllegalArgumentException("Invalid InetAddress");
+        }
+    }
+
+    /**
+     * Create a new {@link StaticIpAddress} instance with specified {@link InetAddress}
+     *
+     * @param address {@link InetAddress} to use
+     * @return {@link StaticIpAddress} instance
+     */
+    public static StaticIpAddress of(InetAddress address) {
+        return new StaticIpAddress(address);
+    }
+
+    /**
+     * Create a new {@link StaticIpAddress} instance with specified {@link String} IP address
+     *
+     * @param address {@link String} IP address
+     * @return {@link StaticIpAddress} instance
+     */
+    public static StaticIpAddress of(String address) throws UnknownHostException {
+        ObjectUtil.checkNotNull(address, "Address");
+        return new StaticIpAddress(InetAddress.getByName(address));
+    }
+
+    /**
+     * Create a new {@link StaticIpAddress} instance with specified {@link Byte} array IP address
+     *
+     * @param address {@link Byte} array IP address
+     * @return {@link StaticIpAddress} instance
+     */
+    public static StaticIpAddress of(byte[] address) throws UnknownHostException {
+        ObjectUtil.checkNotNull(address, "Address");
+        return new StaticIpAddress(InetAddress.getByAddress(address));
+    }
+
+    @Override
+    public InetAddress address() {
+        return address;
+    }
+
+    @Override
+    public int v4AddressAsInt() {
+        return addressV4;
+    }
+
+    @Override
+    public int v4SubnetMaskAsInt() {
+        return subnetMaskV4;
+    }
+
+    @Override
+    public BigInteger v6NetworkAddressAsBigInt() {
+        return addressV6;
+    }
+
+    @Override
+    public BigInteger v6SubnetMaskAsBigInt() {
+        return subnetMaskV6;
+    }
+
+    @Override
+    public Version version() {
+        return address instanceof Inet4Address ? Version.v4 : Version.v6;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        StaticIpAddress that = (StaticIpAddress) o;
+
+        // Hashcode matching is enough because hashcode is generated
+        // using InetAddress instance only.
+        return hashCode() == that.hashCode();
+    }
+
+    @Override
+    public int compareTo(Address address) {
+        if (address.version() == Version.v4) {
+            return compareIntegers(address.v4AddressAsInt() & v4SubnetMaskAsInt(), v4AddressAsInt());
+        } else if (address.version() == Version.v6) {
+            return v6NetworkAddressAsBigInt().and(v6SubnetMaskAsBigInt()).compareTo(address.v6NetworkAddressAsBigInt());
+        } else {
+            // Unsupported IP version. So let's return -1
+            // because we have no idea at all about it.
+            return -1;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return hash(address);
+    }
+
+    @Override
+    public String toString() {
+        return "StaticIpAddress{" +
+                "address=" + address +
+                ", addressV4=" + addressV4 +
+                ", addressV6=" + addressV6 +
+                '}';
+    }
+}

--- a/security/src/main/java/io/netty/security/core/Table.java
+++ b/security/src/main/java/io/netty/security/core/Table.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.security.core;
+
+import java.util.List;
+
+/**
+ * A table is a collection of rules sorted according to its priority number.
+ */
+public interface Table extends RuleLookup, Comparable<Table>, LockMechanism {
+
+    /**
+     * This number determines on which level a table will be placed
+     */
+    int priority();
+
+    /**
+     * Table name
+     */
+    String name();
+
+    /**
+     * {@link List} of {@link Rule} associated with this {@link Table}
+     */
+    List<Rule> rules();
+
+    /**
+     * Add a {@link Rule} into this {@link Table}
+     *
+     * @param rule {@link Rule} instance
+     */
+    void addRule(Rule rule);
+
+    /**
+     * Remove a {@link Rule} from this {@link Table}
+     *
+     * @param rule {@link Rule} instance
+     */
+    void removeRule(Rule rule);
+
+    @Override
+    int compareTo(Table table);
+}

--- a/security/src/main/java/io/netty/security/core/Tables.java
+++ b/security/src/main/java/io/netty/security/core/Tables.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.security.core;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * {@link Tables} holds multiple {@link Table}s according
+ * to their priority and provides {@link Table} addition, removal,
+ * and retrieval.
+ */
+public interface Tables {
+
+    /**
+     * Add a new {@link Table}
+     *
+     * @param table {@link Table} to add
+     * @throws NullPointerException     If {@link Table} parameter is {@code null}
+     * @throws IllegalArgumentException If a {@link Table} already exists with the same priority
+     */
+    void addTable(Table table);
+
+    /**
+     * Remove a {@link Table}
+     *
+     * @param priority Priority of table to remove
+     * @return {@link Boolean#TRUE} if removal was successful else {@link Boolean#FALSE}
+     */
+    boolean removeTable(int priority);
+
+    /**
+     * Returns {@link Table}s {@link Collection}
+     */
+    Collection<Table> tables();
+
+    /**
+     * Returns the {@link Table}s {@link Map}
+     */
+    Map<Integer, Table> tablesMap();
+}

--- a/security/src/main/java/io/netty/security/core/Util.java
+++ b/security/src/main/java/io/netty/security/core/Util.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.security.core;
+
+import io.netty.channel.socket.DatagramChannel;
+import io.netty.channel.socket.DatagramPacket;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.security.core.standards.StandardFiveTuple;
+import io.netty.util.internal.ObjectUtil;
+
+import java.math.BigInteger;
+import java.net.InetSocketAddress;
+import java.util.Arrays;
+import java.util.Objects;
+
+public final class Util {
+    private static final BigInteger MINUS_ONE = BigInteger.valueOf(-1);
+
+    public static int prefixToSubnetMaskV4(int cidrPrefix) {
+        return (int) (-1L << 32 - cidrPrefix);
+    }
+
+    public static BigInteger prefixToSubnetMaskV6(int cidrPrefix) {
+        return MINUS_ONE.shiftLeft(128 - cidrPrefix);
+    }
+
+    /**
+     * Copy of {@link Integer#compare(int, int)}
+     */
+    public static int compareIntegers(int x, int y) {
+        return x < y ? -1 : x == y ? 0 : 1;
+    }
+
+    /**
+     * Copy of {@link Objects#hash(Object...)}
+     */
+    public static int hash(Object... values) {
+        return Arrays.hashCode(values);
+    }
+
+    /**
+     * Create a new {@link StandardFiveTuple} from {@link SocketChannel}
+     *
+     * @param socketChannel {@link SocketChannel} to use
+     * @return new {@link StandardFiveTuple} instance
+     */
+    public static FiveTuple generateFiveTupleFrom(SocketChannel socketChannel) {
+        ObjectUtil.checkNotNull(socketChannel, "SocketChannel");
+
+        if (socketChannel.localAddress() instanceof InetSocketAddress &&
+                socketChannel.remoteAddress() instanceof InetSocketAddress) {
+            InetSocketAddress local = socketChannel.localAddress();
+            InetSocketAddress remote = socketChannel.remoteAddress();
+
+            return StandardFiveTuple.from(Protocol.TCP, remote.getPort(), local.getPort(),
+                    StaticIpAddress.of(remote.getAddress()), StaticIpAddress.of(local.getAddress()));
+        } else {
+            throw new IllegalArgumentException("SocketChannel addresses (local and remote) " +
+                    "must be InetSocketAddress");
+        }
+    }
+
+    /**
+     * Create a new {@link StandardFiveTuple} from {@link DatagramChannel}
+     *
+     * @param datagramChannel {@link DatagramChannel} to use
+     * @return new {@link StandardFiveTuple} instance
+     */
+    public static StandardFiveTuple generateFiveTupleFrom(DatagramChannel datagramChannel) {
+        ObjectUtil.checkNotNull(datagramChannel, "DatagramChannel");
+
+        if (datagramChannel.localAddress() instanceof InetSocketAddress &&
+                datagramChannel.remoteAddress() instanceof InetSocketAddress) {
+            InetSocketAddress local = datagramChannel.localAddress();
+            InetSocketAddress remote = datagramChannel.remoteAddress();
+
+            return StandardFiveTuple.from(Protocol.UDP, remote.getPort(), local.getPort(),
+                    StaticIpAddress.of(remote.getAddress()), StaticIpAddress.of(local.getAddress()));
+        } else {
+            throw new IllegalArgumentException("DatagramChannel addresses (local and remote) " +
+                    "must be InetSocketAddress");
+        }
+    }
+
+    /**
+     * Create a new {@link StandardFiveTuple} from {@link DatagramPacket}
+     *
+     * @param datagramPacket {@link DatagramChannel} to use
+     * @return new {@link StandardFiveTuple} instance
+     */
+    public static StandardFiveTuple generateFiveTupleFrom(DatagramPacket datagramPacket) {
+        ObjectUtil.checkNotNull(datagramPacket, "DatagramChannel");
+
+        if (datagramPacket.recipient() instanceof InetSocketAddress &&
+                datagramPacket.sender() instanceof InetSocketAddress) {
+            InetSocketAddress local = datagramPacket.recipient();
+            InetSocketAddress remote = datagramPacket.sender();
+
+            return StandardFiveTuple.from(Protocol.UDP, remote.getPort(), local.getPort(),
+                    StaticIpAddress.of(remote.getAddress()), StaticIpAddress.of(local.getAddress()));
+        } else {
+            throw new IllegalArgumentException("DatagramPacket addresses (local and remote) " +
+                    "must be InetSocketAddress");
+        }
+    }
+
+    /**
+     * Convert Hex {@link String} to byte array
+     *
+     * @param str Hex string
+     * @return byte array
+     */
+    public static byte[] hexStringToByteArray(String str) {
+        final int len = str.length();
+        byte[] data = new byte[len / 2];
+        for (int i = 0; i < len; i += 2) {
+            data[i / 2] = (byte) ((Character.digit(str.charAt(i), 16) << 4) + Character.digit(str.charAt(i + 1), 16));
+        }
+        return data;
+    }
+
+    private Util() {
+        // Prevent outside initialization
+    }
+}

--- a/security/src/main/java/io/netty/security/core/events/ChannelClosedEvent.java
+++ b/security/src/main/java/io/netty/security/core/events/ChannelClosedEvent.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.security.core.events;
+
+import io.netty.channel.Channel;
+
+/**
+ * This event is fired when an {@link Channel} is closed.
+ */
+public final class ChannelClosedEvent {
+
+    public static final ChannelClosedEvent INSTANCE = new ChannelClosedEvent();
+
+    private ChannelClosedEvent() {
+        // Prevent outside initialization
+    }
+}

--- a/security/src/main/java/io/netty/security/core/events/ObjectDroppedAndChannelClosedEvent.java
+++ b/security/src/main/java/io/netty/security/core/events/ObjectDroppedAndChannelClosedEvent.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.security.core.events;
+
+import io.netty.channel.Channel;
+
+/**
+ * This event is fired when an {@link Object} is dropped and {@link Channel} is closed.
+ */
+public final class ObjectDroppedAndChannelClosedEvent {
+
+    public static final ObjectDroppedAndChannelClosedEvent INSTANCE = new ObjectDroppedAndChannelClosedEvent();
+
+    private ObjectDroppedAndChannelClosedEvent() {
+        // Prevent outside initialization
+    }
+}

--- a/security/src/main/java/io/netty/security/core/events/ObjectDroppedEvent.java
+++ b/security/src/main/java/io/netty/security/core/events/ObjectDroppedEvent.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.security.core.events;
+
+/**
+ * This event is fired when an {@link Object} is dropped.
+ */
+public final class ObjectDroppedEvent {
+
+    public static final ObjectDroppedEvent INSTANCE = new ObjectDroppedEvent();
+
+    private ObjectDroppedEvent() {
+        // Prevent outside initialization
+    }
+}

--- a/security/src/main/java/io/netty/security/core/events/package-info.java
+++ b/security/src/main/java/io/netty/security/core/events/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * This package contains events which are fired by Netty Security.
+ */
+package io.netty.security.core.events;

--- a/security/src/main/java/io/netty/security/core/package-info.java
+++ b/security/src/main/java/io/netty/security/core/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * Netty Security provides security APIs such as IP address filtering,
+ * payload matching, traffic filtering, and more. It provides extensible API
+ * which can be used for custom protocols and implementations.
+ */
+package io.netty.security.core;

--- a/security/src/main/java/io/netty/security/core/payload/BufferPayload.java
+++ b/security/src/main/java/io/netty/security/core/payload/BufferPayload.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.security.core.payload;
+
+import io.netty.buffer.ByteBuf;
+
+/**
+ * {@link BufferPayload} implements {@link ByteBuf} as needle
+ * for matching payload.
+ */
+public interface BufferPayload extends Payload<ByteBuf> {
+    // Marker interface
+}

--- a/security/src/main/java/io/netty/security/core/payload/HexPayload.java
+++ b/security/src/main/java/io/netty/security/core/payload/HexPayload.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.security.core.payload;
+
+import io.netty.buffer.ByteBuf;
+
+/**
+ * {@link HexPayload} implements {@link ByteBuf} as needle
+ * for matching payload.
+ */
+public interface HexPayload extends BufferPayload {
+    // Marker Interface
+}

--- a/security/src/main/java/io/netty/security/core/payload/Payload.java
+++ b/security/src/main/java/io/netty/security/core/payload/Payload.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.security.core.payload;
+
+/**
+ * Payload or Needle is the data to match against actual Payload or Haystack.
+ *
+ * @param <P> Payload type
+ */
+@FunctionalInterface
+public interface Payload<P> {
+
+    /**
+     * Returns {@code null} payload needle
+     */
+    Payload<?> NULL_PAYLOAD = new Payload<Object>() {
+        @Override
+        public Object needle() {
+            return null;
+        }
+    };
+
+    /**
+     * Returns Payload Needle
+     */
+    P needle();
+}

--- a/security/src/main/java/io/netty/security/core/payload/PayloadMatcher.java
+++ b/security/src/main/java/io/netty/security/core/payload/PayloadMatcher.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.security.core.payload;
+
+@FunctionalInterface
+public interface PayloadMatcher<N, H> {
+
+    /**
+     * Match any payload
+     */
+    PayloadMatcher<Object, Object> ANY_PAYLOAD = new PayloadMatcher<Object, Object>() {
+        @Override
+        public boolean validate(Object needle, Object haystack) {
+            return true;
+        }
+    };
+
+    /**
+     * Validate a payload
+     *
+     * @param needle   Needle
+     * @param haystack Haystack
+     * @return {@link Boolean#TRUE} if payload matches else {@link Boolean#FALSE}
+     */
+    boolean validate(N needle, H haystack);
+}

--- a/security/src/main/java/io/netty/security/core/payload/RegexPayload.java
+++ b/security/src/main/java/io/netty/security/core/payload/RegexPayload.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.security.core.payload;
+
+import java.util.regex.Pattern;
+
+/**
+ * {@link RegexPayload} implements {@link Pattern} as needle
+ * for matching payload.
+ */
+public interface RegexPayload extends Payload<Pattern> {
+
+    /**
+     * {@link Pattern} payload
+     */
+    @Override
+    Pattern needle();
+}

--- a/security/src/main/java/io/netty/security/core/payload/package-info.java
+++ b/security/src/main/java/io/netty/security/core/payload/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * This package contains interfaces for Payload operations.
+ */
+package io.netty.security.core.payload;

--- a/security/src/main/java/io/netty/security/core/standards/StandardBufferPayload.java
+++ b/security/src/main/java/io/netty/security/core/standards/StandardBufferPayload.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.security.core.standards;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.security.core.payload.BufferPayload;
+import io.netty.util.internal.ObjectUtil;
+
+import static io.netty.security.core.Util.hash;
+
+public final class StandardBufferPayload implements BufferPayload {
+    private final ByteBuf buffer;
+
+    private StandardBufferPayload(ByteBuf buffer) {
+        this.buffer = ObjectUtil.checkNotNull(buffer, "Buffer");
+    }
+
+    /**
+     * Create a new {@link StandardBufferPayload} with specified {@link ByteBuf}
+     *
+     * @param buffer {@link ByteBuf} to use as needle
+     * @return New {@link StandardBufferPayload} instance
+     */
+    public static StandardBufferPayload create(ByteBuf buffer) {
+        return new StandardBufferPayload(buffer);
+    }
+
+    @Override
+    public ByteBuf needle() {
+        return buffer;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        StandardBufferPayload that = (StandardBufferPayload) o;
+        return ByteBufUtil.equals(buffer, that.buffer);
+    }
+
+    @Override
+    public int hashCode() {
+        return hash(buffer);
+    }
+
+    @Override
+    public String toString() {
+        return "BufferPayloadHolder{buffer=" + buffer + '}';
+    }
+}

--- a/security/src/main/java/io/netty/security/core/standards/StandardFilter.java
+++ b/security/src/main/java/io/netty/security/core/standards/StandardFilter.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.security.core.standards;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufHolder;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.socket.DatagramPacket;
+import io.netty.security.core.Action;
+import io.netty.security.core.BasicFilter;
+import io.netty.security.core.FiveTuple;
+import io.netty.security.core.Rule;
+import io.netty.security.core.Table;
+import io.netty.security.core.Tables;
+import io.netty.security.core.payload.Payload;
+import io.netty.util.internal.ObjectUtil;
+
+/**
+ * This is a standard implementation of {@link BasicFilter}
+ * which handles {@link ChannelHandlerContext#fireChannelActive()},
+ * {@link DatagramPacket}, {@link ByteBuf} and {@link ByteBufHolder}.
+ */
+public final class StandardFilter implements BasicFilter {
+
+    private final Tables tables;
+    private final Action defaultAction;
+
+    private StandardFilter(Tables tables, Action defaultAction) {
+        this.tables = ObjectUtil.checkNotNull(tables, "Tables");
+        this.defaultAction = ObjectUtil.checkNotNull(defaultAction, "DefaultAction");
+    }
+
+    /**
+     * Create a new instance {@link StandardFilter}
+     *
+     * @param tables        {@link Tables} to use
+     * @param defaultAction {@link Action} to be taken if a request does
+     *                      not match against any rules in the {@link Tables}
+     * @throws NullPointerException If any parameter is {@code null}
+     */
+    public static StandardFilter of(Tables tables, Action defaultAction) {
+        return new StandardFilter(tables, defaultAction);
+    }
+
+    @Override
+    public Action validateChannelActive(FiveTuple fiveTuple) {
+        return checkRule(fiveTuple, null);
+    }
+
+    @Override
+    public Action validateDatagramPacket(DatagramPacket datagramPacket, FiveTuple fiveTuple) {
+        return checkRule(fiveTuple, datagramPacket.content());
+    }
+
+    @Override
+    public Action validateBuffer(ByteBuf buffer, FiveTuple fiveTuple) {
+        return checkRule(fiveTuple, buffer);
+    }
+
+    private Action checkRule(FiveTuple fiveTuple, ByteBuf bufferPayload) {
+        Rule rule = ruleLookup(fiveTuple, bufferPayload);
+        if (rule != null) {
+            return rule.action();
+        }
+
+        // If rule is null then we couldn't locate the appropriate rule.
+        // We will fall back to default action now.
+        return defaultAction;
+    }
+
+    @Override
+    public Action validateObject(Object msg, FiveTuple fiveTuple) {
+        if (msg instanceof DatagramPacket) {
+            return validateDatagramPacket((DatagramPacket) msg, fiveTuple);
+        } else if (msg instanceof ByteBuf) {
+            return validateBuffer((ByteBuf) msg, fiveTuple);
+        } else {
+            throw new IllegalArgumentException("Unsupported Object: " + msg.getClass().getSimpleName());
+        }
+    }
+
+    /**
+     * Lookup for appropriate {@link Rule} in {@link Tables}
+     *
+     * @param fiveTuple {@link FiveTuple} implementation
+     * @return {@link Rule} if found else {@code null}
+     */
+    private Rule ruleLookup(FiveTuple fiveTuple, ByteBuf bufferPayload) {
+        // Iterate over all Tables and lookup for Rule using FiveTuple.
+        for (Table table : tables.tables()) {
+            Rule rule = table.lookup(fiveTuple);
+
+            // If rule was found then check if there are any payload instructions.
+            // If there are, check payload one by one and if it matches, return rule.
+            // If there are none, just return rule.
+            if (rule != null) {
+                if (!rule.payloads().isEmpty() && bufferPayload != null) {
+                    for (int i = 0; i < rule.payloads().size(); i++) {
+                        Payload<?> payload = rule.payloads().get(i);
+                        if (rule.payloadMatcher().validate(payload.needle(), bufferPayload)) {
+                            return rule;
+                        }
+                    }
+                } else {
+                    return rule;
+                }
+            }
+        }
+
+        // for-loop was not executed because there were no rules.
+        // Let's return null since we couldn't find anything.
+        return null;
+    }
+}

--- a/security/src/main/java/io/netty/security/core/standards/StandardFiveTuple.java
+++ b/security/src/main/java/io/netty/security/core/standards/StandardFiveTuple.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.security.core.standards;
+
+import io.netty.security.core.Address;
+import io.netty.security.core.FiveTuple;
+import io.netty.security.core.Protocol;
+import io.netty.util.internal.ObjectUtil;
+
+import static io.netty.security.core.Util.compareIntegers;
+import static io.netty.security.core.Util.hash;
+
+public final class StandardFiveTuple implements FiveTuple {
+    private final Protocol protocol;
+    private final int sourcePort;
+    private final int destinationPort;
+    private final Address sourceIpAddress;
+    private final Address destinationIpAddress;
+
+    private StandardFiveTuple(Protocol protocol, int sourcePort, int destinationPort,
+                              Address sourceIpAddress, Address destinationIpAddress) {
+        this.protocol = ObjectUtil.checkNotNull(protocol, "Protocol");
+        this.sourcePort = ObjectUtil.checkInRange(sourcePort, 1, 65_535, "SourcePort");
+        this.destinationPort = ObjectUtil.checkInRange(destinationPort, 1, 65_535, "DestinationPort");
+        this.sourceIpAddress = ObjectUtil.checkNotNull(sourceIpAddress, "SourceIPAddress");
+        this.destinationIpAddress = ObjectUtil.checkNotNull(destinationIpAddress, "DestinationIPAddress");
+    }
+
+    /**
+     * Create a new {@link StandardFiveTuple}
+     *
+     * @param protocol             {@link Protocol} type
+     * @param sourcePort           Source Port
+     * @param destinationPort      Destination Port
+     * @param sourceIpAddress      Source IP Address
+     * @param destinationIpAddress Destination IP Address
+     * @return new {@link StandardFiveTuple} instance
+     */
+    public static StandardFiveTuple from(Protocol protocol, int sourcePort, int destinationPort,
+                                         Address sourceIpAddress, Address destinationIpAddress) {
+        return new StandardFiveTuple(protocol, sourcePort, destinationPort, sourceIpAddress, destinationIpAddress);
+    }
+
+    @Override
+    public Protocol protocol() {
+        return protocol;
+    }
+
+    @Override
+    public int sourcePort() {
+        return sourcePort;
+    }
+
+    @Override
+    public int destinationPort() {
+        return destinationPort;
+    }
+
+    @Override
+    public Address sourceIpAddress() {
+        return sourceIpAddress;
+    }
+
+    @Override
+    public Address destinationIpAddress() {
+        return destinationIpAddress;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        StandardFiveTuple that = (StandardFiveTuple) o;
+        return hashCode() == that.hashCode();
+    }
+
+    @Override
+    public int compareTo(FiveTuple o) {
+        // Protocol
+        int compare = compareIntegers(protocol().ordinal(), o.protocol().ordinal());
+        if (compare != 0) {
+            return compare;
+        }
+
+        // Source Port
+        compare = compareIntegers(sourcePort(), o.sourcePort());
+        if (compare != 0) {
+            return compare;
+        }
+
+        // Destination Port
+        compare = compareIntegers(destinationPort(), o.destinationPort());
+        if (compare != 0) {
+            return compare;
+        }
+
+        // If Source version is v4 then we have v4 destination as well.
+        // If Source version is v6 then we have v6 destination as well.
+        if (sourceIpAddress().version() == Address.Version.v4) {
+            // Source Address
+            compare = compareIntegers(sourceIpAddress().v4AddressAsInt(), o.sourceIpAddress().v4AddressAsInt());
+            if (compare != 0) {
+                return compare;
+            }
+
+            return compareIntegers(destinationIpAddress().v4AddressAsInt(), o.destinationIpAddress().v4AddressAsInt());
+        }
+        if (sourceIpAddress().version() == Address.Version.v6) {
+            compare = sourceIpAddress().v6NetworkAddressAsBigInt()
+                    .compareTo(o.sourceIpAddress().v6NetworkAddressAsBigInt());
+            if (compare != 0) {
+                return compare;
+            }
+
+            return destinationIpAddress().v6NetworkAddressAsBigInt()
+                    .compareTo(o.destinationIpAddress().v6NetworkAddressAsBigInt());
+        }
+
+        // Unsupported IP version. So let's return -1
+        // because we have no idea at all about it.
+        return -1;
+    }
+
+    @Override
+    public int hashCode() {
+        return hash(protocol, sourcePort, destinationPort, sourceIpAddress, destinationIpAddress);
+    }
+
+    @Override
+    public String toString() {
+        return "StandardFiveTuple{" +
+                "protocol=" + protocol +
+                ", sourcePort=" + sourcePort +
+                ", destinationPort=" + destinationPort +
+                ", sourceIpAddress=" + sourceIpAddress +
+                ", destinationIpAddress=" + destinationIpAddress +
+                '}';
+    }
+}

--- a/security/src/main/java/io/netty/security/core/standards/StandardFiveTuple.java
+++ b/security/src/main/java/io/netty/security/core/standards/StandardFiveTuple.java
@@ -33,8 +33,8 @@ public final class StandardFiveTuple implements FiveTuple {
     private StandardFiveTuple(Protocol protocol, int sourcePort, int destinationPort,
                               Address sourceIpAddress, Address destinationIpAddress) {
         this.protocol = ObjectUtil.checkNotNull(protocol, "Protocol");
-        this.sourcePort = ObjectUtil.checkInRange(sourcePort, 1, 65_535, "SourcePort");
-        this.destinationPort = ObjectUtil.checkInRange(destinationPort, 1, 65_535, "DestinationPort");
+        this.sourcePort = ObjectUtil.checkInRange(sourcePort, 1, 65535, "SourcePort");
+        this.destinationPort = ObjectUtil.checkInRange(destinationPort, 1, 65535, "DestinationPort");
         this.sourceIpAddress = ObjectUtil.checkNotNull(sourceIpAddress, "SourceIPAddress");
         this.destinationIpAddress = ObjectUtil.checkNotNull(destinationIpAddress, "DestinationIPAddress");
     }

--- a/security/src/main/java/io/netty/security/core/standards/StandardHexPayload.java
+++ b/security/src/main/java/io/netty/security/core/standards/StandardHexPayload.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.security.core.standards;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.security.core.payload.HexPayload;
+import io.netty.util.internal.ObjectUtil;
+
+import static io.netty.security.core.Util.hexStringToByteArray;
+
+/**
+ * {@link StandardHexPayload} handles Hex Payload Needle. It will convert
+ * Hex String or Hex {@link ByteBuf} into Hex {@link ByteBuf}.
+ */
+public final class StandardHexPayload implements HexPayload {
+
+    private final ByteBuf buffer;
+
+    private StandardHexPayload(ByteBuf buffer) {
+        this.buffer = ObjectUtil.checkNotNull(buffer, "Buffer");
+    }
+
+    /**
+     * Create a new {@link StandardRegexPayload} with specified {@link String}
+     *
+     * @param hexString {@link String} to use as needle
+     * @return New {@link StandardRegexPayload} instance
+     */
+    public static StandardHexPayload create(String hexString) {
+        byte[] hex = hexStringToByteArray(hexString);
+        return new StandardHexPayload(Unpooled.wrappedBuffer(hex));
+    }
+
+    @Override
+    public ByteBuf needle() {
+        return buffer;
+    }
+}

--- a/security/src/main/java/io/netty/security/core/standards/StandardNetworkHandler.java
+++ b/security/src/main/java/io/netty/security/core/standards/StandardNetworkHandler.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.security.core.standards;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.socket.DatagramChannel;
+import io.netty.channel.socket.DatagramPacket;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.security.core.Action;
+import io.netty.security.core.Filter;
+import io.netty.security.core.FiveTuple;
+import io.netty.security.core.Util;
+import io.netty.security.core.events.ChannelClosedEvent;
+import io.netty.security.core.events.ObjectDroppedAndChannelClosedEvent;
+import io.netty.security.core.events.ObjectDroppedEvent;
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.internal.ObjectUtil;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * This is a standard network handler which performs network filtering.
+ * This handler instance is thread-safe and should be shared among different channels.
+ */
+@ChannelHandler.Sharable
+public class StandardNetworkHandler extends ChannelInboundHandlerAdapter {
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(StandardNetworkHandler.class);
+    private final Map<Channel, FiveTuple> CHANNEL_TUPLE_MAP = new ConcurrentHashMap<>();
+
+    private final Filter filter;
+
+    /**
+     * Create a new {@link StandardNetworkHandler} instance
+     *
+     * @param filter {@link Filter} implementation to use
+     */
+    public StandardNetworkHandler(Filter filter) {
+        this.filter = ObjectUtil.checkNotNull(filter, "Filter");
+    }
+
+    @Override
+    public void channelActive(ChannelHandlerContext ctx) {
+        if (ctx.channel() instanceof SocketChannel) {
+            channelActive0(ctx, fiveTupleSocketChannel((SocketChannel) ctx.channel()));
+        } else if (ctx.channel() instanceof DatagramChannel) {
+            DatagramChannel channel = (DatagramChannel) ctx.channel();
+
+            // If Channel is connected then we can retrieve FiveTuple information
+            // in just one go. This is a Client implementation, not Server.
+            if (channel.isConnected()) {
+                FiveTuple fiveTuple = Util.generateFiveTupleFrom(channel);
+                channelActive0(ctx, fiveTuple);
+            } else {
+                // Channel is not connected, it means we have to generate FiveTuple
+                // everytime a DatagramPacket arrives.
+                ctx.fireChannelActive();
+            }
+        } else {
+            logger.error("Unknown Channel Type: " + ctx.channel().getClass().getSimpleName());
+        }
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) {
+        CHANNEL_TUPLE_MAP.remove(ctx.channel());
+        ctx.fireChannelInactive();
+    }
+
+    private void channelActive0(ChannelHandlerContext ctx, FiveTuple fiveTuple) {
+        // Process the connection
+        Action action = filter.validateChannelActive(fiveTuple);
+        if (action == Action.ACCEPT) {
+            // Pass the event to next Handler in Pipeline
+            ctx.fireChannelActive();
+        } else if (action == Action.REJECT || action == Action.DROP) {
+            ctx.channel().close();
+            ctx.fireUserEventTriggered(ChannelClosedEvent.INSTANCE);
+        } else {
+            throw new IllegalArgumentException("Invalid Action: " + action);
+        }
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) {
+        FiveTuple fiveTuple;
+        if (ctx.channel() instanceof SocketChannel) {
+            fiveTuple = fiveTupleSocketChannel((SocketChannel) ctx.channel());
+        } else if (ctx.channel() instanceof DatagramChannel) {
+            DatagramChannel datagramChannel = (DatagramChannel) ctx.channel();
+            if (datagramChannel.isConnected()) {
+                fiveTuple = fiveTupleDatagramChannel((DatagramChannel) ctx.channel());
+            } else {
+                fiveTuple = Util.generateFiveTupleFrom((DatagramPacket) msg);
+            }
+        } else {
+            throw new IllegalArgumentException("Channel not supported: " + ctx.channel());
+        }
+
+        Action action = filter.validateObject(msg, fiveTuple);
+        switch (action) {
+            case ACCEPT:
+                ctx.fireChannelRead(msg);
+                break;
+            case DROP:
+                ReferenceCountUtil.release(msg);
+                ctx.fireUserEventTriggered(ObjectDroppedEvent.INSTANCE);
+                break;
+            case REJECT:
+                ReferenceCountUtil.release(msg);
+                ctx.channel().close();
+                ctx.fireUserEventTriggered(ObjectDroppedAndChannelClosedEvent.INSTANCE);
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid Action: " + action);
+        }
+    }
+
+    private FiveTuple fiveTupleSocketChannel(SocketChannel channel) {
+        FiveTuple fiveTuple = CHANNEL_TUPLE_MAP.get(channel);
+        if (fiveTuple == null) {
+            CHANNEL_TUPLE_MAP.put(channel, Util.generateFiveTupleFrom(channel));
+        }
+        return fiveTuple;
+    }
+
+    private FiveTuple fiveTupleDatagramChannel(DatagramChannel channel) {
+        FiveTuple fiveTuple = CHANNEL_TUPLE_MAP.get(channel);
+        if (fiveTuple == null) {
+            CHANNEL_TUPLE_MAP.put(channel, Util.generateFiveTupleFrom(channel));
+        }
+        return fiveTuple;
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
+    }
+}

--- a/security/src/main/java/io/netty/security/core/standards/StandardNetworkHandler.java
+++ b/security/src/main/java/io/netty/security/core/standards/StandardNetworkHandler.java
@@ -44,7 +44,7 @@ import java.util.concurrent.ConcurrentHashMap;
 @ChannelHandler.Sharable
 public class StandardNetworkHandler extends ChannelInboundHandlerAdapter {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(StandardNetworkHandler.class);
-    private final Map<Channel, FiveTuple> CHANNEL_TUPLE_MAP = new ConcurrentHashMap<>();
+    private final Map<Channel, FiveTuple> CHANNEL_TUPLE_MAP = new ConcurrentHashMap<Channel, FiveTuple>();
 
     private final Filter filter;
 

--- a/security/src/main/java/io/netty/security/core/standards/StandardPayloadMatcher.java
+++ b/security/src/main/java/io/netty/security/core/standards/StandardPayloadMatcher.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.security.core.standards;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.security.core.InternalBufferUtils;
+import io.netty.security.core.payload.BufferPayload;
+import io.netty.security.core.payload.PayloadMatcher;
+import io.netty.security.core.payload.RegexPayload;
+import io.netty.util.CharsetUtil;
+
+/**
+ * {@link StandardPayloadMatcher} matches {@link RegexPayload} or {@link BufferPayload} needle
+ * against {@link ByteBuf} haystack.
+ */
+public class StandardPayloadMatcher implements PayloadMatcher<Object, Object> {
+
+    @Override
+    public boolean validate(Object needle, Object haystack) {
+        if (!(haystack instanceof ByteBuf)) {
+            throw new IllegalArgumentException("Unsupported Haystack: " + haystack);
+        }
+
+        ByteBuf haystackBuffer = (ByteBuf) haystack;
+        if (needle instanceof RegexPayload) {
+            RegexPayload payload = (RegexPayload) needle;
+            return payload.needle().matcher(haystackBuffer.toString(CharsetUtil.US_ASCII)).find();
+        } else if (needle instanceof BufferPayload) { // This also covers HexPayload
+            BufferPayload payload = (BufferPayload) needle;
+            return InternalBufferUtils.bytesBefore(haystackBuffer, InternalBufferUtils.UNCHECKED_LOAD_BYTE_BUFFER,
+                    payload.needle(), InternalBufferUtils.UNCHECKED_LOAD_BYTE_BUFFER) >= 0;
+        } else {
+            throw new IllegalArgumentException("Unsupported Needle: " + needle);
+        }
+    }
+}

--- a/security/src/main/java/io/netty/security/core/standards/StandardPorts.java
+++ b/security/src/main/java/io/netty/security/core/standards/StandardPorts.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.security.core.standards;
+
+import io.netty.security.core.Ports;
+import io.netty.util.internal.ObjectUtil;
+
+import static io.netty.security.core.Util.compareIntegers;
+import static io.netty.security.core.Util.hash;
+
+public final class StandardPorts implements Ports {
+
+    private final int start;
+    private final int end;
+
+    private StandardPorts(int start, int end) {
+        this.start = ObjectUtil.checkInRange(start, 1, 65_535, "PortStart");
+        this.end = ObjectUtil.checkInRange(end, 1, 65_535, "PortEnd");
+
+        if (start > end) {
+            throw new IllegalArgumentException("Port start must be smaller than Port end");
+        }
+    }
+
+    /**
+     * Create a new {@link StandardPorts} instance with specified start
+     * and end port.
+     *
+     * @param start Port Start
+     * @param end   Port End
+     * @return {@link StandardPorts} instance
+     */
+    public static StandardPorts from(int start, int end) {
+        return new StandardPorts(start, end);
+    }
+
+    /**
+     * Create a new {@link StandardPorts} instance with specified start.
+     *
+     * @param port Port
+     * @return {@link StandardPorts} instance
+     */
+    public static StandardPorts of(int port) {
+        return new StandardPorts(port, port);
+    }
+
+    @Override
+    public int start() {
+        return start;
+    }
+
+    @Override
+    public int end() {
+        return end;
+    }
+
+    @Override
+    public int compareTo(Ports ports) {
+        return compare(ports.start(), ports.end());
+    }
+
+    @Override
+    public int lookup(int port) {
+        return compare(port, port);
+    }
+
+    @Override
+    public boolean lookupPort(int port) {
+        return compare(port, port) == 0;
+    }
+
+    public int compare(int start, int end) {
+        if (start >= start() && end <= end()) {
+            return 0;
+        }
+
+        int compare = compareIntegers(start, start());
+        if (compare != 0) {
+            return compare;
+        }
+
+        return compareIntegers(end, end());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        StandardPorts that = (StandardPorts) o;
+        return hashCode() == that.hashCode();
+    }
+
+    @Override
+    public int hashCode() {
+        return hash(start, end);
+    }
+
+    @Override
+    public String toString() {
+        return "StandardPorts{start=" + start + ", end=" + end + '}';
+    }
+}

--- a/security/src/main/java/io/netty/security/core/standards/StandardPorts.java
+++ b/security/src/main/java/io/netty/security/core/standards/StandardPorts.java
@@ -27,8 +27,8 @@ public final class StandardPorts implements Ports {
     private final int end;
 
     private StandardPorts(int start, int end) {
-        this.start = ObjectUtil.checkInRange(start, 1, 65_535, "PortStart");
-        this.end = ObjectUtil.checkInRange(end, 1, 65_535, "PortEnd");
+        this.start = ObjectUtil.checkInRange(start, 1, 65535, "PortStart");
+        this.end = ObjectUtil.checkInRange(end, 1, 65535, "PortEnd");
 
         if (start > end) {
             throw new IllegalArgumentException("Port start must be smaller than Port end");

--- a/security/src/main/java/io/netty/security/core/standards/StandardRegexPayload.java
+++ b/security/src/main/java/io/netty/security/core/standards/StandardRegexPayload.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.security.core.standards;
+
+import io.netty.security.core.payload.RegexPayload;
+import io.netty.util.internal.ObjectUtil;
+
+import java.util.regex.Pattern;
+
+/**
+ * {@link StandardRegexPayload} holds Payload Needle as {@link Pattern}
+ * which is used to match Payload Haystack.
+ */
+public final class StandardRegexPayload implements RegexPayload {
+
+    private final Pattern pattern;
+
+    private StandardRegexPayload(Pattern pattern) {
+        this.pattern = ObjectUtil.checkNotNull(pattern, "Pattern");
+    }
+
+    /**
+     * Create a new {@link StandardRegexPayload} with specified {@link Pattern}
+     *
+     * @param pattern {@link Pattern} to use as needle
+     * @return New {@link StandardRegexPayload} instance
+     */
+    public static StandardRegexPayload create(Pattern pattern) {
+        return new StandardRegexPayload(pattern);
+    }
+
+    @Override
+    public Pattern needle() {
+        return pattern;
+    }
+}

--- a/security/src/main/java/io/netty/security/core/standards/StandardRule.java
+++ b/security/src/main/java/io/netty/security/core/standards/StandardRule.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.security.core.standards;
+
+import io.netty.security.core.Action;
+import io.netty.security.core.IpAddresses;
+import io.netty.security.core.Ports;
+import io.netty.security.core.Protocol;
+import io.netty.security.core.Rule;
+import io.netty.security.core.payload.Payload;
+import io.netty.security.core.payload.PayloadMatcher;
+import io.netty.util.internal.ObjectUtil;
+
+import java.util.List;
+
+import static io.netty.security.core.Util.compareIntegers;
+import static io.netty.security.core.Util.hash;
+
+public class StandardRule implements Rule {
+    private final Protocol protocol;
+    private final Ports sourcePorts;
+    private final Ports destinationPorts;
+    private final IpAddresses sourceIpAddresses;
+    private final IpAddresses destinationIpAddress;
+    private final List<? extends Payload<?>> payloads;
+    private final PayloadMatcher<Object, Object> payloadMatcher;
+    private final Action action;
+
+    StandardRule(Protocol protocol, Ports sourcePorts, Ports destinationPorts, IpAddresses sourceIpAddresses,
+                 IpAddresses destinationIpAddress, List<? extends Payload<?>> payloads,
+                 PayloadMatcher<Object, Object> payloadMatcher, Action action) {
+        this.protocol = ObjectUtil.checkNotNull(protocol, "Protocol");
+        this.sourcePorts = ObjectUtil.checkNotNull(sourcePorts, "SourcePorts");
+        this.destinationPorts = ObjectUtil.checkNotNull(destinationPorts, "DestinationPorts");
+        this.sourceIpAddresses = ObjectUtil.checkNotNull(sourceIpAddresses, "SourceIPAddresses");
+        this.destinationIpAddress = ObjectUtil.checkNotNull(destinationIpAddress, "DestinationIpAddresses");
+        this.payloads = ObjectUtil.checkNotNull(payloads, "Payloads");
+        this.payloadMatcher = ObjectUtil.checkNotNull(payloadMatcher, "PayloadMatcher");
+        this.action = ObjectUtil.checkNotNull(action, "Action");
+    }
+
+    /**
+     * Create a new {@link StandardRuleBuilder} instance for building new {@link Rule}
+     * with 'Accept Any' set to {@link Boolean#TRUE}
+     *
+     * @return new {@link StandardRuleBuilder} instance
+     */
+    public static StandardRuleBuilder newBuilder() {
+        return new StandardRuleBuilder(true);
+    }
+
+    /**
+     * Create a new {@link StandardRuleBuilder} instance for building new {@link Rule}
+     * with specified property of 'Accept Any'.
+     *
+     * @param acceptAny Set to {@link Boolean#TRUE} to accept any property else
+     *                  set to {@link Boolean#FALSE}
+     * @return new {@link StandardRuleBuilder} instance
+     */
+    public static StandardRuleBuilder newBuilder(boolean acceptAny) {
+        return new StandardRuleBuilder(acceptAny);
+    }
+
+    @Override
+    public Protocol protocol() {
+        return protocol;
+    }
+
+    @Override
+    public Ports sourcePorts() {
+        return sourcePorts;
+    }
+
+    @Override
+    public Ports destinationPorts() {
+        return destinationPorts;
+    }
+
+    @Override
+    public IpAddresses sourceIpAddresses() {
+        return sourceIpAddresses;
+    }
+
+    @Override
+    public IpAddresses destinationIpAddresses() {
+        return destinationIpAddress;
+    }
+
+    @Override
+    public List<? extends Payload<?>> payloads() {
+        return payloads;
+    }
+
+    @Override
+    public PayloadMatcher<Object, Object> payloadMatcher() {
+        return payloadMatcher;
+    }
+
+    @Override
+    public Action action() {
+        return action;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        StandardRule that = (StandardRule) o;
+        return hashCode() == that.hashCode();
+    }
+
+    /**
+     * Compare a {@link Rule} with this instance
+     *
+     * @param rule the object to be compared.
+     * @return 0 if this rule matches
+     */
+    @Override
+    public int compareTo(Rule rule) {
+        // Protocol
+        int compare = compareIntegers(protocol().ordinal(), rule.protocol().ordinal());
+        if (compare != 0) {
+            return compare;
+        }
+
+        // Source Port
+        compare = sourcePorts().compareTo(rule.sourcePorts());
+        if (compare != 0) {
+            return compare;
+        }
+
+        // Destination Port
+        compare = destinationPorts().compareTo(rule.destinationPorts());
+        if (compare != 0) {
+            return compare;
+        }
+
+        // Source IP Address
+        compare = sourceIpAddresses().compareTo(rule.sourceIpAddresses());
+        if (compare != 0) {
+            return compare;
+        }
+
+        // Destination IP Address
+        return destinationIpAddresses().compareTo(rule.destinationIpAddresses());
+    }
+
+    @Override
+    public int hashCode() {
+        return hash(protocol, sourcePorts, destinationPorts, sourceIpAddresses,
+                destinationIpAddress, payloads, payloadMatcher, action);
+    }
+
+    @Override
+    public String toString() {
+        return "StandardRule{" +
+                "protocol=" + protocol +
+                ", sourcePorts=" + sourcePorts +
+                ", destinationPorts=" + destinationPorts +
+                ", sourceIpAddresses=" + sourceIpAddresses +
+                ", destinationIpAddress=" + destinationIpAddress +
+                ", matchType=" + payloads +
+                ", payloadMatcher=" + payloadMatcher +
+                ", action=" + action +
+                '}';
+    }
+}

--- a/security/src/main/java/io/netty/security/core/standards/StandardRuleBuilder.java
+++ b/security/src/main/java/io/netty/security/core/standards/StandardRuleBuilder.java
@@ -52,8 +52,8 @@ public final class StandardRuleBuilder {
     StandardRuleBuilder(boolean acceptAny) {
         // Package access only
         if (acceptAny) {
-            sourcePorts = Ports.ANY_PORT;
-            destinationPorts = Ports.ANY_PORT;
+            sourcePorts = Ports.ANYPORT;
+            destinationPorts = Ports.ANYPORT;
             sourceIpAddresses = IpAddresses.AcceptAnyIpAddresses.INSTANCE;
             destinationIpAddress = IpAddresses.AcceptAnyIpAddresses.INSTANCE;
             payloads = EMPTY_PAYLOAD;

--- a/security/src/main/java/io/netty/security/core/standards/StandardRuleBuilder.java
+++ b/security/src/main/java/io/netty/security/core/standards/StandardRuleBuilder.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.security.core.standards;
+
+import io.netty.security.core.Action;
+import io.netty.security.core.IpAddresses;
+import io.netty.security.core.Ports;
+import io.netty.security.core.Protocol;
+import io.netty.security.core.payload.Payload;
+import io.netty.security.core.payload.PayloadMatcher;
+
+import java.util.Collections;
+import java.util.List;
+
+public final class StandardRuleBuilder {
+    private static final List<? extends Payload<?>> EMPTY_PAYLOAD = Collections.singletonList(Payload.NULL_PAYLOAD);
+
+    private Protocol protocol;
+    private Ports sourcePorts;
+    private Ports destinationPorts;
+    private IpAddresses sourceIpAddresses;
+    private IpAddresses destinationIpAddress;
+    private List<? extends Payload<?>> payloads;
+    private PayloadMatcher<Object, Object> payloadMatcher;
+    private Action action;
+
+    /**
+     * Create a new {@link StandardRuleBuilder} instance
+     */
+    StandardRuleBuilder() {
+        this(false);
+    }
+
+    /**
+     * Create a new {@link StandardRuleBuilder} instance
+     *
+     * @param acceptAny Set to {@link Boolean#TRUE} to accept any port, ip address or payload.
+     */
+    StandardRuleBuilder(boolean acceptAny) {
+        // Package access only
+        if (acceptAny) {
+            sourcePorts = Ports.ANY_PORT;
+            destinationPorts = Ports.ANY_PORT;
+            sourceIpAddresses = IpAddresses.AcceptAnyIpAddresses.INSTANCE;
+            destinationIpAddress = IpAddresses.AcceptAnyIpAddresses.INSTANCE;
+            payloads = EMPTY_PAYLOAD;
+            payloadMatcher = PayloadMatcher.ANY_PAYLOAD;
+        }
+    }
+
+    public StandardRuleBuilder withProtocol(Protocol protocol) {
+        this.protocol = protocol;
+        return this;
+    }
+
+    public StandardRuleBuilder withSourcePorts(Ports sourcePorts) {
+        this.sourcePorts = sourcePorts;
+        return this;
+    }
+
+    public StandardRuleBuilder withDestinationPorts(Ports destinationPorts) {
+        this.destinationPorts = destinationPorts;
+        return this;
+    }
+
+    public StandardRuleBuilder withSourceIpAddresses(IpAddresses sourceIpAddresses) {
+        this.sourceIpAddresses = sourceIpAddresses;
+        return this;
+    }
+
+    public StandardRuleBuilder withDestinationIpAddress(IpAddresses destinationIpAddress) {
+        this.destinationIpAddress = destinationIpAddress;
+        return this;
+    }
+
+    public StandardRuleBuilder withPayloads(List<? extends Payload<?>> payloads) {
+        this.payloads = payloads;
+        return this;
+    }
+
+    public StandardRuleBuilder withPayloadMatcher(PayloadMatcher<Object, Object> payloadMatcher) {
+        this.payloadMatcher = payloadMatcher;
+        return this;
+    }
+
+    public StandardRuleBuilder withAction(Action action) {
+        this.action = action;
+        return this;
+    }
+
+    /**
+     * Build new {@link StandardRule} instance
+     */
+    public StandardRule build() {
+        return new StandardRule(protocol, sourcePorts, destinationPorts, sourceIpAddresses, destinationIpAddress,
+                payloads, payloadMatcher, action);
+    }
+}

--- a/security/src/main/java/io/netty/security/core/standards/StandardTable.java
+++ b/security/src/main/java/io/netty/security/core/standards/StandardTable.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.security.core.standards;
+
+import io.netty.security.core.FiveTuple;
+import io.netty.security.core.Rule;
+import io.netty.security.core.RuleLookup;
+import io.netty.security.core.SafeListController;
+import io.netty.security.core.Table;
+import io.netty.util.internal.ObjectUtil;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import static io.netty.security.core.Util.compareIntegers;
+import static io.netty.security.core.Util.hash;
+
+/**
+ * This is a standard implementation of {@link Table}.
+ * It handles {@link Rule} lookup by implementing {@link RuleLookup}.
+ * Modification of {@link Rule}s such as add or remove is supported.
+ * Take a look at {@link SafeListController} to know how to add or remove rules.
+ */
+public final class StandardTable extends SafeListController<Rule> implements Table {
+    private final int priority;
+    private final String name;
+
+    private StandardTable(int priority, String name) {
+        super(SortAndFilterImpl.INSTANCE);
+        this.priority = ObjectUtil.checkInRange(priority, 1, Integer.MAX_VALUE - 1, "Priority");
+        this.name = ObjectUtil.checkNotNull(name, "Name");
+    }
+
+    /**
+     * Create a new {@link StandardTable} instance
+     *
+     * @param priority Table priority
+     * @param name     Table name
+     * @return New {@link StandardTable} instance
+     */
+    public static StandardTable of(int priority, String name) {
+        return new StandardTable(priority, name);
+    }
+
+    @Override
+    public int priority() {
+        return priority;
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    /**
+     * Return an unmodifiable {@link List} of {@link Rule}.
+     */
+    @Override
+    public List<Rule> rules() {
+        return copy();
+    }
+
+    @Override
+    public void addRule(Rule rule) {
+        add(rule);
+    }
+
+    @Override
+    public void removeRule(Rule rule) {
+        remove(rule);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        StandardTable that = (StandardTable) o;
+        return hashCode() == that.hashCode();
+    }
+
+    @Override
+    public int compareTo(Table table) {
+        return compareIntegers(priority(), table.priority());
+    }
+
+    @Override
+    public int hashCode() {
+        return hash(priority);
+    }
+
+    @Override
+    public Rule lookup(FiveTuple fiveTuple) {
+        int index = Collections.binarySearch(MAIN_LIST, fiveTuple, BinarySearchFiveTupleComparator.INSTANCE);
+
+        if (index >= 0) {
+            return MAIN_LIST.get(index);
+        } else {
+            // If rule was not found, return null.
+            return null;
+        }
+    }
+
+    private static final class SortAndFilterImpl implements SortAndFilter<Rule> {
+
+        private static final SortAndFilterImpl INSTANCE = new SortAndFilterImpl();
+
+        @Override
+        public List<Rule> process(List<Rule> list) {
+            Collections.sort(list);
+            return list;
+        }
+
+    }
+
+    @SuppressWarnings("ComparatorNotSerializable")
+    private static final class BinarySearchFiveTupleComparator implements Comparator<Object> {
+        private static final BinarySearchFiveTupleComparator INSTANCE = new BinarySearchFiveTupleComparator();
+
+        @Override
+        public int compare(Object o1, Object o2) {
+            Rule rule = (Rule) o1;
+            FiveTuple fiveTuple = (FiveTuple) o2;
+
+            int compare = compareIntegers(rule.protocol().ordinal(), fiveTuple.protocol().ordinal());
+            if (compare != 0) {
+                return compare;
+            }
+
+            compare = rule.sourcePorts().lookup(fiveTuple.sourcePort());
+            if (compare != 0) {
+                return compare;
+            }
+
+            compare = rule.destinationPorts().lookup(fiveTuple.destinationPort());
+            if (compare != 0) {
+                return compare;
+            }
+
+            compare = rule.sourceIpAddresses().lookup(fiveTuple.sourceIpAddress());
+            if (compare != 0) {
+                return compare;
+            }
+
+            return rule.destinationIpAddresses().lookup(fiveTuple.destinationIpAddress());
+        }
+    }
+}

--- a/security/src/main/java/io/netty/security/core/standards/StandardTables.java
+++ b/security/src/main/java/io/netty/security/core/standards/StandardTables.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.security.core.standards;
+
+import io.netty.security.core.Table;
+import io.netty.security.core.Tables;
+import io.netty.util.internal.ObjectUtil;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentSkipListMap;
+
+public final class StandardTables implements Tables {
+    private final Map<Integer, Table> TABLES = new ConcurrentSkipListMap<>();
+
+    private StandardTables() {
+        // Prevent outside initialization
+    }
+
+    /**
+     * Create a new {@link StandardTables} instance
+     *
+     * @return New {@link StandardTables} instance
+     */
+    public static StandardTables create() {
+        return new StandardTables();
+    }
+
+    @Override
+    public synchronized void addTable(Table table) {
+        ObjectUtil.checkNotNull(table, "Table");
+
+        // If we already contain a table with that priority
+        // then thrown exception.
+        if (TABLES.containsKey(table.priority())) {
+            throw new IllegalArgumentException("A table already exists with the priority: " + table.priority());
+        }
+
+        TABLES.put(table.priority(), table);
+    }
+
+    /**
+     * Remove a {@link Table}
+     *
+     * @param priority Priority of table to remove
+     * @return {@link Boolean#TRUE} if removal was successful else {@link Boolean#FALSE}
+     */
+    @Override
+    public synchronized boolean removeTable(int priority) {
+        return TABLES.remove(priority) != null;
+    }
+
+    /**
+     * Returns {@link Table}s {@link Collection}
+     */
+    @Override
+    public Collection<Table> tables() {
+        return TABLES.values();
+    }
+
+    @Override
+    public Map<Integer, Table> tablesMap() {
+        return TABLES;
+    }
+}

--- a/security/src/main/java/io/netty/security/core/standards/StandardTables.java
+++ b/security/src/main/java/io/netty/security/core/standards/StandardTables.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentSkipListMap;
 
 public final class StandardTables implements Tables {
-    private final Map<Integer, Table> TABLES = new ConcurrentSkipListMap<>();
+    private final Map<Integer, Table> TABLES = new ConcurrentSkipListMap<Integer, Table>();
 
     private StandardTables() {
         // Prevent outside initialization

--- a/security/src/main/java/io/netty/security/core/standards/package-info.java
+++ b/security/src/main/java/io/netty/security/core/standards/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * This package contains standard implementations of interfaces like
+ * {@link io.netty.security.core.Ports}, {@link io.netty.security.core.Address}, and more.
+ */
+package io.netty.security.core.standards;

--- a/security/src/test/java/io/netty/contrib/security/core/IpAddressTest.java
+++ b/security/src/test/java/io/netty/contrib/security/core/IpAddressTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.contrib.security.core;
+
+import io.netty.security.core.Address;
+import io.netty.security.core.IpAddress;
+import io.netty.security.core.StaticIpAddress;
+import io.netty.security.core.Util;
+import io.netty.util.NetUtil;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class IpAddressTest {
+
+    @Test
+    void ofString() {
+        assertEquals(Address.Version.v4, IpAddress.of("10.10.10.10").version());
+        assertEquals(Address.Version.v6, IpAddress.of("0000:0000:0000:0000:0000:0000:0000:0001").version());
+
+        assertEquals(Util.prefixToSubnetMaskV4(32), IpAddress.of("10.10.10.10").v4SubnetMaskAsInt());
+        assertEquals(Util.prefixToSubnetMaskV6(128),
+                IpAddress.of("0000:0000:0000:0000:0000:0000:0000:0001").v6SubnetMaskAsBigInt());
+    }
+
+    @Test
+    void ofStringWithMask() {
+        IpAddress v4 = IpAddress.of("10.10.10.10", 16);
+        IpAddress v6 = IpAddress.of("0000:0000:0000:0000:0000:0000:0000:0001", 64);
+        assertEquals(Address.Version.v4, v4.version());
+        assertEquals(Address.Version.v6, v6.version());
+
+        assertEquals(Util.prefixToSubnetMaskV4(16), v4.v4SubnetMaskAsInt());
+        assertEquals(Util.prefixToSubnetMaskV6(64), v6.v6SubnetMaskAsBigInt());
+    }
+
+    @Test
+    void ofByteArray() throws Exception {
+        InetAddress v4Address = InetAddress.getByName("10.10.10.10");
+        InetAddress v6Address = InetAddress.getByName("0000:0000:0000:0000:0000:0000:0000:0001");
+
+        IpAddress v4 = IpAddress.of(v4Address.getAddress());
+        IpAddress v6 = IpAddress.of(v6Address.getAddress());
+
+        assertEquals(v4Address, v4.address());
+        assertEquals(v6Address, v6.address());
+    }
+
+    @Test
+    void ofByteArrayWithMask() throws Exception {
+        InetAddress v4Address = InetAddress.getByName("10.10.10.10");
+        InetAddress v6Address = InetAddress.getByName("0000:0000:0000:0000:0000:0000:0000:0001");
+
+        IpAddress v4 = IpAddress.of(v4Address.getAddress(), 16);
+        IpAddress v6 = IpAddress.of(v6Address.getAddress(), 64);
+
+        assertEquals(v4Address, v4.address());
+        assertEquals(v6Address, v6.address());
+    }
+
+    @Test
+    void fromRange() {
+        List<IpAddress> v4 = IpAddress.from("192.168.1.0", "192.168.1.25");
+        List<IpAddress> v6 = IpAddress.from("2001:4860:4860::8888", "2001:4860:4860::8844");
+
+        assertEquals(3, v4.size());
+        assertEquals(6, v6.size());
+    }
+
+    @Test
+    void address() throws Exception {
+        InetAddress inetAddress = InetAddress.getByName("192.168.1.100");
+        Address address = IpAddress.of(inetAddress.getAddress());
+        assertEquals(inetAddress, address.address());
+
+        inetAddress = InetAddress.getByName("0000:0000:0000:0000:0000:0000:0000:0001");
+        address = IpAddress.of(inetAddress.getAddress());
+        assertEquals(inetAddress, address.address());
+    }
+
+    @Test
+    void networkAddressV4() throws Exception {
+        InetAddress inetAddress = InetAddress.getByName("192.168.1.100");
+        Address address = IpAddress.of(inetAddress.getAddress());
+        assertEquals(NetUtil.ipv4AddressToInt((Inet4Address) inetAddress), address.v4AddressAsInt());
+    }
+
+    @Test
+    void subnetMaskV4() throws Exception {
+        InetAddress inetAddress = InetAddress.getByName("192.168.1.100");
+        Address address = IpAddress.of(inetAddress);
+        assertEquals(Util.prefixToSubnetMaskV4(32), address.v4SubnetMaskAsInt());
+    }
+
+    @Test
+    void networkAddressV6() throws Exception {
+        InetAddress inetAddress = InetAddress.getByName("0000:0000:0000:0000:0000:0000:0000:0001");
+        Address address = StaticIpAddress.of(inetAddress);
+        assertEquals(new BigInteger(inetAddress.getAddress()), address.v6NetworkAddressAsBigInt());
+    }
+
+    @Test
+    void subnetMaskV6() throws Exception {
+        InetAddress inetAddress = InetAddress.getByName("0000:0000:0000:0000:0000:0000:0000:0001");
+        Address address = StaticIpAddress.of(inetAddress);
+        assertEquals(Util.prefixToSubnetMaskV6(128), address.v6SubnetMaskAsBigInt());
+    }
+
+    @Test
+    void version() throws Exception {
+        InetAddress inetAddress = InetAddress.getByName("192.168.1.100");
+        Address address = StaticIpAddress.of(inetAddress);
+        assertEquals(Address.Version.v4, address.version());
+
+        inetAddress = InetAddress.getByName("0000:0000:0000:0000:0000:0000:0000:0001");
+        address = StaticIpAddress.of(inetAddress);
+        assertEquals(Address.Version.v6, address.version());
+    }
+}

--- a/security/src/test/java/io/netty/contrib/security/core/IpAddressesTest.java
+++ b/security/src/test/java/io/netty/contrib/security/core/IpAddressesTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.contrib.security.core;
+
+import io.netty.security.core.Address;
+import io.netty.security.core.IpAddress;
+import io.netty.security.core.IpAddresses;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class IpAddressesTest {
+
+    @Test
+    void createEmpty() {
+        IpAddresses ipAddresses = IpAddresses.create();
+        assertTrue(ipAddresses.isLocked());
+        ipAddresses.unlock();
+        assertFalse(ipAddresses.isLocked());
+
+        ipAddresses.add(IpAddress.of("192.168.1.25"));
+        ipAddresses.add(IpAddress.of("10.1.2.3"));
+
+        ipAddresses.lock();
+        assertTrue(ipAddresses.isLocked());
+    }
+
+    @Test
+    void createList() {
+        List<Address> ipAddressList = new ArrayList<>();
+        ipAddressList.add(IpAddress.of("192.168.1.25"));
+        ipAddressList.add(IpAddress.of("10.1.2.3"));
+
+        IpAddresses ipAddresses = IpAddresses.create(ipAddressList);
+        assertTrue(ipAddresses.isLocked());
+    }
+
+    @Test
+    void createVarArgs() {
+        IpAddresses ipAddresses = IpAddresses.create(IpAddress.of("192.168.1.25"), IpAddress.of("10.1.2.3"));
+        assertTrue(ipAddresses.isLocked());
+    }
+}

--- a/security/src/test/java/io/netty/contrib/security/core/SafeListControllerTest.java
+++ b/security/src/test/java/io/netty/contrib/security/core/SafeListControllerTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.contrib.security.core;
+
+import io.netty.security.core.SafeListController;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SafeListControllerTest {
+
+    @Test
+    void lock() {
+        SafeListController<String> impl = new Impl();
+        assertTrue(impl.isLocked());
+
+        impl.unlock();
+        assertFalse(impl.isLocked());
+
+        impl.lock();
+        assertTrue(impl.isLocked());
+    }
+
+    @Test
+    void unlock() {
+        SafeListController<String> impl = new Impl();
+        impl.unlock();
+        assertFalse(impl.isLocked());
+
+        impl.lock();
+        assertTrue(impl.isLocked());
+
+        impl.unlock();
+        assertFalse(impl.isLocked());
+    }
+
+    @Test
+    void add() {
+        final SafeListController<String> impl = new Impl();
+        impl.unlock();
+        assertFalse(impl.isLocked());
+
+        impl.add("Meow");
+        assertEquals(0, impl.copy().size());
+
+        impl.lock();
+        assertTrue(impl.isLocked());
+        assertEquals(1, impl.copy().size());
+
+        assertThrows(IllegalStateException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                impl.add("MeowMeow");
+            }
+        });
+
+        impl.unlock();
+        assertFalse(impl.isLocked());
+        assertDoesNotThrow(new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                impl.add("MeowMeow");
+            }
+        });
+
+        impl.lock();
+        assertTrue(impl.isLocked());
+
+        assertEquals(2, impl.copy().size());
+    }
+
+    @Test
+    void remove() {
+        final SafeListController<String> impl = new Impl();
+        impl.unlock();
+        assertFalse(impl.isLocked());
+
+        impl.add("Meow");
+        assertEquals(0, impl.copy().size());
+
+        impl.lock();
+        assertTrue(impl.isLocked());
+        assertEquals(1, impl.copy().size());
+
+        assertThrows(IllegalStateException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                impl.remove("Meow");
+            }
+        });
+
+        impl.unlock();
+        assertFalse(impl.isLocked());
+        assertDoesNotThrow(new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                impl.remove("Meow");
+            }
+        });
+
+        impl.lock();
+        assertTrue(impl.isLocked());
+
+        assertEquals(0, impl.copy().size());
+    }
+
+    @Test
+    void copy() {
+        SafeListController<String> impl = new Impl();
+        impl.unlock();
+
+        impl.add("MeowMeow");
+        impl.lock();
+
+        assertEquals(1, impl.copy().size());
+        assertEquals(impl.copy().get(0), impl.copy().get(0));
+    }
+
+    @Test
+    void isLocked() {
+        SafeListController<String> impl = new Impl();
+
+        assertTrue(impl.isLocked());
+        impl.unlock();
+        assertFalse(impl.isLocked());
+
+        impl.lock();
+        assertTrue(impl.isLocked());
+    }
+
+    private static final class Impl extends SafeListController<String> {
+        // NO-OP
+    }
+}

--- a/security/src/test/java/io/netty/contrib/security/core/StaticIpAddressTest.java
+++ b/security/src/test/java/io/netty/contrib/security/core/StaticIpAddressTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.contrib.security.core;
+
+import io.netty.security.core.Address;
+import io.netty.security.core.StaticIpAddress;
+import io.netty.security.core.Util;
+import io.netty.util.NetUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import java.math.BigInteger;
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class StaticIpAddressTest {
+
+    @Test
+    void ofInetAddress() {
+        assertDoesNotThrow(new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                StaticIpAddress.of(InetAddress.getByName("192.168.1.100"));
+            }
+        });
+
+        assertDoesNotThrow(new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                StaticIpAddress.of(InetAddress.getByName("0000:0000:0000:0000:0000:0000:0000:0001"));
+            }
+        });
+    }
+
+    @Test
+    void ofString() {
+        assertDoesNotThrow(new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                StaticIpAddress.of("192.168.1.100");
+            }
+        });
+
+        assertDoesNotThrow(new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                StaticIpAddress.of("10.10.10.10");
+            }
+        });
+
+        assertDoesNotThrow(new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                StaticIpAddress.of("0000:0000:0000:0000:0000:0000:0000:0001");
+            }
+        });
+
+        assertDoesNotThrow(new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                StaticIpAddress.of("0:0:0:0:0:0:0:1");
+            }
+        });
+
+        assertDoesNotThrow(new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                StaticIpAddress.of("::1");
+            }
+        });
+
+        assertThrows(UnknownHostException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                StaticIpAddress.of("0000:0000:0000:0000:0000:0000:0000:0001/128");
+            }
+        });
+
+        assertThrows(UnknownHostException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                StaticIpAddress.of("192.168.1.0/24");
+            }
+        });
+    }
+
+    @Test
+    void address() throws Exception {
+        InetAddress inetAddress = InetAddress.getByName("192.168.1.100");
+        Address address = StaticIpAddress.of(inetAddress);
+        assertEquals(inetAddress, address.address());
+
+        inetAddress = InetAddress.getByName("0000:0000:0000:0000:0000:0000:0000:0001");
+        address = StaticIpAddress.of(inetAddress);
+        assertEquals(inetAddress, address.address());
+    }
+
+    @Test
+    void ofByteArray() throws UnknownHostException {
+        assertDoesNotThrow(new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                final InetAddress address = InetAddress.getByName("192.168.1.100");
+                StaticIpAddress.of(address.getAddress());
+            }
+        });
+
+        assertDoesNotThrow(new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                final InetAddress address = InetAddress.getByName("0000:0000:0000:0000:0000:0000:0000:0001");
+                StaticIpAddress.of(address.getAddress());
+            }
+        });
+    }
+
+    @Test
+    void networkAddressV4() throws Exception {
+        InetAddress inetAddress = InetAddress.getByName("192.168.1.100");
+        Address address = StaticIpAddress.of(inetAddress);
+        assertEquals(NetUtil.ipv4AddressToInt((Inet4Address) inetAddress), address.v4AddressAsInt());
+    }
+
+    @Test
+    void subnetMaskV4() throws Exception {
+        InetAddress inetAddress = InetAddress.getByName("192.168.1.100");
+        Address address = StaticIpAddress.of(inetAddress);
+        assertEquals(Util.prefixToSubnetMaskV4(32), address.v4SubnetMaskAsInt());
+    }
+
+    @Test
+    void networkAddressV6() throws Exception {
+        InetAddress inetAddress = InetAddress.getByName("0000:0000:0000:0000:0000:0000:0000:0001");
+        Address address = StaticIpAddress.of(inetAddress);
+        assertEquals(new BigInteger(inetAddress.getAddress()), address.v6NetworkAddressAsBigInt());
+    }
+
+    @Test
+    void subnetMaskV6() throws Exception {
+        InetAddress inetAddress = InetAddress.getByName("0000:0000:0000:0000:0000:0000:0000:0001");
+        Address address = StaticIpAddress.of(inetAddress);
+        assertEquals(Util.prefixToSubnetMaskV6(128), address.v6SubnetMaskAsBigInt());
+    }
+
+    @Test
+    void version() throws Exception {
+        InetAddress inetAddress = InetAddress.getByName("192.168.1.100");
+        Address address = StaticIpAddress.of(inetAddress);
+        assertEquals(Address.Version.v4, address.version());
+
+        inetAddress = InetAddress.getByName("0000:0000:0000:0000:0000:0000:0000:0001");
+        address = StaticIpAddress.of(inetAddress);
+        assertEquals(Address.Version.v6, address.version());
+    }
+}

--- a/security/src/test/java/io/netty/contrib/security/core/standards/StandardBufferPayloadTest.java
+++ b/security/src/test/java/io/netty/contrib/security/core/standards/StandardBufferPayloadTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.contrib.security.core.standards;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.security.core.payload.BufferPayload;
+import io.netty.security.core.payload.PayloadMatcher;
+import io.netty.security.core.standards.StandardBufferPayload;
+import io.netty.security.core.standards.StandardPayloadMatcher;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StandardBufferPayloadTest {
+
+    @Test
+    void createBufferPayloadAndMatch() {
+        ByteBuf completeSentence = ByteBufUtil.writeAscii(ByteBufAllocator.DEFAULT, "Hey, I'm not a cat");
+        ByteBuf justWord = ByteBufUtil.writeAscii(ByteBufAllocator.DEFAULT, "cat");
+
+        BufferPayload bufferPayload = StandardBufferPayload.create(justWord);
+        PayloadMatcher<Object, Object> payloadMatcher = new StandardPayloadMatcher();
+        assertTrue(payloadMatcher.validate(bufferPayload, completeSentence));
+    }
+
+    @Test
+    void createBufferPayloadAndDoesNotMatch() {
+        ByteBuf completeSentence = ByteBufUtil.writeAscii(ByteBufAllocator.DEFAULT, "Hey, I'm not a cat");
+        ByteBuf justWord = ByteBufUtil.writeAscii(ByteBufAllocator.DEFAULT, "Cat"); // cat should be in lowercase
+
+        BufferPayload bufferPayload = StandardBufferPayload.create(justWord);
+        PayloadMatcher<Object, Object> payloadMatcher = new StandardPayloadMatcher();
+        assertFalse(payloadMatcher.validate(bufferPayload, completeSentence));
+    }
+}

--- a/security/src/test/java/io/netty/contrib/security/core/standards/StandardFilterTest.java
+++ b/security/src/test/java/io/netty/contrib/security/core/standards/StandardFilterTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.contrib.security.core.standards;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.socket.DatagramPacket;
+import io.netty.security.core.Action;
+import io.netty.security.core.Filter;
+import io.netty.security.core.IpAddress;
+import io.netty.security.core.IpAddresses;
+import io.netty.security.core.Protocol;
+import io.netty.security.core.StaticIpAddress;
+import io.netty.security.core.Table;
+import io.netty.security.core.Tables;
+import io.netty.security.core.standards.StandardFilter;
+import io.netty.security.core.standards.StandardFiveTuple;
+import io.netty.security.core.standards.StandardPorts;
+import io.netty.security.core.standards.StandardRule;
+import io.netty.security.core.standards.StandardTable;
+import io.netty.security.core.standards.StandardTables;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class StandardFilterTest {
+
+    @Test
+    void validateChannelActive() throws UnknownHostException {
+        Table table = StandardTable.of(100, "SimpleTable");
+        table.unlock();
+        table.addRule(StandardRule.newBuilder()
+                .withProtocol(Protocol.TCP)
+                .withSourcePorts(StandardPorts.from(22, 22))
+                .withDestinationPorts(StandardPorts.from(80, 80))
+                .withSourceIpAddresses(IpAddresses.create(StaticIpAddress.of("10.10.10.10")))
+                .withDestinationIpAddress(IpAddresses.create(IpAddress.of("192.168.1.100")))
+                .withAction(Action.ACCEPT)
+                .build());
+        table.lock();
+
+        Tables tables = StandardTables.create();
+        tables.addTable(table);
+
+        Filter filter = StandardFilter.of(tables, Action.REJECT);
+        Action action = filter.validateChannelActive(StandardFiveTuple.from(Protocol.TCP, 23, 80,
+                StaticIpAddress.of("10.10.10.10"), StaticIpAddress.of("192.168.1.100")));
+
+        assertEquals(Action.REJECT, action);
+
+        action = filter.validateChannelActive(StandardFiveTuple.from(Protocol.TCP, 22, 80,
+                StaticIpAddress.of("10.10.10.10"), StaticIpAddress.of("192.168.1.100")));
+
+        assertEquals(Action.ACCEPT, action);
+    }
+
+    @Test
+    void validateDatagramPacket() throws UnknownHostException {
+        Table table = StandardTable.of(100, "SimpleTable");
+        table.unlock();
+        table.addRule(StandardRule.newBuilder()
+                .withProtocol(Protocol.UDP)
+                .withSourcePorts(StandardPorts.from(22, 22))
+                .withDestinationPorts(StandardPorts.from(80, 80))
+                .withSourceIpAddresses(IpAddresses.create(StaticIpAddress.of("10.10.10.10")))
+                .withDestinationIpAddress(IpAddresses.create(IpAddress.of("192.168.1.100")))
+                .withAction(Action.ACCEPT)
+                .build());
+        table.lock();
+
+        Tables tables = StandardTables.create();
+        tables.addTable(table);
+
+        Filter filter = StandardFilter.of(tables, Action.REJECT);
+        DatagramPacket packet = new DatagramPacket(Unpooled.EMPTY_BUFFER,
+                new InetSocketAddress("192.168.1.100", 80), new InetSocketAddress("10.10.10.2", 22));
+        Action action = filter.validateObject(packet, StandardFiveTuple.from(Protocol.UDP, 22, 80,
+                StaticIpAddress.of("10.10.10.10"), StaticIpAddress.of("192.168.1.100")));
+
+        assertEquals(Action.ACCEPT, action);
+
+        packet = new DatagramPacket(Unpooled.EMPTY_BUFFER,
+                new InetSocketAddress("192.168.1.100", 80), new InetSocketAddress("10.10.10.2", 22));
+        action = filter.validateObject(packet, StandardFiveTuple.from(Protocol.UDP, 10000, 80,
+                StaticIpAddress.of("10.10.10.10"), StaticIpAddress.of("192.168.1.100")));
+
+        assertEquals(Action.REJECT, action);
+    }
+
+    @Test
+    void validateBuffer() throws UnknownHostException {
+        Table table = StandardTable.of(100, "SimpleTable");
+        table.unlock();
+        table.addRule(StandardRule.newBuilder()
+                .withProtocol(Protocol.TCP)
+                .withSourcePorts(StandardPorts.from(22, 22))
+                .withDestinationPorts(StandardPorts.from(80, 80))
+                .withSourceIpAddresses(IpAddresses.create(StaticIpAddress.of("10.10.10.10")))
+                .withDestinationIpAddress(IpAddresses.create(IpAddress.of("192.168.1.100")))
+                .withAction(Action.ACCEPT)
+                .build());
+        table.lock();
+
+        Tables tables = StandardTables.create();
+        tables.addTable(table);
+
+        Filter filter = StandardFilter.of(tables, Action.REJECT);
+        Action action = filter.validateObject(Unpooled.EMPTY_BUFFER, StandardFiveTuple.from(Protocol.TCP, 22, 80,
+                StaticIpAddress.of("10.10.10.10"), StaticIpAddress.of("192.168.1.100")));
+
+        assertEquals(Action.ACCEPT, action);
+
+        action = filter.validateObject(Unpooled.EMPTY_BUFFER, StandardFiveTuple.from(Protocol.TCP, 10000, 80,
+                StaticIpAddress.of("10.10.10.10"), StaticIpAddress.of("192.168.1.100")));
+
+        assertEquals(Action.REJECT, action);
+    }
+}

--- a/security/src/test/java/io/netty/contrib/security/core/standards/StandardFiveTupleTest.java
+++ b/security/src/test/java/io/netty/contrib/security/core/standards/StandardFiveTupleTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.contrib.security.core.standards;
+
+import io.netty.security.core.FiveTuple;
+import io.netty.security.core.Protocol;
+import io.netty.security.core.StaticIpAddress;
+import io.netty.security.core.standards.StandardFiveTuple;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class StandardFiveTupleTest {
+
+    @Test
+    void from() throws Exception {
+        FiveTuple fiveTuple = StandardFiveTuple.from(Protocol.UDP, 9110, 2580,
+                StaticIpAddress.of("192.168.1.2"), StaticIpAddress.of("10.10.10.10"));
+
+        assertEquals(Protocol.UDP, fiveTuple.protocol());
+        assertEquals(9110, fiveTuple.sourcePort());
+        assertEquals(2580, fiveTuple.destinationPort());
+        assertEquals(StaticIpAddress.of("192.168.1.2"), fiveTuple.sourceIpAddress());
+        assertEquals(StaticIpAddress.of("10.10.10.10"), fiveTuple.destinationIpAddress());
+    }
+
+    @Test
+    void compareTo() throws Exception {
+        FiveTuple fiveTuple = StandardFiveTuple.from(Protocol.UDP, 9110, 2580,
+                StaticIpAddress.of("192.168.1.2"), StaticIpAddress.of("10.10.10.10"));
+
+
+        FiveTuple standardFiveTuple = StandardFiveTuple.from(Protocol.UDP, 9110, 2580,
+                StaticIpAddress.of("192.168.1.2"), StaticIpAddress.of("10.10.10.10"));
+        assertEquals(0, fiveTuple.compareTo(standardFiveTuple));
+
+        standardFiveTuple = StandardFiveTuple.from(Protocol.TCP, 9110, 2580,
+                StaticIpAddress.of("192.168.1.2"), StaticIpAddress.of("10.10.10.10"));
+        assertEquals(1, fiveTuple.compareTo(standardFiveTuple));
+    }
+}

--- a/security/src/test/java/io/netty/contrib/security/core/standards/StandardHexPayloadTest.java
+++ b/security/src/test/java/io/netty/contrib/security/core/standards/StandardHexPayloadTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.contrib.security.core.standards;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.security.core.payload.HexPayload;
+import io.netty.security.core.payload.PayloadMatcher;
+import io.netty.security.core.standards.StandardHexPayload;
+import io.netty.security.core.standards.StandardPayloadMatcher;
+import org.junit.jupiter.api.Test;
+
+import static io.netty.security.core.Util.hexStringToByteArray;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StandardHexPayloadTest {
+
+    @Test
+    void createHexStringPayloadAndMatch() {
+        ByteBuf completeSentence = Unpooled.wrappedBuffer(hexStringToByteArray("4865792C2049276D206E6F74206120636174"));
+
+        HexPayload hexPayload = StandardHexPayload.create("636174"); // cat
+        PayloadMatcher<Object, Object> payloadMatcher = new StandardPayloadMatcher();
+        assertTrue(payloadMatcher.validate(hexPayload, completeSentence));
+    }
+}

--- a/security/src/test/java/io/netty/contrib/security/core/standards/StandardNetworkHandlerTest.java
+++ b/security/src/test/java/io/netty/contrib/security/core/standards/StandardNetworkHandlerTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.contrib.security.core.standards;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.socket.DatagramChannel;
+import io.netty.channel.socket.DatagramPacket;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.security.core.Action;
+import io.netty.security.core.IpAddress;
+import io.netty.security.core.IpAddresses;
+import io.netty.security.core.Protocol;
+import io.netty.security.core.Tables;
+import io.netty.security.core.standards.StandardFilter;
+import io.netty.security.core.standards.StandardNetworkHandler;
+import io.netty.security.core.standards.StandardPorts;
+import io.netty.security.core.standards.StandardRule;
+import io.netty.security.core.standards.StandardTable;
+import io.netty.security.core.standards.StandardTables;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class StandardNetworkHandlerTest {
+
+    @Test
+    void socketChannelActiveAndBufferTest() throws Exception {
+        SocketChannel socketChannel = mock(SocketChannel.class);
+        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+
+        Tables tables = StandardTables.create();
+        StandardNetworkHandler standardNetworkHandler =
+                new StandardNetworkHandler(StandardFilter.of(tables, Action.DROP));
+
+        // Mock Addresses because we need them in FiveTuple
+        when(socketChannel.localAddress()).thenReturn(new InetSocketAddress("10.10.10.1", 8080));
+        when(socketChannel.remoteAddress()).thenReturn(new InetSocketAddress("192.168.1.1", 9110));
+
+        // Mock Socket Channel
+        when(ctx.channel()).thenReturn(socketChannel);
+        when(ctx.channel().close()).thenReturn(null); // No need to return on #close
+        when(ctx.fireChannelRead(any())).thenReturn(null);
+
+        // Make call to channelActive and verify Channel#close was executed.
+        standardNetworkHandler.channelActive(ctx);
+        verify(ctx.channel(), times(1)).close();
+
+        StandardTable table = StandardTable.of(1, "MainTable");
+        table.unlock();
+        table.addRule(StandardRule.newBuilder()
+                .withProtocol(Protocol.TCP)
+                .withSourcePorts(StandardPorts.of(9110))
+                .withDestinationPorts(StandardPorts.of(8080))
+                .withSourceIpAddresses(IpAddresses.create(IpAddress.of("192.168.1.1")))
+                .withDestinationIpAddress(IpAddresses.create(IpAddress.of("10.10.10.1")))
+                .withAction(Action.ACCEPT)
+                .build());
+        table.lock();
+        tables.addTable(table);
+
+        // Since we inserted rule to allow us, lets call channelActive
+        // once again and verify Channel#close was called only once.
+        standardNetworkHandler.channelActive(ctx);
+        verify(ctx.channel(), times(1)).close();
+
+        // ------------------------ Buffer ------------------------
+
+        // Validate Buffer
+        ByteBuf buffer = Unpooled.buffer(1);
+        standardNetworkHandler.channelRead(ctx, buffer);
+        buffer.release();
+        verify(ctx, times(1)).fireChannelRead(any());
+    }
+
+    @Test
+    void datagramPacketTest() throws Exception {
+        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+        DatagramChannel datagramChannel = mock(DatagramChannel.class);
+
+        when(ctx.channel()).thenReturn(datagramChannel);
+        when(datagramChannel.isConnected()).thenReturn(false);
+
+        Tables tables = StandardTables.create();
+        StandardNetworkHandler standardNetworkHandler =
+                new StandardNetworkHandler(StandardFilter.of(tables, Action.DROP));
+
+        StandardTable table = StandardTable.of(1, "MainTable");
+        table.unlock();
+        table.addRule(StandardRule.newBuilder()
+                .withProtocol(Protocol.UDP)
+                .withSourcePorts(StandardPorts.of(9110))
+                .withDestinationPorts(StandardPorts.of(8080))
+                .withSourceIpAddresses(IpAddresses.create(IpAddress.of("192.168.1.1")))
+                .withDestinationIpAddress(IpAddresses.create(IpAddress.of("10.10.10.1")))
+                .withAction(Action.ACCEPT)
+                .build());
+        table.lock();
+        tables.addTable(table);
+
+        ByteBuf buffer = ByteBufUtil.writeAscii(ByteBufAllocator.DEFAULT, "Meow");
+
+        DatagramPacket datagramPacket = new DatagramPacket(buffer,
+                new InetSocketAddress("10.10.10.1", 8080),
+                new InetSocketAddress("192.168.1.1", 9111)); // Different port
+
+        // refCnt will return '1' because we just created
+        // the packet. However, once we pass packet to channelRead
+        // it will drop and release the packet because of default action.
+        assertThat(datagramPacket.refCnt()).isEqualTo(1);
+        standardNetworkHandler.channelRead(ctx, datagramPacket);
+        assertThat(datagramPacket.refCnt()).isEqualTo(0);
+
+        buffer = ByteBufUtil.writeAscii(ByteBufAllocator.DEFAULT, "Meow");
+
+        datagramPacket = new DatagramPacket(buffer,
+                new InetSocketAddress("10.10.10.1", 8080),
+                new InetSocketAddress("192.168.1.1", 9110)); // Allowed port
+
+        assertThat(datagramPacket.refCnt()).isEqualTo(1);
+        standardNetworkHandler.channelRead(ctx, datagramPacket);
+        verify(ctx, times(1)).fireChannelRead(any());
+        assertThat(datagramPacket.refCnt()).isEqualTo(1);
+
+        datagramPacket.release();
+    }
+}

--- a/security/src/test/java/io/netty/contrib/security/core/standards/StandardPortsTest.java
+++ b/security/src/test/java/io/netty/contrib/security/core/standards/StandardPortsTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.contrib.security.core.standards;
+
+import io.netty.security.core.Ports;
+import io.netty.security.core.standards.StandardPorts;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StandardPortsTest {
+
+    @Test
+    void from() {
+        assertDoesNotThrow(new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                StandardPorts.from(1, 10);
+            }
+        });
+
+        assertDoesNotThrow(new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                StandardPorts.from(101, 101);
+            }
+        });
+
+        assertDoesNotThrow(new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                StandardPorts.from(5000, 5001);
+            }
+        });
+
+        assertThrows(IllegalArgumentException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                StandardPorts.from(0, 100);
+            }
+        });
+
+        assertThrows(IllegalArgumentException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                StandardPorts.from(101, 100);
+            }
+        });
+
+        assertThrows(IllegalArgumentException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                StandardPorts.from(0, 65_536);
+            }
+        });
+    }
+
+    @Test
+    void start() {
+        assertEquals(5000, StandardPorts.from(5000, 10000).start());
+        assertEquals(10000, StandardPorts.from(10000, 10000).start());
+    }
+
+    @Test
+    void end() {
+        assertEquals(10000, StandardPorts.from(5000, 10000).end());
+        assertEquals(10002, StandardPorts.from(10000, 10002).end());
+    }
+
+    @Test
+    void lookup() {
+        Ports ports = StandardPorts.from(5, 30);
+        assertTrue(ports.lookupPort(5));
+        assertTrue(ports.lookupPort(22));
+        assertTrue(ports.lookupPort(30));
+    }
+
+    @Test
+    void compareTo() {
+        Ports ports = StandardPorts.from(5, 30);
+        assertEquals(-1, ports.lookup(1));
+        assertEquals(-1, ports.lookup(4));
+        assertEquals(0, ports.lookup(5));
+        assertEquals(0, ports.lookup(22));
+        assertEquals(0, ports.lookup(30));
+        assertEquals(1, ports.lookup(31));
+        assertEquals(1, ports.lookup(50));
+    }
+}

--- a/security/src/test/java/io/netty/contrib/security/core/standards/StandardRegexPayloadTest.java
+++ b/security/src/test/java/io/netty/contrib/security/core/standards/StandardRegexPayloadTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.contrib.security.core.standards;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.security.core.payload.PayloadMatcher;
+import io.netty.security.core.payload.RegexPayload;
+import io.netty.security.core.standards.StandardPayloadMatcher;
+import io.netty.security.core.standards.StandardRegexPayload;
+import org.junit.jupiter.api.Test;
+
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StandardRegexPayloadTest {
+
+    @Test
+    void createRegexStringPayloadAndMatch() {
+        ByteBuf completeSentence = ByteBufUtil.writeAscii(ByteBufAllocator.DEFAULT, "1");
+
+        RegexPayload regexPayload = StandardRegexPayload.create(Pattern.compile("\\d"));
+        PayloadMatcher<Object, Object> payloadMatcher = new StandardPayloadMatcher();
+        assertTrue(payloadMatcher.validate(regexPayload, completeSentence));
+    }
+}

--- a/security/src/test/java/io/netty/contrib/security/core/standards/StandardRuleTest.java
+++ b/security/src/test/java/io/netty/contrib/security/core/standards/StandardRuleTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.contrib.security.core.standards;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.security.core.Action;
+import io.netty.security.core.IpAddress;
+import io.netty.security.core.IpAddresses;
+import io.netty.security.core.Protocol;
+import io.netty.security.core.StaticIpAddress;
+import io.netty.security.core.payload.BufferPayload;
+import io.netty.security.core.standards.StandardBufferPayload;
+import io.netty.security.core.standards.StandardPayloadMatcher;
+import io.netty.security.core.standards.StandardPorts;
+import io.netty.security.core.standards.StandardRule;
+import io.netty.security.core.standards.StandardRuleBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StandardRuleTest {
+
+    @Test
+    void newBuilder() {
+        assertNotNull(StandardRule.newBuilder());
+        assertInstanceOf(StandardRuleBuilder.class, StandardRule.newBuilder());
+    }
+
+    @Test
+    void protocol() {
+        StandardRule standardRule = StandardRule.newBuilder(true)
+                .withProtocol(Protocol.TCP)
+                .withSourcePorts(StandardPorts.from(5000, 10000))
+                .withDestinationPorts(StandardPorts.from(2221, 2223))
+                .withSourceIpAddresses(IpAddresses.create(IpAddress.of("10.10.10.10", 32)))
+                .withDestinationIpAddress(IpAddresses.create(IpAddress.of("0.0.0.0", 0)))
+                .withAction(Action.DROP)
+                .build();
+
+        assertEquals(Protocol.TCP, standardRule.protocol());
+
+        standardRule = StandardRule.newBuilder(true)
+                .withProtocol(Protocol.UDP)
+                .withSourcePorts(StandardPorts.from(5000, 10000))
+                .withDestinationPorts(StandardPorts.from(2221, 2223))
+                .withSourceIpAddresses(IpAddresses.create(IpAddress.of("10.10.10.10", 32)))
+                .withDestinationIpAddress(IpAddresses.create(IpAddress.of("0.0.0.0", 0)))
+                .withAction(Action.DROP)
+                .build();
+
+        assertEquals(Protocol.UDP, standardRule.protocol());
+
+        standardRule = StandardRule.newBuilder(true)
+                .withProtocol(Protocol.UDP)
+                .withSourcePorts(StandardPorts.from(5000, 10000))
+                .withDestinationPorts(StandardPorts.from(2221, 2223))
+                .withSourceIpAddresses(IpAddresses.create(IpAddress.of("10.10.10.10", 32)))
+                .withDestinationIpAddress(IpAddresses.create(IpAddress.of("0.0.0.0", 0)))
+                .withAction(Action.DROP)
+                .build();
+
+        assertNotEquals(Protocol.TCP, standardRule.protocol());
+    }
+
+    @Test
+    void sourcePorts() {
+        StandardRule standardRule = StandardRule.newBuilder(true)
+                .withProtocol(Protocol.UDP)
+                .withSourcePorts(StandardPorts.from(5000, 10000))
+                .withDestinationPorts(StandardPorts.from(2221, 2223))
+                .withSourceIpAddresses(IpAddresses.create(IpAddress.of("10.10.10.10", 32)))
+                .withDestinationIpAddress(IpAddresses.create(IpAddress.of("0.0.0.0", 0)))
+                .withAction(Action.DROP)
+                .build();
+
+        assertTrue(standardRule.sourcePorts().lookupPort(5555));
+    }
+
+    @Test
+    void destinationPorts() {
+        StandardRule standardRule = StandardRule.newBuilder(true)
+                .withProtocol(Protocol.UDP)
+                .withSourcePorts(StandardPorts.from(5000, 10000))
+                .withDestinationPorts(StandardPorts.from(2221, 2223))
+                .withSourceIpAddresses(IpAddresses.create(IpAddress.of("10.10.10.10", 32)))
+                .withDestinationIpAddress(IpAddresses.create(IpAddress.of("0.0.0.0", 0)))
+                .withAction(Action.DROP)
+                .build();
+
+        assertTrue(standardRule.destinationPorts().lookupPort(2222));
+    }
+
+    @Test
+    void sourceIpAddresses() throws Exception {
+        StandardRule standardRule = StandardRule.newBuilder(true)
+                .withProtocol(Protocol.UDP)
+                .withSourcePorts(StandardPorts.from(5000, 10000))
+                .withDestinationPorts(StandardPorts.from(2221, 2223))
+                .withSourceIpAddresses(IpAddresses.create(IpAddress.of("10.10.10.10", 24)))
+                .withDestinationIpAddress(IpAddresses.create(IpAddress.of("0.0.0.0", 0)))
+                .withAction(Action.DROP)
+                .build();
+
+        assertTrue(standardRule.sourceIpAddresses().lookupAddress(StaticIpAddress.of("10.10.10.1")));
+        assertTrue(standardRule.sourceIpAddresses().lookupAddress(StaticIpAddress.of("10.10.10.200")));
+        assertTrue(standardRule.sourceIpAddresses().lookupAddress(StaticIpAddress.of("10.10.10.255")));
+    }
+
+    @Test
+    void destinationIpAddresses() throws Exception {
+        StandardRule standardRule = StandardRule.newBuilder(true)
+                .withProtocol(Protocol.UDP)
+                .withSourcePorts(StandardPorts.from(5000, 10000))
+                .withDestinationPorts(StandardPorts.from(2221, 2223))
+                .withSourceIpAddresses(IpAddresses.create(IpAddress.of("10.10.10.10", 24)))
+                .withDestinationIpAddress(IpAddresses.create(IpAddress.of("192.168.10.10", 24)))
+                .withAction(Action.DROP)
+                .build();
+
+        assertTrue(standardRule.destinationIpAddresses().lookupAddress(StaticIpAddress.of("192.168.10.1")));
+        assertTrue(standardRule.destinationIpAddresses().lookupAddress(StaticIpAddress.of("192.168.10.10")));
+        assertTrue(standardRule.destinationIpAddresses().lookupAddress(StaticIpAddress.of("192.168.10.100")));
+        assertTrue(standardRule.destinationIpAddresses().lookupAddress(StaticIpAddress.of("192.168.10.255")));
+    }
+
+    @Test
+    void matchPayload() {
+        ByteBuf justWord = ByteBufUtil.writeAscii(ByteBufAllocator.DEFAULT, "cat");
+        BufferPayload bufferPayload = StandardBufferPayload.create(justWord);
+
+        StandardRule standardRule = StandardRule.newBuilder(true)
+                .withProtocol(Protocol.UDP)
+                .withSourcePorts(StandardPorts.from(5000, 10000))
+                .withDestinationPorts(StandardPorts.from(2221, 2223))
+                .withSourceIpAddresses(IpAddresses.create(IpAddress.of("10.10.10.10", 24)))
+                .withDestinationIpAddress(IpAddresses.create(IpAddress.of("192.168.10.10", 24)))
+                .withPayloadMatcher(new StandardPayloadMatcher())
+                .withPayloads(Collections.singletonList(bufferPayload))
+                .withAction(Action.ACCEPT)
+                .build();
+
+        assertEquals(bufferPayload, standardRule.payloads().get(0));
+    }
+
+    @Test
+    void action() {
+        StandardRule standardRule = StandardRule.newBuilder(true)
+                .withProtocol(Protocol.TCP)
+                .withSourcePorts(StandardPorts.from(5000, 10000))
+                .withDestinationPorts(StandardPorts.from(2221, 2223))
+                .withSourceIpAddresses(IpAddresses.create(IpAddress.of("10.10.10.10", 32)))
+                .withDestinationIpAddress(IpAddresses.create(IpAddress.of("0.0.0.0", 0)))
+                .withAction(Action.DROP)
+                .build();
+
+        assertEquals(Action.DROP, standardRule.action());
+
+        standardRule = StandardRule.newBuilder(true)
+                .withProtocol(Protocol.UDP)
+                .withSourcePorts(StandardPorts.from(5000, 10000))
+                .withDestinationPorts(StandardPorts.from(2221, 2223))
+                .withSourceIpAddresses(IpAddresses.create(IpAddress.of("10.10.10.10", 32)))
+                .withDestinationIpAddress(IpAddresses.create(IpAddress.of("0.0.0.0", 0)))
+                .withAction(Action.ACCEPT)
+                .build();
+
+        assertEquals(Action.ACCEPT, standardRule.action());
+    }
+
+    @Test
+    void compareTo() {
+        StandardRule standardRule = StandardRule.newBuilder(true)
+                .withProtocol(Protocol.TCP)
+                .withSourcePorts(StandardPorts.from(5000, 10000))
+                .withDestinationPorts(StandardPorts.from(2221, 2223))
+                .withSourceIpAddresses(IpAddresses.create(IpAddress.of("10.10.10.10", 24)))
+                .withDestinationIpAddress(IpAddresses.create(IpAddress.of("0.0.0.0", 0)))
+                .withAction(Action.DROP)
+                .build();
+
+        StandardRule standardRule2 = StandardRule.newBuilder(true)
+                .withProtocol(Protocol.TCP)
+                .withSourcePorts(StandardPorts.from(5000, 10001))
+                .withDestinationPorts(StandardPorts.from(2221, 2223))
+                .withSourceIpAddresses(IpAddresses.create(IpAddress.of("10.10.10.10", 24)))
+                .withDestinationIpAddress(IpAddresses.create(IpAddress.of("0.0.0.0", 0)))
+                .withAction(Action.DROP)
+                .build();
+
+        assertEquals(1, standardRule.compareTo(standardRule2));
+    }
+}

--- a/security/src/test/java/io/netty/contrib/security/core/standards/StandardTableTest.java
+++ b/security/src/test/java/io/netty/contrib/security/core/standards/StandardTableTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.contrib.security.core.standards;
+
+import io.netty.security.core.Action;
+import io.netty.security.core.IpAddress;
+import io.netty.security.core.IpAddresses;
+import io.netty.security.core.Protocol;
+import io.netty.security.core.Rule;
+import io.netty.security.core.StaticIpAddress;
+import io.netty.security.core.Table;
+import io.netty.security.core.standards.StandardFiveTuple;
+import io.netty.security.core.standards.StandardPorts;
+import io.netty.security.core.standards.StandardRule;
+import io.netty.security.core.standards.StandardTable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import java.net.UnknownHostException;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StandardTableTest {
+
+    @Test
+    void of() {
+        assertDoesNotThrow(new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                StandardTable.of(1, "CatTable");
+            }
+        });
+
+        assertThrows(IllegalArgumentException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                StandardTable.of(0, "MeowTable");
+            }
+        });
+
+        assertThrows(IllegalArgumentException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                StandardTable.of(Integer.MAX_VALUE, "MeowTable");
+            }
+        });
+
+        assertDoesNotThrow(new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                StandardTable.of(Integer.MAX_VALUE - 1, "MeowTable");
+            }
+        });
+    }
+
+    @Test
+    void priority() {
+        Table table = StandardTable.of(9110, "Meow");
+        assertEquals(9110, table.priority());
+    }
+
+    @Test
+    void name() {
+        Table table = StandardTable.of(9110, "NettySecurity");
+        assertEquals("NettySecurity", table.name());
+    }
+
+    @Test
+    void rules() {
+        StandardTable table = StandardTable.of(9110, "NettySecurity");
+
+        Rule rule = StandardRule.newBuilder()
+                .withProtocol(Protocol.UDP)
+                .withSourcePorts(StandardPorts.from(50000, 55555))
+                .withDestinationPorts(StandardPorts.of(80))
+                .withSourceIpAddresses(IpAddresses.create(IpAddress.of("192.168.1.0", 24)))
+                .withDestinationIpAddress(IpAddresses.create(IpAddress.of("10.10.10.10", 32)))
+                .withAction(Action.ACCEPT)
+                .build();
+
+        table.unlock();
+        assertFalse(table.isLocked());
+
+        table.add(rule);
+        table.lock();
+        assertTrue(table.isLocked());
+
+        assertEquals(rule, table.rules().get(0));
+    }
+
+    @Test
+    void lookup() throws UnknownHostException {
+        StandardTable table = StandardTable.of(9110, "NettySecurity");
+        table.unlock();
+        assertFalse(table.isLocked());
+
+        IpAddress srcAddress = IpAddress.of("192.168.1.0", 24);
+        IpAddress dstAddress = IpAddress.of("10.10.10.10", 32);
+
+        for (int i = 1; i <= 65_000; i++) {
+            Rule rule = StandardRule.newBuilder()
+                    .withProtocol(Protocol.UDP)
+                    .withSourcePorts(StandardPorts.from(50000, 55555))
+                    .withDestinationPorts(StandardPorts.of(i))
+                    .withSourceIpAddresses(IpAddresses.create(srcAddress))
+                    .withDestinationIpAddress(IpAddresses.create(dstAddress))
+                    .withAction(Action.ACCEPT)
+                    .build();
+
+            table.add(rule);
+        }
+
+        table.lock();
+        assertTrue(table.isLocked());
+
+        Rule rule = table.lookup(StandardFiveTuple.from(Protocol.UDP, 55555, 60000,
+                StaticIpAddress.of("192.168.1.10"), StaticIpAddress.of("10.10.10.10")));
+
+        assertNotNull(rule);
+
+        assertEquals(Protocol.UDP, rule.protocol());
+        assertEquals(50000, rule.sourcePorts().start());
+        assertEquals(55555, rule.sourcePorts().end());
+        assertEquals(60000, rule.destinationPorts().start());
+        assertEquals(srcAddress.address(), rule.sourceIpAddresses().copy().get(0).address());
+        assertEquals(dstAddress.address(), rule.destinationIpAddresses().copy().get(0).address());
+        assertEquals(Action.ACCEPT, rule.action());
+    }
+}

--- a/security/src/test/java/io/netty/contrib/security/core/standards/StandardTablesTest.java
+++ b/security/src/test/java/io/netty/contrib/security/core/standards/StandardTablesTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.contrib.security.core.standards;
+
+import io.netty.security.core.Table;
+import io.netty.security.core.standards.StandardTable;
+import io.netty.security.core.standards.StandardTables;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class StandardTablesTest {
+
+    @Test
+    void create() {
+        assertDoesNotThrow(new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                StandardTables.create();
+            }
+        });
+
+        assertNotNull(StandardTables.create());
+    }
+
+    @Test
+    void addTable() {
+        Table table = StandardTable.of(1, "SimpleTable");
+
+        StandardTables standardTables = StandardTables.create();
+        standardTables.addTable(table);
+
+        assertEquals(1, standardTables.tablesMap().size());
+    }
+
+    @Test
+    void removeTable() {
+        Table table = StandardTable.of(1, "SimpleTable");
+
+        StandardTables standardTables = StandardTables.create();
+        standardTables.addTable(table);
+
+        assertEquals(table, standardTables.tablesMap().get(table.priority()));
+        standardTables.removeTable(table.priority());
+
+        assertEquals(0, standardTables.tablesMap().size());
+    }
+
+    @Test
+    void tables() {
+        Table table = StandardTable.of(1, "SimpleTable");
+
+        StandardTables standardTables = StandardTables.create();
+        standardTables.addTable(table);
+
+        assertEquals(table, standardTables.tablesMap().get(table.priority()));
+    }
+}


### PR DESCRIPTION
Motivation:
Applications need robust security components which can be used for access control, traffic management, payload matching, and more. Currently, we rely on low-level firewalls such as Iptables (Linux) or Windows Firewall (Windows). They work great and perfectly but they're not platform-independent.

Java is a platform-independent language and applications just work on any supported platform but when it comes to low-level firewalls, we have to configure platform-dependent solutions. This requires root (Superuser) permission and granting this permission is not a good security practice. Also, applications running on serverless architecture, or inside containers will have more hard time configuring these traditional solutions.

Modification:
To combat this, I'm introducing Netty Security. It works on any platform where Java (and Netty) is supported. There is no need for root (Superuser) permissions and it is configured purely from code.

Result:
New Feature: Netty Security
