### PR TITLE
Add resource leak listener

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
@@ -1463,4 +1463,13 @@ public abstract class AbstractByteBuf extends ByteBuf {
     final void discardMarks() {
         markedReaderIndex = markedWriterIndex = 0;
     }
+
+    /**
+     * Set leakDetector's LeakListener.
+     *
+     * @param leakListener If leakListener is not null, it will be notified once a ByteBuf leak is detected.
+     */
+    public static void setLeakListener(ResourceLeakDetector.LeakListener leakListener) {
+        leakDetector.setLeakListener(leakListener);
+    }
 }

--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
@@ -1463,13 +1463,4 @@ public abstract class AbstractByteBuf extends ByteBuf {
     final void discardMarks() {
         markedReaderIndex = markedWriterIndex = 0;
     }
-
-    /**
-     * Set leakDetector's LeakListener.
-     *
-     * @param leakListener If leakListener is not null, it will be notified once a ByteBuf leak is detected.
-     */
-    public static void setLeakListener(ResourceLeakDetector.LeakListener leakListener) {
-        leakDetector.setLeakListener(leakListener);
-    }
 }

--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -20,6 +20,7 @@ import io.netty.util.ByteProcessor;
 import io.netty.util.CharsetUtil;
 import io.netty.util.IllegalReferenceCountException;
 import io.netty.util.Recycler.EnhancedHandle;
+import io.netty.util.ResourceLeakDetector;
 import io.netty.util.concurrent.FastThreadLocal;
 import io.netty.util.internal.MathUtil;
 import io.netty.util.internal.ObjectPool;
@@ -1936,6 +1937,15 @@ public final class ByteBufUtil {
             out.write(in, inOffset, len);
             outLen -= len;
         } while (outLen > 0);
+    }
+
+    /**
+     * Set {@link AbstractByteBuf#leakDetector}'s {@link ResourceLeakDetector.LeakListener}.
+     *
+     * @param leakListener If leakListener is not null, it will be notified once a ByteBuf leak is detected.
+     */
+    public static void setLeakListener(ResourceLeakDetector.LeakListener leakListener) {
+        AbstractByteBuf.leakDetector.setLeakListener(leakListener);
     }
 
     private ByteBufUtil() { }

--- a/common/src/main/java/io/netty/util/ResourceLeakDetector.java
+++ b/common/src/main/java/io/netty/util/ResourceLeakDetector.java
@@ -172,6 +172,11 @@ public class ResourceLeakDetector<T> {
     private final int samplingInterval;
 
     /**
+     * Will be notified once a leak is detected.
+     */
+    private volatile LeakListener leakListener;
+
+    /**
      * @deprecated use {@link ResourceLeakDetectorFactory#newResourceLeakDetector(Class, int, long)}.
      */
     @Deprecated
@@ -315,6 +320,11 @@ public class ResourceLeakDetector<T> {
                 } else {
                     reportTracedLeak(resourceType, records);
                 }
+
+                LeakListener listener = leakListener;
+                if (listener != null) {
+                    listener.onLeak(resourceType, records);
+                }
             }
         }
     }
@@ -357,6 +367,21 @@ public class ResourceLeakDetector<T> {
      */
     protected Object getInitialHint(String resourceType) {
         return null;
+    }
+
+    /**
+     * Set leak listener. Previous listener will be replaced.
+     */
+    public void setLeakListener(LeakListener leakListener) {
+        this.leakListener = leakListener;
+    }
+
+    public interface LeakListener {
+
+        /**
+         * Will be called once a leak is detected.
+         */
+        void onLeak(String resourceType, String records);
     }
 
     @SuppressWarnings("deprecation")


### PR DESCRIPTION
Motivation:

When a leak is detected, the logger will print `LEAK: ....`.
This is very useful to find resource leak, but it is a little inconvenient, because the log file need to be checked manually.

Another approach is to custom resource leak detector by configuration `io.netty.customResourceLeakDetector` and implement `ResourceLeakDetector` with a sub-class, but this is a heavy-weight operation for users.

There should be an easy way for users to find resource leak.

Modification:

Add leak listener interface to `ResourceLeakDetector`.
Then users can set listener and do something when a leak is detected. For example:
```
ByteBufUtil.setLeakListener((resType, record) -> {
    MyMonitor.reportAsync("ByteBufLeak", 1);  // user can then config email/message/call alarm on the monitor.
});
```

Result:

This new approach is very light-weight for users to find resource leak.

