### PR TITLE
Ensure Http2StreamFrameToHttpObjectCodec#decode doesn't add transfer-encoding for 204/304 response

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamFrameToHttpObjectCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamFrameToHttpObjectCodec.java
@@ -112,7 +112,7 @@ public class Http2StreamFrameToHttpObjectCodec extends MessageToMessageCodec<Htt
                 }
             } else {
                 HttpMessage req = newMessage(id, headers);
-                if (!HttpUtil.isContentLengthSet(req)) {
+                if ((status == null || !isContentAlwaysEmpty(status)) && !HttpUtil.isContentLengthSet(req)) {
                     req.headers().add(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
                 }
                 out.add(req);
@@ -265,6 +265,22 @@ public class Http2StreamFrameToHttpObjectCodec extends MessageToMessageCodec<Htt
             return char0 == '1'
                 && char1 >= '0' && char1 <= '9'
                 && char2 >= '0' && char2 <= '9' && char2 != '1';
+        }
+        return false;
+    }
+
+    /*
+     * https://datatracker.ietf.org/doc/html/rfc9113#section-8.1.1
+     * '204' or '304' responses contain no content
+     */
+    private static boolean isContentAlwaysEmpty(CharSequence status) {
+        if (status.length() == 3) {
+            char char0 = status.charAt(0);
+            char char1 = status.charAt(1);
+            char char2 = status.charAt(2);
+            return char0 >= '2' && char0 <= '3'
+                && char1 == '0'
+                && char2 == '4';
         }
         return false;
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamFrameToHttpObjectCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamFrameToHttpObjectCodec.java
@@ -278,7 +278,7 @@ public class Http2StreamFrameToHttpObjectCodec extends MessageToMessageCodec<Htt
             char char0 = status.charAt(0);
             char char1 = status.charAt(1);
             char char2 = status.charAt(2);
-            return char0 >= '2' && char0 <= '3'
+            return (char0 == '2' || char0 == '3')
                 && char1 == '0'
                 && char2 == '4';
         }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2StreamFrameToHttpObjectCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2StreamFrameToHttpObjectCodecTest.java
@@ -55,7 +55,9 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -794,7 +796,7 @@ public class Http2StreamFrameToHttpObjectCodecTest {
         HttpResponse request = ch.readInbound();
         assertThat(request.status().codeAsText().toString(), is(statusCode));
         assertThat(request.protocolVersion(), is(HttpVersion.HTTP_1_1));
-        assertFalse(request instanceof FullHttpRequest);
+        assertThat(request, is(not(instanceOf(FullHttpResponse.class))));
         assertFalse(HttpUtil.isTransferEncodingChunked(request));
 
         assertThat(ch.readInbound(), is(nullValue()));

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2StreamFrameToHttpObjectCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2StreamFrameToHttpObjectCodecTest.java
@@ -49,6 +49,8 @@ import io.netty.handler.ssl.SslProvider;
 import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -774,6 +776,26 @@ public class Http2StreamFrameToHttpObjectCodecTest {
         assertThat(response.protocolVersion(), is(HttpVersion.HTTP_1_1));
         assertFalse(response instanceof FullHttpResponse);
         assertFalse(HttpUtil.isTransferEncodingChunked(response));
+
+        assertThat(ch.readInbound(), is(nullValue()));
+        assertFalse(ch.finish());
+    }
+
+    @ParameterizedTest()
+    @ValueSource(strings = {"204", "304"})
+    public void testDecodeResponseHeadersContentAlwaysEmpty(String statusCode) {
+        EmbeddedChannel ch = new EmbeddedChannel(new Http2StreamFrameToHttpObjectCodec(false));
+        Http2Headers headers = new DefaultHttp2Headers();
+        headers.scheme(HttpScheme.HTTP.name());
+        headers.status(statusCode);
+
+        assertTrue(ch.writeInbound(new DefaultHttp2HeadersFrame(headers)));
+
+        HttpResponse request = ch.readInbound();
+        assertThat(request.status().codeAsText().toString(), is(statusCode));
+        assertThat(request.protocolVersion(), is(HttpVersion.HTTP_1_1));
+        assertFalse(request instanceof FullHttpRequest);
+        assertFalse(HttpUtil.isTransferEncodingChunked(request));
 
         assertThat(ch.readInbound(), is(nullValue()));
         assertFalse(ch.finish());


### PR DESCRIPTION
Motivation:

There are servers that return  `204`/`304` response as `HEADERS` and `DATA`, where the `DATA` has no content.

`INBOUND HEADERS: streamId=3 headers=DefaultHttp2Headers[:status: 204, date: Wed, 25 Jan 2023 07:46:07 GMT] padding=0 endStream=false`
 and
`INBOUND DATA: streamId=3 padding=0 endStream=true length=0 bytes=`

For such responses `Http2StreamFrameToHttpObjectCodec#decode` should not add `transfer-encoding: chunked`.

Modification:

- Ensure `Http2StreamFrameToHttpObjectCodec#decode` doesn't add `transfer-encoding: chunked` for `204`/`304` response
- junit test is added

Result:
`204`/`304` response is correctly decoded.