### PR TITLE
Make releasing objects back to Recycler faster

### DIFF
--- a/common/src/main/java/io/netty/util/Recycler.java
+++ b/common/src/main/java/io/netty/util/Recycler.java
@@ -16,12 +16,14 @@
 package io.netty.util;
 
 import io.netty.util.concurrent.FastThreadLocal;
+import io.netty.util.concurrent.FastThreadLocalThread;
 import io.netty.util.internal.ObjectPool;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import org.jctools.queues.MessagePassingQueue;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import java.util.ArrayDeque;
 import java.util.Queue;
@@ -54,6 +56,7 @@ public abstract class Recycler<T> {
     private static final int RATIO;
     private static final int DEFAULT_QUEUE_CHUNK_SIZE_PER_THREAD;
     private static final boolean BLOCKING_POOL;
+    private static final boolean BATCH_FAST_TL_ONLY;
 
     static {
         // In the future, we might have different maxCapacity for different object types.
@@ -74,6 +77,7 @@ public abstract class Recycler<T> {
         RATIO = max(0, SystemPropertyUtil.getInt("io.netty.recycler.ratio", 8));
 
         BLOCKING_POOL = SystemPropertyUtil.getBoolean("io.netty.recycler.blocking", false);
+        BATCH_FAST_TL_ONLY = SystemPropertyUtil.getBoolean("io.netty.recycler.batchFastThreadLocalOnly", true);
 
         if (logger.isDebugEnabled()) {
             if (DEFAULT_MAX_CAPACITY_PER_THREAD == 0) {
@@ -81,11 +85,13 @@ public abstract class Recycler<T> {
                 logger.debug("-Dio.netty.recycler.ratio: disabled");
                 logger.debug("-Dio.netty.recycler.chunkSize: disabled");
                 logger.debug("-Dio.netty.recycler.blocking: disabled");
+                logger.debug("-Dio.netty.recycler.batchFastThreadLocalOnly: disabled");
             } else {
                 logger.debug("-Dio.netty.recycler.maxCapacityPerThread: {}", DEFAULT_MAX_CAPACITY_PER_THREAD);
                 logger.debug("-Dio.netty.recycler.ratio: {}", RATIO);
                 logger.debug("-Dio.netty.recycler.chunkSize: {}", DEFAULT_QUEUE_CHUNK_SIZE_PER_THREAD);
                 logger.debug("-Dio.netty.recycler.blocking: {}", BLOCKING_POOL);
+                logger.debug("-Dio.netty.recycler.batchFastThreadLocalOnly: {}", BATCH_FAST_TL_ONLY);
             }
         }
     }
@@ -104,6 +110,7 @@ public abstract class Recycler<T> {
             super.onRemoval(value);
             MessagePassingQueue<DefaultHandle<T>> handles = value.pooledHandles;
             value.pooledHandles = null;
+            value.owner = null;
             handles.clear();
         }
     };
@@ -195,9 +202,10 @@ public abstract class Recycler<T> {
         return true;
     }
 
+    @VisibleForTesting
     final int threadLocalSize() {
         LocalPool<T> localPool = threadLocal.getIfExists();
-        return localPool == null ? 0 : localPool.pooledHandles.size();
+        return localPool == null ? 0 : localPool.pooledHandles.size() + localPool.batch.size();
     }
 
     /**
@@ -255,14 +263,21 @@ public abstract class Recycler<T> {
         }
     }
 
-    private static final class LocalPool<T> {
+    private static final class LocalPool<T> implements MessagePassingQueue.Consumer<DefaultHandle<T>> {
         private final int ratioInterval;
+        private final int chunkSize;
+        private final ArrayDeque<DefaultHandle<T>> batch;
+        private volatile Thread owner;
         private volatile MessagePassingQueue<DefaultHandle<T>> pooledHandles;
         private int ratioCounter;
 
         @SuppressWarnings("unchecked")
         LocalPool(int maxCapacity, int ratioInterval, int chunkSize) {
             this.ratioInterval = ratioInterval;
+            this.chunkSize = chunkSize;
+            batch = new ArrayDeque<DefaultHandle<T>>(chunkSize);
+            Thread currentThread = Thread.currentThread();
+            owner =  !BATCH_FAST_TL_ONLY || currentThread instanceof FastThreadLocalThread ? currentThread : null;
             if (BLOCKING_POOL) {
                 pooledHandles = new BlockingMessageQueue<DefaultHandle<T>>(maxCapacity);
             } else {
@@ -276,7 +291,10 @@ public abstract class Recycler<T> {
             if (handles == null) {
                 return null;
             }
-            DefaultHandle<T> handle = handles.relaxedPoll();
+            if (batch.isEmpty()) {
+                handles.drain(this, chunkSize);
+            }
+            DefaultHandle<T> handle = batch.pollFirst();
             if (null != handle) {
                 handle.toClaimed();
             }
@@ -285,9 +303,19 @@ public abstract class Recycler<T> {
 
         void release(DefaultHandle<T> handle) {
             handle.toAvailable();
-            MessagePassingQueue<DefaultHandle<T>> handles = pooledHandles;
-            if (handles != null) {
-                handles.relaxedOffer(handle);
+            Thread owner = this.owner;
+            if (owner != null && Thread.currentThread() == owner && batch.size() < chunkSize) {
+                accept(handle);
+            } else {
+                if (owner != null && owner.getState() == Thread.State.TERMINATED) {
+                    this.owner = null;
+                    pooledHandles = null;
+                } else {
+                    MessagePassingQueue<DefaultHandle<T>> handles = pooledHandles;
+                    if (handles != null) {
+                        handles.relaxedOffer(handle);
+                    }
+                }
             }
         }
 
@@ -298,13 +326,18 @@ public abstract class Recycler<T> {
             }
             return null;
         }
+
+        @Override
+        public void accept(DefaultHandle<T> e) {
+            batch.addLast(e);
+        }
     }
 
     /**
      * This is an implementation of {@link MessagePassingQueue}, similar to what might be returned from
      * {@link PlatformDependent#newMpscQueue(int)}, but intended to be used for debugging purpose.
      * The implementation relies on synchronised monitor locks for thread-safety.
-     * The {@code drain} and {@code fill} bulk operations are not supported by this implementation.
+     * The {@code fill} bulk operation is not supported by this implementation.
      */
     private static final class BlockingMessageQueue<T> implements MessagePassingQueue<T> {
         private final Queue<T> deque;
@@ -379,7 +412,12 @@ public abstract class Recycler<T> {
 
         @Override
         public int drain(Consumer<T> c, int limit) {
-            throw new UnsupportedOperationException();
+            T obj;
+            int i = 0;
+            for (; i < limit && (obj = poll()) != null; i++) {
+                c.accept(obj);
+            }
+            return i;
         }
 
         @Override

--- a/common/src/test/java/io/netty/util/RecyclerFastThreadLocalTest.java
+++ b/common/src/test/java/io/netty/util/RecyclerFastThreadLocalTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util;
+
+import io.netty.util.concurrent.FastThreadLocalThread;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+@ExtendWith(RunInFastThreadLocalThreadExtension.class)
+public class RecyclerFastThreadLocalTest extends RecyclerTest {
+    @NotNull
+    @Override
+    protected Thread newThread(Runnable runnable) {
+        return new FastThreadLocalThread(runnable);
+    }
+
+    @Override
+    @Test
+    @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
+    public void testThreadCanBeCollectedEvenIfHandledObjectIsReferenced() throws Exception {
+        final Recycler<HandledObject> recycler = newRecycler(1024);
+        final AtomicBoolean collected = new AtomicBoolean();
+        final AtomicReference<HandledObject> reference = new AtomicReference<HandledObject>();
+        Thread thread = new FastThreadLocalThread(new Runnable() {
+            @Override
+            public void run() {
+                HandledObject object = recycler.get();
+                // Store a reference to the HandledObject to ensure it is not collected when the run method finish.
+                reference.set(object);
+            }
+        }) {
+            @Override
+            protected void finalize() throws Throwable {
+                super.finalize();
+                collected.set(true);
+            }
+        };
+        assertFalse(collected.get());
+        thread.start();
+        thread.join();
+
+        // Null out so it can be collected.
+        thread = null;
+
+        // Loop until the Thread was collected. If we can not collect it the Test will fail due of a timeout.
+        while (!collected.get()) {
+            System.gc();
+            System.runFinalization();
+            Thread.sleep(50);
+        }
+
+        // Now call recycle after the Thread was collected to ensure this still works...
+        reference.getAndSet(null).recycle();
+    }
+}

--- a/common/src/test/java/io/netty/util/RunInFastThreadLocalThreadExtension.java
+++ b/common/src/test/java/io/netty/util/RunInFastThreadLocalThreadExtension.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util;
+
+import io.netty.util.concurrent.FastThreadLocalThread;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.InvocationInterceptor;
+import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Annotate your test class with {@code @ExtendWith(RunInFastThreadLocalThreadExtension.class)} to have all test methods
+ * run in a {@link io.netty.util.concurrent.FastThreadLocalThread}.
+ * <p>
+ * This extension implementation is modified from the JUnit 5
+ * <a href="https://junit.org/junit5/docs/current/user-guide/#extensions-intercepting-invocations">
+ * intercepting invocations</a> example.
+ */
+public class RunInFastThreadLocalThreadExtension implements InvocationInterceptor {
+    @Override
+    public void interceptTestMethod(
+            final Invocation<Void> invocation,
+            final ReflectiveInvocationContext<Method> invocationContext,
+            final ExtensionContext extensionContext) throws Throwable {
+        final AtomicReference<Throwable> throwable = new AtomicReference<Throwable>();
+        Thread thread = new FastThreadLocalThread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    invocation.proceed();
+                } catch (Throwable t) {
+                    throwable.set(t);
+                }
+            }
+        });
+        thread.start();
+        thread.join();
+        Throwable t = throwable.get();
+        if (t != null) {
+            throw t;
+        }
+    }
+}


