### PR TITLE
Set top level permission to remaining workflows

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -24,6 +24,8 @@ on:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+  
+permissions: read-all
 
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryhandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=240

--- a/.github/workflows/ci-pr-reports.yml
+++ b/.github/workflows/ci-pr-reports.yml
@@ -22,8 +22,7 @@ on:
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryhandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
 
-permissions:
-  contents: read
+permissions: read-all
 
 jobs:
   tests:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -22,6 +22,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryhandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
 
@@ -103,6 +106,9 @@ jobs:
     name: linux-aarch64-verify-native
     # The host should always be Linux
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      packages: write  # for uraimo/run-on-arch-action to cache docker images
     needs: verify-pr
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci-release-5.yml
+++ b/.github/workflows/ci-release-5.yml
@@ -20,6 +20,9 @@ on:
   # Releases can only be triggered via the action tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryhandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
 

--- a/.github/workflows/ci-release-5.yml
+++ b/.github/workflows/ci-release-5.yml
@@ -20,8 +20,7 @@ on:
   # Releases can only be triggered via the action tab
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: read-all
 
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryhandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=240

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -20,6 +20,9 @@ on:
   # Releases can only be triggered via the action tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryhandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
 

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -20,8 +20,7 @@ on:
   # Releases can only be triggered via the action tab
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: read-all
 
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryhandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=240


### PR DESCRIPTION
Motivation:

Setting minimum permissions on workflow's top level is good practice. Similar changes were previously discussed in https://github.com/netty/netty/pull/12462. Since some workflows were left out of the previous PR, this PR is a small update to restrict their permissions.

Modification:

Set top level read only permission to `ci-deploy.yml`, `ci-pr.yml`, `ci-release.yml` and `ci-release5.yml`

I wasn't able to test the workflows:

- `ci-release.yml` and `ci-release5.yml`: although I wasn't able to test successfully, considering that they are basically using personalized secrets and not the standard GITHUB_TOKEN (github.token), I've considered that no write permission would be needed to it. To avoid errors I've opted for `read-all` instead of `contents: read`.

- `ci-deploy.yml` also seems to not be working so I wasn't able to provide a success example either.

- `ci-pr.yml` run example https://github.com/joycebrum/netty/actions/runs/4994205584. Not sure why it didn't run on my fork but the errors seems not to be related to any permission. Anyway, I've changed the permission to read-all which certainly will be enough since it runs on pull request (which will always be no more than read-all to external PRs).

Result:

Similar change discussed at https://github.com/netty/netty/pull/12462: since github workflow default behavior is to grant write all permission to any workflow it is both a recommendation from [OpenSSF Scorecard](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and the [Github](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions) to always use credentials that are minimally scoped.
