### PR TITLE
add brotli4j aarch64 dependencies

### DIFF
--- a/codec-http/pom.xml
+++ b/codec-http/pom.xml
@@ -83,7 +83,17 @@
     </dependency>
     <dependency>
       <groupId>com.aayushatharva.brotli4j</groupId>
+      <artifactId>native-linux-aarch64</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.aayushatharva.brotli4j</groupId>
       <artifactId>native-osx-x86_64</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.aayushatharva.brotli4j</groupId>
+      <artifactId>native-osx-aarch64</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/codec/pom.xml
+++ b/codec/pom.xml
@@ -100,7 +100,17 @@
     </dependency>
     <dependency>
       <groupId>com.aayushatharva.brotli4j</groupId>
+      <artifactId>native-linux-aarch64</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>com.aayushatharva.brotli4j</groupId>
       <artifactId>native-osx-x86_64</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>com.aayushatharva.brotli4j</groupId>
+      <artifactId>native-osx-aarch64</artifactId>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -827,7 +827,17 @@
       </dependency>
       <dependency>
         <groupId>com.aayushatharva.brotli4j</groupId>
+        <artifactId>native-linux-aarch64</artifactId>
+        <version>${brotli4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.aayushatharva.brotli4j</groupId>
         <artifactId>native-osx-x86_64</artifactId>
+        <version>${brotli4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.aayushatharva.brotli4j</groupId>
+        <artifactId>native-osx-aarch64</artifactId>
         <version>${brotli4j.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
Motivation:

improve development experience on MacOS M1 laptops

Modification:

add brotli4j aarch64 dependencies to pom.xml files

Result:

BrotliEncoderTest passes on MacOS M1 laptop.
