### PR TITLE
Replace arena.session() by arena.scope() for JDK 20

### DIFF
--- a/buffer-memory-segment/src/main/java/io/netty5/buffer/memseg/MemSegBuffer.java
+++ b/buffer-memory-segment/src/main/java/io/netty5/buffer/memseg/MemSegBuffer.java
@@ -67,7 +67,7 @@ class MemSegBuffer extends AdaptableBuffer<MemSegBuffer>
 
     static {
         try (Arena arena = Arena.openShared()) {
-            CLOSED_SEGMENT = MemorySegment.allocateNative(0, arena.session());
+            CLOSED_SEGMENT = MemorySegment.allocateNative(0, arena.scope());
         }
     }
 

--- a/buffer-memory-segment/src/main/java/io/netty5/buffer/memseg/SegmentMemoryManager.java
+++ b/buffer-memory-segment/src/main/java/io/netty5/buffer/memseg/SegmentMemoryManager.java
@@ -41,7 +41,7 @@ public class SegmentMemoryManager implements MemoryManager {
             long size, Function<Drop<Buffer>, Drop<Buffer>> adaptor, AllocatorControl control) {
         Arena arena = Arena.openShared();
         InternalBufferUtils.MEM_USAGE_NATIVE.add(size);
-        var segment = MemorySegment.allocateNative(size, arena.session());
+        var segment = MemorySegment.allocateNative(size, arena.scope());
         var drop = adaptor.apply(drop(arena, size));
         return createBuffer(segment, drop, control);
     }

--- a/buffer-memory-segment/src/test/java/io/netty5/buffer/memseg/benchmarks/MemorySegmentCloseBenchmark.java
+++ b/buffer-memory-segment/src/test/java/io/netty5/buffer/memseg/benchmarks/MemorySegmentCloseBenchmark.java
@@ -68,14 +68,14 @@ public class MemorySegmentCloseBenchmark {
     @Benchmark
     public MemorySegment nativeConfined() {
         try (Arena arena = Arena.openConfined()) {
-            return MemorySegment.allocateNative(size, arena.session());
+            return MemorySegment.allocateNative(size, arena.scope());
         }
     }
 
     @Benchmark
     public MemorySegment nativeShared() {
         try (Arena arena = Arena.openShared()) {
-            return MemorySegment.allocateNative(size, arena.session());
+            return MemorySegment.allocateNative(size, arena.scope());
         }
     }
 }


### PR DESCRIPTION
Motivation:

Fix netty5-buffer-memory-segment for latest JDK 20 build.

Modification:

Replace Arena.session by Arena.scope.

Result:

Successfully compiles on latest JDK20.