### PR TITLE
ServerBootstrapAcceptor added to pipeline outside the eventloop

### DIFF
--- a/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
@@ -148,13 +148,8 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
                     pipeline.addLast(handler);
                 }
 
-                ch.eventLoop().execute(new Runnable() {
-                    @Override
-                    public void run() {
-                        pipeline.addLast(new ServerBootstrapAcceptor(
-                                ch, currentChildGroup, currentChildHandler, currentChildOptions, currentChildAttrs));
-                    }
-                });
+                pipeline.addLast(new ServerBootstrapAcceptor(ch, currentChildGroup, currentChildHandler,
+                                                             currentChildOptions, currentChildAttrs));
             }
         });
     }

--- a/transport/src/main/java/io/netty/channel/DefaultMaxMessagesRecvByteBufAllocator.java
+++ b/transport/src/main/java/io/netty/channel/DefaultMaxMessagesRecvByteBufAllocator.java
@@ -101,7 +101,7 @@ public abstract class DefaultMaxMessagesRecvByteBufAllocator implements MaxMessa
         private final UncheckedBooleanSupplier defaultMaybeMoreSupplier = new UncheckedBooleanSupplier() {
             @Override
             public boolean get() {
-                return attemptedBytesRead == lastBytesRead;
+                return lastBytesRead > 0 && attemptedBytesRead == lastBytesRead;
             }
         };
 
@@ -146,8 +146,8 @@ public abstract class DefaultMaxMessagesRecvByteBufAllocator implements MaxMessa
         @Override
         public boolean continueReading(UncheckedBooleanSupplier maybeMoreDataSupplier) {
             return config.isAutoRead() &&
-                   (!respectMaybeMoreData || maybeMoreDataSupplier.get()) &&
-                   totalMessages < maxMessagePerRead && (ignoreBytesRead || totalBytesRead > 0);
+                   (ignoreBytesRead || (!respectMaybeMoreData || maybeMoreDataSupplier.get())) &&
+                   totalMessages < maxMessagePerRead;
         }
 
         @Override


### PR DESCRIPTION
Motivation:

ServerBootstrapAcceptor doesn't need added in the eventloop.

ref: pr [5576](https://github.com/netty/netty/pull/5576)

ref: commit [26aa3485](https://github.com/netty/netty/commit/26aa34853a8974d212e12b98e708790606bea5fa) method: handlerAdded 

with the commit [26aa3485](https://github.com/netty/netty/commit/26aa34853a8974d212e12b98e708790606bea5fa) , ServerBootstrapAcceptor doesn't need added in the eventloop.

Modification:

ServerBootstrapAcceptor add to pipeline

Result:

Fixes #<GitHub issue number>. 

If there is no issue then describe the changes introduced by this PR.
