### PR TITLE
Optimize PoolSubpage

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolSubpage.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolSubpage.java
@@ -22,7 +22,6 @@ import static io.netty.buffer.PoolChunk.RUN_OFFSET_SHIFT;
 import static io.netty.buffer.PoolChunk.SIZE_SHIFT;
 import static io.netty.buffer.PoolChunk.IS_USED_SHIFT;
 import static io.netty.buffer.PoolChunk.IS_SUBPAGE_SHIFT;
-import static io.netty.buffer.SizeClasses.LOG2_QUANTUM;
 
 final class PoolSubpage<T> implements PoolSubpageMetric {
 
@@ -32,17 +31,17 @@ final class PoolSubpage<T> implements PoolSubpageMetric {
     private final int runOffset;
     private final int runSize;
     private final long[] bitmap;
+    private final int bitmapLength;
+    private final int maxNumElems;
 
     PoolSubpage<T> prev;
     PoolSubpage<T> next;
 
     boolean doNotDestroy;
-    private int maxNumElems;
-    private int bitmapLength;
     private int nextAvail;
     private int numAvail;
 
-    private final ReentrantLock lock = new ReentrantLock();
+    private final ReentrantLock lock;
 
     // TODO: Test if adding padding helps under contention
     //private long pad0, pad1, pad2, pad3, pad4, pad5, pad6, pad7;
@@ -50,11 +49,15 @@ final class PoolSubpage<T> implements PoolSubpageMetric {
     /** Special constructor that creates a linked list head */
     PoolSubpage() {
         chunk = null;
+        lock = new ReentrantLock();
+
         pageShifts = -1;
         runOffset = -1;
         elemSize = -1;
         runSize = -1;
         bitmap = null;
+        bitmapLength = -1;
+        maxNumElems = -1;
     }
 
     PoolSubpage(PoolSubpage<T> head, PoolChunk<T> chunk, int pageShifts, int runOffset, int runSize, int elemSize) {
@@ -63,17 +66,19 @@ final class PoolSubpage<T> implements PoolSubpageMetric {
         this.runOffset = runOffset;
         this.runSize = runSize;
         this.elemSize = elemSize;
-        bitmap = new long[runSize >>> 6 + LOG2_QUANTUM]; // runSize / 64 / QUANTUM
 
         doNotDestroy = true;
-        if (elemSize != 0) {
-            maxNumElems = numAvail = runSize / elemSize;
-            nextAvail = 0;
-            bitmapLength = maxNumElems >>> 6;
-            if ((maxNumElems & 63) != 0) {
-                bitmapLength ++;
-            }
+
+        maxNumElems = numAvail = runSize / elemSize;
+        int bitmapLength = maxNumElems >>> 6;
+        if ((maxNumElems & 63) != 0) {
+            bitmapLength ++;
         }
+        this.bitmapLength = bitmapLength;
+        bitmap = new long[bitmapLength];
+        nextAvail = 0;
+
+        lock = null;
         addToPool(head);
     }
 
@@ -109,9 +114,6 @@ final class PoolSubpage<T> implements PoolSubpageMetric {
      *         {@code false} if this subpage is not used by its chunk and thus it's OK to be released.
      */
     boolean free(PoolSubpage<T> head, int bitmapIdx) {
-        if (elemSize == 0) {
-            return true;
-        }
         int q = bitmapIdx >>> 6;
         int r = bitmapIdx & 63;
         assert (bitmap[q] >>> r & 1) != 0;

--- a/buffer/src/main/java/io/netty/buffer/PoolSubpage.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolSubpage.java
@@ -50,7 +50,6 @@ final class PoolSubpage<T> implements PoolSubpageMetric {
     PoolSubpage() {
         chunk = null;
         lock = new ReentrantLock();
-
         pageShifts = -1;
         runOffset = -1;
         elemSize = -1;


### PR DESCRIPTION
 Motivation:
 Optimize PoolSubpage


 Modification:
 1. `PoolSubpage.lock` is used by head only, so it could be created for head only.
 
2. `PoolSubpage.elemSize` is determined by `SizeClasses.sizeIdx2sizeTab`, which minimum value is 16, so the comparison between `elemSize` and `0` should be removed.

 3. `PoolSubpage.bitmap` may waste memory. For example, when `PooledByteBufAllocator.DEFAULT.directBuffer(800)` creates a `PoolSubpage` object:
    * `runSize` is 57344 (i.e., 56KB),
    * `elemSize` is 896,
    * `maxNumElems = runSize/elemSize` is 64,
    * `bitmapLength` is 1 (i.e., 64 bits is enough for 64 elements)
    * **but** `bitmap.length` is 56: (`runSize >>> 6 + LOG2_QUANTUM /*4*/ == 56`), which could be 1.

 4. Make `bitmapLength` and `maxNumElems` final.

 Result:
PoolSubpage is more clear, and save some memory.