### PR TITLE
Replace 'size > 0' check with '!empty' in PoolThreadCache

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolThreadCache.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolThreadCache.java
@@ -246,7 +246,7 @@ final class PoolThreadCache {
 
     private static void checkCacheMayLeak(MemoryRegionCache<?>[] caches, String type) {
         for (MemoryRegionCache<?> cache : caches) {
-            if (cache.queue.size() > 0) {
+            if (!cache.queue.isEmpty()) {
                 logger.debug("{} memory may leak.", type);
                 return;
             }


### PR DESCRIPTION
Motivation:
We manually fetch the collection size and then check if the size is greater than zero or not to see if it's non-empty.

Modification:
We can use the inverted `Collection#isEmpty` method to do the exact same thing in a much clean way.

Result:
Cleaner code
