### PR TITLE
Http types slow path checks (Fixes #13268) 

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpRequestDecoder.java
@@ -301,4 +301,15 @@ public class HttpRequestDecoder extends HttpObjectDecoder {
     protected boolean isDecodingRequest() {
         return true;
     }
+
+    @Override
+    protected boolean isContentAlwaysEmpty(final HttpMessage msg) {
+        // fast-path to save expensive O(n) checks; users can override createMessage
+        // and extends DefaultHttpRequest making implementing HttpResponse:
+        // this is why we cannot use instanceof DefaultHttpRequest here :(
+        if (msg.getClass() == DefaultHttpRequest.class) {
+            return false;
+        }
+        return super.isContentAlwaysEmpty(msg);
+    }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseEncoder.java
@@ -28,6 +28,10 @@ public class HttpResponseEncoder extends HttpObjectEncoder<HttpResponse> {
 
     @Override
     public boolean acceptOutboundMessage(Object msg) throws Exception {
+        // common fast path
+        if (msg.getClass() == DefaultFullHttpResponse.class) {
+            return true;
+        }
         return super.acceptOutboundMessage(msg) && !(msg instanceof HttpRequest);
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseEncoder.java
@@ -28,8 +28,14 @@ public class HttpResponseEncoder extends HttpObjectEncoder<HttpResponse> {
 
     @Override
     public boolean acceptOutboundMessage(Object msg) throws Exception {
-        // common fast path
-        if (msg.getClass() == DefaultFullHttpResponse.class) {
+        // JDK type checks vs non-implemented interfaces costs O(N), where
+        // N is the number of interfaces already implemented by the concrete type that's being tested.
+        // !(msg instanceof HttpRequest) is supposed to always be true (and meaning that msg isn't a HttpRequest),
+        // but sadly was part of the original behaviour of this method and cannot be removed.
+        // We place here exact checks vs DefaultHttpResponse and DefaultFullHttpResponse because bad users can
+        // extends such types and make them to implement HttpRequest (non-sense, but still possible).
+        final Class<?> msgClass = msg.getClass();
+        if (msgClass == DefaultFullHttpResponse.class || msgClass == DefaultHttpResponse.class) {
             return true;
         }
         return super.acceptOutboundMessage(msg) && !(msg instanceof HttpRequest);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtensionHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtensionHandler.java
@@ -116,7 +116,8 @@ public class WebSocketServerExtensionHandler extends ChannelDuplexHandler {
      *         }
      *     }
      * </pre>
-     * <strong>IMPORTANT:</strong>It already call {@code super.channelRead(ctx, request)} before returning.
+     * <strong>IMPORTANT:</strong>
+     * It already call {@code super.channelRead(ctx, request)} before returning.
      */
     @UnstableApi
     protected void onHttpRequestChannelRead(ChannelHandlerContext ctx, HttpRequest request) throws Exception {
@@ -197,7 +198,8 @@ public class WebSocketServerExtensionHandler extends ChannelDuplexHandler {
      *         }
      *     }
      * </pre>
-     * <strong>IMPORTANT:</strong>It already call {@code super.write(ctx, response, promise)} before returning.
+     * <strong>IMPORTANT:</strong>
+     * It already call {@code super.write(ctx, response, promise)} before returning.
      */
     @UnstableApi
     protected void onHttpResponseWrite(ChannelHandlerContext ctx, HttpResponse response, ChannelPromise promise)

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtensionHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtensionHandler.java
@@ -17,16 +17,22 @@ package io.netty.handler.codec.http.websocketx.extensions;
 
 import static io.netty.util.internal.ObjectUtil.checkNonEmpty;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.util.internal.UnstableApi;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -66,62 +72,138 @@ public class WebSocketServerExtensionHandler extends ChannelDuplexHandler {
 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-        if (msg instanceof HttpRequest) {
-            List<WebSocketServerExtension> validExtensionsList = null;
-            HttpRequest request = (HttpRequest) msg;
+        // fast-path
+        if (msg != LastHttpContent.EMPTY_LAST_CONTENT) {
+            if (msg instanceof DefaultHttpRequest) {
+                onHttpRequestChannelRead(ctx, (DefaultHttpRequest) msg);
+            } else if (msg instanceof HttpRequest) {
+                onHttpRequestChannelRead(ctx, (HttpRequest) msg);
+            } else {
+                super.channelRead(ctx, msg);
+            }
+        } else {
+            super.channelRead(ctx, msg);
+        }
+    }
 
-            if (WebSocketExtensionUtil.isWebsocketUpgrade(request.headers())) {
-                String extensionsHeader = request.headers().getAsString(HttpHeaderNames.SEC_WEBSOCKET_EXTENSIONS);
+    /**
+     * This is a method exposed to perform fail-fast checks of user-defined http types.<p>
+     * eg:<br>
+     * If the user has defined a specific {@link HttpRequest} type i.e.{@code CustomHttpRequest} and
+     * {@link #channelRead} can receive {@link LastHttpContent#EMPTY_LAST_CONTENT} {@code msg}
+     * types too, can override it like this:
+     * <pre>
+     *     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+     *         if (msg != LastHttpContent.EMPTY_LAST_CONTENT) {
+     *             if (msg instanceof CustomHttpRequest) {
+     *                 onHttpRequestChannelRead(ctx, (CustomHttpRequest) msg);
+     *             } else {
+     *                 // if it's handling other HttpRequest types it MUST use onHttpRequestChannelRead again
+     *                 // or have to delegate it to super.channelRead (that can perform redundant checks).
+     *                 // If msg is not implementing HttpRequest, it can call ctx.fireChannelRead(msg) on it
+     *                 // ...
+     *                 super.channelRead(ctx, msg);
+     *             }
+     *         } else {
+     *             // given that msg isn't a HttpRequest type we can just skip calling super.channelRead
+     *             ctx.fireChannelRead(msg);
+     *         }
+     *     }
+     * </pre>
+     * <strong>IMPORTANT:</strong>It already call {@code super.channelRead(ctx, request)} before returning.
+     */
+    @UnstableApi
+    protected void onHttpRequestChannelRead(ChannelHandlerContext ctx, HttpRequest request) throws Exception {
+        List<WebSocketServerExtension> validExtensionsList = null;
 
-                if (extensionsHeader != null) {
-                    List<WebSocketExtensionData> extensions =
-                            WebSocketExtensionUtil.extractExtensions(extensionsHeader);
-                    int rsv = 0;
+        if (WebSocketExtensionUtil.isWebsocketUpgrade(request.headers())) {
+            String extensionsHeader = request.headers().getAsString(HttpHeaderNames.SEC_WEBSOCKET_EXTENSIONS);
 
-                    for (WebSocketExtensionData extensionData : extensions) {
-                        Iterator<WebSocketServerExtensionHandshaker> extensionHandshakersIterator =
-                                extensionHandshakers.iterator();
-                        WebSocketServerExtension validExtension = null;
+            if (extensionsHeader != null) {
+                List<WebSocketExtensionData> extensions =
+                        WebSocketExtensionUtil.extractExtensions(extensionsHeader);
+                int rsv = 0;
 
-                        while (validExtension == null && extensionHandshakersIterator.hasNext()) {
-                            WebSocketServerExtensionHandshaker extensionHandshaker =
-                                    extensionHandshakersIterator.next();
-                            validExtension = extensionHandshaker.handshakeExtension(extensionData);
+                for (WebSocketExtensionData extensionData : extensions) {
+                    Iterator<WebSocketServerExtensionHandshaker> extensionHandshakersIterator =
+                            extensionHandshakers.iterator();
+                    WebSocketServerExtension validExtension = null;
+
+                    while (validExtension == null && extensionHandshakersIterator.hasNext()) {
+                        WebSocketServerExtensionHandshaker extensionHandshaker =
+                                extensionHandshakersIterator.next();
+                        validExtension = extensionHandshaker.handshakeExtension(extensionData);
+                    }
+
+                    if (validExtension != null && ((validExtension.rsv() & rsv) == 0)) {
+                        if (validExtensionsList == null) {
+                            validExtensionsList = new ArrayList<WebSocketServerExtension>(1);
                         }
-
-                        if (validExtension != null && ((validExtension.rsv() & rsv) == 0)) {
-                            if (validExtensionsList == null) {
-                                validExtensionsList = new ArrayList<WebSocketServerExtension>(1);
-                            }
-                            rsv = rsv | validExtension.rsv();
-                            validExtensionsList.add(validExtension);
-                        }
+                        rsv = rsv | validExtension.rsv();
+                        validExtensionsList.add(validExtension);
                     }
                 }
             }
-
-            if (validExtensionsList == null) {
-                validExtensionsList = Collections.emptyList();
-            }
-            validExtensions.offer(validExtensionsList);
         }
 
-        super.channelRead(ctx, msg);
+        if (validExtensionsList == null) {
+            validExtensionsList = Collections.emptyList();
+        }
+        validExtensions.offer(validExtensionsList);
+        super.channelRead(ctx, request);
     }
 
     @Override
     public void write(final ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
-        if (msg instanceof HttpResponse) {
-            List<WebSocketServerExtension> validExtensionsList = validExtensions.poll();
-            HttpResponse httpResponse = (HttpResponse) msg;
-            //checking the status is faster than looking at headers
-            //so we do this first
-            if (HttpResponseStatus.SWITCHING_PROTOCOLS.equals(httpResponse.status())) {
-                handlePotentialUpgrade(ctx, promise, httpResponse, validExtensionsList);
+        if (msg != Unpooled.EMPTY_BUFFER && !(msg instanceof ByteBuf)) {
+            if (msg instanceof DefaultHttpResponse) {
+                onHttpResponseWrite(ctx, (DefaultHttpResponse) msg, promise);
+            } else if (msg instanceof HttpResponse) {
+                onHttpResponseWrite(ctx, (HttpResponse) msg, promise);
+            } else {
+                super.write(ctx, msg, promise);
             }
+        } else {
+            super.write(ctx, msg, promise);
         }
+    }
 
-        super.write(ctx, msg, promise);
+    /**
+     * This is a method exposed to perform fail-fast checks of user-defined http types.<p>
+     * eg:<br>
+     * If the user has defined a specific {@link HttpResponse} type i.e.{@code CustomHttpResponse} and
+     * {@link #write} can receive {@link ByteBuf} {@code msg} types too, it can be overridden like this:
+     * <pre>
+     *     public void write(final ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+     *         if (msg != Unpooled.EMPTY_BUFFER && !(msg instanceof ByteBuf)) {
+     *             if (msg instanceof CustomHttpResponse) {
+     *                 onHttpResponseWrite(ctx, (CustomHttpResponse) msg, promise);
+     *             } else {
+     *                 // if it's handling other HttpResponse types it MUST use onHttpResponseWrite again
+     *                 // or have to delegate it to super.write (that can perform redundant checks).
+     *                 // If msg is not implementing HttpResponse, it can call ctx.write(msg, promise) on it
+     *                 // ...
+     *                 super.write(ctx, msg, promise);
+     *             }
+     *         } else {
+     *             // given that msg isn't a HttpResponse type we can just skip calling super.write
+     *             ctx.write(msg, promise);
+     *         }
+     *     }
+     * </pre>
+     * <strong>IMPORTANT:</strong>It already call {@code super.write(ctx, response, promise)} before returning.
+     */
+    @UnstableApi
+    protected void onHttpResponseWrite(ChannelHandlerContext ctx, HttpResponse response, ChannelPromise promise)
+            throws Exception {
+        List<WebSocketServerExtension> validExtensionsList = validExtensions.poll();
+        HttpResponse httpResponse = response;
+        //checking the status is faster than looking at headers
+        //so we do this first
+        if (HttpResponseStatus.SWITCHING_PROTOCOLS.equals(httpResponse.status())) {
+            handlePotentialUpgrade(ctx, promise, httpResponse, validExtensionsList);
+        }
+        super.write(ctx, response, promise);
     }
 
     private void handlePotentialUpgrade(final ChannelHandlerContext ctx,

--- a/microbench/src/main/java/io/netty/microbench/http/HttpRequestResponseBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/http/HttpRequestResponseBenchmark.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.microbench.http;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.CompositeByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpRequestDecoder;
+import io.netty.handler.codec.http.HttpResponseEncoder;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.handler.codec.http.websocketx.extensions.WebSocketExtensionData;
+import io.netty.handler.codec.http.websocketx.extensions.WebSocketServerExtension;
+import io.netty.handler.codec.http.websocketx.extensions.WebSocketServerExtensionHandler;
+import io.netty.handler.codec.http.websocketx.extensions.WebSocketServerExtensionHandshaker;
+import io.netty.microbench.util.AbstractMicrobenchmark;
+import io.netty.util.AsciiString;
+import io.netty.util.CharsetUtil;
+import io.netty.util.ReferenceCountUtil;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Thread)
+@Warmup(iterations = 10, time = 1)
+@Measurement(iterations = 10, time = 1)
+public class HttpRequestResponseBenchmark extends AbstractMicrobenchmark {
+
+    ByteBuf GET;
+    int readerIndex;
+    int writeIndex;
+    EmbeddedChannel nettyChannel;
+    @Param({ "true", "false" })
+    boolean websocket;
+
+    static class Alloc implements ByteBufAllocator {
+
+        private final ByteBuf buf = Unpooled.buffer();
+        private final int capacity = buf.capacity();
+
+        @Override
+        public ByteBuf buffer() {
+            buf.clear();
+            return buf;
+        }
+
+        @Override
+        public ByteBuf buffer(int initialCapacity) {
+            if (initialCapacity <= capacity) {
+                return buffer();
+            } else {
+                throw new IllegalArgumentException();
+            }
+        }
+
+        @Override
+        public ByteBuf buffer(int initialCapacity, int maxCapacity) {
+            if (initialCapacity <= capacity) {
+                return buffer();
+            } else {
+                throw new IllegalArgumentException();
+            }
+        }
+
+        @Override
+        public ByteBuf ioBuffer() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ByteBuf ioBuffer(int initialCapacity) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ByteBuf ioBuffer(int initialCapacity, int maxCapacity) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ByteBuf heapBuffer() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ByteBuf heapBuffer(int initialCapacity) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ByteBuf heapBuffer(int initialCapacity, int maxCapacity) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ByteBuf directBuffer() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ByteBuf directBuffer(int initialCapacity) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ByteBuf directBuffer(int initialCapacity, int maxCapacity) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CompositeByteBuf compositeBuffer() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CompositeByteBuf compositeBuffer(int maxNumComponents) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CompositeByteBuf compositeHeapBuffer() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CompositeByteBuf compositeHeapBuffer(int maxNumComponents) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CompositeByteBuf compositeDirectBuffer() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CompositeByteBuf compositeDirectBuffer(int maxNumComponents) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isDirectBufferPooled() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int calculateNewCapacity(int minNewCapacity, int maxCapacity) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @Setup
+    public void setup() {
+        HttpRequestDecoder httpRequestDecoder = new HttpRequestDecoder(
+                HttpRequestDecoder.DEFAULT_MAX_INITIAL_LINE_LENGTH, HttpRequestDecoder.DEFAULT_MAX_HEADER_SIZE,
+                HttpRequestDecoder.DEFAULT_MAX_CHUNK_SIZE, false);
+        HttpResponseEncoder httpResponseEncoder = new HttpResponseEncoder();
+        ChannelInboundHandlerAdapter inboundHandlerAdapter = new ChannelInboundHandlerAdapter() {
+
+            private final byte[] STATIC_PLAINTEXT = "Hello, World!".getBytes(CharsetUtil.UTF_8);
+            private final int STATIC_PLAINTEXT_LEN = STATIC_PLAINTEXT.length;
+            private final ByteBuf PLAINTEXT_CONTENT_BUFFER =
+                    Unpooled.unreleasableBuffer(Unpooled.directBuffer().writeBytes(STATIC_PLAINTEXT));
+            private final CharSequence PLAINTEXT_CLHEADER_VALUE = new AsciiString(String.valueOf(STATIC_PLAINTEXT_LEN));
+
+            private final CharSequence TYPE_PLAIN = new AsciiString("text/plain");
+            private final CharSequence SERVER_NAME = new AsciiString("Netty");
+            private final CharSequence CONTENT_TYPE_ENTITY = HttpHeaderNames.CONTENT_TYPE;
+            private final CharSequence DATE_ENTITY = HttpHeaderNames.DATE;
+            private final CharSequence CONTENT_LENGTH_ENTITY = HttpHeaderNames.CONTENT_LENGTH;
+            private final CharSequence SERVER_ENTITY = HttpHeaderNames.SERVER;
+
+            private final DateFormat FORMAT = new SimpleDateFormat("E, dd MMM yyyy HH:mm:ss z");
+            private final CharSequence date = new AsciiString(FORMAT.format(new Date()));
+
+            @Override
+            public void channelRead(ChannelHandlerContext ctx, Object o) {
+                // this is saving a slow type check on LastHttpContent vs HttpRequest
+                if (o == LastHttpContent.EMPTY_LAST_CONTENT) {
+                    return;
+                }
+                if (o.getClass() == DefaultHttpRequest.class) {
+                    writeResponse(ctx, PLAINTEXT_CONTENT_BUFFER.duplicate(), TYPE_PLAIN,
+                                  PLAINTEXT_CLHEADER_VALUE);
+                } else if (o instanceof HttpRequest) {
+                    try {
+                        // slow path: shouldn't happen here
+                        writeResponse(ctx, PLAINTEXT_CONTENT_BUFFER.duplicate(), TYPE_PLAIN, PLAINTEXT_CLHEADER_VALUE);
+                    } finally {
+                        ReferenceCountUtil.release(o);
+                    }
+                } else {
+                    ReferenceCountUtil.release(o);
+                }
+            }
+
+            @Override
+            public void channelReadComplete(ChannelHandlerContext ctx) {
+                ctx.flush();
+            }
+
+            private void writeResponse(ChannelHandlerContext ctx, ByteBuf buf, CharSequence contentType,
+                                       CharSequence contentLength) {
+                // Build the response object.
+                FullHttpResponse response =
+                        new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK, buf, false);
+                HttpHeaders headers = response.headers();
+                headers.set(CONTENT_TYPE_ENTITY, contentType);
+                headers.set(SERVER_ENTITY, SERVER_NAME);
+                headers.set(DATE_ENTITY, date);
+                headers.set(CONTENT_LENGTH_ENTITY, contentLength);
+                ctx.write(response, ctx.voidPromise());
+            }
+        };
+        if (websocket) {
+            nettyChannel = new EmbeddedChannel(httpRequestDecoder, httpResponseEncoder,
+                                               new WebSocketServerExtensionHandler(
+                                                       new WebSocketServerExtensionHandshaker() {
+                                                           @Override
+                                                           public WebSocketServerExtension handshakeExtension(
+                                                                   WebSocketExtensionData extensionData) {
+                                                               return null;
+                                                           }
+                                                       }), inboundHandlerAdapter);
+        } else {
+            nettyChannel = new EmbeddedChannel(httpRequestDecoder, httpResponseEncoder, inboundHandlerAdapter);
+        }
+        nettyChannel.config().setAllocator(new Alloc());
+        GET = Unpooled.unreleasableBuffer(Unpooled.copiedBuffer("GET / HTTP/1.1\r\n\r\n".getBytes()));
+        readerIndex = GET.readerIndex();
+        writeIndex = GET.writerIndex();
+    }
+
+    @Benchmark
+    public Object netty() {
+        GET.setIndex(readerIndex, writeIndex);
+        nettyChannel.writeInbound(GET);
+        return nettyChannel.outboundMessages().poll();
+    }
+}


### PR DESCRIPTION
Motivation:

Http encoders/decoders and websocket handlers perform slow type checks
i.e. O(N) search among all implemented interfaces for non-implemented interfaces.

Modifications:

Perform instance exact matches and/or class type check vs common used types, while exposing
unstable APIs to allow users to do the same, if necessary.

Result:

Better performance of Http pipeline with/without websocket handler.
Fixes https://github.com/netty/netty/issues/13261