### PR TITLE
Channel#bytesBefore[un]writable off by 1

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
@@ -925,7 +925,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
         assertFalse(parentChannel.isWritable());
 
         assertTrue(childChannel.isWritable());
-        assertEquals(4096, childChannel.bytesBeforeUnwritable());
+        assertEquals(4097, childChannel.bytesBeforeUnwritable());
 
         // Flush everything which simulate writing everything to the socket.
         parentChannel.flush();


### PR DESCRIPTION
Motivation:
Channel#bytesBefore[un]writable methods are described as returning the number of bytes until writability state changes. The ChannelConfig buffer high/low water marks are described as the thresholds must be exceeded before writability changes. The implementation of bytesBefore[un]writable methods return the number of bytes until the threshold is meet but not exceeded. If implementations depend upon this to drive readability they may hang.

Modifications:
- Channel#bytesBefore[un]writable implementations in http/2 and ChannelOutboundBuffer increment the value by 1 to return how much is required to cross the water mark therefore trigger a change in writability.