### PR TITLE
Fix caching of NetworkInterfaces when using Graal

### DIFF
--- a/common/src/main/java/io/netty/util/NetUtil.java
+++ b/common/src/main/java/io/netty/util/NetUtil.java
@@ -72,6 +72,11 @@ public final class NetUtil {
     public static final NetworkInterface LOOPBACK_IF;
 
     /**
+     * An unmodifiable Collection of all the interfaces on this machine.
+     */
+    public static final Collection<NetworkInterface> NETWORK_INTERFACES;
+
+    /**
      * The SOMAXCONN value of the current machine.  If failed to get the value,  {@code 200} is used as a
      * default value for Windows and {@code 128} for others.
      */
@@ -137,13 +142,16 @@ public final class NetUtil {
         logger.debug("-Djava.net.preferIPv4Stack: {}", IPV4_PREFERRED);
         logger.debug("-Djava.net.preferIPv6Addresses: {}", IPV6_ADDRESSES_PREFERRED);
 
+        NETWORK_INTERFACES = NetUtilInitializations.networkInterfaces();
+
         // Create IPv4 loopback address.
         LOCALHOST4 = NetUtilInitializations.createLocalhost4();
 
         // Create IPv6 loopback address.
         LOCALHOST6 = NetUtilInitializations.createLocalhost6();
 
-        NetworkIfaceAndInetAddress loopback = NetUtilInitializations.determineLoopback(LOCALHOST4, LOCALHOST6);
+        NetworkIfaceAndInetAddress loopback =
+                NetUtilInitializations.determineLoopback(NETWORK_INTERFACES, LOCALHOST4, LOCALHOST6);
         LOOPBACK_IF = loopback.iface();
         LOCALHOST = loopback.address();
 
@@ -242,15 +250,6 @@ public final class NetUtil {
             // raised will directly lead to throwable.
             process.destroy();
         }
-    }
-
-    /**
-     * Returns an unmodifiable Collection of all the interfaces on this machine.
-     *
-     * @return collections of network interfaces.
-     */
-    public static Collection<NetworkInterface> networkInterfaces() {
-        return NetUtilInitializations.networkInterfaces();
     }
 
     /**

--- a/common/src/main/java/io/netty/util/NetUtilInitializations.java
+++ b/common/src/main/java/io/netty/util/NetUtilInitializations.java
@@ -37,23 +37,6 @@ final class NetUtilInitializations {
      */
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(NetUtilInitializations.class);
 
-    private static final Collection<NetworkInterface> NETWORK_INTERFACES;
-
-    static {
-        List<NetworkInterface> networkInterfaces = new ArrayList<NetworkInterface>();
-        try {
-            Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
-            if (interfaces != null) {
-                while (interfaces.hasMoreElements()) {
-                    networkInterfaces.add(interfaces.nextElement());
-                }
-            }
-        } catch (SocketException e) {
-            logger.warn("Failed to retrieve the list of available network interfaces", e);
-        }
-        NETWORK_INTERFACES = Collections.unmodifiableList(networkInterfaces);
-    }
-
     private NetUtilInitializations() {
     }
 
@@ -85,10 +68,26 @@ final class NetUtilInitializations {
         return localhost6;
     }
 
-    static NetworkIfaceAndInetAddress determineLoopback(Inet4Address localhost4, Inet6Address localhost6) {
+    static Collection<NetworkInterface> networkInterfaces() {
+        List<NetworkInterface> networkInterfaces = new ArrayList<NetworkInterface>();
+        try {
+            Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+            if (interfaces != null) {
+                while (interfaces.hasMoreElements()) {
+                    networkInterfaces.add(interfaces.nextElement());
+                }
+            }
+        } catch (SocketException e) {
+            logger.warn("Failed to retrieve the list of available network interfaces", e);
+        }
+        return Collections.unmodifiableList(networkInterfaces);
+    }
+
+    static NetworkIfaceAndInetAddress determineLoopback(
+            Collection<NetworkInterface> networkInterfaces, Inet4Address localhost4, Inet6Address localhost6) {
         // Retrieve the list of available network interfaces.
         List<NetworkInterface> ifaces = new ArrayList<NetworkInterface>();
-        for (NetworkInterface iface: NETWORK_INTERFACES) {
+        for (NetworkInterface iface: networkInterfaces) {
             // Use the interface with proper INET addresses only.
             if (SocketUtils.addressesFromNetworkInterface(iface).hasMoreElements()) {
                 ifaces.add(iface);
@@ -161,10 +160,6 @@ final class NetUtilInitializations {
         }
 
         return new NetworkIfaceAndInetAddress(loopbackIface, loopbackAddr);
-    }
-
-    static Collection<NetworkInterface> networkInterfaces() {
-        return NETWORK_INTERFACES;
     }
 
     static final class NetworkIfaceAndInetAddress {

--- a/common/src/main/java/io/netty/util/internal/MacAddressUtil.java
+++ b/common/src/main/java/io/netty/util/internal/MacAddressUtil.java
@@ -51,7 +51,7 @@ public final class MacAddressUtil {
 
         // Retrieve the list of available network interfaces.
         Map<NetworkInterface, InetAddress> ifaces = new LinkedHashMap<NetworkInterface, InetAddress>();
-        for (NetworkInterface iface: NetUtil.networkInterfaces()) {
+        for (NetworkInterface iface: NetUtil.NETWORK_INTERFACES) {
             // Use the interface with proper INET addresses only.
             Enumeration<InetAddress> addrs = SocketUtils.addressesFromNetworkInterface(iface);
             if (addrs.hasMoreElements()) {

--- a/common/src/main/resources/META-INF/native-image/io.netty/netty-common/native-image.properties
+++ b/common/src/main/resources/META-INF/native-image/io.netty/netty-common/native-image.properties
@@ -15,4 +15,5 @@
 Args = --initialize-at-run-time=io.netty.util.AbstractReferenceCounted,io.netty.util.concurrent.GlobalEventExecutor,io.netty.util.concurrent.ImmediateEventExecutor,io.netty.util.concurrent.ScheduledFutureTask,io.netty.util.internal.ThreadLocalRandom \
        --initialize-at-run-time=io.netty.util.NetUtilSubstitutions$NetUtilLocalhost4LazyHolder \
        --initialize-at-run-time=io.netty.util.NetUtilSubstitutions$NetUtilLocalhost6LazyHolder \
-       --initialize-at-run-time=io.netty.util.NetUtilSubstitutions$NetUtilLocalhostLazyHolder
+       --initialize-at-run-time=io.netty.util.NetUtilSubstitutions$NetUtilLocalhostLazyHolder \
+       --initialize-at-run-time=io.netty.util.NetUtilSubstitutions$NetUtilNetworkInterfacesLazyHolder

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -164,7 +164,7 @@ public class DnsNameResolver extends InetNameResolver {
      * Returns {@code true} if any {@link NetworkInterface} supports {@code IPv6}, {@code false} otherwise.
      */
     private static boolean anyInterfaceSupportsIpV6() {
-        for (NetworkInterface iface : NetUtil.networkInterfaces()) {
+        for (NetworkInterface iface : NetUtil.NETWORK_INTERFACES) {
             Enumeration<InetAddress> addresses = iface.getInetAddresses();
             while (addresses.hasMoreElements()) {
                 InetAddress inetAddress = addresses.nextElement();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramMulticastTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramMulticastTest.java
@@ -200,7 +200,7 @@ public class DatagramMulticastTest extends AbstractDatagramTest {
     }
 
     private NetworkInterface multicastNetworkInterface() throws IOException {
-        for (NetworkInterface iface : NetUtil.networkInterfaces()) {
+        for (NetworkInterface iface : NetUtil.NETWORK_INTERFACES) {
             if (iface.isUp() && iface.supportsMulticast()) {
                 Enumeration<InetAddress> addresses = iface.getInetAddresses();
                 while (addresses.hasMoreElements()) {


### PR DESCRIPTION
Motivation:

When using Graal we need to take special care for the cached NetworkInterfaces. This was missed while doing changes in 350bd0f6c3e61cdc327d54bcc8fe765203d4b59f

Modifications:

Add code to handle Graal

Result:

Build pass again when using Graal
