### PR TITLE
Add handling of inflight lookups to reduce real queries when lookup s…

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -56,6 +56,7 @@ import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.FastThreadLocal;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
+import io.netty.util.concurrent.GenericFutureListener;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.PlatformDependent;
@@ -76,8 +77,10 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static io.netty.resolver.dns.DefaultDnsServerAddressStreamProvider.DNS_PORT;
@@ -261,6 +264,9 @@ public class DnsNameResolver extends InetNameResolver {
     private final boolean completeOncePreferredResolved;
     private final ChannelFactory<? extends SocketChannel> socketChannelFactory;
 
+    private final int maxNumConsolidation;
+    private final Map<String, Future<List<InetAddress>>> inflightLookups;
+
     /**
      * Creates a new DNS-based name resolver that communicates with the specified list of DNS servers.
      *
@@ -389,7 +395,7 @@ public class DnsNameResolver extends InetNameResolver {
                 null, dnsQueryLifecycleObserverFactory, queryTimeoutMillis, resolvedAddressTypes,
                 recursionDesired, maxQueriesPerResolve, traceEnabled, maxPayloadSize, optResourceEnabled,
                 hostsFileEntriesResolver, dnsServerAddressStreamProvider, searchDomains, ndots, decodeIdn,
-                completeOncePreferredResolved);
+                completeOncePreferredResolved, 0);
     }
 
     DnsNameResolver(
@@ -413,7 +419,8 @@ public class DnsNameResolver extends InetNameResolver {
             String[] searchDomains,
             int ndots,
             boolean decodeIdn,
-            boolean completeOncePreferredResolved) {
+            boolean completeOncePreferredResolved,
+            int maxNumConsolidation) {
         super(eventLoop);
         this.queryTimeoutMillis = queryTimeoutMillis > 0
             ? queryTimeoutMillis
@@ -470,6 +477,12 @@ public class DnsNameResolver extends InetNameResolver {
         preferredAddressType = preferredAddressType(this.resolvedAddressTypes);
         this.authoritativeDnsServerCache = checkNotNull(authoritativeDnsServerCache, "authoritativeDnsServerCache");
         nameServerComparator = new NameServerComparator(preferredAddressType.addressType());
+        this.maxNumConsolidation = maxNumConsolidation;
+        if (maxNumConsolidation > 0) {
+            inflightLookups = new HashMap<String, Future<List<InetAddress>>>();
+        } else {
+            inflightLookups = null;
+        }
 
         Bootstrap b = new Bootstrap();
         b.group(executor());
@@ -1133,21 +1146,66 @@ public class DnsNameResolver extends InetNameResolver {
         }
     }
 
-    private void doResolveAllUncached0(String hostname,
-                                       DnsRecord[] additionals,
-                                       Promise<?> originalPromise,
-                                       Promise<List<InetAddress>> promise,
-                                       DnsCache resolveCache,
-                                       boolean completeEarlyIfPossible) {
+    private void doResolveAllUncached0(final String hostname,
+                                       final DnsRecord[] additionals,
+                                       final Promise<?> originalPromise,
+                                       final Promise<List<InetAddress>> promise,
+                                       final DnsCache resolveCache,
+                                       final boolean completeEarlyIfPossible) {
 
         assert executor().inEventLoop();
 
+        if (inflightLookups != null && (additionals == null || additionals.length == 0)) {
+            Future<List<InetAddress>> inflightFuture = inflightLookups.get(hostname);
+            if (inflightFuture != null) {
+                inflightFuture.addListener(new GenericFutureListener<Future<? super List<InetAddress>>>() {
+                    @SuppressWarnings("unchecked")
+                    @Override
+                    public void operationComplete(Future<? super List<InetAddress>> future) {
+                        if (future.isSuccess()) {
+                            promise.setSuccess((List<InetAddress>) future.getNow());
+                        } else {
+                            Throwable cause = future.cause();
+                            if (isTimeoutError(cause)) {
+                                // The failure was caused by a timeout. This might be happening as a result of
+                                // the remote server be overloaded for some short amount of time or because
+                                // UDP packets were dropped on the floor. In this case lets try to just do the
+                                // query explicit and don't cascade this possible temporary failure.
+                                resolveNow(hostname, additionals, originalPromise, promise,
+                                        resolveCache, completeEarlyIfPossible);
+                            } else {
+                                promise.setFailure(cause);
+                            }
+                        }
+                    }
+                });
+                return;
+            // Check if we have space left in the map.
+            } else if (inflightLookups.size() < maxNumConsolidation) {
+                inflightLookups.put(hostname, promise);
+                promise.addListener(new GenericFutureListener<Future<? super List<InetAddress>>>() {
+                    @Override
+                    public void operationComplete(Future<? super List<InetAddress>> future) {
+                        inflightLookups.remove(hostname);
+                    }
+                });
+            }
+        }
+        resolveNow(hostname, additionals, originalPromise, promise, resolveCache, completeEarlyIfPossible);
+    }
+
+    private void resolveNow(final String hostname,
+                            final DnsRecord[] additionals,
+                            final Promise<?> originalPromise,
+                            final Promise<List<InetAddress>> promise,
+                            final DnsCache resolveCache,
+                            final boolean completeEarlyIfPossible) {
         final DnsServerAddressStream nameServerAddrs =
                 dnsServerAddressStreamProvider.nameServerAddressStream(hostname);
-        new DnsAddressResolveContext(this, originalPromise, hostname, additionals, nameServerAddrs,
-                                     maxQueriesPerResolve, resolveCache,
-                                     authoritativeDnsServerCache, completeEarlyIfPossible)
-                .resolve(promise);
+        DnsAddressResolveContext ctx = new DnsAddressResolveContext(this, originalPromise, hostname, additionals,
+                nameServerAddrs, maxQueriesPerResolve, resolveCache,
+                authoritativeDnsServerCache, completeEarlyIfPossible);
+        ctx.resolve(promise);
     }
 
     private static String hostname(String inetHost) {


### PR DESCRIPTION
…ame hostname

Motivation:

To reduce the overhead we can shortcut queries for the same hostname until the first query comes back. This will reduce queries and so overhead

Modifications:

- Add new builder option that allows to shortcut queries to the same hostname (default this is disabled)

Result:

Be able to reduce queries
