### PR TITLE
Skip revapi checks for testsuite modules

### DIFF
--- a/testsuite-autobahn/pom.xml
+++ b/testsuite-autobahn/pom.xml
@@ -30,6 +30,7 @@
 
   <properties>
     <japicmp.skip>true</japicmp.skip>
+    <revapi.skip>true</revapi.skip>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
     <javaModuleName>io.netty.testsuite_autobahn</javaModuleName>

--- a/testsuite-http2/pom.xml
+++ b/testsuite-http2/pom.xml
@@ -30,6 +30,7 @@
 
   <properties>
     <japicmp.skip>true</japicmp.skip>
+    <revapi.skip>true</revapi.skip>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
     <javaModuleName>io.netty.testsuite_http2</javaModuleName>

--- a/testsuite-native-image-client-runtime-init/pom.xml
+++ b/testsuite-native-image-client-runtime-init/pom.xml
@@ -30,6 +30,7 @@
 
   <properties>
     <japicmp.skip>true</japicmp.skip>
+    <revapi.skip>true</revapi.skip>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
     <javaModuleName>io.netty.testsuite_native_image_client_runtime_init</javaModuleName>

--- a/testsuite-native-image-client/pom.xml
+++ b/testsuite-native-image-client/pom.xml
@@ -30,6 +30,7 @@
 
   <properties>
     <japicmp.skip>true</japicmp.skip>
+    <revapi.skip>true</revapi.skip>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
     <javaModuleName>io.netty.testsuite_native_image_client</javaModuleName>

--- a/testsuite-native-image/pom.xml
+++ b/testsuite-native-image/pom.xml
@@ -30,6 +30,7 @@
 
   <properties>
     <japicmp.skip>true</japicmp.skip>
+    <revapi.skip>true</revapi.skip>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
     <javaModuleName>io.netty.testsuite_native_image</javaModuleName>

--- a/testsuite-native/pom.xml
+++ b/testsuite-native/pom.xml
@@ -30,6 +30,7 @@
 
   <properties>
     <japicmp.skip>true</japicmp.skip>
+    <revapi.skip>true</revapi.skip>
     <skipNativeTestsuite>false</skipNativeTestsuite>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>

--- a/testsuite-osgi/pom.xml
+++ b/testsuite-osgi/pom.xml
@@ -32,6 +32,7 @@
     <exam.version>4.13.0</exam.version>
     <argLine.java9.extras>--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/jdk.internal.loader=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.security=ALL-UNNAMED</argLine.java9.extras>
     <japicmp.skip>true</japicmp.skip>
+    <revapi.skip>true</revapi.skip>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
     <javaModuleName>io.netty.testsuite_osgi</javaModuleName>

--- a/testsuite-shading/pom.xml
+++ b/testsuite-shading/pom.xml
@@ -40,6 +40,7 @@
     <skipShadingTestsuite>true</skipShadingTestsuite>
     <shadedPackagePrefix>io.netty.</shadedPackagePrefix>
     <japicmp.skip>true</japicmp.skip>
+    <revapi.skip>true</revapi.skip>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
     <javaModuleName>io.netty.testsuite_shading</javaModuleName>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -120,6 +120,7 @@
     <!-- Needed for SSL tests as these use the SelfSignedCertificate --> 
     <argLine.java9.extras>--add-exports java.base/sun.security.x509=ALL-UNNAMED</argLine.java9.extras>
     <japicmp.skip>true</japicmp.skip>
+    <revapi.skip>true</revapi.skip>
     <javaModuleName>io.netty.testsuite</javaModuleName>
   </properties>
 


### PR DESCRIPTION
Motivation:

We should skip revapi checks for testsuite modules as these are not expected to be public API

Modifications:

Add configuration for skipping

Result:

No API check for testsuites
