### PR TITLE
A few more fix-ups after the logging changes in #13285

### DIFF
--- a/buffer-memory-segment/src/test/java/io/netty5/buffer/tests/EchoIT.java
+++ b/buffer-memory-segment/src/test/java/io/netty5/buffer/tests/EchoIT.java
@@ -31,9 +31,9 @@ import io.netty5.channel.nio.NioHandler;
 import io.netty5.channel.socket.SocketChannel;
 import io.netty5.channel.socket.nio.NioServerSocketChannel;
 import io.netty5.channel.socket.nio.NioSocketChannel;
+import io.netty5.handler.logging.LogLevel;
 import io.netty5.handler.logging.LoggingHandler;
 import org.junit.jupiter.api.Test;
-import org.slf4j.event.Level;
 
 import java.net.InetSocketAddress;
 
@@ -54,12 +54,12 @@ public class EchoIT {
                   .channel(NioServerSocketChannel.class)
                   .childOption(ChannelOption.BUFFER_ALLOCATOR, DefaultBufferAllocators.preferredAllocator())
                   .option(ChannelOption.SO_BACKLOG, 100)
-                  .handler(new LoggingHandler(Level.INFO))
+                  .handler(new LoggingHandler(LogLevel.INFO))
                   .childHandler(new ChannelInitializer<SocketChannel>() {
                       @Override
                       public void initChannel(SocketChannel ch) throws Exception {
                           ChannelPipeline p = ch.pipeline();
-                          p.addLast(new LoggingHandler(Level.INFO));
+                          p.addLast(new LoggingHandler(LogLevel.INFO));
                           p.addLast(serverHandler);
                       }
                   });
@@ -79,7 +79,7 @@ public class EchoIT {
                      @Override
                      public void initChannel(SocketChannel ch) throws Exception {
                          ChannelPipeline p = ch.pipeline();
-                         p.addLast(new LoggingHandler(Level.INFO));
+                         p.addLast(new LoggingHandler(LogLevel.INFO));
                          p.addLast(new EchoClientHandler());
                      }
                  });

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2FrameLogger.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2FrameLogger.java
@@ -19,6 +19,7 @@ import io.netty5.buffer.Buffer;
 import io.netty5.buffer.BufferUtil;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.http2.headers.Http2Headers;
