### PR TITLE
Use MacOS SDK 10.9 to prevent apple notarization failures

### DIFF
--- a/resolver-dns-native-macos/pom.xml
+++ b/resolver-dns-native-macos/pom.xml
@@ -35,7 +35,7 @@
         </os>
       </activation>
       <properties>
-        <jni.compiler.args.ldflags>LDFLAGS=-Wl,-weak_library,${unix.common.lib.unpacked.dir}/lib${unix.common.lib.name}.a -Wl,-platform_version,macos,10.6,10.6</jni.compiler.args.ldflags>
+        <jni.compiler.args.ldflags>LDFLAGS=-Wl,-weak_library,${unix.common.lib.unpacked.dir}/lib${unix.common.lib.name}.a -Wl,-platform_version,macos,10.9,10.9</jni.compiler.args.ldflags>
         <skipTests>false</skipTests>
       </properties>
       <build>
@@ -80,7 +80,7 @@
                   <configureArgs>
                     <arg>${jni.compiler.args.ldflags}</arg>
                     <arg>${jni.compiler.args.cflags}</arg>
-                    <arg>MACOSX_DEPLOYMENT_TARGET=10.6</arg>
+                    <arg>MACOSX_DEPLOYMENT_TARGET=10.9</arg>
                   </configureArgs>
                 </configuration>
                 <goals>
@@ -246,8 +246,8 @@
     <profile>
       <id>mac-intel-cross-compile</id>
       <properties>
-        <jni.compiler.args.ldflags>LDFLAGS=-arch x86_64 -Wl,-weak_library,${unix.common.lib.unpacked.dir}/lib${unix.common.lib.name}.a -Wl,-platform_version,macos,10.6,10.6</jni.compiler.args.ldflags>
-        <jni.compiler.args.cflags>CFLAGS=-target x86_64-apple-macos10.6 -O3 -Werror -fno-omit-frame-pointer -Wunused-variable -fvisibility=hidden -I${unix.common.include.unpacked.dir}</jni.compiler.args.cflags>
+        <jni.compiler.args.ldflags>LDFLAGS=-arch x86_64 -Wl,-weak_library,${unix.common.lib.unpacked.dir}/lib${unix.common.lib.name}.a -Wl,-platform_version,macos,10.9,10.9</jni.compiler.args.ldflags>
+        <jni.compiler.args.cflags>CFLAGS=-target x86_64-apple-macos10.9 -O3 -Werror -fno-omit-frame-pointer -Wunused-variable -fvisibility=hidden -I${unix.common.include.unpacked.dir}</jni.compiler.args.cflags>
 
         <!-- use aarch_64 as this is also what os.detected.arch will use on an aarch64 system -->
         <jni.classifier>${os.detected.name}-x86_64</jni.classifier>
@@ -297,7 +297,7 @@
                     <arg>${jni.compiler.args.ldflags}</arg>
                     <arg>${jni.compiler.args.cflags}</arg>
                     <configureArg>--host=x86_64-apple-darwin</configureArg>
-                    <arg>MACOSX_DEPLOYMENT_TARGET=10.6</arg>
+                    <arg>MACOSX_DEPLOYMENT_TARGET=10.9</arg>
                   </configureArgs>
                 </configuration>
                 <goals>

--- a/transport-native-kqueue/pom.xml
+++ b/transport-native-kqueue/pom.xml
@@ -35,7 +35,7 @@
         </os>
       </activation>
       <properties>
-        <jni.compiler.args.ldflags>LDFLAGS=-Wl,-weak_library,${unix.common.lib.unpacked.dir}/lib${unix.common.lib.name}.a -Wl,-platform_version,macos,10.6,10.6</jni.compiler.args.ldflags>
+        <jni.compiler.args.ldflags>LDFLAGS=-Wl,-weak_library,${unix.common.lib.unpacked.dir}/lib${unix.common.lib.name}.a -Wl,-platform_version,macos,10.9,10.9</jni.compiler.args.ldflags>
       </properties>
       <build>
         <plugins>
@@ -82,7 +82,7 @@
                     <!-- support for __attribute__((weak_import)) by the linker was added in 10.2 (but 10.6 is the minimum we can use on 10.14) so ensure we
                          explicitly set the target platform. Otherwise we may get fatal link errors due to weakly linked
                          methods which are not expected to be present on MacOS (e.g. accept4). -->
-                    <arg>MACOSX_DEPLOYMENT_TARGET=10.6</arg>
+                    <arg>MACOSX_DEPLOYMENT_TARGET=10.9</arg>
                     <configureArg>--libdir=${project.build.directory}/native-build/target/lib</configureArg>
                   </configureArgs>
                 </configuration>
