### PR TITLE
Native image: add support for unix domain sockets

### DIFF
--- a/transport-classes-epoll/src/main/resources/META-INF/native-image/io.netty/netty-transport-classes-epoll/reflect-config.json
+++ b/transport-classes-epoll/src/main/resources/META-INF/native-image/io.netty/netty-transport-classes-epoll/reflect-config.json
@@ -10,6 +10,20 @@
     "condition": {
       "typeReachable": "io.netty.channel.epoll.Native"
     },
+    "name":"io.netty.channel.epoll.EpollDomainSocketChannel",
+    "allDeclaredConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.epoll.Native"
+    },
+    "name":"io.netty.channel.epoll.EpollServerDomainSocketChannel",
+    "allDeclaredConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.epoll.Native"
+    },
     "name": "io.netty.util.internal.NativeLibraryUtil",
     "allDeclaredMethods": true
   }


### PR DESCRIPTION
Motivation:

unix domain sockets with graalvm native image require additional reflection configuration.

Modification:

add unix domain sockets graalvm configuration in reflect-config.json.

Result:

unix domain sockets with graalvm native image work out of the box.