### PR TITLE
Added "@Override" to the methods initChannel()

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTransportTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTransportTest.java
@@ -682,6 +682,7 @@ public class Http2MultiplexTransportTest {
                     ch.config().setOption(ChannelOption.SO_SNDBUF, 1);
                     ch.pipeline().addLast(new Http2FrameCodecBuilder(true).build());
                     ch.pipeline().addLast(new Http2MultiplexHandler(new ChannelInitializer<Channel>() {
+                        @Override
                         protected void initChannel(Channel ch) {
                             ch.pipeline().remove(this);
                             ch.pipeline().addLast(new MultiplexInboundStream(handlerInactivatedFlushed,

--- a/example/src/main/java/io/netty/example/mqtt/heartBeat/MqttHeartBeatBroker.java
+++ b/example/src/main/java/io/netty/example/mqtt/heartBeat/MqttHeartBeatBroker.java
@@ -44,6 +44,7 @@ public final class MqttHeartBeatBroker {
             b.option(ChannelOption.SO_BACKLOG, 1024);
             b.channel(NioServerSocketChannel.class);
             b.childHandler(new ChannelInitializer<SocketChannel>() {
+                @Override
                 protected void initChannel(SocketChannel ch) throws Exception {
                     ch.pipeline().addLast("encoder", MqttEncoder.INSTANCE);
                     ch.pipeline().addLast("decoder", new MqttDecoder());

--- a/example/src/main/java/io/netty/example/mqtt/heartBeat/MqttHeartBeatClient.java
+++ b/example/src/main/java/io/netty/example/mqtt/heartBeat/MqttHeartBeatClient.java
@@ -46,6 +46,7 @@ public final class MqttHeartBeatClient {
             b.group(workerGroup);
             b.channel(NioSocketChannel.class);
             b.handler(new ChannelInitializer<SocketChannel>() {
+                @Override
                 protected void initChannel(SocketChannel ch) throws Exception {
                     ch.pipeline().addLast("encoder", MqttEncoder.INSTANCE);
                     ch.pipeline().addLast("decoder", new MqttDecoder());


### PR DESCRIPTION
Motivation:

Overridden methods are not annotated with "@ Override".

Modification:

Added "@ Override" to the methods initChannel(): 
- io.netty.handler.codec.http2.Http2MultiplexTransportTest#asyncSettingsAck0
- io.netty.example.mqtt.heartBeat.MqttHeartBeatBroker#main
- io.netty.example.mqtt.heartBeat.MqttHeartBeatClient#main

Result:

The code looks more intuitive.