### PR TITLE
Create thread dumps for all running JVMs when the build gets cancelled

### DIFF
--- a/.github/actions/thread-dump-jvms/action.yml
+++ b/.github/actions/thread-dump-jvms/action.yml
@@ -1,0 +1,29 @@
+# ----------------------------------------------------------------------------
+# Copyright 2021 The Netty Project
+#
+# The Netty Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+name: thread dump jvms
+description: Triggers a thread dump for all running JVMs
+runs:
+  using: composite
+  steps:
+    - run: |
+        for java_pid in $(jps -q -J-XX:+PerfDisableSharedMem); do
+          echo "----------------------- pid $java_pid -----------------------"
+          cat /proc/$java_pid/cmdline | xargs -0 echo
+          jcmd $java_pid Thread.print -l
+          jcmd $java_pid GC.heap_info
+        done
+        exit 0
+      shell: bash

--- a/.github/actions/thread-dump-jvms/action.yml
+++ b/.github/actions/thread-dump-jvms/action.yml
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright 2021 The Netty Project
+# Copyright 2023 The Netty Project
 #
 # The Netty Project licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance
@@ -19,11 +19,29 @@ runs:
   using: composite
   steps:
     - run: |
-        for java_pid in $(jps -q -J-XX:+PerfDisableSharedMem); do
-          echo "----------------------- pid $java_pid -----------------------"
-          cat /proc/$java_pid/cmdline | xargs -0 echo
-          jcmd $java_pid Thread.print -l
-          jcmd $java_pid GC.heap_info
-        done
+        if [[ "$OSTYPE" == "linux-gnu"* ]] && command -v sudo &> /dev/null; then
+          # use jattach so that Java processes in docker containers are also covered
+          # download jattach
+          curl -s -L -o /tmp/jattach https://github.com/apangin/jattach/releases/download/v2.1/jattach
+          if command -v sha256sum &> /dev/null; then
+            # verify hash of jattach binary
+            sha256sum -c <(echo "07885fdc782e02e7302c6d190f54c3930afa10a38140365adf54076ec1086a8e  /tmp/jattach") || exit 1
+          fi
+          chmod +x /tmp/jattach
+          for java_pid in $(sudo pgrep java); do
+            echo "----------------------- pid $java_pid -----------------------"
+            echo "command line: $(sudo cat /proc/$java_pid/cmdline | xargs -0 echo)"
+            sudo /tmp/jattach $java_pid jcmd VM.command_line || true
+            sudo /tmp/jattach $java_pid jcmd "Thread.print -l"
+            sudo /tmp/jattach $java_pid jcmd GC.heap_info || true
+          done
+        else
+          for java_pid in $(jps -q -J-XX:+PerfDisableSharedMem); do
+            echo "----------------------- pid $java_pid -----------------------"
+            jcmd $java_pid VM.command_line || true
+            jcmd $java_pid Thread.print -l
+            jcmd $java_pid GC.heap_info || true
+          done
+        fi
         exit 0
       shell: bash

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -73,6 +73,10 @@ jobs:
       - name: Checking bom dependency versions
         run: ./.github/scripts/check_bom_dependencies.sh
 
+      - name: print JVM thread dumps when cancelled
+        uses: ./.github/actions/thread-dump-jvms
+        if: cancelled()
+
       - uses: actions/upload-artifact@v2
         if: ${{ failure() }}
         with:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -77,6 +77,10 @@ jobs:
       - name: Build project
         run: ./mvnw.cmd -B -ntp --file pom.xml clean package -Pboringssl -DskipHttp2Testsuite=true -DskipAutobahnTestsuite=true
 
+      - name: print JVM thread dumps when cancelled
+        uses: ./.github/actions/thread-dump-jvms
+        if: cancelled()
+
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v2
@@ -196,6 +200,10 @@ jobs:
 
       - name: Checking for detected leak
         run: ./.github/scripts/check_leak.sh build-leak.output
+
+      - name: print JVM thread dumps when cancelled
+        uses: ./.github/actions/thread-dump-jvms
+        if: cancelled()
 
       - name: Upload Test Results
         if: always()

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -49,6 +49,10 @@ jobs:
       - name: Checking bom dependency versions
         run: ./.github/scripts/check_bom_dependencies.sh
 
+      - name: print JVM thread dumps when cancelled
+        uses: ./.github/actions/thread-dump-jvms
+        if: cancelled()
+
   build-pr-windows:
     runs-on: windows-2019
     name: windows-x86_64-java11-boringssl


### PR DESCRIPTION
Motivation:

When a GitHub Actions build job gets cancelled because of a timeout, it would be useful to have a thread dump for all running JVM processes so that it would be able to find the reason why the build job timed out.

Modification:

Add an inline composite action that uses bash, jps and jcmd to create thread dumps for all running Java processes. 
This is referenced in ci-pr.yml workflow's verify-pr job and gets run when the build job is cancelled.
This is an example of a thread dump that gets created: https://github.com/lhotari/netty/pull/1/checks#step:7:28 .