### PR TITLE
Remove unnecessary version checks

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/LinuxSocket.java
+++ b/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/LinuxSocket.java
@@ -21,7 +21,6 @@ import io.netty5.channel.unix.Errors;
 import io.netty5.channel.unix.NativeInetAddress;
 import io.netty5.channel.unix.PeerCredentials;
 import io.netty5.channel.unix.Socket;
-import io.netty5.util.internal.PlatformDependent;
 import io.netty5.util.internal.SocketUtils;
 import org.jetbrains.annotations.Nullable;
 
@@ -90,7 +89,7 @@ final class LinuxSocket extends Socket {
     NetworkInterface getNetworkInterface() throws IOException {
         int ret = getInterface(intValue(), ipv6);
         if (ipv6) {
-            return PlatformDependent.javaVersion() >= 7 ? NetworkInterface.getByIndex(ret) : null;
+            return NetworkInterface.getByIndex(ret);
         }
         InetAddress address = inetAddress(ret);
         return address != null ? NetworkInterface.getByInetAddress(address) : null;
@@ -138,15 +137,13 @@ final class LinuxSocket extends Socket {
     }
 
     private static int interfaceIndex(NetworkInterface networkInterface) {
-        return PlatformDependent.javaVersion() >= 7 ? networkInterface.getIndex() : -1;
+        return networkInterface.getIndex();
     }
 
     private static int interfaceIndex(InetAddress address) throws IOException {
-        if (PlatformDependent.javaVersion() >= 7) {
-            NetworkInterface iface = NetworkInterface.getByInetAddress(address);
-            if (iface != null) {
-                return iface.getIndex();
-            }
+        NetworkInterface iface = NetworkInterface.getByInetAddress(address);
+        if (iface != null) {
+            return iface.getIndex();
         }
         return -1;
     }


### PR DESCRIPTION
Motivation:

Netty 5's runtime requirement is Java 11 or newer

Modifications:

remove unnecessary version checks

Result:

clean up