### PR TITLE
Make transport.Bootstrap usable with no netty-resolver on classpath

### DIFF
--- a/transport/src/main/java/io/netty/bootstrap/BootstrapConfig.java
+++ b/transport/src/main/java/io/netty/bootstrap/BootstrapConfig.java
@@ -37,7 +37,8 @@ public final class BootstrapConfig extends AbstractBootstrapConfig<Bootstrap, Ch
     }
 
     /**
-     * Returns the configured {@link AddressResolverGroup} or the default if non is configured yet.
+     * Returns the configured {@link AddressResolverGroup}, {@code null} if resolver was disabled
+     * with {@link Bootstrap#disableResolver()}, or the default if non is configured yet.
      */
     public AddressResolverGroup<?> resolver() {
         return bootstrap.resolver();
@@ -47,7 +48,11 @@ public final class BootstrapConfig extends AbstractBootstrapConfig<Bootstrap, Ch
     public String toString() {
         StringBuilder buf = new StringBuilder(super.toString());
         buf.setLength(buf.length() - 1);
-        buf.append(", resolver: ").append(resolver());
+        AddressResolverGroup<?> resolver = resolver();
+        if (resolver != null) {
+            buf.append(", resolver: ")
+                    .append(resolver);
+        }
         SocketAddress remoteAddress = remoteAddress();
         if (remoteAddress != null) {
             buf.append(", remoteAddress: ")

--- a/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
+++ b/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
@@ -38,6 +38,7 @@ import io.netty.channel.local.LocalServerChannel;
 import io.netty.resolver.AddressResolver;
 import io.netty.resolver.AddressResolverGroup;
 import io.netty.resolver.AbstractAddressResolver;
+import io.netty.resolver.DefaultAddressResolverGroup;
 import io.netty.util.AttributeKey;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
@@ -69,6 +70,8 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -300,6 +303,24 @@ public class BootstrapTest {
     }
 
     @Test
+    void testResolverDefault() throws Exception {
+        Bootstrap bootstrap = new Bootstrap();
+
+        assertTrue(bootstrap.config().toString().contains("resolver:"));
+        assertNotNull(bootstrap.config().resolver());
+        assertEquals(DefaultAddressResolverGroup.class, bootstrap.config().resolver().getClass());
+    }
+
+    @Test
+    void testResolverDisabled() throws Exception {
+        Bootstrap bootstrap = new Bootstrap();
+        bootstrap.disableResolver();
+
+        assertFalse(bootstrap.config().toString().contains("resolver:"));
+        assertNull(bootstrap.config().resolver());
+    }
+
+    @Test
     public void testAsyncResolutionSuccess() throws Exception {
         final Bootstrap bootstrapA = new Bootstrap();
         bootstrapA.group(groupA);
@@ -311,6 +332,10 @@ public class BootstrapTest {
         bootstrapB.group(groupB);
         bootstrapB.channel(LocalServerChannel.class);
         bootstrapB.childHandler(dummyHandler);
+
+        assertTrue(bootstrapA.config().toString().contains("resolver:"));
+        assertThat(bootstrapA.resolver(), is(instanceOf(TestAddressResolverGroup.class)));
+
         SocketAddress localAddress = bootstrapB.bind(LocalAddress.ANY).sync().channel().localAddress();
 
         // Connect to the server using the asynchronous resolver.


### PR DESCRIPTION
Motivation:
Since some address families (e.g. unix sockets) do not need name resolver, It should be possible to exclude netty-resolver from classpath.

Currently excluding name resolver leads to NoClassDefFoundError: AddressResolverGroup during Bootstrap instantiation.

Modification:

Add disableResolver() method to Bootstrap.

Change BootstrapConfig.resolver() return null if Bootstrap.disableResolver() is called.

Introduce ExternalAddressResolver class to hold AddressResolver related references to avoid NoClassDefFoundError if Bootstrap.disableResolver() called and no netty-resolver is on classpath.

Result:

Bootstrap is usable with no netty-resolver on classpath.

Motivation:

Explain here the context, and why you're making that change.
What is the problem you're trying to solve.

Modification:

Describe the modifications you've done.

Result:

Fixes #<GitHub issue number>. 

If there is no issue then describe the changes introduced by this PR.
