### PR TITLE
Add Buffer#transferTo(FileChannel, long, int)

### DIFF
--- a/buffer-memory-segment/src/main/java/io/netty5/buffer/memseg/MemSegBuffer.java
+++ b/buffer-memory-segment/src/main/java/io/netty5/buffer/memseg/MemSegBuffer.java
@@ -386,6 +386,21 @@ class MemSegBuffer extends AdaptableBuffer<MemSegBuffer>
     }
 
     @Override
+    public int transferTo(FileChannel channel, long position, int length) throws IOException {
+        if (!isAccessible()) {
+            throw bufferIsClosed(this);
+        }
+        length = Math.min(readableBytes(), length);
+        if (length == 0) {
+            return 0;
+        }
+        checkGet(readerOffset(), length);
+        int bytesWritten = channel.write(readableBuffer().limit(length), position);
+        skipReadableBytes(bytesWritten);
+        return bytesWritten;
+    }
+
+    @Override
     public int transferFrom(FileChannel channel, long position, int length) throws IOException {
         checkPositiveOrZero(position, "position");
         checkPositiveOrZero(length, "length");

--- a/buffer/src/main/java/io/netty5/buffer/Buffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/Buffer.java
@@ -358,6 +358,23 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
     int transferTo(WritableByteChannel channel, int length) throws IOException;
 
     /**
+     * Read from this buffer and write to the given channel at the given position.
+     * The number of bytes actually written to the channel are returned.
+     * No more than the given {@code length} of bytes, or the number of {@linkplain #readableBytes() readable bytes},
+     * will be written to the channel, whichever is smaller.
+     * The channel's position is not modified.
+     * The {@linkplain #readerOffset() reader-offset} of this buffer will likewise be advanced by the number of bytes
+     * written.
+     *
+     * @param channel The channel to write to.
+     * @param position The file position.
+     * @param length The maximum number of bytes to write.
+     * @return The actual number of bytes written, possibly zero.
+     * @throws IOException If the write-operation on the channel failed for some reason.
+     */
+    int transferTo(FileChannel channel, long position, int length) throws IOException;
+
+    /**
      * Read from the given channel starting from the given position and write to this buffer.
      * The number of bytes actually read from the channel are returned, or -1 is returned if the channel has reached
      * the end-of-stream.

--- a/buffer/src/main/java/io/netty5/buffer/Buffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/Buffer.java
@@ -344,7 +344,7 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
      * No more than the given {@code length} of bytes, or the number of {@linkplain #readableBytes() readable bytes},
      * will be written to the channel, whichever is smaller.
      * If the channel has a position, then it will be advanced by the number of bytes written.
-     * The {@linkplain #readerOffset() reader-offset} of this buffer will likewise be advanced by the number of bytes
+     * The {@linkplain #readerOffset() reader-offset} of this buffer will, however, be advanced by the number of bytes
      * written.
      *
      * @implNote {@linkplain CompositeBuffer composite buffers} may offer an optimized implementation of this method,
@@ -363,7 +363,7 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
      * No more than the given {@code length} of bytes, or the number of {@linkplain #readableBytes() readable bytes},
      * will be written to the channel, whichever is smaller.
      * The channel's position is not modified.
-     * The {@linkplain #readerOffset() reader-offset} of this buffer will likewise be advanced by the number of bytes
+     * The {@linkplain #readerOffset() reader-offset} of this buffer will, however, be advanced by the number of bytes
      * written.
      *
      * @param channel The channel to write to.

--- a/buffer/src/main/java/io/netty5/buffer/Buffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/Buffer.java
@@ -344,7 +344,7 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
      * No more than the given {@code length} of bytes, or the number of {@linkplain #readableBytes() readable bytes},
      * will be written to the channel, whichever is smaller.
      * If the channel has a position, then it will be advanced by the number of bytes written.
-     * The {@linkplain #readerOffset() reader-offset} of this buffer will, however, be advanced by the number of bytes
+     * The {@linkplain #readerOffset() reader-offset} of this buffer will likewise be advanced by the number of bytes
      * written.
      *
      * @implNote {@linkplain CompositeBuffer composite buffers} may offer an optimized implementation of this method,

--- a/buffer/src/main/java/io/netty5/buffer/BufferStub.java
+++ b/buffer/src/main/java/io/netty5/buffer/BufferStub.java
@@ -147,6 +147,11 @@ public class BufferStub implements Buffer {
     }
 
     @Override
+    public int transferTo(FileChannel channel, long position, int length) throws IOException {
+        return delegate.transferTo(channel, position, length);
+    }
+
+    @Override
     public int transferFrom(FileChannel channel, long position, int length) throws IOException {
         return delegate.transferFrom(channel, position, length);
     }

--- a/buffer/src/main/java/io/netty5/buffer/DefaultCompositeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/DefaultCompositeBuffer.java
@@ -564,8 +564,12 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
                 totalBytesWritten = toIntExact(gatheringChannel.write(byteBuffers, 0, bufferCount));
             } else {
                 for (int i = 0; i < bufferCount; i++) {
+                    int expectWritten = byteBuffers[i].remaining();
                     int bytesWritten = channel.write(byteBuffers[i]);
                     totalBytesWritten = addExact(totalBytesWritten, bytesWritten);
+                    if (bytesWritten < expectWritten) {
+                        break;
+                    }
                 }
             }
         } finally {
@@ -593,8 +597,12 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
             }
             int bufferCount = countAndPrepareBuffersForChannelIO(length, byteBuffers);
             for (int i = 0; i < bufferCount; i++) {
+                int expectWritten = byteBuffers[i].remaining();
                 int bytesWritten = channel.write(byteBuffers[i], addExact(position, totalBytesWritten));
                 totalBytesWritten = addExact(totalBytesWritten, bytesWritten);
+                if (bytesWritten < expectWritten) {
+                    break;
+                }
             }
         } finally {
             skipReadableBytes(totalBytesWritten);

--- a/buffer/src/main/java/io/netty5/buffer/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/bytebuffer/NioBuffer.java
@@ -327,6 +327,21 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
     }
 
     @Override
+    public int transferTo(FileChannel channel, long position, int length) throws IOException {
+        if (!isAccessible()) {
+            throw bufferIsClosed();
+        }
+        length = Math.min(readableBytes(), length);
+        if (length == 0) {
+            return 0;
+        }
+        checkGet(readerOffset(), length);
+        int bytesWritten = channel.write(readableBuffer().limit(length), position);
+        skipReadableBytes(bytesWritten);
+        return bytesWritten;
+    }
+
+    @Override
     public int transferFrom(FileChannel channel, long position, int length) throws IOException {
         checkPositiveOrZero(position, "position");
         checkPositiveOrZero(length, "length");

--- a/buffer/src/main/java/io/netty5/buffer/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/unsafe/UnsafeBuffer.java
@@ -334,6 +334,21 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
     }
 
     @Override
+    public int transferTo(FileChannel channel, long position, int length) throws IOException {
+        if (!isAccessible()) {
+            throw bufferIsClosed();
+        }
+        length = Math.min(readableBytes(), length);
+        if (length == 0) {
+            return 0;
+        }
+        checkGet(readerOffset(), length);
+        int bytesWritten = channel.write(readableBuffer().limit(length), position);
+        skipReadableBytes(bytesWritten);
+        return bytesWritten;
+    }
+
+    @Override
     public int transferFrom(FileChannel channel, long position, int length) throws IOException {
         checkPositiveOrZero(position, "position");
         checkPositiveOrZero(length, "length");

--- a/buffer/src/test/java/io/netty5/buffer/tests/BufferAndChannelTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/tests/BufferAndChannelTest.java
@@ -77,7 +77,8 @@ public class BufferAndChannelTest extends BufferTestSupport {
         doTransferToMustThrowIfBufferIsClosed(fixture, true);
     }
 
-    private static void doTransferToMustThrowIfBufferIsClosed(Fixture fixture, boolean withPosition) throws IOException {
+    private static void doTransferToMustThrowIfBufferIsClosed(Fixture fixture, boolean withPosition)
+            throws IOException {
         try (BufferAllocator allocator = fixture.createAllocator()) {
             long position = channel.position();
             long size = channel.size();
@@ -270,7 +271,8 @@ public class BufferAndChannelTest extends BufferTestSupport {
         doTransferToMustIgnoreZeroLengthOperations(fixture, true);
     }
 
-    private static void doTransferToMustIgnoreZeroLengthOperations(Fixture fixture, boolean withPosition) throws IOException {
+    private static void doTransferToMustIgnoreZeroLengthOperations(Fixture fixture, boolean withPosition)
+            throws IOException {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             long position = channel.position();
@@ -324,7 +326,8 @@ public class BufferAndChannelTest extends BufferTestSupport {
         doTransferToMustMoveReadOnlyDataToChannel(fixture, true);
     }
 
-    private static void doTransferToMustMoveReadOnlyDataToChannel(Fixture fixture, boolean withPosition) throws IOException {
+    private static void doTransferToMustMoveReadOnlyDataToChannel(Fixture fixture, boolean withPosition)
+            throws IOException {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             long value = ThreadLocalRandom.current().nextLong();
@@ -352,7 +355,8 @@ public class BufferAndChannelTest extends BufferTestSupport {
         doTransferToZeroBytesMustNotThrowOnClosedChannel(fixture, true);
     }
 
-    private static void doTransferToZeroBytesMustNotThrowOnClosedChannel(Fixture fixture, boolean withPosition) throws IOException {
+    private static void doTransferToZeroBytesMustNotThrowOnClosedChannel(Fixture fixture, boolean withPosition)
+            throws IOException {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer empty = allocator.allocate(0);
              Buffer notEmpty = allocator.allocate(4).writeInt(42)) {

--- a/buffer/src/test/java/io/netty5/buffer/tests/BufferAndChannelTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/tests/BufferAndChannelTest.java
@@ -68,18 +68,40 @@ public class BufferAndChannelTest extends BufferTestSupport {
     @ParameterizedTest
     @MethodSource("allocators")
     public void transferToMustThrowIfBufferIsClosed(Fixture fixture) throws IOException {
+        doTransferToMustThrowIfBufferIsClosed(fixture, false);
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void transferToWithPositionMustThrowIfBufferIsClosed(Fixture fixture) throws IOException {
+        doTransferToMustThrowIfBufferIsClosed(fixture, true);
+    }
+
+    private static void doTransferToMustThrowIfBufferIsClosed(Fixture fixture, boolean withPosition) throws IOException {
         try (BufferAllocator allocator = fixture.createAllocator()) {
             long position = channel.position();
             long size = channel.size();
             Buffer empty = allocator.allocate(8);
             empty.close();
-            assertThrows(BufferClosedException.class, () -> empty.transferTo(channel, 8));
+            assertThrows(BufferClosedException.class, () -> {
+                if (withPosition) {
+                    empty.transferTo(channel, position, 8);
+                } else {
+                    empty.transferTo(channel, 8);
+                }
+            });
             assertThat(channel.position()).isEqualTo(position);
             assertThat(channel.size()).isEqualTo(size);
             Buffer withData = allocator.allocate(8);
             withData.writeLong(0x0102030405060708L);
             withData.close();
-            assertThrows(BufferClosedException.class, () -> withData.transferTo(channel, 8));
+            assertThrows(BufferClosedException.class, () -> {
+                if (withPosition) {
+                    withData.transferTo(channel, position, 8);
+                } else {
+                    withData.transferTo(channel, 8);
+                }
+            });
             assertThat(channel.position()).isEqualTo(position);
             assertThat(channel.size()).isEqualTo(size);
         }
@@ -88,16 +110,33 @@ public class BufferAndChannelTest extends BufferTestSupport {
     @ParameterizedTest
     @MethodSource("allocators")
     public void transferToMustCapAtReadableBytes(Fixture fixture) throws IOException {
+        doTransferToMustCapAtReadableBytes(fixture, false);
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void transferToWithPositionMustCapAtReadableBytes(Fixture fixture) throws IOException {
+        doTransferToMustCapAtReadableBytes(fixture, true);
+    }
+
+    private static void doTransferToMustCapAtReadableBytes(Fixture fixture, boolean withPosition) throws IOException {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             buf.writeLong(0x0102030405060708L);
             buf.writerOffset(buf.writerOffset() - 5);
             long position = channel.position();
             long size = channel.size();
-            int bytesWritten = buf.transferTo(channel, 8);
-            assertThat(bytesWritten).isEqualTo(3);
-            assertThat(channel.position()).isEqualTo(3 + position);
-            assertThat(channel.size()).isEqualTo(3 + size);
+            if (withPosition) {
+                int bytesWritten = buf.transferTo(channel, position, 8);
+                assertThat(bytesWritten).isEqualTo(3);
+                assertThat(channel.position()).isEqualTo(position);
+                assertThat(channel.size()).isEqualTo(Math.max(size, 3 + position));
+            } else {
+                int bytesWritten = buf.transferTo(channel, 8);
+                assertThat(bytesWritten).isEqualTo(3);
+                assertThat(channel.position()).isEqualTo(3 + position);
+                assertThat(channel.size()).isEqualTo(3 + size);
+            }
             assertThat(buf.writableBytes()).isEqualTo(5);
             assertThat(buf.readableBytes()).isZero();
         }
@@ -106,15 +145,32 @@ public class BufferAndChannelTest extends BufferTestSupport {
     @ParameterizedTest
     @MethodSource("allocators")
     public void transferToMustCapAtLength(Fixture fixture) throws IOException {
+        doTransferToMustCapAtLength(fixture, false);
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void transferToWithPositionMustCapAtLength(Fixture fixture) throws IOException {
+        doTransferToMustCapAtLength(fixture, true);
+    }
+
+    private static void doTransferToMustCapAtLength(Fixture fixture, boolean withPosition) throws IOException {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             buf.writeLong(0x0102030405060708L);
             long position = channel.position();
             long size = channel.size();
-            int bytesWritten = buf.transferTo(channel, 3);
-            assertThat(bytesWritten).isEqualTo(3);
-            assertThat(channel.position()).isEqualTo(3 + position);
-            assertThat(channel.size()).isEqualTo(3 + size);
+            if (withPosition) {
+                int bytesWritten = buf.transferTo(channel, position, 3);
+                assertThat(bytesWritten).isEqualTo(3);
+                assertThat(channel.position()).isEqualTo(position);
+                assertThat(channel.size()).isEqualTo(Math.max(size, position + 3));
+            } else {
+                int bytesWritten = buf.transferTo(channel, 3);
+                assertThat(bytesWritten).isEqualTo(3);
+                assertThat(channel.position()).isEqualTo(3 + position);
+                assertThat(channel.size()).isEqualTo(3 + size);
+            }
             assertThat(buf.readableBytes()).isEqualTo(5);
         }
     }
@@ -122,10 +178,26 @@ public class BufferAndChannelTest extends BufferTestSupport {
     @ParameterizedTest
     @MethodSource("allocators")
     public void transferToMustThrowIfChannelIsClosed(Fixture fixture) throws IOException {
+        doTransferToWithPositionMustThrowIfChannelIsClosed(fixture, false);
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void transferToWithPositionMustThrowIfChannelIsClosed(Fixture fixture) throws IOException {
+        doTransferToWithPositionMustThrowIfChannelIsClosed(fixture, true);
+    }
+
+    private static void doTransferToWithPositionMustThrowIfChannelIsClosed(Fixture fixture, boolean withPosition) {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             buf.writeLong(0x0102030405060708L);
-            assertThrows(ClosedChannelException.class, () -> buf.transferTo(closedChannel, 8));
+            assertThrows(ClosedChannelException.class, () -> {
+                if (withPosition) {
+                    buf.transferTo(closedChannel, 0, 8);
+                } else {
+                    buf.transferTo(closedChannel, 8);
+                }
+            });
             assertTrue(buf.isAccessible());
             assertThat(buf.readableBytes()).isEqualTo(8);
         }
@@ -134,10 +206,26 @@ public class BufferAndChannelTest extends BufferTestSupport {
     @ParameterizedTest
     @MethodSource("allocators")
     public void transferToMustThrowIfChannelIsNull(Fixture fixture) throws IOException {
+        doTransferToMustThrowIfChannelIsNull(fixture, false);
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void transferToWithPositionMustThrowIfChannelIsNull(Fixture fixture) throws IOException {
+        doTransferToMustThrowIfChannelIsNull(fixture, true);
+    }
+
+    private static void doTransferToMustThrowIfChannelIsNull(Fixture fixture, boolean withPosition) {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             buf.writeLong(0x0102030405060708L);
-            assertThrows(NullPointerException.class, () -> buf.transferTo(null, 8));
+            assertThrows(NullPointerException.class, () -> {
+                if (withPosition) {
+                    buf.transferTo(null, 0, 8);
+                } else {
+                    buf.transferTo(null, 8);
+                }
+            });
             assertTrue(buf.isAccessible());
             assertThat(buf.readableBytes()).isEqualTo(8);
         }
@@ -146,10 +234,26 @@ public class BufferAndChannelTest extends BufferTestSupport {
     @ParameterizedTest
     @MethodSource("allocators")
     public void transferToMustThrowIfLengthIsNegative(Fixture fixture) throws IOException {
+        doTransferToMustThrowIfLengthIsNegative(fixture, false);
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void transferToWithPositionMustThrowIfLengthIsNegative(Fixture fixture) throws IOException {
+        doTransferToMustThrowIfLengthIsNegative(fixture, true);
+    }
+
+    private static void doTransferToMustThrowIfLengthIsNegative(Fixture fixture, boolean withPosition) {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             buf.writeLong(0x0102030405060708L);
-            assertThrows(IllegalArgumentException.class, () -> buf.transferTo(channel, -1));
+            assertThrows(IllegalArgumentException.class, () -> {
+                if (withPosition) {
+                    buf.transferTo(channel, 0, -1);
+                } else {
+                    buf.transferTo(channel, -1);
+                }
+            });
             assertThat(buf.readableBytes()).isEqualTo(8);
         }
     }
@@ -157,12 +261,22 @@ public class BufferAndChannelTest extends BufferTestSupport {
     @ParameterizedTest
     @MethodSource("allocators")
     public void transferToMustIgnoreZeroLengthOperations(Fixture fixture) throws IOException {
+        doTransferToMustIgnoreZeroLengthOperations(fixture, false);
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void transferToWithPositionMustIgnoreZeroLengthOperations(Fixture fixture) throws IOException {
+        doTransferToMustIgnoreZeroLengthOperations(fixture, true);
+    }
+
+    private static void doTransferToMustIgnoreZeroLengthOperations(Fixture fixture, boolean withPosition) throws IOException {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             long position = channel.position();
             long size = channel.size();
             buf.writeLong(0x0102030405060708L);
-            int bytesWritten = buf.transferTo(channel, 0);
+            int bytesWritten = withPosition ? buf.transferTo(channel, position, 0) : buf.transferTo(channel, 0);
             assertThat(bytesWritten).isZero();
             assertThat(buf.readableBytes()).isEqualTo(8);
             assertThat(channel.position()).isEqualTo(position);
@@ -173,12 +287,22 @@ public class BufferAndChannelTest extends BufferTestSupport {
     @ParameterizedTest
     @MethodSource("allocators")
     public void transferToMustMoveDataToChannel(Fixture fixture) throws IOException {
+        doTransferToMustMoveDataToChannel(fixture, false);
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void transferToWithPositionMustMoveDataToChannel(Fixture fixture) throws IOException {
+        doTransferToMustMoveDataToChannel(fixture, true);
+    }
+
+    private static void doTransferToMustMoveDataToChannel(Fixture fixture, boolean withPosition) throws IOException {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             long value = ThreadLocalRandom.current().nextLong();
             buf.writeLong(value);
             long position = channel.position();
-            int bytesWritten = buf.transferTo(channel, 8);
+            int bytesWritten = withPosition ? buf.transferTo(channel, position, 8) : buf.transferTo(channel, 8);
             assertThat(bytesWritten).isEqualTo(8);
             ByteBuffer buffer = ByteBuffer.allocate(8);
             int bytesRead = channel.read(buffer, position);
@@ -191,12 +315,22 @@ public class BufferAndChannelTest extends BufferTestSupport {
     @ParameterizedTest
     @MethodSource("allocators")
     public void transferToMustMoveReadOnlyDataToChannel(Fixture fixture) throws IOException {
+        doTransferToMustMoveReadOnlyDataToChannel(fixture, false);
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void transferToWithPositionMustMoveReadOnlyDataToChannel(Fixture fixture) throws IOException {
+        doTransferToMustMoveReadOnlyDataToChannel(fixture, true);
+    }
+
+    private static void doTransferToMustMoveReadOnlyDataToChannel(Fixture fixture, boolean withPosition) throws IOException {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             long value = ThreadLocalRandom.current().nextLong();
             buf.writeLong(value).makeReadOnly();
             long position = channel.position();
-            int bytesWritten = buf.transferTo(channel, 8);
+            int bytesWritten = withPosition ? buf.transferTo(channel, position, 8) : buf.transferTo(channel, 8);
             assertThat(bytesWritten).isEqualTo(8);
             ByteBuffer buffer = ByteBuffer.allocate(8);
             int bytesRead = channel.read(buffer, position);
@@ -209,11 +343,26 @@ public class BufferAndChannelTest extends BufferTestSupport {
     @ParameterizedTest
     @MethodSource("allocators")
     public void transferToZeroBytesMustNotThrowOnClosedChannel(Fixture fixture) throws IOException {
+        doTransferToZeroBytesMustNotThrowOnClosedChannel(fixture, false);
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void transferToWithPositionZeroBytesMustNotThrowOnClosedChannel(Fixture fixture) throws IOException {
+        doTransferToZeroBytesMustNotThrowOnClosedChannel(fixture, true);
+    }
+
+    private static void doTransferToZeroBytesMustNotThrowOnClosedChannel(Fixture fixture, boolean withPosition) throws IOException {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer empty = allocator.allocate(0);
              Buffer notEmpty = allocator.allocate(4).writeInt(42)) {
-            empty.transferTo(closedChannel, 4);
-            notEmpty.transferTo(closedChannel, 0);
+            if (withPosition) {
+                empty.transferTo(closedChannel, 0, 4);
+                notEmpty.transferTo(closedChannel, 0, 0);
+            } else {
+                empty.transferTo(closedChannel, 4);
+                notEmpty.transferTo(closedChannel, 0);
+            }
         }
     }
 

--- a/buffer/src/test/java/io/netty5/buffer/tests/MockFileChannel.java
+++ b/buffer/src/test/java/io/netty5/buffer/tests/MockFileChannel.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.buffer.tests;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
+
+class MockFileChannel extends FileChannel {
+    @Override
+    public int read(ByteBuffer dst) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long read(ByteBuffer[] dsts, int offset, int length) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int write(ByteBuffer src) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long write(ByteBuffer[] srcs, int offset, int length) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long position() throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FileChannel position(long newPosition) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long size() throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FileChannel truncate(long size) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void force(boolean metaData) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long transferTo(long position, long count, WritableByteChannel target) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long transferFrom(ReadableByteChannel src, long position, long count) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int read(ByteBuffer dst, long position) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int write(ByteBuffer src, long position) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public MappedByteBuffer map(MapMode mode, long position, long size) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FileLock lock(long position, long size, boolean shared) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FileLock tryLock(long position, long size, boolean shared) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void implCloseChannel() throws IOException {
+    }
+}


### PR DESCRIPTION
Motivation:

Writing to a file with an explicit position allows concurrent transfers.

Modifications:

Very similar to #12396. Add #transferTo method with position, implementations are basically the same as transferTo without position. Copy the unit tests with a position arg.

Result:

Concurrent writes of different buffers to the same file using transferTo are now possible.