### PR TITLE
Use network byte order when encoding ipv4 address and port for Socks codecs

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -693,6 +693,24 @@ public final class ByteBufUtil {
     }
 
     /**
+     * Reads a big-endian unsigned 16-bit short integer from the buffer.
+     */
+    @SuppressWarnings("deprecation")
+    public static int readUnsignedShortBE(ByteBuf buf) {
+        return buf.order() == ByteOrder.BIG_ENDIAN? buf.readUnsignedShort() :
+                swapShort((short) buf.readUnsignedShort());
+    }
+
+    /**
+     * Reads a big-endian 32-bit integer from the buffer.
+     */
+    @SuppressWarnings("deprecation")
+    public static int readIntBE(ByteBuf buf) {
+        return buf.order() == ByteOrder.BIG_ENDIAN? buf.readInt() :
+                swapInt(buf.readInt());
+    }
+
+    /**
      * Read the given amount of bytes into a new {@link ByteBuf} that is allocated from the {@link ByteBufAllocator}.
      */
     public static ByteBuf readBytes(ByteBufAllocator alloc, ByteBuf buffer, int length) {

--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -698,7 +698,7 @@ public final class ByteBufUtil {
     @SuppressWarnings("deprecation")
     public static int readUnsignedShortBE(ByteBuf buf) {
         return buf.order() == ByteOrder.BIG_ENDIAN? buf.readUnsignedShort() :
-                swapShort((short) buf.readUnsignedShort());
+                swapShort((short) buf.readUnsignedShort()) & 0xFFFF;
     }
 
     /**

--- a/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
@@ -290,7 +290,8 @@ public class ByteBufUtilTest {
     @ParameterizedTest(name = PARAMETERIZED_NAME)
     @MethodSource("noUnsafe")
     public void readUnsignedShortBE(BufferType bufferType) {
-        int shortValue = 0x1234;
+        int shortValue = 0x1234; // unsigned short
+        int swappedShortValue = 0x3412; // swapped version of the value above
 
         ByteBuf buf = buffer(bufferType, 2).order(ByteOrder.BIG_ENDIAN);
         buf.writeShort(shortValue);
@@ -298,16 +299,37 @@ public class ByteBufUtilTest {
         buf.resetReaderIndex();
         buf.resetWriterIndex();
         buf.writeShortLE(shortValue);
-        assertEquals(ByteBufUtil.swapShort((short) shortValue), ByteBufUtil.readUnsignedShortBE(buf));
+        assertEquals(swappedShortValue, ByteBufUtil.readUnsignedShortBE(buf));
         buf.release();
 
         buf = buffer(bufferType, 2).order(ByteOrder.LITTLE_ENDIAN);
         buf.writeShort(shortValue);
-        assertEquals(ByteBufUtil.swapShort((short) shortValue), ByteBufUtil.readUnsignedShortBE(buf));
+        assertEquals(swappedShortValue, ByteBufUtil.readUnsignedShortBE(buf));
         buf.resetReaderIndex();
         buf.resetWriterIndex();
         buf.writeShortLE(shortValue);
-        assertEquals(ByteBufUtil.swapShort((short) shortValue), ByteBufUtil.readUnsignedShortBE(buf));
+        assertEquals(swappedShortValue, ByteBufUtil.readUnsignedShortBE(buf));
+        buf.release();
+
+        shortValue = 0xfedc; // unsigned short
+        swappedShortValue = 0xdcfe; // swapped version of the value above
+
+        buf = buffer(bufferType, 2).order(ByteOrder.BIG_ENDIAN);
+        buf.writeShort(shortValue);
+        assertEquals(shortValue, ByteBufUtil.readUnsignedShortBE(buf));
+        buf.resetReaderIndex();
+        buf.resetWriterIndex();
+        buf.writeShortLE(shortValue);
+        assertEquals(swappedShortValue, ByteBufUtil.readUnsignedShortBE(buf));
+        buf.release();
+
+        buf = buffer(bufferType, 2).order(ByteOrder.LITTLE_ENDIAN);
+        buf.writeShort(shortValue);
+        assertEquals(swappedShortValue, ByteBufUtil.readUnsignedShortBE(buf));
+        buf.resetReaderIndex();
+        buf.resetWriterIndex();
+        buf.writeShortLE(shortValue);
+        assertEquals(swappedShortValue, ByteBufUtil.readUnsignedShortBE(buf));
         buf.release();
     }
 

--- a/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
@@ -286,6 +286,56 @@ public class ByteBufUtilTest {
         buf.release();
     }
 
+    @SuppressWarnings("deprecation")
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void readUnsignedShortBE(BufferType bufferType) {
+        int shortValue = 0x1234;
+
+        ByteBuf buf = buffer(bufferType, 2).order(ByteOrder.BIG_ENDIAN);
+        buf.writeShort(shortValue);
+        assertEquals(shortValue, ByteBufUtil.readUnsignedShortBE(buf));
+        buf.resetReaderIndex();
+        buf.resetWriterIndex();
+        buf.writeShortLE(shortValue);
+        assertEquals(ByteBufUtil.swapShort((short) shortValue), ByteBufUtil.readUnsignedShortBE(buf));
+        buf.release();
+
+        buf = buffer(bufferType, 2).order(ByteOrder.LITTLE_ENDIAN);
+        buf.writeShort(shortValue);
+        assertEquals(ByteBufUtil.swapShort((short) shortValue), ByteBufUtil.readUnsignedShortBE(buf));
+        buf.resetReaderIndex();
+        buf.resetWriterIndex();
+        buf.writeShortLE(shortValue);
+        assertEquals(ByteBufUtil.swapShort((short) shortValue), ByteBufUtil.readUnsignedShortBE(buf));
+        buf.release();
+    }
+
+    @SuppressWarnings("deprecation")
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void readIntBE(BufferType bufferType) {
+        int intValue = 0x12345678;
+
+        ByteBuf buf = buffer(bufferType, 4).order(ByteOrder.BIG_ENDIAN);
+        buf.writeInt(intValue);
+        assertEquals(intValue, ByteBufUtil.readIntBE(buf));
+        buf.resetReaderIndex();
+        buf.resetWriterIndex();
+        buf.writeIntLE(intValue);
+        assertEquals(ByteBufUtil.swapInt(intValue), ByteBufUtil.readIntBE(buf));
+        buf.release();
+
+        buf = buffer(bufferType, 4).order(ByteOrder.LITTLE_ENDIAN);
+        buf.writeInt(intValue);
+        assertEquals(ByteBufUtil.swapInt(intValue), ByteBufUtil.readIntBE(buf));
+        buf.resetReaderIndex();
+        buf.resetWriterIndex();
+        buf.writeIntLE(intValue);
+        assertEquals(ByteBufUtil.swapInt(intValue), ByteBufUtil.readIntBE(buf));
+        buf.release();
+    }
+
     @ParameterizedTest(name = PARAMETERIZED_NAME)
     @MethodSource("noUnsafe")
     public void testWriteUsAscii(BufferType bufferType) {

--- a/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
@@ -296,8 +296,7 @@ public class ByteBufUtilTest {
         ByteBuf buf = buffer(bufferType, 2).order(ByteOrder.BIG_ENDIAN);
         buf.writeShort(shortValue);
         assertEquals(shortValue, ByteBufUtil.readUnsignedShortBE(buf));
-        buf.resetReaderIndex();
-        buf.resetWriterIndex();
+        buf.clear();
         buf.writeShortLE(shortValue);
         assertEquals(swappedShortValue, ByteBufUtil.readUnsignedShortBE(buf));
         buf.release();
@@ -305,8 +304,7 @@ public class ByteBufUtilTest {
         buf = buffer(bufferType, 2).order(ByteOrder.LITTLE_ENDIAN);
         buf.writeShort(shortValue);
         assertEquals(swappedShortValue, ByteBufUtil.readUnsignedShortBE(buf));
-        buf.resetReaderIndex();
-        buf.resetWriterIndex();
+        buf.clear();
         buf.writeShortLE(shortValue);
         assertEquals(swappedShortValue, ByteBufUtil.readUnsignedShortBE(buf));
         buf.release();
@@ -317,8 +315,7 @@ public class ByteBufUtilTest {
         buf = buffer(bufferType, 2).order(ByteOrder.BIG_ENDIAN);
         buf.writeShort(shortValue);
         assertEquals(shortValue, ByteBufUtil.readUnsignedShortBE(buf));
-        buf.resetReaderIndex();
-        buf.resetWriterIndex();
+        buf.clear();
         buf.writeShortLE(shortValue);
         assertEquals(swappedShortValue, ByteBufUtil.readUnsignedShortBE(buf));
         buf.release();
@@ -326,8 +323,7 @@ public class ByteBufUtilTest {
         buf = buffer(bufferType, 2).order(ByteOrder.LITTLE_ENDIAN);
         buf.writeShort(shortValue);
         assertEquals(swappedShortValue, ByteBufUtil.readUnsignedShortBE(buf));
-        buf.resetReaderIndex();
-        buf.resetWriterIndex();
+        buf.clear();
         buf.writeShortLE(shortValue);
         assertEquals(swappedShortValue, ByteBufUtil.readUnsignedShortBE(buf));
         buf.release();
@@ -342,8 +338,7 @@ public class ByteBufUtilTest {
         ByteBuf buf = buffer(bufferType, 4).order(ByteOrder.BIG_ENDIAN);
         buf.writeInt(intValue);
         assertEquals(intValue, ByteBufUtil.readIntBE(buf));
-        buf.resetReaderIndex();
-        buf.resetWriterIndex();
+        buf.clear();
         buf.writeIntLE(intValue);
         assertEquals(ByteBufUtil.swapInt(intValue), ByteBufUtil.readIntBE(buf));
         buf.release();
@@ -351,8 +346,7 @@ public class ByteBufUtilTest {
         buf = buffer(bufferType, 4).order(ByteOrder.LITTLE_ENDIAN);
         buf.writeInt(intValue);
         assertEquals(ByteBufUtil.swapInt(intValue), ByteBufUtil.readIntBE(buf));
-        buf.resetReaderIndex();
-        buf.resetWriterIndex();
+        buf.clear();
         buf.writeIntLE(intValue);
         assertEquals(ByteBufUtil.swapInt(intValue), ByteBufUtil.readIntBE(buf));
         buf.release();

--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCmdRequest.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCmdRequest.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.socks;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.util.CharsetUtil;
 import io.netty.util.NetUtil;
 import io.netty.util.internal.ObjectUtil;
@@ -115,20 +116,20 @@ public final class SocksCmdRequest extends SocksRequest {
         switch (addressType) {
             case IPv4: {
                 byteBuf.writeBytes(NetUtil.createByteArrayFromIpAddressString(host));
-                byteBuf.writeShort(port);
+                ByteBufUtil.writeShortBE(byteBuf, port);
                 break;
             }
 
             case DOMAIN: {
                 byteBuf.writeByte(host.length());
                 byteBuf.writeCharSequence(host, CharsetUtil.US_ASCII);
-                byteBuf.writeShort(port);
+                ByteBufUtil.writeShortBE(byteBuf, port);
                 break;
             }
 
             case IPv6: {
                 byteBuf.writeBytes(NetUtil.createByteArrayFromIpAddressString(host));
-                byteBuf.writeShort(port);
+                ByteBufUtil.writeShortBE(byteBuf, port);
                 break;
             }
         }

--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCmdRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCmdRequestDecoder.java
@@ -56,15 +56,15 @@ public class SocksCmdRequestDecoder extends ReplayingDecoder<State> {
             case READ_CMD_ADDRESS: {
                 switch (addressType) {
                     case IPv4: {
-                        String host = NetUtil.intToIpAddress(byteBuf.readInt());
-                        int port = byteBuf.readUnsignedShort();
+                        String host = NetUtil.intToIpAddress(SocksCommonUtils.readIntBE(byteBuf));
+                        int port = SocksCommonUtils.readUnsignedShortBE(byteBuf);
                         out.add(new SocksCmdRequest(cmdType, addressType, host, port));
                         break;
                     }
                     case DOMAIN: {
                         int fieldLength = byteBuf.readByte();
                         String host = SocksCommonUtils.readUsAscii(byteBuf, fieldLength);
-                        int port = byteBuf.readUnsignedShort();
+                        int port = SocksCommonUtils.readUnsignedShortBE(byteBuf);
                         out.add(new SocksCmdRequest(cmdType, addressType, host, port));
                         break;
                     }
@@ -72,7 +72,7 @@ public class SocksCmdRequestDecoder extends ReplayingDecoder<State> {
                         byte[] bytes = new byte[16];
                         byteBuf.readBytes(bytes);
                         String host = SocksCommonUtils.ipv6toStr(bytes);
-                        int port = byteBuf.readUnsignedShort();
+                        int port = SocksCommonUtils.readUnsignedShortBE(byteBuf);
                         out.add(new SocksCmdRequest(cmdType, addressType, host, port));
                         break;
                     }

--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCmdRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCmdRequestDecoder.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.socks;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ReplayingDecoder;
 import io.netty.handler.codec.socks.SocksCmdRequestDecoder.State;
@@ -56,15 +57,15 @@ public class SocksCmdRequestDecoder extends ReplayingDecoder<State> {
             case READ_CMD_ADDRESS: {
                 switch (addressType) {
                     case IPv4: {
-                        String host = NetUtil.intToIpAddress(SocksCommonUtils.readIntBE(byteBuf));
-                        int port = SocksCommonUtils.readUnsignedShortBE(byteBuf);
+                        String host = NetUtil.intToIpAddress(ByteBufUtil.readIntBE(byteBuf));
+                        int port = ByteBufUtil.readUnsignedShortBE(byteBuf);
                         out.add(new SocksCmdRequest(cmdType, addressType, host, port));
                         break;
                     }
                     case DOMAIN: {
                         int fieldLength = byteBuf.readByte();
                         String host = SocksCommonUtils.readUsAscii(byteBuf, fieldLength);
-                        int port = SocksCommonUtils.readUnsignedShortBE(byteBuf);
+                        int port = ByteBufUtil.readUnsignedShortBE(byteBuf);
                         out.add(new SocksCmdRequest(cmdType, addressType, host, port));
                         break;
                     }
@@ -72,7 +73,7 @@ public class SocksCmdRequestDecoder extends ReplayingDecoder<State> {
                         byte[] bytes = new byte[16];
                         byteBuf.readBytes(bytes);
                         String host = SocksCommonUtils.ipv6toStr(bytes);
-                        int port = SocksCommonUtils.readUnsignedShortBE(byteBuf);
+                        int port = ByteBufUtil.readUnsignedShortBE(byteBuf);
                         out.add(new SocksCmdRequest(cmdType, addressType, host, port));
                         break;
                     }

--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCmdResponse.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCmdResponse.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.socks;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.util.CharsetUtil;
 import io.netty.util.NetUtil;
 import io.netty.util.internal.ObjectUtil;
@@ -147,7 +148,7 @@ public final class SocksCmdResponse extends SocksResponse {
                 byte[] hostContent = host == null ?
                         IPv4_HOSTNAME_ZEROED : NetUtil.createByteArrayFromIpAddressString(host);
                 byteBuf.writeBytes(hostContent);
-                byteBuf.writeShort(port);
+                ByteBufUtil.writeShortBE(byteBuf, port);
                 break;
             }
             case DOMAIN: {
@@ -158,14 +159,14 @@ public final class SocksCmdResponse extends SocksResponse {
                     byteBuf.writeByte(DOMAIN_ZEROED.length);
                     byteBuf.writeBytes(DOMAIN_ZEROED);
                 }
-                byteBuf.writeShort(port);
+                ByteBufUtil.writeShortBE(byteBuf, port);
                 break;
             }
             case IPv6: {
                 byte[] hostContent = host == null
                         ? IPv6_HOSTNAME_ZEROED : NetUtil.createByteArrayFromIpAddressString(host);
                 byteBuf.writeBytes(hostContent);
-                byteBuf.writeShort(port);
+                ByteBufUtil.writeShortBE(byteBuf, port);
                 break;
             }
         }

--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCmdResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCmdResponseDecoder.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.socks;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ReplayingDecoder;
 import io.netty.handler.codec.socks.SocksCmdResponseDecoder.State;
@@ -56,15 +57,15 @@ public class SocksCmdResponseDecoder extends ReplayingDecoder<State> {
             case READ_CMD_ADDRESS: {
                 switch (addressType) {
                     case IPv4: {
-                        String host = NetUtil.intToIpAddress(SocksCommonUtils.readIntBE(byteBuf));
-                        int port = SocksCommonUtils.readUnsignedShortBE(byteBuf);
+                        String host = NetUtil.intToIpAddress(ByteBufUtil.readIntBE(byteBuf));
+                        int port = ByteBufUtil.readUnsignedShortBE(byteBuf);
                         out.add(new SocksCmdResponse(cmdStatus, addressType, host, port));
                         break;
                     }
                     case DOMAIN: {
                         int fieldLength = byteBuf.readByte();
                         String host = SocksCommonUtils.readUsAscii(byteBuf, fieldLength);
-                        int port = SocksCommonUtils.readUnsignedShortBE(byteBuf);
+                        int port = ByteBufUtil.readUnsignedShortBE(byteBuf);
                         out.add(new SocksCmdResponse(cmdStatus, addressType, host, port));
                         break;
                     }
@@ -72,7 +73,7 @@ public class SocksCmdResponseDecoder extends ReplayingDecoder<State> {
                         byte[] bytes = new byte[16];
                         byteBuf.readBytes(bytes);
                         String host = SocksCommonUtils.ipv6toStr(bytes);
-                        int port = SocksCommonUtils.readUnsignedShortBE(byteBuf);
+                        int port = ByteBufUtil.readUnsignedShortBE(byteBuf);
                         out.add(new SocksCmdResponse(cmdStatus, addressType, host, port));
                         break;
                     }

--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCmdResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCmdResponseDecoder.java
@@ -56,15 +56,15 @@ public class SocksCmdResponseDecoder extends ReplayingDecoder<State> {
             case READ_CMD_ADDRESS: {
                 switch (addressType) {
                     case IPv4: {
-                        String host = NetUtil.intToIpAddress(byteBuf.readInt());
-                        int port = byteBuf.readUnsignedShort();
+                        String host = NetUtil.intToIpAddress(SocksCommonUtils.readIntBE(byteBuf));
+                        int port = SocksCommonUtils.readUnsignedShortBE(byteBuf);
                         out.add(new SocksCmdResponse(cmdStatus, addressType, host, port));
                         break;
                     }
                     case DOMAIN: {
                         int fieldLength = byteBuf.readByte();
                         String host = SocksCommonUtils.readUsAscii(byteBuf, fieldLength);
-                        int port = byteBuf.readUnsignedShort();
+                        int port = SocksCommonUtils.readUnsignedShortBE(byteBuf);
                         out.add(new SocksCmdResponse(cmdStatus, addressType, host, port));
                         break;
                     }
@@ -72,7 +72,7 @@ public class SocksCmdResponseDecoder extends ReplayingDecoder<State> {
                         byte[] bytes = new byte[16];
                         byteBuf.readBytes(bytes);
                         String host = SocksCommonUtils.ipv6toStr(bytes);
-                        int port = byteBuf.readUnsignedShort();
+                        int port = SocksCommonUtils.readUnsignedShortBE(byteBuf);
                         out.add(new SocksCmdResponse(cmdStatus, addressType, host, port));
                         break;
                     }

--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCommonUtils.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCommonUtils.java
@@ -19,7 +19,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.util.CharsetUtil;
 import io.netty.util.internal.StringUtil;
 
-public final class SocksCommonUtils {
+final class SocksCommonUtils {
     public static final SocksRequest UNKNOWN_SOCKS_REQUEST = new UnknownSocksRequest();
     public static final SocksResponse UNKNOWN_SOCKS_RESPONSE = new UnknownSocksResponse();
 

--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCommonUtils.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCommonUtils.java
@@ -16,11 +16,8 @@
 package io.netty.handler.codec.socks;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufUtil;
 import io.netty.util.CharsetUtil;
 import io.netty.util.internal.StringUtil;
-
-import java.nio.ByteOrder;
 
 public final class SocksCommonUtils {
     public static final SocksRequest UNKNOWN_SOCKS_REQUEST = new UnknownSocksRequest();
@@ -65,14 +62,4 @@ public final class SocksCommonUtils {
         buffer.skipBytes(length);
         return s;
     }
-
-    public static int readUnsignedShortBE(ByteBuf buf) {
-        return buf.order() == ByteOrder.BIG_ENDIAN? buf.readUnsignedShort() :
-            ByteBufUtil.swapShort((short) buf.readUnsignedShort());
-    }
-
-    public static int readIntBE(ByteBuf buf) {
-      return buf.order() == ByteOrder.BIG_ENDIAN? buf.readInt() :
-          ByteBufUtil.swapInt(buf.readInt());
-  }
 }

--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCommonUtils.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCommonUtils.java
@@ -16,10 +16,13 @@
 package io.netty.handler.codec.socks;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.util.CharsetUtil;
 import io.netty.util.internal.StringUtil;
 
-final class SocksCommonUtils {
+import java.nio.ByteOrder;
+
+public final class SocksCommonUtils {
     public static final SocksRequest UNKNOWN_SOCKS_REQUEST = new UnknownSocksRequest();
     public static final SocksResponse UNKNOWN_SOCKS_RESPONSE = new UnknownSocksResponse();
 
@@ -62,4 +65,14 @@ final class SocksCommonUtils {
         buffer.skipBytes(length);
         return s;
     }
+
+    public static int readUnsignedShortBE(ByteBuf buf) {
+        return buf.order() == ByteOrder.BIG_ENDIAN? buf.readUnsignedShort() :
+            ByteBufUtil.swapShort((short) buf.readUnsignedShort());
+    }
+
+    public static int readIntBE(ByteBuf buf) {
+      return buf.order() == ByteOrder.BIG_ENDIAN? buf.readInt() :
+          ByteBufUtil.swapInt(buf.readInt());
+  }
 }

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v4/Socks4ClientDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v4/Socks4ClientDecoder.java
@@ -20,6 +20,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.ReplayingDecoder;
+import io.netty.handler.codec.socks.SocksCommonUtils;
 import io.netty.handler.codec.socksx.v4.Socks4ClientDecoder.State;
 import io.netty.util.NetUtil;
 import io.netty.util.internal.UnstableApi;
@@ -57,8 +58,8 @@ public class Socks4ClientDecoder extends ReplayingDecoder<State> {
                 }
 
                 final Socks4CommandStatus status = Socks4CommandStatus.valueOf(in.readByte());
-                final int dstPort = in.readUnsignedShort();
-                final String dstAddr = NetUtil.intToIpAddress(in.readInt());
+                final int dstPort = SocksCommonUtils.readUnsignedShortBE(in);
+                final String dstAddr = NetUtil.intToIpAddress(SocksCommonUtils.readIntBE(in));
 
                 out.add(new DefaultSocks4CommandResponse(status, dstAddr, dstPort));
                 checkpoint(State.SUCCESS);

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v4/Socks4ClientDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v4/Socks4ClientDecoder.java
@@ -16,11 +16,11 @@
 package io.netty.handler.codec.socksx.v4;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.ReplayingDecoder;
-import io.netty.handler.codec.socks.SocksCommonUtils;
 import io.netty.handler.codec.socksx.v4.Socks4ClientDecoder.State;
 import io.netty.util.NetUtil;
 import io.netty.util.internal.UnstableApi;
@@ -58,8 +58,8 @@ public class Socks4ClientDecoder extends ReplayingDecoder<State> {
                 }
 
                 final Socks4CommandStatus status = Socks4CommandStatus.valueOf(in.readByte());
-                final int dstPort = SocksCommonUtils.readUnsignedShortBE(in);
-                final String dstAddr = NetUtil.intToIpAddress(SocksCommonUtils.readIntBE(in));
+                final int dstPort = ByteBufUtil.readUnsignedShortBE(in);
+                final String dstAddr = NetUtil.intToIpAddress(ByteBufUtil.readIntBE(in));
 
                 out.add(new DefaultSocks4CommandResponse(status, dstAddr, dstPort));
                 checkpoint(State.SUCCESS);

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v4/Socks4ClientEncoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v4/Socks4ClientEncoder.java
@@ -42,7 +42,7 @@ public final class Socks4ClientEncoder extends MessageToByteEncoder<Socks4Comman
     protected void encode(ChannelHandlerContext ctx, Socks4CommandRequest msg, ByteBuf out) throws Exception {
         out.writeByte(msg.version().byteValue());
         out.writeByte(msg.type().byteValue());
-        out.writeShort(msg.dstPort());
+        ByteBufUtil.writeShortBE(out, msg.dstPort());
         if (NetUtil.isValidIpV4Address(msg.dstAddr())) {
             out.writeBytes(NetUtil.createByteArrayFromIpAddressString(msg.dstAddr()));
             ByteBufUtil.writeAscii(out, msg.userId());

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v4/Socks4ServerDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v4/Socks4ServerDecoder.java
@@ -20,6 +20,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.ReplayingDecoder;
+import io.netty.handler.codec.socks.SocksCommonUtils;
 import io.netty.handler.codec.socksx.SocksVersion;
 import io.netty.handler.codec.socksx.v4.Socks4ServerDecoder.State;
 import io.netty.util.CharsetUtil;
@@ -68,8 +69,8 @@ public class Socks4ServerDecoder extends ReplayingDecoder<State> {
                 }
 
                 type = Socks4CommandType.valueOf(in.readByte());
-                dstPort = in.readUnsignedShort();
-                dstAddr = NetUtil.intToIpAddress(in.readInt());
+                dstPort = SocksCommonUtils.readUnsignedShortBE(in);
+                dstAddr = NetUtil.intToIpAddress(SocksCommonUtils.readIntBE(in));
                 checkpoint(State.READ_USERID);
             }
             case READ_USERID: {

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v4/Socks4ServerDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v4/Socks4ServerDecoder.java
@@ -16,11 +16,11 @@
 package io.netty.handler.codec.socksx.v4;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.ReplayingDecoder;
-import io.netty.handler.codec.socks.SocksCommonUtils;
 import io.netty.handler.codec.socksx.SocksVersion;
 import io.netty.handler.codec.socksx.v4.Socks4ServerDecoder.State;
 import io.netty.util.CharsetUtil;
@@ -69,8 +69,8 @@ public class Socks4ServerDecoder extends ReplayingDecoder<State> {
                 }
 
                 type = Socks4CommandType.valueOf(in.readByte());
-                dstPort = SocksCommonUtils.readUnsignedShortBE(in);
-                dstAddr = NetUtil.intToIpAddress(SocksCommonUtils.readIntBE(in));
+                dstPort = ByteBufUtil.readUnsignedShortBE(in);
+                dstAddr = NetUtil.intToIpAddress(ByteBufUtil.readIntBE(in));
                 checkpoint(State.READ_USERID);
             }
             case READ_USERID: {

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v4/Socks4ServerEncoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v4/Socks4ServerEncoder.java
@@ -17,6 +17,7 @@
 package io.netty.handler.codec.socksx.v4;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToByteEncoder;
@@ -38,7 +39,7 @@ public final class Socks4ServerEncoder extends MessageToByteEncoder<Socks4Comman
     protected void encode(ChannelHandlerContext ctx, Socks4CommandResponse msg, ByteBuf out) throws Exception {
         out.writeByte(0);
         out.writeByte(msg.status().byteValue());
-        out.writeShort(msg.dstPort());
+        ByteBufUtil.writeShortBE(out, msg.dstPort());
         out.writeBytes(msg.dstAddr() == null? IPv4_HOSTNAME_ZEROED
                                             : NetUtil.createByteArrayFromIpAddressString(msg.dstAddr()));
     }

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5AddressDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5AddressDecoder.java
@@ -18,6 +18,7 @@ package io.netty.handler.codec.socksx.v5;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.DecoderException;
+import io.netty.handler.codec.socks.SocksCommonUtils;
 import io.netty.util.CharsetUtil;
 import io.netty.util.NetUtil;
 
@@ -36,7 +37,7 @@ public interface Socks5AddressDecoder {
         @Override
         public String decodeAddress(Socks5AddressType addrType, ByteBuf in) throws Exception {
             if (addrType == Socks5AddressType.IPv4) {
-                return NetUtil.intToIpAddress(in.readInt());
+                return NetUtil.intToIpAddress(SocksCommonUtils.readIntBE(in));
             }
             if (addrType == Socks5AddressType.DOMAIN) {
                 final int length = in.readUnsignedByte();

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5AddressDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5AddressDecoder.java
@@ -17,8 +17,8 @@
 package io.netty.handler.codec.socksx.v5;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.handler.codec.DecoderException;
-import io.netty.handler.codec.socks.SocksCommonUtils;
 import io.netty.util.CharsetUtil;
 import io.netty.util.NetUtil;
 
@@ -37,7 +37,7 @@ public interface Socks5AddressDecoder {
         @Override
         public String decodeAddress(Socks5AddressType addrType, ByteBuf in) throws Exception {
             if (addrType == Socks5AddressType.IPv4) {
-                return NetUtil.intToIpAddress(SocksCommonUtils.readIntBE(in));
+                return NetUtil.intToIpAddress(ByteBufUtil.readIntBE(in));
             }
             if (addrType == Socks5AddressType.DOMAIN) {
                 final int length = in.readUnsignedByte();

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5ClientEncoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5ClientEncoder.java
@@ -110,6 +110,6 @@ public class Socks5ClientEncoder extends MessageToByteEncoder<Socks5Message> {
         final Socks5AddressType dstAddrType = msg.dstAddrType();
         out.writeByte(dstAddrType.byteValue());
         addressEncoder.encodeAddress(dstAddrType, msg.dstAddr(), out);
-        out.writeShort(msg.dstPort());
+        ByteBufUtil.writeShortBE(out, msg.dstPort());
     }
 }

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5CommandRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5CommandRequestDecoder.java
@@ -17,11 +17,11 @@
 package io.netty.handler.codec.socksx.v5;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.ReplayingDecoder;
-import io.netty.handler.codec.socks.SocksCommonUtils;
 import io.netty.handler.codec.socksx.SocksVersion;
 import io.netty.handler.codec.socksx.v5.Socks5CommandRequestDecoder.State;
 import io.netty.util.internal.ObjectUtil;
@@ -70,7 +70,7 @@ public class Socks5CommandRequestDecoder extends ReplayingDecoder<State> {
                 in.skipBytes(1); // RSV
                 final Socks5AddressType dstAddrType = Socks5AddressType.valueOf(in.readByte());
                 final String dstAddr = addressDecoder.decodeAddress(dstAddrType, in);
-                final int dstPort = SocksCommonUtils.readUnsignedShortBE(in);
+                final int dstPort = ByteBufUtil.readUnsignedShortBE(in);
 
                 out.add(new DefaultSocks5CommandRequest(type, dstAddrType, dstAddr, dstPort));
                 checkpoint(State.SUCCESS);

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5CommandRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5CommandRequestDecoder.java
@@ -21,6 +21,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.ReplayingDecoder;
+import io.netty.handler.codec.socks.SocksCommonUtils;
 import io.netty.handler.codec.socksx.SocksVersion;
 import io.netty.handler.codec.socksx.v5.Socks5CommandRequestDecoder.State;
 import io.netty.util.internal.ObjectUtil;
@@ -69,7 +70,7 @@ public class Socks5CommandRequestDecoder extends ReplayingDecoder<State> {
                 in.skipBytes(1); // RSV
                 final Socks5AddressType dstAddrType = Socks5AddressType.valueOf(in.readByte());
                 final String dstAddr = addressDecoder.decodeAddress(dstAddrType, in);
-                final int dstPort = in.readUnsignedShort();
+                final int dstPort = SocksCommonUtils.readUnsignedShortBE(in);
 
                 out.add(new DefaultSocks5CommandRequest(type, dstAddrType, dstAddr, dstPort));
                 checkpoint(State.SUCCESS);

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5CommandResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5CommandResponseDecoder.java
@@ -17,11 +17,11 @@
 package io.netty.handler.codec.socksx.v5;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.ReplayingDecoder;
-import io.netty.handler.codec.socks.SocksCommonUtils;
 import io.netty.handler.codec.socksx.SocksVersion;
 import io.netty.handler.codec.socksx.v5.Socks5CommandResponseDecoder.State;
 import io.netty.util.internal.ObjectUtil;
@@ -69,7 +69,7 @@ public class Socks5CommandResponseDecoder extends ReplayingDecoder<State> {
                 in.skipBytes(1); // Reserved
                 final Socks5AddressType addrType = Socks5AddressType.valueOf(in.readByte());
                 final String addr = addressDecoder.decodeAddress(addrType, in);
-                final int port = SocksCommonUtils.readUnsignedShortBE(in);
+                final int port = ByteBufUtil.readUnsignedShortBE(in);
 
                 out.add(new DefaultSocks5CommandResponse(status, addrType, addr, port));
                 checkpoint(State.SUCCESS);

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5CommandResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5CommandResponseDecoder.java
@@ -21,6 +21,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.ReplayingDecoder;
+import io.netty.handler.codec.socks.SocksCommonUtils;
 import io.netty.handler.codec.socksx.SocksVersion;
 import io.netty.handler.codec.socksx.v5.Socks5CommandResponseDecoder.State;
 import io.netty.util.internal.ObjectUtil;
@@ -68,7 +69,7 @@ public class Socks5CommandResponseDecoder extends ReplayingDecoder<State> {
                 in.skipBytes(1); // Reserved
                 final Socks5AddressType addrType = Socks5AddressType.valueOf(in.readByte());
                 final String addr = addressDecoder.decodeAddress(addrType, in);
-                final int port = in.readUnsignedShort();
+                final int port = SocksCommonUtils.readUnsignedShortBE(in);
 
                 out.add(new DefaultSocks5CommandResponse(status, addrType, addr, port));
                 checkpoint(State.SUCCESS);

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5ServerEncoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5ServerEncoder.java
@@ -17,6 +17,7 @@
 package io.netty.handler.codec.socksx.v5;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.EncoderException;
@@ -87,6 +88,6 @@ public class Socks5ServerEncoder extends MessageToByteEncoder<Socks5Message> {
         out.writeByte(bndAddrType.byteValue());
         addressEncoder.encodeAddress(bndAddrType, msg.bndAddr(), out);
 
-        out.writeShort(msg.bndPort());
+        ByteBufUtil.writeShortBE(out, msg.bndPort());
     }
 }

--- a/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksCmdRequestTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksCmdRequestTest.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.socks;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
@@ -122,7 +123,7 @@ public class SocksCmdRequestTest {
         assertEquals((byte) asciiHost.length(), buffer.readUnsignedByte());
         assertEquals(asciiHost,
             CharBuffer.wrap(buffer.readCharSequence(asciiHost.length(), CharsetUtil.US_ASCII)));
-        assertEquals(port, SocksCommonUtils.readUnsignedShortBE(buffer));
+        assertEquals(port, ByteBufUtil.readUnsignedShortBE(buffer));
 
         buffer.release();
     }
@@ -147,7 +148,7 @@ public class SocksCmdRequestTest {
         assertEquals((byte) asciiHost.length(), buffer.readUnsignedByte());
         assertEquals(asciiHost,
             CharBuffer.wrap(buffer.readCharSequence(asciiHost.length(), CharsetUtil.US_ASCII)));
-        assertEquals(port, SocksCommonUtils.readUnsignedShortBE(buffer));
+        assertEquals(port, ByteBufUtil.readUnsignedShortBE(buffer));
 
         buffer.release();
     }

--- a/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksCmdRequestTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksCmdRequestTest.java
@@ -16,7 +16,6 @@
 package io.netty.handler.codec.socks;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
@@ -123,7 +122,7 @@ public class SocksCmdRequestTest {
         assertEquals((byte) asciiHost.length(), buffer.readUnsignedByte());
         assertEquals(asciiHost,
             CharBuffer.wrap(buffer.readCharSequence(asciiHost.length(), CharsetUtil.US_ASCII)));
-        assertEquals(port, readUnsignedShortBE(buffer));
+        assertEquals(port, SocksCommonUtils.readUnsignedShortBE(buffer));
 
         buffer.release();
     }
@@ -148,7 +147,7 @@ public class SocksCmdRequestTest {
         assertEquals((byte) asciiHost.length(), buffer.readUnsignedByte());
         assertEquals(asciiHost,
             CharBuffer.wrap(buffer.readCharSequence(asciiHost.length(), CharsetUtil.US_ASCII)));
-        assertEquals(port, readUnsignedShortBE(buffer));
+        assertEquals(port, SocksCommonUtils.readUnsignedShortBE(buffer));
 
         buffer.release();
     }
@@ -169,9 +168,4 @@ public class SocksCmdRequestTest {
             assertTrue(e instanceof IllegalArgumentException);
         }
     }
-
-    public static int readUnsignedShortBE(ByteBuf buf) {
-      return buf.order() == ByteOrder.BIG_ENDIAN? buf.readUnsignedShort() :
-              ByteBufUtil.swapShort((short) buf.readUnsignedShort());
-  }
 }

--- a/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksCmdRequestTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksCmdRequestTest.java
@@ -140,7 +140,6 @@ public class SocksCmdRequestTest {
         ByteBuf buffer = Unpooled.buffer(24).order(ByteOrder.LITTLE_ENDIAN);
         rq.encodeAsByteBuf(buffer);
 
-        buffer.resetReaderIndex();
         assertEquals(SocksProtocolVersion.SOCKS5.byteValue(), buffer.readByte());
         assertEquals(SocksCmdType.BIND.byteValue(), buffer.readByte());
         assertEquals((byte) 0x00, buffer.readByte());

--- a/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksCmdRequestTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksCmdRequestTest.java
@@ -16,11 +16,13 @@
 package io.netty.handler.codec.socks;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
 
 import java.net.IDN;
+import java.nio.ByteOrder;
 import java.nio.CharBuffer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -121,7 +123,32 @@ public class SocksCmdRequestTest {
         assertEquals((byte) asciiHost.length(), buffer.readUnsignedByte());
         assertEquals(asciiHost,
             CharBuffer.wrap(buffer.readCharSequence(asciiHost.length(), CharsetUtil.US_ASCII)));
-        assertEquals(port, buffer.readUnsignedShort());
+        assertEquals(port, readUnsignedShortBE(buffer));
+
+        buffer.release();
+    }
+
+    @Test
+    public void testEndianessForPort() {
+        String host = "localhost";
+        CharBuffer asciiHost = CharBuffer.wrap(host);
+        short port = 10000;
+
+        SocksCmdRequest rq = new SocksCmdRequest(SocksCmdType.BIND, SocksAddressType.DOMAIN, host, port);
+        assertEquals(host, rq.host());
+
+        ByteBuf buffer = Unpooled.buffer(24).order(ByteOrder.LITTLE_ENDIAN);
+        rq.encodeAsByteBuf(buffer);
+
+        buffer.resetReaderIndex();
+        assertEquals(SocksProtocolVersion.SOCKS5.byteValue(), buffer.readByte());
+        assertEquals(SocksCmdType.BIND.byteValue(), buffer.readByte());
+        assertEquals((byte) 0x00, buffer.readByte());
+        assertEquals(SocksAddressType.DOMAIN.byteValue(), buffer.readByte());
+        assertEquals((byte) asciiHost.length(), buffer.readUnsignedByte());
+        assertEquals(asciiHost,
+            CharBuffer.wrap(buffer.readCharSequence(asciiHost.length(), CharsetUtil.US_ASCII)));
+        assertEquals(port, readUnsignedShortBE(buffer));
 
         buffer.release();
     }
@@ -142,4 +169,9 @@ public class SocksCmdRequestTest {
             assertTrue(e instanceof IllegalArgumentException);
         }
     }
+
+    public static int readUnsignedShortBE(ByteBuf buf) {
+      return buf.order() == ByteOrder.BIG_ENDIAN? buf.readUnsignedShort() :
+              ByteBufUtil.swapShort((short) buf.readUnsignedShort());
+  }
 }


### PR DESCRIPTION
Motivation:

Socks codecs do not always use network byte ordering when encoding/decoding socks messages resulting in connection issues

Modification:

Use BE methods to properly read/write socks messages

Result:

Fixes #13426  
