### PR TITLE
Upgrade to latest netty-tcnative release which doesnt link libcrypt

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -65,7 +65,7 @@
 
   <properties>
     <!-- Keep in sync with ../pom.xml -->
-    <tcnative.version>2.0.55.Final</tcnative.version>
+    <tcnative.version>2.0.56.Final</tcnative.version>
   </properties>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -598,7 +598,7 @@
     <os.detection.classifierWithLikes>fedora,suse,arch</os.detection.classifierWithLikes>
     <tcnative.artifactId>netty-tcnative</tcnative.artifactId>
     <!-- Keep in sync with bom/pom.xml -->
-    <tcnative.version>2.0.55.Final</tcnative.version>
+    <tcnative.version>2.0.56.Final</tcnative.version>
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
     <conscrypt.groupId>org.conscrypt</conscrypt.groupId>
     <conscrypt.artifactId>conscrypt-openjdk-uber</conscrypt.artifactId>


### PR DESCRIPTION
Motivation:

The latest netty-tcnative release doesnt link libcrypt which makes it compatible with newer linux distros without the need to install extra packages.

Modifications:

Upgrade to latest netty-tcnative release

Result:

Less manual steps needed to use netty-tcnative on newer linux distros