### PR TITLE
Fire a PrematureChannelClosureException when Channel is closed while …

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/MessageAggregator.java
+++ b/codec/src/main/java/io/netty/handler/codec/MessageAggregator.java
@@ -431,6 +431,10 @@ public abstract class MessageAggregator<I, S, C extends ByteBufHolder, O extends
 
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        if (this.aggregating) {
+            ctx.fireExceptionCaught(
+                    new PrematureChannelClosureException("Channel closed while still aggregating message"));
+        }
         try {
             // release current message if it is not null as it may be a left-over
             super.channelInactive(ctx);

--- a/codec/src/main/java/io/netty/handler/codec/MessageAggregator.java
+++ b/codec/src/main/java/io/netty/handler/codec/MessageAggregator.java
@@ -105,7 +105,6 @@ public abstract class MessageAggregator<I, S, C extends ByteBufHolder, O extends
         // NOTE: It's tempting to make this check only if aggregating is false. There are however
         // side conditions in decode(...) in respect to large messages.
         if (isStartMessage(in)) {
-            aggregating = true;
             return true;
         } else {
             return aggregating && isContentMessage(in);
@@ -205,9 +204,8 @@ public abstract class MessageAggregator<I, S, C extends ByteBufHolder, O extends
 
     @Override
     protected void decode(final ChannelHandlerContext ctx, I msg, List<Object> out) throws Exception {
-        assert aggregating;
-
         if (isStartMessage(msg)) {
+            aggregating = true;
             handlingOversizedMessage = false;
             if (currentMessage != null) {
                 currentMessage.release();


### PR DESCRIPTION
…aggregating is still in progress

Motivation:

We should throw a PrematureChannelClosureException when the Channel is closed while aggregating is still in progress as otherwise the user will never know about this.

Modifications:

- Throw exception
- Add unit test

Result:

Fixes https://github.com/netty/netty/pull/13252
