### PR TITLE
Upgrade Brotli4j to 1.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -617,7 +617,7 @@
     <skipAutobahnTestsuite>false</skipAutobahnTestsuite>
     <skipHttp2Testsuite>false</skipHttp2Testsuite>
     <graalvm.version>19.3.6</graalvm.version>
-    <brotli4j.version>1.8.0</brotli4j.version>
+    <brotli4j.version>1.9.0</brotli4j.version>
     <!-- By default skip native testsuite as it requires a custom environment with graalvm installed -->
     <skipNativeImageTestsuite>true</skipNativeImageTestsuite>
     <skipShadingTestsuite>false</skipShadingTestsuite>


### PR DESCRIPTION
Motivation:
Brotli4j 1.9.0 is released and we should upgrade to it.

Modification:
Upgraded Brotli4j from 1.8.0 to 1.9.0.

Result:
Latest version of Brotli4j
