### PR TITLE
Avoid slow type checks against promises on outbound buffer's progress

### DIFF
--- a/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
@@ -243,9 +243,7 @@ public final class ChannelOutboundBuffer {
         ChannelPromise p = e.promise;
         long progress = e.progress + amount;
         e.progress = progress;
-        if (p == null) {
-            return;
-        }
+        assert p != null;
         final Class<?> promiseClass = p.getClass();
         // fast-path to save O(n) ChannelProgressivePromise's type check on OpenJDK
         if (promiseClass == VoidChannelPromise.class) {

--- a/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
@@ -243,7 +243,18 @@ public final class ChannelOutboundBuffer {
         ChannelPromise p = e.promise;
         long progress = e.progress + amount;
         e.progress = progress;
-        if (p instanceof ChannelProgressivePromise) {
+        if (p == null) {
+            return;
+        }
+        final Class<?> promiseClass = p.getClass();
+        // fast-path to save O(n) ChannelProgressivePromise's type check on OpenJDK
+        if (promiseClass == VoidChannelPromise.class) {
+            return;
+        }
+        // this is going to save from type pollution due to https://bugs.openjdk.org/browse/JDK-8180450
+        if (p instanceof DefaultChannelProgressivePromise) {
+            ((DefaultChannelProgressivePromise) p).tryProgress(progress, e.total);
+        } else if (p instanceof ChannelProgressivePromise) {
             ((ChannelProgressivePromise) p).tryProgress(progress, e.total);
         }
     }


### PR DESCRIPTION
Motivation:

ChannelOutboundBuffer's progress perform expensive type checks that can reduce scalability or just performing wasteful operations over common Netty types. This behaviour pop-up in few real-cases, but sadly it cannot be captured easily by java profilers due to https://github.com/jvm-profiling-tools/async-profiler/issues/673

Modification:

Prefer direct class checks for void promises and guarding Netty types by using concrete class type checks over interface type checks, that will be left to user-defined promises instead.

Result:

Faster type checks for Netty types and faster outbound buffer progress's performance.