### PR TITLE
Search Domains and DNS Resolver on Windows (#13022)

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -60,6 +60,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.1
+
       - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:

--- a/common/src/main/java/io/netty/util/internal/Hidden.java
+++ b/common/src/main/java/io/netty/util/internal/Hidden.java
@@ -155,6 +155,10 @@ class Hidden {
                     "parseEtcResolverOptions");
 
             builder.allowBlockingCallsInside(
+                    "io.netty.resolver.dns.windows.WindowsAdapterInfo",
+                    "loadNativeLibrary");
+
+            builder.allowBlockingCallsInside(
                     "io.netty.resolver.HostsFileEntriesProvider$ParserImpl",
                     "parse");
 

--- a/pom.xml
+++ b/pom.xml
@@ -645,6 +645,7 @@
     <module>resolver-dns</module>
     <module>resolver-dns-classes-macos</module>
     <module>resolver-dns-native-macos</module>
+    <module>resolver-dns-native-windows</module>
     <module>transport</module>
     <module>transport-native-unix-common-tests</module>
     <module>transport-native-unix-common</module>

--- a/resolver-dns-native-windows/pom.xml
+++ b/resolver-dns-native-windows/pom.xml
@@ -1,0 +1,179 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2023 The Netty Project
+  ~
+  ~ The Netty Project licenses this file to you under the Apache License,
+  ~ version 2.0 (the "License"); you may not use this file except in compliance
+  ~ with the License. You may obtain a copy of the License at:
+  ~
+  ~   https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.netty</groupId>
+    <artifactId>netty-parent</artifactId>
+    <version>4.1.88.Final-SNAPSHOT</version>
+  </parent>
+  <artifactId>netty-resolver-dns-native-windows</artifactId>
+
+  <name>Netty/Resolver/DNS/Native/Windows</name>
+  <packaging>jar</packaging>
+
+  <profiles>
+    <profile>
+      <id>windows</id>
+      <activation>
+        <os>
+          <family>windows</family>
+        </os>
+      </activation>
+      <properties>
+        <skipTests>false</skipTests>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <!-- unpack netty-jni-util files -->
+              <execution>
+                <id>unpack</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>unpack-dependencies</goal>
+                </goals>
+                <configuration>
+                  <includeGroupIds>io.netty</includeGroupIds>
+                  <includeArtifactIds>netty-jni-util</includeArtifactIds>
+                  <classifier>sources</classifier>
+                  <outputDirectory>${combinedSources}</outputDirectory>
+                  <includes>**.h,**.c</includes>
+                  <overWriteReleases>false</overWriteReleases>
+                  <overWriteSnapshots>true</overWriteSnapshots>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.fusesource.hawtjni</groupId>
+            <artifactId>hawtjni-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>build-native-lib</id>
+                <phase>compile</phase>
+                <configuration>
+                  <name>netty_resolver_dns_native_windows_${os.detected.arch}</name>
+                  <nativeSourceDirectory>${combinedSources}</nativeSourceDirectory>
+                  <libDirectory>${project.build.directory}/native-build</libDirectory>
+                  <windowsBuildTool>msbuild</windowsBuildTool>
+                  <windowsPlatformToolset>v142</windowsPlatformToolset>
+                  <windowsTargetPlatformVersion>10.0.19041.0</windowsTargetPlatformVersion>
+                </configuration>
+                <goals>
+                  <goal>generate</goal>
+                  <goal>build</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <artifactId>maven-resources-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>copy-sources</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>${combinedSources}</outputDirectory>
+                  <resources>
+                    <resource>
+                      <directory>${project.basedir}/src/main/c/src</directory>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+              <execution>
+                <id>copy-windows-dll</id>
+                <phase>process-classes</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>${project.build.outputDirectory}/META-INF/native/</outputDirectory>
+                  <resources>
+                    <resource>
+                      <directory>${project.build.directory}/native-build/META-INF/native/windows${os.detected.bitness}</directory>
+                      <includes>
+                        <include>netty_resolver_dns_native_windows_${os.detected.arch}.dll</include>
+                      </includes>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <artifactId>maven-jar-plugin</artifactId>
+            <executions>
+              <!-- Generate the JAR that contains the native library in it. -->
+              <execution>
+                <id>native-jar</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+                <configuration>
+                  <archive>
+                    <manifest>
+                      <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                    </manifest>
+                    <manifestEntries>
+                      <Bundle-NativeCode>META-INF/native/netty_resolver_dns_native_windows_${os.detected.arch}.dll; osname=Windows; processor=${os.detected.arch}</Bundle-NativeCode>
+                      <Fragment-Host>io.netty.resolver-dns-classes-windows</Fragment-Host>
+                      <Automatic-Module-Name>${javaModuleName}</Automatic-Module-Name>
+                    </manifestEntries>
+                    <index>true</index>
+                    <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                  </archive>
+                  <classifier>${jni.classifier}</classifier>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+  <properties>
+    <javaModuleNameClassifier>${os.detected.name}.${os.detected.arch}</javaModuleNameClassifier>
+    <javaModuleName>io.netty.resolver.dns.windows.${javaModuleNameClassifier}</javaModuleName>
+    <combinedSources>${project.build.directory}/native-src</combinedSources>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-jni-util</artifactId>
+      <classifier>sources</classifier>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+</project>
+

--- a/resolver-dns-native-windows/src/main/c/src/netty_window_dns_native.c
+++ b/resolver-dns-native-windows/src/main/c/src/netty_window_dns_native.c
@@ -1,0 +1,476 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <jni.h>
+
+#include "netty_jni_util.h"
+
+#include <winsock2.h>
+#include <Ws2ipdef.h>
+#include <ws2tcpip.h>
+#include <iphlpapi.h>
+#include <stdbool.h>
+
+#pragma comment(lib, "IPHLPAPI.lib")
+#pragma comment(lib, "ws2_32.lib")
+
+#define ADAPTER_INFO_CLASS "io/netty/resolver/dns/windows/WindowsAdapterInfo"
+
+static jclass nativeExceptionClass = NULL;
+
+static jclass networkAdapterClass = NULL;
+static jmethodID networkAdapterCtor = NULL;
+
+static jclass stringClass = NULL;
+
+static jclass inetSocketAddressClass = NULL;
+static jmethodID inetSocketAddressCtor = NULL;
+
+static const char* cached_package_prefix = NULL;
+
+int throwNativeException(JNIEnv* env, const char* fmt, ...) {
+    va_list countArgs;
+    va_start(countArgs, fmt);
+
+    va_list printArgs;
+    va_copy(printArgs, countArgs);
+    
+    size_t length = vsnprintf(NULL, 0, fmt, countArgs);
+    size_t nbytes = length + 1;
+
+    va_end(countArgs);
+
+    char* buffer = malloc(nbytes);
+
+    if (buffer == NULL) {
+        va_end(printArgs);
+        return JNI_ERR;
+    }
+
+    vsprintf_s(buffer, nbytes, fmt, printArgs);
+    va_end(printArgs);
+
+    jint result = (*env)->ThrowNew(env, nativeExceptionClass, buffer);
+
+    free(buffer);
+
+    return result;
+}
+
+jint read_adapter_addresses(JNIEnv* env, IP_ADAPTER_ADDRESSES** target) {
+    const int MAX_TRIES = 3;
+
+    // Allocate a 15 KB buffer to start with according to https://learn.microsoft.com/en-us/windows/win32/api/iphlpapi/nf-iphlpapi-getadaptersaddresses
+    unsigned long outBufLen = 15000;
+
+    IP_ADAPTER_ADDRESSES* pAddresses = NULL;
+    unsigned long dwRetVal = 1;
+
+    for (int tries = 0; tries < MAX_TRIES; ++tries) {
+        pAddresses = malloc(outBufLen);
+
+        if (pAddresses == NULL) {
+            fprintf(stderr, "FATAL: Out of memory.\n");
+            fflush(stderr);
+            throwNativeException(env, "Out of memory for IP_ADAPTER_ADDRESSES buffer. Tried to allocate %lu bytes.", outBufLen);
+            return JNI_ERR;
+        }
+
+        unsigned long flags = GAA_FLAG_SKIP_UNICAST | GAA_FLAG_SKIP_ANYCAST
+            | GAA_FLAG_SKIP_MULTICAST | GAA_FLAG_SKIP_FRIENDLY_NAME;
+
+        // This call can update the outBufLen variable with the actual (required) size.
+        dwRetVal = GetAdaptersAddresses(AF_UNSPEC, flags, NULL, pAddresses, &outBufLen);
+
+        if (dwRetVal != ERROR_BUFFER_OVERFLOW) {
+            break;
+        }
+
+        free(pAddresses);
+        pAddresses = NULL;
+    }
+
+    if (dwRetVal == NO_ERROR) {
+        *target = pAddresses;
+        return JNI_OK;
+    }
+
+    if (pAddresses != NULL) {
+        free(pAddresses);
+    }
+
+    throwNativeException(env, "Could not read adapter information. Return code %d", dwRetVal);
+    return JNI_ERR;
+}
+
+jobject sockAddrToJava(JNIEnv* env, LPSOCKADDR sockAddr) {
+    unsigned short port;
+    jstring host;
+    
+    switch (sockAddr->sa_family) {
+    case AF_INET: {
+        char ip[INET_ADDRSTRLEN];
+        struct sockaddr_in* addr_in = (struct sockaddr_in*)sockAddr;
+
+        if (inet_ntop(AF_INET, &addr_in->sin_addr, ip, sizeof(ip)) == NULL) {
+            throwNativeException(env, "Could not convert Ipv4 to String");
+            return NULL;
+        }
+
+        port = ntohs(addr_in->sin_port);
+        host = (*env)->NewStringUTF(env, ip);
+        break;
+    }
+    case AF_INET6: {
+        char ip[INET6_ADDRSTRLEN];
+        struct sockaddr_in6* addr_in = (struct sockaddr_in6*)sockAddr;
+		
+        if (inet_ntop(AF_INET6, &addr_in->sin6_addr, ip, sizeof(ip)) == NULL) {
+            throwNativeException(env, "Could not convert Ipv6 to String");
+            return NULL;
+        }
+
+        port = ntohs(addr_in->sin6_port);
+        host = (*env)->NewStringUTF(env, ip);
+        break;
+    }
+    default:
+        throwNativeException(env, "Unknown address family %d", sockAddr->sa_family);
+        return NULL;
+    }
+
+    return (*env)->NewObject(env, inetSocketAddressClass, inetSocketAddressCtor, host, port);
+}
+
+jobjectArray dnsServersToJava(JNIEnv* env, IP_ADAPTER_ADDRESSES* adapter) {
+    jsize size = 0;
+    for (IP_ADAPTER_DNS_SERVER_ADDRESS* dnsServer = adapter->FirstDnsServerAddress;
+            dnsServer != NULL; dnsServer = dnsServer->Next) {
+        ++size;
+    }
+
+    jobjectArray dnsServers = (*env)->NewObjectArray(env, size, inetSocketAddressClass, NULL);
+
+    if (dnsServers == NULL) {
+        throwNativeException(env, "Could not create dnsServers array");
+        return NULL;
+    }
+
+    jsize index = 0;
+    for (IP_ADAPTER_DNS_SERVER_ADDRESS* dnsServer = adapter->FirstDnsServerAddress;
+        dnsServer != NULL; dnsServer = dnsServer->Next) {
+
+        jobject serverAddress = sockAddrToJava(env, dnsServer->Address.lpSockaddr);
+
+        if (serverAddress == NULL) {
+            return NULL;
+        }
+
+        (*env)->SetObjectArrayElement(env, dnsServers, index, serverAddress);
+        ++index;
+    }
+
+    return dnsServers;
+}
+
+jstring wideCharToString(JNIEnv* env, const wchar_t* input) {
+    size_t bufferSize = (wcslen(input) + 1) * 2;
+
+    char* buffer = malloc(bufferSize);
+
+    if (buffer == NULL) {
+        throwNativeException(env, "Could not allocate buffer for conversion from wchar to char.");
+        return NULL;
+    }
+
+    size_t convertedSize;
+
+    if (wcstombs_s(&convertedSize, buffer, bufferSize, input, bufferSize - 1)) {
+        free(buffer);
+        throwNativeException(env, "Could not convert from wchar to char.");
+        return NULL;
+    }
+
+    jstring result = (*env)->NewStringUTF(env, buffer);
+    free(buffer);
+
+    return result;
+}
+
+jobjectArray searchDomainsToJava(JNIEnv* env, IP_ADAPTER_ADDRESSES* adapter) {
+    jsize size = 0;
+
+    if (adapter->DnsSuffix[0] != '\0') {
+        size++;
+    }
+
+    for (PIP_ADAPTER_DNS_SUFFIX dnsSuffix = adapter->FirstDnsSuffix; dnsSuffix != NULL; dnsSuffix = dnsSuffix->Next) {
+        if (dnsSuffix->String[0] != '\0') {
+            size++;
+        }
+    }
+
+    jobjectArray searchDomains = (*env)->NewObjectArray(env, size, stringClass, NULL);
+
+    if (searchDomains == NULL) {
+        throwNativeException(env, "Could not create searchDomains");
+        return NULL;
+    }
+
+    int index = 0;
+    if (adapter->DnsSuffix[0] != '\0') {
+        jstring dnsSuffix = wideCharToString(env, adapter->DnsSuffix);
+
+        if (dnsSuffix == NULL) {
+            return NULL;
+        }
+
+        (*env)->SetObjectArrayElement(env, searchDomains, index, dnsSuffix);
+        ++index;
+    }
+
+    for (PIP_ADAPTER_DNS_SUFFIX dnsSuffix = adapter->FirstDnsSuffix; dnsSuffix != NULL; dnsSuffix = dnsSuffix->Next) {
+        if (dnsSuffix->String[0] != '\0') {
+            jstring dnsText = wideCharToString(env, dnsSuffix->String);
+
+            if (dnsText == NULL) {
+                return NULL;
+            }
+
+            (*env)->SetObjectArrayElement(env, searchDomains, index, dnsText);
+            ++index;
+        }
+    }
+
+    return searchDomains;
+}
+
+jobject adapterToJava(JNIEnv* env, IP_ADAPTER_ADDRESSES* adapter) {
+    jobjectArray searchDomains = searchDomainsToJava(env, adapter);
+
+    if (searchDomains == NULL) {
+        return NULL;
+    }
+
+    jobject dnsServers = dnsServersToJava(env, adapter);
+
+    if (dnsServers == NULL) {
+        return NULL;
+    }
+
+    return (*env)->NewObject(env, networkAdapterClass, networkAdapterCtor, dnsServers, searchDomains);
+}
+
+bool isRelevantAdapter(IP_ADAPTER_ADDRESSES* adapter) {
+    return adapter->OperStatus == IfOperStatusUp && adapter->IfType != IF_TYPE_SOFTWARE_LOOPBACK;
+}
+
+static jobjectArray windows_adapters(JNIEnv* env, jclass clazz) {
+    IP_ADAPTER_ADDRESSES* adapters;
+
+    if (read_adapter_addresses(env, &adapters) != JNI_OK) {
+        return NULL;
+    }
+
+    jsize adapterCount = 0;
+    for (IP_ADAPTER_ADDRESSES* adapter = adapters; adapter != NULL; adapter = adapter->Next) {
+        if (!isRelevantAdapter(adapter)) {
+            continue;
+        }
+
+        adapterCount++;
+    }
+
+    jobjectArray javaAdapters = (*env)->NewObjectArray(env, adapterCount, networkAdapterClass, NULL);
+
+    if (javaAdapters == NULL) {
+        throwNativeException(env, "Could not create javaAdapters array");
+        goto error;
+    }
+
+    jsize index = 0;
+    for (IP_ADAPTER_ADDRESSES* adapter = adapters; adapter != NULL; adapter = adapter->Next) {
+        if (!isRelevantAdapter(adapter)) {
+            continue;
+        }
+
+        jobject result = adapterToJava(env, adapter);
+
+        if (result == NULL) {
+            goto error;
+        }
+
+        (*env)->SetObjectArrayElement(env, javaAdapters, index, result);
+
+        ++index;
+    }
+
+    free(adapters);
+
+    return javaAdapters;
+
+error:
+    free(adapters);
+    return NULL;
+}
+
+jint loadClass(JNIEnv* env, const char* name, jclass* target) {
+    jclass clazz;
+    NETTY_JNI_UTIL_LOAD_CLASS(env, clazz, name, fail);
+
+    *target = clazz;
+    return JNI_OK;
+fail:
+    fprintf(stderr, "Class not found: %s\n", name);
+    fflush(stderr);
+    return JNI_ERR;
+}
+
+jint loadNettyClass(JNIEnv* env, const char* name, jclass* target, const char* packagePrefix) {
+    char* nettyClassName = netty_jni_util_prepend(packagePrefix, name);
+    jclass clazz;
+    NETTY_JNI_UTIL_LOAD_CLASS(env, clazz, nettyClassName, fail);
+    free(nettyClassName);
+    *target = clazz;
+    return JNI_OK;
+fail:
+    fprintf(stderr, "Class not found: %s\n", nettyClassName);
+    fflush(stderr);
+    free(nettyClassName);
+    return JNI_ERR;
+}
+
+jint loadMethod(JNIEnv* env, jclass clazz, const char* name, const char* sig, jmethodID* target) {
+    *target = (*env)->GetMethodID(env, clazz, name, sig);
+
+    if (*target == NULL) {
+        fprintf(stderr, "Method not found: %s(%s)\n", name, sig);
+        fflush(stderr);
+        return JNI_ERR;
+    }
+
+    return JNI_OK;
+}
+
+static JNINativeMethod* createDynamicMethodsTable(const char* packagePrefix) {
+    JNINativeMethod* dynamicMethods = malloc(sizeof(JNINativeMethod) * 1);
+
+    if (dynamicMethods == NULL) {
+        return NULL;
+    }
+
+    char* dynamicTypeName = netty_jni_util_prepend(packagePrefix, "io/netty/resolver/dns/windows/NetworkAdapter;");
+    char* dynamicArrayTypeName = netty_jni_util_prepend("()[L", dynamicTypeName);
+    free(dynamicTypeName);
+
+    JNINativeMethod* dynamicMethod = &dynamicMethods[0];
+    dynamicMethod->name = "adapters";
+    dynamicMethod->signature = dynamicArrayTypeName;
+    dynamicMethod->fnPtr = (void *) windows_adapters;
+    return dynamicMethods;
+}
+
+static jint register_natives(JNIEnv* env, const char* packagePrefix) {
+    // Register the methods which are not referenced by static member variables
+    JNINativeMethod* dynamicMethods = createDynamicMethodsTable(packagePrefix);
+    if (dynamicMethods == NULL) {
+        return JNI_ERR;
+    }
+
+    cached_package_prefix = packagePrefix;
+
+    jint result = netty_jni_util_register_natives(env,
+            packagePrefix,
+            ADAPTER_INFO_CLASS,
+            dynamicMethods, 1);
+
+    netty_jni_util_free_dynamic_methods_table(dynamicMethods, 0, 1);
+
+    return result == 0 ? JNI_OK : JNI_ERR;
+}
+
+static void unload_jvm_references(JNIEnv* env) {
+    NETTY_JNI_UTIL_UNLOAD_CLASS(env, nativeExceptionClass);
+
+    free(networkAdapterCtor);
+    NETTY_JNI_UTIL_UNLOAD_CLASS(env, networkAdapterClass);
+
+    NETTY_JNI_UTIL_UNLOAD_CLASS(env, stringClass);
+
+    free(inetSocketAddressCtor);
+    NETTY_JNI_UTIL_UNLOAD_CLASS(env, inetSocketAddressClass);
+}
+
+static jint netty_resolver_dns_native_windows_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
+    if (loadClass(env, "java/lang/RuntimeException", &nativeExceptionClass) != JNI_OK) {
+        goto fail;
+    }
+
+    if (loadNettyClass(env, "io/netty/resolver/dns/windows/NetworkAdapter", &networkAdapterClass, packagePrefix) != JNI_OK) {
+        goto fail;
+    }
+
+    if (loadMethod(env, networkAdapterClass, "<init>", "([Ljava/net/InetSocketAddress;[Ljava/lang/String;)V", &networkAdapterCtor) != JNI_OK) {
+        goto fail;
+    }
+
+    if (loadClass(env, "java/lang/String", &stringClass) != JNI_OK) {
+        goto fail;
+    }
+
+    if (loadClass(env, "java/net/InetSocketAddress", &inetSocketAddressClass) != JNI_OK) {
+        goto fail;
+    }
+
+    if (loadMethod(env, inetSocketAddressClass, "<init>", "(Ljava/lang/String;I)V", &inetSocketAddressCtor) != JNI_OK) {
+        goto fail;
+    }
+
+    if (register_natives(env, packagePrefix) != JNI_OK) {
+        goto fail;
+    }
+
+    return NETTY_JNI_UTIL_JNI_VERSION;
+fail:
+    unload_jvm_references(env);
+    return JNI_ERR;
+}
+
+static void netty_resolver_dns_native_windows_JNI_OnUnLoad(JNIEnv* env) {
+    unload_jvm_references(env);
+
+    netty_jni_util_unregister_natives(env, cached_package_prefix, ADAPTER_INFO_CLASS);
+}
+
+// Invoked by the JVM when statically linked
+JNIEXPORT jint JNI_OnLoad_netty_resolver_dns_native_windows(JavaVM* vm, void* reserved) {
+    return netty_jni_util_JNI_OnLoad(vm, reserved, "netty_resolver_dns_native_windows", netty_resolver_dns_native_windows_JNI_OnLoad);
+}
+
+// Invoked by the JVM when statically linked
+JNIEXPORT void JNI_OnUnload_netty_resolver_dns_native_windows(JavaVM* vm, void* reserved) {
+    netty_jni_util_JNI_OnUnload(vm, reserved, netty_resolver_dns_native_windows_JNI_OnUnLoad);
+}
+
+#ifndef NETTY_BUILD_STATIC
+JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved) {
+    return netty_jni_util_JNI_OnLoad(vm, reserved, "netty_resolver_dns_native_windows", netty_resolver_dns_native_windows_JNI_OnLoad);
+}
+
+JNIEXPORT void JNI_OnUnload(JavaVM* vm, void* reserved) {
+    netty_jni_util_JNI_OnUnload(vm, reserved, netty_resolver_dns_native_windows_JNI_OnUnLoad);
+}
+#endif /* NETTY_BUILD_STATIC */

