### PR TITLE
Remove unnecessary redundant `ByteBuffer` casting

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBufferBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBufferBuf.java
@@ -422,7 +422,7 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
         ensureAccessible();
         ByteBuffer src;
         try {
-            src = (ByteBuffer) internalNioBuffer().clear().position(index).limit(index + length);
+            src = internalNioBuffer().clear().position(index).limit(index + length);
         } catch (IllegalArgumentException ignored) {
             throw new IndexOutOfBoundsException("Too many bytes to read - Need " + (index + length));
         }
@@ -445,13 +445,13 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
     @Override
     public ByteBuffer nioBuffer(int index, int length) {
         checkIndex(index, length);
-        return (ByteBuffer) buffer.duplicate().position(index).limit(index + length);
+        return buffer.duplicate().position(index).limit(index + length);
     }
 
     @Override
     public ByteBuffer internalNioBuffer(int index, int length) {
         ensureAccessible();
-        return (ByteBuffer) internalNioBuffer().clear().position(index).limit(index + length);
+        return internalNioBuffer().clear().position(index).limit(index + length);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
@@ -605,7 +605,7 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
         ensureAccessible();
         ByteBuffer src;
         try {
-            src = (ByteBuffer) buffer.duplicate().clear().position(index).limit(index + length);
+            src = buffer.duplicate().clear().position(index).limit(index + length);
         } catch (IllegalArgumentException ignored) {
             throw new IndexOutOfBoundsException("Too many bytes to read - Need " + (index + length));
         }
@@ -616,7 +616,7 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     public ByteBuffer internalNioBuffer(int index, int length) {
         checkIndex(index, length);
-        return (ByteBuffer) internalNioBuffer().clear().position(index).limit(index + length);
+        return internalNioBuffer().clear().position(index).limit(index + length);
     }
 
     private ByteBuffer internalNioBuffer() {
@@ -630,7 +630,7 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     public ByteBuffer nioBuffer(int index, int length) {
         checkIndex(index, length);
-        return ((ByteBuffer) buffer.duplicate().position(index).limit(index + length)).slice();
+        return buffer.duplicate().position(index).limit(index + length).slice();
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
@@ -217,13 +217,13 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
         } else {
             tmpBuf = ByteBuffer.wrap(array);
         }
-        return out.write((ByteBuffer) tmpBuf.clear().position(index).limit(index + length));
+        return out.write(tmpBuf.clear().position(index).limit(index + length));
     }
 
     private int getBytes(int index, FileChannel out, long position, int length, boolean internal) throws IOException {
         ensureAccessible();
         ByteBuffer tmpBuf = internal ? internalNioBuffer() : ByteBuffer.wrap(array);
-        return out.write((ByteBuffer) tmpBuf.clear().position(index).limit(index + length), position);
+        return out.write(tmpBuf.clear().position(index).limit(index + length), position);
     }
 
     @Override
@@ -279,7 +279,7 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     public int setBytes(int index, ScatteringByteChannel in, int length) throws IOException {
         ensureAccessible();
         try {
-            return in.read((ByteBuffer) internalNioBuffer().clear().position(index).limit(index + length));
+            return in.read(internalNioBuffer().clear().position(index).limit(index + length));
         } catch (ClosedChannelException ignored) {
             return -1;
         }
@@ -289,7 +289,7 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     public int setBytes(int index, FileChannel in, long position, int length) throws IOException {
         ensureAccessible();
         try {
-            return in.read((ByteBuffer) internalNioBuffer().clear().position(index).limit(index + length), position);
+            return in.read(internalNioBuffer().clear().position(index).limit(index + length), position);
         } catch (ClosedChannelException ignored) {
             return -1;
         }
@@ -314,7 +314,7 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     public ByteBuffer internalNioBuffer(int index, int length) {
         checkIndex(index, length);
-        return (ByteBuffer) internalNioBuffer().clear().position(index).limit(index + length);
+        return internalNioBuffer().clear().position(index).limit(index + length);
     }
 
     @Override


### PR DESCRIPTION
Motivation:
We are casting unnecessary `ByteBuffer` on methods that already return `ByteBuffer`.

Modification:
Removed unnecessary redundant `ByteBuffer` casting

Result:
Cleaner code
