### PR TITLE
Simplify DnsQueryContext usage again

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DatagramDnsQueryContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DatagramDnsQueryContext.java
@@ -30,11 +30,12 @@ import java.net.InetSocketAddress;
 final class DatagramDnsQueryContext extends DnsQueryContext {
 
     DatagramDnsQueryContext(Channel channel, Future<? extends Channel> channelReadyFuture,
+                            InetSocketAddress nameServerAddr,
                             DnsQueryContextManager queryContextManager,
                             int maxPayLoadSize, boolean recursionDesired,
                             DnsQuestion question, DnsRecord[] additionals,
                             Promise<AddressedEnvelope<DnsResponse, InetSocketAddress>> promise) {
-        super(channel, channelReadyFuture, queryContextManager, maxPayLoadSize, recursionDesired,
+        super(channel, channelReadyFuture, nameServerAddr, queryContextManager, maxPayLoadSize, recursionDesired,
                 question, additionals, promise);
     }
 

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -1332,9 +1332,9 @@ public class DnsNameResolver extends InetNameResolver {
                 checkNotNull(promise, "promise"));
         final int payloadSize = isOptResourceEnabled() ? maxPayloadSize() : 0;
         try {
-            DnsQueryContext queryContext = new DatagramDnsQueryContext(ch, channelReadyPromise, queryContextManager,
-                    payloadSize, isRecursionDesired(), question, additionals, castPromise);
-            ChannelFuture future = queryContext.writeQuery(nameServerAddr, queryTimeoutMillis(), flush);
+            DnsQueryContext queryContext = new DatagramDnsQueryContext(ch, channelReadyPromise, nameServerAddr,
+                    queryContextManager, payloadSize, isRecursionDesired(), question, additionals, castPromise);
+            ChannelFuture future = queryContext.writeQuery(queryTimeoutMillis(), flush);
             queryLifecycleObserver.queryWritten(nameServerAddr, future);
             return castPromise;
         } catch (Exception e) {
@@ -1376,7 +1376,7 @@ public class DnsNameResolver extends InetNameResolver {
 
             // Check if the response was truncated and if we can fallback to TCP to retry.
             if (!res.isTruncated() || socketChannelFactory == null) {
-                qCtx.finishSuccess(qCh, res);
+                qCtx.finishSuccess(res);
                 return;
             }
 
@@ -1393,7 +1393,7 @@ public class DnsNameResolver extends InetNameResolver {
                                 ch, queryId, res.sender(), future.cause());
 
                         // TCP fallback failed, just use the truncated response.
-                        qCtx.finishSuccess(qCh, res);
+                        qCtx.finishSuccess(res);
                         return;
                     }
                     final Channel tcpCh = future.channel();
@@ -1402,8 +1402,8 @@ public class DnsNameResolver extends InetNameResolver {
                             tcpCh.eventLoop().newPromise();
                     final int payloadSize = isOptResourceEnabled() ? maxPayloadSize() : 0;
                     final TcpDnsQueryContext tcpCtx = new TcpDnsQueryContext(tcpCh, channelReadyPromise,
-                            queryContextManager, payloadSize, isRecursionDesired(), qCtx.question(),
-                            EMPTY_ADDITIONALS, promise);
+                            (InetSocketAddress) tcpCh.remoteAddress(), queryContextManager, payloadSize,
+                            isRecursionDesired(), qCtx.question(), EMPTY_ADDITIONALS, promise);
 
                     tcpCh.pipeline().addLast(new TcpDnsResponseDecoder());
                     tcpCh.pipeline().addLast(new ChannelInboundHandlerAdapter() {
@@ -1420,14 +1420,13 @@ public class DnsNameResolver extends InetNameResolver {
 
                             DnsQueryContext foundCtx = queryContextManager.get(res.sender(), queryId);
                             if (foundCtx == tcpCtx) {
-                                tcpCtx.finishSuccess(tcpCh, new AddressedEnvelopeAdapter(
+                                tcpCtx.finishSuccess(new AddressedEnvelopeAdapter(
                                         (InetSocketAddress) ctx.channel().remoteAddress(),
                                         (InetSocketAddress) ctx.channel().localAddress(),
                                         response));
                             } else {
                                 response.release();
-                                tcpCtx.finishFailure((InetSocketAddress) tcpCh.remoteAddress(),
-                                        "Received TCP DNS response with unexpected ID", null, false);
+                                tcpCtx.finishFailure("Received TCP DNS response with unexpected ID", null, false);
                                 if (logger.isDebugEnabled()) {
                                     logger.debug("{} Received a DNS response with an unexpected ID: TCP [{}: {}]",
                                             tcpCh, queryId, tcpCh.remoteAddress());
@@ -1437,7 +1436,7 @@ public class DnsNameResolver extends InetNameResolver {
 
                         @Override
                         public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-                            if (tcpCtx.finishFailure((InetSocketAddress) ctx.channel().remoteAddress(),
+                            if (tcpCtx.finishFailure(
                                     "TCP fallback error", cause, false) && logger.isDebugEnabled()) {
                                 logger.debug("{} Error during processing response: TCP [{}: {}]",
                                         ctx.channel(), queryId,
@@ -1452,17 +1451,16 @@ public class DnsNameResolver extends InetNameResolver {
                         public void operationComplete(
                                 Future<AddressedEnvelope<DnsResponse, InetSocketAddress>> future) {
                             if (future.isSuccess()) {
-                                qCtx.finishSuccess(qCh, future.getNow());
+                                qCtx.finishSuccess(future.getNow());
                                 res.release();
                             } else {
                                 // TCP fallback failed, just use the truncated response.
-                                qCtx.finishSuccess(qCh, res);
+                                qCtx.finishSuccess(res);
                             }
                             tcpCh.close();
                         }
                     });
-                    tcpCtx.writeQuery((InetSocketAddress) tcpCh.remoteAddress(), queryTimeoutMillis(),
-                            true);
+                    tcpCtx.writeQuery(queryTimeoutMillis(), true);
                 }
             });
         }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/TcpDnsQueryContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/TcpDnsQueryContext.java
@@ -30,11 +30,12 @@ import java.net.InetSocketAddress;
 final class TcpDnsQueryContext extends DnsQueryContext {
 
     TcpDnsQueryContext(Channel channel, Future<? extends Channel> channelReadyFuture,
+                       InetSocketAddress nameServerAddr,
                        DnsQueryContextManager queryContextManager,
                        int maxPayLoadSize, boolean recursionDesired,
                        DnsQuestion question, DnsRecord[] additionals,
                        Promise<AddressedEnvelope<DnsResponse, InetSocketAddress>> promise) {
-        super(channel, channelReadyFuture, queryContextManager, maxPayLoadSize, recursionDesired,
+        super(channel, channelReadyFuture, nameServerAddr, queryContextManager, maxPayLoadSize, recursionDesired,
                 question, additionals, promise);
     }
 


### PR DESCRIPTION
Motivation:

22bf43b03999f40459c61b61c453e0989563cc98 made some changes to simplify DnsQueryContext but did introduce one change which might be a bit error-prone.

Modifications:

Don't pass the nameserveraddress and the channel to the finish* and writeQuery methods.

Result:

Always log / use the correct nameserveraddress / channel
