### PR TITLE
Consistent maxOrder value

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/pool/PooledBufferAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/pool/PooledBufferAllocator.java
@@ -88,7 +88,7 @@ public class PooledBufferAllocator implements BufferAllocator, BufferAllocatorMe
             validateAndCalculateChunkSize(DEFAULT_PAGE_SIZE, defaultMaxOrder);
         } catch (Throwable t) {
             maxOrderFallbackCause = t;
-            defaultMaxOrder = 11;
+            defaultMaxOrder = 9;
         }
         DEFAULT_MAX_ORDER = defaultMaxOrder;
 
@@ -373,7 +373,7 @@ public class PooledBufferAllocator implements BufferAllocator, BufferAllocatorMe
     }
 
     /**
-     * Default maximum order - System Property: io.netty5.allocator.maxOrder - default 11
+     * Default maximum order - System Property: io.netty5.allocator.maxOrder - default 9
      */
     public static int defaultMaxOrder() {
         return DEFAULT_MAX_ORDER;


### PR DESCRIPTION
Motivation:

The current implementation of the maxOrder value in the Netty5 is inconsistent, as a recent change (https://github.com/netty/netty/pull/12108) reduced the value from 11 to 9, but this change was not well propagated to Netty 5.

Modification:

Updating the maxOrder value in Netty 5 to match the consistent value of 9.

Result:

Improve consistency. Eliminate unexpected behavior.
