### PR TITLE
Add the AdaptivePoolingAllocator

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -180,6 +180,9 @@ jobs:
           - setup: linux-x86_64-java11-unsafe-buffer
             docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.111.yaml build"
             docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.111.yaml run build-unsafe-buffer"
+          - setup: linux-x86_64-java11-adaptive
+            docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.111.yaml build"
+            docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.111.yaml run build-leak-adaptive"
 
     name: ${{ matrix.setup }} build
     needs: verify-pr

--- a/buffer-memory-segment/src/main/java/io/netty5/buffer/memseg/SegmentMemoryManager.java
+++ b/buffer-memory-segment/src/main/java/io/netty5/buffer/memseg/SegmentMemoryManager.java
@@ -107,6 +107,12 @@ public class SegmentMemoryManager implements MemoryManager {
     }
 
     @Override
+    public int sizeOf(Object memory) {
+        var segment = (MemorySegment) memory;
+        return Math.toIntExact(segment.byteSize());
+    }
+
+    @Override
     public String implementationName() {
         return "MemorySegment";
     }

--- a/buffer/src/main/java/io/netty5/buffer/DefaultBufferAllocators.java
+++ b/buffer/src/main/java/io/netty5/buffer/DefaultBufferAllocators.java
@@ -14,6 +14,7 @@
  */
 package io.netty5.buffer;
 
+import io.netty5.buffer.adapt.AdaptablePoolingAllocator;
 import io.netty5.util.internal.PlatformDependent;
 import io.netty5.util.internal.SystemPropertyUtil;
 import org.slf4j.Logger;
@@ -44,22 +45,25 @@ public final class DefaultBufferAllocators {
                 "io.netty5.allocator.type", PlatformDependent.isAndroid() ? "unpooled" : "pooled");
         allocType = allocType.toLowerCase(Locale.US).trim();
         boolean directBufferPreferred = directBufferPreferred();
+        String allocTypeForLogging = allocType;
 
         final BufferAllocator onHeap;
         final BufferAllocator offHeap;
         if ("unpooled".equals(allocType)) {
             onHeap = BufferAllocator.onHeapUnpooled();
             offHeap = BufferAllocator.offHeapUnpooled();
-            logger.debug("-Dio.netty5.allocator.type: {}", allocType);
         } else if ("pooled".equals(allocType)) {
             onHeap = BufferAllocator.onHeapPooled();
             offHeap = BufferAllocator.offHeapPooled();
-            logger.debug("-Dio.netty5.allocator.type: {}", allocType);
+        } else if ("adaptive".equals(allocType)) {
+            onHeap = new AdaptablePoolingAllocator(false);
+            offHeap = new AdaptablePoolingAllocator(true);
         } else {
             onHeap = BufferAllocator.onHeapPooled();
             offHeap = BufferAllocator.offHeapPooled();
-            logger.debug("-Dio.netty5.allocator.type: pooled (unknown: {})", allocType);
+            allocTypeForLogging = "pooled (unknown: " + allocType + ')';
         }
+        logger.debug("-Dio.netty5.allocator.type: {}", allocTypeForLogging);
         UncloseableBufferAllocator onHeapUnclosable = new UncloseableBufferAllocator(onHeap);
         UncloseableBufferAllocator offHeapUnclosable = new UncloseableBufferAllocator(offHeap);
         DEFAULT_PREFERRED_ALLOCATOR = directBufferPreferred? offHeapUnclosable : onHeapUnclosable;

--- a/buffer/src/main/java/io/netty5/buffer/DefaultBufferAllocators.java
+++ b/buffer/src/main/java/io/netty5/buffer/DefaultBufferAllocators.java
@@ -14,7 +14,7 @@
  */
 package io.netty5.buffer;
 
-import io.netty5.buffer.adapt.AdaptablePoolingAllocator;
+import io.netty5.buffer.adapt.AdaptivePoolingAllocator;
 import io.netty5.util.internal.PlatformDependent;
 import io.netty5.util.internal.SystemPropertyUtil;
 import org.slf4j.Logger;
@@ -56,8 +56,8 @@ public final class DefaultBufferAllocators {
             onHeap = BufferAllocator.onHeapPooled();
             offHeap = BufferAllocator.offHeapPooled();
         } else if ("adaptive".equals(allocType)) {
-            onHeap = new AdaptablePoolingAllocator(false);
-            offHeap = new AdaptablePoolingAllocator(true);
+            onHeap = new AdaptivePoolingAllocator(false);
+            offHeap = new AdaptivePoolingAllocator(true);
         } else {
             onHeap = BufferAllocator.onHeapPooled();
             offHeap = BufferAllocator.offHeapPooled();

--- a/buffer/src/main/java/io/netty5/buffer/LeakInfo.java
+++ b/buffer/src/main/java/io/netty5/buffer/LeakInfo.java
@@ -62,5 +62,16 @@ public interface LeakInfo extends Iterable<TracePoint> {
          * @return A {@link Throwable} with the stack trace of this trace point.
          */
         Throwable traceback();
+
+        /**
+         * Get the name of the type of event this trace point represents.
+         * <p>
+         * The specific names used are implementation defined, and should not be relied upon by client code.
+         * <p>
+         * The name should only be used for debugging purpose.
+         *
+         * @return The event type name.
+         */
+        String eventName();
     }
 }

