### PR TITLE
Add support for local and remote addresses on the server for child ch…

### DIFF
--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketAddressesTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketAddressesTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.testsuite.transport.socket;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.channel.Channel;
+import io.netty5.channel.ChannelHandlerContext;
+import io.netty5.channel.ChannelHandler;
+import io.netty5.util.concurrent.ImmediateEventExecutor;
+import io.netty5.util.concurrent.Promise;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
+
+import java.net.SocketAddress;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public abstract class SocketAddressesTest extends AbstractSocketTest {
+
+    @Test
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    public void testAddresses(TestInfo testInfo) throws Throwable {
+        run(testInfo, new Runner<ServerBootstrap, Bootstrap>() {
+            @Override
+            public void run(ServerBootstrap serverBootstrap, Bootstrap bootstrap) throws Throwable {
+                testAddresses(serverBootstrap, bootstrap);
+            }
+        });
+    }
+
+    protected abstract void assertAddress(SocketAddress address);
+
+    private void testAddresses(ServerBootstrap sb, Bootstrap cb) throws Throwable {
+        Channel serverChannel = null;
+        Channel clientChannel = null;
+        try {
+            final Promise<SocketAddress> localAddressPromise = ImmediateEventExecutor.INSTANCE.newPromise();
+            final Promise<SocketAddress> remoteAddressPromise = ImmediateEventExecutor.INSTANCE.newPromise();
+            serverChannel = sb.childHandler(new ChannelHandler() {
+                @Override
+                public void channelActive(ChannelHandlerContext ctx) {
+                    localAddressPromise.setSuccess(ctx.channel().localAddress());
+                    remoteAddressPromise.setSuccess(ctx.channel().remoteAddress());
+                }
+            }).bind().asStage().get();
+
+            clientChannel = cb.handler(new ChannelHandler() { }).register().asStage().get();
+
+            assertNull(clientChannel.localAddress());
+            assertNull(clientChannel.remoteAddress());
+
+            clientChannel.connect(serverChannel.localAddress(), newSocketAddress()).asStage().get();
+
+            assertAddress(clientChannel.localAddress());
+            assertAddress(clientChannel.remoteAddress());
+
+            assertAddress(localAddressPromise.asFuture().asStage().get());
+            assertAddress(remoteAddressPromise.asFuture().asStage().get());
+        } finally {
+            if (clientChannel != null) {
+                clientChannel.close().asStage().sync();
+            }
+            if (serverChannel != null) {
+                serverChannel.close().asStage().sync();
+            }
+        }
+    }
+}

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
@@ -100,12 +100,8 @@ abstract class AbstractEpollChannel<P extends UnixChannel>
         active = true;
         // Directly cache the remote and local addresses
         // See https://github.com/netty/netty/issues/2359
-        remoteAddress =  remote;
+        remoteAddress =  remote == null ? fd.remoteAddress() : remote;
         localAddress = fd.localAddress();
-    }
-
-    protected final boolean fetchLocalAddress() {
-        return socket.protocolFamily() != SocketProtocolFamily.UNIX;
     }
 
     protected static boolean isSoErrorZero(Socket fd) {
@@ -419,11 +415,7 @@ abstract class AbstractEpollChannel<P extends UnixChannel>
             checkResolvable((InetSocketAddress) local);
         }
         socket.bind(local);
