### PR TITLE
Remove duplicated declaration of log4j2 core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -914,14 +914,6 @@
         <scope>test</scope>
       </dependency>
 
-      <!-- Test dependency for log4j2 tests -->
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-core</artifactId>
-        <version>${log4j2.version}</version>
-        <scope>test</scope>
-      </dependency>
-
       <!-- BlockHound integration -->
       <dependency>
         <groupId>io.projectreactor.tools</groupId>


### PR DESCRIPTION
Motivation:

There were some warning related to duplicated declarations of log4j2 core

Modifications:

Remove duplicated declaration

Result:

No more warnings during build related to duplicated declaration
