### PR TITLE
Fix HttpHeaders.names for non-String headers

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/http/DefaultHttpHeadersTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/DefaultHttpHeadersTest.java
@@ -27,6 +27,12 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import static io.netty.handler.codec.http.HttpHeaderNames.ACCEPT;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONNECTION;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
+import static io.netty.handler.codec.http.HttpHeaderValues.APPLICATION_JSON;
+import static io.netty.handler.codec.http.HttpHeaderValues.CLOSE;
+import static io.netty.handler.codec.http.HttpHeaderValues.ZERO;
 import static io.netty.handler.codec.http.HttpHeadersTestUtils.of;
 import static io.netty.util.AsciiString.contentEquals;
 import static java.util.Arrays.asList;
@@ -285,6 +291,21 @@ public class DefaultHttpHeadersTest {
 
         String[] namesArray = nettyHeaders.toArray(EmptyArrays.EMPTY_STRINGS);
         assertArrayEquals(namesArray, new String[] { HttpHeaderNames.CONTENT_LENGTH.toString() });
+    }
+
+    @Test
+    public void names() {
+        HttpHeaders headers = new DefaultHttpHeaders(true)
+                .add(ACCEPT, APPLICATION_JSON)
+                .add(CONTENT_LENGTH, ZERO)
+                .add(CONNECTION, CLOSE);
+        assertFalse(headers.isEmpty());
+        assertEquals(3, headers.size());
+        Set<String> names = headers.names();
+        assertEquals(3, names.size());
+        assertTrue(names.contains(ACCEPT.toString()));
+        assertTrue(names.contains(CONTENT_LENGTH.toString()));
+        assertTrue(names.contains(CONNECTION.toString()));
     }
 
     private static void assertDefaultValues(final DefaultHttpHeaders headers, final HeaderValue headerValue) {

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -557,6 +557,7 @@ public class HttpRequestDecoderTest {
         assertTrue(channel.writeInbound(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)));
         HttpRequest request = channel.readInbound();
         assertFalse(request.decoderResult().isFailure());
+        assertTrue(request.headers().names().contains("Transfer-Encoding"));
         assertTrue(request.headers().contains("Transfer-Encoding", "chunked", false));
         assertFalse(request.headers().contains("Content-Length"));
         LastHttpContent c = channel.readInbound();

--- a/codec/src/main/java/io/netty/handler/codec/HeadersUtils.java
+++ b/codec/src/main/java/io/netty/handler/codec/HeadersUtils.java
@@ -104,7 +104,7 @@ public final class HeadersUtils {
      * @return a {@link Set} of header values or an empty {@link Set} if no values are found.
      */
     public static Set<String> namesAsString(Headers<CharSequence, CharSequence, ?> headers) {
-        return new CharSequenceDelegatingStringSet(headers.names());
+        return new DelegatingNameSet(headers);
     }
 
     private static final class StringEntryIterator implements Iterator<Entry<String, String>> {
@@ -192,57 +192,31 @@ public final class HeadersUtils {
         }
     }
 
-    private static final class CharSequenceDelegatingStringSet extends DelegatingStringSet<CharSequence> {
-        CharSequenceDelegatingStringSet(Set<CharSequence> allNames) {
-            super(allNames);
-        }
+    private static final class DelegatingNameSet extends AbstractCollection<String> implements Set<String> {
+        private final Headers<CharSequence, CharSequence, ?> headers;
 
-        @Override
-        public boolean add(String e) {
-            return allNames.add(e);
-        }
-
-        @Override
-        public boolean addAll(Collection<? extends String> c) {
-            return allNames.addAll(c);
-        }
-    }
-
-    private abstract static class DelegatingStringSet<T> extends AbstractCollection<String> implements Set<String> {
-        protected final Set<T> allNames;
-
-        DelegatingStringSet(Set<T> allNames) {
-            this.allNames = checkNotNull(allNames, "allNames");
+        DelegatingNameSet(Headers<CharSequence, CharSequence, ?> headers) {
+            this.headers = checkNotNull(headers, "headers");
         }
 
         @Override
         public int size() {
-            return allNames.size();
+            return headers.names().size();
         }
 
         @Override
         public boolean isEmpty() {
-            return allNames.isEmpty();
+            return headers.isEmpty();
         }
 
         @Override
         public boolean contains(Object o) {
-            return allNames.contains(o.toString());
+            return headers.contains(o.toString());
         }
 
         @Override
         public Iterator<String> iterator() {
-            return new StringIterator<T>(allNames.iterator());
-        }
-
-        @Override
-        public boolean remove(Object o) {
-            return allNames.remove(o);
-        }
-
-        @Override
-        public void clear() {
-            allNames.clear();
+            return new StringIterator<CharSequence>(headers.names().iterator());
         }
     }
 }


### PR DESCRIPTION
Motivation:

With #12321, the HttpHeaders object returned by the standard HTTP/1 pipeline now contains AsciiStrings, not Strings. This uncovered a bug where HttpHeaders.names() did not behave properly as a Set<String> when the backing HttpHeaders contained a CharSequence type other than String. This leads to .contains incorrectly returning false when the header is present.

Modification:

Replace CharSequenceDelegatingStringSet with a class that delegates directly to the Headers object, instead of Headers.names(), for the .contains call.

The test is copied from ReadOnlyHttpHeadersTest.

Result:

- The .contains call works properly even when the backing Headers aren't Strings.
- Mutation methods were removed. This is an improvement imo, names() previously returned a copy, so changes would not be reflected in the Headers anyway.
- .contains is now case-insensitive.