### PR TITLE
Adjust resolver code to make it easier to test in the future

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DatagramDnsQueryContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DatagramDnsQueryContext.java
@@ -30,11 +30,11 @@ import java.net.InetSocketAddress;
 final class DatagramDnsQueryContext extends DnsQueryContext {
 
     DatagramDnsQueryContext(Future<? extends Channel> channelReadyFuture, DnsQueryContextManager queryContextManager,
-                            int maxPayLoadSize, boolean recursionDesired, InetSocketAddress nameServerAddr,
+                            int maxPayLoadSize, boolean recursionDesired,
                             DnsQuestion question, DnsRecord[] additionals,
                             Promise<AddressedEnvelope<DnsResponse, InetSocketAddress>> promise) {
         super(channelReadyFuture, queryContextManager, maxPayLoadSize, recursionDesired,
-                nameServerAddr, question, additionals, promise);
+                question, additionals, promise);
     }
 
     @Override

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DatagramDnsQueryContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DatagramDnsQueryContext.java
@@ -22,26 +22,24 @@ import io.netty.handler.codec.dns.DnsQuery;
 import io.netty.handler.codec.dns.DnsQuestion;
 import io.netty.handler.codec.dns.DnsRecord;
 import io.netty.handler.codec.dns.DnsResponse;
