### PR TITLE
Always enable leak tracking for derived buffers if parent is tracked

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/SimpleLeakAwareByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SimpleLeakAwareByteBuf.java
@@ -139,7 +139,7 @@ class SimpleLeakAwareByteBuf extends WrappedByteBuf {
         if (unwrappedDerived instanceof AbstractPooledDerivedByteBuf) {
             // Update the parent to point to this buffer so we correctly close the ResourceLeakTracker.
             ((AbstractPooledDerivedByteBuf) unwrappedDerived).parent(this);
-            
+
             // force tracking of derived buffers (see issue #13414)
             return newLeakAwareByteBuf(derived, AbstractByteBuf.leakDetector.trackForcibly(derived));
         }

--- a/buffer/src/main/java/io/netty/buffer/SimpleLeakAwareByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SimpleLeakAwareByteBuf.java
@@ -139,13 +139,9 @@ class SimpleLeakAwareByteBuf extends WrappedByteBuf {
         if (unwrappedDerived instanceof AbstractPooledDerivedByteBuf) {
             // Update the parent to point to this buffer so we correctly close the ResourceLeakTracker.
             ((AbstractPooledDerivedByteBuf) unwrappedDerived).parent(this);
-
-            ResourceLeakTracker<ByteBuf> newLeak = AbstractByteBuf.leakDetector.track(derived);
-            if (newLeak == null) {
-                // No leak detection, just return the derived buffer.
-                return derived;
-            }
-            return newLeakAwareByteBuf(derived, newLeak);
+            
+            // force tracking of derived buffers (see issue #13414)
+            return newLeakAwareByteBuf(derived, AbstractByteBuf.leakDetector.trackForcibly(derived));
         }
         return newSharedLeakAwareByteBuf(derived);
     }

--- a/common/src/main/java/io/netty/util/ResourceLeakDetector.java
+++ b/common/src/main/java/io/netty/util/ResourceLeakDetector.java
@@ -255,7 +255,7 @@ public class ResourceLeakDetector<T> {
      * @return the {@link ResourceLeakTracker}
      */
     @SuppressWarnings("unchecked")
-    public final ResourceLeakTracker<T> trackForcibly(T obj) {
+    public ResourceLeakTracker<T> trackForcibly(T obj) {
         return track0(obj, true);
     }
 

--- a/common/src/main/java/io/netty/util/ResourceLeakDetector.java
+++ b/common/src/main/java/io/netty/util/ResourceLeakDetector.java
@@ -231,7 +231,7 @@ public class ResourceLeakDetector<T> {
      */
     @Deprecated
     public final ResourceLeak open(T obj) {
-        return track0(obj);
+        return track0(obj, false);
     }
 
     /**
@@ -242,25 +242,33 @@ public class ResourceLeakDetector<T> {
      */
     @SuppressWarnings("unchecked")
     public final ResourceLeakTracker<T> track(T obj) {
-        return track0(obj);
+        return track0(obj, false);
+    }
+
+    /**
+     * Creates a new {@link ResourceLeakTracker} which is expected to be closed via
+     * {@link ResourceLeakTracker#close(Object)} when the related resource is deallocated.
+     *
+     * Unlike {@link #track(Object)}, this method always returns a tracker, regardless
+     * of the detection settings.
+     *
+     * @return the {@link ResourceLeakTracker}
+     */
+    @SuppressWarnings("unchecked")
+    public final ResourceLeakTracker<T> trackForcibly(T obj) {
+        return track0(obj, true);
     }
 
     @SuppressWarnings("unchecked")
-    private DefaultResourceLeak track0(T obj) {
+    private DefaultResourceLeak track0(T obj, boolean force) {
         Level level = ResourceLeakDetector.level;
-        if (level == Level.DISABLED) {
-            return null;
+        if (force ||
+                level == Level.PARANOID ||
+                (level != Level.DISABLED && PlatformDependent.threadLocalRandom().nextInt(samplingInterval) == 0)) {
+            reportLeak();
+            return new DefaultResourceLeak(obj, refQueue, allLeaks, getInitialHint(resourceType));
         }
-
-        if (level.ordinal() < Level.PARANOID.ordinal()) {
-            if ((PlatformDependent.threadLocalRandom().nextInt(samplingInterval)) == 0) {
-                reportLeak();
-                return new DefaultResourceLeak(obj, refQueue, allLeaks, getInitialHint(resourceType));
-            }
-            return null;
-        }
-        reportLeak();
-        return new DefaultResourceLeak(obj, refQueue, allLeaks, getInitialHint(resourceType));
+        return null;
     }
 
     private void clearRefQueue() {


### PR DESCRIPTION
Motivation:

Currently, when leak tracking is set to SIMPLE or ADVANCED, and a derived buffer is created, the buffer is selected for leak tracking if the parent buffer is tracked and the derived buffer is also selected by an independent roll of the dice. As a result, deeply derived buffers are exponentially less likely to be selected for leak tracking. This makes it difficult to find and diagnose leaks related to such buffers.

Modifications:

When a derived buffer is created, and the parent buffer has leak tracking, the derived buffer now always has leak tracking applied.

Result:

Leaks of derived buffers are easier to find. Fixes #13414.