### PR TITLE
Remove redundant native call on epoll/kqueue channel instantiation.

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannelConfig.java
@@ -659,7 +659,7 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
         // Multiply by 2 to give some extra space in case the OS can process write data faster than we can provide.
         int newSendBufferSize = getSendBufferSize() << 1;
         if (newSendBufferSize > 0) {
-            setMaxBytesPerGatheringWrite(getSendBufferSize() << 1);
+            setMaxBytesPerGatheringWrite(newSendBufferSize);
         }
     }
 }

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueSocketChannelConfig.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueSocketChannelConfig.java
@@ -409,7 +409,7 @@ public final class KQueueSocketChannelConfig extends KQueueChannelConfig impleme
         // Multiply by 2 to give some extra space in case the OS can process write data faster than we can provide.
         int newSendBufferSize = getSendBufferSize() << 1;
         if (newSendBufferSize > 0) {
-            setMaxBytesPerGatheringWrite(getSendBufferSize() << 1);
+            setMaxBytesPerGatheringWrite(newSendBufferSize);
         }
     }
 }


### PR DESCRIPTION
Motivation:

on channel instantiation, Epoll & KQueueSocketChannelConfig makes 2 same native calls socket.getSendBufferSize() to calculate and set MaxBytesPerGatheringWrite.

Modification:

call socket.getSendBufferSize() once, use obtained value to both calculate and set MaxBytesPerGatheringWrite.

Result:

no redundant native calls when new Epoll or KQueue channel is instantiated.