### PR TITLE
Update Brotli4j to 1.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -641,7 +641,7 @@
     <skipAutobahnTestsuite>false</skipAutobahnTestsuite>
     <skipHttp2Testsuite>false</skipHttp2Testsuite>
     <graalvm.version>19.3.6</graalvm.version>
-    <brotli4j.version>1.11.0</brotli4j.version>
+    <brotli4j.version>1.12.0</brotli4j.version>
     <!-- By default skip native testsuite as it requires a custom environment with graalvm installed -->
     <skipNativeImageTestsuite>true</skipNativeImageTestsuite>
     <skipShadingTestsuite>false</skipShadingTestsuite>


### PR DESCRIPTION
Motivation:
Brotli4j v1.12.0 is available and we should upgrade to it.

Modification:
Upgraded Brotl4ij to v1.12.0

Result:
Latest Brotli4j
