### PR TITLE
Fix size calculation logic in PooledByteBufAllocator

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -58,7 +58,7 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
 
     private static final int CACHE_NOT_USED = 0;
 
-    private static final int MAX_ORDER_UPPER_BOUNDER = 14;
+    private static final int MAX_ORDER_UPPER_BOUND = 14;
 
     private static final int DEFAULT_MAX_ORDER_SETTING = 9; // 8192 << 9 = 4 MiB per chunk
 
@@ -77,25 +77,12 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
         int defaultAlignment = SystemPropertyUtil.getInt(
                 "io.netty.allocator.directMemoryCacheAlignment", DEFAULT_DIRECT_MEMORY_CACHE_ALIGNMENT_SETTING);
         int defaultPageSize = SystemPropertyUtil.getInt("io.netty.allocator.pageSize", DEFAULT_PAGE_SIZE_SETTING);
-        Throwable pageSizeFallbackCause = null;
-        try {
-            validateAndCalculatePageShifts(defaultPageSize, defaultAlignment);
-        } catch (Throwable t) {
-            pageSizeFallbackCause = t;
-            defaultPageSize = DEFAULT_PAGE_SIZE_SETTING;
-            defaultAlignment = DEFAULT_DIRECT_MEMORY_CACHE_ALIGNMENT_SETTING;
-        }
+        validateAndCalculatePageShifts(defaultPageSize, defaultAlignment);
         DEFAULT_PAGE_SIZE = defaultPageSize;
         DEFAULT_DIRECT_MEMORY_CACHE_ALIGNMENT = defaultAlignment;
 
         int defaultMaxOrder = SystemPropertyUtil.getInt("io.netty.allocator.maxOrder", DEFAULT_MAX_ORDER_SETTING);
-        Throwable maxOrderFallbackCause = null;
-        try {
-            validateAndCalculateChunkSize(DEFAULT_PAGE_SIZE, defaultMaxOrder);
-        } catch (Throwable t) {
-            maxOrderFallbackCause = t;
-            defaultMaxOrder = calculateDefaultMaxOrder(DEFAULT_PAGE_SIZE);
-        }
+        validateAndCalculateChunkSize(DEFAULT_PAGE_SIZE, defaultMaxOrder);
         DEFAULT_MAX_ORDER = defaultMaxOrder;
 
         // Determine reasonable default for nHeapArena and nDirectArena.