--- a/resolver-dns-native-windows/src/main/java/io/netty/resolver/dns/windows/NetworkAdapter.java
+++ b/resolver-dns-native-windows/src/main/java/io/netty/resolver/dns/windows/NetworkAdapter.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns.windows;
+
+import java.net.InetSocketAddress;
+
+final class NetworkAdapter {
+    private final InetSocketAddress[] nameservers;
+    private final String[] searchDomains;
+
+    NetworkAdapter(InetSocketAddress[] nameservers, String[] searchDomains) {
+        this.nameservers = nameservers;
+        this.searchDomains = searchDomains;
+    }
+
+    public InetSocketAddress[] getNameservers() {
+        return nameservers;
+    }
+
+    public String[] getSearchDomains() {
+        return searchDomains;
+    }
+}

--- a/resolver-dns-native-windows/src/main/java/io/netty/resolver/dns/windows/WindowsAdapterInfo.java
+++ b/resolver-dns-native-windows/src/main/java/io/netty/resolver/dns/windows/WindowsAdapterInfo.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.resolver.dns.windows;
+
+import io.netty.util.internal.NativeLibraryLoader;
+import io.netty.util.internal.PlatformDependent;
+
+final class WindowsAdapterInfo {
+    private static final Throwable UNAVAILABILITY_CAUSE;
+
+    static {
+        Throwable cause = null;
+        try {
+            loadNativeLibrary();
+        } catch (Throwable error) {
+            cause = error;
+        }
+        UNAVAILABILITY_CAUSE = cause;
+    }
+
+    private WindowsAdapterInfo() {
+        // Utility
+    }
+
+    private static void loadNativeLibrary() {
+        if (!PlatformDependent.isWindows()) {
+            throw new IllegalStateException("Only supported on Windows");
+        }
+
+        String sharedLibName = "netty_resolver_dns_native_windows" + '_' + PlatformDependent.normalizedArch();
+        ClassLoader cl = PlatformDependent.getClassLoader(WindowsAdapterInfo.class);
+        NativeLibraryLoader.load(sharedLibName, cl);
+    }
+
+    static boolean isAvailable() {
+        return UNAVAILABILITY_CAUSE == null;
+    }
+
+    static void ensureAvailability() {
+        if (UNAVAILABILITY_CAUSE != null) {
+            throw (Error) new UnsatisfiedLinkError(
+                    "failed to load the required native library").initCause(UNAVAILABILITY_CAUSE);
+        }
+    }
+
+    static Throwable unavailabilityCause() {
+        return UNAVAILABILITY_CAUSE;
+    }
+
+    static native NetworkAdapter[] adapters();
+}

