### PR TITLE
[main] Add VM sockets support

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/LinuxSocket.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/LinuxSocket.java
@@ -17,6 +17,7 @@ package io.netty5.channel.epoll;
 
 import io.netty5.channel.ChannelException;
 import io.netty5.channel.DefaultFileRegion;
+import io.netty5.channel.unix.Errors;
 import io.netty5.channel.socket.SocketProtocolFamily;
 import io.netty5.channel.unix.NativeInetAddress;
 import io.netty5.channel.unix.PeerCredentials;
@@ -33,6 +34,7 @@ import java.net.UnknownHostException;
 import java.util.Enumeration;
 
 import static io.netty5.channel.unix.Errors.ioResult;
+import static io.netty5.channel.unix.Errors.newIOException;
 
 /**
  * A socket which provides access Linux native methods.
@@ -306,6 +308,46 @@ public final class LinuxSocket extends Socket {
         return ioResult("sendfile", (int) res);
     }
 
+    public void bindVSock(VSockAddress address) throws IOException {
+        int res = bindVSock(/*fd*/intValue(), address.getCid(), address.getPort());
+        if (res < 0) {
+            throw newIOException("bindVSock", res);
+        }
+    }
+
+    public boolean connectVSock(VSockAddress address) throws IOException {
+        int res = connectVSock(/*fd*/intValue(), address.getCid(), address.getPort());
+        if (res < 0) {
+            return Errors.handleConnectErrno("connectVSock", res);
+        }
+        return true;
+    }
+
+    public VSockAddress remoteVSockAddress() {
+        byte[] addr = remoteVSockAddress(/*fd*/intValue());
+        if (addr == null) {
+            return null;
+        }
+        int cid = getIntAt(addr, 0);
+        int port = getIntAt(addr, 4);
+        return new VSockAddress(cid, port);
+    }
+
+    public VSockAddress localVSockAddress() {
+        byte[] addr = localVSockAddress(/*fd*/intValue());
+        if (addr == null) {
+            return null;
+        }
+        int cid = getIntAt(addr, 0);
+        int port = getIntAt(addr, 4);
+        return new VSockAddress(cid, port);
+    }
+
+    private static int getIntAt(byte[] array, int startIndex) {
+        return array[startIndex] << 24 | (array[startIndex + 1] & 0xFF) << 16
+                | (array[startIndex + 2] & 0xFF) << 8 | (array[startIndex + 3] & 0xFF);
+    }
+
     private static InetAddress deriveInetAddress(NetworkInterface netInterface, boolean ipv6) {
         final InetAddress ipAny = ipv6 ? INET6_ANY : INET_ANY;
         if (netInterface != null) {
@@ -319,6 +361,22 @@ public final class LinuxSocket extends Socket {
             }
         }
         return ipAny;
+    }
+
+    public static LinuxSocket newSocket(int fd) {
+        return new LinuxSocket(fd, /*consistent with 4.1*/SocketProtocolFamily.INET);
+    }
+
+    public static LinuxSocket newVSockStream() {
+        return new LinuxSocket(newVSockStream0(), /*consistent with 4.1*/SocketProtocolFamily.INET);
+    }
+
+    static int newVSockStream0() {
+        int res = newVSockStreamFd();
+        if (res < 0) {
+            throw new ChannelException(newIOException("newVSockStream", res));
+        }
+        return res;
     }
 
     public static LinuxSocket newDatagramSocket(ProtocolFamily family) {
@@ -393,6 +451,12 @@ public final class LinuxSocket extends Socket {
             throw new ChannelException(uhe);
         }
     }
+
+    private static native int newVSockStreamFd();
+    private static native int bindVSock(int fd, int cid, int port);
+    private static native int connectVSock(int fd, int cid, int port);
+    private static native byte[] remoteVSockAddress(int fd);
+    private static native byte[] localVSockAddress(int fd);
 
     private static native void joinGroup(int fd, boolean ipv6, byte[] group, byte[] interfaceAddress,
                                          int scopeId, int interfaceIndex) throws IOException;

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/VSockAddress.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/VSockAddress.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty5.channel.epoll;
+
+import java.net.SocketAddress;
+
+/**
+ * A address for a
+ * <a href="https://man7.org/linux/man-pages/man7/vsock.7.html">VM sockets (Linux VSOCK address family)</a>.
+ */
+
+public final class VSockAddress extends SocketAddress {
+    private static final long serialVersionUID = 8600894096347158429L;
+
+    public static final int VMADDR_CID_ANY = -1;
+    public static final int VMADDR_CID_HYPERVISOR = 0;
+    public static final int VMADDR_CID_LOCAL = 1;
+    public static final int VMADDR_CID_HOST = 2;
+
+    public static final int VMADDR_PORT_ANY = -1;
+
+    private final int cid;
+    private final int port;
+
+    public VSockAddress(int cid, int port) {
+        this.cid = cid;
+        this.port = port;
+    }
+
+    public int getCid() {
+        return cid;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    @Override
+    public String toString() {
+        return "VSockAddress{" +
+                "cid=" + cid +
+                ", port=" + port +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof VSockAddress)) {
+            return false;
+        }
+
+        VSockAddress that = (VSockAddress) o;
+
+        return cid == that.cid && port == that.port;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = cid;
+        result = 31 * result + port;
+        return result;
+    }
+}

