### PR TITLE
Respect offset in io.netty.util.NetUtil#toAddressString(byte[], int, …

### DIFF
--- a/common/src/main/java/io/netty/util/NetUtil.java
+++ b/common/src/main/java/io/netty/util/NetUtil.java
@@ -988,10 +988,9 @@ public final class NetUtil {
 
     private static String toAddressString(byte[] bytes, int offset, boolean ipv4Mapped) {
         final int[] words = new int[IPV6_WORD_COUNT];
-        int i;
-        final int end = offset + words.length;
-        for (i = offset; i < end; ++i) {
-            words[i] = ((bytes[i << 1] & 0xff) << 8) | (bytes[(i << 1) + 1] & 0xff);
+        for (int i = 0; i < words.length; ++i) {
+            int idx = (i << 1) + offset;
+            words[i] = ((bytes[idx] & 0xff) << 8) | (bytes[idx + 1] & 0xff);
         }
 
         // Find longest run of 0s, tie goes to first found instance
@@ -999,7 +998,7 @@ public final class NetUtil {
         int currentLength;
         int shortestStart = -1;
         int shortestLength = 0;
-        for (i = 0; i < words.length; ++i) {
+        for (int i = 0; i < words.length; ++i) {
             if (words[i] == 0) {
                 if (currentStart < 0) {
                     currentStart = i;
@@ -1015,7 +1014,7 @@ public final class NetUtil {
         }
         // If the array ends on a streak of zeros, make sure we account for it
         if (currentStart >= 0) {
-            currentLength = i - currentStart;
+            currentLength = words.length - currentStart;
             if (currentLength > shortestLength) {
                 shortestStart = currentStart;
                 shortestLength = currentLength;
@@ -1032,7 +1031,7 @@ public final class NetUtil {
         final StringBuilder b = new StringBuilder(IPV6_MAX_CHAR_COUNT);
         if (shortestEnd < 0) { // Optimization when there is no compressing needed
             b.append(Integer.toHexString(words[0]));
-            for (i = 1; i < words.length; ++i) {
+            for (int i = 1; i < words.length; ++i) {
                 b.append(':');
                 b.append(Integer.toHexString(words[i]));
             }
@@ -1046,7 +1045,7 @@ public final class NetUtil {
                 b.append(Integer.toHexString(words[0]));
                 isIpv4Mapped = false;
             }
-            for (i = 1; i < words.length; ++i) {
+            for (int i = 1; i < words.length; ++i) {
                 if (!inRangeEndExclusive(i, shortestStart, shortestEnd)) {
                     if (!inRangeEndExclusive(i - 1, shortestStart, shortestEnd)) {
                         // If the last index was not part of the shortened sequence

--- a/common/src/test/java/io/netty/util/NetUtilTest.java
+++ b/common/src/test/java/io/netty/util/NetUtilTest.java
@@ -701,7 +701,7 @@ public class NetUtilTest {
     }
 
     @Test
-    public void testBytesToIpAddress() throws UnknownHostException {
+    public void testBytesToIpAddress() {
         for (Entry<String, String> e : validIpV4Hosts.entrySet()) {
             assertEquals(e.getKey(), bytesToIpAddress(createByteArrayFromIpAddressString(e.getKey())));
             assertEquals(e.getKey(), bytesToIpAddress(validIpV4ToBytes(e.getKey())));
@@ -709,6 +709,31 @@ public class NetUtilTest {
         for (Entry<byte[], String> testEntry : ipv6ToAddressStrings.entrySet()) {
             assertEquals(testEntry.getValue(), bytesToIpAddress(testEntry.getKey()));
         }
+    }
+
+    @Test
+    public void testBytesToIpAddressWithOffset() {
+        for (Entry<String, String> e : validIpV4Hosts.entrySet()) {
+            byte[] bytes = copyWithOffset(createByteArrayFromIpAddressString(e.getKey()));
+            assertEquals(e.getKey(), bytesToIpAddress(bytes, 1, bytes.length - 2));
+
+            byte[] bytes2 = copyWithOffset(createByteArrayFromIpAddressString(e.getKey()));
+            assertEquals(e.getKey(), bytesToIpAddress(bytes2, 1, bytes2.length - 2));
+        }
+
+        for (Entry<byte[], String> testEntry : ipv6ToAddressStrings.entrySet()) {
+            byte[] bytes = copyWithOffset(testEntry.getKey());
+            assertEquals(testEntry.getValue(), bytesToIpAddress(bytes, 1, bytes.length - 2));
+        }
+    }
+
+    private static byte[] copyWithOffset(byte[] bytes) {
+        if (bytes == null) {
+            return null;
+        }
+        byte[] array = new byte[bytes.length + 2];
+        System.arraycopy(bytes, 0, array, 1,  bytes.length);
+        return array;
     }
 
     @Test


### PR DESCRIPTION
…boolean)

Motivation:

We didnt correctly handle the offset and so did throw an ArrayIndexOutOfBoundsException.

Modifications:

- Correctly respect the offset
- Add unit tests

Result:

Fixes https://github.com/netty/netty/issues/13403
