### PR TITLE
Mark Close after PCapWriter is closed

### DIFF
--- a/handler/src/main/java/io/netty/handler/pcap/PcapWriteHandler.java
+++ b/handler/src/main/java/io/netty/handler/pcap/PcapWriteHandler.java
@@ -700,8 +700,8 @@ public final class PcapWriteHandler extends ChannelDuplexHandler implements Clos
         if (state.get() == State.CLOSED) {
             logger.debug("PcapWriterHandler is already closed");
         } else {
-            markClosed();
             pCapWriter.close();
+            markClosed();
             logger.debug("PcapWriterHandler is now closed");
         }
     }

--- a/handler/src/test/java/io/netty/handler/pcap/CloseDetectingByteBufOutputStream.java
+++ b/handler/src/test/java/io/netty/handler/pcap/CloseDetectingByteBufOutputStream.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package io.netty.handler.pcap;
 
 import io.netty.buffer.ByteBuf;

--- a/handler/src/test/java/io/netty/handler/pcap/CloseDetectingByteBufOutputStream.java
+++ b/handler/src/test/java/io/netty/handler/pcap/CloseDetectingByteBufOutputStream.java
@@ -1,0 +1,31 @@
+package io.netty.handler.pcap;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufOutputStream;
+
+import java.io.IOException;
+
+/**
+ * A {@link ByteBufOutputStream} which detects if {@link #close()} was called.
+ */
+final class CloseDetectingByteBufOutputStream extends ByteBufOutputStream {
+
+    private boolean isCloseCalled;
+
+    /**
+     * Creates a new stream which writes data to the specified {@code buffer}.
+     */
+    CloseDetectingByteBufOutputStream(ByteBuf buffer) {
+        super(buffer);
+    }
+
+    public boolean closeCalled() {
+        return isCloseCalled;
+    }
+
+    @Override
+    public void close() throws IOException {
+        super.close();
+        isCloseCalled = true;
+    }
+}


### PR DESCRIPTION
Motivation:
Right now, we mark `PcapWriteHandler` as closed even before closing `PcapWriter`. When we call `PcapWriter#close`, it detects the state to be closed and ignores closing `OutputStream`.

Modification:
To prevent this from happening, we should call `markClosed` only after calling `PcapWriter#close`.

Also added `CloseDetectingByteBufOutputStream` to detect `close` call and assert it in the test case.

Result:
Properly close `PcapWriter` and prevent memory leak of `OutputStream`.