--- a/transport-native-epoll/src/main/c/netty5_epoll_linuxsocket.c
+++ b/transport-native-epoll/src/main/c/netty5_epoll_linuxsocket.c
@@ -74,7 +74,7 @@ static jfieldID fileDescriptorFieldId = NULL;
 // JNI Registered Methods Begin
 
 static jint netty5_epoll_linuxsocket_newVSockStreamFd(JNIEnv* env, jclass clazz) {
-    int fd = nettyNonBlockingSocket(AF_VSOCK, SOCK_STREAM, 0);
+    int fd = netty5_unix_socket_nonBlockingSocket(AF_VSOCK, SOCK_STREAM, 0);
     if (fd == -1) {
         return -errno;
     }

--- a/transport-native-epoll/src/main/c/netty5_epoll_linuxsocket.c
+++ b/transport-native-epoll/src/main/c/netty5_epoll_linuxsocket.c
@@ -29,6 +29,7 @@
 #include <sys/sendfile.h>
 #include <linux/tcp.h> // TCP_NOTSENT_LOWAT is a linux specific define
 #include "netty5_epoll_linuxsocket.h"
+#include "netty5_epoll_vmsocket.h"
 #include "netty5_unix_errors.h"
 #include "netty5_unix_filedescriptor.h"
 #include "netty5_unix_jni.h"
@@ -71,6 +72,92 @@ static jfieldID fdFieldId = NULL;
 static jfieldID fileDescriptorFieldId = NULL;
 
 // JNI Registered Methods Begin
+
+static jint netty5_epoll_linuxsocket_newVSockStreamFd(JNIEnv* env, jclass clazz) {
+    int fd = nettyNonBlockingSocket(AF_VSOCK, SOCK_STREAM, 0);
+    if (fd == -1) {
+        return -errno;
+    }
+    return fd;
+}
+
+static jint netty5_epoll_linuxsocket_bindVSock(JNIEnv* env, jclass clazz, jint fd, jint cid, jint port) {
+    struct sockaddr_vm addr;
+    memset(&addr, 0, sizeof(struct sockaddr_vm));
+
+    addr.svm_family = AF_VSOCK;
+    addr.svm_port = port;
+    addr.svm_cid = cid;
+
+    int res = bind(fd, (struct sockaddr*) &addr, sizeof(struct sockaddr_vm));
+
+    if (res == -1) {
+        return -errno;
+    }
+    return res;
+}
+
+static jint netty5_epoll_linuxsocket_connectVSock(JNIEnv* env, jclass clazz, jint fd, jint cid, jint port) {
+    struct sockaddr_vm addr;
+    memset(&addr, 0, sizeof(struct sockaddr_vm));
+    addr.svm_family = AF_VSOCK;
+    addr.svm_port = port;
+    addr.svm_cid = cid;
+
+    int res;
+    int err;
+    do {
+        res = connect(fd, (struct sockaddr*) &addr, sizeof(struct sockaddr_vm));
+    } while (res == -1 && ((err = errno) == EINTR));
+
+    if (res == -1) {
+        return -errno;
+    }
+    return res;
+}
+
+static jbyteArray createVSockAddressArray(JNIEnv* env, const struct sockaddr_vm* addr) {
+    jbyteArray bArray = (*env)->NewByteArray(env, 8);
+    if (bArray == NULL) {
+        return NULL;
+    }
+
+    unsigned int cid = (addr->svm_cid);
+    unsigned int port = (addr->svm_port);
+
+    unsigned char a[4];
+    a[0] = cid >> 24;
+    a[1] = cid >> 16;
+    a[2] = cid >> 8;
+    a[3] = cid;
+    (*env)->SetByteArrayRegion(env, bArray, 0, 4, (jbyte*) &a);
+
+    a[0] = port >> 24;
+    a[1] = port >> 16;
+    a[2] = port >> 8;
+    a[3] = port;
+    (*env)->SetByteArrayRegion(env, bArray, 4, 4, (jbyte*) &a);
+    return bArray;
+}
+
+static jbyteArray netty5_epoll_linuxsocket_remoteVSockAddress(JNIEnv* env, jclass clazz, jint fd) {
+    struct sockaddr_vm addr = { 0 };
+    socklen_t len = sizeof(addr);
+    if (getpeername(fd, (struct sockaddr*) &addr, &len) == -1) {
+        return NULL;
+    }
+    return createVSockAddressArray(env, &addr);
+}
+
+static jbyteArray netty5_epoll_linuxsocket_localVSockAddress(JNIEnv* env, jclass clazz, jint fd) {
+    struct sockaddr_vm addr = { 0 };
+    socklen_t len = sizeof(addr);
+    if (getsockname(fd, (struct sockaddr*) &addr, &len) == -1) {
+        return NULL;
+    }
+    return createVSockAddressArray(env, &addr);
+}
+
 static void netty5_epoll_linuxsocket_setTimeToLive(JNIEnv* env, jclass clazz, jint fd, jint optval) {
     netty5_unix_socket_setOption(env, fd, IPPROTO_IP, IP_TTL, &optval, sizeof(optval));
 }
@@ -665,6 +752,11 @@ static jlong netty5_epoll_linuxsocket_sendFile(JNIEnv* env, jclass clazz, jint f
 
 // JNI Method Registration Table Begin
 static const JNINativeMethod fixed_method_table[] = {
+  { "newVSockStreamFd", "()I", (void *) netty5_epoll_linuxsocket_newVSockStreamFd },
+  { "bindVSock", "(III)I", (void *) netty5_epoll_linuxsocket_bindVSock },
+  { "connectVSock", "(III)I", (void *) netty5_epoll_linuxsocket_connectVSock },
+  { "remoteVSockAddress", "(I)[B", (void *) netty5_epoll_linuxsocket_remoteVSockAddress },
+  { "localVSockAddress", "(I)[B", (void *) netty5_epoll_linuxsocket_localVSockAddress },
   { "setTimeToLive", "(II)V", (void *) netty5_epoll_linuxsocket_setTimeToLive },
   { "getTimeToLive", "(I)I", (void *) netty5_epoll_linuxsocket_getTimeToLive },
   { "setInterface", "(IZ[BII)V", (void *) netty5_epoll_linuxsocket_setInterface },

--- a/transport-native-epoll/src/main/c/netty5_epoll_vmsocket.h
+++ b/transport-native-epoll/src/main/c/netty5_epoll_vmsocket.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef NETTY_EPOLL_VMSOCKET_H_
+#define NETTY_EPOLL_VMSOCKET_H_
+
+#include <sys/socket.h>
+
+#ifndef AF_VSOCK
+#define AF_VSOCK 40
+#endif
+
+struct sockaddr_vm {
+    sa_family_t svm_family;
+    unsigned short svm_reserved1;
+    unsigned int svm_port;
+    unsigned int svm_cid;
+    unsigned char svm_zero[sizeof(struct sockaddr) -
+                           sizeof(sa_family_t) -
+                           sizeof(unsigned short) -
+                           sizeof(unsigned int) -
+                           sizeof(unsigned int)];
+};
+
+#endif /* NETTY_EPOLL_VMSOCKET_H_ */

--- a/transport-native-unix-common/src/main/c/netty5_unix_socket.c
+++ b/transport-native-unix-common/src/main/c/netty5_unix_socket.c
@@ -61,7 +61,7 @@ extern int accept4(int sockFd, struct sockaddr* addr, socklen_t* addrlen, int fl
 // see sys/un.h#SUN_LEN, this is modified to allow nul bytes
 #define _UNIX_ADDR_LENGTH(path_len) ((uintptr_t) offsetof(struct sockaddr_un, sun_path) + (uintptr_t) path_len)
 
-int nettyNonBlockingSocket(int domain, int type, int protocol) {
+int netty5_unix_socket_nonBlockingSocket(int domain, int type, int protocol) {
 #ifdef SOCK_NONBLOCK
     return socket(domain, type | SOCK_NONBLOCK, protocol);
 #else
@@ -226,7 +226,7 @@ static jboolean netty5_unix_socket_isIPv6Preferred0(JNIEnv* env, jclass clazz, j
         return JNI_FALSE;
     }
 
-    int fd = nettyNonBlockingSocket(AF_INET6, SOCK_STREAM, 0);
+    int fd = netty5_unix_socket_nonBlockingSocket(AF_INET6, SOCK_STREAM, 0);
     if (fd == -1) {
         return errno == EAFNOSUPPORT ? JNI_FALSE : JNI_TRUE;
     }
@@ -272,7 +272,7 @@ static int netty5_unix_socket_setOption0(jint fd, int level, int optname, const 
 }
 
 static jint _socket(JNIEnv* env, jclass clazz, int domain, int type) {
-    int fd = nettyNonBlockingSocket(domain, type, 0);
+    int fd = netty5_unix_socket_nonBlockingSocket(domain, type, 0);
     if (fd == -1) {
         return -errno;
     } else if (domain == AF_INET6) {
@@ -721,7 +721,7 @@ static jint netty5_unix_socket_newSocketStreamFd(JNIEnv* env, jclass clazz, jboo
 }
 
 static jint netty5_unix_socket_newSocketDomainFd(JNIEnv* env, jclass clazz) {
-    int fd = nettyNonBlockingSocket(PF_UNIX, SOCK_STREAM, 0);
+    int fd = netty5_unix_socket_nonBlockingSocket(PF_UNIX, SOCK_STREAM, 0);
     if (fd == -1) {
         return -errno;
     }
@@ -729,7 +729,7 @@ static jint netty5_unix_socket_newSocketDomainFd(JNIEnv* env, jclass clazz) {
 }
 
 static jint netty5_unix_socket_newSocketDomainDgramFd(JNIEnv* env, jclass clazz) {
-    int fd = nettyNonBlockingSocket(PF_UNIX, SOCK_DGRAM, 0);
+    int fd = netty5_unix_socket_nonBlockingSocket(PF_UNIX, SOCK_DGRAM, 0);
     if (fd == -1) {
         return -errno;
     }

--- a/transport-native-unix-common/src/main/c/netty5_unix_socket.c
+++ b/transport-native-unix-common/src/main/c/netty5_unix_socket.c
@@ -61,7 +61,7 @@ extern int accept4(int sockFd, struct sockaddr* addr, socklen_t* addrlen, int fl
 // see sys/un.h#SUN_LEN, this is modified to allow nul bytes
 #define _UNIX_ADDR_LENGTH(path_len) ((uintptr_t) offsetof(struct sockaddr_un, sun_path) + (uintptr_t) path_len)
 
-static int nettyNonBlockingSocket(int domain, int type, int protocol) {
+int nettyNonBlockingSocket(int domain, int type, int protocol) {
 #ifdef SOCK_NONBLOCK
     return socket(domain, type | SOCK_NONBLOCK, protocol);
 #else

--- a/transport-native-unix-common/src/main/c/netty5_unix_socket.h
+++ b/transport-native-unix-common/src/main/c/netty5_unix_socket.h
@@ -20,7 +20,7 @@
 #include <jni.h>
 
 // External C methods
-int nettyNonBlockingSocket(int domain, int type, int protocol);
+int netty5_unix_socket_nonBlockingSocket(int domain, int type, int protocol);
 int netty5_unix_socket_initSockaddr(JNIEnv* env, jboolean ipv6, jbyteArray address, jint scopeId, jint jport, const struct sockaddr_storage* addr, socklen_t* addrSize);
 jbyteArray netty5_unix_socket_createInetSocketAddressArray(JNIEnv* env, const struct sockaddr_storage* addr);
 

--- a/transport-native-unix-common/src/main/c/netty5_unix_socket.h
+++ b/transport-native-unix-common/src/main/c/netty5_unix_socket.h
@@ -20,6 +20,7 @@
 #include <jni.h>
 
 // External C methods
+int nettyNonBlockingSocket(int domain, int type, int protocol);
 int netty5_unix_socket_initSockaddr(JNIEnv* env, jboolean ipv6, jbyteArray address, jint scopeId, jint jport, const struct sockaddr_storage* addr, socklen_t* addrSize);
 jbyteArray netty5_unix_socket_createInetSocketAddressArray(JNIEnv* env, const struct sockaddr_storage* addr);
 

--- a/transport-native-unix-common/src/main/java/io/netty5/channel/unix/Errors.java
+++ b/transport-native-unix-common/src/main/java/io/netty5/channel/unix/Errors.java
@@ -108,7 +108,7 @@ public final class Errors {
         }
     }
 
-    static boolean handleConnectErrno(String method, int err) throws IOException {
+    public static boolean handleConnectErrno(String method, int err) throws IOException {
         if (err == ERRNO_EINPROGRESS_NEGATIVE || err == ERROR_EALREADY_NEGATIVE) {
             // connect not complete yet need to wait for EPOLLOUT event.
             // EALREADY has been observed when using tcp fast open on centos8.


### PR DESCRIPTION
Motivation:

Netty lacks support for VM sockets (linux vsock) which enables guest - host communication even without guest networking configured

Modification:

Add VM sockets support (address type & LinuxSocket API) on linux for SOCK_STREAM case

Result:

Netty has VM sockets support on linux for SOCK_STREAM case

External projects are able to implement VM sockets channels for EPOLL IO

Relates to #13468