### PR TITLE
Enhance CertificateException message when throw due hostname validation

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/EnhancingX509ExtendedTrustManager.java
+++ b/handler/src/main/java/io/netty/handler/ssl/EnhancingX509ExtendedTrustManager.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.ssl;
+
+import io.netty.util.internal.SuppressJava6Requirement;
+
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.X509ExtendedTrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.net.Socket;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.List;
+
+
+/**
+ * Wraps an existing {@link X509ExtendedTrustManager} and enhances the {@link CertificateException} that is thrown
+ * because of hostname validation.
+ */
+@SuppressJava6Requirement(reason = "Usage guarded by java version check")
+final class EnhancingX509ExtendedTrustManager extends X509ExtendedTrustManager {
+    private final X509ExtendedTrustManager wrapped;
+
+    EnhancingX509ExtendedTrustManager(X509TrustManager wrapped) {
+        this.wrapped = (X509ExtendedTrustManager) wrapped;
+    }
+
+    @Override
+    public void checkClientTrusted(X509Certificate[] chain, String authType, Socket socket)
+            throws CertificateException {
+        try {
+            wrapped.checkClientTrusted(chain, authType, socket);
+        } catch (CertificateException e) {
+            throwEnhancedCertificateException(chain, e);
+        }
+    }
+
+    @Override
+    public void checkServerTrusted(X509Certificate[] chain, String authType, Socket socket)
+            throws CertificateException {
+        wrapped.checkServerTrusted(chain, authType, socket);
+    }
+
+    @Override
+    public void checkClientTrusted(X509Certificate[] chain, String authType, SSLEngine engine)
+            throws CertificateException {
+        try {
+            wrapped.checkClientTrusted(chain, authType, engine);
+        } catch (CertificateException e) {
+            throwEnhancedCertificateException(chain, e);
+        }
+    }
+
+    @Override
+    public void checkServerTrusted(X509Certificate[] chain, String authType, SSLEngine engine)
+            throws CertificateException {
+        wrapped.checkServerTrusted(chain, authType, engine);
+    }
+
+    @Override
+    public void checkClientTrusted(X509Certificate[] chain, String authType)
+            throws CertificateException {
+        try {
+            wrapped.checkClientTrusted(chain, authType);
+        } catch (CertificateException e) {
+            throwEnhancedCertificateException(chain, e);
+        }
+    }
+
+    @Override
+    public void checkServerTrusted(X509Certificate[] chain, String authType)
+            throws CertificateException {
+        wrapped.checkServerTrusted(chain, authType);
+    }
+
+    @Override
+    public X509Certificate[] getAcceptedIssuers() {
+        return wrapped.getAcceptedIssuers();
+    }
+
+    private static void throwEnhancedCertificateException(X509Certificate[] chain, CertificateException e)
+            throws CertificateException {
+        // Matching the message is the best we can do sadly.
+        String message = e.getMessage();
+        if (message != null && e.getMessage().startsWith("No subject alternative DNS name matching")) {
+            StringBuilder names = new StringBuilder(64);
+            for (int i = 0; i < chain.length; i++) {
+                X509Certificate cert = chain[i];
+                for (List<?> altNames : cert.getSubjectAlternativeNames()) {
+                    // 2 is dNSName. See X509Certificate javadocs.
+                    if (altNames.size() >= 2 && ((Integer) altNames.get(0)) == 2) {
+                        names.append((String) altNames.get(1)).append(",");
+                    }
+                }
+            }
+            if (names.length() != 0) {
+                // Strip of ,
+                names.setLength(names.length() - 1);
+                throw new CertificateException(message +
+                        " Subject alternative DNS names in the certificate chain: " + names, e);
+            }
+        }
+        throw e;
+    }
+}

