### PR TITLE
Allow PcapWriteHandler instances to write to the same OutputStream

### DIFF
--- a/handler/src/main/java/io/netty/handler/pcap/EthernetPacket.java
+++ b/handler/src/main/java/io/netty/handler/pcap/EthernetPacket.java
@@ -50,7 +50,7 @@ final class EthernetPacket {
      * @param payload Payload of IPv4
      */
     static void writeIPv4(ByteBuf byteBuf, ByteBuf payload) {
-        EthernetPacket.writePacket(byteBuf, payload, DUMMY_SOURCE_MAC_ADDRESS, DUMMY_DESTINATION_MAC_ADDRESS, V4);
+        writePacket(byteBuf, payload, DUMMY_SOURCE_MAC_ADDRESS, DUMMY_DESTINATION_MAC_ADDRESS, V4);
     }
 
     /**
@@ -60,7 +60,7 @@ final class EthernetPacket {
      * @param payload Payload of IPv6
      */
     static void writeIPv6(ByteBuf byteBuf, ByteBuf payload) {
-        EthernetPacket.writePacket(byteBuf, payload, DUMMY_SOURCE_MAC_ADDRESS, DUMMY_DESTINATION_MAC_ADDRESS, V6);
+        writePacket(byteBuf, payload, DUMMY_SOURCE_MAC_ADDRESS, DUMMY_DESTINATION_MAC_ADDRESS, V6);
     }
 
     /**

--- a/handler/src/main/java/io/netty/handler/pcap/PcapHeaders.java
+++ b/handler/src/main/java/io/netty/handler/pcap/PcapHeaders.java
@@ -31,7 +31,7 @@ final class PcapHeaders {
      *      <li> network </li>
      * </ol>
      */
-    private static final byte[] GLOBAL_HEADER = new byte[]{-95, -78, -61, -44, 0, 2, 0, 4, 0, 0,
+    static final byte[] GLOBAL_HEADER = new byte[]{-95, -78, -61, -44, 0, 2, 0, 4, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, -1, -1, 0, 0, 0, 1};
 
     private PcapHeaders() {

--- a/handler/src/main/java/io/netty/handler/pcap/PcapHeaders.java
+++ b/handler/src/main/java/io/netty/handler/pcap/PcapHeaders.java
@@ -34,20 +34,11 @@ final class PcapHeaders {
      *      <li> network </li>
      * </ol>
      */
-    static final byte[] GLOBAL_HEADER = new byte[]{-95, -78, -61, -44, 0, 2, 0, 4, 0, 0,
+    private static final byte[] GLOBAL_HEADER = {-95, -78, -61, -44, 0, 2, 0, 4, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, -1, -1, 0, 0, 0, 1};
 
     private PcapHeaders() {
         // Prevent outside initialization
-    }
-
-    /**
-     * Write Pcap Global Header
-     *
-     * @param byteBuf byteBuf where we'll write header data
-     */
-    public static void writeGlobalHeader(ByteBuf byteBuf) {
-        byteBuf.writeBytes(GLOBAL_HEADER);
     }
 
     /**
@@ -56,7 +47,7 @@ final class PcapHeaders {
      * @param outputStream OutputStream where Pcap data will be written.
      * @throws IOException if there is an error writing to the {@code OutputStream}
      */
-    public static void writeGlobalHeader(OutputStream outputStream) throws IOException {
+    static void writeGlobalHeader(OutputStream outputStream) throws IOException {
         outputStream.write(GLOBAL_HEADER);
     }
 

--- a/handler/src/main/java/io/netty/handler/pcap/PcapHeaders.java
+++ b/handler/src/main/java/io/netty/handler/pcap/PcapHeaders.java
@@ -17,6 +17,9 @@ package io.netty.handler.pcap;
 
 import io.netty.buffer.ByteBuf;
 
+import java.io.IOException;
+import java.io.OutputStream;
+
 final class PcapHeaders {
 
     /**
@@ -45,6 +48,16 @@ final class PcapHeaders {
      */
     public static void writeGlobalHeader(ByteBuf byteBuf) {
         byteBuf.writeBytes(GLOBAL_HEADER);
+    }
+
+    /**
+     * Writes the Pcap Global Header to the provided {@code OutputStream}
+     *
+     * @param outputStream OutputStream where Pcap data will be written.
+     * @throws IOException if there is an error writing to the {@code OutputStream}
+     */
+    public static void writeGlobalHeader(OutputStream outputStream) throws IOException {
+        outputStream.write(GLOBAL_HEADER);
     }
 
     /**

--- a/handler/src/main/java/io/netty/handler/pcap/PcapWriteHandler.java
+++ b/handler/src/main/java/io/netty/handler/pcap/PcapWriteHandler.java
@@ -262,7 +262,7 @@ public final class PcapWriteHandler extends ChannelDuplexHandler implements Clos
             logger.debug("Finished Fake TCP 3-Way Handshake");
         }
 
-        state.set(State.STARTED);
+        state.set(State.WRITING);
     }
 
     @Override
@@ -279,7 +279,7 @@ public final class PcapWriteHandler extends ChannelDuplexHandler implements Clos
         }
 
         // Only write if State is STARTED
-        if (state.get() == State.STARTED) {
+        if (state.get() == State.WRITING) {
             if (channelType == ChannelType.TCP) {
                 handleTCP(ctx, msg, false);
             } else if (channelType == ChannelType.UDP) {
@@ -299,7 +299,7 @@ public final class PcapWriteHandler extends ChannelDuplexHandler implements Clos
         }
 
         // Only write if State is STARTED
-        if (state.get() == State.STARTED) {
+        if (state.get() == State.WRITING) {
             if (channelType == ChannelType.TCP) {
                 handleTCP(ctx, msg, true);
             } else if (channelType == ChannelType.UDP) {
@@ -625,7 +625,15 @@ public final class PcapWriteHandler extends ChannelDuplexHandler implements Clos
         return sharedOutputStream;
     }
 
-    public State state() {
+    /**
+     * Returns {@code true} if the {@link PcapWriteHandler} is currently
+     * writing packets to the {@link OutputStream} else returns {@code false}.
+     */
+    public boolean isWriting() {
+        return state.get() == State.WRITING;
+    }
+
+    State state() {
         return state.get();
     }
 
@@ -633,7 +641,7 @@ public final class PcapWriteHandler extends ChannelDuplexHandler implements Clos
      * Pause the {@link PcapWriteHandler} from writing packets to the {@link OutputStream}.
      */
     public void pause() {
-        if (!state.compareAndSet(State.STARTED, State.PAUSED)) {
+        if (!state.compareAndSet(State.WRITING, State.PAUSED)) {
             throw new IllegalStateException("State must be 'STARTED' to pause but current state is: " + state);
         }
     }
@@ -642,7 +650,7 @@ public final class PcapWriteHandler extends ChannelDuplexHandler implements Clos
      * Resume the {@link PcapWriteHandler} to writing packets to the {@link OutputStream}.
      */
     public void resume() {
-        if (!state.compareAndSet(State.PAUSED, State.STARTED)) {
+        if (!state.compareAndSet(State.PAUSED, State.WRITING)) {
             throw new IllegalStateException("State must be 'PAUSED' to resume but current state is: " + state);
         }
     }

--- a/handler/src/main/java/io/netty/handler/pcap/PcapWriteHandler.java
+++ b/handler/src/main/java/io/netty/handler/pcap/PcapWriteHandler.java
@@ -608,7 +608,6 @@ public final class PcapWriteHandler extends ChannelDuplexHandler implements Clos
         ctx.fireExceptionCaught(cause);
     }
 
-
     /**
      * Logger for TCP
      */

--- a/handler/src/main/java/io/netty/handler/pcap/PcapWriteHandler.java
+++ b/handler/src/main/java/io/netty/handler/pcap/PcapWriteHandler.java
@@ -634,6 +634,23 @@ public final class PcapWriteHandler extends ChannelDuplexHandler implements Clos
         ctx.fireExceptionCaught(cause);
     }
 
+    @Override
+    public String toString() {
+        return "PcapWriteHandler{" +
+                "captureZeroByte=" + captureZeroByte +
+                ", writePcapGlobalHeader=" + writePcapGlobalHeader +
+                ", sharedOutputStream=" + sharedOutputStream +
+                ", sendSegmentNumber=" + sendSegmentNumber +
+                ", receiveSegmentNumber=" + receiveSegmentNumber +
+                ", channelType=" + channelType +
+                ", initiatorAddr=" + initiatorAddr +
+                ", handlerAddr=" + handlerAddr +
+                ", isServerPipeline=" + isServerPipeline +
+                ", isClosed=" + isClosed +
+                ", initialized=" + initialized +
+                '}';
+    }
+
     /**
      * <p> Close {@code PcapWriter} and {@link OutputStream}. </p>
      * <p> Note: Calling this method does not close {@link PcapWriteHandler}.

--- a/handler/src/main/java/io/netty/handler/pcap/PcapWriteHandler.java
+++ b/handler/src/main/java/io/netty/handler/pcap/PcapWriteHandler.java
@@ -133,7 +133,7 @@ public final class PcapWriteHandler extends ChannelDuplexHandler implements Clos
     /**
      * Current of this {@link PcapWriteHandler}
      */
-    private AtomicReference<State> state = new AtomicReference<>(State.INIT);
+    private final AtomicReference<State> state = new AtomicReference<State>(State.INIT);
 
     /**
      * Create new {@link PcapWriteHandler} Instance.

--- a/handler/src/main/java/io/netty/handler/pcap/PcapWriter.java
+++ b/handler/src/main/java/io/netty/handler/pcap/PcapWriter.java
@@ -109,6 +109,15 @@ final class PcapWriter implements Closeable {
     }
 
     @Override
+    public String toString() {
+        return "PcapWriter{" +
+                "outputStream=" + outputStream +
+                ", sharedOutputStream=" + sharedOutputStream +
+                ", isClosed=" + isClosed +
+                '}';
+    }
+
+    @Override
     public void close() throws IOException {
         if (isClosed) {
             logger.debug("PcapWriter is already closed");

--- a/handler/src/main/java/io/netty/handler/pcap/State.java
+++ b/handler/src/main/java/io/netty/handler/pcap/State.java
@@ -18,7 +18,7 @@ package io.netty.handler.pcap;
 /**
  * The state of the {@link PcapWriteHandler}.
  */
-public enum State {
+enum State {
 
     /**
      * The handler is not active.
@@ -26,9 +26,9 @@ public enum State {
     INIT,
 
     /**
-     * The handler is active.
+     * The handler is active and actively writing Pcap data.
      */
-    STARTED,
+    WRITING,
 
     /**
      * The handler is paused. No Pcap data will be written.

--- a/handler/src/main/java/io/netty/handler/pcap/State.java
+++ b/handler/src/main/java/io/netty/handler/pcap/State.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.pcap;
+
+/**
+ * The state of the {@link PcapWriteHandler}.
+ */
+enum State {
+
+    /**
+     * The handler is not active.
+     */
+    INIT,
+
+    /**
+     * The handler is active.
+     */
+    STARTED,
+
+    /**
+     * The handler is closed.
+     */
+    CLOSED
+}

--- a/handler/src/test/java/io/netty/handler/pcap/DiscardingStatsOutputStream.java
+++ b/handler/src/test/java/io/netty/handler/pcap/DiscardingStatsOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Netty Project
+ * Copyright 2023 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/handler/src/test/java/io/netty/handler/pcap/DiscardingStatsOutputStream.java
+++ b/handler/src/test/java/io/netty/handler/pcap/DiscardingStatsOutputStream.java
@@ -24,7 +24,7 @@ final class DiscardingStatsOutputStream extends OutputStream {
 
     @Override
     public void write(int b) throws IOException {
-
+        // NO-OP
     }
 
     @Override

--- a/handler/src/test/java/io/netty/handler/pcap/DiscardingStatsOutputStream.java
+++ b/handler/src/test/java/io/netty/handler/pcap/DiscardingStatsOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 The Netty Project
+ * Copyright 2020 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -15,28 +15,24 @@
  */
 package io.netty.handler.pcap;
 
-/**
- * The state of the {@link PcapWriteHandler}.
- */
-public enum State {
+import java.io.IOException;
+import java.io.OutputStream;
 
-    /**
-     * The handler is not active.
-     */
-    INIT,
+final class DiscardingStatsOutputStream extends OutputStream {
 
-    /**
-     * The handler is active.
-     */
-    STARTED,
+    private int writesCount;
 
-    /**
-     * The handler is paused. No Pcap data will be written.
-     */
-    PAUSED,
+    @Override
+    public void write(int b) throws IOException {
 
-    /**
-     * The handler is closed.
-     */
-    CLOSED
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        writesCount++;
+    }
+
+    int writesCalled() {
+        return writesCount;
+    }
 }

--- a/handler/src/test/java/io/netty/handler/pcap/PcapWriteHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/pcap/PcapWriteHandlerTest.java
@@ -51,6 +51,7 @@ import java.net.InetSocketAddress;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PcapWriteHandlerTest {
@@ -68,8 +69,8 @@ public class PcapWriteHandlerTest {
     private static void udpV4(boolean sharedOutputStream) throws InterruptedException {
         ByteBuf byteBuf = Unpooled.buffer();
 
-        InetSocketAddress srvReqAddr = new InetSocketAddress("127.0.0.1", 0);
-        InetSocketAddress cltReqAddr = new InetSocketAddress("127.0.0.1", 0);
+        InetSocketAddress serverAddr = new InetSocketAddress("127.0.0.1", 0);
+        InetSocketAddress clientAddr = new InetSocketAddress("127.0.0.1", 0);
 
         NioEventLoopGroup eventLoopGroup = new NioEventLoopGroup(2);
 
@@ -84,7 +85,7 @@ public class PcapWriteHandlerTest {
                     }
                 });
 
-        ChannelFuture channelFutureServer = server.bind(srvReqAddr).sync();
+        ChannelFuture channelFutureServer = server.bind(serverAddr).sync();
         assertTrue(channelFutureServer.isSuccess());
 
         // We'll bootstrap a UDP Client for sending UDP Packets to UDP Server.
@@ -96,8 +97,9 @@ public class PcapWriteHandlerTest {
                         .build(new ByteBufOutputStream(byteBuf)));
 
         ChannelFuture channelFutureClient =
-                client.connect(channelFutureServer.channel().localAddress(), cltReqAddr).sync();
+                client.connect(channelFutureServer.channel().localAddress(), clientAddr).sync();
         assertTrue(channelFutureClient.isSuccess());
+
         Channel clientChannel = channelFutureClient.channel();
         assertTrue(clientChannel.writeAndFlush(Unpooled.wrappedBuffer("Meow".getBytes())).sync().isSuccess());
         assertTrue(eventLoopGroup.shutdownGracefully().sync().isSuccess());
@@ -111,81 +113,26 @@ public class PcapWriteHandlerTest {
 
     @Test
     public void embeddedUdp() {
-        ByteBuf byteBuf = Unpooled.buffer();
+        final ByteBuf pcapBuffer = Unpooled.buffer();
+        final ByteBuf payload = Unpooled.wrappedBuffer("Meow".getBytes());
 
         InetSocketAddress serverAddr = new InetSocketAddress("1.1.1.1", 1234);
         InetSocketAddress clientAddr = new InetSocketAddress("2.2.2.2", 3456);
 
-        // we fake a client
-        EmbeddedChannel embeddedChannel = new EmbeddedChannel();
-        embeddedChannel.pipeline()
-                .addLast(PcapWriteHandler.builder()
+        // We fake a client
+        EmbeddedChannel embeddedChannel = new EmbeddedChannel(
+                PcapWriteHandler.builder()
                         .forceUdpChannel(clientAddr, serverAddr)
-                        .build(new ByteBufOutputStream(byteBuf)));
+                        .build(new ByteBufOutputStream(pcapBuffer))
+        );
 
-        embeddedChannel.writeOutbound(Unpooled.wrappedBuffer("Meow".getBytes()));
-        assertEquals(Unpooled.wrappedBuffer("Meow".getBytes()), embeddedChannel.readOutbound());
+        assertTrue(embeddedChannel.writeOutbound(payload));
+        assertEquals(payload, embeddedChannel.readOutbound());
 
-        verifyUdpCapture(true, byteBuf, serverAddr, clientAddr);
-    }
+        // Verify the capture data
+        verifyUdpCapture(true, pcapBuffer, serverAddr, clientAddr);
 
-    private static void verifyUdpCapture(boolean verifyGlobalHeaders, ByteBuf byteBuf,
-                                         InetSocketAddress remoteAddress, InetSocketAddress localAddress) {
-        if (verifyGlobalHeaders) {
-            verifyGlobalHeaders(byteBuf);
-        }
-
-        // Verify Pcap Packet Header
-        byteBuf.readInt(); // Just read, we don't care about timestamps for now
-        byteBuf.readInt(); // Just read, we don't care about timestamps for now
-        assertEquals(46, byteBuf.readInt()); // Length of Packet Saved In Pcap
-        assertEquals(46, byteBuf.readInt()); // Actual Length of Packet
-
-        // -------------------------------------------- Verify Packet --------------------------------------------
-        // Verify Ethernet Packet
-        ByteBuf ethernetPacket = byteBuf.readBytes(46);
-        ByteBuf dstMac = ethernetPacket.readBytes(6);
-        ByteBuf srcMac = ethernetPacket.readBytes(6);
-        assertArrayEquals(new byte[]{0, 0, 94, 0, 83, -1}, ByteBufUtil.getBytes(dstMac));
-        assertArrayEquals(new byte[]{0, 0, 94, 0, 83, 0}, ByteBufUtil.getBytes(srcMac));
-        assertEquals(0x0800, ethernetPacket.readShort());
-
-        // Verify IPv4 Packet
-        ByteBuf ipv4Packet = ethernetPacket.readBytes(32);
-        assertEquals(0x45, ipv4Packet.readByte());    // Version + IHL
-        assertEquals(0x00, ipv4Packet.readByte());    // DSCP
-        assertEquals(32, ipv4Packet.readShort());     // Length
-        assertEquals(0x0000, ipv4Packet.readShort()); // Identification
-        assertEquals(0x0000, ipv4Packet.readShort()); // Fragment
-        assertEquals((byte) 0xff, ipv4Packet.readByte());      // TTL
-        assertEquals((byte) 17, ipv4Packet.readByte());        // Protocol
-        assertEquals(0, ipv4Packet.readShort());      // Checksum
-
-        // Source IPv4 Address
-        assertEquals(NetUtil.ipv4AddressToInt((Inet4Address) localAddress.getAddress()), ipv4Packet.readInt());
-
-        // Destination IPv4 Address
-        assertEquals(NetUtil.ipv4AddressToInt((Inet4Address) remoteAddress.getAddress()), ipv4Packet.readInt());
-
-        // Verify UDP Packet
-        ByteBuf udpPacket = ipv4Packet.readBytes(12);
-        assertEquals(localAddress.getPort() & 0xffff, udpPacket.readUnsignedShort()); // Source Port
-        assertEquals(remoteAddress.getPort() & 0xffff, udpPacket.readUnsignedShort()); // Destination Port
-        assertEquals(12, udpPacket.readShort());     // Length
-        assertEquals(0x0001, udpPacket.readShort()); // Checksum
-
-        // Verify Payload
-        ByteBuf payload = udpPacket.readBytes(4);
-        assertArrayEquals("Meow".getBytes(CharsetUtil.UTF_8), ByteBufUtil.getBytes(payload)); // Payload
-
-        // Release all ByteBuf
-        assertTrue(dstMac.release());
-        assertTrue(srcMac.release());
-        assertTrue(payload.release());
-        assertTrue(byteBuf.release());
-        assertTrue(ethernetPacket.release());
-        assertTrue(ipv4Packet.release());
-        assertTrue(udpPacket.release());
+        assertFalse(embeddedChannel.finishAndReleaseAll());
     }
 
     @Test
@@ -289,24 +236,147 @@ public class PcapWriteHandlerTest {
 
     @Test
     public void embeddedTcp() {
-        ByteBuf byteBuf = Unpooled.buffer();
+        final ByteBuf pcapBuffer = Unpooled.buffer();
+        final ByteBuf payload = Unpooled.wrappedBuffer("Meow".getBytes());
 
         InetSocketAddress serverAddr = new InetSocketAddress("1.1.1.1", 1234);
         InetSocketAddress clientAddr = new InetSocketAddress("2.2.2.2", 3456);
 
-        EmbeddedChannel embeddedChannel = new EmbeddedChannel();
-        embeddedChannel.pipeline().addLast(PcapWriteHandler.builder()
+        EmbeddedChannel embeddedChannel = new EmbeddedChannel(
+                PcapWriteHandler.builder()
+                        .forceTcpChannel(serverAddr, clientAddr, true)
+                        .build(new ByteBufOutputStream(pcapBuffer))
+        );
+
+        assertTrue(embeddedChannel.writeInbound(payload));
+        assertEquals(payload, embeddedChannel.readInbound());
+
+        assertTrue(embeddedChannel.writeOutbound(payload));
+        assertEquals(payload, embeddedChannel.readOutbound());
+
+        // Verify the capture data
+        verifyTcpCapture(true, pcapBuffer, serverAddr, clientAddr);
+
+        assertFalse(embeddedChannel.finishAndReleaseAll());
+    }
+
+    @Test
+    public void writerStateTest() throws Exception {
+        final ByteBuf payload = Unpooled.wrappedBuffer("Meow".getBytes());
+        final InetSocketAddress serverAddr = new InetSocketAddress("1.1.1.1", 1234);
+        final InetSocketAddress clientAddr = new InetSocketAddress("2.2.2.2", 3456);
+
+        PcapWriteHandler pcapWriteHandler = PcapWriteHandler.builder()
                 .forceTcpChannel(serverAddr, clientAddr, true)
-                .build(new ByteBufOutputStream(byteBuf)));
+                .build(new OutputStream() {
+                    @Override
+                    public void write(int b) {
+                        // Discard everything
+                    }
+                });
 
-        byte[] payload = "Meow".getBytes();
-        embeddedChannel.writeInbound(Unpooled.wrappedBuffer(payload));
-        assertEquals(Unpooled.wrappedBuffer(payload), embeddedChannel.readInbound());
-        embeddedChannel.writeOutbound(Unpooled.wrappedBuffer(payload));
-        assertEquals(Unpooled.wrappedBuffer(payload), embeddedChannel.readOutbound());
-        assertTrue(embeddedChannel.close().isSuccess());
+        // State is INIT because we haven't written anything yet
+        // and 'channelActive' is not called yet as this Handler
+        // is yet to be attached to `EmbeddedChannel`.
+        assertEquals(State.INIT, pcapWriteHandler.state());
 
-        verifyTcpCapture(true, byteBuf, serverAddr, clientAddr);
+        // Create a new 'EmbeddedChannel' and add the 'PcapWriteHandler'
+        EmbeddedChannel embeddedChannel = new EmbeddedChannel(pcapWriteHandler);
+
+        // Write and read some data and verify it.
+        assertTrue(embeddedChannel.writeInbound(payload));
+        assertEquals(payload, embeddedChannel.readInbound());
+
+        assertTrue(embeddedChannel.writeOutbound(payload));
+        assertEquals(payload, embeddedChannel.readOutbound());
+
+        // State is now STARTED because we attached Handler to 'EmbeddedChannel'.
+        assertEquals(State.WRITING, pcapWriteHandler.state());
+
+        // Close the PcapWriter. This should trigger closure of PcapWriteHandler too.
+        pcapWriteHandler.pCapWriter().close();
+
+        // State should be changed to closed by now
+        assertEquals(State.CLOSED, pcapWriteHandler.state());
+
+        // Close PcapWriteHandler again. This should be a no-op.
+        pcapWriteHandler.close();
+
+        // State should still be CLOSED. No change.
+        assertEquals(State.CLOSED, pcapWriteHandler.state());
+
+        // Close the 'EmbeddedChannel'.
+        assertFalse(embeddedChannel.finishAndReleaseAll());
+    }
+
+    @Test
+    public void pauseResumeTest() throws Exception {
+        final byte[] payload = "Meow".getBytes();
+        final InetSocketAddress serverAddr = new InetSocketAddress("1.1.1.1", 1234);
+        final InetSocketAddress clientAddr = new InetSocketAddress("2.2.2.2", 3456);
+
+        DiscardingStatsOutputStream discardingStatsOutputStream = new DiscardingStatsOutputStream();
+        PcapWriteHandler pcapWriteHandler = PcapWriteHandler.builder()
+                .forceTcpChannel(serverAddr, clientAddr, true)
+                .build(discardingStatsOutputStream);
+
+        // Verify that no writes have been called yet.
+        assertEquals(0, discardingStatsOutputStream.writesCalled());
+
+        // Create a new 'EmbeddedChannel' and add the 'PcapWriteHandler'
+        EmbeddedChannel embeddedChannel = new EmbeddedChannel(pcapWriteHandler);
+
+        for (int i = 0; i < 10; i++) {
+            assertTrue(embeddedChannel.writeInbound(Unpooled.wrappedBuffer(payload)));
+        }
+
+        // Since we have written 10 times, we should have a value greater than 0.
+        // We can't say it will be 10 exactly because there will be pcap headers also.
+        final int initialWritesCalled = discardingStatsOutputStream.writesCalled();
+        assertThat(initialWritesCalled).isGreaterThan(0);
+
+        // Pause the Pcap
+        pcapWriteHandler.pause();
+        assertEquals(State.PAUSED, pcapWriteHandler.state());
+
+        // Write 100 times. No writes should be called in OutputStream.
+        for (int i = 0; i < 100; i++) {
+            assertTrue(embeddedChannel.writeInbound(Unpooled.wrappedBuffer(payload)));
+        }
+
+        // Current stats and previous stats should be same.
+        assertEquals(initialWritesCalled, discardingStatsOutputStream.writesCalled());
+
+        // Let's resume the Pcap now.
+        pcapWriteHandler.resume();
+        assertEquals(State.WRITING, pcapWriteHandler.state());
+
+        // Write 100 times. Writes should be called in OutputStream now.
+        for (int i = 0; i < 100; i++) {
+            assertTrue(embeddedChannel.writeInbound(Unpooled.wrappedBuffer(payload)));
+        }
+
+        // Verify we have written more than before.
+        assertThat(discardingStatsOutputStream.writesCalled()).isGreaterThan(initialWritesCalled);
+
+        // Close PcapWriteHandler again. This should be a no-op.
+        pcapWriteHandler.close();
+
+        // State should still be CLOSED. No change.
+        assertEquals(State.CLOSED, pcapWriteHandler.state());
+
+        // Close the 'EmbeddedChannel'.
+        assertTrue(embeddedChannel.finishAndReleaseAll());
+    }
+
+    private static void verifyGlobalHeaders(ByteBuf byteBuf) {
+        assertEquals(0xa1b2c3d4, byteBuf.readInt()); // magic_number
+        assertEquals(2, byteBuf.readShort());        // version_major
+        assertEquals(4, byteBuf.readShort());        // version_minor
+        assertEquals(0, byteBuf.readInt());          // thiszone
+        assertEquals(0, byteBuf.readInt());          // sigfigs
+        assertEquals(0xffff, byteBuf.readInt());     // snaplen
+        assertEquals(1, byteBuf.readInt());          // network
     }
 
     private static void verifyTcpCapture(boolean verifyGlobalHeaders, ByteBuf byteBuf,
@@ -353,124 +423,62 @@ public class PcapWriteHandlerTest {
         assertEquals(serverAddr.getPort() & 0xffff, tcpPacket.readUnsignedShort()); // Destination Port
     }
 
-    private static void verifyGlobalHeaders(ByteBuf byteBuf) {
-        assertEquals(0xa1b2c3d4, byteBuf.readInt()); // magic_number
-        assertEquals(2, byteBuf.readShort());        // version_major
-        assertEquals(4, byteBuf.readShort());        // version_minor
-        assertEquals(0, byteBuf.readInt());          // thiszone
-        assertEquals(0, byteBuf.readInt());          // sigfigs
-        assertEquals(0xffff, byteBuf.readInt());     // snaplen
-        assertEquals(1, byteBuf.readInt());          // network
-    }
-
-    @Test
-    public void writerStateTest() throws Exception {
-        final byte[] payload = "Meow".getBytes();
-        final InetSocketAddress serverAddr = new InetSocketAddress("1.1.1.1", 1234);
-        final InetSocketAddress clientAddr = new InetSocketAddress("2.2.2.2", 3456);
-
-        PcapWriteHandler pcapWriteHandler = PcapWriteHandler.builder()
-                .forceTcpChannel(serverAddr, clientAddr, true)
-                .build(new OutputStream() {
-                    @Override
-                    public void write(int b) {
-                        // Discard everything
-                    }
-                });
-
-        // State is INIT because we haven't written anything yet
-        // and 'channelActive' is not called yet as this Handler
-        // is yet to be attached to `EmbeddedChannel`.
-        assertEquals(State.INIT, pcapWriteHandler.state());
-
-        // Create a new 'EmbeddedChannel' and add the 'PcapWriteHandler'
-        EmbeddedChannel embeddedChannel = new EmbeddedChannel();
-        embeddedChannel.pipeline().addFirst(pcapWriteHandler);
-
-        // Write and read some data and verify it.
-        embeddedChannel.writeInbound(Unpooled.wrappedBuffer(payload));
-        assertEquals(Unpooled.wrappedBuffer(payload), embeddedChannel.readInbound());
-
-        embeddedChannel.writeOutbound(Unpooled.wrappedBuffer(payload));
-        assertEquals(Unpooled.wrappedBuffer(payload), embeddedChannel.readOutbound());
-
-        // State is now STARTED because we attached Handler to 'EmbeddedChannel'.
-        assertEquals(State.WRITING, pcapWriteHandler.state());
-
-        // Close the PcapWriter. This should trigger closure of PcapWriteHandler too.
-        pcapWriteHandler.pCapWriter().close();
-
-        // State should be changed to closed by now
-        assertEquals(State.CLOSED, pcapWriteHandler.state());
-
-        // Close PcapWriteHandler again. This should be a no-op.
-        pcapWriteHandler.close();
-
-        // State should still be CLOSED. No change.
-        assertEquals(State.CLOSED, pcapWriteHandler.state());
-
-        // Close the 'EmbeddedChannel'.
-        assertTrue(embeddedChannel.close().isSuccess());
-    }
-
-    @Test
-    public void pauseResumeTest() throws Exception {
-        final byte[] payload = "Meow".getBytes();
-        final InetSocketAddress serverAddr = new InetSocketAddress("1.1.1.1", 1234);
-        final InetSocketAddress clientAddr = new InetSocketAddress("2.2.2.2", 3456);
-
-        DiscardingStatsOutputStream discardingStatsOutputStream = new DiscardingStatsOutputStream();
-        PcapWriteHandler pcapWriteHandler = PcapWriteHandler.builder()
-                .forceTcpChannel(serverAddr, clientAddr, true)
-                .build(discardingStatsOutputStream);
-
-        // Create a new 'EmbeddedChannel' and add the 'PcapWriteHandler'
-        EmbeddedChannel embeddedChannel = new EmbeddedChannel();
-        embeddedChannel.pipeline().addFirst(pcapWriteHandler);
-
-        // Verify that no writes have been called yet.
-        assertEquals(0, discardingStatsOutputStream.writesCalled());
-
-        for (int i = 0; i < 10; i++) {
-            embeddedChannel.writeInbound(Unpooled.wrappedBuffer(payload));
+    private static void verifyUdpCapture(boolean verifyGlobalHeaders, ByteBuf byteBuf,
+                                         InetSocketAddress remoteAddress, InetSocketAddress localAddress) {
+        if (verifyGlobalHeaders) {
+            verifyGlobalHeaders(byteBuf);
         }
 
-        // Since we have written 10 times, we should have a value greater than 0.
-        // We can't say it will be 10 exactly because there will be pcap headers also.
-        final int initialWritesCalled = discardingStatsOutputStream.writesCalled();
-        assertThat(initialWritesCalled).isGreaterThan(0);
+        // Verify Pcap Packet Header
+        byteBuf.readInt(); // Just read, we don't care about timestamps for now
+        byteBuf.readInt(); // Just read, we don't care about timestamps for now
+        assertEquals(46, byteBuf.readInt()); // Length of Packet Saved In Pcap
+        assertEquals(46, byteBuf.readInt()); // Actual Length of Packet
 
-        // Pause the Pcap
-        pcapWriteHandler.pause();
-        assertEquals(State.PAUSED, pcapWriteHandler.state());
+        // -------------------------------------------- Verify Packet --------------------------------------------
+        // Verify Ethernet Packet
+        ByteBuf ethernetPacket = byteBuf.readBytes(46);
+        ByteBuf dstMac = ethernetPacket.readBytes(6);
+        ByteBuf srcMac = ethernetPacket.readBytes(6);
+        assertArrayEquals(new byte[]{0, 0, 94, 0, 83, -1}, ByteBufUtil.getBytes(dstMac));
+        assertArrayEquals(new byte[]{0, 0, 94, 0, 83, 0}, ByteBufUtil.getBytes(srcMac));
+        assertEquals(0x0800, ethernetPacket.readShort());
 
-        // Write 100 times. No writes should be called in OutputStream.
-        for (int i = 0; i < 100; i++) {
-            embeddedChannel.writeInbound(Unpooled.wrappedBuffer(payload));
-        }
+        // Verify IPv4 Packet
+        ByteBuf ipv4Packet = ethernetPacket.readBytes(32);
+        assertEquals(0x45, ipv4Packet.readByte());    // Version + IHL
+        assertEquals(0x00, ipv4Packet.readByte());    // DSCP
+        assertEquals(32, ipv4Packet.readShort());     // Length
+        assertEquals(0x0000, ipv4Packet.readShort()); // Identification
+        assertEquals(0x0000, ipv4Packet.readShort()); // Fragment
+        assertEquals((byte) 0xff, ipv4Packet.readByte());      // TTL
+        assertEquals((byte) 17, ipv4Packet.readByte());        // Protocol
+        assertEquals(0, ipv4Packet.readShort());      // Checksum
 
-        // Current stats and previous stats should be same.
-        assertEquals(initialWritesCalled, discardingStatsOutputStream.writesCalled());
+        // Source IPv4 Address
+        assertEquals(NetUtil.ipv4AddressToInt((Inet4Address) localAddress.getAddress()), ipv4Packet.readInt());
 
-        // Let's resume the Pcap now.
-        pcapWriteHandler.resume();
-        assertEquals(State.WRITING, pcapWriteHandler.state());
+        // Destination IPv4 Address
+        assertEquals(NetUtil.ipv4AddressToInt((Inet4Address) remoteAddress.getAddress()), ipv4Packet.readInt());
 
-        // Write 100 times. Writes should be called in OutputStream now.
-        for (int i = 0; i < 100; i++) {
-            embeddedChannel.writeInbound(Unpooled.wrappedBuffer(payload));
-        }
+        // Verify UDP Packet
+        ByteBuf udpPacket = ipv4Packet.readBytes(12);
+        assertEquals(localAddress.getPort() & 0xffff, udpPacket.readUnsignedShort()); // Source Port
+        assertEquals(remoteAddress.getPort() & 0xffff, udpPacket.readUnsignedShort()); // Destination Port
+        assertEquals(12, udpPacket.readShort());     // Length
+        assertEquals(0x0001, udpPacket.readShort()); // Checksum
 
-        // Verify we have written more than before.
-        assertThat(discardingStatsOutputStream.writesCalled()).isGreaterThan(initialWritesCalled);
+        // Verify Payload
+        ByteBuf payload = udpPacket.readBytes(4);
+        assertArrayEquals("Meow".getBytes(CharsetUtil.UTF_8), ByteBufUtil.getBytes(payload)); // Payload
 
-        // Close PcapWriteHandler again. This should be a no-op.
-        pcapWriteHandler.close();
-
-        // State should still be CLOSED. No change.
-        assertEquals(State.CLOSED, pcapWriteHandler.state());
-
-        // Close the 'EmbeddedChannel'.
-        assertTrue(embeddedChannel.close().isSuccess());
+        // Release all ByteBuf
+        assertTrue(dstMac.release());
+        assertTrue(srcMac.release());
+        assertTrue(payload.release());
+        assertTrue(byteBuf.release());
+        assertTrue(ethernetPacket.release());
+        assertTrue(ipv4Packet.release());
+        assertTrue(udpPacket.release());
     }
 }

--- a/handler/src/test/java/io/netty/handler/pcap/PcapWriteHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/pcap/PcapWriteHandlerTest.java
@@ -395,7 +395,7 @@ public class PcapWriteHandlerTest {
         assertEquals(Unpooled.wrappedBuffer(payload), embeddedChannel.readOutbound());
 
         // State is now STARTED because we attached Handler to 'EmbeddedChannel'.
-        assertEquals(State.STARTED, pcapWriteHandler.state());
+        assertEquals(State.WRITING, pcapWriteHandler.state());
 
         // Close the PcapWriter. This should trigger closure of PcapWriteHandler too.
         pcapWriteHandler.pCapWriter().close();
@@ -454,7 +454,7 @@ public class PcapWriteHandlerTest {
 
         // Let's resume the Pcap now.
         pcapWriteHandler.resume();
-        assertEquals(State.STARTED, pcapWriteHandler.state());
+        assertEquals(State.WRITING, pcapWriteHandler.state());
 
         // Write 100 times. Writes should be called in OutputStream now.
         for (int i = 0; i < 100; i++) {


### PR DESCRIPTION
Motivation:
Currently, PcapWriteHandler expects a dedicated OutputStream, and cannot support multiple streams written to a single PCAP file. These modifications are intended to support sharing the OutputStream between multiple concurrent PcapWriteHandler instances.

Modification:
Added a "shareOutputStream" flag to PcapWriteHandler (and PcapWriter) to enable synchronization on the OutputStream in order to prevent interleaved writes. Also, provide a method to write the PCAP Global Header to the OutputStream.

Result:
Allows multiple channels to write to the same PCAP file.

This PR adds further improvement done in PR #12337 and supersedes it.
Original Author: @RoganDawes 