### PR TITLE
Reuse Bootstrap to create SocketChannel for DNS TCP

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolveContext.java
@@ -22,6 +22,7 @@ import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.List;
 
+import io.netty.channel.Channel;
 import io.netty.channel.EventLoop;
 import io.netty.handler.codec.dns.DnsRecord;
 import io.netty.handler.codec.dns.DnsRecordType;
@@ -33,12 +34,12 @@ final class DnsAddressResolveContext extends DnsResolveContext<InetAddress> {
     private final AuthoritativeDnsServerCache authoritativeDnsServerCache;
     private final boolean completeEarlyIfPossible;
 
-    DnsAddressResolveContext(DnsNameResolver parent, Promise<?> originalPromise,
+    DnsAddressResolveContext(DnsNameResolver parent, Channel channel, Promise<?> originalPromise,
                              String hostname, DnsRecord[] additionals,
                              DnsServerAddressStream nameServerAddrs, int allowedQueries, DnsCache resolveCache,
                              AuthoritativeDnsServerCache authoritativeDnsServerCache,
                              boolean completeEarlyIfPossible) {
-        super(parent, originalPromise, hostname, DnsRecord.CLASS_IN,
+        super(parent, channel, originalPromise, hostname, DnsRecord.CLASS_IN,
               parent.resolveRecordTypes(), additionals, nameServerAddrs, allowedQueries);
         this.resolveCache = resolveCache;
         this.authoritativeDnsServerCache = authoritativeDnsServerCache;
@@ -46,12 +47,13 @@ final class DnsAddressResolveContext extends DnsResolveContext<InetAddress> {
     }
 
     @Override
-    DnsResolveContext<InetAddress> newResolverContext(DnsNameResolver parent, Promise<?> originalPromise,
+    DnsResolveContext<InetAddress> newResolverContext(DnsNameResolver parent, Channel channel,
+                                                      Promise<?> originalPromise,
                                                       String hostname,
                                                       int dnsClass, DnsRecordType[] expectedTypes,
                                                       DnsRecord[] additionals,
                                                       DnsServerAddressStream nameServerAddrs, int allowedQueries) {
-        return new DnsAddressResolveContext(parent, originalPromise, hostname, additionals, nameServerAddrs,
+        return new DnsAddressResolveContext(parent, channel, originalPromise, hostname, additionals, nameServerAddrs,
                 allowedQueries, resolveCache, authoritativeDnsServerCache, completeEarlyIfPossible);
     }
 
@@ -80,12 +82,12 @@ final class DnsAddressResolveContext extends DnsResolveContext<InetAddress> {
     @Override
     void cache(String hostname, DnsRecord[] additionals,
                DnsRecord result, InetAddress convertedResult) {
-        resolveCache.cache(hostname, additionals, convertedResult, result.timeToLive(), parent.ch.eventLoop());
+        resolveCache.cache(hostname, additionals, convertedResult, result.timeToLive(), channel().eventLoop());
     }
 
     @Override
     void cache(String hostname, DnsRecord[] additionals, UnknownHostException cause) {
-        resolveCache.cache(hostname, additionals, cause, parent.ch.eventLoop());
+        resolveCache.cache(hostname, additionals, cause, channel().eventLoop());
     }
 
     @Override

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -143,9 +143,7 @@ public class DnsNameResolver extends InetNameResolver {
         }
         WINDOWS_HOST_NAME = hostName;
         logger.debug("Windows hostname: {}", WINDOWS_HOST_NAME);
-    }
 
-    static {
         String[] searchDomains;
         try {
             List<String> list = PlatformDependent.isWindows()
@@ -225,15 +223,15 @@ public class DnsNameResolver extends InetNameResolver {
     private static final DatagramDnsQueryEncoder DATAGRAM_ENCODER = new DatagramDnsQueryEncoder();
     private static final TcpDnsQueryEncoder TCP_ENCODER = new TcpDnsQueryEncoder();
 
-    final Promise<Channel> channelReadyPromise;
-    final Channel ch;
+    private final Promise<Channel> channelReadyPromise;
+    private final Channel ch;
 
     // Comparator that ensures we will try first to use the nameservers that use our preferred address type.
     private final Comparator<InetSocketAddress> nameServerComparator;
     /**
      * Manages the {@link DnsQueryContext}s in progress and their query IDs.
      */
-    final DnsQueryContextManager queryContextManager = new DnsQueryContextManager();
+    private final DnsQueryContextManager queryContextManager = new DnsQueryContextManager();
 
     /**
      * Cache for {@link #doResolve(String, Promise)} and {@link #doResolveAll(String, Promise)}.
@@ -268,7 +266,7 @@ public class DnsNameResolver extends InetNameResolver {
     private final boolean decodeIdn;
     private final DnsQueryLifecycleObserverFactory dnsQueryLifecycleObserverFactory;
     private final boolean completeOncePreferredResolved;
-    private final ChannelFactory<? extends SocketChannel> socketChannelFactory;
+    private final Bootstrap socketBootstrap;
 
     private final int maxNumConsolidation;
     private final Map<String, Future<List<InetAddress>>> inflightLookups;
@@ -451,7 +449,15 @@ public class DnsNameResolver extends InetNameResolver {
         this.ndots = ndots >= 0 ? ndots : DEFAULT_OPTIONS.ndots();
         this.decodeIdn = decodeIdn;
         this.completeOncePreferredResolved = completeOncePreferredResolved;
-        this.socketChannelFactory = socketChannelFactory;
+        if (socketChannelFactory == null) {
+            socketBootstrap = null;
+        } else {
+            socketBootstrap = new Bootstrap();
+            socketBootstrap.option(ChannelOption.SO_REUSEADDR, true)
+                    .group(executor())
+                    .channelFactory(socketChannelFactory)
+                    .handler(TCP_ENCODER);
+        }
         switch (this.resolvedAddressTypes) {
             case IPV4_ONLY:
                 supportsAAAARecords = false;
@@ -919,8 +925,8 @@ public class DnsNameResolver extends InetNameResolver {
         // It was not A/AAAA question or there was no entry in /etc/hosts.
         final DnsServerAddressStream nameServerAddrs =
                 dnsServerAddressStreamProvider.nameServerAddressStream(hostname);
-        new DnsRecordResolveContext(this, promise, question, additionals, nameServerAddrs, maxQueriesPerResolve)
-                .resolve(promise);
+        new DnsRecordResolveContext(this, ch, promise, question, additionals,
+                nameServerAddrs, maxQueriesPerResolve).resolve(promise);
         return promise;
     }
 
@@ -1213,8 +1219,8 @@ public class DnsNameResolver extends InetNameResolver {
                             final boolean completeEarlyIfPossible) {
         final DnsServerAddressStream nameServerAddrs =
                 dnsServerAddressStreamProvider.nameServerAddressStream(hostname);
-        DnsAddressResolveContext ctx = new DnsAddressResolveContext(this, originalPromise, hostname, additionals,
-                nameServerAddrs, maxQueriesPerResolve, resolveCache,
+        DnsAddressResolveContext ctx = new DnsAddressResolveContext(this, ch, originalPromise, hostname,
+                additionals, nameServerAddrs, maxQueriesPerResolve, resolveCache,
                 authoritativeDnsServerCache, completeEarlyIfPossible);
         ctx.resolve(promise);
     }
@@ -1380,17 +1386,12 @@ public class DnsNameResolver extends InetNameResolver {
             }
 
             // Check if the response was truncated and if we can fallback to TCP to retry.
-            if (!res.isTruncated() || socketChannelFactory == null) {
+            if (!res.isTruncated() || socketBootstrap == null) {
                 qCtx.finishSuccess(res);
                 return;
             }
 
-            Bootstrap bs = new Bootstrap();
-            bs.option(ChannelOption.SO_REUSEADDR, true)
-            .group(executor())
-            .channelFactory(socketChannelFactory)
-            .handler(TCP_ENCODER);
-            bs.connect(res.sender()).addListener(new ChannelFutureListener() {
+            socketBootstrap.connect(res.sender()).addListener(new ChannelFutureListener() {
                 @Override
                 public void operationComplete(ChannelFuture future) {
                     if (!future.isSuccess()) {

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsRecordResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsRecordResolveContext.java
@@ -18,6 +18,7 @@ package io.netty.resolver.dns;
 import java.net.UnknownHostException;
 import java.util.List;
 
+import io.netty.channel.Channel;
 import io.netty.channel.EventLoop;
 import io.netty.handler.codec.dns.DnsQuestion;
 import io.netty.handler.codec.dns.DnsRecord;
@@ -27,29 +28,30 @@ import io.netty.util.concurrent.Promise;
 
 final class DnsRecordResolveContext extends DnsResolveContext<DnsRecord> {
 
-    DnsRecordResolveContext(DnsNameResolver parent, Promise<?> originalPromise, DnsQuestion question,
+    DnsRecordResolveContext(DnsNameResolver parent, Channel channel, Promise<?> originalPromise, DnsQuestion question,
                             DnsRecord[] additionals, DnsServerAddressStream nameServerAddrs, int allowedQueries) {
-        this(parent, originalPromise, question.name(), question.dnsClass(),
+        this(parent, channel, originalPromise, question.name(), question.dnsClass(),
              new DnsRecordType[] { question.type() },
              additionals, nameServerAddrs, allowedQueries);
     }
 
-    private DnsRecordResolveContext(DnsNameResolver parent, Promise<?> originalPromise, String hostname,
-                                    int dnsClass, DnsRecordType[] expectedTypes,
+    private DnsRecordResolveContext(DnsNameResolver parent, Channel channel, Promise<?> originalPromise,
+                                    String hostname, int dnsClass, DnsRecordType[] expectedTypes,
                                     DnsRecord[] additionals,
                                     DnsServerAddressStream nameServerAddrs,
                                     int allowedQueries) {
-        super(parent, originalPromise, hostname, dnsClass, expectedTypes, additionals, nameServerAddrs, allowedQueries);
+        super(parent, channel, originalPromise, hostname, dnsClass, expectedTypes,
+                additionals, nameServerAddrs, allowedQueries);
     }
 
     @Override
-    DnsResolveContext<DnsRecord> newResolverContext(DnsNameResolver parent, Promise<?> originalPromise,
+    DnsResolveContext<DnsRecord> newResolverContext(DnsNameResolver parent, Channel channel, Promise<?> originalPromise,
                                                     String hostname,
                                                     int dnsClass, DnsRecordType[] expectedTypes,
                                                     DnsRecord[] additionals,
                                                     DnsServerAddressStream nameServerAddrs,
                                                     int allowedQueries) {
-        return new DnsRecordResolveContext(parent, originalPromise, hostname, dnsClass,
+        return new DnsRecordResolveContext(parent, channel, originalPromise, hostname, dnsClass,
                                            expectedTypes, additionals, nameServerAddrs, allowedQueries);
     }
 

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -3252,7 +3252,14 @@ public class DnsNameResolverTest {
         DnsNameResolver resolver = null;
         try {
             DnsNameResolverBuilder builder = newResolver();
-
+            final DatagramChannel datagramChannel = new NioDatagramChannel();
+            ChannelFactory<DatagramChannel> channelFactory = new ChannelFactory<DatagramChannel>() {
+                @Override
+                public DatagramChannel newChannel() {
+                    return datagramChannel;
+                }
+            };
+            builder.channelFactory(channelFactory);
             if (tcpFallback) {
                 dnsServer2.start(null, (InetSocketAddress) serverSocket.getLocalSocketAddress());
 
@@ -3267,7 +3274,7 @@ public class DnsNameResolverTest {
                     .nameServerProvider(new SingletonDnsServerAddressStreamProvider(dnsServer2.localAddress()));
             resolver = builder.build();
             if (truncatedBecauseOfMtu) {
-                resolver.ch.pipeline().addFirst(new ChannelInboundHandlerAdapter() {
+                datagramChannel.pipeline().addFirst(new ChannelInboundHandlerAdapter() {
                     @Override
                     public void channelRead(ChannelHandlerContext ctx, Object msg) {
                         if (msg instanceof DatagramPacket) {


### PR DESCRIPTION
Motivation:

There is no need to create a new Bootstrap each time we open a new connection.

Modifications:

- Create the Bootstrap only once
- Tighten up some visibility

Result:

Produce less GC
