### PR TITLE
Cache NetworkInterfaces after retrieval to speedup initialization time

### DIFF
--- a/common/src/main/java/io/netty/util/NetUtil.java
+++ b/common/src/main/java/io/netty/util/NetUtil.java
@@ -37,6 +37,7 @@ import java.net.UnknownHostException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Arrays;
+import java.util.Collection;
 
 import static io.netty.util.AsciiString.indexOf;
 
@@ -241,6 +242,15 @@ public final class NetUtil {
             // raised will directly lead to throwable.
             process.destroy();
         }
+    }
+
+    /**
+     * Returns an unmodifiable Collection of all the interfaces on this machine.
+     *
+     * @return collections of network interfaces.
+     */
+    public static Collection<NetworkInterface> networkInterfaces() {
+        return NetUtilInitializations.networkInterfaces();
     }
 
     /**

--- a/common/src/main/java/io/netty/util/NetUtilInitializations.java
+++ b/common/src/main/java/io/netty/util/NetUtilInitializations.java
@@ -26,6 +26,8 @@ import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 
@@ -34,6 +36,23 @@ final class NetUtilInitializations {
      * The logger being used by this class
      */
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(NetUtilInitializations.class);
+
+    private static final Collection<NetworkInterface> NETWORK_INTERFACES;
+
+    static {
+        List<NetworkInterface> networkInterfaces = new ArrayList<NetworkInterface>();
+        try {
+            Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+            if (interfaces != null) {
+                while (interfaces.hasMoreElements()) {
+                    networkInterfaces.add(interfaces.nextElement());
+                }
+            }
+        } catch (SocketException e) {
+            logger.warn("Failed to retrieve the list of available network interfaces", e);
+        }
+        NETWORK_INTERFACES = Collections.unmodifiableList(networkInterfaces);
+    }
 
     private NetUtilInitializations() {
     }
@@ -69,19 +88,11 @@ final class NetUtilInitializations {
     static NetworkIfaceAndInetAddress determineLoopback(Inet4Address localhost4, Inet6Address localhost6) {
         // Retrieve the list of available network interfaces.
         List<NetworkInterface> ifaces = new ArrayList<NetworkInterface>();
-        try {
-            Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
-            if (interfaces != null) {
-                while (interfaces.hasMoreElements()) {
-                    NetworkInterface iface = interfaces.nextElement();
-                    // Use the interface with proper INET addresses only.
-                    if (SocketUtils.addressesFromNetworkInterface(iface).hasMoreElements()) {
-                        ifaces.add(iface);
-                    }
-                }
+        for (NetworkInterface iface: NETWORK_INTERFACES) {
+            // Use the interface with proper INET addresses only.
+            if (SocketUtils.addressesFromNetworkInterface(iface).hasMoreElements()) {
+                ifaces.add(iface);
             }
-        } catch (SocketException e) {
-            logger.warn("Failed to retrieve the list of available network interfaces", e);
         }
 
         // Find the first loopback interface available from its INET address (127.0.0.1 or ::1)
@@ -150,6 +161,10 @@ final class NetUtilInitializations {
         }
 
         return new NetworkIfaceAndInetAddress(loopbackIface, loopbackAddr);
+    }
+
+    static Collection<NetworkInterface> networkInterfaces() {
+        return NETWORK_INTERFACES;
     }
 
     static final class NetworkIfaceAndInetAddress {

--- a/common/src/main/java/io/netty/util/internal/MacAddressUtil.java
+++ b/common/src/main/java/io/netty/util/internal/MacAddressUtil.java
@@ -51,23 +51,15 @@ public final class MacAddressUtil {
 
         // Retrieve the list of available network interfaces.
         Map<NetworkInterface, InetAddress> ifaces = new LinkedHashMap<NetworkInterface, InetAddress>();
-        try {
-            Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
-            if (interfaces != null) {
-                while (interfaces.hasMoreElements()) {
-                    NetworkInterface iface = interfaces.nextElement();
-                    // Use the interface with proper INET addresses only.
-                    Enumeration<InetAddress> addrs = SocketUtils.addressesFromNetworkInterface(iface);
-                    if (addrs.hasMoreElements()) {
-                        InetAddress a = addrs.nextElement();
-                        if (!a.isLoopbackAddress()) {
-                            ifaces.put(iface, a);
-                        }
-                    }
+        for (NetworkInterface iface: NetUtil.networkInterfaces()) {
+            // Use the interface with proper INET addresses only.
+            Enumeration<InetAddress> addrs = SocketUtils.addressesFromNetworkInterface(iface);
+            if (addrs.hasMoreElements()) {
+                InetAddress a = addrs.nextElement();
+                if (!a.isLoopbackAddress()) {
+                    ifaces.put(iface, a);
                 }
             }
-        } catch (SocketException e) {
-            logger.warn("Failed to retrieve the list of available network interfaces", e);
         }
 
         for (Entry<NetworkInterface, InetAddress> entry: ifaces.entrySet()) {

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -71,7 +71,6 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.NetworkInterface;
 import java.net.SocketAddress;
-import java.net.SocketException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -165,22 +164,15 @@ public class DnsNameResolver extends InetNameResolver {
      * Returns {@code true} if any {@link NetworkInterface} supports {@code IPv6}, {@code false} otherwise.
      */
     private static boolean anyInterfaceSupportsIpV6() {
-        try {
-            Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
-            while (interfaces.hasMoreElements()) {
-                NetworkInterface iface = interfaces.nextElement();
-                Enumeration<InetAddress> addresses = iface.getInetAddresses();
-                while (addresses.hasMoreElements()) {
-                    InetAddress inetAddress = addresses.nextElement();
-                    if (inetAddress instanceof Inet6Address && !inetAddress.isAnyLocalAddress() &&
+        for (NetworkInterface iface : NetUtil.networkInterfaces()) {
+            Enumeration<InetAddress> addresses = iface.getInetAddresses();
+            while (addresses.hasMoreElements()) {
+                InetAddress inetAddress = addresses.nextElement();
+                if (inetAddress instanceof Inet6Address && !inetAddress.isAnyLocalAddress() &&
                         !inetAddress.isLoopbackAddress() && !inetAddress.isLinkLocalAddress()) {
-                        return true;
-                    }
+                    return true;
                 }
             }
-        } catch (SocketException e) {
-            logger.debug("Unable to detect if any interface supports IPv6, assuming IPv4-only", e);
-            // ignore
         }
         return false;
     }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramMulticastTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramMulticastTest.java
@@ -25,6 +25,7 @@ import io.netty.channel.socket.DatagramPacket;
 import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.channel.socket.oio.OioDatagramChannel;
 import io.netty.testsuite.transport.TestsuitePermutation;
+import io.netty.util.NetUtil;
 import io.netty.util.internal.SocketUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -199,9 +200,7 @@ public class DatagramMulticastTest extends AbstractDatagramTest {
     }
 
     private NetworkInterface multicastNetworkInterface() throws IOException {
-        Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
-        while (interfaces.hasMoreElements()) {
-            NetworkInterface iface = interfaces.nextElement();
+        for (NetworkInterface iface : NetUtil.networkInterfaces()) {
             if (iface.isUp() && iface.supportsMulticast()) {
                 Enumeration<InetAddress> addresses = iface.getInetAddresses();
                 while (addresses.hasMoreElements()) {


### PR DESCRIPTION
Motivation:

We can justt cache the NetworkInterfaces once and so cut down on initialization time

Modifications:

- Cache once and expose via NetUtil
- Update code to use the new static method.

Result:

Fixes https://github.com/netty/netty/issues/13054
