### PR TITLE
Use defined osmaven version everywhere

### DIFF
--- a/testsuite-shading/pom.xml
+++ b/testsuite-shading/pom.xml
@@ -50,7 +50,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.1</version>
+        <version>${osmaven.version}</version>
       </extension>
     </extensions>
     <plugins>


### PR DESCRIPTION
Motivation:

We already have a property defined for os-maven-plugin, let's use it to make it easier to keep versions in sync.

Modifications:

Use property

Result:

Cleanup
