### PR TITLE
Fix incorrect statement in ChannelOutboundBuffer javadocs

### DIFF
--- a/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
@@ -47,7 +47,6 @@ import static java.lang.Math.min;
  * <p>
  * All methods must be called by a transport implementation from an I/O thread, except the following ones:
  * <ul>
- * <li>{@link #size()} and {@link #isEmpty()}</li>
  * <li>{@link #isWritable()}</li>
  * <li>{@link #getUserDefinedWritability(int)} and {@link #setUserDefinedWritability(int, boolean)}</li>
  * </ul>


### PR DESCRIPTION
Motivation:

The javadocs of ChannelOutboundBuffer state that its fine to call isEmpty() and size() from any thread. This is not correct, these methods should only be called from within the EventLoop thread.

Modifications:

Fix docs

Result:

Correct javadocs. Fixes https://github.com/netty/netty/issues/13501
