### PR TITLE
Ensure ByteBuf.capacity(...) will never throw AssertionError

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -283,23 +283,44 @@ abstract class PoolArena<T> extends SizeClasses implements PoolArenaMetric {
         return smallSubpagePools[sizeIdx];
     }
 
-    void reallocate(PooledByteBuf<T> buf, int newCapacity, boolean freeOldMemory) {
+    void reallocate(PooledByteBuf<T> buf, int newCapacity) {
         assert newCapacity >= 0 && newCapacity <= buf.maxCapacity();
 
-        int oldCapacity = buf.length;
-        if (oldCapacity == newCapacity) {
-            return;
+        final int oldCapacity;
+        final PoolChunk<T> oldChunk;
+        final ByteBuffer oldNioBuffer;
+        final long oldHandle;
+        final T oldMemory;
+        final int oldOffset;
+        final int oldMaxLength;
+        final PoolArenasCache oldCache;
+
+        // We synchronize on the ByteBuf itself to ensure there is no "concurrent" reallocations for the same buffer.
+        // We do this to ensure the ByteBuf internal fields that are used to allocate / free are not accessed
+        // concurrently. This is important as otherwise we might end up corrupting our internal state of our data
+        // structures.
+        //
+        // Also note we don't use a Lock here but just synchronized even tho this might seem like a bad choice for Loom.
+        // This is done to minimize the overhead per ByteBuf. The time this would block another thread should be
+        // relative small and so not be a problem for Loom.
+        // See https://github.com/netty/netty/issues/13467
+        synchronized (buf) {
+            oldCapacity = buf.length;
+            if (oldCapacity == newCapacity) {
+                return;
+            }
+
+            oldChunk = buf.chunk;
+            oldNioBuffer = buf.tmpNioBuf;
+            oldHandle = buf.handle;
+            oldMemory = buf.memory;
+            oldOffset = buf.offset;
+            oldMaxLength = buf.maxLength;
+            oldCache = buf.cache;
+
+            // This does not touch buf's reader/writer indices
+            allocate(parent.threadCache(), buf, newCapacity);
         }
-
-        PoolChunk<T> oldChunk = buf.chunk;
-        ByteBuffer oldNioBuffer = buf.tmpNioBuf;
-        long oldHandle = buf.handle;
-        T oldMemory = buf.memory;
-        int oldOffset = buf.offset;
-        int oldMaxLength = buf.maxLength;
-
-        // This does not touch buf's reader/writer indices
-        allocate(parent.threadCache(), buf, newCapacity);
         int bytesToCopy;
         if (newCapacity > oldCapacity) {
             bytesToCopy = oldCapacity;
@@ -308,9 +329,7 @@ abstract class PoolArena<T> extends SizeClasses implements PoolArenaMetric {
             bytesToCopy = newCapacity;
         }
         memoryCopy(oldMemory, oldOffset, buf, bytesToCopy);
-        if (freeOldMemory) {
-            free(oldChunk, oldNioBuffer, oldHandle, oldMaxLength, buf.cache);
-        }
+        free(oldChunk, oldNioBuffer, oldHandle, oldMaxLength, oldCache);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
@@ -120,7 +120,7 @@ abstract class PooledByteBuf<T> extends AbstractReferenceCountedByteBuf {
 
         // Reallocation required.
         chunk.decrementPinnedMemory(maxLength);
-        chunk.arena.reallocate(this, newCapacity, true);
+        chunk.arena.reallocate(this, newCapacity);
         return this;
     }
 


### PR DESCRIPTION
Motivation:

Due of how we implemented PoolArena.reallocate(...) it was possible that we triggered an AssertionError while trying to resize a buffer.

Modifications:

- Ensure some parts of reallocation for a ByteBuf are serialized
- Change method signature to remove not needed param
- Add unit test

Result:

Fixes https://github.com/netty/netty/issues/13461 and https://github.com/netty/netty/issues/13467