-        if (fetchLocalAddress()) {
-            this.localAddress = socket.localAddress();
-        } else {
-            this.localAddress = local;
-        }
+        this.localAddress = socket.localAddress();
     }
 
     /**
@@ -451,12 +443,10 @@ abstract class AbstractEpollChannel<P extends UnixChannel>
                     remoteAddress : computeRemoteAddr(remoteSocketAddr, (InetSocketAddress) socket.remoteAddress());
             active = true;
         }
-        if (fetchLocalAddress()) {
-            // We always need to set the localAddress even if not connected yet as the bind already took place.
-            //
-            // See https://github.com/netty/netty/issues/3463
-            this.localAddress = socket.localAddress();
-        }
+        // We always need to set the localAddress even if not connected yet as the bind already took place.
+        //
+        // See https://github.com/netty/netty/issues/3463
+        this.localAddress = socket.localAddress();
         return connected;
     }
 

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
@@ -415,7 +415,13 @@ abstract class AbstractEpollChannel<P extends UnixChannel>
             checkResolvable((InetSocketAddress) local);
         }
         socket.bind(local);
-        this.localAddress = socket.localAddress();
+        if (socket.protocolFamily() != SocketProtocolFamily.UNIX) {
+            this.localAddress = socket.localAddress();
+        } else {
+            // getsockname(...) is not widely supported for UDS.
+            // See https://man.freebsd.org/cgi/man.cgi?query=getsockname&sektion=2&n=1
+            this.localAddress = local;
+        }
     }
 
     /**

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
@@ -402,7 +402,8 @@ abstract class AbstractEpollChannel<P extends UnixChannel>
             active = true;
             clearFlag(Native.EPOLLOUT);
             if (requestedRemoteAddress instanceof InetSocketAddress) {
-                remoteAddress = computeRemoteAddr((InetSocketAddress) requestedRemoteAddress, socket.remoteAddress());
+                remoteAddress = computeRemoteAddr((InetSocketAddress) requestedRemoteAddress,
+                        (InetSocketAddress) socket.remoteAddress());
             } else {
                 remoteAddress = requestedRemoteAddress;
             }
@@ -447,7 +448,7 @@ abstract class AbstractEpollChannel<P extends UnixChannel>
         boolean connected = doConnect0(remoteAddress, initialData);
         if (connected) {
             this.remoteAddress = remoteSocketAddr == null ?
-                    remoteAddress : computeRemoteAddr(remoteSocketAddr, socket.remoteAddress());
+                    remoteAddress : computeRemoteAddr(remoteSocketAddr, (InetSocketAddress) socket.remoteAddress());
             active = true;
         }
         if (fetchLocalAddress()) {

--- a/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/AbstractIOUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/AbstractIOUringChannel.java
@@ -434,7 +434,8 @@ abstract class AbstractIOUringChannel<P extends UnixChannel>
         if (socket.finishConnect()) {
             active = true;
             if (requestedRemoteAddress instanceof InetSocketAddress) {
-                remote = computeRemoteAddr((InetSocketAddress) requestedRemoteAddress, socket.remoteAddress());
+                remote = computeRemoteAddr((InetSocketAddress) requestedRemoteAddress,
+                        (InetSocketAddress) socket.remoteAddress());
             } else {
                 remote = requestedRemoteAddress;
             }

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueChannel.java
@@ -457,7 +457,7 @@ abstract class AbstractKQueueChannel<P extends UnixChannel>
     }
 
     protected boolean fetchLocalAddress() {
-        return true;//socket.protocolFamily() != SocketProtocolFamily.UNIX;
+        return true; //socket.protocolFamily() != SocketProtocolFamily.UNIX;
     }
 
     /**

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueChannel.java
@@ -449,7 +449,13 @@ abstract class AbstractKQueueChannel<P extends UnixChannel>
             checkResolvable((InetSocketAddress) local);
         }
         socket.bind(local);
-        this.localAddress = socket.localAddress();
+        if (socket.protocolFamily() != SocketProtocolFamily.UNIX) {
+            this.localAddress = socket.localAddress();
+        } else {
+            // getsockname(...) is not widely supported for UDS.
+            // See https://man.freebsd.org/cgi/man.cgi?query=getsockname&sektion=2&n=1
+            this.localAddress = local;
+        }
     }
 
     /**

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueChannel.java
@@ -432,7 +432,8 @@ abstract class AbstractKQueueChannel<P extends UnixChannel>
             active = true;
             writeFilter(false);
             if (requestedRemoteAddress instanceof InetSocketAddress) {
-                remoteAddress = computeRemoteAddr((InetSocketAddress) requestedRemoteAddress, socket.remoteAddress());
+                remoteAddress = computeRemoteAddr((InetSocketAddress) requestedRemoteAddress,
+                        (InetSocketAddress) socket.remoteAddress());
             } else {
                 remoteAddress = requestedRemoteAddress;
             }
@@ -456,7 +457,7 @@ abstract class AbstractKQueueChannel<P extends UnixChannel>
     }
 
     protected boolean fetchLocalAddress() {
-        return socket.protocolFamily() != SocketProtocolFamily.UNIX;
+        return true;//socket.protocolFamily() != SocketProtocolFamily.UNIX;
     }
 
     /**
@@ -482,7 +483,7 @@ abstract class AbstractKQueueChannel<P extends UnixChannel>
         if (connected) {
             active = true;
             this.remoteAddress = remoteSocketAddr == null?
-                    remoteAddress : computeRemoteAddr(remoteSocketAddr, socket.remoteAddress());
+                    remoteAddress : computeRemoteAddr(remoteSocketAddr, (InetSocketAddress) socket.remoteAddress());
         }
 
         if (fetchLocalAddress()) {

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueChannel.java
@@ -94,7 +94,7 @@ abstract class AbstractKQueueChannel<P extends UnixChannel>
         // Directly cache the remote and local addresses
         // See https://github.com/netty/netty/issues/2359
         this.localAddress = fd.localAddress();
-        this.remoteAddress = remote;
+        this.remoteAddress = remote == null ? fd.remoteAddress() : remote;
     }
 
     @Override
@@ -449,15 +449,7 @@ abstract class AbstractKQueueChannel<P extends UnixChannel>
             checkResolvable((InetSocketAddress) local);
         }
         socket.bind(local);
-        if (fetchLocalAddress()) {
-            this.localAddress = socket.localAddress();
-        } else {
-            this.localAddress = local;
-        }
-    }
-
-    protected boolean fetchLocalAddress() {
-        return true; //socket.protocolFamily() != SocketProtocolFamily.UNIX;
+        this.localAddress = socket.localAddress();
     }
 
     /**
@@ -486,12 +478,10 @@ abstract class AbstractKQueueChannel<P extends UnixChannel>
                     remoteAddress : computeRemoteAddr(remoteSocketAddr, (InetSocketAddress) socket.remoteAddress());
         }
 
-        if (fetchLocalAddress()) {
-            // We always need to set the localAddress even if not connected yet as the bind already took place.
-            //
-            // See https://github.com/netty/netty/issues/3463
-            this.localAddress = socket.localAddress();
-        }
+        // We always need to set the localAddress even if not connected yet as the bind already took place.
+        //
+        // See https://github.com/netty/netty/issues/3463
+        this.localAddress = socket.localAddress();
         return connected;
     }
 

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDomainSocketAddressesTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDomainSocketAddressesTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.epoll;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.channel.socket.DomainSocketAddress;
+import io.netty5.testsuite.transport.TestsuitePermutation;
+import io.netty5.testsuite.transport.socket.SocketAddressesTest;
+
+import java.net.SocketAddress;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class EpollDomainSocketAddressesTest extends SocketAddressesTest {
+
+    @Override
+    protected SocketAddress newSocketAddress() {
+        return EpollSocketTestPermutation.newDomainSocketAddress();
+    }
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return EpollSocketTestPermutation.INSTANCE.domainSocket();
+    }
+
+    @Override
+    protected void assertAddress(SocketAddress address) {
+        assertNotNull(((DomainSocketAddress) address).path());
+    }
+}

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollSocketAddressesTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollSocketAddressesTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.epoll;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.testsuite.transport.TestsuitePermutation;
+import io.netty5.testsuite.transport.socket.SocketAddressesTest;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EpollSocketAddressesTest extends SocketAddressesTest {
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return EpollSocketTestPermutation.INSTANCE.socketWithFastOpen();
+    }
+
+    @Override
+    protected void assertAddress(SocketAddress address) {
+        assertTrue(((InetSocketAddress) address).getPort() > 0);
+        assertFalse(((InetSocketAddress) address).getAddress().isAnyLocalAddress());
+    }
+}

--- a/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueDomainSocketAddressesTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueDomainSocketAddressesTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.kqueue;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.channel.socket.DomainSocketAddress;
+import io.netty5.testsuite.transport.TestsuitePermutation;
+import io.netty5.testsuite.transport.socket.SocketAddressesTest;
+
+import java.net.SocketAddress;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class KQueueDomainSocketAddressesTest extends SocketAddressesTest {
+
+    @Override
+    protected SocketAddress newSocketAddress() {
+        return KQueueSocketTestPermutation.newDomainSocketAddress();
+    }
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return KQueueSocketTestPermutation.INSTANCE.domainSocket();
+    }
+
+    @Override
+    protected void assertAddress(SocketAddress address) {
+        assertNotNull(((DomainSocketAddress) address).path());
+    }
+}

--- a/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueSocketAddressesTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueSocketAddressesTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.kqueue;
+
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.testsuite.transport.TestsuitePermutation;
+import io.netty5.testsuite.transport.socket.SocketAddressesTest;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class KQueueSocketAddressesTest extends SocketAddressesTest {
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return KQueueSocketTestPermutation.INSTANCE.socket();
+    }
+
+    @Override
+    protected void assertAddress(SocketAddress address) {
+        assertTrue(((InetSocketAddress) address).getPort() > 0);
+        assertFalse(((InetSocketAddress) address).getAddress().isAnyLocalAddress());
+    }
+}

--- a/transport-native-unix-common/src/main/c/netty5_unix_socket.c
+++ b/transport-native-unix-common/src/main/c/netty5_unix_socket.c
@@ -675,7 +675,7 @@ static jint netty5_unix_socket_accept(JNIEnv* env, jclass clazz, jint fd, jbyteA
 }
 
 static jbyteArray netty5_unix_socket_remoteAddress(JNIEnv* env, jclass clazz, jint fd) {
-    struct sockaddr_storage addr;
+    struct sockaddr_storage addr = { 0 };
     socklen_t len = sizeof(addr);
     if (getpeername(fd, (struct sockaddr*) &addr, &len) == -1) {
         return NULL;
@@ -684,7 +684,7 @@ static jbyteArray netty5_unix_socket_remoteAddress(JNIEnv* env, jclass clazz, ji
 }
 
 static jbyteArray netty5_unix_socket_remoteDomainSocketAddress(JNIEnv* env, jclass clazz, jint fd) {
-    struct sockaddr_storage addr;
+    struct sockaddr_storage addr = { 0 };
     socklen_t len = sizeof(addr);
     if (getpeername(fd, (struct sockaddr*) &addr, &len) == -1) {
         return NULL;
@@ -693,7 +693,7 @@ static jbyteArray netty5_unix_socket_remoteDomainSocketAddress(JNIEnv* env, jcla
 }
 
 static jbyteArray netty5_unix_socket_localAddress(JNIEnv* env, jclass clazz, jint fd) {
-    struct sockaddr_storage addr;
+    struct sockaddr_storage addr = { 0 };
     socklen_t len = sizeof(addr);
     if (getsockname(fd, (struct sockaddr*) &addr, &len) == -1) {
         return NULL;
@@ -702,7 +702,7 @@ static jbyteArray netty5_unix_socket_localAddress(JNIEnv* env, jclass clazz, jin
 }
 
 static jbyteArray netty5_unix_socket_localDomainSocketAddress(JNIEnv* env, jclass clazz, jint fd) {
-    struct sockaddr_storage addr;
+    struct sockaddr_storage addr = { 0 };
     socklen_t len = sizeof(addr);
     if (getsockname(fd, (struct sockaddr*) &addr, &len) == -1) {
         return NULL;


### PR DESCRIPTION
…annels when UDS (#13323)

Motivation:
Local and remote addresses are not available on the server for child channels when Unix Domain Sockets is used. There are use cases where one may need this information in order to collect metrics per local or remote addresses.

Modifications:
- Add JNI code for obtaining local/remote address
- When creating a child channel initialise the local/remote addresses.
- Add junit tests

Result:
Local and remote addresses are now available on the server for child channels when Unix Domain Sockets is used.

