### PR TITLE
Build on JDK20 during PR verification

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -161,9 +161,9 @@ jobs:
           - setup: linux-x86_64-java17
             docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-7.117.yaml build"
             docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-7.117.yaml run build-leak"
-          - setup: linux-x86_64-java19
-            docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-7.119.yaml build"
-            docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-7.119.yaml run build-leak"
+          - setup: linux-x86_64-java20
+            docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.20.yaml build"
+            docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.20.yaml run build-leak"
           - setup: linux-x86_64-java11-boringssl
             docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.111.yaml build"
             docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.111.yaml run build-leak-boringssl-static"

--- a/docker/docker-compose.centos-6.20.yaml
+++ b/docker/docker-compose.centos-6.20.yaml
@@ -1,0 +1,24 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: netty:centos-6-20
+    build:
+      args:
+        java_version : "20-zulu"
+
+  build:
+    image: netty:centos-6-20
+
+  build-leak:
+    image: netty:centos-6-20
+
+  build-boringssl-static:
+    image: netty:centos-6-20
+
+  build-leak-boringssl-static:
+    image: netty:centos-6-20
+
+  shell:
+    image: netty:centos-6-20

--- a/handler-proxy/pom.xml
+++ b/handler-proxy/pom.xml
@@ -76,6 +76,12 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
     </dependency>
+    <!-- For SelfSignedCertificate usage on JDK20+ -->
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <!-- Automatic native-image reflection metadata generation for handlers dependencies -->
     <dependency>

--- a/handler/src/main/java/io/netty/handler/ssl/util/OpenJdkSelfSignedCertGenerator.java
+++ b/handler/src/main/java/io/netty/handler/ssl/util/OpenJdkSelfSignedCertGenerator.java
@@ -157,6 +157,7 @@ final class OpenJdkSelfSignedCertGenerator {
         CERT_IMPL_GET_METHOD = certImplGetMethod;
         CERT_IMPL_SIGN_METHOD = certImplSignMethod;
     }
