### PR TITLE
Remove drop attach in DefaultCompositeBuffer#prepareSend()

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/DefaultCompositeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/DefaultCompositeBuffer.java
@@ -1322,7 +1322,6 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
             var composite = new DefaultCompositeBuffer(allocator, received, drop);
             composite.readOnly = readOnly;
             composite.implicitCapacityLimit = implicitCapacityLimit;
-            drop.attach(composite);
             return composite;
         };
     }


### PR DESCRIPTION
Motivation:
The `prepareSend()` method in the `DefaultCompositeBuffer` class contained a call to `drop.attach(composite)` at returning lambda. as well as SendFromOwned#receive().

Modification:
Removed the call to `drop.attach(composite)` at the returning lambda.

Result:
No duplicate drop attach. drop attach after ownership changed like other buffer implementations.