### PR TITLE
Guard against unbounded grow of suppressed exceptions storage

### DIFF
--- a/common/src/main/java/io/netty/util/internal/EmptyArrays.java
+++ b/common/src/main/java/io/netty/util/internal/EmptyArrays.java
@@ -37,5 +37,7 @@ public final class EmptyArrays {
     public static final X509Certificate[] EMPTY_X509_CERTIFICATES = {};
     public static final javax.security.cert.X509Certificate[] EMPTY_JAVAX_X509_CERTIFICATES = {};
 
+    public static final Throwable[] EMPTY_THROWABLES = {};
+
     private EmptyArrays() { }
 }

--- a/common/src/main/java/io/netty/util/internal/ThrowableUtil.java
+++ b/common/src/main/java/io/netty/util/internal/ThrowableUtil.java
@@ -22,8 +22,6 @@ import java.util.List;
 
 public final class ThrowableUtil {
 
-    private static final Throwable[] EMPTY = new Throwable[0];
-
     private ThrowableUtil() { }
 
     /**
@@ -82,7 +80,7 @@ public final class ThrowableUtil {
     @SuppressJava6Requirement(reason = "Throwable getSuppressed is only available for >= 7. Has check for < 7.")
     public static Throwable[] getSuppressed(Throwable source) {
         if (!haveSuppressed()) {
-            return EMPTY;
+            return EmptyArrays.EMPTY_THROWABLES;
         }
         return source.getSuppressed();
     }

--- a/common/src/main/java/io/netty/util/internal/ThrowableUtil.java
+++ b/common/src/main/java/io/netty/util/internal/ThrowableUtil.java
@@ -22,6 +22,8 @@ import java.util.List;
 
 public final class ThrowableUtil {
 
+    private static final Throwable[] EMPTY = new Throwable[0];
+
     private ThrowableUtil() { }
 
     /**
@@ -75,5 +77,13 @@ public final class ThrowableUtil {
         for (Throwable t : suppressed) {
             addSuppressed(target, t);
         }
+    }
+
+    @SuppressJava6Requirement(reason = "Throwable getSuppressed is only available for >= 7. Has check for < 7.")
+    public static Throwable[] getSuppressed(Throwable source) {
+        if (!haveSuppressed()) {
+            return EMPTY;
+        }
+        return source.getSuppressed();
     }
 }


### PR DESCRIPTION
Motivation:

We should guard against unbounded grows of suppressed exceptions in our SSLEngine implementation to prevent possible OOME

Modifications:

- Check if a suppressed exception was already added for a specific error code before adding it again
- Ensure we always null out pending exception field.

Result:

Fixes https://github.com/netty/netty/issues/13350
