### PR TITLE
Correctly and consistent handle finish encoding for compression

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/Bzip2Constants.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Bzip2Constants.java
@@ -49,8 +49,6 @@ final class Bzip2Constants {
     static final int MIN_BLOCK_SIZE = 1;
     static final int MAX_BLOCK_SIZE = 9;
 
-    static final int THREAD_POOL_DELAY_SECONDS = 10;
-
     static final int MAX_BLOCK_LENGTH = MAX_BLOCK_SIZE * BASE_BLOCK_SIZE;
 
     /**

--- a/codec/src/main/java/io/netty/handler/codec/compression/EncoderUtil.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/EncoderUtil.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.util.concurrent.Future;
+
+import java.util.concurrent.TimeUnit;
+
+final class EncoderUtil {
+    private static final int THREAD_POOL_DELAY_SECONDS = 10;
+
+    static void closeAfterFinishEncode(final ChannelHandlerContext ctx, final ChannelFuture finishFuture,
+                                       final ChannelPromise promise) {
+        if (!finishFuture.isDone()) {
+            // Ensure the channel is closed even if the write operation completes in time.
+            final Future<?> future = ctx.executor().schedule(new Runnable() {
+                @Override
+                public void run() {
+                    ctx.close(promise);
+                }
+            }, THREAD_POOL_DELAY_SECONDS, TimeUnit.SECONDS);
+
+            finishFuture.addListener(new ChannelFutureListener() {
+                @Override
+                public void operationComplete(ChannelFuture f)  {
+                    // Cancel the scheduled timeout.
+                    future.cancel(true);
+                    if (!promise.isDone()) {
+                        ctx.close(promise);
+                    }
+                }
+            });
+        } else {
+            ctx.close(promise);
+        }
+    }
+
+    private EncoderUtil() { }
+}
+

--- a/codec/src/main/java/io/netty/handler/codec/compression/JZlibEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JZlibEncoder.java
@@ -24,6 +24,7 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.PromiseNotifier;
 import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.ObjectUtil;
@@ -324,21 +325,30 @@ public class JZlibEncoder extends ZlibEncoder {
             final ChannelHandlerContext ctx,
             final ChannelPromise promise) {
         ChannelFuture f = finishEncode(ctx, ctx.newPromise());
-        f.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture f) throws Exception {
-                ctx.close(promise);
-            }
-        });
 
         if (!f.isDone()) {
             // Ensure the channel is closed even if the write operation completes in time.
-            ctx.executor().schedule(new Runnable() {
+            final Future<?> future = ctx.executor().schedule(new Runnable() {
                 @Override
                 public void run() {
-                    ctx.close(promise);
+                    if (!promise.isDone()) {
+                        ctx.close(promise);
+                    }
                 }
             }, THREAD_POOL_DELAY_SECONDS, TimeUnit.SECONDS);
+
+            f.addListener(new ChannelFutureListener() {
+                @Override
+                public void operationComplete(ChannelFuture f) {
+                    // Cancel the scheduled timeout.
+                    future.cancel(true);
+                    if (!promise.isDone()) {
+                        ctx.close(promise);
+                    }
+                }
+            });
+        } else {
+            ctx.close(promise);
         }
     }
 

--- a/codec/src/main/java/io/netty/handler/codec/compression/Lz4Constants.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Lz4Constants.java
@@ -42,8 +42,6 @@ final class Lz4Constants {
      */
     static final int TOKEN_OFFSET = 8;
 
-    static final int THREAD_POOL_DELAY_SECONDS = 10;
-
     static final int COMPRESSED_LENGTH_OFFSET = TOKEN_OFFSET + 1;
     static final int DECOMPRESSED_LENGTH_OFFSET = COMPRESSED_LENGTH_OFFSET + 4;
     static final int CHECKSUM_OFFSET = DECOMPRESSED_LENGTH_OFFSET + 4;


### PR DESCRIPTION
Motivation:

We never cancelled the schedule close operation which could lead to exceptions and extra work.

Modifications:

- Move the logic for scheduling the close to an extra static method and reuse
- Ensure cancellation is done if the close is not needed anymore

Result:

Correctly handle closing and cancellation when doing compression
