### PR TITLE
Implement contains for SelectedSelectionKeySet

### DIFF
--- a/transport/src/main/java/io/netty/channel/nio/SelectedSelectionKeySet.java
+++ b/transport/src/main/java/io/netty/channel/nio/SelectedSelectionKeySet.java
@@ -20,6 +20,7 @@ import java.util.AbstractSet;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 
 final class SelectedSelectionKeySet extends AbstractSet<SelectionKey> {
 
@@ -51,6 +52,13 @@ final class SelectedSelectionKeySet extends AbstractSet<SelectionKey> {
 
     @Override
     public boolean contains(Object o) {
+        SelectionKey[] array = keys;
+        for (int i = 0, s = size; i < s; i++) {
+            SelectionKey k = array[i];
+            if (k.equals(o)) {
+                return true;
+            }
+        }
         return false;
     }
 

--- a/transport/src/test/java/io/netty/channel/nio/SelectedSelectionKeySetTest.java
+++ b/transport/src/test/java/io/netty/channel/nio/SelectedSelectionKeySetTest.java
@@ -102,8 +102,8 @@ public class SelectedSelectionKeySetTest {
         SelectedSelectionKeySet set = new SelectedSelectionKeySet();
         assertTrue(set.add(mockKey));
         assertTrue(set.add(mockKey2));
-        assertFalse(set.contains(mockKey));
-        assertFalse(set.contains(mockKey2));
+        assertTrue(set.contains(mockKey));
+        assertTrue(set.contains(mockKey2));
         assertFalse(set.contains(mockKey3));
     }
 


### PR DESCRIPTION
Motivation:
The `contains` method may be called in the `sub.nio.ch.SelectorImpl.processReadyEvents` method on macOS and Windows, so we need to implement it correctly. Otherwise, we can lose read-poll events.
See the investigation on the Hazelcast repo: https://github.com/hazelcast/hazelcast/pull/24267

Modification:
Add a contains method that just does a linear scan for the selection key. This preserves the performance characteristics of all the other methods.
Result:
Fixes #13328