### PR TITLE
WebSocketClientProtocolHandler: add option to disable UTF8 validation

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolConfig.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolConfig.java
@@ -51,6 +51,7 @@ public final class WebSocketClientProtocolConfig {
     private final long forceCloseTimeoutMillis;
     private final boolean absoluteUpgradeUrl;
     private final boolean generateOriginHeader;
+    private final boolean withUTF8Validator;
 
     private WebSocketClientProtocolConfig(
         URI webSocketUri,
@@ -67,7 +68,8 @@ public final class WebSocketClientProtocolConfig {
         long handshakeTimeoutMillis,
         long forceCloseTimeoutMillis,
         boolean absoluteUpgradeUrl,
-        boolean generateOriginHeader
+        boolean generateOriginHeader,
+        boolean withUTF8Validator
     ) {
         this.webSocketUri = webSocketUri;
         this.subprotocol = subprotocol;
@@ -84,6 +86,7 @@ public final class WebSocketClientProtocolConfig {
         this.handshakeTimeoutMillis = checkPositive(handshakeTimeoutMillis, "handshakeTimeoutMillis");
         this.absoluteUpgradeUrl = absoluteUpgradeUrl;
         this.generateOriginHeader = generateOriginHeader;
+        this.withUTF8Validator = withUTF8Validator;
     }
 
     public URI webSocketUri() {
@@ -146,6 +149,10 @@ public final class WebSocketClientProtocolConfig {
         return generateOriginHeader;
     }
 
+    public boolean withUTF8Validator() {
+        return withUTF8Validator;
+    }
+
     @Override
     public String toString() {
         return "WebSocketClientProtocolConfig" +
@@ -187,7 +194,8 @@ public final class WebSocketClientProtocolConfig {
                 DEFAULT_HANDSHAKE_TIMEOUT_MILLIS,
                 -1,
                 false,
-                DEFAULT_GENERATE_ORIGIN_HEADER);
+                DEFAULT_GENERATE_ORIGIN_HEADER,
+                true);
     }
 
     public static final class Builder {
@@ -206,6 +214,7 @@ public final class WebSocketClientProtocolConfig {
         private long forceCloseTimeoutMillis;
         private boolean absoluteUpgradeUrl;
         private boolean generateOriginHeader;
+        private boolean withUTF8Validator;
 
         private Builder(WebSocketClientProtocolConfig clientConfig) {
             this(ObjectUtil.checkNotNull(clientConfig, "clientConfig").webSocketUri(),
@@ -222,7 +231,8 @@ public final class WebSocketClientProtocolConfig {
                  clientConfig.handshakeTimeoutMillis(),
                  clientConfig.forceCloseTimeoutMillis(),
                  clientConfig.absoluteUpgradeUrl(),
-                 clientConfig.generateOriginHeader());
+                 clientConfig.generateOriginHeader(),
+                 clientConfig.withUTF8Validator());
         }
 
         private Builder(URI webSocketUri,
@@ -239,7 +249,8 @@ public final class WebSocketClientProtocolConfig {
                         long handshakeTimeoutMillis,
                         long forceCloseTimeoutMillis,
                         boolean absoluteUpgradeUrl,
-                        boolean generateOriginHeader) {
+                        boolean generateOriginHeader,
+                        boolean withUTF8Validator) {
             this.webSocketUri = webSocketUri;
             this.subprotocol = subprotocol;
             this.version = version;
@@ -255,6 +266,7 @@ public final class WebSocketClientProtocolConfig {
             this.forceCloseTimeoutMillis = forceCloseTimeoutMillis;
             this.absoluteUpgradeUrl = absoluteUpgradeUrl;
             this.generateOriginHeader = generateOriginHeader;
+            this.withUTF8Validator = withUTF8Validator;
         }
 
         /**
@@ -392,6 +404,14 @@ public final class WebSocketClientProtocolConfig {
         }
 
         /**
+         * Toggles UTF8 validation for payload of text websocket frames. By default validation is enabled.
+         */
+        public Builder withUTF8Validator(boolean withUTF8Validator) {
+            this.withUTF8Validator = withUTF8Validator;
+            return this;
+        }
+
+        /**
          * Build unmodifiable client protocol configuration.
          */
         public WebSocketClientProtocolConfig build() {
@@ -410,7 +430,8 @@ public final class WebSocketClientProtocolConfig {
                 handshakeTimeoutMillis,
                 forceCloseTimeoutMillis,
                 absoluteUpgradeUrl,
-                generateOriginHeader
+                generateOriginHeader,
+                withUTF8Validator
             );
         }
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandler.java
@@ -384,7 +384,7 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
             ctx.pipeline().addBefore(ctx.name(), WebSocketClientProtocolHandshakeHandler.class.getName(),
                 new WebSocketClientProtocolHandshakeHandler(handshaker, clientConfig.handshakeTimeoutMillis()));
         }
-        if (cp.get(Utf8FrameValidator.class) == null) {
+        if (clientConfig.withUTF8Validator() && cp.get(Utf8FrameValidator.class) == null) {
             // Add the UFT8 checking before this one.
             ctx.pipeline().addBefore(ctx.name(), Utf8FrameValidator.class.getName(),
                     new Utf8FrameValidator());


### PR DESCRIPTION
WebSocketClientProtocolHandler: add option to disable UTF8 validation of text frames.

Motivation:

WebSocketClientProtocolHandler unconditionally adds UTF8 validation handler, even if one is not necessary (e.g. text frames are not used by application).

Modification:

add WebSocketClientProtocolConfig.withUTF8Validator option.

WebSocketClientProtocolHandler uses .withUTF8Validator option when adding Utf8FrameValidator to channel pipeline.

Result:

configurable UTF8 validation of text frames payload in WebSocketClientProtocolHandler.