### PR TITLE
Add another fast-past for ChannelOutboundBuffer slow type checks

### DIFF
--- a/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
@@ -21,6 +21,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.util.Recycler.EnhancedHandle;
 import io.netty.util.ReferenceCountUtil;
+import io.netty.util.concurrent.DefaultProgressivePromise;
 import io.netty.util.concurrent.FastThreadLocal;
 import io.netty.util.internal.InternalThreadLocalMap;
 import io.netty.util.internal.ObjectPool;
@@ -247,7 +248,7 @@ public final class ChannelOutboundBuffer {
         assert p != null;
         final Class<?> promiseClass = p.getClass();
         // fast-path to save O(n) ChannelProgressivePromise's type check on OpenJDK
-        if (promiseClass == VoidChannelPromise.class) {
+        if (promiseClass == VoidChannelPromise.class || promiseClass == DefaultChannelPromise.class) {
             return;
         }
         // this is going to save from type pollution due to https://bugs.openjdk.org/browse/JDK-8180450


### PR DESCRIPTION
Motivation:

https://github.com/netty/netty/pull/13376 has introduced a peeling-off of call-site to avoid some slow-type check, but if non ChannelProgressivePromise types hit it can still perform un-necessary type checks

Modification:

Adding an additional common promise type that doesn't implement ChannelProgressivePromise

Result:

Faster type checks for Netty types and faster outbound buffer progress's performance.