### PR TITLE
OpenSSL MAX_CERTIFICATE_LIST_BYTES option supported

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
@@ -735,7 +735,8 @@ public final class OpenSsl {
                 return option == OpenSslContextOption.ASYNC_PRIVATE_KEY_METHOD ||
                         option == OpenSslContextOption.PRIVATE_KEY_METHOD ||
                         option == OpenSslContextOption.CERTIFICATE_COMPRESSION_ALGORITHMS ||
-                        option == OpenSslContextOption.TLS_FALSE_START;
+                        option == OpenSslContextOption.TLS_FALSE_START ||
+                        option == OpenSslContextOption.MAX_CERTIFICATE_LIST_BYTES;
             }
         }
         return false;


### PR DESCRIPTION
Motivation:
isOptionSupported wasn't updated to reflect the newly added MAX_CERTIFICATE_LIST_BYTES option.

Modifications:
- SslProvider.isOptionSupported to support MAX_CERTIFICATE_LIST_BYTES if OpenSSL is used.