--- a/buffer/src/main/java/io/netty5/buffer/MemoryManager.java
+++ b/buffer/src/main/java/io/netty5/buffer/MemoryManager.java
@@ -222,6 +222,14 @@ public interface MemoryManager {
     void clearMemory(Object memory);
 
     /**
+     * Get the size, in bytes, of the given memory allocation.
+     *
+     * @param memory The opaque memory to get the size of.
+     * @return The size of the given memory, in bytes.
+     */
+    int sizeOf(Object memory);
+
+    /**
      * Get the name for this implementation, which can be used for finding this particular implementation via the
      * {@link #lookupImplementation(String)} method.
      *

--- a/buffer/src/main/java/io/netty5/buffer/adapt/AdaptablePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/adapt/AdaptablePoolingAllocator.java
@@ -40,7 +40,7 @@ import static io.netty5.util.internal.PlatformDependent.threadId;
 
 public class AdaptablePoolingAllocator implements BufferAllocator {
     private static final int RETIRE_CAPACITY = 4 * 1024;
-    private static final int DEFAULT_MIN_CHUNK_SIZE = 128 * 1028;
+    private static final int DEFAULT_MIN_CHUNK_SIZE = 128 * 1024;
     private static final int MAX_STRIPES = NettyRuntime.availableProcessors() * 2;
 
     private final AllocationType allocationType;
@@ -246,12 +246,12 @@ public class AdaptablePoolingAllocator implements BufferAllocator {
             int bucket = Integer.SIZE - Integer.numberOfLeadingZeros(normalizedSize);
             histo[histoIndex][bucket]++;
             if (histoCount == 10_000) {
-                rotateHistograms(bucket);
+                rotateHistograms();
             }
             histoCount++;
         }
 
-        private void rotateHistograms(int bucket) {
+        private void rotateHistograms() {
             Arrays.fill(sums, (short) 0);
             int sum = 0;
             for (short[] buckets : histo) {
@@ -269,7 +269,7 @@ public class AdaptablePoolingAllocator implements BufferAllocator {
                 }
                 targetPercentile -= sums[sizeBucket];
             }
-            int percentileSize = 1 << bucket + 6;
+            int percentileSize = 1 << sizeBucket + 6;
             prefChunkSize = Math.max(percentileSize * 10, DEFAULT_MIN_CHUNK_SIZE);
 
             histoIndex = histoIndex + 1 & histo.length - 1;

--- a/buffer/src/main/java/io/netty5/buffer/adapt/AdaptablePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/adapt/AdaptablePoolingAllocator.java
@@ -179,7 +179,7 @@ public class AdaptablePoolingAllocator implements BufferAllocator {
                     }
                 }
                 expansions++;
-            } while (expansions < 3 && tryExpandMagazines(mags.length));
+            } while (expansions <= 3 && tryExpandMagazines(mags.length));
         }
         // The magazines failed us, or the buffer is too big to be pooled. Allocate unpooled buffer.
         return manager.allocateShared(allocatorControl, size, standardDrop(manager), allocationType);

--- a/buffer/src/main/java/io/netty5/buffer/adapt/AdaptablePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/adapt/AdaptablePoolingAllocator.java
@@ -265,7 +265,7 @@ public class AdaptablePoolingAllocator implements BufferAllocator {
         private void recordAllocationSize(int size) {
             int normalizedSize = size - 1 >> 6 & (1 << 15) - 1;
             int bucket = Integer.SIZE - Integer.numberOfLeadingZeros(normalizedSize);
-            histo[histoIndex][bucket] += 1;
+            histo[histoIndex][bucket]++;
             if (histoCount == 10_000) {
                 rotateHistograms(bucket);
             }

--- a/buffer/src/main/java/io/netty5/buffer/adapt/AdaptablePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/adapt/AdaptablePoolingAllocator.java
@@ -172,6 +172,7 @@ public class AdaptablePoolingAllocator implements BufferAllocator {
         }
     }
 
+    @SuppressWarnings("checkstyle:finalclass") // Checkstyle mistakenly believes this class should be final.
     private static class AllocationStatistics extends StampedLock {
         private static final long serialVersionUID = -8319929980932269688L;
         private static final int MIN_DATUM_TARGET = 1024;

--- a/buffer/src/main/java/io/netty5/buffer/adapt/AdaptablePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/adapt/AdaptablePoolingAllocator.java
@@ -185,7 +185,7 @@ public class AdaptablePoolingAllocator implements BufferAllocator {
         private static final int INIT_DATUM_TARGET = 8192;
         private static final int HISTO_MIN_BUCKET_SHIFT = 13; // Smallest bucket is 1 << 13 = 8192 bytes in size.
         private static final int HISTO_MAX_BUCKET_SHIFT = 20; // Biggest bucket is 1 << 20 = 1 MiB bytes in size.
-        private static final int HISTO_BUCKET_COUNT = 1 << HISTO_MAX_BUCKET_SHIFT - HISTO_MIN_BUCKET_SHIFT;
+        private static final int HISTO_BUCKET_COUNT = 1 + HISTO_MAX_BUCKET_SHIFT - HISTO_MIN_BUCKET_SHIFT; // 8 buckets
         private static final int HISTO_MAX_BUCKET_MASK = HISTO_BUCKET_COUNT - 1;
 
         protected final AdaptablePoolingAllocator parent;

--- a/buffer/src/main/java/io/netty5/buffer/adapt/AdaptablePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/adapt/AdaptablePoolingAllocator.java
@@ -186,6 +186,9 @@ public class AdaptablePoolingAllocator implements BufferAllocator {
     }
 
     private boolean tryExpandMagazines(int currentLength) {
+        if (currentLength >= MAX_STRIPES) {
+            return true;
+        }
         long writeLock = magazineExpandLock.tryWriteLock();
         if (writeLock != 0) {
             try {

--- a/buffer/src/main/java/io/netty5/buffer/adapt/AdaptablePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/adapt/AdaptablePoolingAllocator.java
@@ -1,0 +1,397 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.buffer.adapt;
+
+import io.netty5.buffer.AllocationType;
+import io.netty5.buffer.AllocatorControl;
+import io.netty5.buffer.Buffer;
+import io.netty5.buffer.BufferAllocator;
+import io.netty5.buffer.Drop;
+import io.netty5.buffer.MemoryManager;
+import io.netty5.buffer.StandardAllocationTypes;
+import io.netty5.buffer.internal.ArcDrop;
+import io.netty5.buffer.internal.CleanerDrop;
+import io.netty5.buffer.internal.InternalBufferUtils;
+import io.netty5.util.internal.PlatformDependent;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.VarHandle;
+import java.util.Arrays;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.locks.StampedLock;
+import java.util.function.Supplier;
+
+import static io.netty5.buffer.internal.InternalBufferUtils.allocatorClosedException;
+import static io.netty5.buffer.internal.InternalBufferUtils.standardDrop;
+
+public class AdaptablePoolingAllocator implements BufferAllocator {
+    private static final int RETIRE_CAPACITY = 4 * 1024;
+    private static final int DEFAULT_MIN_CHUNK_SIZE = 128 * 1028;
+    private static final int MAX_STRIPES = Runtime.getRuntime().availableProcessors() * 2;
+    private static final MethodHandle THREAD_ID = getThreadIdMethodHandle();
+
+    private static MethodHandle getThreadIdMethodHandle() {
+        try {
+            if (PlatformDependent.javaVersion() < 19) {
+                return MethodHandles.lookup().findVirtual(Thread.class, "getId", MethodType.methodType(long.class));
+            }
+            return MethodHandles.lookup().findVirtual(Thread.class, "threadId", MethodType.methodType(long.class));
+        } catch (Exception e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    private final AllocationType allocationType;
+    private final MemoryManager manager;
+    private final ConcurrentLinkedQueue<Buffer> centralQueue;
+    private final AllocatorControl allocatorControl;
+    private final StampedLock magazineExpandLock;
+    private volatile Magazine[] magazines;
+    private volatile boolean closed;
+
+    public AdaptablePoolingAllocator(boolean direct) {
+        this(MemoryManager.instance(), direct);
+    }
+
+    public AdaptablePoolingAllocator(MemoryManager manager, boolean direct) {
+        allocationType = direct ? StandardAllocationTypes.OFF_HEAP : StandardAllocationTypes.ON_HEAP;
+        this.manager = manager;
+        centralQueue = new ConcurrentLinkedQueue<>();
+        allocatorControl = new SimpleAllocatorControl(this);
+        magazineExpandLock = new StampedLock();
+        Magazine[] mags = new Magazine[4];
+        for (int i = 0; i < mags.length; i++) {
+            mags[i] = new Magazine(this);
+        }
+        magazines = mags;
+    }
+
+    @Override
+    public boolean isPooling() {
+        return true;
+    }
+
+    @Override
+    public AllocationType getAllocationType() {
+        return allocationType;
+    }
+
+    @Override
+    public Buffer allocate(int size) {
+        if (closed) {
+            throw allocatorClosedException();
+        }
+        InternalBufferUtils.assertValidBufferSize(size);
+        int expansions = 0;
+        do {
+            Magazine[] mags = magazines;
+            int mask = mags.length - 1;
+            int index = (int) (threadId(Thread.currentThread()) & mask);
+            for (int i = 0, m = Integer.numberOfTrailingZeros(~mask); i < m; i++) {
+                Magazine mag = mags[index + i & mask];
+                long writeLock = mag.tryWriteLock();
+                if (writeLock != 0) {
+                    try {
+                        return mag.allocate(size);
+                    } finally {
+                        mag.unlockWrite(writeLock);
+                    }
+                }
+            }
+            tryExpandMagazines();
+            expansions++;
+        } while (expansions < 3);
+        // The magazines failed us. Allocate unpooled buffer.
+        return manager.allocateShared(allocatorControl, size, standardDrop(manager), allocationType);
+    }
+
+    private static long threadId(Thread thread) {
+        try {
+            return (long) THREAD_ID.invokeExact(thread);
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void tryExpandMagazines() {
+        long writeLock = magazineExpandLock.tryWriteLock();
+        if (writeLock != 0) {
+            try {
+                Magazine[] mags = magazines;
+                if (mags.length >= MAX_STRIPES) {
+                    return;
+                }
+                Magazine[] expanded = Arrays.copyOf(mags, mags.length * 2);
+                for (int i = mags.length, m = expanded.length; i < m; i++) {
+                    expanded[i] = new Magazine(this);
+                }
+                magazines = expanded;
+            } finally {
+                magazineExpandLock.unlockWrite(writeLock);
+            }
+        }
+    }
+
+    @Override
+    public Supplier<Buffer> constBufferSupplier(byte[] bytes) {
+        if (closed) {
+            throw allocatorClosedException();
+        }
+        Buffer constantBuffer = manager.allocateShared(
+                allocatorControl, bytes.length, drop -> CleanerDrop.wrapWithoutLeakDetection(drop, manager),
+                allocationType);
+        constantBuffer.writeBytes(bytes).makeReadOnly();
+        return () -> manager.allocateConstChild(constantBuffer);
+    }
+
+    @Override
+    public void close() {
+        closed = true;
+        long magsExpandWriteLock = magazineExpandLock.writeLock();
+        try {
+            for (Magazine mag : magazines) {
+                long writeLock = mag.writeLock();
+                try {
+                    mag.close();
+                } finally {
+                    mag.unlockWrite(writeLock);
+                }
+            }
+        } finally {
+            magazineExpandLock.unlockWrite(magsExpandWriteLock);
+        }
+        drainCloseCentralQueue();
+    }
+
+    private void drainCloseCentralQueue() {
+        Buffer curr;
+        while ((curr = centralQueue.poll()) != null) {
+            curr.close();
+        }
+    }
+
+    private void offerToQueue(Buffer buffer) {
+        centralQueue.offer(buffer);
+        if (closed) {
+            drainCloseCentralQueue();
+        }
+    }
+
+    private static final class Magazine extends StampedLock {
+        private static final long serialVersionUID = -4068223712022528165L;
+        private static final VarHandle NEXT_IN_LINE;
+
+        static {
+            try {
+                NEXT_IN_LINE = MethodHandles.lookup().findVarHandle(Magazine.class, "nextInLine", Buffer.class);
+            } catch (NoSuchFieldException | IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        private final AdaptablePoolingAllocator parent;
+        private Buffer current;
+        @SuppressWarnings("unused") // updated via VarHandle
+        private volatile Buffer nextInLine;
+
+        Magazine(AdaptablePoolingAllocator parent) {
+            this.parent = parent;
+        }
+
+        public Buffer allocate(int size) {
+            recordAllocationSize(size);
+            Buffer curr = current;
+            if (curr != null && curr.capacity() >= size) {
+                if (curr.capacity() == size) {
+                    current = null;
+                    return curr;
+                }
+                return curr.split(size);
+            }
+            if (curr != null) {
+                curr.close();
+            }
+            if (nextInLine != null) {
+                curr = (Buffer) NEXT_IN_LINE.getAndSet(this, (Buffer) null);
+            } else {
+                curr = parent.centralQueue.poll();
+                if (curr == null) {
+                    curr = newChunkAllocation(size);
+                }
+            }
+            current = curr;
+            final Buffer result;
+            if (curr.capacity() > size) {
+                result = curr.split(size);
+            } else if (curr.capacity() == size) {
+                result = curr;
+                current = null;
+            } else {
+                Buffer buffer = newChunkAllocation(size);
+                result = buffer.split(size);
+                if (curr.capacity() < RETIRE_CAPACITY) {
+                    curr.close();
+                    current = buffer;
+                } else if (!(boolean) NEXT_IN_LINE.compareAndSet(this, null, buffer)) {
+                    parent.offerToQueue(buffer);
+                }
+            }
+            return result;
+        }
+
+        private final short[][] histo = {
+           new short[16], new short[16], new short[16], new short[16],
+        };
+        private final short[] sums = new short[16];
+
+        private int histoIndex;
+        private int histoCount;
+        private volatile int prefChunkSize = DEFAULT_MIN_CHUNK_SIZE;
+        private void recordAllocationSize(int size) {
+            int normalizedSize = size - 1 >> 6 & (1 << 15) - 1;
+            int bucket = Integer.SIZE - Integer.numberOfLeadingZeros(normalizedSize);
+            histo[histoIndex][bucket] += 1;
+            if (histoCount == 10_000) {
+                rotateHistograms(bucket);
+            }
+            histoCount++;
+        }
+
+        private void rotateHistograms(int bucket) {
+            Arrays.fill(sums, (short) 0);
+            int sum = 0;
+            for (short[] buckets : histo) {
+                int len = buckets.length;
+                for (int i = 0; i < len; i++) {
+                    sums[i] += buckets[i];
+                    sum  += buckets[i];
+                }
+            }
+            int targetPercentile = (int) (sum * 0.99);
+            int sizeBucket = 0;
+            for (; sizeBucket < sums.length; sizeBucket++) {
+                if (sums[sizeBucket] > targetPercentile) {
+                    break;
+                }
+                targetPercentile -= sums[sizeBucket];
+            }
+            int percentileSize = 1 << bucket + 6;
+            prefChunkSize = Math.max(percentileSize * 10, DEFAULT_MIN_CHUNK_SIZE);
+
+            histoIndex = histoIndex + 1 & histo.length - 1;
+            Arrays.fill(histo[histoIndex], (short) 0);
+        }
+
+        /**
+         * Get the preferred chunk size, based on statistics from the {@linkplain #recordAllocationSize(int) recorded}
+         * allocation sizes.
+         * <p>
+         * This method must be thread-safe.
+         *
+         * @return The currently preferred chunk allocation size.
+         */
+        private int preferredChunkSize() {
+            return prefChunkSize;
+        }
+
+        private Buffer newChunkAllocation(int promptingSize) {
+            int size = Math.max(promptingSize * 10, preferredChunkSize());
+            return parent.manager.allocateShared(parent.allocatorControl, size, this::decorate, parent.allocationType);
+        }
+
+        private Drop<Buffer> decorate(Drop<Buffer> drop) {
+            if (drop instanceof ArcDrop) {
+                drop = ((ArcDrop<Buffer>) drop).unwrap();
+            }
+            return CleanerDrop.wrap(ArcDrop.wrap(new PoolDrop(drop, this)), parent.manager);
+        }
+
+        boolean trySetNextInLine(Buffer buffer) {
+            return (boolean) NEXT_IN_LINE.compareAndSet(this, null, buffer);
+        }
+
+        void close() {
+            Buffer curr = current;
+            if (curr != null) {
+                current = null;
+                curr.close();
+            }
+            curr = (Buffer) NEXT_IN_LINE.getAndSet(this, null);
+            if (curr != null) {
+                curr.close();
+            }
+        }
+    }
+
+    private static final class PoolDrop implements Drop<Buffer> {
+        private final Drop<Buffer> drop;
+        private final Magazine magazine;
+        private Object memory;
+
+        PoolDrop(Drop<Buffer> drop, Magazine magazine) {
+            this.drop = drop;
+            this.magazine = magazine;
+        }
+
+        @Override
+        public void drop(Buffer obj) {
+            Magazine mag = magazine;
+            AdaptablePoolingAllocator parent = mag.parent;
+            MemoryManager manager = parent.manager;
+            int chunkSize = mag.preferredChunkSize();
+            int memSize = manager.sizeOf(memory);
+            if (parent.closed || memSize < chunkSize || memSize > chunkSize + (chunkSize >> 1)) {
+                // Drop the chunk if the parent allocator is closed, or if the chunk is smaller than the
+                // preferred chunk size, or over 50% larger than the preferred chunk size.
+                drop.drop(obj);
+            } else {
+                Buffer buffer = manager.recoverMemory(
+                        parent.allocatorControl, memory, CleanerDrop.wrap(ArcDrop.wrap(this), manager));
+                if (!mag.trySetNextInLine(buffer)) {
+                    parent.offerToQueue(buffer);
+                }
+            }
+        }
+
+        @Override
+        public Drop<Buffer> fork() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void attach(Buffer obj) {
+            if (memory == null) {
+                memory = magazine.parent.manager.unwrapRecoverableMemory(obj);
+            }
+            drop.attach(obj);
+        }
+    }
+
+    private static final class SimpleAllocatorControl implements AllocatorControl {
+        private final BufferAllocator allocator;
+
+        private SimpleAllocatorControl(BufferAllocator allocator) {
+            this.allocator = allocator;
+        }
+
+        @Override
+        public BufferAllocator getAllocator() {
+            return allocator;
+        }
+    }
+}

