### PR TITLE
`StacklessSSLHandshakeException`: add a short stack-trace

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -1068,8 +1068,9 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
 
         // Add a supressed exception if the handshake was not completed yet.
         if (isStateSet(STATE_HANDSHAKE_STARTED) && !handshakePromise.isDone()) {
-            ThrowableUtil.addSuppressed(exception,
-                    new StacklessSSLHandshakeException("Connection closed while SSL/TLS handshake was in progress"));
+            ThrowableUtil.addSuppressed(exception, StacklessSSLHandshakeException.newInstance(
+                    "Connection closed while SSL/TLS handshake was in progress",
+                    SslHandler.class, "channelInactive"));
         }
 
         // Make sure to release SSLEngine,

--- a/handler/src/main/java/io/netty/handler/ssl/StacklessSSLHandshakeException.java
+++ b/handler/src/main/java/io/netty/handler/ssl/StacklessSSLHandshakeException.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.ssl;
 
+import io.netty.util.internal.ThrowableUtil;
+
 import javax.net.ssl.SSLHandshakeException;
 
 /**
@@ -24,13 +26,7 @@ final class StacklessSSLHandshakeException extends SSLHandshakeException {
 
     private static final long serialVersionUID = -1244781947804415549L;
 
-    /**
-     * Constructs an exception reporting an error found by
-     * an SSL subsystem during handshaking.
-     *
-     * @param reason describes the problem.
-     */
-    StacklessSSLHandshakeException(String reason) {
+    private StacklessSSLHandshakeException(String reason) {
         super(reason);
     }
 
@@ -39,5 +35,12 @@ final class StacklessSSLHandshakeException extends SSLHandshakeException {
         // This is a performance optimization to not fill in the
         // stack trace as this is a stackless exception.
         return this;
+    }
+
+    /**
+     * Creates a new {@link StacklessSSLHandshakeException} which has the origin of the given {@link Class} and method.
+     */
+    static StacklessSSLHandshakeException newInstance(String reason, Class<?> clazz, String method) {
+        return ThrowableUtil.unknownStackTrace(new StacklessSSLHandshakeException(reason), clazz, method);
     }
 }


### PR DESCRIPTION
Motivation:

Currently, `StacklessSSLHandshakeException` doesn't have any stack-trace which makes it harder to understand where it comes from.

Modifications:

- Add one-line stack-trace using `ThrowableUtil.unknownStackTrace` utility;

Result:

Similar to `StacklessClosedChannelException`,
`StacklessSSLHandshakeException` always has one-line stack-trace to indicate where it originated.