### PR TITLE
Adapt to DirectByteBuffer constructor in Java 21

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -283,15 +283,9 @@ final class PlatformDependent0 {
                             @Override
                             public Object run() {
                                 try {
-                                    Constructor<?> constructor = null;
-                                    try {
-                                        constructor =
-                                                direct.getClass().getDeclaredConstructor(long.class, int.class);
-                                    } catch (NoSuchMethodException e) {
-                                        // Breaking change in Java 21
-                                        constructor =
-                                                direct.getClass().getDeclaredConstructor(long.class, long.class);
-                                    }
+                                    final Constructor<?> constructor = javaVersion() >= 21 ?
+                                            direct.getClass().getDeclaredConstructor(long.class, long.class) :
+                                            direct.getClass().getDeclaredConstructor(long.class, int.class);
                                     Throwable cause = ReflectionUtil.trySetAccessible(constructor, true);
                                     if (cause != null) {
                                         return cause;

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -283,8 +283,15 @@ final class PlatformDependent0 {
                             @Override
                             public Object run() {
                                 try {
-                                    final Constructor<?> constructor =
-                                            direct.getClass().getDeclaredConstructor(long.class, int.class);
+                                    Constructor<?> constructor = null;
+                                    try {
+                                        constructor =
+                                                direct.getClass().getDeclaredConstructor(long.class, int.class);
+                                    } catch (NoSuchMethodException e) {
+                                        // Breaking change in Java 21
+                                        constructor =
+                                                direct.getClass().getDeclaredConstructor(long.class, long.class);
+                                    }
                                     Throwable cause = ReflectionUtil.trySetAccessible(constructor, true);
                                     if (cause != null) {
                                         return cause;
@@ -479,7 +486,7 @@ final class PlatformDependent0 {
 
         INTERNAL_UNSAFE = internalUnsafe;
 
-        logger.debug("java.nio.DirectByteBuffer.<init>(long, int): {}",
+        logger.debug("java.nio.DirectByteBuffer.<init>(long, {int,long}): {}",
                 DIRECT_BUFFER_CONSTRUCTOR != null ? "available" : "unavailable");
     }
 


### PR DESCRIPTION
Motivation:

The signature changed between Java 20 and 21 for the DirectByteBuffer constructor.
See https://github.com/openjdk/jdk/commit/a56598f5a534cc9223367e7faa8433ea38661db9

Modification:

Simply add a check for `<init>(long, long)` on top of `<init>(long, int)`

Result:

It's able to compile and run on Java 21