### PR TITLE
Remove Checks for ByteBuffer#alignedSlice(int)

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/pool/PooledBufferAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/pool/PooledBufferAllocator.java
@@ -211,11 +211,6 @@ public class PooledBufferAllocator implements BufferAllocator, BufferAllocatorMe
         this.normalCacheSize = normalCacheSize;
 
         if (directMemoryCacheAlignment != 0) {
-            if (!PlatformDependent.hasAlignDirectByteBuffer()) {
-                throw new UnsupportedOperationException("Buffer alignment is not supported. " +
-                        "Either Unsafe or ByteBuffer.alignSlice() must be available.");
-            }
-
             // Ensure page size is a whole multiple of the alignment, or bump it to the next whole multiple.
             pageSize = (int) PlatformDependent.align(pageSize, directMemoryCacheAlignment);
         }

--- a/common/src/main/java/io/netty5/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty5/util/internal/PlatformDependent.java
@@ -773,26 +773,11 @@ public final class PlatformDependent {
         decrementMemoryCounter(capacity);
     }
 
-    public static boolean hasAlignDirectByteBuffer() {
-        return hasUnsafe() || PlatformDependent0.hasAlignSliceMethod();
-    }
-
     public static ByteBuffer alignDirectBuffer(ByteBuffer buffer, int alignment) {
         if (!buffer.isDirect()) {
             throw new IllegalArgumentException("Cannot get aligned slice of non-direct byte buffer.");
         }
-        if (PlatformDependent0.hasAlignSliceMethod()) {
-            return PlatformDependent0.alignSlice(buffer, alignment);
-        }
-        if (hasUnsafe()) {
-            long address = directBufferAddress(buffer);
-            long aligned = align(address, alignment);
-            buffer.position((int) (aligned - address));
-            return buffer.slice();
-        }
-        // We don't have enough information to be able to align any buffers.
-        throw new UnsupportedOperationException("Cannot align direct buffer. " +
-                "Needs either Unsafe or ByteBuffer.alignSlice method available.");
+        return buffer.alignedSlice(alignment);
     }
 
     public static long align(long value, int alignment) {

--- a/common/src/main/java/io/netty5/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty5/util/internal/PlatformDependent0.java
@@ -49,7 +49,6 @@ final class PlatformDependent0 {
     private static final MethodHandle DIRECT_BUFFER_CONSTRUCTOR_HANDLE;
     private static final Throwable EXPLICIT_NO_UNSAFE_CAUSE = explicitNoUnsafeCause0();
     private static final MethodHandle ALLOCATE_ARRAY_HANDLE;
-    private static final Method ALIGN_SLICE;
     private static final int JAVA_VERSION = javaVersion0();
     private static final boolean IS_ANDROID = isAndroid0();
 
@@ -364,14 +363,6 @@ final class PlatformDependent0 {
             ALLOCATE_ARRAY_HANDLE = allocateArrayHandle;
         }
 
-        ALIGN_SLICE = (Method) AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
-            try {
-                return ByteBuffer.class.getDeclaredMethod("alignedSlice", int.class);
-            } catch (Exception e) {
-                return null;
-            }
-        });
-
         logger.debug("java.nio.DirectByteBuffer.<init>(long, int, Object): {}",
                 DIRECT_BUFFER_CONSTRUCTOR_HANDLE != null ? "available" : "unavailable");
     }
@@ -433,18 +424,6 @@ final class PlatformDependent0 {
         // Just use 1 to make it safe to use in all cases:
         // See: https://pubs.opengroup.org/onlinepubs/009695399/functions/malloc.html
         return newDirectBuffer(UNSAFE.allocateMemory(Math.max(1, capacity)), capacity, null);
-    }
-
-    static boolean hasAlignSliceMethod() {
-        return ALIGN_SLICE != null;
-    }
-
-    static ByteBuffer alignSlice(ByteBuffer buffer, int alignment) {
-        try {
-            return (ByteBuffer) ALIGN_SLICE.invoke(buffer, alignment);
-        } catch (IllegalAccessException | InvocationTargetException e) {
-            throw new Error(e);
-        }
     }
 
     static boolean hasAllocateArrayMethod() {


### PR DESCRIPTION
Motivation:

Netty 5's runtime requirement is Java 11 or newer

ByteBuffer#alignedSlice(int) is supported since >= 9.0

Modifications:

remove checks for ByteBuffer#alignedSlice(int)

Result:

Clean up