### PR TITLE
Respect MALLOC_ARENA_MAX when set to determine the default number of …

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -102,7 +102,7 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
          */
         int defaultMinNumArena = NettyRuntime.availableProcessors() * 2;
 
-        // Respect MAX_ARENA_MAX if set.
+        // Respect MALLOC_ARENA_MAX if set.
         final String mallocArenaMaxStr = System.getenv("MALLOC_ARENA_MAX");
         if (mallocArenaMaxStr != null) {
             try {

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -100,20 +100,7 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
          *
          * See https://github.com/netty/netty/issues/3888.
          */
-        int defaultMinNumArena = NettyRuntime.availableProcessors() * 2;
-
-        // Respect MALLOC_ARENA_MAX if set.
-        final String mallocArenaMaxStr = System.getenv("MALLOC_ARENA_MAX");
-        if (mallocArenaMaxStr != null) {
-            try {
-                int value = Integer.parseInt(mallocArenaMaxStr);
-                if (value > 0) {
-                    defaultMinNumArena = Math.min(value, defaultMinNumArena);
-                }
-            } catch (NumberFormatException ignore) {
-                // ignore
-            }
-        }
+        int defaultMinNumArena = mallocArenaMax(NettyRuntime.availableProcessors() * 2);
 
         final int defaultChunkSize = DEFAULT_PAGE_SIZE << DEFAULT_MAX_ORDER;
         DEFAULT_NUM_HEAP_ARENA = Math.max(0,
@@ -190,6 +177,22 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
             logger.debug("-Dio.netty.allocator.maxCachedByteBuffersPerChunk: {}",
                     DEFAULT_MAX_CACHED_BYTEBUFFERS_PER_CHUNK);
         }
+    }
+
+    private static int mallocArenaMax(int defaultMinNumArena) {
+        // Respect MALLOC_ARENA_MAX if set.
+        final String mallocArenaMaxStr = System.getenv("MALLOC_ARENA_MAX");
+        if (mallocArenaMaxStr != null) {
+            try {
+                int value = Integer.parseInt(mallocArenaMaxStr);
+                if (value > 0) {
+                    return Math.min(value, defaultMinNumArena);
+                }
+            } catch (NumberFormatException ignore) {
+                // ignore
+            }
+        }
+        return defaultMinNumArena;
     }
 
     public static final PooledByteBufAllocator DEFAULT =

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -100,7 +100,21 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
          *
          * See https://github.com/netty/netty/issues/3888.
          */
-        final int defaultMinNumArena = NettyRuntime.availableProcessors() * 2;
+        int defaultMinNumArena = NettyRuntime.availableProcessors() * 2;
+
+        // Respect MAX_ARENA_MAX if set.
+        final String mallocArenaMaxStr = System.getenv("MALLOC_ARENA_MAX");
+        if (mallocArenaMaxStr != null) {
+            try {
+                int value = Integer.parseInt(mallocArenaMaxStr);
+                if (value > 0) {
+                    defaultMinNumArena = Math.min(Integer.parseInt(mallocArenaMaxStr), defaultMinNumArena);
+                }
+            } catch (NumberFormatException ignore) {
+                // ignore
+            }
+        }
+
         final int defaultChunkSize = DEFAULT_PAGE_SIZE << DEFAULT_MAX_ORDER;
         DEFAULT_NUM_HEAP_ARENA = Math.max(0,
                 SystemPropertyUtil.getInt(

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -108,7 +108,7 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
             try {
                 int value = Integer.parseInt(mallocArenaMaxStr);
                 if (value > 0) {
-                    defaultMinNumArena = Math.min(Integer.parseInt(mallocArenaMaxStr), defaultMinNumArena);
+                    defaultMinNumArena = Math.min(value, defaultMinNumArena);
                 }
             } catch (NumberFormatException ignore) {
                 // ignore


### PR DESCRIPTION
…arenas.

Motivation:

We should most likely also respect MALLOC_ARENA_MAX (just as other allocators do) when calculate the default number of arenas.

Modifications:

Check if MALLOC_ARENA_MAX is set and if so use it.

Result:

Better defaults
