### PR TITLE
assert PoolSubpage's bitmap.length

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolSubpage.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolSubpage.java
@@ -74,6 +74,9 @@ final class PoolSubpage<T> implements PoolSubpageMetric {
                 bitmapLength ++;
             }
         }
+
+        assert bitmap.length == bitmapLength;
+
         addToPool(head);
     }
 

--- a/buffer/src/test/java/io/netty/buffer/PoolSubpageTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PoolSubpageTest.java
@@ -1,0 +1,14 @@
+package io.netty.buffer;
+
+import org.junit.jupiter.api.Test;
+
+public class PoolSubpageTest {
+
+    @Test
+    public void testBitMapLen() {
+        PoolSubpage head = new PoolSubpage();
+        head.prev = head;
+        head.next = head;
+        new PoolSubpage(head, null, 13, 0, 8192, 32);
+    }
+}


### PR DESCRIPTION
Motivation:

in some case, PoolSubpage's bitmap.length > bitmapLength. this pr is for verify it.

The fix is in [pr](https://github.com/netty/netty/pull/13413)

@normanmaurer 

Modification:

add assert

Result:

Fixes #<GitHub issue number>. 

If there is no issue then describe the changes introduced by this PR.
