### PR TITLE
Handle EHOSTUNREACH errors in io.netty.channel.unix.Errors (#13317)

### DIFF
--- a/transport-native-unix-common/src/main/c/netty_unix_errors.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_errors.c
@@ -188,6 +188,10 @@ static jint netty_unix_errors_errorENETUNREACH(JNIEnv* env, jclass clazz) {
     return ENETUNREACH;
 }
 
+static jint netty_unix_errors_errorEHOSTUNREACH(JNIEnv* env, jclass clazz) {
+    return EHOSTUNREACH;
+}
+
 static jstring netty_unix_errors_strError(JNIEnv* env, jclass clazz, jint error) {
     return (*env)->NewStringUTF(env, strerror(error));
 }
@@ -207,6 +211,7 @@ static const JNINativeMethod statically_referenced_fixed_method_table[] = {
   { "errorEISCONN", "()I", (void *) netty_unix_errors_errorEISCONN },
   { "errorEALREADY", "()I", (void *) netty_unix_errors_errorEALREADY },
   { "errorENETUNREACH", "()I", (void *) netty_unix_errors_errorENETUNREACH },
+  { "errorEHOSTUNREACH", "()I", (void *) netty_unix_errors_errorEHOSTUNREACH },
   { "strError", "(I)Ljava/lang/String;", (void *) netty_unix_errors_strError }
 };
 static const jint statically_referenced_fixed_method_table_size = sizeof(statically_referenced_fixed_method_table) / sizeof(statically_referenced_fixed_method_table[0]);

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/Errors.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/Errors.java
@@ -36,6 +36,7 @@ import static io.netty.channel.unix.ErrorsStaticallyReferencedJniMethods.errnoEP
 import static io.netty.channel.unix.ErrorsStaticallyReferencedJniMethods.errnoEWOULDBLOCK;
 import static io.netty.channel.unix.ErrorsStaticallyReferencedJniMethods.errorEALREADY;
 import static io.netty.channel.unix.ErrorsStaticallyReferencedJniMethods.errorECONNREFUSED;
+import static io.netty.channel.unix.ErrorsStaticallyReferencedJniMethods.errorEHOSTUNREACH;
 import static io.netty.channel.unix.ErrorsStaticallyReferencedJniMethods.errorEISCONN;
 import static io.netty.channel.unix.ErrorsStaticallyReferencedJniMethods.errorENETUNREACH;
 import static io.netty.channel.unix.ErrorsStaticallyReferencedJniMethods.strError;
@@ -58,6 +59,7 @@ public final class Errors {
     public static final int ERROR_EISCONN_NEGATIVE = -errorEISCONN();
     public static final int ERROR_EALREADY_NEGATIVE = -errorEALREADY();
     public static final int ERROR_ENETUNREACH_NEGATIVE = -errorENETUNREACH();
+    public static final int ERROR_EHOSTUNREACH_NEGATIVE = -errorEHOSTUNREACH();
 
     /**
      * Holds the mappings for errno codes to String messages.
@@ -152,7 +154,7 @@ public final class Errors {
     }
 
     private static IOException newConnectException0(String method, int err) {
-        if (err == ERROR_ENETUNREACH_NEGATIVE) {
+        if (err == ERROR_ENETUNREACH_NEGATIVE || err == ERROR_EHOSTUNREACH_NEGATIVE) {
             return new NoRouteToHostException();
         }
         if (err == ERROR_EISCONN_NEGATIVE) {

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/ErrorsStaticallyReferencedJniMethods.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/ErrorsStaticallyReferencedJniMethods.java
@@ -42,5 +42,6 @@ final class ErrorsStaticallyReferencedJniMethods {
     static native int errorEISCONN();
     static native int errorEALREADY();
     static native int errorENETUNREACH();
+    static native int errorEHOSTUNREACH();
     static native String strError(int err);
 }


### PR DESCRIPTION
Fixes #13317 