### PR TITLE
Release websocket handshake response if pipeline checks fail

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker.java
@@ -215,6 +215,7 @@ public abstract class WebSocketServerHandshaker {
             if (ctx == null) {
                 promise.setFailure(
                         new IllegalStateException("No HttpDecoder and no HttpServerCodec in the pipeline"));
+                response.release();
                 return promise;
             }
             p.addBefore(ctx.name(), "wsencoder", newWebSocketEncoder());


### PR DESCRIPTION
Motivation:
The WebSocketServerHandshaker require that either an HttpRequestDecoder or an HttpServerCodec exist in the pipeline. If they do not, we can't send a websocket handshake response. The handshake response is allocated prior to the pipeline checks. Therefor, if the checks fail, we need to release the response before returning the failed future.

It might be possible to delay the allocation of the response until after the pipeline checks, but doing so breaks assumptions made by numerous tests.

Modification:
If the pipeline checks fail, release the handshake response before returning the failed promise.

Result:
We no longer leak a buffer in the handshake response if the pipeline checks fail.

Fixes #13337
