### PR TITLE
Fix flaky test

### DIFF
--- a/handler/src/test/java/io/netty5/handler/ssl/CipherSuiteConverterTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/CipherSuiteConverterTest.java
@@ -19,6 +19,7 @@ package io.netty5.handler.ssl;
 import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -26,6 +27,7 @@ import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+@Isolated
 public class CipherSuiteConverterTest {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(CipherSuiteConverterTest.class);


### PR DESCRIPTION
Motivation:

CipherSuiteConverterTest is flaky. since the test is not thread-safe.

Modification:

Make the test class executed in `@Isolated`.

Result:

Fix flaky test. No more fails on CipherSuiteConverterTest