### PR TITLE
unit test for headers.contains CharSequence

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/http/DefaultHttpHeadersTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/DefaultHttpHeadersTest.java
@@ -310,6 +310,22 @@ public class DefaultHttpHeadersTest {
         assertTrue(names.contains(CONNECTION.toString()));
     }
 
+    @Test
+    public void testContainsName() {
+        HttpHeaders headers = new DefaultHttpHeaders(true)
+                .add(CONTENT_LENGTH, "36");
+        assertTrue(headers.contains("Content-Length"));
+        assertTrue(headers.contains("content-length"));
+        assertTrue(headers.contains(CONTENT_LENGTH));
+        headers.remove(CONTENT_LENGTH);
+        assertFalse(headers.contains("Content-Length"));
+        assertFalse(headers.contains("content-length"));
+        assertFalse(headers.contains(CONTENT_LENGTH));
+
+        assertFalse(headers.contains("non-existent-name"));
+        assertFalse(headers.contains(new AsciiString("non-existent-name")));
+    }
+
     private static void assertDefaultValues(final DefaultHttpHeaders headers, final HeaderValue headerValue) {
         assertTrue(contentEquals(headerValue.asList().get(0), headers.get(HEADER_NAME)));
         List<CharSequence> expected = headerValue.asList();

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersTest.java
@@ -17,6 +17,7 @@
 package io.netty.handler.codec.http2;
 
 import io.netty.handler.codec.http2.Http2Headers.PseudoHeaderName;
+import io.netty.util.AsciiString;
 import io.netty.util.internal.StringUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
@@ -25,6 +26,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 
 import java.util.Map.Entry;
 
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
 import static io.netty.util.AsciiString.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -173,6 +175,22 @@ public class DefaultHttp2HeadersTest {
         assertFalse(headers.contains("name1", "Value2"));
         assertTrue(headers.contains("2name", "Value3", true));
         assertFalse(headers.contains("2name", "Value3", false));
+    }
+
+    @Test
+    public void testContainsName() {
+        Http2Headers headers = new DefaultHttp2Headers();
+        headers.add(CONTENT_LENGTH, "36");
+        assertFalse(headers.contains("Content-Length"));
+        assertTrue(headers.contains("content-length"));
+        assertTrue(headers.contains(CONTENT_LENGTH));
+        headers.remove(CONTENT_LENGTH);
+        assertFalse(headers.contains("Content-Length"));
+        assertFalse(headers.contains("content-length"));
+        assertFalse(headers.contains(CONTENT_LENGTH));
+
+        assertFalse(headers.contains("non-existent-name"));
+        assertFalse(headers.contains(new AsciiString("non-existent-name")));
     }
 
     @Test


### PR DESCRIPTION
Motivation:

increase test coverage for DefaultHttpHeaders and DefaultHttp2Headers

Modification:

add unit tests for the contains(CharSequence) method

Result:

All unit tests pass.

