### PR TITLE
WebSocketServerProtocolHandler: make HandshakeComplete event ctor public

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
@@ -80,7 +80,7 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
         private final HttpHeaders requestHeaders;
         private final String selectedSubprotocol;
 
-        HandshakeComplete(String requestUri, HttpHeaders requestHeaders, String selectedSubprotocol) {
+        public HandshakeComplete(String requestUri, HttpHeaders requestHeaders, String selectedSubprotocol) {
             this.requestUri = requestUri;
             this.requestHeaders = requestHeaders;
             this.selectedSubprotocol = selectedSubprotocol;


### PR DESCRIPTION
Motivation:

alternative websocket implementations may prefer to use all netty's server handshake lifecycle events.

Modification:

make HandshakeComplete constructor public.

Result:

alternative websocket implementations are able to use netty's server handshake lifecycle events.