### PR TITLE
Allow to override fallback nameservers

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsServerAddressStreamProvider.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsServerAddressStreamProvider.java
@@ -86,6 +86,11 @@ public final class DefaultDnsServerAddressStreamProvider implements DnsServerAdd
             String defaultNameserverString = SystemPropertyUtil.get(DEFAULT_FALLBACK_SERVER_PROPERTY, null);
             if (defaultNameserverString != null) {
                 for (String server : defaultNameserverString.split(",")) {
+                    String dns = server.trim();
+                    if (!NetUtil.isValidIpV4Address(dns) || !NetUtil.isValidIpV6Address(dns)) {
+                        throw new ExceptionInInitializerError(DEFAULT_FALLBACK_SERVER_PROPERTY + " doesn't" +
+                                " contain a valid list of NameServers: " + defaultNameserverString);
+                    }
                     defaultNameServers.add(SocketUtils.socketAddress(server.trim(), DNS_PORT));
                 }
                 if (defaultNameServers.isEmpty()) {

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsServerAddressStreamProvider.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsServerAddressStreamProvider.java
@@ -87,7 +87,7 @@ public final class DefaultDnsServerAddressStreamProvider implements DnsServerAdd
             if (defaultNameserverString != null) {
                 for (String server : defaultNameserverString.split(",")) {
                     String dns = server.trim();
-                    if (!NetUtil.isValidIpV4Address(dns) || !NetUtil.isValidIpV6Address(dns)) {
+                    if (!NetUtil.isValidIpV4Address(dns) && !NetUtil.isValidIpV6Address(dns)) {
                         throw new ExceptionInInitializerError(DEFAULT_FALLBACK_SERVER_PROPERTY + " doesn't" +
                                 " contain a valid list of NameServers: " + defaultNameserverString);
                     }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsServerAddressStreamProvider.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsServerAddressStreamProvider.java
@@ -18,6 +18,7 @@ package io.netty.resolver.dns;
 import io.netty.util.NetUtil;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SocketUtils;
+import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -39,6 +40,7 @@ import static io.netty.resolver.dns.DnsServerAddresses.sequential;
 public final class DefaultDnsServerAddressStreamProvider implements DnsServerAddressStreamProvider {
     private static final InternalLogger logger =
             InternalLoggerFactory.getInstance(DefaultDnsServerAddressStreamProvider.class);
+    private static final String DEFAULT_FALLBACK_SERVER_PROPERTY = "io.netty.resolver.dns.defaultNameServerFallback";
     public static final DefaultDnsServerAddressStreamProvider INSTANCE = new DefaultDnsServerAddressStreamProvider();
 
     private static final List<InetSocketAddress> DEFAULT_NAME_SERVER_LIST;
@@ -53,7 +55,7 @@ public final class DefaultDnsServerAddressStreamProvider implements DnsServerAdd
             DirContextUtils.addNameServers(defaultNameServers, DNS_PORT);
         }
 
-        // Only try when using Java8 and lower as otherwise it will produce:
+        // Only try when using on Java8 and lower as otherwise it will produce:
         // WARNING: Illegal reflective access by io.netty.resolver.dns.DefaultDnsServerAddressStreamProvider
         if (PlatformDependent.javaVersion() < 9 && defaultNameServers.isEmpty()) {
             try {
@@ -81,25 +83,42 @@ public final class DefaultDnsServerAddressStreamProvider implements DnsServerAdd
                         "Default DNS servers: {} (sun.net.dns.ResolverConfiguration)", defaultNameServers);
             }
         } else {
-            // Depending if IPv6 or IPv4 is used choose the correct DNS servers provided by google:
-            // https://developers.google.com/speed/public-dns/docs/using
-            // https://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html
-            if (NetUtil.isIpV6AddressesPreferred() ||
-                    (NetUtil.LOCALHOST instanceof Inet6Address && !NetUtil.isIpV4StackPreferred())) {
-                Collections.addAll(
-                        defaultNameServers,
-                        SocketUtils.socketAddress("2001:4860:4860::8888", DNS_PORT),
-                        SocketUtils.socketAddress("2001:4860:4860::8844", DNS_PORT));
-            } else {
-                Collections.addAll(
-                        defaultNameServers,
-                        SocketUtils.socketAddress("8.8.8.8", DNS_PORT),
-                        SocketUtils.socketAddress("8.8.4.4", DNS_PORT));
-            }
+            String defaultNameserverString = SystemPropertyUtil.get(DEFAULT_FALLBACK_SERVER_PROPERTY, null);
+            if (defaultNameserverString != null) {
+                for (String server : defaultNameserverString.split(",")) {
+                    defaultNameServers.add(SocketUtils.socketAddress(server.trim(), DNS_PORT));
+                }
+                if (defaultNameServers.isEmpty()) {
+                    throw new ExceptionInInitializerError(DEFAULT_FALLBACK_SERVER_PROPERTY + " doesn't" +
+                            " contain a valid list of NameServers: " + defaultNameserverString);
+                }
 
-            if (logger.isWarnEnabled()) {
-                logger.warn(
-                        "Default DNS servers: {} (Google Public DNS as a fallback)", defaultNameServers);
+                if (logger.isWarnEnabled()) {
+                    logger.warn(
+                            "Default DNS servers: {} (Configured by {} system property)",
+                            defaultNameServers, DEFAULT_FALLBACK_SERVER_PROPERTY);
+                }
+            } else {
+                // Depending if IPv6 or IPv4 is used choose the correct DNS servers provided by google:
+                // https://developers.google.com/speed/public-dns/docs/using
+                // https://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html
+                if (NetUtil.isIpV6AddressesPreferred() ||
+                        (NetUtil.LOCALHOST instanceof Inet6Address && !NetUtil.isIpV4StackPreferred())) {
+                    Collections.addAll(
+                            defaultNameServers,
+                            SocketUtils.socketAddress("2001:4860:4860::8888", DNS_PORT),
+                            SocketUtils.socketAddress("2001:4860:4860::8844", DNS_PORT));
+                } else {
+                    Collections.addAll(
+                            defaultNameServers,
+                            SocketUtils.socketAddress("8.8.8.8", DNS_PORT),
+                            SocketUtils.socketAddress("8.8.4.4", DNS_PORT));
+                }
+
+                if (logger.isWarnEnabled()) {
+                    logger.warn(
+                            "Default DNS servers: {} (Google Public DNS as a fallback)", defaultNameServers);
+                }
             }
         }
 


### PR DESCRIPTION
Motivation:

Sometimes netty might not be able to detect the default nameserver to use. In this case we did fallback to use the public google nameservers. We should allows people to specify the fallback nameserver by a property to ensure they have full-control over which informations are sent over the network.

Modifications:

Add system property that can be used to override the fallback nameservers

Result:

More control to the user
