### PR TITLE
fix brotli compression

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentCompressorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentCompressorTest.java
@@ -49,6 +49,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
 
 import java.nio.charset.StandardCharsets;
 
@@ -780,9 +781,13 @@ public class HttpContentCompressorTest {
         assertTrue(ch.finishAndReleaseAll());
     }
 
+    static boolean isBrotliAvailable() {
+        return Brotli.isAvailable();
+    }
+
     @Test
+    @EnabledIf("isBrotliAvailable")
     public void testBrotliFullHttpResponse() throws Exception {
-        assertTrue(Brotli.isAvailable());
         HttpContentCompressor compressor = new HttpContentCompressor((CompressionOptions[]) null);
         EmbeddedChannel ch = new EmbeddedChannel(compressor);
         assertTrue(ch.writeInbound(newBrotliRequest()));
@@ -820,8 +825,8 @@ public class HttpContentCompressorTest {
     }
 
     @Test
+    @EnabledIf("isBrotliAvailable")
     public void testBrotliChunkedContent() throws Exception {
-        assertTrue(Brotli.isAvailable());
         HttpContentCompressor compressor = new HttpContentCompressor((CompressionOptions[]) null);
         EmbeddedChannel ch = new EmbeddedChannel(compressor);
         assertTrue(ch.writeInbound(newBrotliRequest()));

--- a/codec/src/main/java/io/netty/handler/codec/compression/BrotliEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/BrotliEncoder.java
@@ -69,7 +69,6 @@ public final class BrotliEncoder extends MessageToByteEncoder<ByteBuf> {
     private final boolean isSharable;
     private Writer writer;
 
-
     /**
      * Create a new {@link BrotliEncoder} Instance with {@link BrotliOptions#DEFAULT}
      * and {@link #isSharable()} set to {@code true}

--- a/codec/src/main/java/io/netty/handler/codec/compression/BrotliEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/BrotliEncoder.java
@@ -21,14 +21,12 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.MessageToByteEncoder;
 import io.netty.util.AttributeKey;
 import io.netty.util.ReferenceCountUtil;
-import io.netty.util.concurrent.ScheduledFuture;
 import io.netty.util.internal.ObjectUtil;
 
 import java.io.IOException;
@@ -36,7 +34,6 @@ import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.WritableByteChannel;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Compress a {@link ByteBuf} with the Brotli compression.


### PR DESCRIPTION
Motivation:

Brotli compressed http responses are not properly encoded.

Modification:

- change BrotliEncoder behavior so that the "finish" operation is performed before the channel is closed
- add new Brotli unit tests

Result:

All brotli tests pass.

