### PR TITLE
Add SslProvider.isOptionSupported(...)

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
@@ -725,6 +725,22 @@ public final class OpenSsl {
         return TLSV13_SUPPORTED;
     }
 
+    static boolean isOptionSupported(SslContextOption<?> option) {
+        if (isAvailable()) {
+            if (option == OpenSslContextOption.USE_TASKS) {
+                return true;
+            }
+            // Check for options that are only supported by BoringSSL atm.
+            if (isBoringSSL()) {
+                return option == OpenSslContextOption.ASYNC_PRIVATE_KEY_METHOD ||
+                        option == OpenSslContextOption.PRIVATE_KEY_METHOD ||
+                        option == OpenSslContextOption.CERTIFICATE_COMPRESSION_ALGORITHMS ||
+                        option == OpenSslContextOption.TLS_FALSE_START;
+            }
+        }
+        return false;
+    }
+
     private static Set<String> protocols(String property) {
         String protocolsString = SystemPropertyUtil.get(property, null);
         if (protocolsString != null) {

--- a/handler/src/main/java/io/netty/handler/ssl/SslProvider.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslProvider.java
@@ -81,6 +81,23 @@ public enum SslProvider {
     }
 
     /**
+     * Returns {@code true} if the specified {@link SslProvider} supports the specified {@link SslContextOption},
+     * {@code false} otherwise.
+     */
+    public static boolean isOptionSupported(SslProvider sslProvider, SslContextOption<?> option) {
+        switch (sslProvider) {
+            case JDK:
+                // We currently don't support any SslContextOptions when using the JDK implementation
+                return false;
+            case OPENSSL:
+            case OPENSSL_REFCNT:
+                return OpenSsl.isOptionSupported(option);
+            default:
+                throw new Error("Unknown SslProvider: " + sslProvider);
+        }
+    }
+
+    /**
      * Returns {@code true} if the specified {@link SslProvider} enables
      * <a href="https://tools.ietf.org/html/rfc8446">TLS 1.3</a> by default, {@code false} otherwise.
      */


### PR DESCRIPTION
Motivation:

Sometimes it is useful to understand if an SslContextOption is supported or not by a given SslProvider.

Modifications:

Add new static method which allows to check if an option is supported or not

Result:

Easier to reason about if an option is supported or not
