### PR TITLE
Add support for local and remote addresses on the server for child channels when UDS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1261,6 +1261,18 @@
                   <annotation>@io.netty.channel.ChannelHandlerMask.Skip</annotation>
                   <justification>No change in compatibility</justification>
                 </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.finalMethodAddedToNonFinalClass</code>
+                  <new>method io.netty.channel.unix.DomainSocketAddress io.netty.channel.unix.Socket::localDomainSocketAddress()</new>
+                  <justification>Acceptable incompatibility for required change</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.finalMethodAddedToNonFinalClass</code>
+                  <new>method io.netty.channel.unix.DomainSocketAddress io.netty.channel.unix.Socket::remoteDomainSocketAddress()</new>
+                  <justification>Acceptable incompatibility for required change</justification>
+                </item>
               </differences>
             </revapi.differences>
           </analysisConfiguration>

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketAddressesTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketAddressesTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.testsuite.transport.socket;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.util.concurrent.ImmediateEventExecutor;
+import io.netty.util.concurrent.Promise;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
+
+import java.net.SocketAddress;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public abstract class SocketAddressesTest extends AbstractSocketTest {
+
+    @Test
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    public void testAddresses(TestInfo testInfo) throws Throwable {
+        run(testInfo, new Runner<ServerBootstrap, Bootstrap>() {
+            @Override
+            public void run(ServerBootstrap serverBootstrap, Bootstrap bootstrap) throws Throwable {
+                testAddresses(serverBootstrap, bootstrap);
+            }
+        });
+    }
+
+    protected abstract void assertAddress(SocketAddress address);
+
+    private void testAddresses(ServerBootstrap sb, Bootstrap cb) throws Throwable {
+        Channel serverChannel = null;
+        Channel clientChannel = null;
+        try {
+            final Promise<SocketAddress> localAddressPromise = ImmediateEventExecutor.INSTANCE.newPromise();
+            final Promise<SocketAddress> remoteAddressPromise = ImmediateEventExecutor.INSTANCE.newPromise();
+            serverChannel = sb.childHandler(new ChannelInboundHandlerAdapter() {
+                @Override
+                public void channelActive(ChannelHandlerContext ctx) {
+                    localAddressPromise.setSuccess(ctx.channel().localAddress());
+                    remoteAddressPromise.setSuccess(ctx.channel().remoteAddress());
+                }
+            }).bind().syncUninterruptibly().channel();
+
+            clientChannel = cb.handler(new ChannelInboundHandlerAdapter()).register().syncUninterruptibly().channel();
+
+            assertNull(clientChannel.localAddress());
+            assertNull(clientChannel.remoteAddress());
+
+            clientChannel.connect(serverChannel.localAddress(), newSocketAddress()).syncUninterruptibly().channel();
+
+            assertAddress(clientChannel.localAddress());
+            assertAddress(clientChannel.remoteAddress());
+
+            assertAddress(localAddressPromise.get());
+            assertAddress(remoteAddressPromise.get());
+        } finally {
+            if (clientChannel != null) {
+                clientChannel.close().syncUninterruptibly();
+            }
+            if (serverChannel != null) {
+                serverChannel.close().syncUninterruptibly();
+            }
+        }
+    }
+}

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannel.java
@@ -41,7 +41,7 @@ public final class EpollDomainSocketChannel extends AbstractEpollStreamChannel i
     }
 
     EpollDomainSocketChannel(Channel parent, FileDescriptor fd) {
-        super(parent, new LinuxSocket(fd.intValue()));
+        this(parent, new LinuxSocket(fd.intValue()));
     }
 
     public EpollDomainSocketChannel(int fd) {
@@ -50,6 +50,8 @@ public final class EpollDomainSocketChannel extends AbstractEpollStreamChannel i
 
     public EpollDomainSocketChannel(Channel parent, LinuxSocket fd) {
         super(parent, fd);
+        local = fd.localDomainSocketAddress();
+        remote = fd.remoteDomainSocketAddress();
     }
 
     public EpollDomainSocketChannel(int fd, boolean active) {

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainSocketChannel.java
@@ -47,6 +47,8 @@ public final class KQueueDomainSocketChannel extends AbstractKQueueStreamChannel
 
     KQueueDomainSocketChannel(Channel parent, BsdSocket fd) {
         super(parent, fd, true);
+        local = fd.localDomainSocketAddress();
+        remote = fd.remoteDomainSocketAddress();
     }
 
     @Override

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketAddressesTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketAddressesTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.epoll;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.unix.DomainSocketAddress;
+import io.netty.testsuite.transport.TestsuitePermutation;
+import io.netty.testsuite.transport.socket.SocketAddressesTest;
+
+import java.net.SocketAddress;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class EpollDomainSocketAddressesTest extends SocketAddressesTest {
+
+    @Override
+    protected SocketAddress newSocketAddress() {
+        return EpollSocketTestPermutation.newDomainSocketAddress();
+    }
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return EpollSocketTestPermutation.INSTANCE.domainSocket();
+    }
+
+    @Override
+    protected void assertAddress(SocketAddress address) {
+        assertNotNull(((DomainSocketAddress) address).path());
+    }
+}

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketAddressesTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketAddressesTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.epoll;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.testsuite.transport.TestsuitePermutation;
+import io.netty.testsuite.transport.socket.SocketAddressesTest;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EpollSocketAddressesTest extends SocketAddressesTest {
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return EpollSocketTestPermutation.INSTANCE.socketWithFastOpen();
+    }
+
+    @Override
+    protected void assertAddress(SocketAddress address) {
+        assertTrue(((InetSocketAddress) address).getPort() > 0);
+        assertFalse(((InetSocketAddress) address).getAddress().isAnyLocalAddress());
+    }
+}

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDomainSocketAddressesTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDomainSocketAddressesTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.kqueue;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.unix.DomainSocketAddress;
+import io.netty.testsuite.transport.TestsuitePermutation;
+import io.netty.testsuite.transport.socket.SocketAddressesTest;
+
+import java.net.SocketAddress;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class KQueueDomainSocketAddressesTest extends SocketAddressesTest {
+
+    @Override
+    protected SocketAddress newSocketAddress() {
+        return KQueueSocketTestPermutation.newSocketAddress();
+    }
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return KQueueSocketTestPermutation.INSTANCE.domainSocket();
+    }
+
+    @Override
+    protected void assertAddress(SocketAddress address) {
+        assertNotNull(((DomainSocketAddress) address).path());
+    }
+}

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketAddressesTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketAddressesTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.kqueue;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.testsuite.transport.TestsuitePermutation;
+import io.netty.testsuite.transport.socket.SocketAddressesTest;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class KQueueSocketAddressesTest extends SocketAddressesTest {
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return KQueueSocketTestPermutation.INSTANCE.socket();
+    }
+
+    @Override
+    protected void assertAddress(SocketAddress address) {
+        assertTrue(((InetSocketAddress) address).getPort() > 0);
+        assertFalse(((InetSocketAddress) address).getAddress().isAnyLocalAddress());
+    }
+}

