### PR TITLE
enable brotli4j in example applications

### DIFF
--- a/example/pom.xml
+++ b/example/pom.xml
@@ -159,7 +159,58 @@
       <artifactId>logback-classic</artifactId>
       <scope>runtime</scope>
     </dependency>
-    
+
+    <!-- brotli4j is needed for content compression -->
+    <dependency>
+      <groupId>com.aayushatharva.brotli4j</groupId>
+      <artifactId>brotli4j</artifactId>
+      <version>${brotli4j.version}</version>
+      <scope>runtime</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>com.aayushatharva.brotli4j</groupId>
+      <artifactId>native-linux-x86_64</artifactId>
+      <version>${brotli4j.version}</version>
+      <scope>runtime</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>com.aayushatharva.brotli4j</groupId>
+      <artifactId>native-linux-aarch64</artifactId>
+      <version>${brotli4j.version}</version>
+      <scope>runtime</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>com.aayushatharva.brotli4j</groupId>
+      <artifactId>native-linux-armv7</artifactId>
+      <version>${brotli4j.version}</version>
+      <scope>runtime</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>com.aayushatharva.brotli4j</groupId>
+      <artifactId>native-osx-x86_64</artifactId>
+      <version>${brotli4j.version}</version>
+      <scope>runtime</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>com.aayushatharva.brotli4j</groupId>
+      <artifactId>native-osx-aarch64</artifactId>
+      <version>${brotli4j.version}</version>
+      <scope>runtime</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>com.aayushatharva.brotli4j</groupId>
+      <artifactId>native-windows-x86_64</artifactId>
+      <version>${brotli4j.version}</version>
+      <scope>runtime</scope>
+      <optional>true</optional>
+    </dependency>
+
     <!-- Needed for OCSP -->
     <dependency>
       <groupId>org.bouncycastle</groupId>

--- a/example/src/main/java/io/netty/example/http/helloworld/HttpHelloWorldServerInitializer.java
+++ b/example/src/main/java/io/netty/example/http/helloworld/HttpHelloWorldServerInitializer.java
@@ -18,6 +18,8 @@ package io.netty.example.http.helloworld;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.compression.CompressionOptions;
+import io.netty.handler.codec.http.HttpContentCompressor;
 import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.codec.http.HttpServerExpectContinueHandler;
 import io.netty.handler.ssl.SslContext;
@@ -37,6 +39,7 @@ public class HttpHelloWorldServerInitializer extends ChannelInitializer<SocketCh
             p.addLast(sslCtx.newHandler(ch.alloc()));
         }
         p.addLast(new HttpServerCodec());
+        p.addLast(new HttpContentCompressor((CompressionOptions[]) null));
         p.addLast(new HttpServerExpectContinueHandler());
         p.addLast(new HttpHelloWorldServerHandler());
     }

--- a/example/src/main/java/io/netty/example/http/snoop/HttpSnoopServerInitializer.java
+++ b/example/src/main/java/io/netty/example/http/snoop/HttpSnoopServerInitializer.java
@@ -18,6 +18,8 @@ package io.netty.example.http.snoop;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.compression.CompressionOptions;
+import io.netty.handler.codec.http.HttpContentCompressor;
 import io.netty.handler.codec.http.HttpRequestDecoder;
 import io.netty.handler.codec.http.HttpResponseEncoder;
 import io.netty.handler.ssl.SslContext;
@@ -41,7 +43,7 @@ public class HttpSnoopServerInitializer extends ChannelInitializer<SocketChannel
         //p.addLast(new HttpObjectAggregator(1048576));
         p.addLast(new HttpResponseEncoder());
         // Remove the following line if you don't want automatic content compression.
-        //p.addLast(new HttpContentCompressor());
+        //p.addLast(new HttpContentCompressor((CompressionOptions[]) null));
         p.addLast(new HttpSnoopServerHandler());
     }
 }

--- a/example/src/main/java/io/netty/example/http/upload/HttpUploadServerInitializer.java
+++ b/example/src/main/java/io/netty/example/http/upload/HttpUploadServerInitializer.java
@@ -18,6 +18,7 @@ package io.netty.example.http.upload;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.compression.CompressionOptions;
 import io.netty.handler.codec.http.HttpContentCompressor;
 import io.netty.handler.codec.http.HttpRequestDecoder;
 import io.netty.handler.codec.http.HttpResponseEncoder;
@@ -43,7 +44,7 @@ public class HttpUploadServerInitializer extends ChannelInitializer<SocketChanne
         pipeline.addLast(new HttpResponseEncoder());
 
         // Remove the following line if you don't want automatic content compression.
-        pipeline.addLast(new HttpContentCompressor());
+        pipeline.addLast(new HttpContentCompressor((CompressionOptions[]) null));
 
         pipeline.addLast(new HttpUploadServerHandler());
     }

--- a/example/src/main/java/io/netty/example/portunification/PortUnificationServerHandler.java
+++ b/example/src/main/java/io/netty/example/portunification/PortUnificationServerHandler.java
@@ -23,6 +23,7 @@ import io.netty.example.factorial.FactorialServerHandler;
 import io.netty.example.factorial.NumberEncoder;
 import io.netty.example.http.snoop.HttpSnoopServerHandler;
 import io.netty.handler.codec.ByteToMessageDecoder;
+import io.netty.handler.codec.compression.CompressionOptions;
 import io.netty.handler.codec.compression.ZlibCodecFactory;
 import io.netty.handler.codec.compression.ZlibWrapper;
 import io.netty.handler.codec.http.HttpContentCompressor;
@@ -129,7 +130,7 @@ public class PortUnificationServerHandler extends ByteToMessageDecoder {
         ChannelPipeline p = ctx.pipeline();
         p.addLast("decoder", new HttpRequestDecoder());
         p.addLast("encoder", new HttpResponseEncoder());
-        p.addLast("deflater", new HttpContentCompressor());
+        p.addLast("deflater", new HttpContentCompressor((CompressionOptions[]) null));
         p.addLast("handler", new HttpSnoopServerHandler());
         p.remove(this);
     }


### PR DESCRIPTION
Motivation:

The [example] applications cannot return Brotli compressed
responses because brotli4j is not on the classpath.

Modification:

add brotli4j to [example] pom.xml

Result:

Brotli compression is enabled in the [example] applications.

