### PR TITLE
Add unit tests that ensure we correctly handle partial timeouts when …

### DIFF
--- a/resolver-dns/src/test/java/io/netty/resolver/dns/TestDnsServer.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/TestDnsServer.java
@@ -85,17 +85,18 @@ class TestDnsServer extends DnsServer {
 
     @Override
     public void start() throws IOException {
-        start(false);
+        start(null);
     }
 
     /**
-     * Start the {@link TestDnsServer} but drop all {@code AAAA} queries and not send any response to these at all.
+     * Start the {@link TestDnsServer} but drop all {@link RecordType} queries
+     * and not send any response to these at all.
      */
-    public void start(final boolean dropAAAAQueries) throws IOException {
-        start(dropAAAAQueries, new InetSocketAddress(NetUtil.LOCALHOST4, 0));
+    public void start(final RecordType dropRecordType) throws IOException {
+        start(dropRecordType, new InetSocketAddress(NetUtil.LOCALHOST4, 0));
     }
 
-    public void start(final boolean dropAAAAQueries, InetSocketAddress address) throws IOException {
+    public void start(final RecordType dropRecordType, InetSocketAddress address) throws IOException {
         UdpTransport transport = new UdpTransport(address.getHostName(), address.getPort());
         setTransports(transport);
 
@@ -107,7 +108,7 @@ class TestDnsServer extends DnsServer {
                 // USe our own codec to support AAAA testing
                 session.getFilterChain()
                         .addFirst("codec", new ProtocolCodecFilter(
-                                new TestDnsProtocolUdpCodecFactory(dropAAAAQueries)));
+                                new TestDnsProtocolUdpCodecFactory(dropRecordType)));
             }
         });
 
@@ -155,10 +156,10 @@ class TestDnsServer extends DnsServer {
     private final class TestDnsProtocolUdpCodecFactory implements ProtocolCodecFactory {
         private final DnsMessageEncoder encoder = new DnsMessageEncoder();
         private final TestAAAARecordEncoder recordEncoder = new TestAAAARecordEncoder();
-        private final boolean dropAAAArecords;
+        private final RecordType dropRecordType;
 
-        TestDnsProtocolUdpCodecFactory(boolean dropAAAArecords) {
-            this.dropAAAArecords = dropAAAArecords;
+        TestDnsProtocolUdpCodecFactory(RecordType dropRecordType) {
+            this.dropRecordType = dropRecordType;
         }
 
         @Override
@@ -169,24 +170,26 @@ class TestDnsServer extends DnsServer {
                 public void encode(IoSession session, Object message, ProtocolEncoderOutput out) {
                     IoBuffer buf = IoBuffer.allocate(1024);
                     DnsMessage dnsMessage = filterMessage((DnsMessage) message);
-                    encoder.encode(buf, dnsMessage);
-                    for (ResourceRecord record : dnsMessage.getAnswerRecords()) {
-                        // This is a hack to allow to also test for AAAA resolution as DnsMessageEncoder
-                        // does not support it and it is hard to extend, because the interesting methods
-                        // are private...
-                        // In case of RecordType.AAAA we need to encode the RecordType by ourselves.
-                        if (record.getRecordType() == RecordType.AAAA) {
-                            try {
-                                recordEncoder.put(buf, record);
-                            } catch (IOException e) {
-                                // Should never happen
-                                throw new IllegalStateException(e);
+                    if (dnsMessage != null) {
+                        encoder.encode(buf, dnsMessage);
+                        for (ResourceRecord record : dnsMessage.getAnswerRecords()) {
+                            // This is a hack to allow to also test for AAAA resolution as DnsMessageEncoder
+                            // does not support it and it is hard to extend, because the interesting methods
+                            // are private...
+                            // In case of RecordType.AAAA we need to encode the RecordType by ourselves.
+                            if (record.getRecordType() == RecordType.AAAA) {
+                                try {
+                                    recordEncoder.put(buf, record);
+                                } catch (IOException e) {
+                                    // Should never happen
+                                    throw new IllegalStateException(e);
+                                }
                             }
                         }
-                    }
-                    buf.flip();
+                        buf.flip();
 
-                    out.write(buf);
+                        out.write(buf);
+                    }
                 }
             };
         }
@@ -199,9 +202,9 @@ class TestDnsServer extends DnsServer {
                 @Override
                 public void decode(IoSession session, IoBuffer in, ProtocolDecoderOutput out) throws IOException {
                     DnsMessage message = decoder.decode(in);
-                    if (dropAAAArecords) {
+                    if (dropRecordType != null) {
                         for (QuestionRecord record: message.getQuestionRecords()) {
-                            if (record.getRecordType() == RecordType.AAAA) {
+                            if (record.getRecordType() == dropRecordType) {
                                 return;
                             }
                         }


### PR DESCRIPTION
…doing DNS queries

Motivation:

When we do an A and AAAA query and one is successful while the other times out we need to ensure we still not fail the promise. This was already the case but we didnt have tests for this.

Modifications:

Added unit test to validate correct behaviour

Result:

More testing around timeout handling
