### PR TITLE
Use `assertThat#instanceOf` and `assertThat#isNotInstanceOf` [Buffer]

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
@@ -126,7 +126,7 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
 
     @Test
     public void testWithoutUseCacheForAllThreads() {
-        assertFalse(Thread.currentThread() instanceof FastThreadLocalThread);
+        assertThat(Thread.currentThread()).isNotInstanceOf(FastThreadLocalThread.class);
 
         PooledByteBufAllocator pool = new PooledByteBufAllocator(
                 /*preferDirect=*/ false,

--- a/buffer/src/test/java/io/netty/buffer/ReadOnlyByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ReadOnlyByteBufTest.java
@@ -32,6 +32,7 @@ import static io.netty.buffer.Unpooled.EMPTY_BUFFER;
 import static io.netty.buffer.Unpooled.LITTLE_ENDIAN;
 import static io.netty.buffer.Unpooled.buffer;
 import static io.netty.buffer.Unpooled.unmodifiableBuffer;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -57,7 +58,7 @@ public class ReadOnlyByteBufTest {
 
     @Test
     public void testUnmodifiableBuffer() {
-        assertTrue(unmodifiableBuffer(buffer(1)) instanceof ReadOnlyByteBuf);
+        assertThat(unmodifiableBuffer(buffer(1))).isInstanceOf(ReadOnlyByteBuf.class);
     }
 
     @Test
@@ -77,16 +78,16 @@ public class ReadOnlyByteBufTest {
     @Test
     public void shouldReturnReadOnlyDerivedBuffer() {
         ByteBuf buf = unmodifiableBuffer(buffer(1));
-        assertTrue(buf.duplicate() instanceof ReadOnlyByteBuf);
-        assertTrue(buf.slice() instanceof ReadOnlyByteBuf);
-        assertTrue(buf.slice(0, 1) instanceof ReadOnlyByteBuf);
-        assertTrue(buf.duplicate() instanceof ReadOnlyByteBuf);
+        assertThat(buf.duplicate()).isInstanceOf(ReadOnlyByteBuf.class);
+        assertThat(buf.slice()).isInstanceOf(ReadOnlyByteBuf.class);
+        assertThat(buf.slice(0, 1)).isInstanceOf(ReadOnlyByteBuf.class);
+        assertThat(buf.duplicate()).isInstanceOf(ReadOnlyByteBuf.class);
     }
 
     @Test
     public void shouldReturnWritableCopy() {
         ByteBuf buf = unmodifiableBuffer(buffer(1));
-        assertFalse(buf.copy() instanceof ReadOnlyByteBuf);
+        assertThat(buf.copy()).isNotInstanceOf(ReadOnlyByteBuf.class);
     }
 
     @Test


### PR DESCRIPTION
Motivation:
We use `assertTrue(obj instanceOf Cat)` for asserting object instances. While this is correct and works, it becomes impossible to debug when the assertion fails because we have no clue at all which instance type made the assertion fail.

Modification:
To address this, we should use `assertThat#instanceOf` which will do the exact same thing but in a much cleaner way. Also, it will give us more information when it fails like why the assertion of instance check failed and what exactly we got in place of the expected one.

Result:
Cleaner and easier to debug test case failure

This PR migrates the entire buffer module completely to the new API.
Previous PR: #13130