### PR TITLE
Allow to change the limit for the maximum size of the certificate chain.

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -65,7 +65,7 @@
 
   <properties>
     <!-- Keep in sync with ../pom.xml -->
-    <tcnative.version>2.0.60.Final-SNAPSHOT</tcnative.version>
+    <tcnative.version>2.0.60.Final</tcnative.version>
   </properties>
 
   <build>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -65,7 +65,7 @@
 
   <properties>
     <!-- Keep in sync with ../pom.xml -->
-    <tcnative.version>2.0.59.Final</tcnative.version>
+    <tcnative.version>2.0.60.Final-SNAPSHOT</tcnative.version>
   </properties>
 
   <build>

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslContextOption.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslContextOption.java
@@ -68,4 +68,10 @@ public final class OpenSslContextOption<T> extends SslContextOption<T> {
      */
     public static final OpenSslContextOption<OpenSslCertificateCompressionConfig> CERTIFICATE_COMPRESSION_ALGORITHMS =
             new OpenSslContextOption<OpenSslCertificateCompressionConfig>("CERTIFICATE_COMPRESSION_ALGORITHMS");
+
+    /**
+     * Set the maximum number of bytes that is allowed during the handshake for certificate chain.
+     */
+    public static final OpenSslContextOption<Long> MAX_CERTIFICATE_LIST =
+            new OpenSslContextOption<Long>("MAX_CERTIFICATE_LIST");
 }

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslContextOption.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslContextOption.java
@@ -72,6 +72,6 @@ public final class OpenSslContextOption<T> extends SslContextOption<T> {
     /**
      * Set the maximum number of bytes that is allowed during the handshake for certificate chain.
      */
-    public static final OpenSslContextOption<Long> MAX_CERTIFICATE_LIST =
-            new OpenSslContextOption<Long>("MAX_CERTIFICATE_LIST");
+    public static final OpenSslContextOption<Integer> MAX_CERTIFICATE_LIST_BYTES =
+            new OpenSslContextOption<Integer>("MAX_CERTIFICATE_LIST_BYTES");
 }

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -227,7 +227,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
         OpenSslPrivateKeyMethod privateKeyMethod = null;
         OpenSslAsyncPrivateKeyMethod asyncPrivateKeyMethod = null;
         OpenSslCertificateCompressionConfig certCompressionConfig = null;
-        Long maxCertificateList = null;
+        Integer maxCertificateList = null;
 
         if (ctxOptions != null) {
             for (Map.Entry<SslContextOption<?>, Object> ctxOpt : ctxOptions) {
@@ -243,8 +243,8 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
                     asyncPrivateKeyMethod = (OpenSslAsyncPrivateKeyMethod) ctxOpt.getValue();
                 } else if (option == OpenSslContextOption.CERTIFICATE_COMPRESSION_ALGORITHMS) {
                     certCompressionConfig = (OpenSslCertificateCompressionConfig) ctxOpt.getValue();
-                } else if (option == OpenSslContextOption.MAX_CERTIFICATE_LIST) {
-                    maxCertificateList = (Long) ctxOpt.getValue();
+                } else if (option == OpenSslContextOption.MAX_CERTIFICATE_LIST_BYTES) {
+                    maxCertificateList = (Integer) ctxOpt.getValue();
                 } else {
                     logger.debug("Skipping unsupported " + SslContextOption.class.getSimpleName()
                             + ": " + ctxOpt.getKey());

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -227,6 +227,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
         OpenSslPrivateKeyMethod privateKeyMethod = null;
         OpenSslAsyncPrivateKeyMethod asyncPrivateKeyMethod = null;
         OpenSslCertificateCompressionConfig certCompressionConfig = null;
+        Long maxCertificateList = null;
 
         if (ctxOptions != null) {
             for (Map.Entry<SslContextOption<?>, Object> ctxOpt : ctxOptions) {
@@ -242,6 +243,8 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
                     asyncPrivateKeyMethod = (OpenSslAsyncPrivateKeyMethod) ctxOpt.getValue();
                 } else if (option == OpenSslContextOption.CERTIFICATE_COMPRESSION_ALGORITHMS) {
                     certCompressionConfig = (OpenSslCertificateCompressionConfig) ctxOpt.getValue();
+                } else if (option == OpenSslContextOption.MAX_CERTIFICATE_LIST) {
+                    maxCertificateList = (Long) ctxOpt.getValue();
                 } else {
                     logger.debug("Skipping unsupported " + SslContextOption.class.getSimpleName()
                             + ": " + ctxOpt.getKey());
@@ -415,6 +418,9 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
                             throw new IllegalStateException();
                     }
                 }
+            }
+            if (maxCertificateList != null) {
+                SSLContext.setMaxCertList(ctx, maxCertificateList);
             }
             // Set the curves.
             SSLContext.setCurvesList(ctx, OpenSsl.NAMED_GROUPS);

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
@@ -1613,14 +1613,14 @@ public class OpenSslEngineTest extends SSLEngineTest {
                 .sslContextProvider(clientSslContextProvider())
                 .protocols(param.protocols())
                 .ciphers(param.ciphers())
-                .option(OpenSslContextOption.MAX_CERTIFICATE_LIST, 10L)
+                .option(OpenSslContextOption.MAX_CERTIFICATE_LIST_BYTES, 10)
                 .build());
         serverSslCtx = wrapContext(param, SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                 .sslProvider(sslServerProvider())
                 .sslContextProvider(serverSslContextProvider())
                 .protocols(param.protocols())
                 .ciphers(param.ciphers())
-                .option(OpenSslContextOption.MAX_CERTIFICATE_LIST, 10L)
+                .option(OpenSslContextOption.MAX_CERTIFICATE_LIST_BYTES, 10)
                 .clientAuth(ClientAuth.REQUIRE)
                 .build());
 

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
@@ -1601,4 +1601,43 @@ public class OpenSslEngineTest extends SSLEngineTest {
                 wrapEngine(clientSslCtx.newHandler(UnpooledByteBufAllocator.DEFAULT).engine()),
                 wrapEngine(serverSslCtx.newHandler(UnpooledByteBufAllocator.DEFAULT).engine()));
     }
