### PR TITLE
Always respect completeOncePreferredResolved in DnsNameResolver

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -1022,7 +1022,7 @@ public class DnsNameResolver extends InetNameResolver {
                                    final Promise<InetAddress> promise,
                                    DnsCache resolveCache, boolean completeEarlyIfPossible) {
         final Promise<List<InetAddress>> allPromise = executor().newPromise();
-        doResolveAllUncached(hostname, additionals, promise, allPromise, resolveCache, true);
+        doResolveAllUncached(hostname, additionals, promise, allPromise, resolveCache, completeEarlyIfPossible);
         allPromise.addListener(new FutureListener<List<InetAddress>>() {
             @Override
             public void operationComplete(Future<List<InetAddress>> future) {


### PR DESCRIPTION
Motivation:

We missed to respect completeOncePreferredResolved setting in DnsNameResolver in one case as we always used true as value no matter what was configured by the user.

Modifications:

Correctly use the passed parameter.

Result:

Response completeOncePreferredResolved in all cases
