### PR TITLE
Use internalNioBuffer(...) when possible to reduce object creation

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/BrotliEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/BrotliEncoder.java
@@ -205,7 +205,7 @@ public final class BrotliEncoder extends MessageToByteEncoder<ByteBuf> {
                 //
                 // A race condition will not arise because one flush call to encoder will result
                 // in only 1 call at `write(ByteBuffer)`.
-                ByteBuffer nioBuffer = msg.nioBuffer();
+                ByteBuffer nioBuffer = CompressionUtil.safeReadableNioBuffer(msg);
                 int position = nioBuffer.position();
                 brotliEncoderChannel.write(nioBuffer);
                 msg.skipBytes(nioBuffer.position() - position);

--- a/codec/src/main/java/io/netty/handler/codec/compression/CompressionUtil.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/CompressionUtil.java
@@ -36,9 +36,8 @@ final class CompressionUtil {
         }
     }
 
-    static ByteBuffer safeNioBuffer(ByteBuf buffer) {
-        return buffer.nioBufferCount() == 1 ? buffer.internalNioBuffer(buffer.readerIndex(), buffer.readableBytes())
-                : buffer.nioBuffer();
+    static ByteBuffer safeReadableNioBuffer(ByteBuf buffer) {
+        return safeNioBuffer(buffer, buffer.readerIndex(), buffer.readableBytes());
     }
 
     static ByteBuffer safeNioBuffer(ByteBuf buffer, int index, int length) {

--- a/codec/src/main/java/io/netty/handler/codec/compression/Lz4FrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Lz4FrameDecoder.java
@@ -227,7 +227,7 @@ public class Lz4FrameDecoder extends ByteToMessageDecoder {
                         case BLOCK_TYPE_COMPRESSED:
                             uncompressed = ctx.alloc().buffer(decompressedLength, decompressedLength);
 
-                            decompressor.decompress(CompressionUtil.safeNioBuffer(in),
+                            decompressor.decompress(CompressionUtil.safeReadableNioBuffer(in),
                                     uncompressed.internalNioBuffer(uncompressed.writerIndex(), decompressedLength));
                             // Update the writerIndex now to reflect what we decompressed.
                             uncompressed.writerIndex(uncompressed.writerIndex() + decompressedLength);


### PR DESCRIPTION
Motivation:

We should try to use internalNioBuffer(...) if possible to reduce the object creation.

Modifications:

Call internalNioBuffer which might be able to re-use the previous created ByteBuffer

Result:

Less object creation during compression
