### PR TITLE
Introduce Http2MultiplexActiveStreamsException that can be used to pr…

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexActiveStreamsException.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexActiveStreamsException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http2;
+
+/**
+ * {@link Exception} that can be used to wrap some {@link Throwable} and fire it through the pipeline.
+ * The {@link Http2MultiplexHandler} will unwrap the original {@link Throwable} and fire it to all its
+ * active {@link Http2StreamChannel}.
+ */
+public final class Http2MultiplexActiveStreamsException extends Exception {
+
+    public Http2MultiplexActiveStreamsException(Throwable cause) {
+        super(cause);
+    }
+
+    @Override
+    public Throwable fillInStackTrace() {
+        return this;
+    }
+}

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
@@ -161,7 +161,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
                 any(ByteBuf.class), any(ChannelPromise.class));
     }
 
-    private Http2StreamChannel newInboundStream(int streamId, boolean endStream, final ChannelHandler childHandler) {
+    Http2StreamChannel newInboundStream(int streamId, boolean endStream, final ChannelHandler childHandler) {
         return newInboundStream(streamId, endStream, null, childHandler);
     }
 


### PR DESCRIPTION
…opagate an error to all active streams

Motivation:

There might be a desire to fire an exception to all the active streams. This is currently harder to do then it should be as the user needs to keep track of the active streams.

Modifications:

- Add Http2MultiplexActiveStreamsException which can be used to wrap an exception which should be fired to all the active streams by Http2MultiplexHandler
- Add unit tests

Result:

Alternative solution for https://github.com/netty/netty/pull/12830. Thanks @yawkat

