### PR TITLE
Move the invocation of `chunk.decrementPinnedMemory(int)` into `PoolArena.free(...)` method

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -230,6 +230,7 @@ abstract class PoolArena<T> extends SizeClasses implements PoolArenaMetric {
     }
 
     void free(PoolChunk<T> chunk, ByteBuffer nioBuffer, long handle, int normCapacity, PoolArenasCache cache) {
+        chunk.decrementPinnedMemory(normCapacity);
         if (chunk.unpooled) {
             int size = chunk.chunkSize();
             destroyChunk(chunk);

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
@@ -119,7 +119,6 @@ abstract class PooledByteBuf<T> extends AbstractReferenceCountedByteBuf {
         }
 
         // Reallocation required.
-        chunk.decrementPinnedMemory(maxLength);
         chunk.arena.reallocate(this, newCapacity, true);
         return this;
     }
@@ -173,7 +172,6 @@ abstract class PooledByteBuf<T> extends AbstractReferenceCountedByteBuf {
             final long handle = this.handle;
             this.handle = -1;
             memory = null;
-            chunk.decrementPinnedMemory(maxLength);
             chunk.arena.free(chunk, tmpNioBuf, handle, maxLength, cache);
             tmpNioBuf = null;
             chunk = null;


### PR DESCRIPTION
`chunk.decrementPinnedMemory(int)` is better to be invoked from `PoolArena.free(...)` method, there are 3 reasons to make this change:
1. Reduce race overhead of invoking `chunk.decrementPinnedMemory(int)` when calling `PooledByteBuf.capacity(int)` concurrently.
2. After PR [13478](https://github.com/netty/netty/pull/13478), this change will make `chunk.decrementPinnedMemory(int)` not to be invoked concurrently when calling `PooledByteBuf.capacity(int)` concurrently.
3. From 'method cohesive' perspective, `chunk.decrementPinnedMemory(int)` is more appropriate to be invoked from `PoolArena.free(...)` method.