### PR TITLE
Remove duplicated entry in pom.xml

### DIFF
--- a/codec-http2/pom.xml
+++ b/codec-http2/pom.xml
@@ -71,10 +71,6 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
     </dependency>


### PR DESCRIPTION
Motivation:

We had some duplicated entry that did cause warnings.

Modifications:

Remove duplicated entry

Result:

No more warnings

