### PR TITLE
`Http2MultiplexHandler` forward some user events to active streams

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
@@ -125,6 +125,10 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
                 anyHttp2Settings(), anyChannelPromise());
     }
 
+    Channel parentChannel() {
+        return parentChannel;
+    }
+
     private ChannelHandlerContext eqCodecCtx() {
         return eq(codec.ctx);
     }


### PR DESCRIPTION
Motivation:

The following 4 user events mean that one of the sides of the parent channel is shutdown. `Http2MultiplexHandler` should propagate those events to all active streams to let them identify if they still can complete or not. For example, streams that didn't receive `endStream` flag can decide to close if they observe one of these events. These events should still propagate through the parent channel pipeline.

Modifications:
- Create `Http2FrameStreamVisitor`s for `ChannelInputShutdownEvent`, `ChannelInputShutdownReadComplete`, `ChannelOutputShutdownEvent`, `SslCloseCompletionEvent`;
- Propagate these events to all active streams;
- Add a test to validate new behavior;

Result:

Active child streams can observe when parent channel's input or output is shutdown or if it received `close_notify`.