### PR TITLE
Fix BrotliEncoder bug that does not mark  ByteBuf it encodes as read

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/BrotliEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/BrotliEncoder.java
@@ -207,6 +207,7 @@ public final class BrotliEncoder extends MessageToByteEncoder<ByteBuf> {
                 // in only 1 call at `write(ByteBuffer)`.
                 brotliEncoderChannel.write(msg.nioBuffer());
                 brotliEncoderChannel.flush();
+                msg.skipBytes(msg.readableBytes());
             } catch (Exception e) {
                 ReferenceCountUtil.release(msg);
                 throw e;

--- a/codec/src/main/java/io/netty/handler/codec/compression/BrotliEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/BrotliEncoder.java
@@ -205,9 +205,11 @@ public final class BrotliEncoder extends MessageToByteEncoder<ByteBuf> {
                 //
                 // A race condition will not arise because one flush call to encoder will result
                 // in only 1 call at `write(ByteBuffer)`.
-                brotliEncoderChannel.write(msg.nioBuffer());
+                ByteBuffer nioBuffer = msg.nioBuffer();
+                int position = nioBuffer.position();
+                brotliEncoderChannel.write(nioBuffer);
+                msg.skipBytes(position - nioBuffer.position());
                 brotliEncoderChannel.flush();
-                msg.skipBytes(msg.readableBytes());
             } catch (Exception e) {
                 ReferenceCountUtil.release(msg);
                 throw e;

--- a/codec/src/main/java/io/netty/handler/codec/compression/BrotliEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/BrotliEncoder.java
@@ -208,7 +208,7 @@ public final class BrotliEncoder extends MessageToByteEncoder<ByteBuf> {
                 ByteBuffer nioBuffer = msg.nioBuffer();
                 int position = nioBuffer.position();
                 brotliEncoderChannel.write(nioBuffer);
-                msg.skipBytes(position - nioBuffer.position());
+                msg.skipBytes(nioBuffer.position() - position);
                 brotliEncoderChannel.flush();
             } catch (Exception e) {
                 ReferenceCountUtil.release(msg);

--- a/codec/src/test/java/io/netty/handler/codec/compression/AbstractEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/AbstractEncoderTest.java
@@ -87,6 +87,7 @@ public abstract class AbstractEncoderTest extends AbstractCompressionTest {
         final int dataLength = data.readableBytes();
         assertTrue(channel.writeOutbound(data.retain()));
         assertTrue(channel.finish());
+        assertEquals(0, data.readableBytes());
 
         ByteBuf decompressed = readDecompressed(dataLength);
         assertEquals(data.resetReaderIndex(), decompressed);
@@ -101,12 +102,14 @@ public abstract class AbstractEncoderTest extends AbstractCompressionTest {
         while (written + length < dataLength) {
             ByteBuf in = data.retainedSlice(written, length);
             assertTrue(channel.writeOutbound(in));
+            assertEquals(0, in.readableBytes());
             written += length;
             length = rand.nextInt(100);
         }
         ByteBuf in = data.retainedSlice(written, dataLength - written);
         assertTrue(channel.writeOutbound(in));
         assertTrue(channel.finish());
+        assertEquals(0, in.readableBytes());
 
         ByteBuf decompressed = readDecompressed(dataLength);
         assertEquals(data, decompressed);


### PR DESCRIPTION
### Expected behavior

The BrotliEncoder respects the implicit HttpContentCompressor contract that ByteBuf should be marked as read (readableBytes() == 0).

### Actual behavior

The BrotliEncoder does not mark encoded ByteBuf as read, HttpContent encoded by HttpContentCompressor can have their content be sent twice once decoded and once encoded, corrupting the response. This happens because the Brotli4J library uses the ByteBuf NIO buffer and does not read it through the ByteBuf like other compressor usually do.

### Steps to reproduce

Sending a chunked HTTP response encoded with the Brotli compressor reproduces it.

### Netty version

Any Brotli4j version, but I haven't checked.
