### PR TITLE
Ensure we use io.netty5 everywhere

### DIFF
--- a/codec-http2/pom.xml
+++ b/codec-http2/pom.xml
@@ -29,7 +29,7 @@
   <name>Netty5/Codec/HTTP2</name>
 
   <properties>
-    <javaModuleName>io.netty.codec.http2</javaModuleName>
+    <javaModuleName>io.netty5.codec.http2</javaModuleName>
     <!-- Needed for SSL tests as these use the SelfSignedCertificate -->
     <argLine.java9.extras>--add-exports java.base/sun.security.x509=ALL-UNNAMED</argLine.java9.extras>
   </properties>

--- a/codec/src/main/java/io/netty5/handler/codec/compression/ZlibCompressor.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/ZlibCompressor.java
@@ -61,11 +61,11 @@ public final class ZlibCompressor implements Compressor {
 
     static {
         MAX_INITIAL_OUTPUT_BUFFER_SIZE = SystemPropertyUtil.getInt(
-                "io.netty.jdkzlib.encoder.maxInitialOutputBufferSize",
+                "io.netty5.jdkzlib.encoder.maxInitialOutputBufferSize",
                 65536);
 
         if (logger.isDebugEnabled()) {
-            logger.debug("-Dio.netty.jdkzlib.encoder.maxInitialOutputBufferSize={}", MAX_INITIAL_OUTPUT_BUFFER_SIZE);
+            logger.debug("-Dio.netty5.jdkzlib.encoder.maxInitialOutputBufferSize={}", MAX_INITIAL_OUTPUT_BUFFER_SIZE);
         }
     }
 

--- a/common/src/main/java/io/netty5/util/internal/Hidden.java
+++ b/common/src/main/java/io/netty5/util/internal/Hidden.java
@@ -124,7 +124,7 @@ class Hidden {
                     "verify");
 
             builder.allowBlockingCallsInside(
-                    "io.netty.handler.ssl.JdkSslContext$Defaults",
+                    "io.netty5.handler.ssl.JdkSslContext$Defaults",
                     "init");
 
             // Let's whitelist SSLEngineImpl.unwrap(...) for now as it may fail otherwise for TLS 1.3.

--- a/common/src/main/java/io/netty5/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty5/util/internal/PlatformDependent.java
@@ -246,17 +246,17 @@ public final class PlatformDependent {
      */
     @VisibleForTesting
     static boolean addPropertyOsClassifiers(Set<String> allowedClassifiers, Set<String> availableClassifiers) {
-        // empty: -Dio.netty.osClassifiers (no distro specific classifiers for native libs)
-        // single ID: -Dio.netty.osClassifiers=ubuntu
-        // pair ID, ID_LIKE: -Dio.netty.osClassifiers=ubuntu,debian
+        // empty: -Dio.netty5.osClassifiers (no distro specific classifiers for native libs)
+        // single ID: -Dio.netty5.osClassifiers=ubuntu
+        // pair ID, ID_LIKE: -Dio.netty5.osClassifiers=ubuntu,debian
         // illegal otherwise
-        String osClassifiersPropertyName = "io.netty.osClassifiers";
+        String osClassifiersPropertyName = "io.netty5.osClassifiers";
         String osClassifiers = SystemPropertyUtil.get(osClassifiersPropertyName);
         if (osClassifiers == null) {
             return false;
         }
         if (osClassifiers.isEmpty()) {
-            // let users omit classifiers with just -Dio.netty.osClassifiers
+            // let users omit classifiers with just -Dio.netty5.osClassifiers
             return true;
         }
         String[] classifiers = osClassifiers.split(",");

--- a/common/src/test/java/io/netty5/util/internal/OsClassifiersTest.java
+++ b/common/src/test/java/io/netty5/util/internal/OsClassifiersTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class OsClassifiersTest {
-    private static final String OS_CLASSIFIERS_PROPERTY = "io.netty.osClassifiers";
+    private static final String OS_CLASSIFIERS_PROPERTY = "io.netty5.osClassifiers";
 
     private Properties systemProperties;
 
@@ -57,7 +57,7 @@ public class OsClassifiersTest {
 
     @Test
     void testOsClassifiersPropertyEmpty() {
-        // empty property -Dio.netty.osClassifiers
+        // empty property -Dio.netty5.osClassifiers
         systemProperties.setProperty(OS_CLASSIFIERS_PROPERTY, "");
         Set<String> allowed = Collections.singleton("fedora");
         Set<String> available = new LinkedHashSet<>(2);

--- a/native-image/ni_metadata.sh
+++ b/native-image/ni_metadata.sh
@@ -28,7 +28,7 @@ mkdir -p "${COLLECTED_CONFIG_PATH}" "${MERGED_CONFIG_PATH}"
 
 # Execute the netty build.
 cd "${SCRIPT_PATH}/.."
-./mvnw -DfailIfNoTests=false -Dtest=\!EpollDatagramMulticastIpv6WithIpv4AddrTest,\!ShadingIT,\!FlowControlHandlerTest,\!CloseNotifyTest,\!Http2MultiplexTransportTest -Dit.test=\!ShadingIT -DskipHttp2Testsuite=true -DargLine.javaProperties="-Dio.netty.tryReflectionSetAccessible=true -agentlib:native-image-agent=config-output-dir=${COLLECTED_CONFIG_PATH}/{pid},experimental-conditional-config-part" package
+./mvnw -DfailIfNoTests=false -Dtest=\!EpollDatagramMulticastIpv6WithIpv4AddrTest,\!ShadingIT,\!FlowControlHandlerTest,\!CloseNotifyTest,\!Http2MultiplexTransportTest -Dit.test=\!ShadingIT -DskipHttp2Testsuite=true -DargLine.javaProperties="-Dio.netty5.tryReflectionSetAccessible=true -agentlib:native-image-agent=config-output-dir=${COLLECTED_CONFIG_PATH}/{pid},experimental-conditional-config-part" package
 
 # Merge all of the generated metadata.
 NI_CONFIG_INPUT_ARGS=""

--- a/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/Native.java
+++ b/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/Native.java
@@ -35,9 +35,9 @@ import java.util.Locale;
 
 final class Native {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(Native.class);
-    static final int DEFAULT_RING_SIZE = Math.max(64, SystemPropertyUtil.getInt("io.netty.iouring.ringSize", 4096));
+    static final int DEFAULT_RING_SIZE = Math.max(64, SystemPropertyUtil.getInt("io.netty5.iouring.ringSize", 4096));
     static final int DEFAULT_IOSEQ_ASYNC_THRESHOLD =
-            Math.max(0, SystemPropertyUtil.getInt("io.netty.iouring.iosqeAsyncThreshold", 25));
+            Math.max(0, SystemPropertyUtil.getInt("io.netty5.iouring.iosqeAsyncThreshold", 25));
 
     static {
         Selector selector = null;
@@ -311,7 +311,7 @@ final class Native {
 
     static void checkKernelVersion(String kernelVersion) {
         boolean enforceKernelVersion = SystemPropertyUtil.getBoolean(
-                "io.netty.transport.iouring.enforceKernelVersion", true);
+                "io.netty5.transport.iouring.enforceKernelVersion", true);
         boolean kernelSupported = checkKernelVersion0(kernelVersion);
         if (!kernelSupported) {
             if (enforceKernelVersion) {


### PR DESCRIPTION
Motivation:

We had some leftovers that used io.netty still.

Modifications:

Replace io.netty with io.netty5

Result:

Fix usage of old package name
