### PR TITLE
`DnsQueryContext`: include query id and question info in exception message

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContext.java
@@ -237,11 +237,16 @@ abstract class DnsQueryContext implements FutureListener<AddressedEnvelope<DnsRe
             return false;
         }
         final InetSocketAddress nameServerAddr = nameServerAddr();
+        final DnsQuestion question = question();
 
-        final StringBuilder buf = new StringBuilder(message.length() + 64);
+        final StringBuilder buf = new StringBuilder(message.length() + 128);
         buf.append('[')
+           .append(id)
+           .append(": ")
            .append(nameServerAddr)
            .append("] ")
+           .append(question)
+           .append(' ')
            .append(message)
            .append(" (no stack trace available)");
 
@@ -249,9 +254,9 @@ abstract class DnsQueryContext implements FutureListener<AddressedEnvelope<DnsRe
         if (timeout) {
             // This was caused by a timeout so use DnsNameResolverTimeoutException to allow the user to
             // handle it special (like retry the query).
-            e = new DnsNameResolverTimeoutException(nameServerAddr, question(), buf.toString());
+            e = new DnsNameResolverTimeoutException(nameServerAddr, question, buf.toString());
         } else {
-            e = new DnsNameResolverException(nameServerAddr, question(), buf.toString(), cause);
+            e = new DnsNameResolverException(nameServerAddr, question, buf.toString(), cause);
         }
         return promise.tryFailure(e);
     }


### PR DESCRIPTION
Motivation:

When we fail the query with timeout or any other error, exception message includes the address of the remote resolver but no info about what query was sent.

Modifications:

- Include id of the query and question in the exception message;

Result:

Users can see in logs what was the query id and question (address, record type) that failed.