--- a/transport-native-unix-common/src/main/c/netty_unix_socket.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_socket.c
@@ -140,6 +140,18 @@ static jobject createDomainDatagramSocketAddress(JNIEnv* env, const struct socka
     return obj;
 }
 
+static jbyteArray netty_unix_socket_createDomainSocketAddressArray(JNIEnv* env, const struct sockaddr_storage* addr) {
+    struct sockaddr_un* s = (struct sockaddr_un*) addr;
+    int pathLength = strlen(s->sun_path);
+    jbyteArray pathBytes = (*env)->NewByteArray(env, pathLength);
+    if (pathBytes == NULL) {
+        return NULL;
+    }
+
+    (*env)->SetByteArrayRegion(env, pathBytes, 0, pathLength, (jbyte*) &s->sun_path);
+    return pathBytes;
+}
+
 static jsize addressLength(const struct sockaddr_storage* addr) {
     int len = netty_unix_socket_ipAddressLength(addr);
     if (len == 4) {
@@ -671,6 +683,15 @@ static jbyteArray netty_unix_socket_remoteAddress(JNIEnv* env, jclass clazz, jin
     return netty_unix_socket_createInetSocketAddressArray(env, &addr);
 }
 
+static jbyteArray netty_unix_socket_remoteDomainSocketAddress(JNIEnv* env, jclass clazz, jint fd) {
+    struct sockaddr_storage addr;
+    socklen_t len = sizeof(addr);
+    if (getpeername(fd, (struct sockaddr*) &addr, &len) == -1) {
+        return NULL;
+    }
+    return netty_unix_socket_createDomainSocketAddressArray(env, &addr);
+}
+
 static jbyteArray netty_unix_socket_localAddress(JNIEnv* env, jclass clazz, jint fd) {
     struct sockaddr_storage addr;
     socklen_t len = sizeof(addr);
@@ -678,6 +699,15 @@ static jbyteArray netty_unix_socket_localAddress(JNIEnv* env, jclass clazz, jint
         return NULL;
     }
     return netty_unix_socket_createInetSocketAddressArray(env, &addr);
+}
+
+static jbyteArray netty_unix_socket_localDomainSocketAddress(JNIEnv* env, jclass clazz, jint fd) {
+    struct sockaddr_storage addr;
+    socklen_t len = sizeof(addr);
+    if (getsockname(fd, (struct sockaddr*) &addr, &len) == -1) {
+        return NULL;
+    }
+    return netty_unix_socket_createDomainSocketAddressArray(env, &addr);
 }
 
 static jint netty_unix_socket_newSocketDgramFd(JNIEnv* env, jclass clazz, jboolean ipv6) {
@@ -1152,6 +1182,8 @@ static const JNINativeMethod fixed_method_table[] = {
   { "accept", "(I[B)I", (void *) netty_unix_socket_accept },
   { "remoteAddress", "(I)[B", (void *) netty_unix_socket_remoteAddress },
   { "localAddress", "(I)[B", (void *) netty_unix_socket_localAddress },
+  { "remoteDomainSocketAddress", "(I)[B", (void *) netty_unix_socket_remoteDomainSocketAddress },
+  { "localDomainSocketAddress", "(I)[B", (void *) netty_unix_socket_localDomainSocketAddress },
   { "newSocketDgramFd", "(Z)I", (void *) netty_unix_socket_newSocketDgramFd },
   { "newSocketStreamFd", "(Z)I", (void *) netty_unix_socket_newSocketStreamFd },
   { "newSocketDomainFd", "()I", (void *) netty_unix_socket_newSocketDomainFd },

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/Socket.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/Socket.java
@@ -414,11 +414,21 @@ public class Socket extends FileDescriptor {
         return addr == null ? null : address(addr, 0, addr.length);
     }
 
+    public final DomainSocketAddress remoteDomainSocketAddress() {
+        byte[] addr = remoteDomainSocketAddress(fd);
+        return addr == null ? null : new DomainSocketAddress(new String(addr));
+    }
+
     public final InetSocketAddress localAddress() {
         byte[] addr = localAddress(fd);
         // addr may be null if getpeername failed.
         // See https://github.com/netty/netty/issues/3328
         return addr == null ? null : address(addr, 0, addr.length);
+    }
+
+    public final DomainSocketAddress localDomainSocketAddress() {
+        byte[] addr = localDomainSocketAddress(fd);
+        return addr == null ? null : new DomainSocketAddress(new String(addr));
     }
 
     public final int getReceiveBufferSize() throws IOException {
@@ -633,7 +643,9 @@ public class Socket extends FileDescriptor {
     private static native int accept(int fd, byte[] addr);
 
     private static native byte[] remoteAddress(int fd);
+    private static native byte[] remoteDomainSocketAddress(int fd);
     private static native byte[] localAddress(int fd);
+    private static native byte[] localDomainSocketAddress(int fd);
 
     private static native int send(int fd, ByteBuffer buf, int pos, int limit);
     private static native int sendAddress(int fd, long address, int pos, int limit);


### PR DESCRIPTION
Motivation:
Local and remote addresses are not available on the server for child channels when Unix Domain Sockets is used.
There are use cases where one may need this information in order to collect metrics per local or remote addresses.

Modifications:
- Add JNI code for obtaining local/remote address
- When creating a child channel initialise the local/remote addresses.
- Add junit tests

Result:
Local and remote addresses are now available on the server for child channels when Unix Domain Sockets is used.
