### PR TITLE
Fix PooledDrop

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/SensitiveBufferAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/SensitiveBufferAllocator.java
@@ -129,7 +129,7 @@ public final class SensitiveBufferAllocator implements BufferAllocator {
         public Drop<Buffer> fork() {
             // ZeroingDrop should be guarded by an ArcDrop, because we can only zero after we're sure
             // there is no more structural sharing of the memory!
-            throw new UnsupportedOperationException();
+            throw new IllegalStateException(this + " cannot fork. Must be guarded by an ArcDrop.");
         }
 
         @Override

--- a/buffer/src/main/java/io/netty5/buffer/pool/PooledDrop.java
+++ b/buffer/src/main/java/io/netty5/buffer/pool/PooledDrop.java
@@ -41,10 +41,24 @@ class PooledDrop implements Drop<Buffer> {
 
     @Override
     public Drop<Buffer> fork() {
-        return new PooledDrop(chunk, threadCache, handle, normSize);
+        throw new IllegalStateException(this + " cannot fork. Must be guarded by an ArcDrop.");
     }
 
     @Override
     public void attach(Buffer obj) {
+        baseDrop.attach(chunk.base);
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder()
+                .append("PooledDrop@")
+                .append(Integer.toHexString(System.identityHashCode(this)))
+                .append('(')
+                .append(chunk)
+                .append(", ")
+                .append(baseDrop)
+                .append(')');
+        return sb.toString();
     }
 }


### PR DESCRIPTION
Motivation:
`PooledDrop` should be guarded by an `ArcDrop`. However, currently we didn't enforce it.

Modification:
Modified the `PooledDrop#fork()` to throw an `IllegalStateException`.

Modified the `PooledDrop#attach(obj)` to attach forked `chunk.baseDrop`

Modified the `ZeroingDrop#fork()` to throw `IllegalStateException`. (like `FreeAddress`)

Result:
`PooledDrop` enforces that it must be guarded by an `ArcDrop`.

Standardized ErrorType and message.

Forked `chunk.baseDrop` now attaches correctly.