### PR TITLE
Remove invalid annotation usage which did break javadocs generation

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/serialization/package-info.java
+++ b/codec/src/main/java/io/netty/handler/codec/serialization/package-info.java
@@ -29,5 +29,4 @@
  * @deprecated This package has been deprecated with no replacement,
  * because serialization can be a security liability
  */
-@Deprecated
 package io.netty.handler.codec.serialization;


### PR DESCRIPTION
Motivation:

The `@Deprecated` annotation is not valid in a package-info.java file and so broke our javadoc generation during the release process

Modifications:

Remove annotation

Result:

Javadoc generation works again during release process
