### PR TITLE
Give explicit error on missing BouncyCastle PKIX library

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/util/SelfSignedCertificate.java
+++ b/handler/src/main/java/io/netty/handler/ssl/util/SelfSignedCertificate.java
@@ -240,7 +240,12 @@ public final class SelfSignedCertificate {
             paths = BouncyCastleSelfSignedCertGenerator.generate(
                     fqdn, keypair, random, notBefore, notAfter, algorithm);
         } catch (Throwable t) {
-            logger.debug("Failed to generate a self-signed X.509 certificate using Bouncy Castle:", t);
+            if (!isBouncyCastleAvailable()) {
+                logger.debug("Failed to generate a self-signed X.509 certificate because " +
+                        "BouncyCastle PKIX is not available in classpath");
+            } else {
+                logger.debug("Failed to generate a self-signed X.509 certificate using Bouncy Castle:", t);
+            }
             try {
                 // Try the OpenJDK's proprietary implementation.
                 paths = OpenJdkSelfSignedCertGenerator.generate(fqdn, keypair, random, notBefore, notAfter, algorithm);
@@ -399,6 +404,15 @@ public final class SelfSignedCertificate {
             if (logger.isWarnEnabled()) {
                 logger.warn("Failed to close a file: " + keyFile, e);
             }
+        }
+    }
+
+    private static boolean isBouncyCastleAvailable() {
+        try {
+            Class.forName("org.bouncycastle.cert.X509v3CertificateBuilder");
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
         }
     }
 }


### PR DESCRIPTION
Motivation:
If the BounyCastle PKIX library is missing from the classpath, Netty throws an exception like this: `Failed to generate a self-signed X.509 certificate using Bouncy Castle`. This is not really helpful as the user has to go through Stacktrace to find out what went wrong. To combat this, I added a util method that checks if `org.bouncycastle.cert.X509v3CertificateBuilder` is available in the classpath or not. Based on this, we can return explicit clear exceptions which helps in debugging.

`org.bouncycastle.cert.X509v3CertificateBuilder` is part of the BounyCastle PKIX library.

Modification:
Added `isBouncyCastleAvailable()` method to check for `org.bouncycastle.cert.X509v3CertificateBuilder` availability in classpath.

Result:
Clear explicit error on missing BouncyCastle PKIX library
