### PR TITLE
Allow to adjust the GlobalEventExecutor quietPeriod via a system prop…

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
@@ -55,7 +55,6 @@ public final class GlobalEventExecutor extends AbstractScheduledEventExecutor im
         SCHEDULE_QUIET_PERIOD_INTERVAL = TimeUnit.SECONDS.toNanos(quietPeriod);
     }
 
-
     public static final GlobalEventExecutor INSTANCE = new GlobalEventExecutor();
 
     final BlockingQueue<Runnable> taskQueue = new LinkedBlockingQueue<Runnable>();

--- a/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
@@ -16,6 +16,7 @@
 package io.netty.util.concurrent;
 
 import io.netty.util.internal.ObjectUtil;
+import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.ThreadExecutorMap;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -35,14 +36,23 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Single-thread singleton {@link EventExecutor}.  It starts the thread automatically and stops it when there is no
- * task pending in the task queue for 1 second.  Please note it is not scalable to schedule large number of tasks to
- * this executor; use a dedicated executor.
+ * task pending in the task queue for {@code io.netty.globalEventExecutor.quietPeriodSeconds} second
+ * (default is 1 second).  Please note it is not scalable to schedule large number of tasks to this executor;
+ * use a dedicated executor.
  */
 public final class GlobalEventExecutor extends AbstractScheduledEventExecutor implements OrderedEventExecutor {
 
-    private static final InternalLogger logger = InternalLoggerFactory.getInstance(GlobalEventExecutor.class);
+    private static final long SCHEDULE_QUIET_PERIOD_INTERVAL;
 
-    private static final long SCHEDULE_QUIET_PERIOD_INTERVAL = TimeUnit.SECONDS.toNanos(1);
+    static {
+        int quietPeriod = SystemPropertyUtil.getInt("io.netty.globalEventExecutor.quietPeriodSeconds", 1);
+        if (quietPeriod <= 0) {
+            quietPeriod = 1;
+        }
+        SCHEDULE_QUIET_PERIOD_INTERVAL = TimeUnit.SECONDS.toNanos(quietPeriod);
+    }
+
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(GlobalEventExecutor.class);
 
     public static final GlobalEventExecutor INSTANCE = new GlobalEventExecutor();
 

--- a/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
@@ -41,6 +41,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * use a dedicated executor.
  */
 public final class GlobalEventExecutor extends AbstractScheduledEventExecutor implements OrderedEventExecutor {
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(GlobalEventExecutor.class);
 
     private static final long SCHEDULE_QUIET_PERIOD_INTERVAL;
 
@@ -49,10 +50,11 @@ public final class GlobalEventExecutor extends AbstractScheduledEventExecutor im
         if (quietPeriod <= 0) {
             quietPeriod = 1;
         }
+        logger.debug("-Dio.netty.globalEventExecutor.quietPeriodSeconds: {}", quietPeriod);
+
         SCHEDULE_QUIET_PERIOD_INTERVAL = TimeUnit.SECONDS.toNanos(quietPeriod);
     }
 
-    private static final InternalLogger logger = InternalLoggerFactory.getInstance(GlobalEventExecutor.class);
 
     public static final GlobalEventExecutor INSTANCE = new GlobalEventExecutor();
 


### PR DESCRIPTION
…erty

Motivation:

The GlobalEventExecutor will shutdown its "internal thread" after the used quietPeriod if there is no more work to do. This quietPeriod was hardcoded to 1 second which might not be long enough for some applications and so will cause a lot of threads be started and destroyed.

Modifications:

Add io.netty.globalEventExecutor.quietPeriodSeconds property which allows the user to configure the quietPeriod. Default is still 1 second

Result:

Be able to influence the quietPeriod of GlobalEventExecutor via a system property
