### PR TITLE
Update GH actions version.

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -89,9 +89,10 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
-          java-version: 8
+          distribution: 'zulu'
+          java-version: '8'
 
       # Cache .m2/repository
       - name: Cache local Maven repository

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -31,9 +31,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
-          java-version: 8
+          distribution: 'zulu'
+          java-version: '8'
+
       # Cache .m2/repository
       - name: Cache local Maven repository
         uses: actions/cache@v3
@@ -61,9 +63,10 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
-          java-version: 11
+          distribution: 'zulu'
+          java-version: '11'
 
       # Cache .m2/repository
       # Caching of maven dependencies
@@ -114,7 +117,7 @@ jobs:
             ${{ runner.os }}-maven-build-pr-aarch64-
             ${{ runner.os }}-maven-
 
-      - uses: uraimo/run-on-arch-action@v2.0.9
+      - uses: uraimo/run-on-arch-action@v2.5.0
         name: Run commands
         id: runcmd
         with:

--- a/.github/workflows/ci-release-5.yml
+++ b/.github/workflows/ci-release-5.yml
@@ -32,8 +32,9 @@ jobs:
           ref: main
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: 'zulu'
           java-version: '11'
 
       - name: Setup git configuration
@@ -97,8 +98,9 @@ jobs:
         run: chmod 755 ./prepare-release-workspace/mvnw
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: 'zulu'
           java-version: '11'
 
       - name: Setup git configuration
@@ -183,8 +185,9 @@ jobs:
         run: chmod 755 ./prepare-release-workspace/mvnw
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: 'zulu'
           java-version: '11'
 
       - name: Setup git configuration

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -32,9 +32,10 @@ jobs:
           ref: 4.1
 
       - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
-          java-version: 8
+          distribution: 'zulu'
+          java-version: '8'
 
       - name: Setup git configuration
         run: |
@@ -97,9 +98,10 @@ jobs:
         run: chmod 755 ./prepare-release-workspace/mvnw
 
       - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
-          java-version: 8
+          distribution: 'zulu'
+          java-version: '8'
 
       - name: Setup git configuration
         run: |
@@ -183,9 +185,10 @@ jobs:
         run: chmod 755 ./prepare-release-workspace/mvnw
 
       - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
-          java-version: 8
+          distribution: 'zulu'
+          java-version: '8'
 
       - name: Setup git configuration
         run: |


### PR DESCRIPTION
Motivation:

GH workflow reporting warnings.
`Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/setup-java@v1`

`Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: uraimo/run-on-arch-action@v2.0.9`

Modification:

Update the actions to use Node.js 16

Result:

Remove warnings.