### PR TITLE
HTTP/2 don't propagate `ChannelInputShutdownEvent` to active streams

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
@@ -35,7 +35,6 @@ import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.VoidChannelPromise;
 import io.netty.channel.WriteBufferWaterMark;
-import io.netty.channel.socket.ChannelInputShutdownEvent;
 import io.netty.channel.socket.ChannelInputShutdownReadComplete;
 import io.netty.channel.socket.ChannelOutputShutdownEvent;
 import io.netty.handler.codec.http2.Http2FrameCodec.DefaultHttp2FrameStream;
@@ -70,9 +69,6 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
             return true;
         }
     };
-
-    static final Http2FrameStreamVisitor CHANNEL_INPUT_SHUTDOWN_EVENT_VISITOR =
-            new UserEventStreamVisitor(ChannelInputShutdownEvent.INSTANCE);
 
     static final Http2FrameStreamVisitor CHANNEL_INPUT_SHUTDOWN_READ_COMPLETE_VISITOR =
             new UserEventStreamVisitor(ChannelInputShutdownReadComplete.INSTANCE);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
@@ -23,18 +23,15 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.EventLoop;
-import io.netty.channel.socket.ChannelInputShutdownEvent;
 import io.netty.channel.socket.ChannelInputShutdownReadComplete;
 import io.netty.channel.socket.ChannelOutputShutdownEvent;
 import io.netty.handler.ssl.SslCloseCompletionEvent;
 import io.netty.util.ReferenceCounted;
-
 import io.netty.util.internal.UnstableApi;
 
 import java.util.ArrayDeque;
 import java.util.Queue;
 
-import static io.netty.handler.codec.http2.AbstractHttp2StreamChannel.CHANNEL_INPUT_SHUTDOWN_EVENT_VISITOR;
 import static io.netty.handler.codec.http2.AbstractHttp2StreamChannel.CHANNEL_INPUT_SHUTDOWN_READ_COMPLETE_VISITOR;
 import static io.netty.handler.codec.http2.AbstractHttp2StreamChannel.CHANNEL_OUTPUT_SHUTDOWN_EVENT_VISITOR;
 import static io.netty.handler.codec.http2.AbstractHttp2StreamChannel.SSL_CLOSE_COMPLETION_EVENT_VISITOR;
@@ -295,9 +292,7 @@ public class Http2MultiplexCodec extends Http2FrameCodec {
 
     @Override
     final void onUserEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
-        if (evt == ChannelInputShutdownEvent.INSTANCE) {
-            forEachActiveStream(CHANNEL_INPUT_SHUTDOWN_EVENT_VISITOR);
-        } else if (evt == ChannelInputShutdownReadComplete.INSTANCE) {
+        if (evt == ChannelInputShutdownReadComplete.INSTANCE) {
             forEachActiveStream(CHANNEL_INPUT_SHUTDOWN_READ_COMPLETE_VISITOR);
         } else if (evt == ChannelOutputShutdownEvent.INSTANCE) {
             forEachActiveStream(CHANNEL_OUTPUT_SHUTDOWN_EVENT_VISITOR);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexHandler.java
@@ -25,7 +25,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoop;
 import io.netty.channel.ServerChannel;
-import io.netty.channel.socket.ChannelInputShutdownEvent;
 import io.netty.channel.socket.ChannelInputShutdownReadComplete;
 import io.netty.channel.socket.ChannelOutputShutdownEvent;
 import io.netty.handler.codec.http2.Http2FrameCodec.DefaultHttp2FrameStream;
@@ -38,7 +37,6 @@ import java.util.ArrayDeque;
 import java.util.Queue;
 import javax.net.ssl.SSLException;
 
-import static io.netty.handler.codec.http2.AbstractHttp2StreamChannel.CHANNEL_INPUT_SHUTDOWN_EVENT_VISITOR;
 import static io.netty.handler.codec.http2.AbstractHttp2StreamChannel.CHANNEL_INPUT_SHUTDOWN_READ_COMPLETE_VISITOR;
 import static io.netty.handler.codec.http2.AbstractHttp2StreamChannel.CHANNEL_OUTPUT_SHUTDOWN_EVENT_VISITOR;
 import static io.netty.handler.codec.http2.AbstractHttp2StreamChannel.SSL_CLOSE_COMPLETION_EVENT_VISITOR;
@@ -264,9 +262,7 @@ public final class Http2MultiplexHandler extends Http2ChannelDuplexHandler {
             }
             return;
         }
-        if (evt == ChannelInputShutdownEvent.INSTANCE) {
-            forEachActiveStream(CHANNEL_INPUT_SHUTDOWN_EVENT_VISITOR);
-        } else if (evt == ChannelInputShutdownReadComplete.INSTANCE) {
+        if (evt == ChannelInputShutdownReadComplete.INSTANCE) {
             forEachActiveStream(CHANNEL_INPUT_SHUTDOWN_READ_COMPLETE_VISITOR);
         } else if (evt == ChannelOutputShutdownEvent.INSTANCE) {
             forEachActiveStream(CHANNEL_OUTPUT_SHUTDOWN_EVENT_VISITOR);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
@@ -26,7 +26,6 @@ import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.channel.socket.ChannelInputShutdownEvent;
 import io.netty.channel.socket.ChannelInputShutdownReadComplete;
 import io.netty.channel.socket.ChannelOutputShutdownEvent;
 import io.netty.handler.codec.http.HttpHeaderNames;
@@ -1409,7 +1408,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
     }
 
     private static Collection<Object> userEvents() {
-        return Arrays.asList(ChannelInputShutdownEvent.INSTANCE, ChannelInputShutdownReadComplete.INSTANCE,
+        return Arrays.asList(ChannelInputShutdownReadComplete.INSTANCE,
                 ChannelOutputShutdownEvent.INSTANCE, SslCloseCompletionEvent.SUCCESS);
     }
 


### PR DESCRIPTION
Motivation:

Follow-up for #13394 to remove `ChannelInputShutdownEvent` propagation. Discussed with @Scottmitch, `ChannelInputShutdownEvent` is a premature event, most users should rely on `ChannelInputShutdownReadComplete` instead. Let's propagate only the later one and if there is a use-case for `ChannelInputShutdownEvent` we can add its propagation later.

Modifications:

- Remove `CHANNEL_INPUT_SHUTDOWN_EVENT_VISITOR` to stop propagation of `ChannelInputShutdownEvent`;
- Adjust tests;

Result:

`ChannelInputShutdownEvent` is not propagated for now. We can add it back when there is a use-case.