### PR TITLE
Only do extra CNAME query if we couldnt follow the whole CNAME chain in the response

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
@@ -889,7 +889,6 @@ abstract class DnsResolveContext<T> {
             // Note that we do not break from the loop here, so we decode/cache all A/AAAA records.
         }
 
-
         if (found && !cnameNeedsFollow) {
             // If we found the correct result we can just stop here without following any extra CNAME records in the
             // response.

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
@@ -787,6 +787,7 @@ abstract class DnsResolveContext<T> {
 
         boolean found = false;
         boolean completeEarly = this.completeEarly;
+        boolean cnameNeedsFollow = !cnames.isEmpty();
         for (int i = 0; i < answerCount; i ++) {
             final DnsRecord r = response.recordAt(DnsSection.ANSWER, i);
             final DnsRecordType type = r.type();
@@ -813,6 +814,8 @@ abstract class DnsResolveContext<T> {
                 do {
                     resolved = cnamesCopy.remove(resolved);
                     if (recordName.equals(resolved)) {
+                        // We followed a CNAME chain that was part of the response without any extra queries.
+                        cnameNeedsFollow = false;
                         break;
                     }
                 } while (resolved != null);
@@ -886,14 +889,15 @@ abstract class DnsResolveContext<T> {
             // Note that we do not break from the loop here, so we decode/cache all A/AAAA records.
         }
 
-        if (cnames.isEmpty()) {
-            if (found) {
-                if (completeEarly) {
-                    this.completeEarly = true;
-                }
-                queryLifecycleObserver.querySucceed();
-                return;
+
+        if (found && !cnameNeedsFollow) {
+            // If we found the correct result we can just stop here without following any extra CNAME records in the
+            // response.
+            if (completeEarly) {
+                this.completeEarly = true;
             }
+            queryLifecycleObserver.querySucceed();
+        } else if (cnames.isEmpty()) {
             queryLifecycleObserver.queryFailed(NO_MATCHING_RECORD_QUERY_FAILED_EXCEPTION);
         } else {
             queryLifecycleObserver.querySucceed();

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -2409,7 +2409,7 @@ public class DnsNameResolverTest {
     // cname3.netty.io.       20     IN    A        10.0.0.2
     @Test
     public void testCNAMEFollowInResponseWithoutExtraQuery() throws IOException {
-        AtomicInteger queryCount = new AtomicInteger();
+        final AtomicInteger queryCount = new AtomicInteger();
         TestDnsServer dnsServer2 = new TestDnsServer(new RecordStore() {
 
             @Override

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -2403,12 +2403,10 @@ public class DnsNameResolverTest {
     //
     // This should only result in one query.
     // ;; ANSWER SECTION:
-    //somehost.netty.io.		594	IN	CNAME	cname.netty.io.
-    //cname.netty.io. 9042	IN	CNAME	cname2.netty.io.
-    //cname2.netty.io. 1312 IN CNAME	cname3.netty.io.io.
-    //cname3.netty.io. 20	IN	A	10.0.0.2
-    //
-    //
+    // somehost.netty.io.     594    IN    CNAME    cname.netty.io.
+    // cname.netty.io.        9042   IN    CNAME    cname2.netty.io.
+    // cname2.netty.io.       1312   IN    CNAME    cname3.netty.io.io.
+    // cname3.netty.io.       20     IN    A        10.0.0.2
     @Test
     public void testCNAMEFollowInResponseWithoutExtraQuery() throws IOException {
         AtomicInteger queryCount = new AtomicInteger();


### PR DESCRIPTION


Motivation:

If we receive a response with a CNAME chain in it we should only do an extra query if we could follow the whole chain. Otherwise we will produce more queries if necessary and so might overload the remote DNS server.

Modifications:

- Only do extra CNAME query if we couldnt follow the whole chain.
- Add unit test

Result:

Produce less queries when handling CNAMEs