### PR TITLE
Add `StacklessSSLHandshakeException` for `ClosedChannelException`

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -1067,7 +1067,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
         ClosedChannelException exception = new ClosedChannelException();
 
         // Add a supressed exception if the handshake was not completed yet.
-        if (!isStateSet(STATE_HANDSHAKE_STARTED) || handshakePromise.isDone()) {
+        if (isStateSet(STATE_HANDSHAKE_STARTED) && !handshakePromise.isDone()) {
             ThrowableUtil.addSuppressed(exception,
                     new StacklessSSLHandshakeException("Connection closed before SSL/TLS handshake completed"));
         }

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -1069,7 +1069,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
         // Add a supressed exception if the handshake was not completed yet.
         if (isStateSet(STATE_HANDSHAKE_STARTED) && !handshakePromise.isDone()) {
             ThrowableUtil.addSuppressed(exception,
-                    new StacklessSSLHandshakeException("Connection closed before SSL/TLS handshake completed"));
+                    new StacklessSSLHandshakeException("Connection closed while SSL/TLS handshake was in progress"));
         }
 
         // Make sure to release SSLEngine,

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -47,6 +47,7 @@ import io.netty.util.concurrent.Promise;
 import io.netty.util.concurrent.PromiseNotifier;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
+import io.netty.util.internal.ThrowableUtil;
 import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -1067,8 +1068,8 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
 
         // Add a supressed exception if the handshake was not completed yet.
         if (!isStateSet(STATE_HANDSHAKE_STARTED) || handshakePromise.isDone()) {
-            exception.addSuppressed(new StacklessSSLHandshakeException("Connection closed before " +
-                    "SSL/TLS handshake completed"));
+            ThrowableUtil.addSuppressed(exception,
+                    new StacklessSSLHandshakeException("Connection closed before SSL/TLS handshake completed"));
         }
 
         // Make sure to release SSLEngine,

--- a/handler/src/main/java/io/netty/handler/ssl/StacklessSSLHandshakeException.java
+++ b/handler/src/main/java/io/netty/handler/ssl/StacklessSSLHandshakeException.java
@@ -20,7 +20,7 @@ import javax.net.ssl.SSLHandshakeException;
 /**
  * A {@link SSLHandshakeException} that does not fill in the stack trace.
  */
