### PR TITLE
HttpResponseStatus missing HTTP status code 418 "I'm a teapot"

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseStatus.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseStatus.java
@@ -226,6 +226,13 @@ public class HttpResponseStatus implements Comparable<HttpResponseStatus> {
      * 417 Expectation Failed
      */
     public static final HttpResponseStatus EXPECTATION_FAILED = newStatus(417, "Expectation Failed");
+    
+    /**
+     * 418 I'm a teapot
+     *
+     * @see <a href="https://save418.com/">Save 418</a>
+     */
+    public static final HttpResponseStatus IM_A_TEAPOT = newStatus(418, "I'm a teapot");
 
     /**
      * 421 Misdirected Request

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseStatus.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseStatus.java
@@ -426,6 +426,8 @@ public class HttpResponseStatus implements Comparable<HttpResponseStatus> {
             return REQUESTED_RANGE_NOT_SATISFIABLE;
         case 417:
             return EXPECTATION_FAILED;
+        case 418:
+            return IM_A_TEAPOT;
         case 421:
             return MISDIRECTED_REQUEST;
         case 422:


### PR DESCRIPTION
Motivation:

HttpResponseStatus missing HTTP status code 418 "I'm a teapot"

Modification:

Defined IM_A_TEAPOT as a HTTP Status code 418: I'm a teapot

Result:

Introduces 418 as a HttpResponseStatus
