### PR TITLE
Replace `assertTrue` with `assertThat#instanceOf` in ByteBufUtilTest

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static io.netty.buffer.Unpooled.unreleasableBuffer;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -617,7 +618,7 @@ public class ByteBufUtilTest {
     }
 
     private static void assertWrapped(ByteBuf buf) {
-        assertTrue(buf instanceof WrappedByteBuf);
+        assertThat(buf, instanceOf(WrappedByteBuf.class));
     }
 
     @ParameterizedTest(name = PARAMETERIZED_NAME)


### PR DESCRIPTION
Motivation:
We use `assertTrue(obj instanceOf Cat)` for asserting object instances. While this is correct and works, it becomes impossible to debug when the assertion fails because we have no clue at all which instance type made the assertion fail.

Modification:
To address this, we should use `assertThat#instanceOf` which will do the exact same thing but in a much cleaner way. Also, it will give us more information when it fails like why the assertion of instance check failed and what exactly we got in place of the expected one.

Result:
Cleaner and easier to debug test case failure

Note: I will migrate all `assertTrue` usages with `assertThat#instanceOf` one by one.
