### PR TITLE
Add Java 21 support and enable Panama build

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -150,13 +150,11 @@ jobs:
           run: |
             JAVA_HOME=/usr/lib/jvm/java-11-openjdk-arm64 ./mvnw -B -ntp -pl testsuite-native -am clean package -DskipTests=true -Dcheckstyle.skip=true -DskipNativeTestsuite=false -Dtcnative.classifier=
 
-  build-pr-java20panama:
-    name: linux-x86_64-java20-panama
+  build-pr-java21panama:
+    name: linux-x86_64-java21-panama
     # The host should always be Linux
     runs-on: ubuntu-latest
     needs: verify-pr
-    # Disable until fixed (possible compiler bug)
-    if: ${{ false }}
     steps:
       - uses: actions/checkout@v3
 

--- a/docker/Dockerfile.panama_foreign
+++ b/docker/Dockerfile.panama_foreign
@@ -12,7 +12,7 @@ RUN yum install -y alsa-lib-devel cups-devel fontconfig-devel libXtst-devel libX
 # Downloading and installing SDKMAN!
 RUN curl -s  "https://get.sdkman.io" | bash
 
-ENV BOOTSTRAP_JAVA 19.0.1-zulu
+ENV BOOTSTRAP_JAVA 20.0.1-zulu
 
 # Installing Java removing some unnecessary SDKMAN files
 RUN bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && \

--- a/pom.xml
+++ b/pom.xml
@@ -197,6 +197,26 @@
       </properties>
     </profile>
     <profile>
+      <id>java21</id>
+      <activation>
+        <jdk>21</jdk>
+      </activation>
+      <modules>
+        <module>buffer-memory-segment</module>
+      </modules>
+      <properties>
+        <!-- Not use alpn agent as Java11+ supports alpn out of the box -->
+        <argLine.alpnAgent />
+        <argLine.java9.extras />
+        <!-- Export some stuff which is used during our tests -->
+        <argLine.java9>--illegal-access=deny ${argLine.java9.extras}</argLine.java9>
+        <forbiddenapis.skip>true</forbiddenapis.skip>
+        <!-- pax-exam does not work on latest Java12 EA 22 build -->
+        <skipOsgiTestsuite>true</skipOsgiTestsuite>
+        <revapi.skip>true</revapi.skip>
+      </properties>
+    </profile>
+    <profile>
       <id>java20</id>
       <activation>
         <jdk>20</jdk>


### PR DESCRIPTION
Motivation:
The panama snapshot build was disabled because of a compilation error in upstream panama. Let's try to bring it back and see if it works.

Modification:
Update the project `pom.xml` file to support Java 21. Update the panama workflow to use JDK 20 as build-jdk (used for building Panama), and enable the panama build workflow again.

Result:
Maybe this build works again.