### PR TITLE
Replace `EmbeddedChannel`'s 'frozen time' feature with `Ticker`

### DIFF
--- a/common/src/main/java/io/netty5/util/concurrent/DefaultMockTicker.java
+++ b/common/src/main/java/io/netty5/util/concurrent/DefaultMockTicker.java
@@ -22,6 +22,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import static io.netty5.util.internal.ObjectUtil.checkPositiveOrZero;
+import static java.util.Objects.requireNonNull;
 
 /**
  * The default {@link MockTicker} implementation.
@@ -40,6 +41,8 @@ final class DefaultMockTicker implements MockTicker {
     @Override
     public void sleep(long delay, TimeUnit unit) throws InterruptedException {
         checkPositiveOrZero(delay, "delay");
+        requireNonNull(unit, "unit");
+
         if (delay == 0) {
             return;
         }
@@ -59,6 +62,8 @@ final class DefaultMockTicker implements MockTicker {
     @Override
     public void advance(long amount, TimeUnit unit) {
         checkPositiveOrZero(amount, "amount");
+        requireNonNull(unit, "unit");
+
         if (amount == 0) {
             return;
         }

--- a/common/src/main/java/io/netty5/util/concurrent/DefaultMockTicker.java
+++ b/common/src/main/java/io/netty5/util/concurrent/DefaultMockTicker.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.util.concurrent;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static io.netty5.util.internal.ObjectUtil.checkPositiveOrZero;
+
+/**
+ * The default {@link MockTicker} implementation.
+ */
+final class DefaultMockTicker implements MockTicker {
+
+    private final Lock lock = new ReentrantLock();
+    private final Condition cond = lock.newCondition();
+    private final AtomicLong nanoTime = new AtomicLong();
+
+    @Override
+    public long nanoTime() {
+        return nanoTime.get();
+    }
+
+    @Override
+    public void sleep(long delay, TimeUnit unit) throws InterruptedException {
+        checkPositiveOrZero(delay, "delay");
+        if (delay == 0) {
+            return;
+        }
+
+        final long startTimeNanos = nanoTime();
+        final long delayNanos = unit.toNanos(delay);
+        lock.lockInterruptibly();
+        try {
+            do {
+                cond.await();
+            } while (nanoTime() - startTimeNanos < delayNanos);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void advance(long amount, TimeUnit unit) {
+        checkPositiveOrZero(amount, "amount");
+        if (amount == 0) {
+            return;
+        }
+
+        final long amountNanos = unit.toNanos(amount);
+        lock.lock();
+        try {
+            nanoTime.addAndGet(amountNanos);
+            cond.signalAll();
+        } finally {
+            lock.unlock();
+        }
+    }
+}

--- a/common/src/main/java/io/netty5/util/concurrent/GlobalEventExecutor.java
+++ b/common/src/main/java/io/netty5/util/concurrent/GlobalEventExecutor.java
@@ -86,9 +86,9 @@ public final class GlobalEventExecutor extends AbstractScheduledEventExecutor im
                 this, newPromise(), Executors.callable(() -> {
             // NOOP
         }, null),
-                // note: the getCurrentTimeNanos() call here only works because this is a final class, otherwise
+                // note: the ticker().nanoTime() call here only works because this is a final class, otherwise
                 // the method could be overridden leading to unsafe initialization here!
-                deadlineNanos(getCurrentTimeNanos(), SCHEDULE_QUIET_PERIOD_INTERVAL),
+                deadlineNanos(ticker().nanoTime(), SCHEDULE_QUIET_PERIOD_INTERVAL),
                 -SCHEDULE_QUIET_PERIOD_INTERVAL);
 
         scheduledTaskQueue().add(quietPeriodTask);
@@ -139,7 +139,7 @@ public final class GlobalEventExecutor extends AbstractScheduledEventExecutor im
     }
 
     private void fetchFromScheduledTaskQueue() {
-        long nanoTime = getCurrentTimeNanos();
+        long nanoTime = ticker().nanoTime();
         Runnable scheduledTask = pollScheduledTask(nanoTime);
         while (scheduledTask != null) {
             taskQueue.add(scheduledTask);

--- a/common/src/main/java/io/netty5/util/concurrent/MockTicker.java
+++ b/common/src/main/java/io/netty5/util/concurrent/MockTicker.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.util.concurrent;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A fake {@link Ticker} that allows the caller control the flow of time.
+ * This can be useful when you test time-sensitive logic without waiting for too long
+ * or introducing flakiness due to non-deterministic nature of system clock.
+ */
+public interface MockTicker extends Ticker {
+    @Override
+    default long initialNanoTime() {
+        return 0;
+    }
+
+    /**
+     * Advances the current {@link #nanoTime()} by the given amount of time.
+     *
+     * @param amount the amount of time to advance this ticker by.
+     * @param unit the {@link TimeUnit} of {@code amount}.
+     */
+    void advance(long amount, TimeUnit unit);
+
+    /**
+     * Advances the current {@link #nanoTime()} by the given amount of time.
+     *
+     * @param amountMillis the number of milliseconds to advance this ticker by.
+     */
+    default void advanceMillis(long amountMillis) {
+        advance(amountMillis, TimeUnit.MILLISECONDS);
+    }
+}

--- a/common/src/main/java/io/netty5/util/concurrent/MockTicker.java
+++ b/common/src/main/java/io/netty5/util/concurrent/MockTicker.java
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit;
  * or introducing flakiness due to non-deterministic nature of system clock.
  */
 public interface MockTicker extends Ticker {
+
     @Override
     default long initialNanoTime() {
         return 0;

--- a/common/src/main/java/io/netty5/util/concurrent/RunnableScheduledFutureAdapter.java
+++ b/common/src/main/java/io/netty5/util/concurrent/RunnableScheduledFutureAdapter.java
@@ -61,7 +61,7 @@ final class RunnableScheduledFutureAdapter<V> implements AbstractScheduledEventE
 
     @Override
     public long delayNanos() {
-        return delayNanos(executor.getCurrentTimeNanos());
+        return delayNanos(executor.ticker().nanoTime());
     }
 
     @Override
@@ -128,7 +128,7 @@ final class RunnableScheduledFutureAdapter<V> implements AbstractScheduledEventE
                         if (p > 0) {
                             deadlineNanos += p;
                         } else {
-                            deadlineNanos = executor.getCurrentTimeNanos() - p;
+                            deadlineNanos = executor.ticker().nanoTime() - p;
                         }
                         if (!isCancelled()) {
                             executor.schedule(this);

--- a/common/src/main/java/io/netty5/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty5/util/concurrent/SingleThreadEventExecutor.java
@@ -379,7 +379,7 @@ public class SingleThreadEventExecutor extends AbstractScheduledEventExecutor im
      */
     protected final long delayNanos(long currentTimeNanos) {
         assert inEventLoop();
-        currentTimeNanos -= SystemTicker.START_TIME;
+        currentTimeNanos -= ticker().initialNanoTime();
         RunnableScheduledFuture<?> scheduledTask = peekScheduledTask();
         if (scheduledTask == null) {
             return SCHEDULE_PURGE_INTERVAL;

--- a/common/src/main/java/io/netty5/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty5/util/concurrent/SingleThreadEventExecutor.java
@@ -250,7 +250,7 @@ public class SingleThreadEventExecutor extends AbstractScheduledEventExecutor im
     }
 
     private boolean fetchFromScheduledTaskQueue() {
-        long nanoTime = getCurrentTimeNanos();
+        long nanoTime = ticker().nanoTime();
         RunnableScheduledFuture<?> scheduledTask  = pollScheduledTask(nanoTime);
         while (scheduledTask != null) {
             if (!taskQueue.offer(scheduledTask)) {
@@ -379,7 +379,7 @@ public class SingleThreadEventExecutor extends AbstractScheduledEventExecutor im
      */
     protected final long delayNanos(long currentTimeNanos) {
         assert inEventLoop();
-        currentTimeNanos -= START_TIME;
+        currentTimeNanos -= SystemTicker.START_TIME;
         RunnableScheduledFuture<?> scheduledTask = peekScheduledTask();
         if (scheduledTask == null) {
             return SCHEDULE_PURGE_INTERVAL;
@@ -389,7 +389,7 @@ public class SingleThreadEventExecutor extends AbstractScheduledEventExecutor im
     }
 
     /**
-     * Returns the absolute point in time (relative to {@link #getCurrentTimeNanos()} ()}) at which the next
+     * Returns the absolute point in time (relative to {@link #ticker().nanoTime()} ()}) at which the next
      * closest scheduled task should run or {@code -1} if none is scheduled at the mment.
      *
      * This method must be called from the {@link EventExecutor} thread.
@@ -410,7 +410,7 @@ public class SingleThreadEventExecutor extends AbstractScheduledEventExecutor im
      */
     protected final void updateLastExecutionTime() {
         assert inEventLoop();
-        lastExecutionTime = getCurrentTimeNanos();
+        lastExecutionTime = ticker().nanoTime();
     }
 
     /**
@@ -597,7 +597,7 @@ public class SingleThreadEventExecutor extends AbstractScheduledEventExecutor im
         cancelScheduledTasks();
 
         if (gracefulShutdownStartTime == 0) {
-            gracefulShutdownStartTime = getCurrentTimeNanos();
+            gracefulShutdownStartTime = ticker().nanoTime();
         }
 
         if (runAllTasks() || runShutdownHooks()) {
@@ -616,7 +616,7 @@ public class SingleThreadEventExecutor extends AbstractScheduledEventExecutor im
             return false;
         }
 
-        final long nanoTime = getCurrentTimeNanos();
+        final long nanoTime = ticker().nanoTime();
 
         if (isShutdown() || nanoTime - gracefulShutdownStartTime > gracefulShutdownTimeout) {
             return true;

--- a/common/src/main/java/io/netty5/util/concurrent/SystemTicker.java
+++ b/common/src/main/java/io/netty5/util/concurrent/SystemTicker.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.util.concurrent;
+
+import java.util.concurrent.TimeUnit;
+
+enum SystemTicker implements Ticker {
+    INSTANCE;
+
+    static final long START_TIME = System.nanoTime();
+
+    @Override
+    public long initialNanoTime() {
+        return START_TIME;
+    }
+
+    @Override
+    public long nanoTime() {
+        return System.nanoTime() - START_TIME;
+    }
+
+    @Override
+    public void sleep(long delay, TimeUnit unit) throws InterruptedException {
+        Thread.sleep(unit.toMillis(delay), (int) (delay % 1_000_000));
+    }
+}

--- a/common/src/main/java/io/netty5/util/concurrent/SystemTicker.java
+++ b/common/src/main/java/io/netty5/util/concurrent/SystemTicker.java
@@ -34,6 +34,6 @@ enum SystemTicker implements Ticker {
 
     @Override
     public void sleep(long delay, TimeUnit unit) throws InterruptedException {
-        Thread.sleep(unit.toMillis(delay), (int) (delay % 1_000_000));
+        unit.sleep(delay);
     }
 }

--- a/common/src/main/java/io/netty5/util/concurrent/SystemTicker.java
+++ b/common/src/main/java/io/netty5/util/concurrent/SystemTicker.java
@@ -17,7 +17,10 @@ package io.netty5.util.concurrent;
 
 import java.util.concurrent.TimeUnit;
 
+import static java.util.Objects.requireNonNull;
+
 enum SystemTicker implements Ticker {
+
     INSTANCE;
 
     static final long START_TIME = System.nanoTime();
@@ -34,6 +37,7 @@ enum SystemTicker implements Ticker {
 
     @Override
     public void sleep(long delay, TimeUnit unit) throws InterruptedException {
+        requireNonNull(unit, "unit");
         unit.sleep(delay);
     }
 }

--- a/common/src/main/java/io/netty5/util/concurrent/Ticker.java
+++ b/common/src/main/java/io/netty5/util/concurrent/Ticker.java
@@ -18,6 +18,7 @@ package io.netty5.util.concurrent;
 import java.util.concurrent.TimeUnit;
 
 public interface Ticker {
+
     /**
      * Returns the singleton {@link Ticker} that returns the values from the real system clock source.
      * However, note that this is not the same as {@link System#nanoTime()} because we apply a fixed offset

--- a/common/src/main/java/io/netty5/util/concurrent/Ticker.java
+++ b/common/src/main/java/io/netty5/util/concurrent/Ticker.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.util.concurrent;
+
+import java.util.concurrent.TimeUnit;
+
+public interface Ticker {
+    /**
+     * Returns the singleton {@link Ticker} that returns the values from the real system clock source.
+     * However, note that this is not the same as {@link System#nanoTime()} because we apply a fixed offset
+     * to the {@link System#nanoTime() nanoTime}.
+     */
+    static Ticker systemTicker() {
+        return SystemTicker.INSTANCE;
+    }
+
+    /**
+     * Returns a newly created mock {@link Ticker} that allows the caller control the flow of time.
+     * This can be useful when you test time-sensitive logic without waiting for too long or introducing
+     * flakiness due to non-deterministic nature of system clock.
+     */
+    static MockTicker newMockTicker() {
+        return new DefaultMockTicker();
+    }
+
+    /**
+     * The initial value used for delay and computations based upon a monotonic time source.
+     * @return initial value used for delay and computations based upon a monotonic time source.
+     */
+    long initialNanoTime();
+
+    /**
+     * The time elapsed since initialization of this class in nanoseconds. This may return a negative number just like
+     * {@link System#nanoTime()}.
+     */
+    long nanoTime();
+
+    /**
+     * Waits until the given amount of time goes by.
+     *
+     * @param delay the amount of delay.
+     * @param unit the {@link TimeUnit} of {@code delay}.
+     *
+     * @see Thread#sleep(long)
+     */
+    void sleep(long delay, TimeUnit unit) throws InterruptedException;
+
+    /**
+     * Waits until the given amount of time goes by.
+     *
+     * @param delayMillis the number of milliseconds.
+     *
+     * @see Thread#sleep(long)
+     */
+    default void sleepMillis(long delayMillis) throws InterruptedException {
+        sleep(delayMillis, TimeUnit.MILLISECONDS);
+    }
+}

--- a/common/src/test/java/io/netty5/util/concurrent/AbstractScheduledEventExecutorTest.java
+++ b/common/src/test/java/io/netty5/util/concurrent/AbstractScheduledEventExecutorTest.java
@@ -103,7 +103,7 @@ public class AbstractScheduledEventExecutorTest {
     @Test
     public void testDeadlineNanosNotOverflow() {
         assertEquals(Long.MAX_VALUE, AbstractScheduledEventExecutor.deadlineNanos(
-                AbstractScheduledEventExecutor.defaultCurrentTimeNanos(), Long.MAX_VALUE));
+                Ticker.systemTicker().nanoTime(), Long.MAX_VALUE));
     }
 
     private static final class TestScheduledEventExecutor extends AbstractScheduledEventExecutor {

--- a/common/src/test/java/io/netty5/util/concurrent/DefaultMockTickerTest.java
+++ b/common/src/test/java/io/netty5/util/concurrent/DefaultMockTickerTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.util.concurrent;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DefaultMockTickerTest {
+
+    @Test
+    void newMockTickerShouldReturnDefaultMockTicker() {
+        assertTrue(Ticker.newMockTicker() instanceof DefaultMockTicker);
+    }
+    @Test
+    void defaultValues() {
+        final MockTicker ticker = Ticker.newMockTicker();
+        assertEquals(0, ticker.initialNanoTime());
+        assertEquals(0, ticker.nanoTime());
+    }
+
+    @Test
+    void advanceWithoutWaiters() {
+        final MockTicker ticker = Ticker.newMockTicker();
+        ticker.advance(42, TimeUnit.NANOSECONDS);
+        assertEquals(0, ticker.initialNanoTime());
+        assertEquals(42, ticker.nanoTime());
+
+        ticker.advanceMillis(42);
+        assertEquals(42_000_042, ticker.nanoTime());
+    }
+
+    @Test
+    void advanceWithNegativeAmount() {
+        final MockTicker ticker = Ticker.newMockTicker();
+        assertThrows(IllegalArgumentException.class, () -> {
+            ticker.advance(-1, TimeUnit.SECONDS);
+        });
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            ticker.advanceMillis(-1);
+        });
+    }
+
+    @Test
+    void advanceWithWaiters() throws Exception {
+        final MockTicker ticker = Ticker.newMockTicker();
+        final int numWaiters = 4;
+        final List<CompletableFuture<Void>> futures = new ArrayList<>();
+        for (int i = 0; i < numWaiters; i++) {
+            futures.add(CompletableFuture.runAsync(() -> {
+                try {
+                    ticker.sleep(1, TimeUnit.MILLISECONDS);
+                } catch (InterruptedException e) {
+                    throw new CompletionException(e);
+                }
+            }));
+        }
+
+        // Time did not advance at all, and thus future will not complete.
+        for (int i = 0; i < numWaiters; i++) {
+            final int finalI = i;
+            assertThrows(TimeoutException.class, () -> {
+                futures.get(finalI).get(1, TimeUnit.SECONDS);
+            });
+        }
+
+        // Advance just one nanosecond before completion.
+        ticker.advance(999_999, TimeUnit.NANOSECONDS);
+
+        // Still needs one more nanosecond.
+        for (int i = 0; i < numWaiters; i++) {
+            final int finalI = i;
+            assertThrows(TimeoutException.class, () -> {
+                futures.get(finalI).get(1, TimeUnit.SECONDS);
+            });
+        }
+
+        // Reach at the 1 millisecond mark and ensure the future is complete.
+        ticker.advance(1, TimeUnit.NANOSECONDS);
+        for (int i = 0; i < numWaiters; i++) {
+            futures.get(i).get();
+        }
+    }
+
+    @Test
+    void sleepZero() throws InterruptedException {
+        final MockTicker ticker = Ticker.newMockTicker();
+        // All sleep calls with 0 delay should return immediately.
+        ticker.sleep(0, TimeUnit.SECONDS);
+        ticker.sleepMillis(0);
+        assertEquals(0, ticker.nanoTime());
+    }
+}

--- a/common/src/test/java/io/netty5/util/concurrent/DefaultMockTickerTest.java
+++ b/common/src/test/java/io/netty5/util/concurrent/DefaultMockTickerTest.java
@@ -34,6 +34,7 @@ class DefaultMockTickerTest {
     void newMockTickerShouldReturnDefaultMockTicker() {
         assertTrue(Ticker.newMockTicker() instanceof DefaultMockTicker);
     }
+
     @Test
     void defaultValues() {
         final MockTicker ticker = Ticker.newMockTicker();
@@ -81,9 +82,9 @@ class DefaultMockTickerTest {
 
         // Time did not advance at all, and thus future will not complete.
         for (int i = 0; i < numWaiters; i++) {
-            final int finalI = i;
+            final int finalCnt = i;
             assertThrows(TimeoutException.class, () -> {
-                futures.get(finalI).get(1, TimeUnit.SECONDS);
+                futures.get(finalCnt).get(1, TimeUnit.SECONDS);
             });
         }
 
@@ -92,9 +93,9 @@ class DefaultMockTickerTest {
 
         // Still needs one more nanosecond.
         for (int i = 0; i < numWaiters; i++) {
-            final int finalI = i;
+            final int finalCnt = i;
             assertThrows(TimeoutException.class, () -> {
-                futures.get(finalI).get(1, TimeUnit.SECONDS);
+                futures.get(finalCnt).get(1, TimeUnit.SECONDS);
             });
         }
 

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollHandler.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollHandler.java
@@ -27,6 +27,7 @@ import io.netty5.channel.unix.FileDescriptor;
 import io.netty5.channel.unix.IovArray;
 import io.netty5.util.collection.IntObjectHashMap;
 import io.netty5.util.collection.IntObjectMap;
+import io.netty5.util.concurrent.Ticker;
 import io.netty5.util.internal.StringUtil;
 import io.netty5.util.internal.SystemPropertyUtil;
 import io.netty5.util.internal.logging.InternalLogger;
@@ -58,7 +59,7 @@ public class EpollHandler implements IoHandler {
     }
 
     // Pick a number that no task could have previously used.
-    private long prevDeadlineNanos = SingleThreadEventLoop.nanoTime() - 1;
+    private long prevDeadlineNanos = Ticker.systemTicker().nanoTime() - 1;
     private final FileDescriptor epollFd;
     private final FileDescriptor eventFd;
     private final FileDescriptor timerFd;

--- a/transport/src/test/java/io/netty5/channel/embedded/EmbeddedChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/embedded/EmbeddedChannelTest.java
@@ -25,7 +25,9 @@ import io.netty5.channel.ChannelOutboundInvoker;
 import io.netty5.channel.ChannelPipeline;
 import io.netty5.util.Resource;
 import io.netty5.util.concurrent.Future;
+import io.netty5.util.concurrent.MockTicker;
 import io.netty5.util.concurrent.Promise;
+import io.netty5.util.concurrent.Ticker;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -487,8 +489,8 @@ public class EmbeddedChannelTest {
 
     @Test
     void testHasPendingTasks() {
-        EmbeddedChannel channel = new EmbeddedChannel();
-        channel.freezeTime();
+        MockTicker ticker = Ticker.newMockTicker();
+        EmbeddedChannel channel = new EmbeddedChannel(ticker);
         Runnable runnable = () -> { };
 
         // simple execute
@@ -501,7 +503,7 @@ public class EmbeddedChannelTest {
         assertFalse(channel.hasPendingTasks());
         channel.runPendingTasks();
         assertFalse(channel.hasPendingTasks());
-        channel.advanceTimeBy(1, TimeUnit.SECONDS);
+        ticker.advance(1, TimeUnit.SECONDS);
         assertTrue(channel.hasPendingTasks());
         channel.runPendingTasks();
         assertFalse(channel.hasPendingTasks());


### PR DESCRIPTION
Motivation:

Netty currently lacks a standard abstraction for time source, as known as 'ticker' or 'clock'. As a result, Netty relies on ad-hoc overridable protected methods for 'time getter' methods, which gives hard time to users who want to test the time-sensitive logic that involes Netty.

Modifications:

- Added `Ticker` and `MockTicker` and their default implementations.
- (Breaking) Updated `EmbeddedChannel` and `EmbeddedEventLoop` to use `Ticker` instead of its own time manipulation API.
  - Removed the old time manipulation API.
  - Note that I removed `freezeTime()` and `unfreezeTime()` because it can easily be replicated with `advance()`.

Result:

- Netty now has a better abstraction for scheduling and testing time-sensitive logic.
- A user can now specify system, mock or custom `Ticker` implementation when constructing an `EmbeddedChannel`, which is more flexible than the previous API.
  - (Breaking) The previous time-manipulation API in `EmbeddedChannel` has been removed in favor of the new API.
- Partially resolves #12827. However, this PR didn't update `IdleStateHandler` or any other time-sensitive logic in Netty, which is left as future work.
