### PR TITLE
Remove redundant array initialization

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/pool/PoolSubpage.java
+++ b/buffer/src/main/java/io/netty5/buffer/pool/PoolSubpage.java
@@ -68,10 +68,6 @@ final class PoolSubpage implements PoolSubpageMetric {
             if ((maxNumElems & 63) != 0) {
                 bitmapLength ++;
             }
-
-            for (int i = 0; i < bitmapLength; i ++) {
-                bitmap[i] = 0;
-            }
         }
         addToPool(head);
     }


### PR DESCRIPTION
Motivation:
JLS-10.3: An array initializer creates an array and provides initial values for all its components.

This change was applied to Netty4(#12992), but not to Netty5

Modification:
Removed redundant array initialization

Result:
More efficient code