### PR TITLE
Optimize methods in PoolChunk:usage(),freeBytes(),toString()

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -31,7 +31,7 @@ import static io.netty.buffer.PoolChunk.isSubpage;
 import static java.lang.Math.max;
 
 abstract class PoolArena<T> extends SizeClasses implements PoolArenaMetric {
-    static final boolean HAS_UNSAFE = PlatformDependent.hasUnsafe();
+    private static final boolean HAS_UNSAFE = PlatformDependent.hasUnsafe();
 
     enum SizeClass {
         Small,

--- a/buffer/src/main/java/io/netty/buffer/PoolChunk.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunk.java
@@ -287,11 +287,15 @@ final class PoolChunk<T> implements PoolChunkMetric {
     @Override
     public int usage() {
         final int freeBytes;
-        arena.lock();
-        try {
+        if (this.unpooled) {
             freeBytes = this.freeBytes;
-        } finally {
-            arena.unlock();
+        } else {
+            runsAvailLock.lock();
+            try {
+                freeBytes = this.freeBytes;
+            } finally {
+                runsAvailLock.unlock();
+            }
         }
         return usage(freeBytes);
     }
@@ -620,11 +624,14 @@ final class PoolChunk<T> implements PoolChunkMetric {
 
     @Override
     public int freeBytes() {
-        arena.lock();
+        if (this.unpooled) {
+            return freeBytes;
+        }
+        runsAvailLock.lock();
         try {
             return freeBytes;
         } finally {
-            arena.unlock();
+            runsAvailLock.unlock();
         }
     }
 
@@ -635,11 +642,15 @@ final class PoolChunk<T> implements PoolChunkMetric {
     @Override
     public String toString() {
         final int freeBytes;
-        arena.lock();
-        try {
+        if (this.unpooled) {
             freeBytes = this.freeBytes;
-        } finally {
-            arena.unlock();
+        } else {
+            runsAvailLock.lock();
+            try {
+                freeBytes = this.freeBytes;
+            } finally {
+                runsAvailLock.unlock();
+            }
         }
 
         return new StringBuilder()


### PR DESCRIPTION
Motivation:

When we call `PoolChunk`'s methods :`usage(),freeBytes(),toString()`:
1. If `poolChunk.unpooled == true`, then there is no need to acquire the lock `arena.lock()`.
2. The `arena.lock()` can be replaced by `runsAvailLock.lock()`, which will narrow the lock scope and reduce the lock contention.

Modification:

Optimize methods in PoolChunk:usage(),freeBytes(),toString().

Result:

Optimize methods in PoolChunk:usage(),freeBytes(),toString().
