### PR TITLE
Correctly retain slice when calling ReplayingDecoderByteBuf.retainedS…

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/ReplayingDecoderByteBuf.java
+++ b/codec/src/main/java/io/netty/handler/codec/ReplayingDecoderByteBuf.java
@@ -869,7 +869,7 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
     @Override
     public ByteBuf retainedSlice(int index, int length) {
         checkIndex(index, length);
-        return buffer.slice(index, length);
+        return buffer.retainedSlice(index, length);
     }
 
     @Override

--- a/codec/src/test/java/io/netty/handler/codec/ReplayingDecoderByteBufTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/ReplayingDecoderByteBufTest.java
@@ -104,4 +104,26 @@ public class ReplayingDecoderByteBufTest {
         buf.release();
     }
 
+    // See https://github.com/netty/netty/issues/13455
+    @Test
+    void testRetainedSlice() {
+        ByteBuf buf = Unpooled.buffer(10);
+        int i = 0;
+        while (buf.isWritable()) {
+            buf.writeByte(i++);
+        }
+        ReplayingDecoderByteBuf buffer = new ReplayingDecoderByteBuf(buf);
+        ByteBuf slice = buffer.retainedSlice(0, 4);
+        assertEquals(2, slice.refCnt());
+
+        i = 0;
+        while (slice.isReadable()) {
+            assertEquals(i++, slice.readByte());
+        }
+        slice.release();
+        buf.release();
+        assertEquals(0, slice.refCnt());
+        assertEquals(0, buf.refCnt());
+        assertEquals(0, buffer.refCnt());
+    }
 }


### PR DESCRIPTION
…lice(...)

Motivation:

We need to retain the slice when calling retainedSlice(...). Due a bug we did miss to do so.

Modifications:

- Delegate to the correct method.
- Add test-case

Result:

Fixes https://github.com/netty/netty/issues/13455
