### PR TITLE
Add missing dependency on jctools-core in microbench/pom.xml

### DIFF
--- a/microbench/pom.xml
+++ b/microbench/pom.xml
@@ -208,6 +208,11 @@
       <classifier>${tcnative.classifier}</classifier>
       <optional>false</optional>
     </dependency>
+    <dependency>
+      <groupId>org.jctools</groupId>
+      <artifactId>jctools-core</artifactId>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
Motivation:

#13220  seems to have introduced a build/compile failure because of a missing Maven dependency on `jctools-core`. Adding this dependency to `microbench/pom.xml` fixes the compile failure of the `RecyclerBenchmark` class.

Modification:

Added the following depencency to `microbench/pom.xml`:

```xml
<dependency>
  <groupId>org.jctools</groupId>
  <artifactId>jctools-core</artifactId>
  <scope>compile</scope>
</dependency>
```

Result:

Build is successful.