### PR DESCRIPTION
Motivation:
The Recycler implementation was changed in https://github.com/netty/netty/pull/11858 to rely on an MPSC queue implementation for delivering released objects back to their originating thread local pool. Typically, the release will often happen from the same thread that claimed the object, so the overhead of having a thread-safe release goes to waste.

Modification:
We add an unsynchronized ArrayDeque for batching claims out of the `pooledHandles`. This amortises `claim` calls.

We then also re-introduce the concept of an owner thread (but by default only if said thread is a FastThreadLocalThread), and release directly into the claim `batch` if the release is from the owner thread.

Result:
The `RecyclerBenchmark.recyclerGetAndRecycle` benchmark sees a 27.4% improvement, and the `RecyclerBenchmark.producerConsumer` benchmark sees a 22.5% improvement.

Fixes https://github.com/netty/netty/issues/13153

Previous performance:

```
Benchmark                                                    Mode  Cnt      Score     Error   Units
RecyclerBenchmark.plainNew                                   avgt   20      2.482 ±   0.028   ns/op
RecyclerBenchmark.plainNew:·gc.alloc.rate                    avgt   20  30743.573 ± 344.199  MB/sec
RecyclerBenchmark.plainNew:·gc.alloc.rate.norm               avgt   20     80.000 ±   0.001    B/op
RecyclerBenchmark.plainNew:·gc.count                         avgt   20   1347.000            counts
RecyclerBenchmark.plainNew:·gc.time                          avgt   20    790.000                ms
RecyclerBenchmark.producerConsumer                           avgt   20    256.606 ±  76.322   ns/op
RecyclerBenchmark.producerConsumer:consumer                  avgt   20    256.604 ±  76.322   ns/op
RecyclerBenchmark.producerConsumer:producer                  avgt   20    256.608 ±  76.322   ns/op
RecyclerBenchmark.producerConsumer:·gc.alloc.rate            avgt   20    108.235 ±  18.323  MB/sec
RecyclerBenchmark.producerConsumer:·gc.alloc.rate.norm       avgt   20     15.485 ±   6.790    B/op
RecyclerBenchmark.producerConsumer:·gc.count                 avgt   20      5.000            counts
RecyclerBenchmark.producerConsumer:·gc.time                  avgt   20      3.000                ms
RecyclerBenchmark.recyclerGetAndOrphan                       avgt   20      6.114 ±   0.052   ns/op
RecyclerBenchmark.recyclerGetAndOrphan:·gc.alloc.rate        avgt   20  12945.295 ± 110.092  MB/sec
RecyclerBenchmark.recyclerGetAndOrphan:·gc.alloc.rate.norm   avgt   20     83.000 ±   0.001    B/op
RecyclerBenchmark.recyclerGetAndOrphan:·gc.count             avgt   20    567.000            counts
RecyclerBenchmark.recyclerGetAndOrphan:·gc.time              avgt   20    323.000                ms
RecyclerBenchmark.recyclerGetAndRecycle                      avgt   20     19.754 ±   0.627   ns/op
RecyclerBenchmark.recyclerGetAndRecycle:·gc.alloc.rate       avgt   20      0.001 ±   0.003  MB/sec
RecyclerBenchmark.recyclerGetAndRecycle:·gc.alloc.rate.norm  avgt   20     ≈ 10⁻⁵              B/op
RecyclerBenchmark.recyclerGetAndRecycle:·gc.count            avgt   20        ≈ 0            counts
```