@@ -165,20 +152,9 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
         if (logger.isDebugEnabled()) {
             logger.debug("-Dio.netty.allocator.numHeapArenas: {}", DEFAULT_NUM_HEAP_ARENA);
             logger.debug("-Dio.netty.allocator.numDirectArenas: {}", DEFAULT_NUM_DIRECT_ARENA);
-            if (pageSizeFallbackCause == null) {
-                logger.debug("-Dio.netty.allocator.pageSize: {}", DEFAULT_PAGE_SIZE);
-                logger.debug("-Dio.netty.allocator.directMemoryCacheAlignment: {}",
-                        DEFAULT_DIRECT_MEMORY_CACHE_ALIGNMENT);
-            } else {
-                logger.debug("-Dio.netty.allocator.pageSize: {}", DEFAULT_PAGE_SIZE, pageSizeFallbackCause);
-                logger.debug("-Dio.netty.allocator.directMemoryCacheAlignment: {}",
-                        DEFAULT_DIRECT_MEMORY_CACHE_ALIGNMENT, pageSizeFallbackCause);
-            }
-            if (maxOrderFallbackCause == null) {
-                logger.debug("-Dio.netty.allocator.maxOrder: {}", DEFAULT_MAX_ORDER);
-            } else {
-                logger.debug("-Dio.netty.allocator.maxOrder: {}", DEFAULT_MAX_ORDER, maxOrderFallbackCause);
-            }
+            logger.debug("-Dio.netty.allocator.pageSize: {}", DEFAULT_PAGE_SIZE);
+            logger.debug("-Dio.netty.allocator.directMemoryCacheAlignment: {}", DEFAULT_DIRECT_MEMORY_CACHE_ALIGNMENT);
+            logger.debug("-Dio.netty.allocator.maxOrder: {}", DEFAULT_MAX_ORDER);
             logger.debug("-Dio.netty.allocator.chunkSize: {}", DEFAULT_PAGE_SIZE << DEFAULT_MAX_ORDER);
             logger.debug("-Dio.netty.allocator.smallCacheSize: {}", DEFAULT_SMALL_CACHE_SIZE);
             logger.debug("-Dio.netty.allocator.normalCacheSize: {}", DEFAULT_NORMAL_CACHE_SIZE);
@@ -363,9 +339,9 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
     }
 
     private static int validateAndCalculateChunkSize(int pageSize, int maxOrder) {
-        if (maxOrder > MAX_ORDER_UPPER_BOUNDER || maxOrder < 0) {
+        if (maxOrder > MAX_ORDER_UPPER_BOUND || maxOrder < 0) {
             throw new IllegalArgumentException(String.format("maxOrder: " + maxOrder + " (expected: 0-%d)",
-                    MAX_ORDER_UPPER_BOUNDER));
+                    MAX_ORDER_UPPER_BOUND));
         }
 
         // Ensure the resulting chunkSize does not overflow.

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -28,7 +28,6 @@ import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.ThreadExecutorMap;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
-import org.jctools.util.Pow2;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -309,7 +308,7 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
         if (pageSize > MAX_CHUNK_SIZE) {
             throw new IllegalArgumentException("pageSize: " + pageSize + " (expected: " + MAX_CHUNK_SIZE + ')');
         }
-        if (!Pow2.isPowerOfTwo(pageSize)) {
+        if (!PlatformDependent.isPowerOfTwo(pageSize)) {
             throw new IllegalArgumentException("pageSize: " + pageSize + " (expected: power of 2)");
         }
         if (pageSize < alignment) {
@@ -318,7 +317,7 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
         }
 
         checkPositiveOrZero(alignment, "alignment");
-        if (!Pow2.isPowerOfTwo(alignment)) {
+        if (!PlatformDependent.isPowerOfTwo(alignment)) {
             throw new IllegalArgumentException("alignment: " + alignment + " (expected: power of two)");
         }
         // At this point we know that `pageSize` is aligned with `alignment`, because:

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -1503,6 +1503,10 @@ public final class PlatformDependent {
         return file;
     }
 
+    public static boolean isPowerOfTwo(final int value) {
+        return Pow2.isPowerOfTwo(value);
+    }
+
     /**
      * Adds only those classifier strings to <tt>dest</tt> which are present in <tt>allowed</tt>.
      *


### PR DESCRIPTION
Motivation:

1. When set `"io.netty.allocator.pageSize"` to `4MiB` or larger, the `PooledByteBufAllocator.DEFAULT` instance throws `java.lang.IllegalArgumentException` in the construction stage:
```
public class TestDemo {
    static {
        System.setProperty("io.netty.allocator.pageSize", (1 << 22) + ""); // Set page size to 4MiB
    }

    public static void main(String[] args) {
        System.out.println(PooledByteBufAllocator.DEFAULT.metric()); // Throws `pageSize` overflow exception.
    }
}
```

- The `pageSize` for `PooledByteBufAllocator.DEFAULT` is initialized and validated in the static block, and it is supposed to resolve the overflow problem in the static block initialization stage.

- After the static block initialization finished, the `PooledByteBufAllocator.DEFAULT` should not throw `pageSize` overflow exception in the construction stage.

2. Some size-validation logics in the `PooledByteBufAllocator`'s constructor and static block can be optimized. 
For example: 
Some validation code in the constructor should move into method `validateAndCalculatePageShifts()`.

Modification:

Correct the size validation logic.

Result:

Fix the problem above, and optimize size-validation related code.
