### PR TITLE
Optimize method: PoolChunk#allocateRun(int)

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/pool/PoolChunk.java
+++ b/buffer/src/main/java/io/netty5/buffer/pool/PoolChunk.java
@@ -242,13 +242,11 @@ final class PoolChunk implements PoolChunkMetric {
 
     private void removeAvailRun(long handle) {
         int pageIdxFloor = arena.pages2pageIdxFloor(runPages(handle));
-        LongPriorityQueue queue = runsAvail[pageIdxFloor];
-        removeAvailRun(queue, handle);
+        runsAvail[pageIdxFloor].remove(handle);
+        removeAvailRun0(handle);
     }
 
-    private void removeAvailRun(LongPriorityQueue queue, long handle) {
-        queue.remove(handle);
-
+    private void removeAvailRun0(long handle) {
         int runOffset = runOffset(handle);
         int pages = runPages(handle);
         //remove first page of run
@@ -330,7 +328,7 @@ final class PoolChunk implements PoolChunkMetric {
 
             assert handle != LongPriorityQueue.NO_VALUE && !isUsed(handle) : "invalid handle: " + handle;
 
-            removeAvailRun(queue, handle);
+            removeAvailRun0(handle);
 
             if (handle != -1) {
                 handle = splitLargeRun(handle, pages);


### PR DESCRIPTION
Motivation:

when `removeAvailRun(queue, handle)` is called within the `allocateRun(int)`, the handle is already removed from queue. So, no need to iterate through entire queue to remove the handle.

Modification:

Moved the logic for removing the handle from the queue to a more appropriate location.

Result:

Removed unnecessary iteration.