This change:

```
Benchmark                                                    Mode  Cnt      Score     Error   Units
RecyclerBenchmark.plainNew                                   avgt   20      2.476 ±   0.009   ns/op
RecyclerBenchmark.plainNew:·gc.alloc.rate                    avgt   20  30812.454 ± 116.539  MB/sec
RecyclerBenchmark.plainNew:·gc.alloc.rate.norm               avgt   20     80.000 ±   0.001    B/op
RecyclerBenchmark.plainNew:·gc.count                         avgt   20   1351.000            counts
RecyclerBenchmark.plainNew:·gc.time                          avgt   20    733.000                ms
RecyclerBenchmark.producerConsumer                           avgt   20    198.829 ±  10.838   ns/op
RecyclerBenchmark.producerConsumer:consumer                  avgt   20    198.828 ±  10.839   ns/op
RecyclerBenchmark.producerConsumer:producer                  avgt   20    198.829 ±  10.838   ns/op
RecyclerBenchmark.producerConsumer:·gc.alloc.rate            avgt   20     92.369 ±  25.226  MB/sec
RecyclerBenchmark.producerConsumer:·gc.alloc.rate.norm       avgt   20      9.802 ±   3.137    B/op
RecyclerBenchmark.producerConsumer:·gc.count                 avgt   20      3.000            counts
RecyclerBenchmark.producerConsumer:·gc.time                  avgt   20      2.000                ms
RecyclerBenchmark.recyclerGetAndOrphan                       avgt   20      6.850 ±   0.034   ns/op
RecyclerBenchmark.recyclerGetAndOrphan:·gc.alloc.rate        avgt   20  11554.170 ±  56.474  MB/sec
RecyclerBenchmark.recyclerGetAndOrphan:·gc.alloc.rate.norm   avgt   20     83.000 ±   0.001    B/op
RecyclerBenchmark.recyclerGetAndOrphan:·gc.count             avgt   20    507.000            counts
RecyclerBenchmark.recyclerGetAndOrphan:·gc.time              avgt   20    288.000                ms
RecyclerBenchmark.recyclerGetAndRecycle                      avgt   20     14.330 ±   0.010   ns/op
RecyclerBenchmark.recyclerGetAndRecycle:·gc.alloc.rate       avgt   20      0.001 ±   0.003  MB/sec
RecyclerBenchmark.recyclerGetAndRecycle:·gc.alloc.rate.norm  avgt   20     ≈ 10⁻⁵              B/op
RecyclerBenchmark.recyclerGetAndRecycle:·gc.count            avgt   20        ≈ 0            counts
```