+import io.netty5.handler.logging.LogLevel;
 import io.netty5.util.internal.UnstableApi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,20 +42,20 @@ public class Http2FrameLogger {
     private final Logger logger;
     private final Level level;
 
-    public Http2FrameLogger(Level level) {
+    public Http2FrameLogger(LogLevel level) {
         this(requireNonNull(level, "level"), LoggerFactory.getLogger(Http2FrameLogger.class));
     }
 
-    public Http2FrameLogger(Level level, String name) {
+    public Http2FrameLogger(LogLevel level, String name) {
         this(requireNonNull(level, "level"), LoggerFactory.getLogger(requireNonNull(name, "name")));
     }
 
-    public Http2FrameLogger(Level level, Class<?> clazz) {
+    public Http2FrameLogger(LogLevel level, Class<?> clazz) {
         this(requireNonNull(level, "level"), LoggerFactory.getLogger(requireNonNull(clazz, "clazz")));
     }
 
-    private Http2FrameLogger(Level level, Logger logger) {
-        this.level = level;
+    private Http2FrameLogger(LogLevel level, Logger logger) {
+        this.level = level.unwrap();
         this.logger = logger;
     }
 

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameCodecTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameCodecTest.java
@@ -30,6 +30,7 @@ import io.netty5.handler.codec.http.HttpVersion;
 import io.netty5.handler.codec.http2.Http2Exception.StreamException;
 import io.netty5.handler.codec.http2.Http2Stream.State;
 import io.netty5.handler.codec.http2.headers.Http2Headers;
+import io.netty5.handler.logging.LogLevel;
 import io.netty5.util.AbstractReferenceCounted;
 import io.netty5.util.AsciiString;
 import io.netty5.util.ReferenceCounted;
@@ -42,7 +43,6 @@ import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
-import org.slf4j.event.Level;
 
 import java.lang.reflect.Constructor;
 import java.net.InetSocketAddress;
@@ -121,7 +121,7 @@ public class Http2FrameCodecTest {
     private void setUp(Http2FrameCodecBuilder frameCodecBuilder, Http2Settings initialRemoteSettings) throws Exception {
         frameWriter = Http2TestUtil.mockedFrameWriter();
 
-        frameCodec = frameCodecBuilder.frameWriter(frameWriter).frameLogger(new Http2FrameLogger(Level.TRACE))
+        frameCodec = frameCodecBuilder.frameWriter(frameWriter).frameLogger(new Http2FrameLogger(LogLevel.TRACE))
                 .initialSettings(initialRemoteSettings).build();
         inboundHandler = new LastInboundHandler();
 

--- a/example/src/main/java/io/netty5/example/http2/helloworld/client/Http2ClientInitializer.java
+++ b/example/src/main/java/io/netty5/example/http2/helloworld/client/Http2ClientInitializer.java
@@ -40,7 +40,7 @@ import io.netty5.handler.ssl.SslContext;
 
 import java.net.InetSocketAddress;
 
-import static org.slf4j.event.Level.INFO;
+import static io.netty5.handler.logging.LogLevel.INFO;
 
 /**
  * Configures the client pipeline to support HTTP/2 frames.

--- a/example/src/main/java/io/netty5/example/http2/helloworld/server/HelloWorldHttp2HandlerBuilder.java
+++ b/example/src/main/java/io/netty5/example/http2/helloworld/server/HelloWorldHttp2HandlerBuilder.java
@@ -21,7 +21,7 @@ import io.netty5.handler.codec.http2.Http2ConnectionEncoder;
 import io.netty5.handler.codec.http2.Http2FrameLogger;
 import io.netty5.handler.codec.http2.Http2Settings;
 
-import static org.slf4j.event.Level.INFO;
+import static io.netty5.handler.logging.LogLevel.INFO;
 
 public final class HelloWorldHttp2HandlerBuilder
         extends AbstractHttp2ConnectionHandlerBuilder<HelloWorldHttp2Handler, HelloWorldHttp2HandlerBuilder> {

--- a/handler/src/main/java/io/netty5/handler/logging/LogLevel.java
+++ b/handler/src/main/java/io/netty5/handler/logging/LogLevel.java
@@ -83,13 +83,12 @@ public enum LogLevel {
     }
 
     /**
-     * For internal use only.
-     *
-     * <p/>Converts the specified {@link LogLevel} to its {@link Level} variant.
+     * Convert this specified {@link LogLevel} to the level-type Netty uses internally.
      *
      * @return the converted level.
      */
-    Level toInternalLevel() {
-        return internalLevel;
+    @SuppressWarnings("unchecked")
+    public <T> T unwrap() {
+        return (T) internalLevel;
     }
 }

--- a/handler/src/main/java/io/netty5/handler/logging/LoggingHandler.java
+++ b/handler/src/main/java/io/netty5/handler/logging/LoggingHandler.java
@@ -77,7 +77,7 @@ public class LoggingHandler implements ChannelHandler {
      * @param bufferFormat the ByteBuf format
      */
     public LoggingHandler(LogLevel level, BufferFormat bufferFormat) {
-        this.level = requireNonNull(level, "level").toInternalLevel();
+        this.level = requireNonNull(level, "level").unwrap();
         this.bufferFormat = requireNonNull(bufferFormat, "bufferFormat");
         logger = getLogger(getClass());
     }
@@ -111,7 +111,7 @@ public class LoggingHandler implements ChannelHandler {
      */
     public LoggingHandler(Class<?> clazz, LogLevel level, BufferFormat bufferFormat) {
         requireNonNull(clazz, "clazz");
-        this.level = requireNonNull(level, "level").toInternalLevel();
+        this.level = requireNonNull(level, "level").unwrap();
         this.bufferFormat = requireNonNull(bufferFormat, "bufferFormat");
         logger = getLogger(clazz);
     }
@@ -144,7 +144,7 @@ public class LoggingHandler implements ChannelHandler {
      */
     public LoggingHandler(String name, LogLevel level, BufferFormat bufferFormat) {
         requireNonNull(name, "name");
-        this.level = requireNonNull(level, "level").toInternalLevel();
+        this.level = requireNonNull(level, "level").unwrap();
         this.bufferFormat = requireNonNull(bufferFormat, "bufferFormat");
         logger = getLogger(name);
     }
@@ -169,7 +169,7 @@ public class LoggingHandler implements ChannelHandler {
     }
 
     /**
-     * Returns the {@link Level} that this handler uses to log
+     * Returns the {@link LogLevel} that this handler uses to log
      */
     public LogLevel level() {
         return LogLevel.from(level);

--- a/resolver-dns/src/main/java/io/netty5/resolver/dns/LoggingDnsQueryLifeCycleObserverFactory.java
+++ b/resolver-dns/src/main/java/io/netty5/resolver/dns/LoggingDnsQueryLifeCycleObserverFactory.java
@@ -16,9 +16,9 @@
 package io.netty5.resolver.dns;
 
 import io.netty5.handler.codec.dns.DnsQuestion;
+import io.netty5.handler.logging.LogLevel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.event.Level;
 
 import static java.util.Objects.requireNonNull;
 
@@ -32,20 +32,20 @@ import static java.util.Objects.requireNonNull;
 public final class LoggingDnsQueryLifeCycleObserverFactory implements DnsQueryLifecycleObserverFactory {
     private static final Logger DEFAULT_LOGGER = LoggerFactory.getLogger(LoggingDnsQueryLifeCycleObserverFactory.class);
     private final Logger logger;
-    private final Level level;
+    private final LogLevel level;
 
     /**
-     * Create {@link DnsQueryLifecycleObserver} instances that log events at the default {@link Level#DEBUG} level.
+     * Create {@link DnsQueryLifecycleObserver} instances that log events at the default {@link io.netty5.handler.logging.LogLevel#DEBUG} level.
      */
     public LoggingDnsQueryLifeCycleObserverFactory() {
-        this(Level.DEBUG);
+        this(LogLevel.DEBUG);
     }
 
     /**
      * Create {@link DnsQueryLifecycleObserver} instances that log events at the given log level.
      * @param level The log level to use for logging resolver events.
      */
-    public LoggingDnsQueryLifeCycleObserverFactory(Level level) {
+    public LoggingDnsQueryLifeCycleObserverFactory(LogLevel level) {
         this.level = requireNonNull(level, "level");
         logger = DEFAULT_LOGGER;
     }
@@ -56,7 +56,7 @@ public final class LoggingDnsQueryLifeCycleObserverFactory implements DnsQueryLi
      * @param classContext The class context for the logger to use.
      * @param level The log level to use for logging resolver events.
      */
-    public LoggingDnsQueryLifeCycleObserverFactory(Class<?> classContext, Level level) {
+    public LoggingDnsQueryLifeCycleObserverFactory(Class<?> classContext, LogLevel level) {
         this.level = requireNonNull(level, "level");
         logger = LoggerFactory.getLogger(requireNonNull(classContext, "classContext"));
     }
@@ -67,7 +67,7 @@ public final class LoggingDnsQueryLifeCycleObserverFactory implements DnsQueryLi
      * @param name The name for the logger to use.
      * @param level The log level to use for logging resolver events.
      */
-    public LoggingDnsQueryLifeCycleObserverFactory(String name, Level level) {
+    public LoggingDnsQueryLifeCycleObserverFactory(String name, LogLevel level) {
         this.level = requireNonNull(level, "level");
         logger = LoggerFactory.getLogger(requireNonNull(name, "name"));
     }

--- a/resolver-dns/src/main/java/io/netty5/resolver/dns/LoggingDnsQueryLifeCycleObserverFactory.java
+++ b/resolver-dns/src/main/java/io/netty5/resolver/dns/LoggingDnsQueryLifeCycleObserverFactory.java
@@ -35,7 +35,7 @@ public final class LoggingDnsQueryLifeCycleObserverFactory implements DnsQueryLi
     private final LogLevel level;
 
     /**
-     * Create {@link DnsQueryLifecycleObserver} instances that log events at the default {@link io.netty5.handler.logging.LogLevel#DEBUG} level.
+     * Create {@link DnsQueryLifecycleObserver} instances that log events at the default {@link LogLevel#DEBUG} level.
      */
     public LoggingDnsQueryLifeCycleObserverFactory() {
         this(LogLevel.DEBUG);

--- a/resolver-dns/src/main/java/io/netty5/resolver/dns/LoggingDnsQueryLifecycleObserver.java
+++ b/resolver-dns/src/main/java/io/netty5/resolver/dns/LoggingDnsQueryLifecycleObserver.java
@@ -17,6 +17,7 @@ package io.netty5.resolver.dns;
 
 import io.netty5.handler.codec.dns.DnsQuestion;
 import io.netty5.handler.codec.dns.DnsResponseCode;
+import io.netty5.handler.logging.LogLevel;
 import io.netty5.util.concurrent.Future;
 import org.slf4j.Logger;
 import org.slf4j.event.Level;
@@ -32,10 +33,10 @@ final class LoggingDnsQueryLifecycleObserver implements DnsQueryLifecycleObserve
     private final DnsQuestion question;
     private InetSocketAddress dnsServerAddress;
 
-    LoggingDnsQueryLifecycleObserver(DnsQuestion question, Logger logger, Level level) {
+    LoggingDnsQueryLifecycleObserver(DnsQuestion question, Logger logger, LogLevel level) {
         this.question = requireNonNull(question, "question");
         this.logger = requireNonNull(logger, "logger");
-        this.level = requireNonNull(level, "level");
+        this.level = requireNonNull(level, "level").unwrap();
     }
 
     @Override

--- a/testsuite-http2/src/main/java/io/netty5/testsuite/http2/HelloWorldHttp2HandlerBuilder.java
+++ b/testsuite-http2/src/main/java/io/netty5/testsuite/http2/HelloWorldHttp2HandlerBuilder.java
@@ -22,7 +22,7 @@ import io.netty5.handler.codec.http2.Http2ConnectionEncoder;
 import io.netty5.handler.codec.http2.Http2FrameLogger;
 import io.netty5.handler.codec.http2.Http2Settings;
 
-import static org.slf4j.event.Level.INFO;
+import static io.netty5.handler.logging.LogLevel.INFO;
 
 public final class HelloWorldHttp2HandlerBuilder
         extends AbstractHttp2ConnectionHandlerBuilder<HelloWorldHttp2Handler, HelloWorldHttp2HandlerBuilder> {


### PR DESCRIPTION
Motivation:
The is _a lot_ going on in #13285, and we missed that we exposed the SLF4J level in a couple of places. We also _somehow_ missed that we broke compilation of EchoIT in the buffer-memory-segment module.

Modification:
Replace the remaining places that exposed SLF4J Level to the public API, and fix the compilation.

Result:
No more left-overs to clean up after #13285