### PR TITLE
Don't attach cleaners to buffers by default

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/internal/CleanerDrop.java
+++ b/buffer/src/main/java/io/netty5/buffer/internal/CleanerDrop.java
@@ -37,7 +37,10 @@ public final class CleanerDrop<T extends Buffer> implements Drop<T> {
      * it becomes cleanable.
      */
     public static <T extends Buffer> Drop<T> wrap(Drop<T> drop, MemoryManager manager) {
-        return innerWrap(drop, manager, true);
+        if (LeakDetection.ALWAYS_ATTACH_CLEANER || LeakDetection.leakDetectionEnabled > 0) {
+            return innerWrap(drop, manager, true);
+        }
+        return drop;
     }
 
     /**

--- a/buffer/src/main/java/io/netty5/buffer/internal/LeakDetection.java
+++ b/buffer/src/main/java/io/netty5/buffer/internal/LeakDetection.java
@@ -39,6 +39,8 @@ import static java.util.Objects.requireNonNull;
  */
 @UnstableApi
 public final class LeakDetection {
+    static final boolean ALWAYS_ATTACH_CLEANER =
+            SystemPropertyUtil.getBoolean("io.netty5.buffer.alwaysAttachCleaner", false);
     static volatile int leakDetectionEnabled;
 
     // Protected by synchronizing on the instance.


### PR DESCRIPTION
Motivation:
Creating and cleaning Cleanables can be expensive; MacOS appear to be particularly affected. The cleaners are important for leak detection, but otherwise do not impact functionality. We can skip their overhead by default, when no leak detection is enabled for buffers.

Modification:
Add a new `io.netty5.buffer.alwaysAttachCleaner` system property that is `false` by default. Make the CleanerDrop only wrap a drop if we have a leak detector installed, or if `io.netty5.buffer.alwaysAttachCleaner` is `true`.

Result:
Allocating and closing buffers are now faster, especially on MacOS platforms. For instance, allocator benchmarks show roughly a doubling in throughput on MacOS/M1.