### PR TITLE
Avoid double-free of datagrams in io_uring

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/IOUringDatagramChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/IOUringDatagramChannel.java
@@ -424,9 +424,6 @@ public final class IOUringDatagramChannel extends AbstractIOUringChannel<UnixCha
             segmentSize = 0;
         }
 
-        // Since we remove the messages from WriteSink/OutboundBuffer, it falls to us to close the buffer, and complete
-        // the promise.
-        promise.asFuture().addListener(data, CLOSE_BUFFER);
         short pendingId = pendingWrites.addPending(promise);
 
         try (var itr = data.forEachComponent()) {


### PR DESCRIPTION
Motivation:
Since 28533a18027bd637cb8c5f6cd60324850bd9578d, the ChannelOutboundBuffer always attaches a message-closing listener to the write promise. That means we should not add another such listener when we submit writes for datagrams.

Modification:
Remove the step where we add a CLOSE_BUFFER listener to the write promise, when we submit datagram writes in io_uring.

Result:
No more occasional double-free errors for datagrams in the io_uring integration.
