### PR TITLE
Bump up os-maven-plugin to 1.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -593,7 +593,7 @@
     <argLine.javaProperties>-D_</argLine.javaProperties>
     <!-- Configure the os-maven-plugin extension to expand the classifier on                  -->
     <!-- Fedora-"like" systems. This is currently only used for the netty-tcnative dependency -->
-    <osmaven.version>1.7.0</osmaven.version>
+    <osmaven.version>1.7.1</osmaven.version>
     <!-- keep in sync with PlatformDependent#ALLOWED_LINUX_OS_CLASSIFIERS -->
     <os.detection.classifierWithLikes>fedora,suse,arch</os.detection.classifierWithLikes>
     <tcnative.artifactId>netty-tcnative</tcnative.artifactId>

--- a/testsuite-shading/pom.xml
+++ b/testsuite-shading/pom.xml
@@ -50,7 +50,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.6.0</version>
+        <version>1.7.1</version>
       </extension>
     </extensions>
     <plugins>


### PR DESCRIPTION
Motivation:

os-maven-plugin 1.7.0 does not recognize LoongArch information, os-maven-plugin supports LoongArch since 1.7.1

Modification:

Update pom.xml and testsuite-shading/pom.xml

Result:

LoongArch cpu information can be correctly identified
