### PR TITLE
Enhance DNS logs and make them consistent

### DIFF
--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsMessageUtil.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsMessageUtil.java
@@ -79,6 +79,7 @@ final class DnsMessageUtil {
            .append('(');
 
         appendAddresses(buf, msg)
+           .append("id: ")
            .append(msg.id())
            .append(", ")
            .append(msg.opCode());
@@ -98,6 +99,7 @@ final class DnsMessageUtil {
            .append('(');
 
         appendAddresses(buf, msg)
+           .append("id: ")
            .append(msg.id())
            .append(", ")
            .append(msg.opCode())

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContext.java
@@ -218,9 +218,11 @@ abstract class DnsQueryContext implements FutureListener<AddressedEnvelope<DnsRe
     void finish(AddressedEnvelope<? extends DnsResponse, InetSocketAddress> envelope) {
         final DnsResponse res = envelope.content();
         if (res.count(DnsSection.QUESTION) != 1) {
-            logger.warn("Received a DNS response with invalid number of questions: {}", envelope);
+            logger.warn("{} Received a DNS response with invalid number of questions. Expected: 1, found: {}",
+                    channel(), envelope);
         } else if (!question().equals(res.recordAt(DnsSection.QUESTION))) {
-            logger.warn("Received a mismatching DNS response: {}", envelope);
+            logger.warn("{} Received a mismatching DNS response. Expected: [{}], found: {}",
+                    channel(), question(), envelope);
         } else if (trySuccess(envelope)) {
             return; // Ownership transferred, don't release
         }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
@@ -845,9 +845,10 @@ abstract class DnsResolveContext<T> {
                     }
                     if (resolved == null) {
                         if (logger.isDebugEnabled()) {
-                            logger.debug("Ignoring record {} as it contains a different name than the " +
-                                            "question name [{}]. Cnames: {}, Search domains: {}",
-                                    r.toString(), questionName, cnames, parent.searchDomains());
+                            logger.debug("{} Ignoring record {} for [{}: {}] as it contains a different name than " +
+                                            "the question name [{}]. Cnames: {}, Search domains: {}",
+                                    parent.ch, r.toString(), response.id(), envelope.sender(), questionName, cnames,
+                                    parent.searchDomains());
                         }
                         continue;
                     }
@@ -857,8 +858,9 @@ abstract class DnsResolveContext<T> {
             final T converted = convertRecord(r, hostname, additionals, parent.executor());
             if (converted == null) {
                 if (logger.isDebugEnabled()) {
-                    logger.debug("Ignoring record {} as the converted record is null. hostname [{}], Additionals: {}",
-                            r.toString(), hostname, additionals);
+                    logger.debug("{} Ignoring record {} for [{}: {}] as the converted record is null. "
+                                    + "Hostname [{}], Additionals: {}",
+                            parent.ch, r.toString(), response.id(), envelope.sender(), hostname, additionals);
                 }
                 continue;
             }


### PR DESCRIPTION
Motivation:

Always include information that helps to correlate log events.

Modifications:

- Always include `Channel` at the beginning of every log, when channel is available;
- Always include `[queryId: sender]` when available;
- `DnsQueryContext`: include expected values when logging at `WARN` level;

Result:

Consistent logging, easier to correlate log events.