### PR TITLE
Fix FlowControlHandler's behaviour to pass read events when auto-reading is turned off

### DIFF
--- a/handler/src/main/java/io/netty/handler/flow/FlowControlHandler.java
+++ b/handler/src/main/java/io/netty/handler/flow/FlowControlHandler.java
@@ -141,8 +141,10 @@ public class FlowControlHandler extends ChannelDuplexHandler {
             // messages from upstream and once one arrives it need to be
             // relayed to downstream to keep the flow going.
             shouldConsume = true;
+            ctx.read();
+        } else if (config.isAutoRead()) {
+            ctx.read();
         }
-        ctx.read();
     }
 
     @Override


### PR DESCRIPTION
Motivation:
Currently, in FlowControlHandler read events are passed onto the pipeline in every case regardless of the auto-reading configuration of the channel.

Modification:
The read method in FlowControlHandler has been adjusted accordingly.

Result:
Not passing read events onto the pipeline (calling ctx.read() which results in reading from the client socket) when the queue is not empty and auto-reading is turned off for the channel.

Fixes #13104. 
