### PR TITLE
Reduce object allocations during SslHandler.flush(...)

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -1038,7 +1038,9 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
             }
 
             for (;;) {
-                ByteBuffer out0 = out.nioBuffer(out.writerIndex(), out.writableBytes());
+                // Use toByteBuffer(...) which might be able to return the internal ByteBuffer and so reduce
+                // allocations.
+                ByteBuffer out0 = toByteBuffer(out, out.writerIndex(), out.writableBytes());
                 SSLEngineResult result = engine.wrap(in0, out0);
                 in.skipBytes(result.bytesConsumed());
                 out.writerIndex(out.writerIndex() + result.bytesProduced());


### PR DESCRIPTION
Motivation:

In SslHandler.flush(...) we called wrap(...) which used nioBuffer(...) to obtain a ByteBuffer from a ByteBuf. This creates more objects then needed. We can use internalNioBuffer(...) for these short living objects which will often not need to allocate anything when using the PooledByteBufAllocator.

Modifications:

Use internalNioBuffer(...) when possible

Result:

Fixes https://github.com/netty/netty/issues/13462