### PR TITLE
`Http2Settings`: validate non-standard setting values

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2SettingsTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2SettingsTest.java
@@ -19,9 +19,22 @@ package io.netty.handler.codec.http2;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import static io.netty.handler.codec.http2.Http2CodecUtil.MAX_CONCURRENT_STREAMS;
+import static io.netty.handler.codec.http2.Http2CodecUtil.MAX_FRAME_SIZE_LOWER_BOUND;
 import static io.netty.handler.codec.http2.Http2CodecUtil.MAX_FRAME_SIZE_UPPER_BOUND;
+import static io.netty.handler.codec.http2.Http2CodecUtil.MAX_HEADER_LIST_SIZE;
+import static io.netty.handler.codec.http2.Http2CodecUtil.MAX_HEADER_TABLE_SIZE;
+import static io.netty.handler.codec.http2.Http2CodecUtil.MAX_INITIAL_WINDOW_SIZE;
 import static io.netty.handler.codec.http2.Http2CodecUtil.MAX_UNSIGNED_INT;
+import static io.netty.handler.codec.http2.Http2CodecUtil.MIN_CONCURRENT_STREAMS;
+import static io.netty.handler.codec.http2.Http2CodecUtil.MIN_HEADER_LIST_SIZE;
+import static io.netty.handler.codec.http2.Http2CodecUtil.MIN_HEADER_TABLE_SIZE;
+import static io.netty.handler.codec.http2.Http2CodecUtil.MIN_INITIAL_WINDOW_SIZE;
+import static java.lang.Long.MAX_VALUE;
+import static java.lang.Long.MIN_VALUE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -67,57 +80,173 @@ public class Http2SettingsTest {
     }
 
     @Test
-    public void nonStandardSettingsShouldBeSet() {
-        char key = 0;
-        settings.put(key, (Long) 123L);
-        assertEquals(123L, (long) settings.get(key));
-    }
-
-    @Test
     public void settingsShouldSupportUnsignedShort() {
         char key = (char) (Short.MAX_VALUE + 1);
         settings.put(key, (Long) 123L);
         assertEquals(123L, (long) settings.get(key));
     }
 
