### PR TITLE
Correct group size calculation in SizeClasses to save memory

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/SizeClasses.java
+++ b/buffer/src/main/java/io/netty/buffer/SizeClasses.java
@@ -116,7 +116,7 @@ abstract class SizeClasses implements SizeClassesMetric {
     private final int[] size2idxTab;
 
     protected SizeClasses(int pageSize, int pageShifts, int chunkSize, int directMemoryCacheAlignment) {
-        int group = log2(chunkSize) + 1 - LOG2_QUANTUM;
+        int group = log2(chunkSize) - LOG2_QUANTUM - LOG2_SIZE_CLASS_GROUP + 1;
 
         //generate size classes
         //[index, log2Group, log2Delta, nDelta, isMultiPageSize, isSubPage, log2DeltaLookup]


### PR DESCRIPTION
Motivation:
In `SizeClasses` constructor, the `group` size calculation in `short[group * 4][7] sizeClasses` is wrong, which will create unnecessary array cells. For example:
If trunk size is `4 MiB (1 << 22)`, the `group` size was `19`, but it should be `17`.

Modification:

Correct `group` size calculation in `SizeClasses`.

Result:

Reduce `group` size in `sizeClasses` to save memory.
