### PR TITLE
Make decodeParams and findPathEndIndex static methods public available.

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/QueryStringDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/QueryStringDecoder.java
@@ -223,7 +223,7 @@ public class QueryStringDecoder {
         return pathEndIdx;
     }
 
-    private static Map<String, List<String>> decodeParams(String s, int from, Charset charset, int paramsLimit,
+    public static Map<String, List<String>> decodeParams(String s, int from, Charset charset, int paramsLimit,
                                                           boolean semicolonIsNormalChar) {
         int len = s.length();
         if (from >= len) {
@@ -380,7 +380,7 @@ public class QueryStringDecoder {
         return strBuf.toString();
     }
 
-    private static int findPathEndIndex(String uri) {
+    public static int findPathEndIndex(String uri) {
         int len = uri.length();
         for (int i = 0; i < len; i++) {
             char c = uri.charAt(i);


### PR DESCRIPTION
Motivation:

We would like to reuse the decodeParams method in QueryStringDecoder to https://github.com/reactor/reactor-netty/issues/68 without creating a QueryStringDecoder object. Currently `decodeParams` and `findPathEndIndex` static methods are not publicly available. Making both methods publicly available enable others to use these battle tested, standard conforming functions.

Modification:
Changed the `decodeParams`  and `findPathEndIndex` access modifier from private to public.

Result:

Fixes #13239. 