+import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 
 import java.net.InetSocketAddress;
 
 final class DatagramDnsQueryContext extends DnsQueryContext {
 
-    DatagramDnsQueryContext(DnsNameResolver parent, InetSocketAddress nameServerAddr, DnsQuestion question,
-                            DnsRecord[] additionals,
+    DatagramDnsQueryContext(Future<? extends Channel> channelReadyFuture, DnsQueryContextManager queryContextManager,
+                            int maxPayLoadSize, boolean recursionDesired, InetSocketAddress nameServerAddr,
+                            DnsQuestion question, DnsRecord[] additionals,
                             Promise<AddressedEnvelope<DnsResponse, InetSocketAddress>> promise) {
-        super(parent, nameServerAddr, question, additionals, promise);
+        super(channelReadyFuture, queryContextManager, maxPayLoadSize, recursionDesired,
+                nameServerAddr, question, additionals, promise);
     }
 
     @Override
-    protected DnsQuery newQuery(int id) {
-        return new DatagramDnsQuery(null, nameServerAddr(), id);
-    }
-
-    @Override
-    protected Channel channel() {
-        return parent().ch;
+    protected DnsQuery newQuery(int id, InetSocketAddress nameServerAddr) {
+        return new DatagramDnsQuery(null, nameServerAddr, id);
     }
 
     @Override

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DatagramDnsQueryContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DatagramDnsQueryContext.java
@@ -29,11 +29,12 @@ import java.net.InetSocketAddress;
 
 final class DatagramDnsQueryContext extends DnsQueryContext {
 
-    DatagramDnsQueryContext(Future<? extends Channel> channelReadyFuture, DnsQueryContextManager queryContextManager,
+    DatagramDnsQueryContext(Channel channel, Future<? extends Channel> channelReadyFuture,
+                            DnsQueryContextManager queryContextManager,
                             int maxPayLoadSize, boolean recursionDesired,
                             DnsQuestion question, DnsRecord[] additionals,
                             Promise<AddressedEnvelope<DnsResponse, InetSocketAddress>> promise) {
-        super(channelReadyFuture, queryContextManager, maxPayLoadSize, recursionDesired,
+        super(channel, channelReadyFuture, queryContextManager, maxPayLoadSize, recursionDesired,
                 question, additionals, promise);
     }
 

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContext.java
@@ -132,7 +132,7 @@ abstract class DnsQueryContext implements FutureListener<AddressedEnvelope<DnsRe
         sendQuery(query, queryTimeoutMillis, flush, writePromise);
     }
 
-    private void sendQuery(final DnsQuery query, long queryTimeoutMillis,
+    private void sendQuery(final DnsQuery query, final long queryTimeoutMillis,
                            final boolean flush, final ChannelPromise writePromise) {
         if (channelReadyFuture.isSuccess()) {
             writeQuery(query, queryTimeoutMillis, flush, writePromise);

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContextManager.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContextManager.java
@@ -38,8 +38,8 @@ final class DnsQueryContextManager {
     private final Map<InetSocketAddress, DnsQueryContextMap> map =
             new HashMap<InetSocketAddress, DnsQueryContextMap>();
 
-    int add(DnsQueryContext qCtx) {
-        final DnsQueryContextMap contexts = getOrCreateContextMap(qCtx.nameServerAddr());
+    int add(InetSocketAddress nameServerAddr, DnsQueryContext qCtx) {
+        final DnsQueryContextMap contexts = getOrCreateContextMap(nameServerAddr);
         return contexts.add(qCtx);
     }
 

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
@@ -19,7 +19,6 @@ package io.netty.resolver.dns;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.channel.AddressedEnvelope;
-import io.netty.channel.ChannelPromise;
 import io.netty.channel.EventLoop;
 import io.netty.handler.codec.CorruptedFrameException;
 import io.netty.handler.codec.dns.DefaultDnsQuestion;
@@ -432,7 +431,6 @@ abstract class DnsResolveContext<T> {
                                       queryLifecycleObserver, promise, cause);
             return;
         }
-        final ChannelPromise writePromise = parent.ch.newPromise();
         final Promise<AddressedEnvelope<? extends DnsResponse, InetSocketAddress>> queryPromise =
                 parent.ch.eventLoop().newPromise();
 
@@ -447,11 +445,9 @@ abstract class DnsResolveContext<T> {
         }
 
         final Future<AddressedEnvelope<DnsResponse, InetSocketAddress>> f =
-                parent.query0(nameServerAddr, question, additionals, flush, writePromise, queryPromise);
+                parent.query0(nameServerAddr, question, queryLifecycleObserver, additionals, flush, queryPromise);
 
         queriesInProgress.add(f);
-
-        queryLifecycleObserver.queryWritten(nameServerAddr, writePromise);
 
         f.addListener(new FutureListener<AddressedEnvelope<DnsResponse, InetSocketAddress>>() {
             @Override

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/TcpDnsQueryContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/TcpDnsQueryContext.java
@@ -22,28 +22,24 @@ import io.netty.handler.codec.dns.DnsQuery;
 import io.netty.handler.codec.dns.DnsQuestion;
 import io.netty.handler.codec.dns.DnsRecord;
 import io.netty.handler.codec.dns.DnsResponse;
+import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 
 import java.net.InetSocketAddress;
 
 final class TcpDnsQueryContext extends DnsQueryContext {
 
-    private final Channel channel;
-
-    TcpDnsQueryContext(DnsNameResolver parent, Channel channel, InetSocketAddress nameServerAddr, DnsQuestion question,
-                       DnsRecord[] additionals, Promise<AddressedEnvelope<DnsResponse, InetSocketAddress>> promise) {
-        super(parent, nameServerAddr, question, additionals, promise);
-        this.channel = channel;
+    TcpDnsQueryContext(Future<? extends Channel> channelReadyFuture, DnsQueryContextManager queryContextManager,
+                       int maxPayLoadSize, boolean recursionDesired, InetSocketAddress nameServerAddr,
+                       DnsQuestion question, DnsRecord[] additionals,
+                       Promise<AddressedEnvelope<DnsResponse, InetSocketAddress>> promise) {
+        super(channelReadyFuture, queryContextManager, maxPayLoadSize, recursionDesired, nameServerAddr,
+                question, additionals, promise);
     }
 
     @Override
-    protected DnsQuery newQuery(int id) {
+    protected DnsQuery newQuery(int id, InetSocketAddress nameServerAddr) {
         return new DefaultDnsQuery(id);
-    }
-
-    @Override
-    protected Channel channel() {
-        return channel;
     }
 
     @Override

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/TcpDnsQueryContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/TcpDnsQueryContext.java
@@ -29,11 +29,12 @@ import java.net.InetSocketAddress;
 
 final class TcpDnsQueryContext extends DnsQueryContext {
 
-    TcpDnsQueryContext(Future<? extends Channel> channelReadyFuture, DnsQueryContextManager queryContextManager,
+    TcpDnsQueryContext(Channel channel, Future<? extends Channel> channelReadyFuture,
+                       DnsQueryContextManager queryContextManager,
                        int maxPayLoadSize, boolean recursionDesired,
                        DnsQuestion question, DnsRecord[] additionals,
                        Promise<AddressedEnvelope<DnsResponse, InetSocketAddress>> promise) {
-        super(channelReadyFuture, queryContextManager, maxPayLoadSize, recursionDesired,
+        super(channel, channelReadyFuture, queryContextManager, maxPayLoadSize, recursionDesired,
                 question, additionals, promise);
     }
 

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/TcpDnsQueryContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/TcpDnsQueryContext.java
@@ -30,10 +30,10 @@ import java.net.InetSocketAddress;
 final class TcpDnsQueryContext extends DnsQueryContext {
 
     TcpDnsQueryContext(Future<? extends Channel> channelReadyFuture, DnsQueryContextManager queryContextManager,
-                       int maxPayLoadSize, boolean recursionDesired, InetSocketAddress nameServerAddr,
+                       int maxPayLoadSize, boolean recursionDesired,
                        DnsQuestion question, DnsRecord[] additionals,
                        Promise<AddressedEnvelope<DnsResponse, InetSocketAddress>> promise) {
-        super(channelReadyFuture, queryContextManager, maxPayLoadSize, recursionDesired, nameServerAddr,
+        super(channelReadyFuture, queryContextManager, maxPayLoadSize, recursionDesired,
                 question, additionals, promise);
     }
 


### PR DESCRIPTION
Motivation:

DnsQueryContext had a dependency on DnsNameResolver which made it hard to write tests for things like DnsQueryContextManager and DnsQueryContext in isolation.

Modifications:

- Remove dependecy on DnsNameResolver
- Cleanup code

Result:

Easier to write self-contained tests and cleanup
