### PR TITLE
Add preprocessor logic for Apple builds where symbols are not always available.

### DIFF
--- a/transport-native-unix-common/src/main/c/netty_unix_filedescriptor.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_filedescriptor.c
@@ -247,6 +247,7 @@ static int create_pipe(int fd[2], int flags) {
             return errno;
         }
     }
+    return 0;
 #endif  // PIPE2_SUPPORTED
     if (pipe(fd) != 0) {
         return errno;


### PR DESCRIPTION
Apple builds can fail when certain symbols are not present. This change adds preprocessor checks to guard against these failures.
