### PR TITLE
Upgrade to latest jni-util release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -702,7 +702,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-jni-util</artifactId>
-        <version>0.0.6.Final</version>
+        <version>0.0.7.Final</version>
         <classifier>sources</classifier>
         <optional>true</optional>
       </dependency>


### PR DESCRIPTION
Motivation:

We released a new version of jni-util

Modifications:

- Update to latest version

Result:

Use up-to-date version
