### PR TITLE
Pseudo-header with empty value results in RST_STREAM with PROTOCOL_ERROR reason

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
@@ -177,9 +177,11 @@ public class DefaultHttp2Headers
         // This method has a noop override for backward compatibility, see https://github.com/netty/netty/pull/12975
         super.validateValue(validator, name, value);
         // https://datatracker.ietf.org/doc/html/rfc9113#section-8.3.1
-        if ((value == null || value.length() == 0) && hasPseudoHeaderFormat(name) && getPseudoHeader(name) == PATH) {
+        // pseudo headers must not be empty
+        if (nameValidator() == HTTP2_NAME_VALIDATOR && (value == null || value.length() == 0) &&
+                hasPseudoHeaderFormat(name)) {
             PlatformDependent.throwException(connectionError(
-                    PROTOCOL_ERROR, "HTTP/2 pseudo-header ':path' must not be empty.", name));
+                    PROTOCOL_ERROR, "HTTP/2 pseudo-header '%s' must not be empty.", name));
         }
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
@@ -24,7 +24,6 @@ import io.netty.util.internal.UnstableApi;
 
 import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
 import static io.netty.handler.codec.http2.Http2Exception.connectionError;
-import static io.netty.handler.codec.http2.Http2Headers.PseudoHeaderName.PATH;
 import static io.netty.handler.codec.http2.Http2Headers.PseudoHeaderName.getPseudoHeader;
 import static io.netty.handler.codec.http2.Http2Headers.PseudoHeaderName.hasPseudoHeaderFormat;
 import static io.netty.util.AsciiString.CASE_INSENSITIVE_HASHER;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
@@ -24,6 +24,7 @@ import io.netty.util.internal.UnstableApi;
 
 import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
 import static io.netty.handler.codec.http2.Http2Exception.connectionError;
+import static io.netty.handler.codec.http2.Http2Headers.PseudoHeaderName.PATH;
 import static io.netty.handler.codec.http2.Http2Headers.PseudoHeaderName.getPseudoHeader;
 import static io.netty.handler.codec.http2.Http2Headers.PseudoHeaderName.hasPseudoHeaderFormat;
 import static io.netty.util.AsciiString.CASE_INSENSITIVE_HASHER;
@@ -175,6 +176,11 @@ public class DefaultHttp2Headers
     protected void validateValue(ValueValidator<CharSequence> validator, CharSequence name, CharSequence value) {
         // This method has a noop override for backward compatibility, see https://github.com/netty/netty/pull/12975
         super.validateValue(validator, name, value);
+        // https://datatracker.ietf.org/doc/html/rfc9113#section-8.3.1
+        if ((value == null || value.length() == 0) && hasPseudoHeaderFormat(name) && getPseudoHeader(name) == PATH) {
+            PlatformDependent.throwException(connectionError(
+                    PROTOCOL_ERROR, "HTTP/2 pseudo-header ':path' must not be empty.", name));
+        }
     }
 
     @Override

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackDecoderTest.java
@@ -33,6 +33,7 @@ package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.util.AsciiString;
 import io.netty.util.internal.StringUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -54,6 +55,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockingDetails;
@@ -864,14 +866,15 @@ public class HpackDecoderTest {
         }
     }
 
-    @Test
-    public void testPseudoHeaderPathMustNotBeEmpty() throws Exception {
+    @ParameterizedTest
+    @CsvSource(value = {":method,''", ":scheme,''", ":authority,''", ":path,''"})
+    public void testPseudoHeaderEmptyValidationEnabled(String name, String value) throws Exception {
         final ByteBuf in = Unpooled.buffer(200);
         try {
             HpackEncoder hpackEncoder = new HpackEncoder(true);
 
             Http2Headers toEncode = new InOrderHttp2Headers();
-            toEncode.add(":path", "");
+            toEncode.add(name, value);
             hpackEncoder.encodeHeaders(1, in, toEncode, NEVER_SENSITIVE);
 
             final Http2Headers decoded = new DefaultHttp2Headers();
@@ -884,6 +887,26 @@ public class HpackDecoderTest {
             });
             assertThat(e.streamId(), is(3));
             assertThat(e.error(), is(PROTOCOL_ERROR));
+        } finally {
+            in.release();
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {":method,''", ":scheme,''", ":authority,''", ":path,''"})
+    public void testPseudoHeaderEmptyValidationDisabled(String name, String value) throws Exception {
+        final ByteBuf in = Unpooled.buffer(200);
+        try {
+            HpackEncoder hpackEncoder = new HpackEncoder(true);
+
+            Http2Headers toEncode = new InOrderHttp2Headers();
+            toEncode.add(name, value);
+            hpackEncoder.encodeHeaders(1, in, toEncode, NEVER_SENSITIVE);
+
+            final Http2Headers decoded = new DefaultHttp2Headers(false);
+            hpackDecoder.decode(3, in, decoded, true);
+
+            assertSame(AsciiString.EMPTY_STRING, decoded.get(name));
         } finally {
             in.release();
         }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilTest.java
@@ -83,8 +83,20 @@ public class HttpConversionUtilTest {
         HttpConversionUtil.setHttp2Authority(null, headers);
         assertNull(headers.authority());
 
-        HttpConversionUtil.setHttp2Authority("", headers);
-        assertSame(AsciiString.EMPTY_STRING, headers.authority());
+        // https://datatracker.ietf.org/doc/html/rfc9113#section-8.3.1
+        // Clients that generate HTTP/2 requests directly MUST use the ":authority" pseudo-header
+        // field to convey authority information, unless there is no authority information to convey
+        // (in which case it MUST NOT generate ":authority").
+        // An intermediary that forwards a request over HTTP/2 MUST construct an ":authority" pseudo-header
+        // field using the authority information from the control data of the original request, unless the
+        // original request's target URI does not contain authority information
+        // (in which case it MUST NOT generate ":authority").
+        assertThrows(Http2Exception.class, new Executable() {
+            @Override
+            public void execute() {
+                HttpConversionUtil.setHttp2Authority("", new DefaultHttp2Headers());
+            }
+        });
     }
 
     @Test


### PR DESCRIPTION
Motivation:

According to `RFC9113` 
https://datatracker.ietf.org/doc/html/rfc9113#section-8.3.1 
Pseudo-header `:path` must not have empty value.

Modifications:

- Extend `DefaultHttp2Headers#validateValue` with validation for pseudo-header `:path`
- Add junit test

Result:

Pseudo-header `:path` with empty value results in `RST_STREAM` with `PROTOCOL_ERROR` reason.

Related to #13235