### PR TITLE
Fix Classloader memory leak via JNI global references

### DIFF
--- a/resolver-dns-native-macos/src/main/c/netty_resolver_dns_macos.c
+++ b/resolver-dns-native-macos/src/main/c/netty_resolver_dns_macos.c
@@ -154,6 +154,7 @@ static JNINativeMethod* createDynamicMethodsTable(const char* packagePrefix) {
 static void netty_resolver_dns_native_macos_JNI_OnUnLoad(JNIEnv* env) {
     NETTY_JNI_UTIL_UNLOAD_CLASS(env, byteArrayClass);
     NETTY_JNI_UTIL_UNLOAD_CLASS(env, stringClass);
+    NETTY_JNI_UTIL_UNLOAD_CLASS(env, dnsResolverClass);
     netty_jni_util_unregister_natives(env, staticPackagePrefix, STREAM_CLASSNAME);
 
     if (staticPackagePrefix != NULL) {


### PR DESCRIPTION
Motivation:

We did forget to call NETTY_JNI_UTIL_UNLOAD_CLASS for one class which caused a JNI global reference to not be deleted.

Modifications:

Add missing NETTY_JNI_UTIL_UNLOAD_CLASS call

Result:

Fixes https://github.com/netty/netty/issues/13480
