### PR TITLE
Return correct value from SSLSession.getPacketSize() when using nativ…

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -65,7 +65,7 @@
 
   <properties>
     <!-- Keep in sync with ../pom.xml -->
-    <tcnative.version>2.0.54.Final</tcnative.version>
+    <tcnative.version>2.0.55.Final</tcnative.version>
   </properties>
 
   <build>

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -2627,7 +2627,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
 
         @Override
         public int getPacketBufferSize() {
-            return maxEncryptedPacketLength();
+            return SSL.SSL_MAX_ENCRYPTED_LENGTH;
         }
 
         @Override

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -1708,16 +1708,24 @@ public abstract class SSLEngineTest {
                 assertFalse(cTOs.hasRemaining());
             }
 
-            cTOsHasRemaining = cTOs.hasRemaining();
-            sTOcHasRemaining = sTOc.hasRemaining();
+            cTOsHasRemaining = compactOrClear(cTOs);
+            sTOcHasRemaining = compactOrClear(sTOc);
 
-            sTOc.compact();
-            cTOs.compact();
         } while (!clientHandshakeFinished || !serverHandshakeFinished ||
                 // We need to ensure we feed all the data to the engine to not end up with a corrupted state.
                 // This is especially important with TLS1.3 which may produce sessions after the "main handshake" is
                 // done
                 cTOsHasRemaining || sTOcHasRemaining);