--- a/resolver-dns-native-windows/src/main/java/io/netty/resolver/dns/windows/package-info.java
+++ b/resolver-dns-native-windows/src/main/java/io/netty/resolver/dns/windows/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Windows specific nameserver resolution.
+ */
+package io.netty.resolver.dns.windows;

--- a/resolver-dns-native-windows/src/test/java/io/netty/resolver/dns/windows/WindowsAdapterInfoTest.java
+++ b/resolver-dns-native-windows/src/test/java/io/netty/resolver/dns/windows/WindowsAdapterInfoTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns.windows;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@EnabledOnOs(OS.WINDOWS)
+public class WindowsAdapterInfoTest {
+    @Test
+    void loads() {
+        System.out.println("Loading Exception (if any): " + WindowsAdapterInfo.unavailabilityCause());
+
+        assertThat(WindowsAdapterInfo.isAvailable()).isTrue();
+        assertThat(WindowsAdapterInfo.adapters()).isNotNull();
+
+        NetworkAdapter[] adapters = WindowsAdapterInfo.adapters();
+
+        for (NetworkAdapter adapter : adapters) {
+            System.out.println("=== Search Domains ===");
+            System.out.println(Arrays.toString(adapter.getSearchDomains()));
+            System.out.println("=== Nameservers ===");
+            System.out.println(Arrays.toString(adapter.getNameservers()));
+        }
+    }
+}