-    @Test
-    public void headerListSizeUnsignedInt() {
-        settings.maxHeaderListSize(MAX_UNSIGNED_INT);
-        assertEquals(MAX_UNSIGNED_INT, (long) settings.maxHeaderListSize());
+    @ParameterizedTest(name = "{displayName} [{index}] value={0}")
+    @ValueSource(longs = {MIN_HEADER_LIST_SIZE, MIN_HEADER_LIST_SIZE + 1L,
+            MAX_HEADER_LIST_SIZE - 1L, MAX_HEADER_LIST_SIZE})
+    public void headerListSize(final long value) {
+        settings.maxHeaderListSize(value);
+        assertEquals(value, (long) settings.maxHeaderListSize());
     }
 
-    @Test
-    public void headerListSizeBoundCheck() {
+    @ParameterizedTest(name = "{displayName} [{index}] value={0}")
+    @ValueSource(longs = {MIN_VALUE, MIN_HEADER_LIST_SIZE - 1L, MAX_HEADER_LIST_SIZE + 1L, MAX_VALUE})
+    public void headerListSizeBoundCheck(final long value) {
         assertThrows(IllegalArgumentException.class, new Executable() {
             @Override
             public void execute() {
-                settings.maxHeaderListSize(Long.MAX_VALUE);
+                settings.maxHeaderListSize(value);
             }
         });
     }
 
-    @Test
-    public void headerTableSizeUnsignedInt() {
-        settings.put(Http2CodecUtil.SETTINGS_HEADER_TABLE_SIZE, (Long) MAX_UNSIGNED_INT);
-        assertEquals(MAX_UNSIGNED_INT, (long) settings.get(Http2CodecUtil.SETTINGS_HEADER_TABLE_SIZE));
+    @ParameterizedTest(name = "{displayName} [{index}] value={0}")
+    @ValueSource(longs = {MIN_HEADER_TABLE_SIZE, MIN_HEADER_TABLE_SIZE + 1L,
+            MAX_HEADER_TABLE_SIZE - 1L, MAX_HEADER_TABLE_SIZE})
+    public void headerTableSize(final long value) {
+        settings.headerTableSize(value);
+        assertEquals(value, (long) settings.headerTableSize());
     }
 
-    @Test
-    public void headerTableSizeBoundCheck() {
+    @ParameterizedTest(name = "{displayName} [{index}] value={0}")
+    @ValueSource(longs = {MIN_VALUE, MIN_HEADER_TABLE_SIZE - 1L, MAX_HEADER_TABLE_SIZE + 1L, MAX_VALUE})
+    public void headerTableSizeBoundCheck(final long value) {
         assertThrows(IllegalArgumentException.class, new Executable() {
             @Override
             public void execute() {
-                settings.put(Http2CodecUtil.SETTINGS_HEADER_TABLE_SIZE, (Long) Long.MAX_VALUE);
+                settings.headerTableSize(value);
             }
         });
     }
 
-    @Test
-    public void headerTableSizeBoundCheck2() {
+    @ParameterizedTest(name = "{displayName} [{index}] value={0}")
+    @ValueSource(booleans = {false, true})
+    public void pushEnabled(final boolean value) {
+        settings.pushEnabled(value);
+        assertEquals(value, settings.pushEnabled());
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] value={0}")
+    @ValueSource(longs = {0, 1})
+    public void enablePush(final long value) {
+        settings.put(Http2CodecUtil.SETTINGS_ENABLE_PUSH, (Long) value);
+        assertEquals(value, (long) settings.get(Http2CodecUtil.SETTINGS_ENABLE_PUSH));
+        assertEquals(value == 1, settings.pushEnabled());
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] value={0}")
+    @ValueSource(longs = {MIN_VALUE, -1, 2, MAX_VALUE})
+    public void enablePushBoundCheck(final long value) {
         assertThrows(IllegalArgumentException.class, new Executable() {
             @Override
             public void execute() {
-                settings.put(Http2CodecUtil.SETTINGS_HEADER_TABLE_SIZE, Long.valueOf(-1L));
+                settings.put(Http2CodecUtil.SETTINGS_ENABLE_PUSH, (Long) value);
+            }
+        });
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] value={0}")
+    @ValueSource(longs = {MIN_CONCURRENT_STREAMS, MIN_CONCURRENT_STREAMS + 1L,
+            MAX_CONCURRENT_STREAMS - 1L, MAX_CONCURRENT_STREAMS})
+    public void maxConcurrentStreams(final long value) {
+        settings.maxConcurrentStreams(value);
+        assertEquals(value, (long) settings.maxConcurrentStreams());
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] value={0}")
+    @ValueSource(longs = {MIN_VALUE, MIN_CONCURRENT_STREAMS - 1L, MAX_CONCURRENT_STREAMS + 1L, MAX_VALUE})
+    public void maxConcurrentStreamsBoundCheck(final long value) {
+        assertThrows(IllegalArgumentException.class, new Executable() {
+            @Override
+            public void execute() {
+                settings.maxConcurrentStreams(value);
+            }
+        });
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] value={0}")
+    @ValueSource(ints = {MIN_INITIAL_WINDOW_SIZE, MIN_INITIAL_WINDOW_SIZE + 1,
+            MAX_INITIAL_WINDOW_SIZE - 1, MAX_INITIAL_WINDOW_SIZE})
+    public void initialWindowSize(final int value) {
+        settings.initialWindowSize(value);
+        assertEquals(value, (int) settings.initialWindowSize());
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] value={0}")
+    @ValueSource(ints = {Integer.MIN_VALUE, MIN_INITIAL_WINDOW_SIZE - 1})
+    public void initialWindowSizeIntBoundCheck(final int value) {
+        assertThrows(IllegalArgumentException.class, new Executable() {
+            @Override
+            public void execute() {
+                settings.initialWindowSize(value);
+            }
+        });
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] value={0}")
+    @ValueSource(longs = {MIN_VALUE, MIN_INITIAL_WINDOW_SIZE - 1L, MAX_INITIAL_WINDOW_SIZE + 1L, MAX_VALUE})
+    public void initialWindowSizeBoundCheck(final long value) {
+        assertThrows(IllegalArgumentException.class, new Executable() {
+            @Override
+            public void execute() {
+                settings.put(Http2CodecUtil.SETTINGS_INITIAL_WINDOW_SIZE, (Long) value);
+            }
+        });
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] value={0}")
+    @ValueSource(ints = {MAX_FRAME_SIZE_LOWER_BOUND, MAX_FRAME_SIZE_LOWER_BOUND + 1,
+            MAX_FRAME_SIZE_UPPER_BOUND - 1, MAX_FRAME_SIZE_UPPER_BOUND})
+    public void maxFrameSize(final int value) {
+        settings.maxFrameSize(value);
+        assertEquals(value, (int) settings.maxFrameSize());
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] value={0}")
+    @ValueSource(ints = {Integer.MIN_VALUE, 0, MAX_FRAME_SIZE_LOWER_BOUND - 1,
+            MAX_FRAME_SIZE_UPPER_BOUND + 1, Integer.MAX_VALUE})
+    public void maxFrameSizeIntBoundCheck(final int value) {
+        assertThrows(IllegalArgumentException.class, new Executable() {
+            @Override
+            public void execute() {
+                settings.maxFrameSize(value);
+            }
+        });
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] value={0}")
+    @ValueSource(longs = {MIN_VALUE, 0L, MAX_FRAME_SIZE_LOWER_BOUND - 1L, MAX_FRAME_SIZE_UPPER_BOUND + 1L,
+            Integer.MAX_VALUE, MAX_VALUE})
+    public void maxFrameSizeBoundCheck(final long value) {
+        assertThrows(IllegalArgumentException.class, new Executable() {
+            @Override
+            public void execute() {
+                settings.put(Http2CodecUtil.SETTINGS_MAX_FRAME_SIZE, (Long) value);
+            }
+        });
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] value={0}")
+    @ValueSource(longs = {0L, 1L, 123L, Integer.MAX_VALUE, MAX_UNSIGNED_INT - 1L, MAX_UNSIGNED_INT})
+    public void nonStandardSetting(final long value) {
+        char key = 0;
+        settings.put(key, (Long) value);
+        assertEquals(value, (long) settings.get(key));
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] value={0}")
+    @ValueSource(longs = {MIN_VALUE, Integer.MIN_VALUE, -1L, MAX_UNSIGNED_INT + 1L, MAX_VALUE})
+    public void nonStandardSettingBoundCheck(final long value) {
+        final char key = 0;
+        assertThrows(IllegalArgumentException.class, new Executable() {
+            @Override
+            public void execute() {
+                settings.put(key, (Long) value);
             }
         });
     }


### PR DESCRIPTION
Motivation:

RFC9113 Section 6.5.1 defines settings value as unsigned 32-bit. We should validate that users don't pass a `long` value outside of this range.

Modifications:

- `Http2Settings` throws `IllegalArgumentException` if a non-standard setting has value outside unsigned 32-bit integer range;
- `Http2Settings.verifyStandardSetting` always includes expected range when it throws `IllegalArgumentException`;
- Enhance `Http2SettingsTest` to validate valid and invalid values for each setting;
- `Http2Settings.keyToString` encodes non-standard settings as hex value;

Result:

Value range for non-standard settings is also validated. Exceptions always include expected range in the message.