### PR TITLE
Ensure DnsQueryContext collisions are as rare as possible

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContext.java
@@ -274,6 +274,8 @@ abstract class DnsQueryContext implements FutureListener<AddressedEnvelope<DnsRe
 
         // Remove the id from the manager as soon as the query completes. This may be because of success, failure or
         // cancellation
-        parent.queryContextManager.remove(nameServerAddr, id);
+        DnsQueryContext self = parent.queryContextManager.remove(nameServerAddr, id);
+
+        assert self == this;
     }
 }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContextManager.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContextManager.java
@@ -19,7 +19,6 @@ package io.netty.resolver.dns;
 import io.netty.util.NetUtil;
 import io.netty.util.collection.IntObjectHashMap;
 import io.netty.util.collection.IntObjectMap;
-import io.netty.util.internal.PlatformDependent;
 
 import java.net.Inet4Address;
 import java.net.Inet6Address;
@@ -35,92 +34,69 @@ final class DnsQueryContextManager {
      * A map whose key is the DNS server address and value is the map of the DNS query ID and its corresponding
      * {@link DnsQueryContext}.
      */
-    final Map<InetSocketAddress, IntObjectMap<DnsQueryContext>> map =
-            new HashMap<InetSocketAddress, IntObjectMap<DnsQueryContext>>();
+    private final Map<InetSocketAddress, DnsQueryContextMap> map =
+            new HashMap<InetSocketAddress, DnsQueryContextMap>();
 
     int add(DnsQueryContext qCtx) {
-        final IntObjectMap<DnsQueryContext> contexts = getOrCreateContextMap(qCtx.nameServerAddr());
-
-        int id = PlatformDependent.threadLocalRandom().nextInt(65536 - 1) + 1;
-        final int maxTries = 65535 << 1;
-        int tries = 0;
-
-        synchronized (contexts) {
-            for (;;) {
-                if (!contexts.containsKey(id)) {
-                    contexts.put(id, qCtx);
-                    return id;
-                }
-
-                id = id + 1 & 0xFFFF;
-
-                if (++tries >= maxTries) {
-                    throw new IllegalStateException("query ID space exhausted: " + qCtx.question());
-                }
-            }
-        }
+        final DnsQueryContextMap contexts = getOrCreateContextMap(qCtx.nameServerAddr());
+        return contexts.add(qCtx);
     }
 
     DnsQueryContext get(InetSocketAddress nameServerAddr, int id) {
-        final IntObjectMap<DnsQueryContext> contexts = getContextMap(nameServerAddr);
-        final DnsQueryContext qCtx;
-        if (contexts != null) {
-            synchronized (contexts) {
-                qCtx = contexts.get(id);
-            }
-        } else {
-            qCtx = null;
-        }
-
-        return qCtx;
-    }
-
-    DnsQueryContext remove(InetSocketAddress nameServerAddr, int id) {
-        final IntObjectMap<DnsQueryContext> contexts = getContextMap(nameServerAddr);
+        final DnsQueryContextMap contexts = getContextMap(nameServerAddr);
         if (contexts == null) {
             return null;
         }
-
-        synchronized (contexts) {
-            return  contexts.remove(id);
-        }
+        return contexts.get(id);
     }
 
-    private IntObjectMap<DnsQueryContext> getContextMap(InetSocketAddress nameServerAddr) {
+    DnsQueryContext remove(InetSocketAddress nameServerAddr, int id) {
+        final DnsQueryContextMap contexts = getContextMap(nameServerAddr);
+        if (contexts == null) {
+            return null;
+        }
+        return contexts.remove(id);
+    }
+
+    private DnsQueryContextMap getContextMap(InetSocketAddress nameServerAddr) {
         synchronized (map) {
             return map.get(nameServerAddr);
         }
     }
 
-    private IntObjectMap<DnsQueryContext> getOrCreateContextMap(InetSocketAddress nameServerAddr) {
+    private DnsQueryContextMap getOrCreateContextMap(InetSocketAddress nameServerAddr) {
         synchronized (map) {
-            final IntObjectMap<DnsQueryContext> contexts = map.get(nameServerAddr);
+            final DnsQueryContextMap contexts = map.get(nameServerAddr);
             if (contexts != null) {
                 return contexts;
             }
 
-            final IntObjectMap<DnsQueryContext> newContexts = new IntObjectHashMap<DnsQueryContext>();
+            final DnsQueryContextMap newContexts = new DnsQueryContextMap();
             final InetAddress a = nameServerAddr.getAddress();
             final int port = nameServerAddr.getPort();
-            map.put(nameServerAddr, newContexts);
+            DnsQueryContextMap old = map.put(nameServerAddr, newContexts);
+            // Assert that we didn't replace an existing mapping.
+            assert old == null;
 
             if (a instanceof Inet4Address) {
                 // Also add the mapping for the IPv4-compatible IPv6 address.
                 final Inet4Address a4 = (Inet4Address) a;
                 if (a4.isLoopbackAddress()) {
-                    map.put(new InetSocketAddress(NetUtil.LOCALHOST6, port), newContexts);
+                    old = map.put(new InetSocketAddress(NetUtil.LOCALHOST6, port), newContexts);
                 } else {
-                    map.put(new InetSocketAddress(toCompactAddress(a4), port), newContexts);
+                    old = map.put(new InetSocketAddress(toCompactAddress(a4), port), newContexts);
                 }
             } else if (a instanceof Inet6Address) {
                 // Also add the mapping for the IPv4 address if this IPv6 address is compatible.
                 final Inet6Address a6 = (Inet6Address) a;
                 if (a6.isLoopbackAddress()) {
-                    map.put(new InetSocketAddress(NetUtil.LOCALHOST4, port), newContexts);
+                    old = map.put(new InetSocketAddress(NetUtil.LOCALHOST4, port), newContexts);
                 } else if (a6.isIPv4CompatibleAddress()) {
-                    map.put(new InetSocketAddress(toIPv4Address(a6), port), newContexts);
+                    old = map.put(new InetSocketAddress(toIPv4Address(a6), port), newContexts);
                 }
             }
+            // Assert that we didn't replace an existing mapping.
+            assert old == null;
 
             return newContexts;
         }
@@ -137,12 +113,61 @@ final class DnsQueryContextManager {
     }
 
     private static Inet4Address toIPv4Address(Inet6Address a6) {
+        assert a6.isIPv4CompatibleAddress();
+
         byte[] b6 = a6.getAddress();
         byte[] b4 = { b6[12], b6[13], b6[14], b6[15] };
         try {
             return (Inet4Address) InetAddress.getByAddress(b4);
         } catch (UnknownHostException e) {
             throw new Error(e);
+        }
+    }
+
+    private static final class DnsQueryContextMap {
+        private static final int MAX_ID = 65535;
+        private static final int MAX_TRIES = MAX_ID << 1;
+
+        // We increment on every usage so start with -1, this will ensure we start with 0 as first id.
+        private int id = -1;
+        private final IntObjectMap<DnsQueryContext> map = new IntObjectHashMap<DnsQueryContext>();
+
+        synchronized int add(DnsQueryContext ctx) {
+            int tries = 0;
+
+            for (;;) {
+                int id = nextId();
+                // Let's directly use put as its very unlikely that we still have the id in use.
+                DnsQueryContext oldCtx = map.put(id, ctx);
+                if (oldCtx == null) {
+                    return id;
+                }
+                // Restore the mapping to the old context.
+                map.put(id, oldCtx);
+
+                if (++tries >= MAX_TRIES) {
+                    throw new IllegalStateException(
+                            "query ID space exhausted after " + MAX_TRIES + ": " + ctx.question());
+                }
+            }
+        }
+
+        synchronized DnsQueryContext get(int id) {
+            return map.get(id);
+        }
+
+        synchronized DnsQueryContext remove(int id) {
+            return map.remove(id);
+        }
+
+        private int nextId() {
+            id++;
+            // id is 16bit so ensure we not overflow:
+            // See https://datatracker.ietf.org/doc/html/rfc1035#section-4.1.1
+            if (id == 65535) {
+                id = 0;
+            }
+            return id;
         }
     }
 }


### PR DESCRIPTION
Motivation:

Due of how query ids were generated it was likely that we would re-use an id while we still receive the response later for the original query that used the id.

One example:

- we timed out the query and so removed it internally froom the context manager
- when picking the next id we ended up with re-using the same id (because random might not be as random as we think here...)
- the response to the query we timed out was received now
- we looked up the context and picked the new, tried to notify about the response and failed because the hostname didnt match what we expect.

Modifications:

- Always just increase the id when trying to obtain a new one. It's much likely that this way we will not reuse something that might still produce a response
- Add some asserts to ensure we actually do the right thing
- Improve code

Result:

Less likely to reuse id while response might still be received
