### PR TITLE
Remove deprecated methods in CharsetUtil

### DIFF
--- a/common/src/main/java/io/netty5/util/CharsetUtil.java
+++ b/common/src/main/java/io/netty5/util/CharsetUtil.java
@@ -47,14 +47,6 @@ public final class CharsetUtil {
     };
 
     /**
-     * @deprecated Use {@link #encoder(Charset)}.
-     */
-    @Deprecated
-    public static CharsetEncoder getEncoder(Charset charset) {
-        return encoder(charset);
-    }
-
-    /**
      * Returns a new {@link CharsetEncoder} for the {@link Charset} with specified error actions.
      *
      * @param charset The specified charset
@@ -100,14 +92,6 @@ public final class CharsetUtil {
         e = encoder(charset, CodingErrorAction.REPLACE, CodingErrorAction.REPLACE);
         map.put(charset, e);
         return e;
-    }
-
-    /**
-     * @deprecated Use {@link #decoder(Charset)}.
-     */
-    @Deprecated
-    public static CharsetDecoder getDecoder(Charset charset) {
-        return decoder(charset);
     }
 
     /**


### PR DESCRIPTION
Motivation:

CharsetUtil#getEncoder(Charset)/#getDecoder(Charset) methods are deprecated since 2016. (#4939)

Now is good time to remove deprecated methods.

Modifications:

Removed deprecated methods.

Result:

Clean up