-public final class StacklessSSLHandshakeException extends SSLHandshakeException {
+final class StacklessSSLHandshakeException extends SSLHandshakeException {
 
     private static final long serialVersionUID = -1244781947804415549L;
 
@@ -30,7 +30,7 @@ public final class StacklessSSLHandshakeException extends SSLHandshakeException 
      *
      * @param reason describes the problem.
      */
-    public StacklessSSLHandshakeException(String reason) {
+    StacklessSSLHandshakeException(String reason) {
         super(reason);
     }
 

--- a/handler/src/main/java/io/netty/handler/ssl/StacklessSSLHandshakeException.java
+++ b/handler/src/main/java/io/netty/handler/ssl/StacklessSSLHandshakeException.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import javax.net.ssl.SSLHandshakeException;
+
+/**
+ * A {@link SSLHandshakeException} that does not fill in the stack trace.
+ */
+public final class StacklessSSLHandshakeException extends SSLHandshakeException {
+
+    private static final long serialVersionUID = -1244781947804415549L;
+
+    /**
+     * Constructs an exception reporting an error found by
+     * an SSL subsystem during handshaking.
+     *
+     * @param reason describes the problem.
+     */
+    public StacklessSSLHandshakeException(String reason) {
+        super(reason);
+    }
+
+    @Override
+    public Throwable fillInStackTrace() {
+        // This is a performance optimization to not fill in the
+        // stack trace as this is a stackless exception.
+        return this;
+    }
+}

--- a/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
@@ -90,7 +90,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
-import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLProtocolException;
 import javax.net.ssl.X509ExtendedTrustManager;
 
@@ -569,8 +568,8 @@ public class SslHandlerTest {
 
         assertFalse(ch.finishAndReleaseAll());
 
-        assertThat(handler.handshakeFuture().cause(), instanceOf(SSLHandshakeException.class));
-        assertThat(handler.sslCloseFuture().cause(), instanceOf(SSLHandshakeException.class));
+        assertThat(handler.handshakeFuture().cause(), instanceOf(ClosedChannelException.class));
+        assertThat(handler.sslCloseFuture().cause(), instanceOf(ClosedChannelException.class));
     }
 
     @Test
@@ -591,11 +590,11 @@ public class SslHandlerTest {
 
         SslCompletionEvent evt = events.take();
         assertTrue(evt instanceof SslHandshakeCompletionEvent);
-        assertThat(evt.cause(), instanceOf(SSLHandshakeException.class));
+        assertThat(evt.cause(), instanceOf(ClosedChannelException.class));
 
         evt = events.take();
         assertTrue(evt instanceof SslCloseCompletionEvent);
-        assertThat(evt.cause(), instanceOf(SSLHandshakeException.class));
+        assertThat(evt.cause(), instanceOf(ClosedChannelException.class));
         assertTrue(events.isEmpty());
     }
 

--- a/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
@@ -90,6 +90,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLProtocolException;
 import javax.net.ssl.X509ExtendedTrustManager;
 
@@ -568,8 +569,8 @@ public class SslHandlerTest {
 
         assertFalse(ch.finishAndReleaseAll());
 
-        assertTrue(handler.handshakeFuture().cause() instanceof ClosedChannelException);
-        assertTrue(handler.sslCloseFuture().cause() instanceof ClosedChannelException);
+        assertThat(handler.handshakeFuture().cause(), instanceOf(SSLHandshakeException.class));
+        assertThat(handler.sslCloseFuture().cause(), instanceOf(SSLHandshakeException.class));
     }
 
     @Test
@@ -590,11 +591,11 @@ public class SslHandlerTest {
 
         SslCompletionEvent evt = events.take();
         assertTrue(evt instanceof SslHandshakeCompletionEvent);
-        assertTrue(evt.cause() instanceof ClosedChannelException);
+        assertThat(evt.cause(), instanceOf(SSLHandshakeException.class));
 
         evt = events.take();
         assertTrue(evt instanceof SslCloseCompletionEvent);
-        assertTrue(evt.cause() instanceof ClosedChannelException);
+        assertThat(evt.cause(), instanceOf(SSLHandshakeException.class));
         assertTrue(events.isEmpty());
     }
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
@@ -255,7 +255,7 @@ public class SocketSslClientRenegotiateTest extends AbstractSocketTest {
                     assertSame(SslHandshakeCompletionEvent.SUCCESS, evt);
                 } else {
                     if (ctx.channel().parent() == null) {
-                        assertTrue(handshakeEvt.cause() instanceof ClosedChannelException);
+                        assertTrue(handshakeEvt.cause() instanceof SSLHandshakeException);
                     }
                 }
             }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
@@ -255,7 +255,7 @@ public class SocketSslClientRenegotiateTest extends AbstractSocketTest {
                     assertSame(SslHandshakeCompletionEvent.SUCCESS, evt);
                 } else {
                     if (ctx.channel().parent() == null) {
-                        assertTrue(handshakeEvt.cause() instanceof SSLHandshakeException);
+                        assertTrue(handshakeEvt.cause() instanceof ClosedChannelException);
                     }
                 }
             }


### PR DESCRIPTION
Motivation:
When a channel is closed during the SSL handshake then `java.nio.channels.ClosedChannelException` is thrown. This is correct when we see it from a low-level transport perspective but from a high-level, this error is not detailed enough to debug. And when we log `ClosedChannelException`, we get this line: `java.nio.channels.ClosedChannelException: null` in the stack trace. 

Modification:
To combat this, we should throw `StacklessSSLHandshakeException` with the message `"Connection closed while SSL/TLS handshake was in progress"` as suppressed with`ClosedChannelException`. This will explicitly declare that the handshake failed due to connection closure.

Result:
Fixes #12000