+
+    @MethodSource("newTestParams")
+    @ParameterizedTest
+    public void testMaxCertificateList(final SSLEngineTestParam param) throws Exception {
+        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        clientSslCtx = wrapContext(param, SslContextBuilder.forClient()
+                .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                .keyManager(ssc.certificate(), ssc.privateKey())
+                .sslProvider(sslClientProvider())
+                .sslContextProvider(clientSslContextProvider())
+                .protocols(param.protocols())
+                .ciphers(param.ciphers())
+                .option(OpenSslContextOption.MAX_CERTIFICATE_LIST, 10L)
+                .build());
+        serverSslCtx = wrapContext(param, SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
+                .sslProvider(sslServerProvider())
+                .sslContextProvider(serverSslContextProvider())
+                .protocols(param.protocols())
+                .ciphers(param.ciphers())
+                .option(OpenSslContextOption.MAX_CERTIFICATE_LIST, 10L)
+                .clientAuth(ClientAuth.REQUIRE)
+                .build());
+
+        final SSLEngine client = wrapEngine(clientSslCtx.newEngine(UnpooledByteBufAllocator.DEFAULT));
+        final SSLEngine server = wrapEngine(serverSslCtx.newEngine(UnpooledByteBufAllocator.DEFAULT));
+
+        try {
+            assertThrows(SSLHandshakeException.class, new Executable() {
+                @Override
+                public void execute() throws Throwable {
+                    handshake(param.type(), param.delegate(), client, server);
+                }
+            });
+        } finally {
+            cleanupClientSslEngine(client);
+            cleanupServerSslEngine(server);
+            ssc.delete();
+        }
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -622,7 +622,7 @@
     <os.detection.classifierWithLikes>fedora,suse,arch</os.detection.classifierWithLikes>
     <tcnative.artifactId>netty-tcnative</tcnative.artifactId>
     <!-- Keep in sync with bom/pom.xml -->
-    <tcnative.version>2.0.60.Final-SNAPSHOT</tcnative.version>
+    <tcnative.version>2.0.60.Final</tcnative.version>
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
     <conscrypt.groupId>org.conscrypt</conscrypt.groupId>
     <conscrypt.artifactId>conscrypt-openjdk-uber</conscrypt.artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -622,7 +622,7 @@
     <os.detection.classifierWithLikes>fedora,suse,arch</os.detection.classifierWithLikes>
     <tcnative.artifactId>netty-tcnative</tcnative.artifactId>
     <!-- Keep in sync with bom/pom.xml -->
-    <tcnative.version>2.0.59.Final</tcnative.version>
+    <tcnative.version>2.0.60.Final-SNAPSHOT</tcnative.version>
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
     <conscrypt.groupId>org.conscrypt</conscrypt.groupId>
     <conscrypt.artifactId>conscrypt-openjdk-uber</conscrypt.artifactId>


### PR DESCRIPTION
Motivation:

Sometimes large certificate chains are used which might be larger then the default maximum size.

Modifications:

- Allow to configure the limit
- Add unit test

Result:

Be able to adjust limit