--- a/buffer/src/main/java/io/netty5/buffer/adapt/AdaptablePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/adapt/AdaptablePoolingAllocator.java
@@ -25,6 +25,7 @@ import io.netty5.buffer.StandardAllocationTypes;
 import io.netty5.buffer.internal.ArcDrop;
 import io.netty5.buffer.internal.CleanerDrop;
 import io.netty5.buffer.internal.InternalBufferUtils;
+import io.netty5.util.NettyRuntime;
 import io.netty5.util.internal.PlatformDependent;
 
 import java.lang.invoke.MethodHandle;
@@ -42,7 +43,7 @@ import static io.netty5.buffer.internal.InternalBufferUtils.standardDrop;
 public class AdaptablePoolingAllocator implements BufferAllocator {
     private static final int RETIRE_CAPACITY = 4 * 1024;
     private static final int DEFAULT_MIN_CHUNK_SIZE = 128 * 1028;
-    private static final int MAX_STRIPES = Runtime.getRuntime().availableProcessors() * 2;
+    private static final int MAX_STRIPES = NettyRuntime.availableProcessors() * 2;
     private static final MethodHandle THREAD_ID = getThreadIdMethodHandle();
 
     private static MethodHandle getThreadIdMethodHandle() {

--- a/buffer/src/main/java/io/netty5/buffer/adapt/AdaptablePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/adapt/AdaptablePoolingAllocator.java
@@ -255,15 +255,15 @@ public class AdaptablePoolingAllocator implements BufferAllocator {
         }
 
         private final short[][] histo = {
-           new short[16], new short[16], new short[16], new short[16],
+           new short[15], new short[15], new short[15], new short[15],
         };
-        private final short[] sums = new short[16];
+        private final short[] sums = new short[15];
 
         private int histoIndex;
         private int histoCount;
         private volatile int prefChunkSize = DEFAULT_MIN_CHUNK_SIZE;
         private void recordAllocationSize(int size) {
-            int normalizedSize = size - 1 >> 6 & (1 << 15) - 1;
+            int normalizedSize = size - 1 >> 6 & (1 << 14) - 1;
             int bucket = Integer.SIZE - Integer.numberOfLeadingZeros(normalizedSize);
             histo[histoIndex][bucket]++;
             if (histoCount == 10_000) {

--- a/buffer/src/main/java/io/netty5/buffer/adapt/AdaptablePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/adapt/AdaptablePoolingAllocator.java
@@ -294,6 +294,7 @@ public class AdaptablePoolingAllocator implements BufferAllocator {
             prefChunkSize = Math.max(percentileSize * 10, DEFAULT_MIN_CHUNK_SIZE);
 
             histoIndex = histoIndex + 1 & histo.length - 1;
+            histoCount = 0;
             Arrays.fill(histo[histoIndex], (short) 0);
         }
 

--- a/buffer/src/main/java/io/netty5/buffer/adapt/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/adapt/AdaptivePoolingAllocator.java
@@ -161,12 +161,13 @@ public class AdaptivePoolingAllocator implements BufferAllocator {
         InternalBufferUtils.assertValidBufferSize(size);
         if (size <= MAX_CHUNK_SIZE) {
             int sizeBucket = AllocationStatistics.sizeBucket(size); // Compute outside of Magazine lock for better ILP.
+            long threadId = threadId(Thread.currentThread());
             int expansions = 0;
             Magazine[] mags;
             do {
                 mags = magazines;
                 int mask = mags.length - 1;
-                int index = (int) (threadId(Thread.currentThread()) & mask);
+                int index = (int) (threadId & mask);
                 for (int i = 0, m = Integer.numberOfTrailingZeros(~mask); i < m; i++) {
                     Magazine mag = mags[index + i & mask];
                     long writeLock = mag.tryWriteLock();

--- a/buffer/src/main/java/io/netty5/buffer/adapt/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/adapt/AdaptivePoolingAllocator.java
@@ -101,6 +101,10 @@ public class AdaptivePoolingAllocator implements BufferAllocator {
     private volatile Magazine[] magazines;
     private volatile boolean closed;
 
+    public AdaptivePoolingAllocator() {
+        this(PlatformDependent.directBufferPreferred());
+    }
+
     public AdaptivePoolingAllocator(boolean direct) {
         this(MemoryManager.instance(), direct);
     }

--- a/buffer/src/main/java/io/netty5/buffer/adapt/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/adapt/AdaptivePoolingAllocator.java
@@ -43,7 +43,7 @@ import static io.netty5.util.internal.PlatformDependent.threadId;
 import static java.util.Objects.requireNonNull;
 
 /**
- * An auto-tuning pooling allocator.
+ * An auto-tuning pooling allocator, that follows an anti-generational hypothesis.
  * <p>
  * The allocator is organized into a list of Magazines, and each magazine has a chunk-buffer that they allocate buffers
  * from.
@@ -64,7 +64,7 @@ import static java.util.Objects.requireNonNull;
  * This allows the allocator to quickly respond to changes in the application workload,
  * without suffering undue overhead from maintaining its statistics.
  * <p>
- * Since magazines "relatively thread-local", the allocator has a central queue that allow excess chunks from any
+ * Since magazines are "relatively thread-local", the allocator has a central queue that allow excess chunks from any
  * magazine, to be shared with other magazines.
  * The {@link #createSharedChunkQueue()} method can be overridden to customize this queue.
  */

--- a/buffer/src/main/java/io/netty5/buffer/adapt/package-info.java
+++ b/buffer/src/main/java/io/netty5/buffer/adapt/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * A pooling {@link io.netty5.buffer.BufferAllocator} implementation that dynamically adapts to the given workload.
+ */
+package io.netty5.buffer.adapt;

--- a/buffer/src/main/java/io/netty5/buffer/bytebuffer/ByteBufferMemoryManager.java
+++ b/buffer/src/main/java/io/netty5/buffer/bytebuffer/ByteBufferMemoryManager.java
@@ -100,6 +100,12 @@ public final class ByteBufferMemoryManager implements MemoryManager {
     }
 
     @Override
+    public int sizeOf(Object memory) {
+        ByteBuffer buffer = (ByteBuffer) memory;
+        return buffer.capacity();
+    }
+
+    @Override
     public String implementationName() {
         return "ByteBuffer";
     }

--- a/buffer/src/main/java/io/netty5/buffer/internal/CleanerDrop.java
+++ b/buffer/src/main/java/io/netty5/buffer/internal/CleanerDrop.java
@@ -88,6 +88,11 @@ public final class CleanerDrop<T extends Buffer> implements Drop<T> {
         return drop;
     }
 
+    public Drop<T> forkWithoutTracingSplit() {
+        return innerWrap(runner.drop.fork(), runner.manager, true);
+
+    }
+
     @Override
     public String toString() {
         return "CleanerDrop(" + runner.drop + ')';

--- a/buffer/src/main/java/io/netty5/buffer/internal/CleanerDrop.java
+++ b/buffer/src/main/java/io/netty5/buffer/internal/CleanerDrop.java
@@ -90,7 +90,6 @@ public final class CleanerDrop<T extends Buffer> implements Drop<T> {
 
     public Drop<T> forkWithoutTracingSplit() {
         return innerWrap(runner.drop.fork(), runner.manager, true);
-
     }
 
     @Override

--- a/buffer/src/main/java/io/netty5/buffer/internal/InternalBufferUtils.java
+++ b/buffer/src/main/java/io/netty5/buffer/internal/InternalBufferUtils.java
@@ -23,6 +23,7 @@ import io.netty5.buffer.Drop;
 import io.netty5.buffer.MemoryManager;
 import io.netty5.util.AsciiString;
 import io.netty5.util.internal.PlatformDependent;
+import org.jetbrains.annotations.NotNull;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -135,12 +136,22 @@ public interface InternalBufferUtils {
      */
     static void assertValidBufferSize(long size) {
         if (size < 0) {
-            throw new IllegalArgumentException("Buffer size must not be negative, but was " + size + '.');
+            throw bufferSizeNegative(size);
         }
         if (size > MAX_BUFFER_SIZE) {
-            throw new IllegalArgumentException(
-                    "Buffer size cannot be greater than " + MAX_BUFFER_SIZE + ", but was " + size + '.');
+            throw bufferSizeTooBig(size);
         }
+    }
+
+    @NotNull
+    private static IllegalArgumentException bufferSizeNegative(long size) {
+        return new IllegalArgumentException("Buffer size must not be negative, but was " + size + '.');
+    }
+
+    @NotNull
+    private static IllegalArgumentException bufferSizeTooBig(long size) {
+        return new IllegalArgumentException(
+                "Buffer size cannot be greater than " + MAX_BUFFER_SIZE + ", but was " + size + '.');
     }
 
     static void checkImplicitCapacity(int implicitCapacity, int currentCapacity) {

--- a/buffer/src/main/java/io/netty5/buffer/internal/InternalBufferUtils.java
+++ b/buffer/src/main/java/io/netty5/buffer/internal/InternalBufferUtils.java
@@ -20,6 +20,7 @@ import io.netty5.buffer.BufferClosedException;
 import io.netty5.buffer.BufferComponent;
 import io.netty5.buffer.BufferReadOnlyException;
 import io.netty5.buffer.Drop;
+import io.netty5.buffer.LeakInfo;
 import io.netty5.buffer.MemoryManager;
 import io.netty5.util.AsciiString;
 import io.netty5.util.internal.PlatformDependent;
@@ -34,6 +35,7 @@ import java.lang.ref.Cleaner;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Function;
 
@@ -208,6 +210,7 @@ public interface InternalBufferUtils {
         return bbsliceFallback(buffer, fromOffset, length);
     }
 
+    @SuppressWarnings("DataFlowIssue")
     private static ByteBuffer bbsliceJdk13(ByteBuffer buffer, int fromOffset, int length) {
         try {
             return (ByteBuffer) BB_SLICE_OFFSETS.invokeExact(buffer, fromOffset, length);
@@ -336,6 +339,10 @@ public interface InternalBufferUtils {
 
     static <E extends Throwable> E attachTrace(ResourceSupport<?, ?> obj, E throwable) {
         return ResourceSupport.getTracer(obj).attachTrace(throwable);
+    }
+
+    static Collection<LeakInfo.TracePoint> collectLifecycleTrace(ResourceSupport<?, ?> obj) {
+        return ResourceSupport.getTracer(obj).collectTraces();
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/buffer/src/main/java/io/netty5/buffer/internal/LifecycleTracer.java
+++ b/buffer/src/main/java/io/netty5/buffer/internal/LifecycleTracer.java
@@ -99,11 +99,11 @@ public abstract class LifecycleTracer {
 
     /**
      * Attach a trace to both life-cycles, that a single life-cycle has been split into two.
-     *
+     * <p>
      * Such branches happen when two views are created to share a single underlying resource.
      * The most prominent example of this is the {@link Buffer#split()} method, where a buffer is broken into two that
      * each covers a non-overlapping region of the original memory.
-     *
+     * <p>
      * This method is called on the originating, or "parent" tracer, while the newly allocated "child" is given as an
      * argument.
      *
@@ -317,6 +317,20 @@ public abstract class LifecycleTracer {
         @Override
         public Throwable traceback() {
             return getTraceback(System.nanoTime(), true);
+        }
+
+        @Override
+        public String eventName() {
+            return type.name();
+        }
+
+        @Override
+        public String toString() {
+            Object hint = hint();
+            if (hint != null) {
+                return "Trace[" + type.name() + ", " + hint + ']';
+            }
+            return "Trace[" + type.name() + ']';
         }
 
         private Traceback getTraceback(long timestamp, boolean recurse) {

--- a/buffer/src/main/java/io/netty5/buffer/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/unsafe/UnsafeBuffer.java
@@ -541,7 +541,7 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
         // Release the old memory, and install the new memory:
         Drop<UnsafeBuffer> drop = buffer.unsafeGetDrop();
         disconnectDrop(drop);
-        attachNewMemory(buffer.memory, drop);
+        attachNewMemory(buffer, drop);
         return this;
     }
 
@@ -556,13 +556,13 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
         return drop;
     }
 
-    private void attachNewMemory(UnsafeMemory memory, Drop<UnsafeBuffer> drop) {
-        this.memory = memory;
-        base = memory.base;
-        baseOffset = 0;
-        address = memory.address;
-        rsize = memory.size;
-        wsize = memory.size;
+    private void attachNewMemory(UnsafeBuffer source, Drop<UnsafeBuffer> drop) {
+        memory = source.memory;
+        base = source.base;
+        baseOffset = source.baseOffset;
+        address = source.address;
+        rsize = source.rsize;
+        wsize = source.wsize;
         drop.attach(this);
     }
 

--- a/buffer/src/main/java/io/netty5/buffer/unsafe/UnsafeMemoryManager.java
+++ b/buffer/src/main/java/io/netty5/buffer/unsafe/UnsafeMemoryManager.java
@@ -129,6 +129,11 @@ public final class UnsafeMemoryManager implements MemoryManager {
     }
 
     @Override
+    public int sizeOf(Object memory) {
+        return ((UnsafeMemory) memory).size;
+    }
+
+    @Override
     public String implementationName() {
         return "Unsafe";
     }

--- a/buffer/src/test/java/io/netty5/buffer/tests/BufferAllocateTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/tests/BufferAllocateTest.java
@@ -17,9 +17,14 @@ package io.netty5.buffer.tests;
 
 import io.netty5.buffer.Buffer;
 import io.netty5.buffer.BufferAllocator;
+import io.netty5.buffer.adapt.AdaptivePoolingAllocator;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -57,6 +62,22 @@ public class BufferAllocateTest extends BufferTestSupport {
              Buffer buf2 = allocator.allocate(size)) {
             assertThat(buf.capacity()).isGreaterThanOrEqualTo(size);
             assertThat(buf2.capacity()).isGreaterThanOrEqualTo(size);
+        }
+    }
+
+    @Test
+    public void allocateToUseManyChunks() {
+        try (BufferAllocator allocator = new AdaptivePoolingAllocator()) {
+            List<Buffer> buffers = new ArrayList<>();
+            for (int iteration = 0; iteration < 10; iteration++) {
+                for (int i = 0; i < 16384; i++) {
+                    buffers.add(allocator.allocate(256));
+                }
+                for (Buffer buffer : buffers) {
+                    buffer.close();
+                }
+                buffers.clear();
+            }
         }
     }
 }

--- a/buffer/src/test/java/io/netty5/buffer/tests/BufferAllocateTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/tests/BufferAllocateTest.java
@@ -69,15 +69,13 @@ public class BufferAllocateTest extends BufferTestSupport {
     public void allocateToUseManyChunks() {
         try (BufferAllocator allocator = new AdaptivePoolingAllocator()) {
             List<Buffer> buffers = new ArrayList<>();
-            for (int iteration = 0; iteration < 10; iteration++) {
-                for (int i = 0; i < 16384; i++) {
-                    buffers.add(allocator.allocate(256));
-                }
-                for (Buffer buffer : buffers) {
-                    buffer.close();
-                }
-                buffers.clear();
+            for (int i = 0; i < 16384; i++) {
+                buffers.add(allocator.allocate(256));
             }
+            for (Buffer buffer : buffers) {
+                buffer.close();
+            }
+            buffers.clear();
         }
     }
 }

--- a/buffer/src/test/java/io/netty5/buffer/tests/BufferLifeCycleTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/tests/BufferLifeCycleTest.java
@@ -903,7 +903,7 @@ public class BufferLifeCycleTest extends BufferTestSupport {
     @MethodSource("initialCombinations")
     void allocatingBuffersMustRecordLifecycleTrace(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-             var ignoreLeakDetection = LeakDetection.onLeakDetected(info -> {}); // Ensure tracing is enabled.
+             var ignoreLeakDetection = LeakDetection.onLeakDetected(info -> { }); // Ensure tracing is enabled.
              Buffer buffer = allocator.allocate(32)) {
             buffer.touch("Second lifecycle event.");
             var tracePoints = InternalBufferUtils.collectLifecycleTrace((ResourceSupport<?, ?>) buffer);

--- a/buffer/src/test/java/io/netty5/buffer/tests/BufferLifeCycleTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/tests/BufferLifeCycleTest.java
@@ -18,6 +18,9 @@ package io.netty5.buffer.tests;
 import io.netty5.buffer.Buffer;
 import io.netty5.buffer.BufferAllocator;
 import io.netty5.buffer.BufferClosedException;
+import io.netty5.buffer.LeakInfo;
+import io.netty5.buffer.internal.InternalBufferUtils;
+import io.netty5.buffer.internal.LeakDetection;
 import io.netty5.buffer.internal.ResourceSupport;
 import io.netty5.util.internal.EmptyArrays;
 import org.junit.jupiter.api.Test;
@@ -894,5 +897,18 @@ public class BufferLifeCycleTest extends BufferTestSupport {
         assertThrows(IllegalStateException.class, () -> allocator.constBufferSupplier(new byte[8]));
         // Existing const suppliers continue to work because they hold on to static memory allocation.
         supplier.get().close();
+    }
+
+    @ParameterizedTest
+    @MethodSource("initialCombinations")
+    void allocatingBuffersMustRecordLifecycleTrace(Fixture fixture) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             var ignoreLeakDetection = LeakDetection.onLeakDetected(info -> {}); // Ensure tracing is enabled.
+             Buffer buffer = allocator.allocate(32)) {
+            buffer.touch("Second lifecycle event.");
+            var tracePoints = InternalBufferUtils.collectLifecycleTrace((ResourceSupport<?, ?>) buffer);
+            var eventNames = tracePoints.stream().map(LeakInfo.TracePoint::eventName);
+            assertThat(eventNames).containsExactly("ALLOCATE", "TOUCH");
+        }
     }
 }

--- a/buffer/src/test/java/io/netty5/buffer/tests/BufferTestSupport.java
+++ b/buffer/src/test/java/io/netty5/buffer/tests/BufferTestSupport.java
@@ -22,7 +22,7 @@ import io.netty5.buffer.BufferClosedException;
 import io.netty5.buffer.CompositeBuffer;
 import io.netty5.buffer.MemoryManager;
 import io.netty5.buffer.SensitiveBufferAllocator;
-import io.netty5.buffer.adapt.AdaptablePoolingAllocator;
+import io.netty5.buffer.adapt.AdaptivePoolingAllocator;
 import io.netty5.buffer.internal.ResourceSupport;
 import io.netty5.buffer.pool.PooledBufferAllocator;
 import io.netty5.buffer.tests.Fixture.Properties;
@@ -152,8 +152,8 @@ public abstract class BufferTestSupport {
                                 PooledBufferAllocator.defaultMaxOrder(), PooledBufferAllocator.defaultSmallCacheSize(),
                                 PooledBufferAllocator.defaultNormalCacheSize(), true, 64),
                         POOLED, DIRECT),
-                new Fixture("adaptiveHeap", () -> new AdaptablePoolingAllocator(false), POOLED, HEAP),
-                new Fixture("adaptiveDirect", () -> new AdaptablePoolingAllocator(true), POOLED, DIRECT)
+                new Fixture("adaptiveHeap", () -> new AdaptivePoolingAllocator(false), POOLED, HEAP),
+                new Fixture("adaptiveDirect", () -> new AdaptivePoolingAllocator(true), POOLED, DIRECT)
         );
     }
 

--- a/buffer/src/test/java/io/netty5/buffer/tests/BufferTestSupport.java
+++ b/buffer/src/test/java/io/netty5/buffer/tests/BufferTestSupport.java
@@ -22,6 +22,7 @@ import io.netty5.buffer.BufferClosedException;
 import io.netty5.buffer.CompositeBuffer;
 import io.netty5.buffer.MemoryManager;
 import io.netty5.buffer.SensitiveBufferAllocator;
+import io.netty5.buffer.adapt.AdaptablePoolingAllocator;
 import io.netty5.buffer.internal.ResourceSupport;
 import io.netty5.buffer.pool.PooledBufferAllocator;
 import io.netty5.buffer.tests.Fixture.Properties;
@@ -145,12 +146,14 @@ public abstract class BufferTestSupport {
                 new Fixture("sensitive", SensitiveBufferAllocator::sensitiveOffHeapAllocator, DIRECT, UNCLOSEABLE),
                 new Fixture("pooledHeap", BufferAllocator::onHeapPooled, POOLED, HEAP),
                 new Fixture("pooledDirect", BufferAllocator::offHeapPooled, POOLED, DIRECT),
-                new Fixture("pooledDirect", () ->
+                new Fixture("pooledDirectAlign", () ->
                         new PooledBufferAllocator(MemoryManager.instance(), true,
                                 PooledBufferAllocator.defaultNumDirectArena(), PooledBufferAllocator.defaultPageSize(),
                                 PooledBufferAllocator.defaultMaxOrder(), PooledBufferAllocator.defaultSmallCacheSize(),
                                 PooledBufferAllocator.defaultNormalCacheSize(), true, 64),
-                        POOLED, DIRECT)
+                        POOLED, DIRECT),
+                new Fixture("adaptiveHeap", () -> new AdaptablePoolingAllocator(false), POOLED, HEAP),
+                new Fixture("adaptiveDirect", () -> new AdaptablePoolingAllocator(true), POOLED, DIRECT)
         );
     }
 

--- a/buffer/src/test/java/io/netty5/buffer/tests/CleanerDropTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/tests/CleanerDropTest.java
@@ -221,6 +221,11 @@ public class CleanerDropTest {
         }
 
         @Override
+        public int sizeOf(Object memory) {
+            return manager.sizeOf(memory);
+        }
+
+        @Override
         public String implementationName() {
             return "Leak Tracking " + manager.implementationName();
         }

--- a/buffer/src/test/java/io/netty5/buffer/tests/SensitiveBufferTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/tests/SensitiveBufferTest.java
@@ -175,6 +175,11 @@ public class SensitiveBufferTest {
         }
 
         @Override
+        public int sizeOf(Object memory) {
+            return baseMemoryManager.sizeOf(memory);
+        }
+
+        @Override
         public String implementationName() {
             throw new UnsupportedOperationException();
         }

--- a/common/src/main/java/io/netty5/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty5/util/internal/PlatformDependent.java
@@ -812,7 +812,7 @@ public final class PlatformDependent {
 
     /**
      * Get the ID of the given thread. This is {@code Thread.threadId()} on Java 19 and newer,
-     * or {@code Thread.getd()} on older Java versions.
+     * or {@code Thread.getId()} on older Java versions.
      *
      * @param thread The thread to get the ID from.
      * @return The ID of the given thread.

--- a/common/src/main/java/io/netty5/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty5/util/internal/PlatformDependent.java
@@ -811,6 +811,17 @@ public final class PlatformDependent {
     }
 
     /**
+     * Get the ID of the given thread. This is {@code Thread.threadId()} on Java 19 and newer,
+     * or {@code Thread.getd()} on older Java versions.
+     *
+     * @param thread The thread to get the ID from.
+     * @return The ID of the given thread.
+     */
+    public static long threadId(Thread thread) {
+        return PlatformDependent0.threadId(thread);
+    }
+
+    /**
      * Compare two {@code byte} arrays for equality. For performance reasons no bounds checking on the
      * parameters is performed.
      *

--- a/common/src/main/java/io/netty5/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty5/util/internal/PlatformDependent.java
@@ -15,9 +15,11 @@
  */
 package io.netty5.util.internal;
 
+import org.jctools.queues.MpmcArrayQueue;
 import org.jctools.queues.MpscArrayQueue;
 import org.jctools.queues.MpscChunkedArrayQueue;
 import org.jctools.queues.MpscUnboundedArrayQueue;
+import org.jctools.queues.atomic.MpmcAtomicArrayQueue;
 import org.jctools.queues.atomic.MpscAtomicArrayQueue;
 import org.jctools.queues.atomic.MpscChunkedAtomicArrayQueue;
 import org.jctools.queues.atomic.MpscUnboundedAtomicArrayQueue;
@@ -943,8 +945,8 @@ public final class PlatformDependent {
         return hash;
     }
 
-    private static final class Mpsc {
-        private static final boolean USE_MPSC_CHUNKED_ARRAY_QUEUE;
+    private static final class QueueChoice {
+        private static final boolean USE_CHUNKED_ARRAY_QUEUES;
 
         static {
             Object unsafe = null;
@@ -960,10 +962,10 @@ public final class PlatformDependent {
 
             if (unsafe == null) {
                 logger.debug("org.jctools-core.MpscChunkedArrayQueue: unavailable");
-                USE_MPSC_CHUNKED_ARRAY_QUEUE = false;
+                USE_CHUNKED_ARRAY_QUEUES = false;
             } else {
                 logger.debug("org.jctools-core.MpscChunkedArrayQueue: available");
-                USE_MPSC_CHUNKED_ARRAY_QUEUE = true;
+                USE_CHUNKED_ARRAY_QUEUES = true;
             }
         }
 
@@ -976,13 +978,27 @@ public final class PlatformDependent {
         }
 
         static <T> Queue<T> newChunkedMpscQueue(final int chunkSize, final int capacity) {
-            return USE_MPSC_CHUNKED_ARRAY_QUEUE ? new MpscChunkedArrayQueue<>(chunkSize, capacity)
-                    : new MpscChunkedAtomicArrayQueue<>(chunkSize, capacity);
+            return USE_CHUNKED_ARRAY_QUEUES ?
+                    new MpscChunkedArrayQueue<>(chunkSize, capacity) :
+                    new MpscChunkedAtomicArrayQueue<>(chunkSize, capacity);
+        }
+
+        static <T> Queue<T> newMpmcQueue(final int capacity) {
+            return hasUnsafe() ? new MpmcArrayQueue<>(capacity) : new MpmcAtomicArrayQueue<>(capacity);
         }
 
         static <T> Queue<T> newMpscQueue() {
-            return USE_MPSC_CHUNKED_ARRAY_QUEUE ? new MpscUnboundedArrayQueue<>(MPSC_CHUNK_SIZE)
-                                                : new MpscUnboundedAtomicArrayQueue<>(MPSC_CHUNK_SIZE);
+            return USE_CHUNKED_ARRAY_QUEUES ?
+                    new MpscUnboundedArrayQueue<>(MPSC_CHUNK_SIZE) :
+                    new MpscUnboundedAtomicArrayQueue<>(MPSC_CHUNK_SIZE);
+        }
+
+        static <T> Queue<T> newSpscQueue() {
+            return hasUnsafe() ? new SpscLinkedUnpaddedQueue<>() : new SpscLinkedAtomicQueue<>();
+        }
+
+        static <T> Queue<T> newFixedMpscQueue(int capacity) {
+            return hasUnsafe() ? new MpscArrayQueue<>(capacity) : new MpscAtomicArrayQueue<>(capacity);
         }
     }
 
@@ -992,7 +1008,7 @@ public final class PlatformDependent {
      * @return A MPSC queue which may be unbounded.
      */
     public static <T> Queue<T> newMpscQueue() {
-        return Mpsc.newMpscQueue();
+        return QueueChoice.newMpscQueue();
     }
 
     /**
@@ -1000,7 +1016,7 @@ public final class PlatformDependent {
      * consumer (one thread!).
      */
     public static <T> Queue<T> newMpscQueue(final int maxCapacity) {
-        return Mpsc.newMpscQueue(maxCapacity);
+        return QueueChoice.newMpscQueue(maxCapacity);
     }
 
     /**
@@ -1009,7 +1025,14 @@ public final class PlatformDependent {
      * The queue will grow and shrink its capacity in units of the given chunk size.
      */
     public static <T> Queue<T> newMpscQueue(final int chunkSize, final int maxCapacity) {
-        return Mpsc.newChunkedMpscQueue(chunkSize, maxCapacity);
+        return QueueChoice.newChunkedMpscQueue(chunkSize, maxCapacity);
+    }
+
+    /**
+     * Create a multi-producer, multi-consumer queue with the given capacity.
+     */
+    public static <T> Queue<T> newMpmcQueue(final int capacity) {
+        return QueueChoice.newMpmcQueue(capacity);
     }
 
     /**
@@ -1017,7 +1040,7 @@ public final class PlatformDependent {
      * consumer (one thread!).
      */
     public static <T> Queue<T> newSpscQueue() {
-        return hasUnsafe() ? new SpscLinkedUnpaddedQueue<>() : new SpscLinkedAtomicQueue<>();
+        return QueueChoice.newSpscQueue();
     }
 
     /**
@@ -1025,7 +1048,7 @@ public final class PlatformDependent {
      * consumer (one thread!) with the given fixes {@code capacity}.
      */
     public static <T> Queue<T> newFixedMpscQueue(int capacity) {
-        return hasUnsafe() ? new MpscArrayQueue<>(capacity) : new MpscAtomicArrayQueue<>(capacity);
+        return QueueChoice.newFixedMpscQueue(capacity);
     }
 
     /**

--- a/common/src/main/java/io/netty5/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty5/util/internal/PlatformDependent0.java
@@ -35,6 +35,8 @@ import java.util.Arrays;
 import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static java.lang.invoke.MethodHandles.lookup;
+
 /**
  * The {@link PlatformDependent} operations which requires access to {@code sun.misc.*}.
  */
@@ -50,6 +52,7 @@ final class PlatformDependent0 {
     private static final MethodHandle DIRECT_BUFFER_CONSTRUCTOR_HANDLE;
     private static final Throwable EXPLICIT_NO_UNSAFE_CAUSE = explicitNoUnsafeCause0();
     private static final MethodHandle ALLOCATE_ARRAY_HANDLE;
+    private static final MethodHandle THREAD_ID;
     private static final int JAVA_VERSION = javaVersion0();
     private static final boolean IS_ANDROID = isAndroid0();
 
@@ -215,7 +218,7 @@ final class PlatformDependent0 {
                                                 if (cause != null) {
                                                     return cause;
                                                 }
-                                                MethodHandle constructorHandle = MethodHandles.lookup()
+                                                MethodHandle constructorHandle = lookup()
                                                         .unreflectConstructor(constructor);
                                                 if (constructor.getParameterCount() == 4) {
                                                     Object[] nullArgs = { null };
@@ -345,7 +348,7 @@ final class PlatformDependent0 {
                 final Object finalInternalUnsafe = maybeException;
                 maybeException = AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
                     try {
-                        return MethodHandles.lookup().findVirtual(finalInternalUnsafe.getClass(),
+                        return lookup().findVirtual(finalInternalUnsafe.getClass(),
                                 "allocateUninitializedArray",
                                 MethodType.methodType(Object.class, Class.class, int.class))
                                 .bindTo(finalInternalUnsafe);
@@ -379,6 +382,18 @@ final class PlatformDependent0 {
             }
             ALLOCATE_ARRAY_HANDLE = allocateArrayHandle;
         }
+
+        MethodHandle threadId = null;
+        try {
+            if (PlatformDependent.javaVersion() < 19) {
+                threadId = lookup().findVirtual(Thread.class, "getId", MethodType.methodType(long.class));
+            } else {
+                threadId = lookup().findVirtual(Thread.class, "threadId", MethodType.methodType(long.class));
+            }
+        } catch (Exception e) {
+            logger.debug("threadId method handle unavailable", e);
+        }
+        THREAD_ID = threadId;
 
         logger.debug("java.nio.DirectByteBuffer.<init>(long, {int,long}): {}",
                 DIRECT_BUFFER_CONSTRUCTOR_HANDLE != null ? "available" : "unavailable");
@@ -448,6 +463,17 @@ final class PlatformDependent0 {
         // Just use 1 to make it safe to use in all cases:
         // See: https://pubs.opengroup.org/onlinepubs/009695399/functions/malloc.html
         return newDirectBuffer(UNSAFE.allocateMemory(Math.max(1, capacity)), capacity, null);
+    }
+
+    static long threadId(Thread thread) {
+        if (THREAD_ID == null) {
+            return thread.getId();
+        }
+        try {
+            return (long) THREAD_ID.invokeExact(thread);
+        } catch (Throwable e) {
+            throw new Error(e);
+        }
     }
 
     static boolean hasAllocateArrayMethod() {

--- a/docker/docker-compose.centos-6.111.yaml
+++ b/docker/docker-compose.centos-6.111.yaml
@@ -20,6 +20,9 @@ services:
   build-leak-boringssl-static:
     image: netty:centos-6-1.11
 
+  build-leak-adaptive:
+    image: netty:centos-6-1.11
+
   build-boringssl-snapshot:
     image: netty:centos-6-1.11
 

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -70,6 +70,10 @@ services:
     <<: *common
     command: /bin/bash -cl "./mvnw -PunsafeBuffer clean install -Dio.netty5.testsuite.badHost=netty.io -Dxml.skip=true -Dtcnative.classifier=linux-x86_64-fedora"
 
+  build-leak-adaptive:
+    <<: *common
+    command: /bin/bash -cl "./mvnw -B -ntp -Pboringssl,leak clean install -Dio.netty5.testsuite.badHost=netty.io -Dxml.skip=true -Dio.netty5.allocator.type=adaptive"
+
   build-boringssl-snapshot:
     <<: *common
     command: /bin/bash -cl "./mvnw -B -ntp -pl handler -Pboringssl-snapshot clean package -Dxml.skip=true -Dtcnative.classifier=linux-x86_64"

--- a/microbench/pom.xml
+++ b/microbench/pom.xml
@@ -198,6 +198,11 @@
       <artifactId>jctools-core</artifactId>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk18on</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
   <build>

--- a/microbench/src/main/java/io/netty5/microbench/buffer/BufferAllocatorBenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/buffer/BufferAllocatorBenchmark.java
@@ -18,66 +18,79 @@ package io.netty5.microbench.buffer;
 import io.netty5.buffer.Buffer;
 import io.netty5.buffer.BufferAllocator;
 import io.netty5.buffer.MemoryManager;
+import io.netty5.buffer.adapt.AdaptablePoolingAllocator;
 import io.netty5.buffer.pool.PooledBufferAllocator;
 import io.netty5.microbench.util.AbstractMicrobenchmark;
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import static io.netty5.buffer.DefaultBufferAllocators.preferredAllocator;
 
 /**
  * This class benchmarks different allocators with different allocation sizes.
  */
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
 public class BufferAllocatorBenchmark extends AbstractMicrobenchmark {
 
     private static final BufferAllocator unpooledAllocator = BufferAllocator.offHeapUnpooled();
     private static final BufferAllocator pooledAllocator = new PooledBufferAllocator(
             MemoryManager.instance(), true, 4, 8192, 9, 0, 0, true, 0); // Disable thread-local cache
+    private static final BufferAllocator adaptiveAllocator = new AdaptablePoolingAllocator(true);
 
     private static final int MAX_LIVE_BUFFERS = 8192;
     private static final Random rand = new Random();
-    private static final Buffer[] unpooledHeapBuffers = new Buffer[MAX_LIVE_BUFFERS];
-    private static final Buffer[] unpooledDirectBuffers = new Buffer[MAX_LIVE_BUFFERS];
-    private static final Buffer[] pooledHeapBuffers = new Buffer[MAX_LIVE_BUFFERS];
-    private static final Buffer[] pooledDirectBuffers = new Buffer[MAX_LIVE_BUFFERS];
-    private static final Buffer[] defaultPooledHeapBuffers = new Buffer[MAX_LIVE_BUFFERS];
-    private static final Buffer[] defaultPooledDirectBuffers = new Buffer[MAX_LIVE_BUFFERS];
+    private static final Buffer[] unpooledBuffers = new Buffer[MAX_LIVE_BUFFERS];
+    private static final Buffer[] pooledBuffers = new Buffer[MAX_LIVE_BUFFERS];
+    private static final Buffer[] pooledAdaptiveBuffers = new Buffer[MAX_LIVE_BUFFERS];
+    private static final Buffer[] defaultPooledBuffers = new Buffer[MAX_LIVE_BUFFERS];
 
     @Param({ "00000", "00256", "01024", "04096", "16384", "65536" })
     public int size;
 
     @Benchmark
     public void unpooledAllocAndFree() {
-        int idx = rand.nextInt(unpooledHeapBuffers.length);
-        Buffer oldBuf = unpooledHeapBuffers[idx];
+        int idx = rand.nextInt(unpooledBuffers.length);
+        Buffer oldBuf = unpooledBuffers[idx];
         if (oldBuf != null) {
             oldBuf.close();
         }
-        unpooledHeapBuffers[idx] = unpooledAllocator.allocate(size);
+        unpooledBuffers[idx] = unpooledAllocator.allocate(size);
     }
 
     @Benchmark
     public void pooledAllocAndFree() {
-        int idx = rand.nextInt(pooledHeapBuffers.length);
-        Buffer oldBuf = pooledHeapBuffers[idx];
+        int idx = rand.nextInt(pooledBuffers.length);
+        Buffer oldBuf = pooledBuffers[idx];
         if (oldBuf != null) {
             oldBuf.close();
         }
-        pooledHeapBuffers[idx] = pooledAllocator.allocate(size);
+        pooledBuffers[idx] = pooledAllocator.allocate(size);
+    }
+
+    @Benchmark
+    public void adaptiveAllocAndFree() {
+        int idx = rand.nextInt(pooledAdaptiveBuffers.length);
+        Buffer oldBuf = pooledAdaptiveBuffers[idx];
+        if (oldBuf != null) {
+            oldBuf.close();
+        }
+        pooledAdaptiveBuffers[idx] = adaptiveAllocator.allocate(size);
     }
 
     @Benchmark
     public void defaultPooledAllocAndFree() {
-        int idx = rand.nextInt(defaultPooledHeapBuffers.length);
-        Buffer oldBuf = defaultPooledHeapBuffers[idx];
+        int idx = rand.nextInt(defaultPooledBuffers.length);
+        Buffer oldBuf = defaultPooledBuffers[idx];
         if (oldBuf != null) {
             oldBuf.close();
         }
-        defaultPooledHeapBuffers[idx] = preferredAllocator().allocate(size);
+        defaultPooledBuffers[idx] = preferredAllocator().allocate(size);
     }
 }

--- a/microbench/src/main/java/io/netty5/microbench/buffer/BufferAllocatorBenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/buffer/BufferAllocatorBenchmark.java
@@ -18,7 +18,7 @@ package io.netty5.microbench.buffer;
 import io.netty5.buffer.Buffer;
 import io.netty5.buffer.BufferAllocator;
 import io.netty5.buffer.MemoryManager;
-import io.netty5.buffer.adapt.AdaptablePoolingAllocator;
+import io.netty5.buffer.adapt.AdaptivePoolingAllocator;
 import io.netty5.buffer.pool.PooledBufferAllocator;
 import io.netty5.microbench.util.AbstractMicrobenchmark;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -42,7 +42,7 @@ public class BufferAllocatorBenchmark extends AbstractMicrobenchmark {
     private static final BufferAllocator unpooledAllocator = BufferAllocator.offHeapUnpooled();
     private static final BufferAllocator pooledAllocator = new PooledBufferAllocator(
             MemoryManager.instance(), true, 4, 8192, 9, 0, 0, true, 0); // Disable thread-local cache
-    private static final BufferAllocator adaptiveAllocator = new AdaptablePoolingAllocator(true);
+    private static final BufferAllocator adaptiveAllocator = new AdaptivePoolingAllocator(true);
 
     private static final int MAX_LIVE_BUFFERS = 8192;
     private static final Random rand = new Random();

--- a/microbench/src/main/java/io/netty5/microbench/buffer/BufferAllocatorConcurrentBenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/buffer/BufferAllocatorConcurrentBenchmark.java
@@ -16,7 +16,7 @@
 package io.netty5.microbench.buffer;
 
 import io.netty5.buffer.BufferAllocator;
-import io.netty5.buffer.adapt.AdaptablePoolingAllocator;
+import io.netty5.buffer.adapt.AdaptivePoolingAllocator;
 import io.netty5.microbench.util.AbstractMicrobenchmark;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
@@ -34,7 +34,7 @@ public class BufferAllocatorConcurrentBenchmark extends AbstractMicrobenchmark {
 
     private static final BufferAllocator unpooledAllocator = BufferAllocator.offHeapUnpooled();
     private static final BufferAllocator pooledAllocator = BufferAllocator.offHeapPooled();
-    private static final BufferAllocator adaptiveAllocator = new AdaptablePoolingAllocator(true);
+    private static final BufferAllocator adaptiveAllocator = new AdaptivePoolingAllocator(true);
 
     @Param({ "00064"/*, "00256", "01024", "04096"*/ })
     public int size;

--- a/microbench/src/main/java/io/netty5/microbench/buffer/BufferAllocatorConcurrentBenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/buffer/BufferAllocatorConcurrentBenchmark.java
@@ -16,28 +16,41 @@
 package io.netty5.microbench.buffer;
 
 import io.netty5.buffer.BufferAllocator;
+import io.netty5.buffer.adapt.AdaptablePoolingAllocator;
 import io.netty5.microbench.util.AbstractMicrobenchmark;
 import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Threads;
-import org.openjdk.jmh.annotations.Warmup;
 
+import java.util.concurrent.TimeUnit;
+
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
-@Warmup(iterations = 5)
-@Measurement(iterations = 10)
 @Threads(8)
 public class BufferAllocatorConcurrentBenchmark extends AbstractMicrobenchmark {
 
     private static final BufferAllocator unpooledAllocator = BufferAllocator.offHeapUnpooled();
+    private static final BufferAllocator pooledAllocator = BufferAllocator.offHeapPooled();
+    private static final BufferAllocator adaptiveAllocator = new AdaptablePoolingAllocator(true);
 
-    @Param({ "00064", "00256", "01024", "04096" })
+    @Param({ "00064"/*, "00256", "01024", "04096"*/ })
     public int size;
 
     @Benchmark
-    public void allocateRelease() {
+    public void allocateReleaseUnpooled() {
         unpooledAllocator.allocate(size).close();
+    }
+
+    @Benchmark
+    public void allocateReleasePooled() {
+        pooledAllocator.allocate(size).close();
+    }
+
+    @Benchmark
+    public void allocateReleaseAdaptive() {
+        adaptiveAllocator.allocate(size).close();
     }
 }

--- a/microbench/src/main/java/io/netty5/microbench/http2/Http2ThroughputBenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/http2/Http2ThroughputBenchmark.java
@@ -1,0 +1,455 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty5.microbench.http2;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.buffer.Buffer;
+import io.netty5.buffer.BufferAllocator;
+import io.netty5.buffer.adapt.AdaptablePoolingAllocator;
+import io.netty5.channel.Channel;
+import io.netty5.channel.ChannelHandlerContext;
+import io.netty5.channel.ChannelInitializer;
+import io.netty5.channel.ChannelOption;
+import io.netty5.channel.ChannelPipeline;
+import io.netty5.channel.EventLoopGroup;
+import io.netty5.channel.IoHandlerFactory;
+import io.netty5.channel.MultithreadEventLoopGroup;
+import io.netty5.channel.SimpleChannelInboundHandler;
+import io.netty5.channel.nio.NioHandler;
+import io.netty5.channel.socket.ServerSocketChannel;
+import io.netty5.channel.socket.SocketChannel;
+import io.netty5.channel.socket.nio.NioServerSocketChannel;
+import io.netty5.channel.socket.nio.NioSocketChannel;
+import io.netty5.handler.codec.http2.AbstractHttp2ConnectionHandlerBuilder;
+import io.netty5.handler.codec.http2.DefaultHttp2HeadersFrame;
+import io.netty5.handler.codec.http2.Http2ConnectionDecoder;
+import io.netty5.handler.codec.http2.Http2ConnectionEncoder;
+import io.netty5.handler.codec.http2.Http2ConnectionHandler;
+import io.netty5.handler.codec.http2.Http2DataFrame;
+import io.netty5.handler.codec.http2.Http2Flags;
+import io.netty5.handler.codec.http2.Http2FrameCodec;
+import io.netty5.handler.codec.http2.Http2FrameCodecBuilder;
+import io.netty5.handler.codec.http2.Http2FrameListener;
+import io.netty5.handler.codec.http2.Http2HeadersFrame;
+import io.netty5.handler.codec.http2.Http2MultiplexHandler;
+import io.netty5.handler.codec.http2.Http2SecurityUtil;
+import io.netty5.handler.codec.http2.Http2Settings;
+import io.netty5.handler.codec.http2.Http2StreamChannel;
+import io.netty5.handler.codec.http2.Http2StreamChannelBootstrap;
+import io.netty5.handler.codec.http2.Http2StreamFrame;
+import io.netty5.handler.codec.http2.headers.Http2Headers;
+import io.netty5.handler.ssl.SslContext;
+import io.netty5.handler.ssl.SslContextBuilder;
+import io.netty5.handler.ssl.SupportedCipherSuiteFilter;
+import io.netty5.handler.ssl.util.InsecureTrustManagerFactory;
+import io.netty5.handler.ssl.util.SelfSignedCertificate;
+import io.netty5.microbench.util.AbstractMicrobenchmark;
+import io.netty5.util.concurrent.Future;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLException;
+import java.lang.reflect.Method;
+import java.net.SocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.security.cert.CertificateException;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+import static io.netty5.handler.codec.http.HttpResponseStatus.OK;
+import static io.netty5.handler.ssl.SslProvider.OPENSSL;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+
+@Warmup(iterations = 20, time = 1)
+@Measurement(iterations = 20, time = 1)
+@Threads(1)
+@State(Scope.Benchmark)
+public class Http2ThroughputBenchmark extends AbstractMicrobenchmark {
+    private static final Logger logger = LoggerFactory.getLogger(Http2ThroughputBenchmark.class);
+    private static final BufferAllocator pooled = BufferAllocator.offHeapPooled();
+    private static final BufferAllocator adaptive = new AdaptablePoolingAllocator(true);
+
+    @Param({"true", "false"})
+    public boolean ssl;
+
+    @Param("nio")
+    public Transport transport;
+
+    @Param({"adaptive", "pooled"})
+    public String allocatorConfig;
+
+    private Channel serverChannel;
+    private EventLoopGroup serverGroup;
+    private BufferAllocator allocator;
+    private SocketAddress serverAddress;
+    private EventLoopGroup clientGroup;
+    private Channel clientChannel;
+    private Http2StreamChannel clientStreamChannel;
+    private Semaphore clientResponse;
+    private Http2ClientStreamFrameResponseHandler streamFrameResponseHandler;
+    private IoHandlerFactory handlerFactory;
+    private Bootstrap cb;
+
+    public enum Transport {
+        nio, epoll, kqueue, io_uring
+    }
+
+    @Setup(Level.Trial)
+    public void setupTrial() throws Exception {
+        allocator = configureAllocator();
+
+        // Configure the server.
+        handlerFactory = getHandlerFactory();
+        serverGroup = new MultithreadEventLoopGroup(threadFactory("server"), handlerFactory);
+        ServerBootstrap sb = new ServerBootstrap();
+        sb.option(ChannelOption.SO_BACKLOG, 1024);
+        sb.option(ChannelOption.BUFFER_ALLOCATOR, allocator);
+        sb.childOption(ChannelOption.BUFFER_ALLOCATOR, allocator);
+        sb.group(serverGroup)
+                .channel(serverChannelClass())
+                .childHandler(new Http2ServerInitializer(configureServerSsl()));
+
+        serverChannel = sb.bind(0).asStage().get();
+        serverAddress = serverChannel.localAddress();
+        logger.debug("Server channel: {}", serverChannel);
+
+        // Configure the client.
+        clientGroup = new MultithreadEventLoopGroup(threadFactory("client"), handlerFactory);
+        cb = new Bootstrap();
+        cb.group(clientGroup);
+        cb.channel(clientChannelClass());
+        cb.option(ChannelOption.SO_KEEPALIVE, true);
+        cb.option(ChannelOption.BUFFER_ALLOCATOR, allocator);
+        cb.remoteAddress(serverAddress);
+        cb.handler(new ChannelInitializer<Channel>() {
+            @Override
+            protected void initChannel(Channel ch) throws Exception {
+                ChannelPipeline pipeline = ch.pipeline();
+                SslContext sslContext = configureClientSsl();
+                if (sslContext != null) {
+                    pipeline.addLast(sslContext.newHandler(ch.bufferAllocator()));
+                }
+                final Http2FrameCodec http2FrameCodec = Http2FrameCodecBuilder.forClient().build();
+                ch.pipeline().addLast(http2FrameCodec);
+                ch.pipeline().addLast(new Http2MultiplexHandler(new SimpleChannelInboundHandler<>() {
+                    @Override
+                    protected void messageReceived(ChannelHandlerContext ctx, Object msg) {
+                        // NOOP (this is the handler for 'inbound' streams, which is not relevant in this example)
+                    }
+                }));
+            }
+        });
+
+        // Start the client.
+        clientChannel = cb.connect().asStage().get();
+        logger.debug("Client channel: {}",  clientChannel);
+        clientResponse = new Semaphore(0);
+        streamFrameResponseHandler = new Http2ClientStreamFrameResponseHandler(clientResponse);
+    }
+
+    @Benchmark
+    public void request() throws Exception {
+        final Http2StreamChannelBootstrap streamChannelBootstrap = new Http2StreamChannelBootstrap(clientChannel);
+        clientStreamChannel = streamChannelBootstrap.open().asStage().get();
+        clientStreamChannel.pipeline().addLast(streamFrameResponseHandler);
+
+        // Send request (a HTTP/2 HEADERS frame - with ':method = GET' in this case)
+        final Http2Headers headers = Http2Headers.newHeaders();
+        headers.method("GET");
+        headers.path("/");
+        headers.scheme(ssl? "https" : "http");
+        final Http2HeadersFrame headersFrame = new DefaultHttp2HeadersFrame(headers, true);
+        clientStreamChannel.writeAndFlush(headersFrame);
+
+        // Wait for the responses (or for the latch to expire), then clean up the connections
+        if (!streamFrameResponseHandler.responseSuccessfullyCompleted()) {
+            logger.warn("Did not get HTTP/2 response in expected time.");
+        }
+        clientStreamChannel.close().asStage().get();
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDownTrial() throws InterruptedException {
+        Future<Void> clientClose = clientChannel.close();
+        Future<Void> serverClose = serverChannel.close();
+        try {
+            clientClose.asStage().sync();
+            serverClose.asStage().sync();
+        } finally {
+            clientGroup.shutdownGracefully();
+            serverGroup.shutdownGracefully();
+        }
+    }
+
+    private BufferAllocator configureAllocator() {
+        switch (allocatorConfig) {
+            case "pooled": return pooled;
+            case "adaptive": return adaptive;
+            default: throw new UnsupportedOperationException("Unrecognized allocator: " + allocatorConfig);
+        }
+    }
+
+    private static ThreadFactory threadFactory(String name) {
+        return runnable -> new Thread(runnable, name);
+    }
+
+    private IoHandlerFactory getHandlerFactory() throws Exception {
+        Class<?> factoryClass;
+        switch (transport) {
+            case nio: return NioHandler.newFactory();
+            case epoll: factoryClass = Class.forName("io.netty5.channel.epoll.EpollHandler"); break;
+            case kqueue: factoryClass = Class.forName("io.netty5.channel.kqueue.KQueueHandler"); break;
+            case io_uring: factoryClass = Class.forName("io.netty5.channel.uring.IOUring"); break;
+            default: throw new UnsupportedOperationException("Unrecognized transport: " + transport);
+        }
+        Method newFactory = factoryClass.getDeclaredMethod("newFactory");
+        return (IoHandlerFactory) newFactory.invoke(null);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Class<? extends ServerSocketChannel> serverChannelClass() throws ClassNotFoundException {
+        switch (transport) {
+            case nio: return NioServerSocketChannel.class;
+            case epoll: return (Class<? extends ServerSocketChannel>) Class.forName(
+                    "io.netty5.channel.epoll.EpollServerSocketChannel");
+            case kqueue: return (Class<? extends ServerSocketChannel>) Class.forName(
+                    "io.netty5.channel.kqueue.KQueueServerSocketChannel");
+            case io_uring: return (Class<? extends ServerSocketChannel>) Class.forName(
+                    "io.netty5.channel.uring.IOUringServerSocketChannel");
+            default: throw new UnsupportedOperationException("Unrecognized transport: " + transport);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Class<? extends SocketChannel> clientChannelClass() throws ClassNotFoundException {
+        switch (transport) {
+            case nio: return NioSocketChannel.class;
+            case epoll: return (Class<? extends SocketChannel>) Class.forName(
+                    "io.netty5.channel.epoll.EpollSocketChannel");
+            case kqueue: return (Class<? extends SocketChannel>) Class.forName(
+                    "io.netty5.channel.kqueue.KQueueSocketChannel");
+            case io_uring: return (Class<? extends SocketChannel>) Class.forName(
+                    "io.netty5.channel.uring.IOUringSocketChannel");
+            default: throw new UnsupportedOperationException("Unrecognized transport: " + transport);
+        }
+    }
+
+    private SslContext configureServerSsl() throws CertificateException, SSLException {
+        if (ssl) {
+            SelfSignedCertificate ssc = new SelfSignedCertificate();
+            return SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
+                    .sslProvider(OPENSSL)
+                    .ciphers(Http2SecurityUtil.CIPHERS, SupportedCipherSuiteFilter.INSTANCE)
+                    .build();
+        }
+        return null;
+    }
+
+    private SslContext configureClientSsl() throws CertificateException, SSLException {
+        if (ssl) {
+            return SslContextBuilder.forClient()
+                    .sslProvider(OPENSSL)
+                    .ciphers(Http2SecurityUtil.CIPHERS, SupportedCipherSuiteFilter.INSTANCE)
+                    .trustManager(InsecureTrustManagerFactory.INSTANCE) // Accept the self-signed server cert.
+                    .build();
+        }
+        return null;
+    }
+
+    static class Http2ServerInitializer extends ChannelInitializer<SocketChannel> {
+        private final SslContext sslCtx;
+
+        Http2ServerInitializer(SslContext sslCtx) {
+            this.sslCtx = sslCtx;
+        }
+
+        @Override
+        public void initChannel(SocketChannel ch) {
+            if (sslCtx != null) {
+                configureSsl(ch);
+            }
+            configureClearText(ch);
+        }
+
+        private void configureSsl(SocketChannel ch) {
+            ch.pipeline().addLast(sslCtx.newHandler(ch.bufferAllocator()));
+        }
+
+        private static void configureClearText(SocketChannel ch) {
+            final ChannelPipeline p = ch.pipeline();
+            p.addLast(new HelloWorldHttp2HandlerBuilder().build());
+        }
+    }
+
+    static class HelloWorldHttp2HandlerBuilder extends
+            AbstractHttp2ConnectionHandlerBuilder<HelloWorldHttp2Handler, HelloWorldHttp2HandlerBuilder> {
+        @Override
+        public HelloWorldHttp2Handler build() {
+            return super.build();
+        }
+
+        @Override
+        protected HelloWorldHttp2Handler build(
+                Http2ConnectionDecoder decoder, Http2ConnectionEncoder encoder, Http2Settings initialSettings)
+                throws Exception {
+            HelloWorldHttp2Handler handler = new HelloWorldHttp2Handler(decoder, encoder, initialSettings);
+            frameListener(handler);
+            return handler;
+        }
+    }
+
+    static class HelloWorldHttp2Handler extends Http2ConnectionHandler implements Http2FrameListener {
+        static final byte[] RESPONSE_BYTES = "Hello World".getBytes(StandardCharsets.UTF_8);
+
+        HelloWorldHttp2Handler(Http2ConnectionDecoder decoder, Http2ConnectionEncoder encoder,
+                               Http2Settings initialSettings) {
+            super(decoder, encoder, initialSettings);
+        }
+
+        @Override
+        public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+            super.channelExceptionCaught(ctx, cause);
+            logger.warn("Server-side exception", cause);
+            ctx.close();
+        }
+
+        /**
+         * Sends a "Hello World" DATA frame to the client.
+         */
+        private void sendResponse(ChannelHandlerContext ctx, int streamId, Buffer payload) {
+            // Send a frame for the response status
+            Http2Headers headers = Http2Headers.newHeaders().status(OK.codeAsText());
+            encoder().writeHeaders(ctx, streamId, headers, 0, false);
+            encoder().writeData(ctx, streamId, payload, 0, true);
+
+            // no need to call flush as channelReadComplete(...) will take care of it.
+        }
+
+        @Override
+        public int onDataRead(ChannelHandlerContext ctx, int streamId, Buffer data, int padding, boolean endOfStream) {
+            int processed = data.readableBytes() + padding;
+            if (endOfStream) {
+                sendResponse(ctx, streamId, data);
+            }
+            return processed;
+        }
+
+        @Override
+        public void onHeadersRead(ChannelHandlerContext ctx, int streamId,
+                                  Http2Headers headers, int padding, boolean endOfStream) {
+            if (endOfStream) {
+                final byte[] viaBytes = " - via HTTP/2".getBytes(US_ASCII);
+                Buffer content = ctx.bufferAllocator().allocate(RESPONSE_BYTES.length + viaBytes.length)
+                        .writeBytes(RESPONSE_BYTES).writeBytes(viaBytes);
+                sendResponse(ctx, streamId, content);
+            }
+        }
+
+        @Override
+        public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int streamDependency,
+                                  short weight, boolean exclusive, int padding, boolean endOfStream) {
+            onHeadersRead(ctx, streamId, headers, padding, endOfStream);
+        }
+
+        @Override
+        public void onPriorityRead(ChannelHandlerContext ctx, int streamId, int streamDependency,
+                                   short weight, boolean exclusive) {
+        }
+
+        @Override
+        public void onRstStreamRead(ChannelHandlerContext ctx, int streamId, long errorCode) {
+        }
+
+        @Override
+        public void onSettingsAckRead(ChannelHandlerContext ctx) {
+        }
+
+        @Override
+        public void onSettingsRead(ChannelHandlerContext ctx, Http2Settings settings) {
+        }
+
+        @Override
+        public void onPingRead(ChannelHandlerContext ctx, long data) {
+        }
+
+        @Override
+        public void onPingAckRead(ChannelHandlerContext ctx, long data) {
+        }
+
+        @Override
+        public void onPushPromiseRead(ChannelHandlerContext ctx, int streamId, int promisedStreamId,
+                                      Http2Headers headers, int padding) {
+        }
+
+        @Override
+        public void onGoAwayRead(ChannelHandlerContext ctx, int lastStreamId, long errorCode, Buffer debugData) {
+        }
+
+        @Override
+        public void onWindowUpdateRead(ChannelHandlerContext ctx, int streamId, int windowSizeIncrement) {
+        }
+
+        @Override
+        public void onUnknownFrame(ChannelHandlerContext ctx, byte frameType, int streamId,
+                                   Http2Flags flags, Buffer payload) {
+        }
+    }
+
+    static class Http2ClientStreamFrameResponseHandler extends SimpleChannelInboundHandler<Http2StreamFrame> {
+        private final Semaphore latch;
+
+        Http2ClientStreamFrameResponseHandler(Semaphore clientResponse) {
+            latch = clientResponse;
+        }
+
+        @Override
+        protected void messageReceived(ChannelHandlerContext ctx, Http2StreamFrame msg) {
+            logger.debug("Received HTTP/2 'stream' frame: {}", msg);
+
+            // isEndStream() is not from a common interface, so we currently must check both
+            if (msg instanceof Http2DataFrame && ((Http2DataFrame) msg).isEndStream()) {
+                latch.release();
+            } else if (msg instanceof Http2HeadersFrame && ((Http2HeadersFrame) msg).isEndStream()) {
+                latch.release();
+            }
+        }
+
+        /**
+         * Waits for the latch to be decremented (i.e. for an end of stream message to be received), or for
+         * the latch to expire after 5 seconds.
+         * @return true if a successful HTTP/2 end of stream message was received.
+         */
+        public boolean responseSuccessfullyCompleted() {
+            try {
+                return latch.tryAcquire(5, TimeUnit.SECONDS);
+            } catch (InterruptedException ie) {
+                logger.warn("Latch exception", ie);
+                return false;
+            }
+        }
+    }
+}

--- a/microbench/src/main/java/io/netty5/microbench/http2/Http2ThroughputBenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/http2/Http2ThroughputBenchmark.java
@@ -103,7 +103,7 @@ public class Http2ThroughputBenchmark extends AbstractMicrobenchmark {
     @Param({"true", "false"})
     public boolean ssl;
 
-    @Param("nio")
+    @Param("local")
     public Transport transport;
 
     @Param({"adaptive", "pooled"})

--- a/microbench/src/main/java/io/netty5/microbench/http2/Http2ThroughputBenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/http2/Http2ThroughputBenchmark.java
@@ -18,7 +18,7 @@ import io.netty5.bootstrap.Bootstrap;
 import io.netty5.bootstrap.ServerBootstrap;
 import io.netty5.buffer.Buffer;
 import io.netty5.buffer.BufferAllocator;
-import io.netty5.buffer.adapt.AdaptablePoolingAllocator;
+import io.netty5.buffer.adapt.AdaptivePoolingAllocator;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelInitializer;
@@ -98,7 +98,7 @@ import static java.nio.charset.StandardCharsets.US_ASCII;
 public class Http2ThroughputBenchmark extends AbstractMicrobenchmark {
     private static final Logger logger = LoggerFactory.getLogger(Http2ThroughputBenchmark.class);
     private static final BufferAllocator pooled = BufferAllocator.offHeapPooled();
-    private static final BufferAllocator adaptive = new AdaptablePoolingAllocator(true);
+    private static final BufferAllocator adaptive = new AdaptivePoolingAllocator(true);
 
     @Param({"true", "false"})
     public boolean ssl;

--- a/microbench/src/main/java/io/netty5/microbench/util/AbstractMicrobenchmarkBase.java
+++ b/microbench/src/main/java/io/netty5/microbench/util/AbstractMicrobenchmarkBase.java
@@ -57,8 +57,8 @@ public abstract class AbstractMicrobenchmarkBase {
             "-Dio.netty5.buffer.lifecycleTracingEnabled=false",
             // Enable Unsafe-based buffer implementation:
 //            "-Dio.netty5.tryReflectionSetAccessible=true",
-//            "--add-opens","java.base/java.nio=ALL-UNNAMED",
-//            "--add-opens","java.base/jdk.internal.misc=ALL-UNNAMED",
+//            "--add-opens", "java.base/java.nio=ALL-UNNAMED",
+//            "--add-opens", "java.base/jdk.internal.misc=ALL-UNNAMED",
 //            "-Dio.netty5.buffer.api.MemoryManager=Unsafe"
     };
 

--- a/microbench/src/main/java/io/netty5/microbench/util/AbstractMicrobenchmarkBase.java
+++ b/microbench/src/main/java/io/netty5/microbench/util/AbstractMicrobenchmarkBase.java
@@ -31,14 +31,15 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Base class for all JMH benchmarks.
  */
-@Warmup(iterations = AbstractMicrobenchmarkBase.DEFAULT_WARMUP_ITERATIONS)
-@Measurement(iterations = AbstractMicrobenchmarkBase.DEFAULT_MEASURE_ITERATIONS)
+@Warmup(iterations = AbstractMicrobenchmarkBase.DEFAULT_WARMUP_ITERATIONS, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = AbstractMicrobenchmarkBase.DEFAULT_MEASURE_ITERATIONS, time = 1, timeUnit = TimeUnit.SECONDS)
 @State(Scope.Thread)
 public abstract class AbstractMicrobenchmarkBase {
     protected static final int DEFAULT_WARMUP_ITERATIONS = 10;
@@ -54,6 +55,11 @@ public abstract class AbstractMicrobenchmarkBase {
             "-Dio.netty5.leakDetection.level=disabled",
             "-Dio.netty5.buffer.leakDetectionEnabled=false",
             "-Dio.netty5.buffer.lifecycleTracingEnabled=false",
+            // Enable Unsafe-based buffer implementation:
+//            "-Dio.netty5.tryReflectionSetAccessible=true",
+//            "--add-opens","java.base/java.nio=ALL-UNNAMED",
+//            "--add-opens","java.base/jdk.internal.misc=ALL-UNNAMED",
+//            "-Dio.netty5.buffer.api.MemoryManager=Unsafe"
     };
 
     static {

--- a/microbench/src/main/resources/logback-test.xml
+++ b/microbench/src/main/resources/logback-test.xml
@@ -15,7 +15,5 @@
   ~ under the License.
   -->
 <configuration>
-    <root>
-        <level value="INFO" />
-    </root>
+    <root level="INFO" />
 </configuration>

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/TestsuitePermutation.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/TestsuitePermutation.java
@@ -17,13 +17,15 @@ package io.netty5.testsuite.transport;
 
 import io.netty5.bootstrap.AbstractBootstrap;
 import io.netty5.buffer.BufferAllocator;
+import io.netty5.buffer.adapt.AdaptivePoolingAllocator;
 
 import java.util.List;
 
 public final class TestsuitePermutation {
     private static final List<AllocatorConfig> ALLOCATOR_CONFIGS = List.of(
             new AllocatorConfig(BufferAllocator.offHeapUnpooled()),
-            new AllocatorConfig(BufferAllocator.offHeapPooled()));
+            new AllocatorConfig(BufferAllocator.offHeapPooled()),
+            new AllocatorConfig(new AdaptivePoolingAllocator()));
 
     public static List<AllocatorConfig> allocator() {
         return ALLOCATOR_CONFIGS;


### PR DESCRIPTION
Motivation:
The current PoolingBufferAllocator has a number of issues. The code has proven complex to maintain over the years, and has caused a steady trickle of bugs despite its age. It also makes use of ThreadLocals, which is problematic when used with VirtualThreads as there might be millions of such threads, making the memory usage of PoolThreadLocalCache prohibitively expensive.

Modification:
Instead of using ThreadLocals, the AdaptivePoolingAllocator reduces contention by striping access across a number of magazines. Each thread will have a preferred magazine to access, computed from their thread ID. We use StampedLocks to tryLock the magazine, and if the lock is not immediately available we will continue on to the next magazine. If there is too much contention (too many tryLocks that fail) then the number of magazines is increased, up to twice the number of CPU cores. This behavior is similar in spirit to Stripe64, though the implementation is quite different.

Each magazine does pointer-bump (using Buffer.split) allocations out of a chunk. The default chunk size is 128 KiB.
However, allocation sizes are continuously recorded in a sliding-window histogram. Every few thousand allocations to a magazine, the 99-percentile allocation size is computed from the histogram, and then multiplied by 10. If this value is greater than 128 KiB, then it will be used as the new preferred chunk size. From then on, chunks that are less than this, or over 50% larger than this, will be retired and the memory will be freed.

The maximum size we can track in the histograms is 1 MiB, and the minimum size is 8192 bytes. The sizes are bucketed into powers of two.
This keeps our memory spent on histograms low. This also means our max chunk size is 10 MiB.
We choose 8192 as the minimum bucket size because we also choose 128 KiB as the minimum chunk size, so sizes of 8192 and smaller will have no impact on the chunk size.
This in turn means we have 8 size buckets, and that allows the JIT to optimize the loops over these arrays quite well.
The sliding window also only keep 4 generations of histograms, and we use shorts for bucket counters since we rotate them every 1.024 to 65.534 allocations.
Because processing the histograms is relatively expensive, we adapt the frequency of this processing depending on whether the computed chunk size changed or not.

The allocator has a central queue where magazines can pluck available chunks. However, magazines also have a nextInLine field, which will be checked first - if it is empty we will instead take a chunk from the central queue, or allocate a new one if the queue was empty. When all of the buffers allocated from a chunk have been closed, then the chunk returns to the allocator. When this happens we first check if the nextInLine field of the originating magazine is null - if it is, we atomically return the chunk to that magazine. Otherwise the chunk is given to the central queue.

The dynamic adjustments we do to the chunk sizes and the number of magazines, in response to the workload, is why this allocator is called adaptive.

The adaptive allocator can be enabled as the Netty default allocator by setting the `io.netty5.allocator.type` system property to `adaptive`.

Result:
We have a new pooling allocator with many benefits:

* It does not rely on thread locals.
* It uses less memory than the existing pooling allocator in the practical applications that have been observed so far.
* It is inherently robust to fragmentation as long as buffers are eventually closed.
* It is faster and (perhaps surprisingly) appear to scale better to multi-threaded workloads than the existing allocator.

These are the benchmark results I get for on-heap buffers, from BufferAllocatorConcurrentBenchmark on an M1 Pro machine:

```
Benchmark                (size)   Mode  Cnt       Score      Error   Units
allocateReleaseAdaptive   00064  thrpt   20  134000.741 ± 2052.369  ops/ms
allocateReleasePooled     00064  thrpt   20   82131.491 ± 1149.161  ops/ms
allocateReleaseUnpooled   00064  thrpt   20      97.436 ±  109.054  ops/ms
```

And these are the results for off-heap buffers:

```
Benchmark                (size)   Mode  Cnt       Score      Error   Units
allocateReleaseAdaptive   00064  thrpt   20  238682.626 ± 8149.701  ops/ms
allocateReleasePooled     00064  thrpt   20   86741.222 ± 1431.465  ops/ms
allocateReleaseUnpooled   00064  thrpt   20    3950.274 ±   25.446  ops/ms
```