### PR TITLE
Create a deep-copy of the Throwable before returning it from the cach…

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsCache.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsCache.java
@@ -329,13 +329,12 @@ public class DefaultDnsCache implements DnsCache {
         }
 
         @Override
-        public int hashCode() {
-            return entries.hashCode();
-        }
-
-        @Override
         public boolean equals(Object o) {
-            return o instanceof DnsCacheEntryList && entries.equals(((DnsCacheEntryList) o).entries);
+            if (o instanceof DnsCacheEntryList) {
+                // Fast-path.
+                return entries.equals(((DnsCacheEntryList) o).entries);
+            }
+            return super.equals(o);
         }
     };
 }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsCache.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsCache.java
@@ -202,7 +202,7 @@ public class DefaultDnsCache implements DnsCache {
             hash = System.identityHashCode(this);
         }
 
-        DefaultDnsCacheEntry(DefaultDnsCacheEntry entry) {
+        private DefaultDnsCacheEntry(DefaultDnsCacheEntry entry) {
             this.hostname = entry.hostname;
             if (entry.cause == null) {
                 this.address = entry.address;

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsCache.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsCache.java
@@ -329,6 +329,12 @@ public class DefaultDnsCache implements DnsCache {
         }
 
         @Override
+        public int hashCode() {
+            // Just delegate to super to make checkstyle happy
+            return super.hashCode();
+        }
+
+        @Override
         public boolean equals(Object o) {
             if (o instanceof DnsCacheEntryList) {
                 // Fast-path.

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DefaultDnsCacheTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DefaultDnsCacheTest.java
@@ -23,16 +23,22 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.util.NetUtil;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintWriter;
 import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class DefaultDnsCacheTest {
 
@@ -166,7 +172,7 @@ public class DefaultDnsCacheTest {
             entries = cache.get("netty.io", null);
             DnsCacheEntry entry = entries.get(0);
             assertEquals(1, entries.size());
-            assertSame(exception, entry.cause());
+            assertThrowable(exception, entry.cause());
             assertNull(entry.address());
         } finally {
             group.shutdownGracefully();
@@ -196,6 +202,58 @@ public class DefaultDnsCacheTest {
             assertEntry(entries2.get(1), addr2);
         } finally {
             group.shutdownGracefully();
+        }
+    }
+
+    @Test
+    public void testCacheExceptionIsSafe() throws Exception {
+        EventLoopGroup group = new DefaultEventLoopGroup(1);
+
+        try {
+            EventLoop loop = group.next();
+            final DefaultDnsCache cache = new DefaultDnsCache(1, 100, 100);
+
+            testSuppressed(cache, new UnknownHostException("test"), loop);
+            testSuppressed(cache, new Throwable("test"), loop);
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+
+    private static void testSuppressed(DnsCache cache, Throwable exception, EventLoop loop) {
+        String hostname = UUID.randomUUID().toString();
+        cache.cache(hostname, null, exception, loop);
+        List<? extends DnsCacheEntry> entries = cache.get(hostname, null);
+        DnsCacheEntry entry = entries.get(0);
+        assertEquals(1, entries.size());
+        assertNotSame(exception, entry.cause());
+
+        assertThrowable(exception, entry.cause());
+        entry.cause().addSuppressed(new Throwable());
+
+        assertEquals(0, exception.getSuppressed().length);
+        assertEquals(1, entry.cause().getSuppressed().length);
+        assertNull(entry.address());
+    }
+
+    private static void assertThrowable(Throwable expected, Throwable actual) {
+        assertInstanceOf(expected.getClass(), actual);
+        assertEquals(expected.getMessage(), actual.getMessage());
+        assertEquals(expected.getStackTrace().length, actual.getStackTrace().length);
+        ByteArrayOutputStream expectedOutputStream = new ByteArrayOutputStream();
+        PrintWriter expectedWriter = new PrintWriter(expectedOutputStream);
+        ByteArrayOutputStream actualOutputStream = new ByteArrayOutputStream();
+        PrintWriter actualWriter = new PrintWriter(actualOutputStream);
+
+        try {
+            expected.printStackTrace(expectedWriter);
+
+            expected.printStackTrace(actualWriter);
+
+            assertArrayEquals(expectedOutputStream.toByteArray(), actualOutputStream.toByteArray());
+        } finally {
+            expectedWriter.close();
+            actualWriter.close();
         }
     }
 }

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -2724,7 +2724,7 @@ public class DnsNameResolverTest {
             List<? extends DnsCacheEntry> cached2 = cache.get(domainWithDot, null);
 
             assertEquals(1, cached.size());
-            assertSame(cached, cached2);
+            assertEquals(cached, cached2);
         } finally {
             resolver.close();
         }
@@ -2747,7 +2747,7 @@ public class DnsNameResolverTest {
             List<? extends DnsCacheEntry> cached = cache.cache.get("test.netty.io", null);
             List<? extends DnsCacheEntry> cached2 = cache.cache.get("test.netty.io.", null);
             assertEquals(1, cached.size());
-            assertSame(cached, cached2);
+            assertEquals(cached, cached2);
 
             resolver.resolve("test").syncUninterruptibly();
             List<? extends DnsCacheEntry> entries = cache.cacheHits.get("test.netty.io");


### PR DESCRIPTION
…e to prevent possible leaks.

Motivation:

As we dont know what exactly the user will do with the cached exception we should better ensure to return a copy every time the user tries to access it. The problem is that the exception might stay in the cache for a very long time while the user might call things like addSuppressed(...) on it. This could lead to the sitation that we hold up a lot of references and so "leak" memory until the entry expires.

Modifications:

- Do a deep copy of the cached Throwable before returning it to the user.
- Add unit tests

Result:

No possible to "leak memory"