+    }
+
+
+    private static boolean compactOrClear(ByteBuffer buffer) {
+        if (buffer.hasRemaining()) {
+            buffer.compact();
+            return true;
+        }
+        buffer.clear();
+        return false;
     }
 
     private ByteBuffer increaseDstBufferIfNeeded(SSLEngineResult result, int maxBufferSize,

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -1747,7 +1747,7 @@ public abstract class SSLEngineTest {
 
     private ByteBuffer increaseDstBuffer(int maxBufferSize,
                                                      BufferType type, ByteBuffer dstBuffer) {
-        assertNotEquals(maxBufferSize, dstBuffer.remaining());
+        assumeFalse(maxBufferSize == dstBuffer.remaining());
         // We need to increase the destination buffer
         dstBuffer.flip();
         ByteBuffer tmpBuffer = allocateBuffer(type, maxBufferSize + dstBuffer.remaining());

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -1644,6 +1644,9 @@ public abstract class SSLEngineTest {
 
                 if (isHandshakeFinished(clientResult)) {
                     clientHandshakeFinished = true;
+                } else {
+                    cTOs = increaseDstBufferIfNeeded(clientResult,
+                            clientEngine.getSession().getPacketBufferSize(), type, cTOs);
                 }
             }
 
@@ -1655,6 +1658,9 @@ public abstract class SSLEngineTest {
 
                 if (isHandshakeFinished(serverResult)) {
                     serverHandshakeFinished = true;
+                } else {
+                    sTOc = increaseDstBufferIfNeeded(serverResult,
+                            serverEngine.getSession().getPacketBufferSize(), type, sTOc);
                 }
             }
 
@@ -1678,8 +1684,8 @@ public abstract class SSLEngineTest {
                 if (isHandshakeFinished(clientResult)) {
                     clientHandshakeFinished = true;
                 } else {
-                    clientAppReadBuffer = increaseAppReadBufferIfNeeded(
-                            clientEngine, clientResult, type, clientAppReadBuffer);
+                    clientAppReadBuffer = increaseDstBufferIfNeeded(clientResult,
+                            clientEngine.getSession().getApplicationBufferSize(), type, clientAppReadBuffer);
                 }
             } else {
                 assertEquals(0, sTOc.remaining());
@@ -1695,8 +1701,8 @@ public abstract class SSLEngineTest {
                 if (isHandshakeFinished(serverResult)) {
                     serverHandshakeFinished = true;
                 } else {
-                    serverAppReadBuffer = increaseAppReadBufferIfNeeded(
-                            serverEngine, serverResult, type, serverAppReadBuffer);
+                    serverAppReadBuffer = increaseDstBufferIfNeeded(serverResult,
+                            serverEngine.getSession().getApplicationBufferSize(), type, serverAppReadBuffer);
                 }
             } else {
                 assertFalse(cTOs.hasRemaining());
@@ -1714,14 +1720,13 @@ public abstract class SSLEngineTest {
                 cTOsHasRemaining || sTOcHasRemaining);
     }
 
-    private ByteBuffer increaseAppReadBufferIfNeeded(SSLEngine engine, SSLEngineResult result,
+    private ByteBuffer increaseDstBufferIfNeeded(SSLEngineResult result, int maxBufferSize,
                                                      BufferType type, ByteBuffer dstBuffer) {
         if (result.getStatus() == Status.BUFFER_OVERFLOW) {
             // We need to increase the destination buffer
-            int appSize = engine.getSession().getApplicationBufferSize();
-            assertNotEquals(appSize, dstBuffer.capacity());
+            assertNotEquals(maxBufferSize, dstBuffer.remaining());
             dstBuffer.flip();
-            ByteBuffer tmpBuffer = allocateBuffer(type, appSize + dstBuffer.remaining());
+            ByteBuffer tmpBuffer = allocateBuffer(type, maxBufferSize + dstBuffer.remaining());
             tmpBuffer.put(dstBuffer);
             return tmpBuffer;
         }

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -1724,7 +1724,6 @@ public abstract class SSLEngineTest {
                                                      BufferType type, ByteBuffer dstBuffer) {
         if (result.getStatus() == Status.BUFFER_OVERFLOW) {
             // We need to increase the destination buffer
-            assertNotEquals(maxBufferSize, dstBuffer.remaining());
             dstBuffer.flip();
             ByteBuffer tmpBuffer = allocateBuffer(type, maxBufferSize + dstBuffer.remaining());
             tmpBuffer.put(dstBuffer);

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -1730,6 +1730,7 @@ public abstract class SSLEngineTest {
     private ByteBuffer increaseDstBufferIfNeeded(SSLEngineResult result, int maxBufferSize,
                                                      BufferType type, ByteBuffer dstBuffer) {
         if (result.getStatus() == Status.BUFFER_OVERFLOW) {
+            assertNotEquals(maxBufferSize, dstBuffer.remaining());
             // We need to increase the destination buffer
             dstBuffer.flip();
             ByteBuffer tmpBuffer = allocateBuffer(type, maxBufferSize + dstBuffer.remaining());

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -1718,7 +1718,6 @@ public abstract class SSLEngineTest {
                 cTOsHasRemaining || sTOcHasRemaining);
     }
 
-
     private static boolean compactOrClear(ByteBuffer buffer) {
         if (buffer.hasRemaining()) {
             buffer.compact();

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -1709,7 +1709,8 @@ public abstract class SSLEngineTest {
                 }
 
                 if (serverResult.getStatus() == Status.BUFFER_OVERFLOW) {
-                    serverAppReadBuffer = increaseDstBuffer(serverEngine.getSession().getApplicationBufferSize(), type, serverAppReadBuffer);
+                    serverAppReadBuffer = increaseDstBuffer(
+                            serverEngine.getSession().getApplicationBufferSize(), type, serverAppReadBuffer);
                 }
             } else {
                 assertFalse(cTOs.hasRemaining());

--- a/pom.xml
+++ b/pom.xml
@@ -598,7 +598,7 @@
     <os.detection.classifierWithLikes>fedora,suse,arch</os.detection.classifierWithLikes>
     <tcnative.artifactId>netty-tcnative</tcnative.artifactId>
     <!-- Keep in sync with bom/pom.xml -->
-    <tcnative.version>2.0.54.Final</tcnative.version>
+    <tcnative.version>2.0.55.Final</tcnative.version>
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
     <conscrypt.groupId>org.conscrypt</conscrypt.groupId>
     <conscrypt.artifactId>conscrypt-openjdk-uber</conscrypt.artifactId>


### PR DESCRIPTION
…e SSL implementation

Motivation:

We didnt return the maximum size of SSL packet and tried to calculate it. This didnt work as SSL_max_seal_overhead(...) can only be used to calculate the maximum overhead for when encrypting ourself (and not the remote peer). Because of this we sometimes returned a smaller number then what is possible. This had the affect that when users did use getPacketSize() to size the ByteBuffer we could end up in a situation that would never produce a big enough ByteBuffer and so never finish the handshake.

This issue only accoured when users use the SSLEngine directly. When using our SslHandler we were not affected by this as we use a different approach there.

Modifications:

- Upgrade netty-tcnative to be able to reuse the the defined constant
- Add unit test that did loop forever before this change

Result:

Fixes https://github.com/netty/netty/issues/13073
