### PR TITLE
Add alt-scv header name

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderNames.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderNames.java
@@ -377,5 +377,10 @@ public final class HttpHeaderNames {
      */
     public static final AsciiString X_REQUESTED_WITH = AsciiString.cached("x-requested-with");
 
+    /**
+     * {@code "alt-svc"}
+     */
+    public static final AsciiString ALT_SVC = AsciiString.cached("alt-svc");
+
     private HttpHeaderNames() { }
 }


### PR DESCRIPTION
Motivation:

HTTP3 uses Alt-Svc to announce that it is supported by an endpoint. Let's define a header name for it that the user can use.

See https://datatracker.ietf.org/doc/html/rfc9114#section-3.1.1

Modifications:

Add header name to HttpHeaderNames.

Result:

Easier to enable support for h3

