### PR TITLE
jmh 1.36

### DIFF
--- a/microbench/pom.xml
+++ b/microbench/pom.xml
@@ -31,7 +31,7 @@
   <properties>
     <!-- Skip tests by default; run only if -DskipTests=false is specified -->
     <skipTests>true</skipTests>
-    <jmh.version>1.33</jmh.version>
+    <jmh.version>1.36</jmh.version>
     <!-- This only be set when run on linux as on other platforms we just want to include the jar without native
          code -->
     <epoll.classifier />


### PR DESCRIPTION
Motivation:

upgrade to latest version of JMH

JMH 1.36
https://mail.openjdk.org/pipermail/jmh-dev/2022-November/003553.html

Modification:

updated the jmh.version property


Result:

New JMH version 👍 

