### PR TITLE
make RecvByteBufAllocator.continueReading easier to understand

### DIFF
--- a/transport/src/main/java/io/netty/channel/DefaultMaxMessagesRecvByteBufAllocator.java
+++ b/transport/src/main/java/io/netty/channel/DefaultMaxMessagesRecvByteBufAllocator.java
@@ -101,7 +101,7 @@ public abstract class DefaultMaxMessagesRecvByteBufAllocator implements MaxMessa
         private final UncheckedBooleanSupplier defaultMaybeMoreSupplier = new UncheckedBooleanSupplier() {
             @Override
             public boolean get() {
-                return attemptedBytesRead == lastBytesRead;
+                return lastBytesRead > 0 && attemptedBytesRead == lastBytesRead;
             }
         };
 
@@ -146,8 +146,8 @@ public abstract class DefaultMaxMessagesRecvByteBufAllocator implements MaxMessa
         @Override
         public boolean continueReading(UncheckedBooleanSupplier maybeMoreDataSupplier) {
             return config.isAutoRead() &&
-                   (!respectMaybeMoreData || maybeMoreDataSupplier.get()) &&
-                   totalMessages < maxMessagePerRead && (ignoreBytesRead || totalBytesRead > 0);
+                    (ignoreBytesRead || (!respectMaybeMoreData || maybeMoreDataSupplier.get())) &&
+                    totalMessages < maxMessagePerRead;
         }
 
         @Override

--- a/transport/src/main/java/io/netty/channel/DefaultMaxMessagesRecvByteBufAllocator.java
+++ b/transport/src/main/java/io/netty/channel/DefaultMaxMessagesRecvByteBufAllocator.java
@@ -146,8 +146,8 @@ public abstract class DefaultMaxMessagesRecvByteBufAllocator implements MaxMessa
         @Override
         public boolean continueReading(UncheckedBooleanSupplier maybeMoreDataSupplier) {
             return config.isAutoRead() &&
-                    (ignoreBytesRead || (!respectMaybeMoreData || maybeMoreDataSupplier.get())) &&
-                    totalMessages < maxMessagePerRead;
+                   (ignoreBytesRead || (!respectMaybeMoreData || maybeMoreDataSupplier.get())) &&
+                   totalMessages < maxMessagePerRead;
         }
 
         @Override


### PR DESCRIPTION
Motivation:

make RecvByteBufAllocator.continueReading logic easier to understand

Modification:

determine whether to continue read don't need to know totalBytesRead>0, but need to know lastBytesRead>0 in the maybe more data logic.

Result:

easier understand

Fixes #<GitHub issue number>. 

If there is no issue then describe the changes introduced by this PR.
