### PR TITLE
Remove git checkout HEAD^2 from CodeQL GHA workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,10 +49,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
-      with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can checkout the head.
-        fetch-depth: 2
 
     # Cache .m2/repository
     - name: Cache local Maven repository
@@ -63,11 +59,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-maven-${{ matrix.language }}
           ${{ runner.os }}-maven-
-
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL


### PR DESCRIPTION
Motivation:

The CodeQL workflow is reporting a warning

`"1 issue was detected with this workflow: git checkout HEAD^2 is no longer necessary. Please remove this step as Code Scanning recommends analyzing the merge commit for best results."`

Modification:

Removed the unnecessary part following the instruction from [link](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/troubleshooting-the-codeql-workflow#warning-git-checkout-head2-is-no-longer-necessary)

Result:

No more warnings.