### PR TITLE
Delay possibility to reuse transaction id when query is failing becau…

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -1376,6 +1376,7 @@ public class DnsNameResolver extends InetNameResolver {
                 logger.debug("{} Received a DNS response for a query that was timed out or cancelled: UDP [{}: {}]",
                         qCh, queryId, res.sender());
                 res.release();
+                return;
             }
 
             // Check if the response was truncated and if we can fallback to TCP to retry.

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -1373,7 +1373,7 @@ public class DnsNameResolver extends InetNameResolver {
                 res.release();
                 return;
             } else if (qCtx.isDone()) {
-                logger.debug("{} Received a DNS response for a query that was completed already ID: UDP [{}: {}]",
+                logger.debug("{} Received a DNS response for a query that was timed out or cancelled: UDP [{}: {}]",
                         qCh, queryId, res.sender());
                 res.release();
             }
@@ -1424,8 +1424,8 @@ public class DnsNameResolver extends InetNameResolver {
 
                             DnsQueryContext foundCtx = queryContextManager.get(res.sender(), queryId);
                             if (foundCtx != null && foundCtx.isDone()) {
-                                logger.debug("{} Received a DNS response for a query that was completed " +
-                                                "already ID: TCP [{}: {}]", tcpCh, queryId, res.sender());
+                                logger.debug("{} Received a DNS response for a query that was timed out or cancelled " +
+                                                ": TCP [{}: {}]", tcpCh, queryId, res.sender());
                                 response.release();
                             } else if (foundCtx == tcpCtx) {
                                 tcpCtx.finishSuccess(tcpCh, new AddressedEnvelopeAdapter(

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContext.java
@@ -45,8 +45,13 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
 abstract class DnsQueryContext {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(DnsQueryContext.class);
-    private static final long ID_REUSE_ON_TIMEOUT_DELAY_MILLIS =
-            SystemPropertyUtil.getLong("io.netty.resolver.dns.idReuseOnTimeoutDelayMillis", 10000);
+    private static final long ID_REUSE_ON_TIMEOUT_DELAY_MILLIS;
+
+    static {
+        ID_REUSE_ON_TIMEOUT_DELAY_MILLIS =
+                SystemPropertyUtil.getLong("io.netty.resolver.dns.idReuseOnTimeoutDelayMillis", 10000);
+        logger.debug("-Dio.netty.resolver.dns.idReuseOnTimeoutDelayMillis: {}", ID_REUSE_ON_TIMEOUT_DELAY_MILLIS);
+    }
 
     private final Future<? extends Channel> channelReadyFuture;
     private final Channel channel;


### PR DESCRIPTION
…se of timeout

Motivation:

We should try to make it as unlikely as possible that we will reuse a transaction for a query while the remote peer still might send the response for the previously timed out query. Failing to do so put us in risk that we will not be able to map the response correctly.

This reduces the risk of the following scenario:

- Query is send to the remote nameeserver
- Query is failed as the remote nameserver did not respond in the configured time
- New query is send which uses the same transaction id as the failed one. While we use a random to generate these this can still happen as we only have 16bits for the id
- nameserver sends back the response for the first query (that we already failed as timed out)
- We lookup the query for the id and find the new one and try to complete it with the response for the "old query".
- This fails as validation of hostname etc not matches.

Modifications:

If we fail a query because of a timeout delay the removal of the id from the context map. This will make the id not-reusable until the removal actually take place.

Result:

Much less likely to reuse an id while the remote nameserver might still respond to the old query
