### PR TITLE
Check if CommandLineTools are installed before trying to execute inst…

### DIFF
--- a/common/src/main/java/io/netty/util/internal/NativeLibraryLoader.java
+++ b/common/src/main/java/io/netty/util/internal/NativeLibraryLoader.java
@@ -327,6 +327,11 @@ public final class NativeLibraryLoader {
     }
 
     static void tryPatchShadedLibraryIdAndSign(File libraryFile, String originalName) {
+        if (!new File("/Library/Developer/CommandLineTools").exists()) {
+            logger.debug("Can't patch shaded library id as CommandLineTools are not installed." +
+                    " Consider installing CommandLineTools with 'xcode-select --install'");
+            return;
+        }
         String newId = new String(generateUniqueId(originalName.length()), CharsetUtil.UTF_8);
         if (!tryExec("install_name_tool -id " + newId + " " + libraryFile.getAbsolutePath())) {
             return;


### PR DESCRIPTION
…all_name_tool

Motivation:

We should check if CommandLineTools are installed before trying to execute install_name_tool as otherwise it might open a prompt to ask users to install it which is unexpected.

Modifications:

Check if the folder /Library/Developer/CommandLineTools exists before trying to execute install_name_tool

Result:

Better user experience. Related to https://github.com/netty/netty/issues/13125
