### PR TITLE
fix HttpObjectAggregator content length error causing the pipeline to be unable to handle data

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/MessageAggregator.java
+++ b/codec/src/main/java/io/netty/handler/codec/MessageAggregator.java
@@ -431,6 +431,9 @@ public abstract class MessageAggregator<I, S, C extends ByteBufHolder, O extends
 
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        if(this.aggregating){
+            super.exceptionCaught(ctx,new RemainLengthNotReadException("expected to aggregate more data, currently "+this.currentMessage.content().capacity()+" bits are accepted, but the channel has been closed. "));
+        }
         try {
             // release current message if it is not null as it may be a left-over
             super.channelInactive(ctx);

--- a/codec/src/main/java/io/netty/handler/codec/MessageAggregator.java
+++ b/codec/src/main/java/io/netty/handler/codec/MessageAggregator.java
@@ -432,7 +432,9 @@ public abstract class MessageAggregator<I, S, C extends ByteBufHolder, O extends
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
         if(this.aggregating){
-            ctx.fireExceptionCaught(ctx,new RemainLengthNotReadException("expected to aggregate more data, currently "+this.currentMessage.content().capacity()+" bits are accepted, but the channel has been closed. "));
+            ctx.fireExceptionCaught(ctx,new RemainLengthNotReadException("expected to aggregate more data,"+
+                "currently "+this.currentMessage.content().capacity()+" bits are accepted,"+
+                "but the channel has been closed. "));
         }
         try {
             // release current message if it is not null as it may be a left-over

--- a/codec/src/main/java/io/netty/handler/codec/MessageAggregator.java
+++ b/codec/src/main/java/io/netty/handler/codec/MessageAggregator.java
@@ -432,7 +432,7 @@ public abstract class MessageAggregator<I, S, C extends ByteBufHolder, O extends
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
         if(this.aggregating){
-            super.exceptionCaught(ctx,new RemainLengthNotReadException("expected to aggregate more data, currently "+this.currentMessage.content().capacity()+" bits are accepted, but the channel has been closed. "));
+            ctx.fireExceptionCaught(ctx,new RemainLengthNotReadException("expected to aggregate more data, currently "+this.currentMessage.content().capacity()+" bits are accepted, but the channel has been closed. "));
         }
         try {
             // release current message if it is not null as it may be a left-over

--- a/codec/src/main/java/io/netty/handler/codec/RemainLengthNotReadException.java
+++ b/codec/src/main/java/io/netty/handler/codec/RemainLengthNotReadException.java
@@ -1,0 +1,20 @@
+package io.netty.handler.codec;
+
+public class RemainLengthNotReadException extends DecoderException {
+    private static final long serialVersionUID = -1995801950698951641L;
+
+    public RemainLengthNotReadException() {
+    }
+
+    public RemainLengthNotReadException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public RemainLengthNotReadException(String message) {
+        super(message);
+    }
+
+    public RemainLengthNotReadException(Throwable cause) {
+        super(cause);
+    }
+}


### PR DESCRIPTION
Motivation:

When using HttpObjectAggregator, Http Response returns an illegal Content-Length, HttpObjectAggregator will wait for channel inactive，when the read is complete, the channelpipline will not continue, it should trigger an exception
Modification:

In the channelInactive of MessageAggregator, add aggregating judgment. When aggregating is not completed, and channel inactive, an exception should be thrown to let the channelHandler in the channelpipline handle it.