--- a/resolver-dns/pom.xml
+++ b/resolver-dns/pom.xml
@@ -106,6 +106,12 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-resolver-dns-native-windows</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 </project>
 

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -51,6 +51,7 @@ import io.netty.resolver.HostsFileEntries;
 import io.netty.resolver.HostsFileEntriesResolver;
 import io.netty.resolver.InetNameResolver;
 import io.netty.resolver.ResolvedAddressTypes;
+import io.netty.resolver.dns.windows.WindowsResolverDnsServerAddressStreamProvider;
 import io.netty.util.NetUtil;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.FastThreadLocal;
@@ -63,7 +64,6 @@ import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
-import java.lang.reflect.Method;
 import java.net.IDN;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
@@ -142,7 +142,7 @@ public class DnsNameResolver extends InetNameResolver {
         String[] searchDomains;
         try {
             List<String> list = PlatformDependent.isWindows()
-                    ? getSearchDomainsHack()
+                    ? WindowsResolverDnsServerAddressStreamProvider.getSearchDomains()
                     : UnixResolverDnsServerAddressStreamProvider.parseEtcResolverSearchDomains();
             searchDomains = list.toArray(new String[0]);
         } catch (Exception ignore) {
@@ -175,23 +175,6 @@ public class DnsNameResolver extends InetNameResolver {
             }
         }
         return false;
-    }
-
-    @SuppressWarnings("unchecked")
-    private static List<String> getSearchDomainsHack() throws Exception {
-        // Only try if not using Java9 and later
-        // See https://github.com/netty/netty/issues/9500
-        if (PlatformDependent.javaVersion() < 9) {
-            // This code on Java 9+ yields a warning about illegal reflective access that will be denied in
-            // a future release. There doesn't seem to be a better way to get search domains for Windows yet.
-            Class<?> configClass = Class.forName("sun.net.dns.ResolverConfiguration");
-            Method open = configClass.getMethod("open");
-            Method nameservers = configClass.getMethod("searchlist");
-            Object instance = open.invoke(null);
-
-            return (List<String>) nameservers.invoke(instance);
-        }
-        return Collections.emptyList();
     }
 
     private static final DatagramDnsResponseDecoder DATAGRAM_DECODER = new DatagramDnsResponseDecoder() {

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddressStreamProviders.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddressStreamProviders.java
@@ -15,6 +15,7 @@
  */
 package io.netty.resolver.dns;
 
+import io.netty.resolver.dns.windows.WindowsResolverDnsServerAddressStreamProvider;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -94,7 +95,6 @@ public final class DnsServerAddressStreamProviders {
     /**
      * A {@link DnsServerAddressStreamProvider} which inherits the DNS servers from your local host's configuration.
      * <p>
-     * Note that only macOS and Linux are currently supported.
      * @return A {@link DnsServerAddressStreamProvider} which inherits the DNS servers from your local host's
      * configuration.
      */
@@ -110,6 +110,7 @@ public final class DnsServerAddressStreamProviders {
                 // ignore
             }
         }
+
         return unixDefault();
     }
 
