### PR TITLE
Fix buffer leak in LocalChannelTest

### DIFF
--- a/transport/src/test/java/io/netty5/channel/local/LocalChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/local/LocalChannelTest.java
@@ -457,7 +457,8 @@ public class LocalChannelTest {
           .childHandler(new ChannelHandler() {
               @Override
               public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-                  if (data.equals(msg)) {
+                  if (msg instanceof Buffer && data.equals(msg)) {
+                      ((Buffer) msg).close();
                       messageLatch.countDown();
                       ctx.writeAndFlush(data.copy());
                       ctx.close();


### PR DESCRIPTION
Motivation:
Manually enabling leak detection reveals buffer leak in `LocalChannelTest`:

```
13:13:07.705 [Cleaner-7] ERROR io.netty5.buffer.LoggingLeakCallback - LEAK: Object "buffer (6 bytes)" was not property closed before it was garbage collected. A life-cycle back-trace (if any) is attached as suppressed exceptions. See https://netty.io/wiki/reference-counted-objects.html for more information.
io.netty5.buffer.LoggingLeakCallback$LeakReport: Object life-cycle trace:
	Suppressed: io.netty5.buffer.internal.LifecycleTracer$Traceback: ALLOCATE (current acquires = 0) T-748596us.
		at io.netty5.buffer.internal.ResourceSupport.<init>(ResourceSupport.java:42) ~[netty5-buffer-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at io.netty5.buffer.internal.AdaptableBuffer.<init>(AdaptableBuffer.java:28) ~[netty5-buffer-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at io.netty5.buffer.bytebuffer.NioBuffer.<init>(NioBuffer.java:66) ~[netty5-buffer-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at io.netty5.buffer.bytebuffer.NioBuffer.lambda$prepareSend$0(NioBuffer.java:1154) ~[netty5-buffer-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at io.netty5.buffer.internal.LifecycleTracer$StackTracer.lambda$send$0(LifecycleTracer.java:227) ~[netty5-buffer-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at io.netty5.buffer.internal.SendFromOwned.receive(SendFromOwned.java:50) ~[netty5-buffer-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at io.netty5.buffer.DefaultCompositeBuffer.lambda$prepareSend$2(DefaultCompositeBuffer.java:1320) ~[netty5-buffer-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at io.netty5.buffer.internal.LifecycleTracer$StackTracer.lambda$send$0(LifecycleTracer.java:227) ~[netty5-buffer-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at io.netty5.buffer.internal.SendFromOwned.receive(SendFromOwned.java:50) ~[netty5-buffer-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at io.netty5.channel.local.LocalChannel.doWriteNow(LocalChannel.java:300) ~[classes/:?]
		at io.netty5.channel.AbstractChannel$WriteSink.writeLoopStep(AbstractChannel.java:2147) ~[classes/:?]
		at io.netty5.channel.AbstractChannel.writeLoop(AbstractChannel.java:1105) ~[classes/:?]
		at io.netty5.channel.AbstractChannel.writeFlushedNow(AbstractChannel.java:1085) ~[classes/:?]
		at io.netty5.channel.AbstractChannel.writeFlushed(AbstractChannel.java:1046) ~[classes/:?]
		at io.netty5.channel.AbstractChannel.flushTransport(AbstractChannel.java:1021) ~[classes/:?]
		at io.netty5.channel.AbstractChannel$DefaultAbstractChannelPipeline.flushTransport(AbstractChannel.java:1924) ~[classes/:?]
		at io.netty5.channel.DefaultChannelPipeline$HeadHandler.flush(DefaultChannelPipeline.java:1249) ~[classes/:?]
		at io.netty5.channel.DefaultChannelHandlerContext.invokeFlush(DefaultChannelHandlerContext.java:892) ~[classes/:?]
		at io.netty5.channel.DefaultChannelHandlerContext.invokeWriteAndFlush(DefaultChannelHandlerContext.java:907) ~[classes/:?]
		at io.netty5.channel.DefaultChannelHandlerContext.write(DefaultChannelHandlerContext.java:923) ~[classes/:?]
		at io.netty5.channel.DefaultChannelHandlerContext.writeAndFlush(DefaultChannelHandlerContext.java:902) ~[classes/:?]
		at io.netty5.channel.local.LocalChannelTest$13.channelActive(LocalChannelTest.java:441) ~[test-classes/:?]
		at io.netty5.channel.DefaultChannelHandlerContext.invokeChannelActive(DefaultChannelHandlerContext.java:259) ~[classes/:?]
		at io.netty5.channel.DefaultChannelHandlerContext.findAndInvokeChannelActive(DefaultChannelHandlerContext.java:251) ~[classes/:?]
		at io.netty5.channel.DefaultChannelHandlerContext.fireChannelActive(DefaultChannelHandlerContext.java:238) ~[classes/:?]
		at io.netty5.channel.ChannelHandler.channelActive(ChannelHandler.java:205) ~[classes/:?]
		at io.netty5.channel.DefaultChannelHandlerContext.invokeChannelActive(DefaultChannelHandlerContext.java:259) ~[classes/:?]
		at io.netty5.channel.DefaultChannelPipeline.fireChannelActive(DefaultChannelPipeline.java:808) ~[classes/:?]
		at io.netty5.channel.AbstractChannel.fireChannelActiveIfNotActiveBefore(AbstractChannel.java:504) ~[classes/:?]
		at io.netty5.channel.AbstractChannel.fulfillConnectPromise(AbstractChannel.java:1448) ~[classes/:?]
		at io.netty5.channel.AbstractChannel.finishConnect(AbstractChannel.java:1495) ~[classes/:?]
		at io.netty5.channel.local.LocalChannel.lambda$finishConnectAsync$4(LocalChannel.java:440) ~[classes/:?]
		at io.netty5.util.concurrent.SingleThreadEventExecutor.runTask(SingleThreadEventExecutor.java:338) ~[netty5-common-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at io.netty5.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:361) ~[netty5-common-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at io.netty5.channel.SingleThreadEventLoop.run(SingleThreadEventLoop.java:180) ~[classes/:?]
		at io.netty5.util.concurrent.SingleThreadEventExecutor.lambda$doStartThread$4(SingleThreadEventExecutor.java:774) ~[netty5-common-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at io.netty5.util.internal.ThreadExecutorMap.lambda$apply$1(ThreadExecutorMap.java:68) ~[netty5-common-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at io.netty5.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[netty5-common-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at java.lang.Thread.run(Thread.java:833) ~[?:?]
	Suppressed: io.netty5.buffer.internal.LifecycleTracer$Traceback: TOUCH (ChannelHandlerContext(DefaultChannelPipeline$HeadHandler#0, [id: 0xa55ebcf7, L:null ! R:local:E:0a536770])) T-748483us.
		at io.netty5.buffer.internal.ResourceSupport.touch(ResourceSupport.java:224) ~[netty5-buffer-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at io.netty5.buffer.internal.AdaptableBuffer.touch(AdaptableBuffer.java:34) ~[netty5-buffer-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at io.netty5.buffer.internal.AdaptableBuffer.touch(AdaptableBuffer.java:22) ~[netty5-buffer-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at io.netty5.buffer.DefaultCompositeBuffer.touch(DefaultCompositeBuffer.java:1348) ~[netty5-buffer-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at io.netty5.buffer.DefaultCompositeBuffer.touch(DefaultCompositeBuffer.java:51) ~[netty5-buffer-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at io.netty5.util.Resource.touch(Resource.java:130) ~[netty5-common-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at io.netty5.channel.DefaultChannelPipeline.touch(DefaultChannelPipeline.java:113) ~[classes/:?]
		at io.netty5.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:449) ~[classes/:?]
		at io.netty5.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:838) ~[classes/:?]
		at io.netty5.channel.AbstractChannel$ReadSink.processRead(AbstractChannel.java:1996) ~[classes/:?]
		at io.netty5.channel.local.LocalChannel.doReadNow(LocalChannel.java:219) ~[classes/:?]
		at io.netty5.channel.AbstractChannel$ReadSink.readLoop(AbstractChannel.java:2061) ~[classes/:?]
		at io.netty5.channel.AbstractChannel.readNow(AbstractChannel.java:910) ~[classes/:?]
		at io.netty5.channel.local.LocalChannel.doRead(LocalChannel.java:261) ~[classes/:?]
		at io.netty5.channel.AbstractChannel.readTransport(AbstractChannel.java:889) ~[classes/:?]
		at io.netty5.channel.AbstractChannel$DefaultAbstractChannelPipeline.readTransport(AbstractChannel.java:1910) ~[classes/:?]
		at io.netty5.channel.DefaultChannelPipeline$HeadHandler.read(DefaultChannelPipeline.java:1225) ~[classes/:?]
		at io.netty5.channel.DefaultChannelHandlerContext.invokeRead(DefaultChannelHandlerContext.java:831) ~[classes/:?]
		at io.netty5.channel.DefaultChannelHandlerContext.findAndInvokeRead(DefaultChannelHandlerContext.java:820) ~[classes/:?]
		at io.netty5.channel.DefaultChannelHandlerContext.read(DefaultChannelHandlerContext.java:790) ~[classes/:?]
		at io.netty5.channel.DefaultChannelPipeline.read(DefaultChannelPipeline.java:902) ~[classes/:?]
		at io.netty5.channel.Channel.read(Channel.java:260) ~[classes/:?]
		at io.netty5.channel.AbstractChannel.readIfIsAutoRead(AbstractChannel.java:411) ~[classes/:?]
		at io.netty5.channel.AbstractChannel.lambda$registerTransport$1(AbstractChannel.java:482) ~[classes/:?]
		at io.netty5.util.concurrent.DefaultPromise.notifyListener0(DefaultPromise.java:459) ~[netty5-common-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at io.netty5.util.concurrent.DefaultPromise.notifyListenersNow(DefaultPromise.java:441) ~[netty5-common-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at io.netty5.util.concurrent.DefaultPromise$NotifyListeners.run(DefaultPromise.java:422) ~[netty5-common-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at io.netty5.util.concurrent.SingleThreadEventExecutor.runTask(SingleThreadEventExecutor.java:338) ~[netty5-common-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at io.netty5.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:361) ~[netty5-common-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at io.netty5.channel.SingleThreadEventLoop.run(SingleThreadEventLoop.java:180) ~[classes/:?]
		at io.netty5.util.concurrent.SingleThreadEventExecutor.lambda$doStartThread$4(SingleThreadEventExecutor.java:774) ~[netty5-common-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at io.netty5.util.internal.ThreadExecutorMap.lambda$apply$1(ThreadExecutorMap.java:68) ~[netty5-common-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at io.netty5.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[netty5-common-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at java.lang.Thread.run(Thread.java:833) ~[?:?]
	Suppressed: io.netty5.buffer.internal.LifecycleTracer$Traceback: TOUCH (ChannelHandlerContext(LocalChannelTest$14#0, [id: 0xa55ebcf7, L:null ! R:local:E:0a536770])) T-748539us.
		at io.netty5.buffer.internal.ResourceSupport.touch(ResourceSupport.java:224) ~[netty5-buffer-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at io.netty5.buffer.internal.AdaptableBuffer.touch(AdaptableBuffer.java:34) ~[netty5-buffer-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at io.netty5.buffer.internal.AdaptableBuffer.touch(AdaptableBuffer.java:22) ~[netty5-buffer-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at io.netty5.buffer.DefaultCompositeBuffer.touch(DefaultCompositeBuffer.java:1348) ~[netty5-buffer-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at io.netty5.buffer.DefaultCompositeBuffer.touch(DefaultCompositeBuffer.java:51) ~[netty5-buffer-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at io.netty5.util.Resource.touch(Resource.java:130) ~[netty5-common-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at io.netty5.channel.DefaultChannelPipeline.touch(DefaultChannelPipeline.java:113) ~[classes/:?]
		at io.netty5.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:449) ~[classes/:?]
		at io.netty5.channel.DefaultChannelHandlerContext.findAndInvokeChannelRead(DefaultChannelHandlerContext.java:445) ~[classes/:?]
		at io.netty5.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:426) ~[classes/:?]
		at io.netty5.channel.ChannelHandler.channelRead(ChannelHandler.java:235) ~[classes/:?]
		at io.netty5.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:455) ~[classes/:?]
		at io.netty5.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:838) ~[classes/:?]
		at io.netty5.channel.AbstractChannel$ReadSink.processRead(AbstractChannel.java:1996) ~[classes/:?]
		at io.netty5.channel.local.LocalChannel.doReadNow(LocalChannel.java:219) ~[classes/:?]
		at io.netty5.channel.AbstractChannel$ReadSink.readLoop(AbstractChannel.java:2061) ~[classes/:?]
		at io.netty5.channel.AbstractChannel.readNow(AbstractChannel.java:910) ~[classes/:?]
		at io.netty5.channel.local.LocalChannel.doRead(LocalChannel.java:261) ~[classes/:?]
		at io.netty5.channel.AbstractChannel.readTransport(AbstractChannel.java:889) ~[classes/:?]
		at io.netty5.channel.AbstractChannel$DefaultAbstractChannelPipeline.readTransport(AbstractChannel.java:1910) ~[classes/:?]
		at io.netty5.channel.DefaultChannelPipeline$HeadHandler.read(DefaultChannelPipeline.java:1225) ~[classes/:?]
		at io.netty5.channel.DefaultChannelHandlerContext.invokeRead(DefaultChannelHandlerContext.java:831) ~[classes/:?]
		at io.netty5.channel.DefaultChannelHandlerContext.findAndInvokeRead(DefaultChannelHandlerContext.java:820) ~[classes/:?]
		at io.netty5.channel.DefaultChannelHandlerContext.read(DefaultChannelHandlerContext.java:790) ~[classes/:?]
		at io.netty5.channel.DefaultChannelPipeline.read(DefaultChannelPipeline.java:902) ~[classes/:?]
		at io.netty5.channel.Channel.read(Channel.java:260) ~[classes/:?]
		at io.netty5.channel.AbstractChannel.readIfIsAutoRead(AbstractChannel.java:411) ~[classes/:?]
		at io.netty5.channel.AbstractChannel.lambda$registerTransport$1(AbstractChannel.java:482) ~[classes/:?]
		at io.netty5.util.concurrent.DefaultPromise.notifyListener0(DefaultPromise.java:459) ~[netty5-common-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at io.netty5.util.concurrent.DefaultPromise.notifyListenersNow(DefaultPromise.java:441) ~[netty5-common-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at io.netty5.util.concurrent.DefaultPromise$NotifyListeners.run(DefaultPromise.java:422) ~[netty5-common-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at io.netty5.util.concurrent.SingleThreadEventExecutor.runTask(SingleThreadEventExecutor.java:338) ~[netty5-common-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at io.netty5.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:361) ~[netty5-common-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at io.netty5.channel.SingleThreadEventLoop.run(SingleThreadEventLoop.java:180) ~[classes/:?]
		at io.netty5.util.concurrent.SingleThreadEventExecutor.lambda$doStartThread$4(SingleThreadEventExecutor.java:774) ~[netty5-common-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at io.netty5.util.internal.ThreadExecutorMap.lambda$apply$1(ThreadExecutorMap.java:68) ~[netty5-common-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at io.netty5.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[netty5-common-5.0.0.Alpha6-SNAPSHOT.jar:5.0.0.Alpha6-SNAPSHOT]
		at java.lang.Thread.run(Thread.java:833) ~[?:?]
```

Modification:
- Fix leak in `LocalChannelTest`

Result:
No more leaks in `LocalChannelTest`.