### PR TITLE
implement NonStickyEventExecutorGroup.inEventLoop

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/NonStickyEventExecutorGroup.java
+++ b/common/src/main/java/io/netty/util/concurrent/NonStickyEventExecutorGroup.java
@@ -22,10 +22,8 @@ import io.netty.util.internal.UnstableApi;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -213,7 +211,7 @@ public final class NonStickyEventExecutorGroup implements EventExecutorGroup {
         group.execute(command);
     }
 
-    static final class NonStickyOrderedEventExecutor extends AbstractEventExecutor
+    private static final class NonStickyOrderedEventExecutor extends AbstractEventExecutor
             implements Runnable, OrderedEventExecutor {
         private final EventExecutor executor;
         private final Queue<Runnable> tasks = PlatformDependent.newMpscQueue();
@@ -222,10 +220,10 @@ public final class NonStickyEventExecutorGroup implements EventExecutorGroup {
         private static final int SUBMITTED = 1;
         private static final int RUNNING = 2;
 
-        final AtomicInteger state = new AtomicInteger();
+        private final AtomicInteger state = new AtomicInteger();
         private final int maxTaskExecutePerRun;
 
-        private final Map<Thread, Boolean> threadMap = new ConcurrentHashMap<>();
+        private volatile Thread executingThread;
 
         NonStickyOrderedEventExecutor(EventExecutor executor, int maxTaskExecutePerRun) {
             super(executor);
@@ -238,66 +236,60 @@ public final class NonStickyEventExecutorGroup implements EventExecutorGroup {
             if (!state.compareAndSet(SUBMITTED, RUNNING)) {
                 return;
             }
-            Thread currentThread = Thread.currentThread();
-            threadMap.put(currentThread, true);
-            try {
-                for (; ; ) {
-                    int i = 0;
-                    try {
-                        for (; i < maxTaskExecutePerRun; i++) {
-                            Runnable task = tasks.poll();
-                            if (task == null) {
-                                break;
-                            }
-                            safeExecute(task);
+            executingThread = Thread.currentThread();
+            for (;;) {
+                int i = 0;
+                try {
+                    for (; i < maxTaskExecutePerRun; i++) {
+                        Runnable task = tasks.poll();
+                        if (task == null) {
+                            break;
                         }
-                    } finally {
-                        if (i == maxTaskExecutePerRun) {
-                            try {
-                                state.set(SUBMITTED);
-                                executor.execute(this);
-                                return; // done
-                            } catch (Throwable ignore) {
-                                // Reset the state back to running as we will keep on executing tasks.
-                                state.set(RUNNING);
-                                // if an error happened we should just ignore it and let the loop run again as there is not
-                                // much else we can do. Most likely this was triggered by a full task queue. In this case
-                                // we just will run more tasks and try again later.
-                            }
-                        } else {
-                            state.set(NONE);
-                            // After setting the state to NONE, look at the tasks queue one more time.
-                            // If it is empty, then we can return from this method.
-                            // Otherwise, it means the producer thread has called execute(Runnable)
-                            // and enqueued a task in between the tasks.poll() above and the state.set(NONE) here.
-                            // There are two possible scenarios when this happens
-                            //
-                            // 1. The producer thread sees state == NONE, hence the compareAndSet(NONE, SUBMITTED)
-                            //    is successfully setting the state to SUBMITTED. This mean the producer
-                            //    will call / has called executor.execute(this). In this case, we can just return.
-                            // 2. The producer thread don't see the state change, hence the compareAndSet(NONE, SUBMITTED)
-                            //    returns false. In this case, the producer thread won't call executor.execute.
-                            //    In this case, we need to change the state to RUNNING and keeps running.
-                            //
-                            // The above cases can be distinguished by performing a
-                            // compareAndSet(NONE, RUNNING). If it returns "false", it is case 1; otherwise it is case 2.
-                            if (tasks.isEmpty() || !state.compareAndSet(NONE, RUNNING)) {
-                                return; // done
-                            }
+                        safeExecute(task);
+                    }
+                } finally {
+                    if (i == maxTaskExecutePerRun) {
+                        try {
+                            state.set(SUBMITTED);
+                            executingThread = null;
+                            executor.execute(this);
+                            return; // done
+                        } catch (Throwable ignore) {
+                            // Reset the state back to running as we will keep on executing tasks.
+                            state.set(RUNNING);
+                            // if an error happened we should just ignore it and let the loop run again as there is not
+                            // much else we can do. Most likely this was triggered by a full task queue. In this case
+                            // we just will run more tasks and try again later.
+                        }
+                    } else {
+                        state.set(NONE);
+                        // After setting the state to NONE, look at the tasks queue one more time.
+                        // If it is empty, then we can return from this method.
+                        // Otherwise, it means the producer thread has called execute(Runnable)
+                        // and enqueued a task in between the tasks.poll() above and the state.set(NONE) here.
+                        // There are two possible scenarios when this happens
+                        //
+                        // 1. The producer thread sees state == NONE, hence the compareAndSet(NONE, SUBMITTED)
+                        //    is successfully setting the state to SUBMITTED. This mean the producer
+                        //    will call / has called executor.execute(this). In this case, we can just return.
+                        // 2. The producer thread don't see the state change, hence the compareAndSet(NONE, SUBMITTED)
+                        //    returns false. In this case, the producer thread won't call executor.execute.
+                        //    In this case, we need to change the state to RUNNING and keeps running.
+                        //
+                        // The above cases can be distinguished by performing a
+                        // compareAndSet(NONE, RUNNING). If it returns "false", it is case 1; otherwise it is case 2.
+                        if (tasks.isEmpty() || !state.compareAndSet(NONE, RUNNING)) {
+                            executingThread = null;
+                            return; // done
                         }
                     }
                 }
-            } finally {
-                threadMap.remove(currentThread);
             }
         }
 
         @Override
         public boolean inEventLoop(Thread thread) {
-            if (state.get() != RUNNING) {
-                return false;
-            }
-            return this.threadMap.containsKey(thread);
+            return executingThread == thread;
         }
 
         @Override

--- a/common/src/test/java/io/netty/util/concurrent/NonStickyEventExecutorGroupTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/NonStickyEventExecutorGroupTest.java
@@ -30,6 +30,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -129,7 +130,7 @@ public class NonStickyEventExecutorGroupTest {
     }
 
     private static void execute(EventExecutorGroup group, CountDownLatch startLatch) throws Throwable {
-        EventExecutor executor = group.next();
+        final EventExecutor executor = group.next();
         assertTrue(executor instanceof OrderedEventExecutor);
         final AtomicReference<Throwable> cause = new AtomicReference<Throwable>();
         final AtomicInteger last = new AtomicInteger();
@@ -140,10 +141,15 @@ public class NonStickyEventExecutorGroupTest {
 
         for (int i = 1 ; i <= tasks; i++) {
             final int id = i;
+            assertFalse(executor.inEventLoop());
+            assertFalse(executor.inEventLoop(Thread.currentThread()));
             futures.add(executor.submit(new Runnable() {
                 @Override
                 public void run() {
                     try {
+                        assertTrue(executor.inEventLoop(Thread.currentThread()));
+                        assertTrue(executor.inEventLoop());
+
                         if (cause.get() == null) {
                             int lastId = last.get();
                             if (lastId >= id) {


### PR DESCRIPTION
Motivation:

Current implementation of `NonStickyEventExecutor.inEventLoop()` always returns `false`, causing behavior changes when `DefaultEventExecutor` is replaced with `NonStickyEventExecutor`

Modification:

Thread , currently executing `NonStickyEventExecutor.run()` got saved as a key in CHM (because of Java 6 limitation I could not use `ConcurrentHashMap.newKeySet()`) at the beginning of execution and got removed at the end.
`inEventLoop()` checks if current thread is in the map


Result:

Calls to `inEventLoop()` inside runnable executed by `NonStickyEventExecutor` return `true` and return `false` otherwise
