### PR TITLE
Add a specific test for optional whitespace in HTTP headers

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -633,7 +633,9 @@ public class HttpRequestDecoderTest {
         assertEquals("x1", headers.get("X-1-Header"));
         assertEquals("x2", headers.get("X-2-Header"));
         assertEquals("x3", headers.get("X-3-Header"));
-        assertEquals(LastHttpContent.EMPTY_LAST_CONTENT, channel.readInbound());
+        LastHttpContent last = channel.readInbound();
+        assertEquals(LastHttpContent.EMPTY_LAST_CONTENT, last);
+        last.release();
         assertFalse(channel.finish());
     }
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -602,6 +602,39 @@ public class HttpRequestDecoderTest {
         assertFalse(channel.finish());
     }
 
+    /**
+     * <a href="https://datatracker.ietf.org/doc/html/rfc9112#name-field-syntax">RFC 9112</a> define the header field
+     * syntax thusly, where the field value is bracketed by optional whitespace:
+     * <pre>
+     *     field-line   = field-name ":" OWS field-value OWS
+     * </pre>
+     * Meanwhile, <a href="https://datatracker.ietf.org/doc/html/rfc9110#name-whitespace">RFC 9110</a> says that
+     * "optional whitespace" (OWS) is defined as "zero or more linear whitespace octets".
+     * And a "linear whitespace octet" is defined in the ABNF as either a space or a tab character.
+     */
+    @Test
+    void headerValuesMayBeBracketedByZeroOrMoreWhitespace() throws Exception {
+        String requestStr = "GET / HTTP/1.1\r\n" +
+                "Host:example.com\r\n" + // zero whitespace
+                "X-0-Header:  x0\r\n" + // two whitespace
+                "X-1-Header:\tx1\r\n" + // tab whitespace
+                "X-2-Header: \t x2\r\n" + // mixed whitespace
+                "X-3-Header:x3\t \r\n" + // whitespace after the value
+                "\r\n";
+        HttpRequestDecoder decoder = new HttpRequestDecoder();
+        EmbeddedChannel channel = new EmbeddedChannel(decoder);
+
+        assertTrue(channel.writeInbound(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)));
+        HttpRequest request = channel.readInbound();
+        assertTrue(request.decoderResult().isSuccess());
+        HttpHeaders headers = request.headers();
+        assertEquals("example.com", headers.get("Host"));
+        assertEquals("x0", headers.get("X-0-Header"));
+        assertEquals("x1", headers.get("X-1-Header"));
+        assertEquals("x2", headers.get("X-2-Header"));
+        assertEquals("x3", headers.get("X-3-Header"));
+    }
+
     private static void testInvalidHeaders0(String requestStr) {
         testInvalidHeaders0(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII));
     }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -633,6 +633,7 @@ public class HttpRequestDecoderTest {
         assertEquals("x1", headers.get("X-1-Header"));
         assertEquals("x2", headers.get("X-2-Header"));
         assertEquals("x3", headers.get("X-3-Header"));
+        assertEquals(LastHttpContent.EMPTY_LAST_CONTENT, channel.readInbound());
         assertFalse(channel.finish());
     }
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -633,6 +633,7 @@ public class HttpRequestDecoderTest {
         assertEquals("x1", headers.get("X-1-Header"));
         assertEquals("x2", headers.get("X-2-Header"));
         assertEquals("x3", headers.get("X-3-Header"));
+        assertFalse(channel.finish());
     }
 
     private static void testInvalidHeaders0(String requestStr) {


### PR DESCRIPTION
Motivation:
Since we made header value validation more strict in 4.1.84, we've gotten the occasional issue reported that whitespace isn't handled correctly.

Modification:
Add a test that stresses the optional whitespace decoding of HTTP headers, because I think we didn't have one already.
Also include a javadoc comment with relevant RFC references.

Result:
This proves that we handle optional whitespace correctly when we decode HTTP headers.