--- a/handler/src/main/java/io/netty/handler/ssl/EnhancingX509ExtendedTrustManager.java
+++ b/handler/src/main/java/io/netty/handler/ssl/EnhancingX509ExtendedTrustManager.java
@@ -42,49 +42,49 @@ final class EnhancingX509ExtendedTrustManager extends X509ExtendedTrustManager {
     @Override
     public void checkClientTrusted(X509Certificate[] chain, String authType, Socket socket)
             throws CertificateException {
-        try {
-            wrapped.checkClientTrusted(chain, authType, socket);
-        } catch (CertificateException e) {
-            throwEnhancedCertificateException(chain, e);
-        }
+        wrapped.checkClientTrusted(chain, authType, socket);
     }
 
     @Override
     public void checkServerTrusted(X509Certificate[] chain, String authType, Socket socket)
             throws CertificateException {
-        wrapped.checkServerTrusted(chain, authType, socket);
+        try {
+            wrapped.checkServerTrusted(chain, authType, socket);
+        } catch (CertificateException e) {
+            throwEnhancedCertificateException(chain, e);
+        }
     }
 
     @Override
     public void checkClientTrusted(X509Certificate[] chain, String authType, SSLEngine engine)
             throws CertificateException {
-        try {
-            wrapped.checkClientTrusted(chain, authType, engine);
-        } catch (CertificateException e) {
-            throwEnhancedCertificateException(chain, e);
-        }
+        wrapped.checkClientTrusted(chain, authType, engine);
     }
 
     @Override
     public void checkServerTrusted(X509Certificate[] chain, String authType, SSLEngine engine)
             throws CertificateException {
-        wrapped.checkServerTrusted(chain, authType, engine);
-    }
-
-    @Override
-    public void checkClientTrusted(X509Certificate[] chain, String authType)
-            throws CertificateException {
         try {
-            wrapped.checkClientTrusted(chain, authType);
+            wrapped.checkServerTrusted(chain, authType, engine);
         } catch (CertificateException e) {
             throwEnhancedCertificateException(chain, e);
         }
     }
 
     @Override
+    public void checkClientTrusted(X509Certificate[] chain, String authType)
+            throws CertificateException {
+        wrapped.checkClientTrusted(chain, authType);
+    }
+
+    @Override
     public void checkServerTrusted(X509Certificate[] chain, String authType)
             throws CertificateException {
-        wrapped.checkServerTrusted(chain, authType);
+        try {
+            wrapped.checkServerTrusted(chain, authType);
+        } catch (CertificateException e) {
+            throwEnhancedCertificateException(chain, e);
+        }
     }
 
     @Override

--- a/handler/src/main/java/io/netty/handler/ssl/EnhancingX509ExtendedTrustManager.java
+++ b/handler/src/main/java/io/netty/handler/ssl/EnhancingX509ExtendedTrustManager.java
@@ -24,6 +24,7 @@ import javax.net.ssl.X509TrustManager;
 import java.net.Socket;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.util.Collection;
 import java.util.List;
 
 
@@ -100,10 +101,13 @@ final class EnhancingX509ExtendedTrustManager extends X509ExtendedTrustManager {
             StringBuilder names = new StringBuilder(64);
             for (int i = 0; i < chain.length; i++) {
                 X509Certificate cert = chain[i];
-                for (List<?> altNames : cert.getSubjectAlternativeNames()) {
-                    // 2 is dNSName. See X509Certificate javadocs.
-                    if (altNames.size() >= 2 && ((Integer) altNames.get(0)) == 2) {
-                        names.append((String) altNames.get(1)).append(",");
+                Collection<List<?>> collection = cert.getSubjectAlternativeNames();
+                if (collection != null) {
+                    for (List<?> altNames : collection) {
+                        // 2 is dNSName. See X509Certificate javadocs.
+                        if (altNames.size() >= 2 && ((Integer) altNames.get(0)).intValue() == 2) {
+                            names.append((String) altNames.get(1)).append(",");
+                        }
                     }
                 }
             }
@@ -111,7 +115,8 @@ final class EnhancingX509ExtendedTrustManager extends X509ExtendedTrustManager {
                 // Strip of ,
                 names.setLength(names.length() - 1);
                 throw new CertificateException(message +
-                        " Subject alternative DNS names in the certificate chain: " + names, e);
+                        " Subject alternative DNS names in the certificate chain of " + chain.length +
+                        " certificate(s): " + names, e);
             }
         }
         throw e;

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -660,10 +660,16 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
     protected static X509TrustManager chooseTrustManager(TrustManager[] managers) {
         for (TrustManager m : managers) {
             if (m instanceof X509TrustManager) {
+                X509TrustManager tm = (X509TrustManager) m;
                 if (PlatformDependent.javaVersion() >= 7) {
-                    return OpenSslX509TrustManagerWrapper.wrapIfNeeded((X509TrustManager) m);
+                    tm = OpenSslX509TrustManagerWrapper.wrapIfNeeded((X509TrustManager) m);
+                    if (useExtendedTrustManager(tm)) {
+                        // Wrap the TrustManager to provide a better exception message for users to debug hostname
+                        // validation failures.
+                        tm = new EnhancingX509ExtendedTrustManager(tm);
+                    }
                 }
-                return (X509TrustManager) m;
+                return tm;
             }
         }
         throw new IllegalStateException("no X509TrustManager found");

--- a/handler/src/test/java/io/netty/handler/ssl/EnhancedX509ExtendedTrustManagerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/EnhancedX509ExtendedTrustManagerTest.java
@@ -1,0 +1,319 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.ssl;
+
+import io.netty.util.internal.EmptyArrays;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.X509ExtendedTrustManager;
+import java.math.BigInteger;
+import java.net.Socket;
+import java.security.Principal;
+import java.security.PublicKey;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class EnhancedX509ExtendedTrustManagerTest {
+
+    private static final X509Certificate TEST_CERT = new X509Certificate() {
+
+        @Override
+        public Collection<List<?>> getSubjectAlternativeNames() {
+            return Arrays.asList(Arrays.asList(1, new Object()), Arrays.asList(2, "some.netty.io"));
+        }
+
+        @Override
+        public void checkValidity() {
+            // NOOP
+        }
+
+        @Override
+        public void checkValidity(Date date) {
+            // NOOP
+        }
+
+        @Override
+        public int getVersion() {
+            return 0;
+        }
+
+        @Override
+        public BigInteger getSerialNumber() {
+            return null;
+        }
+
+        @Override
+        public Principal getIssuerDN() {
+            return null;
+        }
+
+        @Override
+        public Principal getSubjectDN() {
+            return null;
+        }
+
+        @Override
+        public Date getNotBefore() {
+            return null;
+        }
+
+        @Override
+        public Date getNotAfter() {
+            return null;
+        }
+
+        @Override
+        public byte[] getTBSCertificate() {
+            return EmptyArrays.EMPTY_BYTES;
+        }
+
+        @Override
+        public byte[] getSignature() {
+            return EmptyArrays.EMPTY_BYTES;
+        }
+
+        @Override
+        public String getSigAlgName() {
+            return null;
+        }
+
+        @Override
+        public String getSigAlgOID() {
+            return null;
+        }
+
+        @Override
+        public byte[] getSigAlgParams() {
+            return EmptyArrays.EMPTY_BYTES;
+        }
+
+        @Override
+        public boolean[] getIssuerUniqueID() {
+            return new boolean[0];
+        }
+
+        @Override
+        public boolean[] getSubjectUniqueID() {
+            return new boolean[0];
+        }
+
+        @Override
+        public boolean[] getKeyUsage() {
+            return new boolean[0];
+        }
+
+        @Override
+        public int getBasicConstraints() {
+            return 0;
+        }
+
+        @Override
+        public byte[] getEncoded() {
+            return EmptyArrays.EMPTY_BYTES;
+        }
+
+        @Override
+        public void verify(PublicKey key) {
+            // NOOP
+        }
+
+        @Override
+        public void verify(PublicKey key, String sigProvider) {
+            // NOOP
+        }
+
+        @Override
+        public String toString() {
+            return null;
+        }
+
+        @Override
+        public PublicKey getPublicKey() {
+            return null;
+        }
+
+        @Override
+        public boolean hasUnsupportedCriticalExtension() {
+            return false;
+        }
+
+        @Override
+        public Set<String> getCriticalExtensionOIDs() {
+            return null;
+        }
+
+        @Override
+        public Set<String> getNonCriticalExtensionOIDs() {
+            return null;
+        }
+
+        @Override
+        public byte[] getExtensionValue(String oid) {
+            return EmptyArrays.EMPTY_BYTES;
+        }
+    };
+
+    private static final EnhancingX509ExtendedTrustManager MATCHING_MANAGER =
+            new EnhancingX509ExtendedTrustManager(new X509ExtendedTrustManager() {
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType, Socket socket)
+                throws CertificateException {
+            throw new CertificateException("No subject alternative DNS name matching netty.io.");
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType, Socket socket) {
+            fail();
+        }
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType, SSLEngine engine)
+                throws CertificateException {
+            throw new CertificateException("No subject alternative DNS name matching netty.io.");
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType, SSLEngine engine) {
+            fail();
+        }
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType)
+                throws CertificateException {
+            throw new CertificateException("No subject alternative DNS name matching netty.io.");
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType) {
+            fail();
+        }
+
+        @Override
+        public X509Certificate[] getAcceptedIssuers() {
+            return new X509Certificate[0];
+        }
+    });
+
+    static List<Executable> throwingMatchingExecutables() {
+        return Arrays.asList(new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                MATCHING_MANAGER.checkClientTrusted(new X509Certificate[] { TEST_CERT }, null);
+            }
+        }, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                MATCHING_MANAGER.checkClientTrusted(new X509Certificate[] { TEST_CERT }, null, (SSLEngine) null);
+            }
+        }, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                MATCHING_MANAGER.checkClientTrusted(new X509Certificate[] { TEST_CERT }, null, (SSLSocket) null);
+            }
+        });
+    }
+
+    private static final EnhancingX509ExtendedTrustManager NON_MATCHING_MANAGER =
+            new EnhancingX509ExtendedTrustManager(new X509ExtendedTrustManager() {
+                @Override
+                public void checkClientTrusted(X509Certificate[] chain, String authType, Socket socket)
+                        throws CertificateException {
+                    throw new CertificateException();
+                }
+
+                @Override
+                public void checkServerTrusted(X509Certificate[] chain, String authType, Socket socket) {
+                    fail();
+                }
+
+                @Override
+                public void checkClientTrusted(X509Certificate[] chain, String authType, SSLEngine engine)
+                        throws CertificateException {
+                    throw new CertificateException();
+                }
+
+                @Override
+                public void checkServerTrusted(X509Certificate[] chain, String authType, SSLEngine engine) {
+                    fail();
+                }
+
+                @Override
+                public void checkClientTrusted(X509Certificate[] chain, String authType)
+                        throws CertificateException {
+                    throw new CertificateException();
+                }
+
+                @Override
+                public void checkServerTrusted(X509Certificate[] chain, String authType) {
+                    fail();
+                }
+
+                @Override
+                public X509Certificate[] getAcceptedIssuers() {
+                    return new X509Certificate[0];
+                }
+            });
+
+    static List<Executable> throwingNonMatchingExecutables() {
+        return Arrays.asList(new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                NON_MATCHING_MANAGER.checkClientTrusted(new X509Certificate[] { TEST_CERT }, null);
+            }
+        }, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                NON_MATCHING_MANAGER.checkClientTrusted(new X509Certificate[] { TEST_CERT }, null, (SSLEngine) null);
+            }
+        }, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                NON_MATCHING_MANAGER.checkClientTrusted(new X509Certificate[] { TEST_CERT }, null, (SSLSocket) null);
+            }
+        });
+    }
+
+    @ParameterizedTest
+    @MethodSource("throwingMatchingExecutables")
+    void testEnhanceException(Executable executable)  {
+        CertificateException exception = assertThrows(CertificateException.class, executable);
+        // We should wrap the original cause with our own.
+        assertInstanceOf(CertificateException.class, exception.getCause());
+    }
+
+    @ParameterizedTest
+    @MethodSource("throwingNonMatchingExecutables")
+    void testNotEnhanceException(Executable executable) {
+        CertificateException exception = assertThrows(CertificateException.class, executable);
+        // We should not wrap the original cause with our own.
+        assertNull(exception.getCause());
+    }
+}


### PR DESCRIPTION
Motivation:

It is hard for end-user to understand why the hostname validation failed. Let's try to help them by including the SubjectAlternativeNames if there are any.

Modifications:

- Wrap the X509ExtendedTrustManager and so be able to catch the CertificateException and add more details if needed
- Add unit test

Result:

Easier to debug hostname validation problems
