### PR TITLE
Add necessary native-image configuration files for epoll

### DIFF
--- a/transport-classes-epoll/src/main/resources/META-INF/native-image/io.netty/netty-transport-classes-epoll/jni-config.json
+++ b/transport-classes-epoll/src/main/resources/META-INF/native-image/io.netty/netty-transport-classes-epoll/jni-config.json
@@ -1,0 +1,170 @@
+[
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.epoll.Native"
+    },
+    "name":"io.netty.channel.ChannelException"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.epoll.Native"
+    },
+    "name":"io.netty.channel.DefaultFileRegion",
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.epoll.Native"
+    },
+    "name":"io.netty.channel.epoll.LinuxSocket"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.epoll.Native"
+    },
+    "name":"io.netty.channel.epoll.Native"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.epoll.Native"
+    },
+    "name":"io.netty.channel.epoll.NativeDatagramPacketArray$NativeDatagramPacket",
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.epoll.Native"
+    },
+    "name":"io.netty.channel.epoll.NativeStaticallyReferencedJniMethods"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.epoll.Native"
+    },
+    "name":"io.netty.channel.unix.Buffer"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.epoll.Native"
+    },
+    "name":"io.netty.channel.unix.DatagramSocketAddress",
+    "methods":[{"name":"<init>","parameterTypes":["byte[]","int","int","int","io.netty.channel.unix.DatagramSocketAddress"] }]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.epoll.Native"
+    },
+    "name":"io.netty.channel.unix.DomainDatagramSocketAddress",
+    "methods":[{"name":"<init>","parameterTypes":["byte[]","int","io.netty.channel.unix.DomainDatagramSocketAddress"] }]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.epoll.Native"
+    },
+    "name":"io.netty.channel.unix.ErrorsStaticallyReferencedJniMethods"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.epoll.Native"
+    },
+    "name":"io.netty.channel.unix.FileDescriptor"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.epoll.Native"
+    },
+    "name":"io.netty.channel.unix.LimitsStaticallyReferencedJniMethods"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.epoll.Native"
+    },
+    "name":"io.netty.channel.unix.PeerCredentials",
+    "methods":[{"name":"<init>","parameterTypes":["int","int","int[]"] }]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.epoll.Native"
+    },
+    "name":"io.netty.channel.unix.Socket"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.epoll.Native"
+    },
+    "name":"java.io.FileDescriptor",
+    "fields":[{"name":"fd"}]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.epoll.Native"
+    },
+    "name":"java.io.IOException"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.epoll.Native"
+    },
+    "name":"java.lang.Boolean",
+    "methods":[{"name":"getBoolean","parameterTypes":["java.lang.String"] }]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.epoll.Native"
+    },
+    "name":"java.lang.OutOfMemoryError"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.epoll.Native"
+    },
+    "name":"java.lang.RuntimeException"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.epoll.Native"
+    },
+    "name":"java.net.InetSocketAddress",
+    "methods":[{"name":"<init>","parameterTypes":["java.lang.String","int"] }]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.epoll.Native"
+    },
+    "name":"java.net.PortUnreachableException"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.epoll.Native"
+    },
+    "name":"java.nio.Buffer",
+    "fields":[
+      {"name":"limit"},
+      {"name":"position"}
+    ],
+    "methods":[
+      {"name":"limit","parameterTypes":[] },
+      {"name":"position","parameterTypes":[] }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.epoll.Native"
+    },
+    "name":"java.nio.DirectByteBuffer"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.epoll.Native"
+    },
+    "name":"java.nio.channels.ClosedChannelException",
+    "methods":[{"name":"<init>","parameterTypes":[] }]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.epoll.Native"
+    },
+    "name":"sun.nio.ch.FileChannelImpl",
+    "fields":[{"name":"fd"}]
+  }
+]

--- a/transport-classes-epoll/src/main/resources/META-INF/native-image/io.netty/netty-transport-classes-epoll/native-image.properties
+++ b/transport-classes-epoll/src/main/resources/META-INF/native-image/io.netty/netty-transport-classes-epoll/native-image.properties
@@ -1,0 +1,15 @@
+# Copyright 2023 The Netty Project
+#
+# The Netty Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+Args = --initialize-at-run-time=io.netty.channel.epoll,io.netty.channel.unix.Limits,io.netty.channel.unix.IovArray,io.netty.channel.unix.Errors

--- a/transport-classes-epoll/src/main/resources/META-INF/native-image/io.netty/netty-transport-classes-epoll/reflect-config.json
+++ b/transport-classes-epoll/src/main/resources/META-INF/native-image/io.netty/netty-transport-classes-epoll/reflect-config.json
@@ -1,0 +1,16 @@
+[
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.epoll.Native"
+    },
+    "name":"io.netty.channel.epoll.EpollServerSocketChannel",
+    "allDeclaredConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.epoll.Native"
+    },
+    "name": "io.netty.util.internal.NativeLibraryUtil",
+    "allDeclaredMethods": true
+  }
+]

--- a/transport-classes-epoll/src/main/resources/META-INF/native-image/io.netty/netty-transport-classes-epoll/resource-config.json
+++ b/transport-classes-epoll/src/main/resources/META-INF/native-image/io.netty/netty-transport-classes-epoll/resource-config.json
@@ -1,0 +1,13 @@
+{
+  "resources":{
+    "includes":[
+      {
+        "condition": {
+          "typeReachable": "io.netty.channel.epoll.Native"
+        },
+        "pattern":".*libnetty_transport_native_epoll_.*\\.so"
+      }
+    ]},
+  "bundles":[]
+}
+


### PR DESCRIPTION
Motivation:

Epoll currently doesn't work out of the box on native-image without passing in additional flags and metadata.

Modification:

This PR adds the necessary metadata so that epoll works out of the box with native-image. The metadata is conditional - it should only be included in an image if epoll is actually used.

Result:

Fixes #10616