### PR TITLE
Fix NPE caused by old bundle plugin version

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -179,7 +179,6 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>2.5.4</version>
         <executions>
           <execution>
             <id>generate-manifest</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1258,7 +1258,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>5.1.1</version>
+        <version>5.1.8</version>
         <executions>
           <execution>
             <id>generate-manifest</id>


### PR DESCRIPTION
Motivation:

We used some very old bundle plugin version in our commons module. This caused a NPE when using a more recent JDK.

Modifications:

- Update the plugin version in general
- Remove extra version declaration in common pom.xml

Result:

No more NPE during build
