### PR TITLE
Optionally depend on bctls-jdk15on

### DIFF
--- a/handler/pom.xml
+++ b/handler/pom.xml
@@ -82,6 +82,11 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bctls-jdk15on</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty.npn</groupId>
       <artifactId>npn-api</artifactId>
       <optional>true</optional>

--- a/pom.xml
+++ b/pom.xml
@@ -783,6 +783,17 @@
         <optional>true</optional>
       </dependency>
 
+      <!--
+        Completely optional and only needed for ALPN.
+      -->
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bctls-jdk15on</artifactId>
+        <version>1.69</version>
+        <scope>compile</scope>
+        <optional>true</optional>
+      </dependency>
+
       <dependency>
         <groupId>com.fasterxml</groupId>
         <artifactId>aalto-xml</artifactId>


### PR DESCRIPTION
Motivation:

The fix for #13106 upgraded maven-bundle-plugin, which detects classes passed to Class.forName(String) and generates Import-Package requirements.

This means Netty-4.1.87.Final's io.netty.handler now requires org.bouncycastle.jsse in OSGi environments.

Modifications:

Add an optional dependency on bctls-jdk15on.

Result:

MANIFEST.MF lists org.bouncycastle.jsse with ;resolution:=optional.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
