### PR TITLE
fix too many flush

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
@@ -806,7 +806,9 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
                     }
                     // We need to double check that there is nothing left to flush such as a
                     // window update frame.
-                    flush();
+                    if (isActive()) {
+                        flush();
+                    }
                     break;
                 }
                 final RecvByteBufAllocator.Handle allocHandle = recvBufAllocHandle();


### PR DESCRIPTION
Motivation:
fix too many flush.
when I call `ctx.write` to send `end frame`,  it will be auto flush.
<img width="1635" alt="image" src="https://user-images.githubusercontent.com/42876375/221396739-143486c4-e2b1-49cb-9605-8afe475e7072.png">
 
Modification:
check `StreamChannel` state before `flush`. 
When stream is closed, it may not need auto `flush`

Result:
reduce the number of flush
<img width="1622" alt="image" src="https://user-images.githubusercontent.com/42876375/221396793-7858d7fa-5b80-4aab-a419-02f60399318b.png">

Fixes #13232 

