### PR TITLE
Always respect completeOncePreferredResolved in DnsNameResolver

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -964,7 +964,7 @@ public class DnsNameResolver extends InetNameResolver {
         }
 
         if (!doResolveCached(hostname, additionals, promise, resolveCache)) {
-            doResolveUncached(hostname, additionals, promise, resolveCache, true);
+            doResolveUncached(hostname, additionals, promise, resolveCache, completeOncePreferredResolved);
         }
     }
 

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -3109,6 +3109,7 @@ public class DnsNameResolverTest {
                     .recursionDesired(false)
                     .queryTimeoutMillis(10000)
                     .resolvedAddressTypes(ResolvedAddressTypes.IPV4_PREFERRED)
+                    .completeOncePreferredResolved(true)
                     .maxQueriesPerResolve(16)
                     .nameServerProvider(new SingletonDnsServerAddressStreamProvider(dnsServer2.localAddress()));
 


### PR DESCRIPTION
Motivation:

5cf0a8db102733384592357b3f86442f6ac11bd3 only partial fixed the problem as we missed to also change the resolve(...) code path.

Modifications:

- Also respect completeOncePreferredResolved when using resolve(...)
- Fix unit test

Result:

Always respect completeOncePreferredResolved.