@@ -123,8 +124,6 @@ public final class DnsServerAddressStreamProviders {
         // We use 5 minutes which is the same as what OpenJDK is using in sun.net.dns.ResolverConfigurationImpl.
         private static final long REFRESH_INTERVAL = TimeUnit.MINUTES.toNanos(5);
 
-        // TODO(scott): how is this done on Windows? This may require a JNI call to GetNetworkParams
-        // https://msdn.microsoft.com/en-us/library/aa365968(VS.85).aspx.
         static final DnsServerAddressStreamProvider DEFAULT_DNS_SERVER_ADDRESS_STREAM_PROVIDER =
                 new DnsServerAddressStreamProvider() {
                     private volatile DnsServerAddressStreamProvider currentProvider = provider();
@@ -145,9 +144,8 @@ public final class DnsServerAddressStreamProviders {
                     }
 
                     private DnsServerAddressStreamProvider provider() {
-                        // If on windows just use the DefaultDnsServerAddressStreamProvider.INSTANCE as otherwise
-                        // we will log some error which may be confusing.
-                        return PlatformDependent.isWindows() ? DefaultDnsServerAddressStreamProvider.INSTANCE :
+                        return PlatformDependent.isWindows() ?
+                                WindowsResolverDnsServerAddressStreamProvider.loadConfig() :
                                 UnixResolverDnsServerAddressStreamProvider.parseSilently();
                     }
                 };

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/windows/WindowsResolverDnsServerAddressStreamProvider.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/windows/WindowsResolverDnsServerAddressStreamProvider.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns.windows;
+
+import io.netty.resolver.dns.DefaultDnsServerAddressStreamProvider;
+import io.netty.resolver.dns.DnsServerAddressStream;
+import io.netty.resolver.dns.DnsServerAddressStreamProvider;
+import io.netty.resolver.dns.DnsServerAddresses;
+import io.netty.util.internal.StringUtil;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class WindowsResolverDnsServerAddressStreamProvider implements DnsServerAddressStreamProvider {
+
+    private final Map<String, DnsServerAddresses> resolverMap;
+
+    private WindowsResolverDnsServerAddressStreamProvider(NetworkAdapter[] adapters) {
+        this.resolverMap = buildMappings(adapters);
+    }
+
+    public static WindowsResolverDnsServerAddressStreamProvider loadConfig() {
+        WindowsAdapterInfo.ensureAvailability();
+        return new WindowsResolverDnsServerAddressStreamProvider(WindowsAdapterInfo.adapters());
+    }
+
+    public static List<String> getSearchDomains() {
+        WindowsAdapterInfo.ensureAvailability();
+
+        NetworkAdapter[] adapters = WindowsAdapterInfo.adapters();
+
+        List<String> searchDomains = new ArrayList<String>(adapters.length);
+
+        for (NetworkAdapter adapter : adapters) {
+            Collections.addAll(searchDomains, adapter.getSearchDomains());
+        }
+
+        return searchDomains;
+    }
+
+    @Override
+    public DnsServerAddressStream nameServerAddressStream(String hostname) {
+        final String originalHostname = hostname;
+        for (;;) {
+            int i = hostname.indexOf('.', 1);
+            if (i < 0 || i == hostname.length() - 1) {
+                // Try access default mapping.
+                DnsServerAddresses addresses = resolverMap.get(StringUtil.EMPTY_STRING);
+                if (addresses != null) {
+                    return addresses.stream();
+                }
+                return DefaultDnsServerAddressStreamProvider.INSTANCE.nameServerAddressStream(originalHostname);
+            }
+
+            DnsServerAddresses addresses = resolverMap.get(hostname);
+            if (addresses != null) {
+                return addresses.stream();
+            }
+
+            hostname = hostname.substring(i + 1);
+        }
+    }
+
+    private static Map<String, DnsServerAddresses> buildMappings(NetworkAdapter[] adapters) {
+        if (adapters == null || adapters.length == 0) {
+            return Collections.emptyMap();
+        }
+
+        Map<String, DnsServerAddresses> resolverMap = new HashMap<String, DnsServerAddresses>(adapters.length);
+        for (NetworkAdapter adapter: adapters) {
+
+            InetSocketAddress[] nameservers = adapter.getNameservers();
+            if (nameservers == null || nameservers.length == 0) {
+                continue;
+            }
+
+            for (String domain : adapter.getSearchDomains()) {
+                if (domain == null) {
+                    // Default mapping.
+                    domain = StringUtil.EMPTY_STRING;
+                }
+
+                for (int a = 0; a < nameservers.length; a++) {
+                    InetSocketAddress address = nameservers[a];
+                    // Check if the default port should be used
+                    if (address.getPort() == 0) {
+                        nameservers[a] = new InetSocketAddress(address.getAddress(), 53);
+                    }
+                }
+
+                resolverMap.put(domain, DnsServerAddresses.sequential(nameservers));
+            }
+        }
+        return resolverMap;
+    }
+}

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/windows/package-info.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/windows/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Windows specific DNS support.
+ */
+package io.netty.resolver.dns.windows;


### PR DESCRIPTION
Motivation:
On Windows with JDK 9+ the search domain and dns servers are missing.

Modification:

This PR uses JNI to fetch the DNS Servers from the operating system.

Result:

Fixes #12712 #11885. 

Co-authored-by: Norman Maurer <norman_maurer@apple.com>
