### PR TITLE
Deprecates LazyRunnable

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutor.java
@@ -187,7 +187,7 @@ public abstract class AbstractEventExecutor extends AbstractExecutorService impl
     }
 
     /**
-     *  @deprecated overrides {@link SingleThreadEventExecutor#wakesUpForTask} to re-create this behaviour
+     *  @deprecated override {@link SingleThreadEventExecutor#wakesUpForTask} to re-create this behaviour
      *
      */
     @Deprecated

--- a/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutor.java
@@ -177,25 +177,19 @@ public abstract class AbstractEventExecutor extends AbstractExecutorService impl
     /**
      * Like {@link #execute(Runnable)} but does not guarantee the task will be run until either
      * a non-lazy task is executed or the executor is shut down.
-     *
-     * This is equivalent to submitting a {@link AbstractEventExecutor.LazyRunnable} to
-     * {@link #execute(Runnable)} but for an arbitrary {@link Runnable}.
-     *
+     * <p>
      * The default implementation just delegates to {@link #execute(Runnable)}.
+     * </p>
      */
     @UnstableApi
     public void lazyExecute(Runnable task) {
-        lazyExecute0(task);
-    }
-
-    private void lazyExecute0(@Schedule Runnable task) {
         execute(task);
     }
 
     /**
-     * Marker interface for {@link Runnable} to indicate that it should be queued for execution
-     * but does not need to run immediately.
+     *  @deprecated overrides {@link SingleThreadEventExecutor#wakesUpForTask} to re-create this behaviour
+     *
      */
-    @UnstableApi
+    @Deprecated
     public interface LazyRunnable extends Runnable { }
 }

--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -824,7 +824,7 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
 
     private void execute0(@Schedule Runnable task) {
         ObjectUtil.checkNotNull(task, "task");
-        execute(task, !(task instanceof LazyRunnable) && wakesUpForTask(task));
+        execute(task, wakesUpForTask(task));
     }
 
     private void lazyExecute0(@Schedule Runnable task) {
@@ -917,7 +917,7 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
     }
 
     /**
-     * @deprecated use {@link AbstractEventExecutor.LazyRunnable}
+     * @deprecated overrides {@link SingleThreadEventExecutor#wakesUpForTask} to re-create this behaviour
      */
     @Deprecated
     protected interface NonWakeupRunnable extends LazyRunnable { }

--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -917,7 +917,7 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
     }
 
     /**
-     * @deprecated overrides {@link SingleThreadEventExecutor#wakesUpForTask} to re-create this behaviour
+     * @deprecated override {@link SingleThreadEventExecutor#wakesUpForTask} to re-create this behaviour
      */
     @Deprecated
     protected interface NonWakeupRunnable extends LazyRunnable { }

--- a/common/src/test/java/io/netty/util/concurrent/SingleThreadEventExecutorTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/SingleThreadEventExecutorTest.java
@@ -17,7 +17,6 @@ package io.netty.util.concurrent;
 
 import org.junit.jupiter.api.Test;
 
-import io.netty.util.concurrent.AbstractEventExecutor.LazyRunnable;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.function.Executable;
 
@@ -208,12 +207,18 @@ public class SingleThreadEventExecutorTest {
         }
     }
 
-    static class LazyLatchTask extends LatchTask implements LazyRunnable { }
+    static class LazyLatchTask extends LatchTask { }
 
     @Test
     public void testLazyExecution() throws Exception {
         final SingleThreadEventExecutor executor = new SingleThreadEventExecutor(null,
                 Executors.defaultThreadFactory(), false) {
+
+            @Override
+            protected boolean wakesUpForTask(final Runnable task) {
+                return !(task instanceof LazyLatchTask);
+            }
+
             @Override
             protected void run() {
                 while (!confirmShutdown()) {

--- a/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
@@ -115,7 +115,7 @@ public abstract class SingleThreadEventLoop extends SingleThreadEventExecutor im
             reject(task);
         }
 
-        if (!(task instanceof LazyRunnable) && wakesUpForTask(task)) {
+        if (wakesUpForTask(task)) {
             wakeup(inEventLoop());
         }
     }


### PR DESCRIPTION
Motivation:

Type check vs LazyRunnable receive an always-on performance hit for a common operation that users shouldn't pay if they won't use it.

Modifications:

Deprecates LazyRunnable providing a comment to help existing users an alternative mechanism.

Result:

Fixes #13335