### PR TITLE
Close EPoll file descriptors during CRaC snapshotting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -604,6 +604,7 @@
     <conscrypt.artifactId>conscrypt-openjdk-uber</conscrypt.artifactId>
     <conscrypt.version>2.5.2</conscrypt.version>
     <conscrypt.classifier />
+    <crac.version>0.1.3</crac.version>
     <jni.classifier>${os.detected.name}-${os.detected.arch}</jni.classifier>
     <logging.config>${project.basedir}/../common/src/test/resources/logback-test.xml</logging.config>
     <logging.logLevel>debug</logging.logLevel>

--- a/transport-classes-epoll/pom.xml
+++ b/transport-classes-epoll/pom.xml
@@ -51,6 +51,11 @@
       <artifactId>netty-transport-native-unix-common</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.github.crac</groupId>
+      <artifactId>org-crac</artifactId>
+      <version>${crac.version}</version>
+    </dependency>
   </dependencies>
 
 


### PR DESCRIPTION
Motivation:

This change intends to support an application using Netty with native epoll (e.g. Quarkus app) to perform the Checkpoint and Restore on JVM implementing this, specifically using [OpenJDK CRaC](https://github.com/openjdk/crac/tree/crac) or future versions of OpenJDK. Package org.crac is a facade that either forwards the invocation to actual implementation or provides a no-op implementation.

Modification:

The biggest risk factor here is that formerly final fields with file descriptors can change; theoretically this could affect performance in absence of checkpoint/restore process. However most likely a modern JVM is smart enough to assume that the field does not change, and optimistically consider it constant anyway.

Result:
    
File descriptors are closed before checkpoint and re-opened after restore. Eventloop thread is blocked during the snapshotting process to avoid using closed FDs.
