### PR TITLE
Fix javadoc tables

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDatagramChannel.java
@@ -76,7 +76,7 @@ import static java.util.Objects.requireNonNull;
  * <th>{@link ChannelOption}</th>
  * <th>{@code INET}</th>
  * <th>{@code INET6}</th>
- * <th>{@code UNIX</th>
+ * <th>{@code UNIX}</th>
  * </tr><tr>
  * <td>{@link IntegerUnixChannelOption}</td><td>X</td><td>X</td><td>X</td>
  * </tr><tr>

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioDatagramChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioDatagramChannel.java
@@ -68,10 +68,6 @@ import static java.util.Objects.requireNonNull;
  * An NIO {@link io.netty5.channel.socket.DatagramChannel} that sends and receives an
  * {@link AddressedEnvelope AddressedEnvelope<ByteBuf, SocketAddress>}.
  *
- * @see AddressedEnvelope
- * @see DatagramPacket
- *
- *
  * <h3>Available options</h3>
  *
  * In addition to the options provided by {@link io.netty5.channel.socket.DatagramChannel},
@@ -82,11 +78,14 @@ import static java.util.Objects.requireNonNull;
  * <th>{@link ChannelOption}</th>
  * <th>{@code INET}</th>
  * <th>{@code INET6}</th>
- * <th>{@code UNIX</th>
+ * <th>{@code UNIX}</th>
  * </tr><tr>
  * <td>{@link NioChannelOption}</td><td>X</td><td>X</td><td>X</td>
  * </tr>
  * </table>
+ *
+ * @see AddressedEnvelope
+ * @see DatagramPacket
  */
 public final class NioDatagramChannel
         extends AbstractNioMessageChannel<Channel, SocketAddress, SocketAddress>

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioServerSocketChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioServerSocketChannel.java
@@ -61,7 +61,7 @@ import static io.netty5.util.internal.ObjectUtil.checkPositiveOrZero;
  * <th>{@link ChannelOption}</th>
  * <th>{@code INET}</th>
  * <th>{@code INET6}</th>
- * <th>{@code UNIX</th>
+ * <th>{@code UNIX}</th>
  * </tr><tr>
  * <td>{@link NioChannelOption}</td><td>X</td><td>X</td><td>X</td>
  * </tr>

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioSocketChannel.java
@@ -59,7 +59,7 @@ import static io.netty5.channel.socket.nio.NioChannelUtil.toUnixDomainSocketAddr
  * <th>{@link ChannelOption}</th>
  * <th>{@code INET}</th>
  * <th>{@code INET6}</th>
- * <th>{@code UNIX</th>
+ * <th>{@code UNIX}</th>
  * </tr><tr>
  * <td>{@link NioChannelOption}</td><td>X</td><td>X</td><td>X</td>
  * </tr>


### PR DESCRIPTION
Motivation:
Typos and wrong place of javadoc's block tag were causing issues with the rendering of the tables.

Modification:
fixed the typo.

Result:
The tables appears as expected.