### PR TITLE
Fix possible NPE when calling PoolArena.toString()

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -567,7 +567,7 @@ abstract class PoolArena<T> extends SizeClasses implements PoolArenaMetric {
     private static void appendPoolSubPages(StringBuilder buf, PoolSubpage<?>[] subpages) {
         for (int i = 0; i < subpages.length; i ++) {
             PoolSubpage<?> head = subpages[i];
-            if (head.next == head) {
+            if (head.next == head || head.next == null) {
                 continue;
             }
 
@@ -575,7 +575,7 @@ abstract class PoolArena<T> extends SizeClasses implements PoolArenaMetric {
                     .append(i)
                     .append(": ");
             PoolSubpage<?> s = head.next;
-            for (;;) {
+            while (s != null) {
                 buf.append(s);
                 s = s.next;
                 if (s == head) {


### PR DESCRIPTION
Motivation:

We did miss a null check and so risk a NPE during generating the String representation of the PoolArena.

Modifications:

Add null checks

Result:

Fixes https://github.com/netty/netty/issues/13390.