+
     @SuppressJava6Requirement(reason = "Usage guarded by dependency check")
     static String[] generate(String fqdn, KeyPair keypair, SecureRandom random, Date notBefore, Date notAfter,
                              String algorithm) throws Exception {

--- a/handler/src/main/java/io/netty/handler/ssl/util/OpenJdkSelfSignedCertGenerator.java
+++ b/handler/src/main/java/io/netty/handler/ssl/util/OpenJdkSelfSignedCertGenerator.java
@@ -16,10 +16,12 @@
 
 package io.netty.handler.ssl.util;
 
+import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SuppressJava6Requirement;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
 import sun.security.x509.AlgorithmId;
 import sun.security.x509.CertificateAlgorithmId;
-import sun.security.x509.CertificateIssuerName;
 import sun.security.x509.CertificateSerialNumber;
 import sun.security.x509.CertificateSubjectName;
 import sun.security.x509.CertificateValidity;
@@ -29,6 +31,11 @@ import sun.security.x509.X500Name;
 import sun.security.x509.X509CertImpl;
 import sun.security.x509.X509CertInfo;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Date;
 import java.math.BigInteger;
 import java.security.KeyPair;
@@ -42,41 +49,165 @@ import static io.netty.handler.ssl.util.SelfSignedCertificate.*;
  * Generates a self-signed certificate using {@code sun.security.x509} package provided by OpenJDK.
  */
 final class OpenJdkSelfSignedCertGenerator {
+    private static final InternalLogger logger =
+            InternalLoggerFactory.getInstance(OpenJdkSelfSignedCertGenerator.class);
+    private static final Method CERT_INFO_SET_METHOD;
+    private static final Constructor<?> ISSUER_NAME_CONSTRUCTOR;
+    private static final Constructor<X509CertImpl> CERT_IMPL_CONSTRUCTOR;
+    private static final Method CERT_IMPL_GET_METHOD;
+    private static final Method CERT_IMPL_SIGN_METHOD;
 
+    // Use reflection as JDK20+ did change things quite a bit.
+    static {
+        Method certInfoSetMethod = null;
+        Constructor<?> issuerNameConstructor = null;
+        Constructor<X509CertImpl> certImplConstructor = null;
+        Method certImplGetMethod = null;
+        Method certImplSignMethod = null;
+        try {
+            Object maybeCertInfoSetMethod = AccessController.doPrivileged(new PrivilegedAction<Object>() {
+                @Override
+                public Object run() {
+                    try {
+                        return X509CertInfo.class.getMethod("set", String.class, Object.class);
+                    } catch (Throwable cause) {
+                        return cause;
+                    }
+                }
+            });
+            if (maybeCertInfoSetMethod instanceof Method) {
+                certInfoSetMethod = (Method) maybeCertInfoSetMethod;
+            } else {
+                throw (Throwable) maybeCertInfoSetMethod;
+            }
+
+            Object maybeIssuerNameConstructor = AccessController.doPrivileged(new PrivilegedAction<Object>() {
+                @Override
+                public Object run() {
+                    try {
+                        Class<?> issuerName = Class.forName("sun.security.x509.CertificateIssuerName", false,
+                                PlatformDependent.getClassLoader(OpenJdkSelfSignedCertGenerator.class));
+                        return issuerName.getConstructor(X500Name.class);
+                    } catch (Throwable cause) {
+                        return cause;
+                    }
+                }
+            });
+            if (maybeIssuerNameConstructor instanceof Constructor) {
+                issuerNameConstructor = (Constructor<?>) maybeIssuerNameConstructor;
+            } else {
+                throw (Throwable) maybeIssuerNameConstructor;
+            }
+
+            Object maybeCertImplConstructor = AccessController.doPrivileged(new PrivilegedAction<Object>() {
+                @Override
+                public Object run() {
+                    try {
+                        return X509CertImpl.class.getConstructor(X509CertInfo.class);
+                    } catch (Throwable cause) {
+                        return cause;
+                    }
+                }
+            });
+            if (maybeCertImplConstructor instanceof Constructor) {
+                @SuppressWarnings("unchecked")
+                Constructor<X509CertImpl> constructor = (Constructor<X509CertImpl>) maybeCertImplConstructor;
+                certImplConstructor = constructor;
+            } else {
+                throw (Throwable) maybeCertImplConstructor;
+            }
+
+            Object maybeCertImplGetMethod = AccessController.doPrivileged(new PrivilegedAction<Object>() {
+                @Override
+                public Object run() {
+                    try {
+                        return X509CertImpl.class.getMethod("get", String.class);
+                    } catch (Throwable cause) {
+                        return cause;
+                    }
+                }
+            });
+            if (maybeCertImplGetMethod instanceof Method) {
+                certImplGetMethod = (Method) maybeCertImplGetMethod;
+            } else {
+                throw (Throwable) maybeCertImplGetMethod;
+            }
+
+            Object maybeCertImplSignMethod = AccessController.doPrivileged(new PrivilegedAction<Object>() {
+                @Override
+                public Object run() {
+                    try {
+                        return X509CertImpl.class.getMethod("sign", PrivateKey.class, String.class);
+                    } catch (Throwable cause) {
+                        return cause;
+                    }
+                }
+            });
+            if (maybeCertImplSignMethod instanceof Method) {
+                certImplSignMethod = (Method) maybeCertImplSignMethod;
+            } else {
+                throw (Throwable) maybeCertImplSignMethod;
+            }
+        } catch (Throwable cause) {
+            logger.debug(OpenJdkSelfSignedCertGenerator.class.getSimpleName() + " not supported", cause);
+        }
+        CERT_INFO_SET_METHOD = certInfoSetMethod;
+        ISSUER_NAME_CONSTRUCTOR = issuerNameConstructor;
+        CERT_IMPL_CONSTRUCTOR = certImplConstructor;
+        CERT_IMPL_GET_METHOD = certImplGetMethod;
+        CERT_IMPL_SIGN_METHOD = certImplSignMethod;
+    }
     @SuppressJava6Requirement(reason = "Usage guarded by dependency check")
     static String[] generate(String fqdn, KeyPair keypair, SecureRandom random, Date notBefore, Date notAfter,
                              String algorithm) throws Exception {
+        if (CERT_INFO_SET_METHOD == null || ISSUER_NAME_CONSTRUCTOR == null ||
+                CERT_IMPL_CONSTRUCTOR == null || CERT_IMPL_GET_METHOD == null || CERT_IMPL_SIGN_METHOD == null) {
+            throw new UnsupportedOperationException(
+                    OpenJdkSelfSignedCertGenerator.class.getSimpleName() + " not supported on the used JDK version");
+        }
         PrivateKey key = keypair.getPrivate();
 
         // Prepare the information required for generating an X.509 certificate.
         X509CertInfo info = new X509CertInfo();
         X500Name owner = new X500Name("CN=" + fqdn);
-        info.set(X509CertInfo.VERSION, new CertificateVersion(CertificateVersion.V3));
-        info.set(X509CertInfo.SERIAL_NUMBER, new CertificateSerialNumber(new BigInteger(64, random)));
+
+        CERT_INFO_SET_METHOD.invoke(info, X509CertInfo.VERSION, new CertificateVersion(CertificateVersion.V3));
+        CERT_INFO_SET_METHOD.invoke(info, X509CertInfo.SERIAL_NUMBER,
+                new CertificateSerialNumber(new BigInteger(64, random)));
         try {
-            info.set(X509CertInfo.SUBJECT, new CertificateSubjectName(owner));
-        } catch (CertificateException ignore) {
-            info.set(X509CertInfo.SUBJECT, owner);
+            CERT_INFO_SET_METHOD.invoke(info, X509CertInfo.SUBJECT, new CertificateSubjectName(owner));
+        } catch (InvocationTargetException ex) {
+            if (ex.getCause() instanceof CertificateException) {
+                CERT_INFO_SET_METHOD.invoke(info, X509CertInfo.SUBJECT, owner);
+            } else {
+                throw ex;
+            }
         }
         try {
-            info.set(X509CertInfo.ISSUER, new CertificateIssuerName(owner));
-        } catch (CertificateException ignore) {
-            info.set(X509CertInfo.ISSUER, owner);
+            CERT_INFO_SET_METHOD.invoke(info, X509CertInfo.ISSUER, ISSUER_NAME_CONSTRUCTOR.newInstance(owner));
+        } catch (InvocationTargetException ex) {
+            if (ex.getCause() instanceof CertificateException) {
+                CERT_INFO_SET_METHOD.invoke(info, X509CertInfo.ISSUER, owner);
+            } else {
+                throw ex;
+            }
         }
-        info.set(X509CertInfo.VALIDITY, new CertificateValidity(notBefore, notAfter));
-        info.set(X509CertInfo.KEY, new CertificateX509Key(keypair.getPublic()));
-        info.set(X509CertInfo.ALGORITHM_ID,
+        CERT_INFO_SET_METHOD.invoke(info, X509CertInfo.VALIDITY, new CertificateValidity(notBefore, notAfter));
+        CERT_INFO_SET_METHOD.invoke(info, X509CertInfo.KEY, new CertificateX509Key(keypair.getPublic()));
+        CERT_INFO_SET_METHOD.invoke(info, X509CertInfo.ALGORITHM_ID,
                 // sha256WithRSAEncryption
                 new CertificateAlgorithmId(AlgorithmId.get("1.2.840.113549.1.1.11")));
 
         // Sign the cert to identify the algorithm that's used.
-        X509CertImpl cert = new X509CertImpl(info);
-        cert.sign(key, algorithm.equalsIgnoreCase("EC") ? "SHA256withECDSA" : "SHA256withRSA");
+        X509CertImpl cert = CERT_IMPL_CONSTRUCTOR.newInstance(info);
+        CERT_IMPL_SIGN_METHOD.invoke(cert, key, algorithm.equalsIgnoreCase("EC") ? "SHA256withECDSA" : "SHA256withRSA");
 
         // Update the algorithm and sign again.
-        info.set(CertificateAlgorithmId.NAME + '.' + CertificateAlgorithmId.ALGORITHM, cert.get(X509CertImpl.SIG_ALG));
-        cert = new X509CertImpl(info);
-        cert.sign(key, algorithm.equalsIgnoreCase("EC") ? "SHA256withECDSA" : "SHA256withRSA");
+        CERT_INFO_SET_METHOD.invoke(info, CertificateAlgorithmId.NAME + ".algorithm",
+                CERT_IMPL_GET_METHOD.invoke(cert, "x509.algorithm"));
+        cert = CERT_IMPL_CONSTRUCTOR.newInstance(info);
+        CERT_IMPL_SIGN_METHOD.invoke(cert, key,
+                algorithm.equalsIgnoreCase("EC") ? "SHA256withECDSA" : "SHA256withRSA");
         cert.verify(keypair.getPublic());
 
         return newSelfSignedCertificate(fqdn, key, cert);

--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,30 @@
       </properties>
     </profile>
     <profile>
+      <id>java20</id>
+      <activation>
+        <jdk>20</jdk>
+      </activation>
+      <properties>
+        <!-- Not use alpn agent as Java11+ supports alpn out of the box -->
+        <argLine.alpnAgent />
+        <argLine.java9.extras />
+        <!-- Export some stuff which is used during our tests -->
+        <argLine.java9>--illegal-access=deny ${argLine.java9.extras}</argLine.java9>
+        <forbiddenapis.skip>true</forbiddenapis.skip>
+        <!-- 1.4.x does not work in Java10+ -->
+        <jboss.marshalling.version>2.0.5.Final</jboss.marshalling.version>
+        <!-- We need to use 1.8 as otherwise default methods are not picked up and so result in compile errors for
+             our EventExecutorGroup implementations
+        -->
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <!-- pax-exam does not work on latest Java12 EA 22 build -->
+        <skipOsgiTestsuite>true</skipOsgiTestsuite>
+        <revapi.skip>true</revapi.skip>
+      </properties>
+    </profile>
+    <profile>
       <id>java19</id>
       <activation>
         <jdk>19</jdk>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -114,6 +114,13 @@
       <artifactId>logback-classic</artifactId>
       <scope>compile</scope>
     </dependency>
+
+    <!-- For SelfSignedCertificate usage on JDK20+ -->
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
   <properties>

--- a/transport-blockhound-tests/pom.xml
+++ b/transport-blockhound-tests/pom.xml
@@ -95,6 +95,15 @@
         <argLine.common>-XX:+AllowRedefinitionToAddDeleteMethods</argLine.common>
       </properties>
     </profile>
+    <profile>
+      <id>java20</id>
+      <activation>
+        <jdk>20</jdk>
+      </activation>
+      <properties>
+        <argLine.common>-XX:+AllowRedefinitionToAddDeleteMethods</argLine.common>
+      </properties>
+    </profile>
   </profiles>
 
   <properties>

--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -419,6 +419,12 @@
       <artifactId>rerunner-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- For SelfSignedCertificate usage on JDK20+ -->
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
 

--- a/transport-native-kqueue/pom.xml
+++ b/transport-native-kqueue/pom.xml
@@ -644,6 +644,13 @@
       <classifier>${tcnative.classifier}</classifier>
       <scope>test</scope>
     </dependency>
+
+    <!-- For SelfSignedCertificate usage on JDK20+ -->
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
Motivation:

JDK20 was released so we should try to build with it for PRs

Modifications:

- Replace CI job that uses JDK19 with JDK20
- Add profiles for JDK20
- Use reflection in OpenJdkSelfSignedCertGenerator to be able to build on JDK20 as well

Result:

Verify PRs with latest JDK
