### PR TITLE
Fix leaks in CloseWebSocketFrameTest

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/CloseWebSocketFrameTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/CloseWebSocketFrameTest.java
@@ -85,7 +85,11 @@ class CloseWebSocketFrameTest {
     }
 
     private static void doTestValidCode(CloseWebSocketFrame frame, int expectedCode, String expectedReason) {
-        assertThat(frame.statusCode()).isEqualTo(expectedCode);
-        assertThat(frame.reasonText()).isEqualTo(expectedReason);
+        try {
+            assertThat(frame.statusCode()).isEqualTo(expectedCode);
+            assertThat(frame.reasonText()).isEqualTo(expectedReason);
+        } finally {
+            frame.release();
+        }
     }
 }


### PR DESCRIPTION
Motivation:

We should release the CloseWebSocketFrame to prevent leaks

Modifications:

Add release() call

Result:

No more leaks in CloseWebSocketFrameTest
