### PR TITLE
Handle NullPointerException thrown from NetworkInterface.getNetworkIn…

### DIFF
--- a/common/src/main/java/io/netty/util/NetUtilInitializations.java
+++ b/common/src/main/java/io/netty/util/NetUtilInitializations.java
@@ -79,6 +79,12 @@ final class NetUtilInitializations {
             }
         } catch (SocketException e) {
             logger.warn("Failed to retrieve the list of available network interfaces", e);
+        } catch (NullPointerException e) {
+            if (!PlatformDependent.isAndroid()) {
+                throw e;
+            }
+            // Might happen on earlier version of Android.
+            // See https://developer.android.com/reference/java/net/NetworkInterface#getNetworkInterfaces()
         }
         return Collections.unmodifiableList(networkInterfaces);
     }


### PR DESCRIPTION
…terfaces() on android.

Motivation:

On earlier version of Android NetworkInterface.getNetworkInterfaces() might throw an NPE.

Modifications:

Catch NPE and only rethrow if not on Android.
