### PR TITLE
Export EPollEventLoop methods for closing/opening native file descriptors as UnstableAPI

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
@@ -31,6 +31,7 @@ import io.netty.util.concurrent.RejectedExecutionHandler;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SystemPropertyUtil;
+import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -45,7 +46,7 @@ import static java.lang.Math.min;
 /**
  * {@link EventLoop} which uses epoll under the covers. Only works on Linux!
  */
-class EpollEventLoop extends SingleThreadEventLoop {
+public class EpollEventLoop extends SingleThreadEventLoop {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(EpollEventLoop.class);
     private static final long EPOLL_WAIT_MILLIS_THRESHOLD =
             SystemPropertyUtil.getLong("io.netty.channel.epoll.epollWaitThreshold", 10);
@@ -56,9 +57,9 @@ class EpollEventLoop extends SingleThreadEventLoop {
         Epoll.ensureAvailability();
     }
 
-    private final FileDescriptor epollFd;
-    private final FileDescriptor eventFd;
-    private final FileDescriptor timerFd;
+    private FileDescriptor epollFd;
+    private FileDescriptor eventFd;
+    private FileDescriptor timerFd;
     private final IntObjectMap<AbstractEpollChannel> channels = new IntObjectHashMap<AbstractEpollChannel>(4096);
     private final boolean allowGrowing;
     private final EpollEventArray events;
@@ -102,6 +103,15 @@ class EpollEventLoop extends SingleThreadEventLoop {
             allowGrowing = false;
             events = new EpollEventArray(maxEvents);
         }
+        openFileDescriptors();
+    }
+
+    /**
+     * This method is intended for use by a process checkpoint/restore
+     * integration, such as OpenJDK CRaC.
+     */
+    @UnstableApi
+    public void openFileDescriptors() {
         boolean success = false;
         FileDescriptor epollFd = null;
         FileDescriptor eventFd = null;
@@ -524,40 +534,7 @@ class EpollEventLoop extends SingleThreadEventLoop {
     @Override
     protected void cleanup() {
         try {
-            // Ensure any in-flight wakeup writes have been performed prior to closing eventFd.
-            while (pendingWakeup) {
-                try {
-                    int count = epollWaitTimeboxed();
-                    if (count == 0) {
-                        // We timed-out so assume that the write we're expecting isn't coming
-                        break;
-                    }
-                    for (int i = 0; i < count; i++) {
-                        if (events.fd(i) == eventFd.intValue()) {
-                            pendingWakeup = false;
-                            break;
-                        }
-                    }
-                } catch (IOException ignore) {
-                    // ignore
-                }
-            }
-            try {
-                eventFd.close();
-            } catch (IOException e) {
-                logger.warn("Failed to close the event fd.", e);
-            }
-            try {
-                timerFd.close();
-            } catch (IOException e) {
-                logger.warn("Failed to close the timer fd.", e);
-            }
-
-            try {
-                epollFd.close();
-            } catch (IOException e) {
-                logger.warn("Failed to close the epoll fd.", e);
-            }
+            closeFileDescriptors();
         } finally {
             // release native memory
             if (iovArray != null) {
@@ -569,6 +546,50 @@ class EpollEventLoop extends SingleThreadEventLoop {
                 datagramPacketArray = null;
             }
             events.free();
+        }
+    }
+
+    /**
+     * This method is intended for use by process checkpoint/restore
+     * integration, such as OpenJDK CRaC.
+     * It's up to the caller to ensure that there is no concurrent use
+     * of the FDs while these are closed, e.g. by blocking the executor.
+     */
+    @UnstableApi
+    public void closeFileDescriptors() {
+        // Ensure any in-flight wakeup writes have been performed prior to closing eventFd.
+        while (pendingWakeup) {
+            try {
+                int count = epollWaitTimeboxed();
+                if (count == 0) {
+                    // We timed-out so assume that the write we're expecting isn't coming
+                    break;
+                }
+                for (int i = 0; i < count; i++) {
+                    if (events.fd(i) == eventFd.intValue()) {
+                        pendingWakeup = false;
+                        break;
+                    }
+                }
+            } catch (IOException ignore) {
+                // ignore
+            }
+        }
+        try {
+            eventFd.close();
+        } catch (IOException e) {
+            logger.warn("Failed to close the event fd.", e);
+        }
+        try {
+            timerFd.close();
+        } catch (IOException e) {
+            logger.warn("Failed to close the timer fd.", e);
+        }
+
+        try {
+            epollFd.close();
+        } catch (IOException e) {
+            logger.warn("Failed to close the epoll fd.", e);
         }
     }
 }


### PR DESCRIPTION
Motivation:

This change intends to support an application using Netty with native epoll (e.g. Quarkus app) to perform the Checkpoint and Restore on JVM implementing this, specifically using OpenJDK CRaC or future versions of mainline OpenJDK.

Modification:

The biggest risk factor here is that formerly final fields with file descriptors can change; theoretically this could affect performance in absence of checkpoint/restore process. However most likely a modern JVM is smart enough to assume that the field does not change, and optimistically consider it constant anyway.

Result:

There is no change in functionality.