### PR TITLE
Correct variable names in DefaultFileRegion

### DIFF
--- a/transport/src/main/java/io/netty/channel/DefaultFileRegion.java
+++ b/transport/src/main/java/io/netty/channel/DefaultFileRegion.java
@@ -47,12 +47,12 @@ public class DefaultFileRegion extends AbstractReferenceCounted implements FileR
     /**
      * Create a new instance
      *
-     * @param file      the {@link FileChannel} which should be transferred
-     * @param position  the position from which the transfer should start
-     * @param count     the number of bytes to transfer
+     * @param fileChannel      the {@link FileChannel} which should be transferred
+     * @param position         the position from which the transfer should start
+     * @param count            the number of bytes to transfer
      */
-    public DefaultFileRegion(FileChannel file, long position, long count) {
-        this.file = ObjectUtil.checkNotNull(file, "file");
+    public DefaultFileRegion(FileChannel fileChannel, long position, long count) {
+        this.file = ObjectUtil.checkNotNull(fileChannel, "fileChannel");
         this.position = checkPositiveOrZero(position, "position");
         this.count = checkPositiveOrZero(count, "count");
         this.f = null;
@@ -62,12 +62,12 @@ public class DefaultFileRegion extends AbstractReferenceCounted implements FileR
      * Create a new instance using the given {@link File}. The {@link File} will be opened lazily or
      * explicitly via {@link #open()}.
      *
-     * @param f         the {@link File} which should be transferred
-     * @param position  the position from which the transfer should start
-     * @param count     the number of bytes to transfer
+     * @param file         the {@link File} which should be transferred
+     * @param position     the position from which the transfer should start
+     * @param count        the number of bytes to transfer
      */
-    public DefaultFileRegion(File f, long position, long count) {
-        this.f = ObjectUtil.checkNotNull(f, "f");
+    public DefaultFileRegion(File file, long position, long count) {
+        this.f = ObjectUtil.checkNotNull(file, "file");
         this.position = checkPositiveOrZero(position, "position");
         this.count = checkPositiveOrZero(count, "count");
     }


### PR DESCRIPTION
Motivation:
The `FileChannel` variable should be called `fileChannel` and `File` should be called `file` so it's easier to debug when `NullPointerException` is thrown by `ObjectUtils`.

Modification:
Updated variable names

Result:
Correct variable names
