### PR TITLE
NetUtil should be able to handle -Djava.net.preferIPv6Addresses=syste…

### DIFF
--- a/common/src/main/java/io/netty/util/NetUtil.java
+++ b/common/src/main/java/io/netty/util/NetUtil.java
@@ -130,8 +130,7 @@ public final class NetUtil {
     /**
      * {@code true} if an IPv6 address should be preferred when a host has both an IPv4 address and an IPv6 address.
      */
-    private static final boolean IPV6_ADDRESSES_PREFERRED =
-            SystemPropertyUtil.getBoolean("java.net.preferIPv6Addresses", false);
+    private static final boolean IPV6_ADDRESSES_PREFERRED;
 
     /**
      * The logger being used by this class
@@ -139,8 +138,15 @@ public final class NetUtil {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(NetUtil.class);
 
     static {
+        String prefer = SystemPropertyUtil.get("java.net.preferIPv6Addresses", "false");
+        if ("true".equalsIgnoreCase(prefer.trim())) {
+            IPV6_ADDRESSES_PREFERRED = true;
+        } else {
+            // Let's just use false in this case as only true is "forcing" ipv6.
+            IPV6_ADDRESSES_PREFERRED = false;
+        }
         logger.debug("-Djava.net.preferIPv4Stack: {}", IPV4_PREFERRED);
-        logger.debug("-Djava.net.preferIPv6Addresses: {}", IPV6_ADDRESSES_PREFERRED);
+        logger.debug("-Djava.net.preferIPv6Addresses: {}", prefer);
 
         NETWORK_INTERFACES = NetUtilInitializations.networkInterfaces();
 


### PR DESCRIPTION
…m without logging an error

Motivation:

Since java11 its supported to use "system" as a value for -Djava.net.preferIPv6Addresses.

Modifications:

Just fallback to "false" if -Djava.net.preferIPv6Addresses is not "true" without logging an error

Result:

Fixes https://github.com/netty/netty/issues/13300
