### PR TITLE
HTTP/2 encoder: allow HEADER_TABLE_SIZE greater than Integer.MAX_VALUE

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
@@ -98,7 +98,7 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder, Ht
 
         Long headerTableSize = settings.headerTableSize();
         if (headerTableSize != null) {
-            outboundHeaderConfig.maxHeaderTableSize((int) min(headerTableSize, MAX_VALUE));
+            outboundHeaderConfig.maxHeaderTableSize(headerTableSize);
         }
 
         Long maxHeaderListSize = settings.maxHeaderListSize();


### PR DESCRIPTION
Motivation:

`HpackEncoder.setMaxHeaderTableSize(...)` supports any unsigned 32-bit integer value, however `DefaultHttp2ConnectionEncoder` adjusts the `SETTINGS_HEADER_TABLE_SIZE` value to 31-bit unsigned integer. `DefaultHttp2ConnectionDecoder` doesn't adjust. We should keep them consistent. Value range is validated by `Http2Settings` and `HpackEncoder`.

Modifications:

- Remove adjustment for `SETTINGS_HEADER_TABLE_SIZE` in `DefaultHttp2ConnectionEncoder.remoteSettings(...)`;

Result:

`DefaultHttp2ConnectionEncoder.remoteSettings(...)` is consistent with `DefaultHttp2ConnectionDecoder.applyLocalSettings(...)`, `SETTINGS_HEADER_TABLE_SIZE` value is not adjusted.

Motivation:

Explain here the context, and why you're making that change.
What is the problem you're trying to solve.