### PR TITLE
Illustrate the right way to send a GET request

### DIFF
--- a/example/src/main/java/io/netty/example/http/upload/HttpUploadClient.java
+++ b/example/src/main/java/io/netty/example/http/upload/HttpUploadClient.java
@@ -22,6 +22,7 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpHeaders;
@@ -187,7 +188,8 @@ public final class HttpUploadClient {
         );
 
         // send request
-        channel.writeAndFlush(request);
+        channel.write(request);
+        channel.writeAndFlush(DefaultLastHttpContent.EMPTY_LAST_CONTENT);
 
         // Wait for the server to close the connection.
         channel.closeFuture().sync();

--- a/example/src/main/java/io/netty/example/ocsp/OcspUtils.java
+++ b/example/src/main/java/io/netty/example/ocsp/OcspUtils.java
@@ -32,7 +32,7 @@ import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.ASN1Primitive;
 import org.bouncycastle.asn1.BERTags;
-import org.bouncycastle.asn1.DERTaggedObject;
+import org.bouncycastle.asn1.DLTaggedObject;
 import org.bouncycastle.asn1.DLSequence;
 import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.cert.ocsp.OCSPReq;
@@ -72,7 +72,7 @@ public final class OcspUtils {
         }
 
         DLSequence aiaSequence = (DLSequence) authorityInfoAccess;
-        DERTaggedObject taggedObject = findObject(aiaSequence, OCSP_RESPONDER_OID, DERTaggedObject.class);
+        DLTaggedObject taggedObject = findObject(aiaSequence, OCSP_RESPONDER_OID, DLTaggedObject.class);
         if (taggedObject == null) {
             return null;
         }


### PR DESCRIPTION
Motivation:
The way to sent a GET request in the HttpUploadClient is wrong,  because if just send a GET request without a following LastHttpContent, the pipeline will be blocked, and  we can't reuse the channel to send another http request. The Example works because the channel is closed. but the following post and multi request both sent a LastHttpContent, so the get request should do this too. 
This may mislead the user.
Modification:
Fix the problem described in the motivation.

Result:
Illustrate the right way to send a GET request
