### PR TITLE
Modify CloseWebSocketFrame#statusCode() to change the fetch c…

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/CloseWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/CloseWebSocketFrame.java
@@ -135,7 +135,7 @@ public class CloseWebSocketFrame extends WebSocketFrame {
             return -1;
         }
 
-        return binaryData.getShort(binaryData.readerIndex());
+        return binaryData.getUnsignedShort(binaryData.readerIndex());
     }
 
     /**

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/CloseWebSocketFrameTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/CloseWebSocketFrameTest.java
@@ -80,6 +80,15 @@ class CloseWebSocketFrameTest {
                 WebSocketCloseStatus.NORMAL_CLOSURE.code(), WebSocketCloseStatus.NORMAL_CLOSURE.reasonText());
     }
 
+    @Test
+    void testCustomCloseCode() {
+        ByteBuf buffer = Unpooled.buffer().writeZero(1);
+        buffer.writeShort(60000)
+                .writeCharSequence("Custom close code", CharsetUtil.US_ASCII);
+        doTestValidCode(new CloseWebSocketFrame(true, 0, buffer.skipBytes(1)),
+                60000, "Custom close code");
+    }
+
     private static void doTestInvalidCode(ThrowableAssert.ThrowingCallable callable) {
         assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(callable);
     }


### PR DESCRIPTION
Motivation:

According to the websocket protocol description, change the get code method in the CloseWebSocketFrame to unsigned.
![image](https://user-images.githubusercontent.com/11245691/211574564-332535a3-0752-4ace-af7a-a0faedae5f61.png)


Modification:

Modify changed CloseWebSocketFrame#statusCode() to change the fetch code to unsigned

Result:

Fixes #13113. 