@@ -251,8 +251,8 @@
         <!-- use aarch_64 as this is also what os.detected.arch will use on an aarch64 system -->
         <jni.classifier>${os.detected.name}-x86_64</jni.classifier>
         <javaModuleNameClassifier>${os.detected.name}.x86_64</javaModuleNameClassifier>
-        <jni.compiler.args.cflags>CFLAGS=-target x86_64-apple-macos10.6 -O3 -Werror -fno-omit-frame-pointer -Wunused-variable -fvisibility=hidden -I${unix.common.include.unpacked.dir}</jni.compiler.args.cflags>
-        <jni.compiler.args.ldflags>LDFLAGS=-arch x86_64 -Wl,-weak_library,${unix.common.lib.unpacked.dir}/lib${unix.common.lib.name}.a -Wl,-platform_version,macos,10.6,10.6</jni.compiler.args.ldflags>
+        <jni.compiler.args.cflags>CFLAGS=-target x86_64-apple-macos10.9 -O3 -Werror -fno-omit-frame-pointer -Wunused-variable -fvisibility=hidden -I${unix.common.include.unpacked.dir}</jni.compiler.args.cflags>
+        <jni.compiler.args.ldflags>LDFLAGS=-arch x86_64 -Wl,-weak_library,${unix.common.lib.unpacked.dir}/lib${unix.common.lib.name}.a -Wl,-platform_version,macos,10.9,10.9</jni.compiler.args.ldflags>
         <skipTests>true</skipTests>
       </properties>
       <build>
@@ -297,7 +297,7 @@
                   <configureArgs>
                     <arg>${jni.compiler.args.ldflags}</arg>
                     <arg>${jni.compiler.args.cflags}</arg>
-                    <arg>MACOSX_DEPLOYMENT_TARGET=10.6</arg>
+                    <arg>MACOSX_DEPLOYMENT_TARGET=10.9</arg>
                     <configureArg>--host=x86_64-apple-darwin</configureArg>
                     <configureArg>--libdir=${project.build.directory}/native-build/target/lib</configureArg>
                   </configureArgs>

--- a/transport-native-unix-common/pom.xml
+++ b/transport-native-unix-common/pom.xml
@@ -154,12 +154,12 @@
                       <env key="OBJ_DIR" value="${nativeObjsOnlyDir}" />
                       <env key="JNI_PLATFORM" value="${jni.platform}" />
                       <env key="CFLAGS" value="-O3 -Werror -Wno-attributes -fPIC -fno-omit-frame-pointer -Wunused-variable -fvisibility=hidden" />
-                      <env key="LDFLAGS" value="-Wl,--no-as-needed -lrt -Wl,-platform_version,macos,10.2,10.2" />
+                      <env key="LDFLAGS" value="-Wl,--no-as-needed -lrt -Wl,-platform_version,macos,10.9,10.9" />
                       <env key="LIB_NAME" value="${nativeLibName}" />
                       <!-- support for __attribute__((weak_import)) by the linker was added in 10.2 so ensure we
                            explicitly set the target platform. Otherwise we may get fatal link errors due to weakly linked
                            methods which are not expected to be present on MacOS (e.g. accept4). -->
-                      <env key="MACOSX_DEPLOYMENT_TARGET" value="10.2" />
+                      <env key="MACOSX_DEPLOYMENT_TARGET" value="10.9" />
                     </exec>
                   </target>
                 </configuration>
@@ -297,9 +297,9 @@
                       <env key="OBJ_DIR" value="${nativeObjsOnlyDir}" />
                       <env key="JNI_PLATFORM" value="${jni.platform}" />
                       <env key="CFLAGS" value="-target arm64-apple-macos11 -O3 -Werror -Wno-attributes -fPIC -fno-omit-frame-pointer -Wunused-variable -fvisibility=hidden" />
-                      <env key="LDFLAGS" value="-arch arm64 -Wl,--no-as-needed -lrt -Wl,-platform_version,macos,10.6,10.6" />
+                      <env key="LDFLAGS" value="-arch arm64 -Wl,--no-as-needed -lrt -Wl,-platform_version,macos,10.9,10.9" />
                       <env key="LIB_NAME" value="${nativeLibName}" />
-                      <env key="MACOSX_DEPLOYMENT_TARGET" value="10.6" />
+                      <env key="MACOSX_DEPLOYMENT_TARGET" value="10.9" />
                     </exec>
                   </target>
                 </configuration>


### PR DESCRIPTION
Motivation:

When using an SDK older then 10.9 the notarization process fails and Apple sends the reason for the failure is that "The binary uses an SDK older than the 10.9 SDK

Modifications:

Update to 10.9

Result:

No more problems with apple notarization. Fixes https://github.com/netty/netty/issues/13228