### PR TITLE
Remove Redundant bitwise operations

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/SizeClasses.java
+++ b/buffer/src/main/java/io/netty/buffer/SizeClasses.java
@@ -338,9 +338,7 @@ abstract class SizeClasses implements SizeClassesMetric {
         int log2Delta = x < LOG2_SIZE_CLASS_GROUP + LOG2_QUANTUM + 1
                 ? LOG2_QUANTUM : x - LOG2_SIZE_CLASS_GROUP - 1;
 
-        int deltaInverseMask = -1 << log2Delta;
-        int mod = (size - 1 & deltaInverseMask) >> log2Delta &
-                  (1 << LOG2_SIZE_CLASS_GROUP) - 1;
+        int mod = size - 1 >> log2Delta & (1 << LOG2_SIZE_CLASS_GROUP) - 1;
 
         return group + mod;
     }
@@ -371,9 +369,7 @@ abstract class SizeClasses implements SizeClassesMetric {
         int log2Delta = x < LOG2_SIZE_CLASS_GROUP + pageShifts + 1?
                 pageShifts : x - LOG2_SIZE_CLASS_GROUP - 1;
 
-        int deltaInverseMask = -1 << log2Delta;
-        int mod = (pageSize - 1 & deltaInverseMask) >> log2Delta &
-                  (1 << LOG2_SIZE_CLASS_GROUP) - 1;
+        int mod = pageSize - 1 >> log2Delta & (1 << LOG2_SIZE_CLASS_GROUP) - 1;
 
         int pageIdx = group + mod;
 


### PR DESCRIPTION
Motivation:

inverseMask is redundant since we will rightShift it with exact same amount

Modifications:

removed redundant operations

Result:

clean up