### PR TITLE
Fix `kevent(..) failed: Invalid argument`

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContext.java
@@ -278,7 +278,7 @@ abstract class DnsQueryContext {
         }
 
         // Schedule a query timeout task if necessary.
-        if (queryTimeoutMillis > 0) {
+        if (queryTimeoutMillis > 0 && queryTimeoutMillis < Long.MAX_VALUE) {
             timeoutFuture = channel.eventLoop().schedule(new Runnable() {
                 @Override
                 public void run() {

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContext.java
@@ -278,7 +278,7 @@ abstract class DnsQueryContext {
         }
 
         // Schedule a query timeout task if necessary.
-        if (queryTimeoutMillis > 0 && queryTimeoutMillis < Long.MAX_VALUE) {
+        if (queryTimeoutMillis > 0) {
             timeoutFuture = channel.eventLoop().schedule(new Runnable() {
                 @Override
                 public void run() {

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoop.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoop.java
@@ -51,6 +51,7 @@ final class KQueueEventLoop extends SingleThreadEventLoop {
     private static final int KQUEUE_WAKE_UP_IDENT = 0;
     // `kqueue()` may return EINVAL when a large number such as Integer.MAX_VALUE is specified as timeout.
     // 24 hours would be a large enough value.
+    // See https://man.freebsd.org/cgi/man.cgi?query=kevent&apropos=0&sektion=0&manpath=FreeBSD+6.1-RELEASE&format=html#end
     private static final int KQUEUE_MAX_TIMEOUT_SECONDS = 86399; // 24 hours - 1 second
 
     static {

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoop.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoop.java
@@ -51,7 +51,7 @@ final class KQueueEventLoop extends SingleThreadEventLoop {
     private static final int KQUEUE_WAKE_UP_IDENT = 0;
     // `kqueue()` may return EINVAL when a large number such as Integer.MAX_VALUE is specified as timeout.
     // 24 hours would be a large enough value.
-    // See https://man.freebsd.org/cgi/man.cgi?query=kevent&apropos=0&sektion=0&manpath=FreeBSD+6.1-RELEASE&format=html#end
+    // https://man.freebsd.org/cgi/man.cgi?query=kevent&apropos=0&sektion=0&manpath=FreeBSD+6.1-RELEASE&format=html#end
     private static final int KQUEUE_MAX_TIMEOUT_SECONDS = 86399; // 24 hours - 1 second
 
     static {

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoop.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoop.java
@@ -49,6 +49,9 @@ final class KQueueEventLoop extends SingleThreadEventLoop {
     private static final AtomicIntegerFieldUpdater<KQueueEventLoop> WAKEN_UP_UPDATER =
             AtomicIntegerFieldUpdater.newUpdater(KQueueEventLoop.class, "wakenUp");
     private static final int KQUEUE_WAKE_UP_IDENT = 0;
+    // `kqueue()` may return EINVAL when a large number such as Integer.MAX_VALUE is specified as timeout.
+    // 24 hours would be a large enough value.
+    private static final int KQUEUE_MAX_TIMEOUT_SECONDS = 86399; // 24 hours - 1 second
 
     static {
         // Ensure JNI is initialized by the time this class is loaded by this time!
@@ -167,8 +170,9 @@ final class KQueueEventLoop extends SingleThreadEventLoop {
         }
 
         long totalDelay = delayNanos(System.nanoTime());
-        int delaySeconds = (int) min(totalDelay / 1000000000L, Integer.MAX_VALUE);
-        return kqueueWait(delaySeconds, (int) min(totalDelay - delaySeconds * 1000000000L, Integer.MAX_VALUE));
+        int delaySeconds = (int) min(totalDelay / 1000000000L, KQUEUE_MAX_TIMEOUT_SECONDS);
+        int delayNanos = (int) (totalDelay % 1000000000L);
+        return kqueueWait(delaySeconds, delayNanos);
     }
 
     private int kqueueWaitNow() throws IOException {


### PR DESCRIPTION
Motivation:

While I was investigating Armeria CI build failures on macOS, many `kevent(..) failed: Invalid argument` error messages were produced on the failed tests.
https://ge.armeria.dev/s/h2fz4h4th66we/tests/task/:core:shadedTest/details/com.linecorp.armeria.server.HttpServerNoKeepAliveTest/shouldDisconnectWhenConnectionCloseIsIncluded(SessionProtocol)%5B4%5D?focused-execution=1&top-execution=1#L7

After adding some debug messages, I figured out that the error raised when a large number such as `Integer.MAX_VALUE` is set as a timeout. 
https://github.com/netty/netty/blob/cbc995865ed1e082d5581744e9c90c6d119652b1/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoop.java#L169-L171
The long timeout is derived from a scheduled task whose timeout is `Long.MAX_VALUE`. We set `Long.MAX_VALUE` to `DnsNameResolver` in order to disable a query timeout for testing.
https://github.com/netty/netty/blob/cbc995865ed1e082d5581744e9c90c6d119652b1/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContext.java#L282-L293 https://github.com/line/armeria/blob/2bfe424b652a16f603e2ba1ca075bf992f80f24e/core/src/test/java/com/linecorp/armeria/internal/client/dns/DefaultDnsResolverTest.java#L91-L93

Failed to find a specification for the timeout value of `kevent()`. However, there was a note on a man page that says the timeout value is limited to 24 hours.
https://man.freebsd.org/cgi/man.cgi?query=kevent&apropos=0&sektion=0&manpath=FreeBSD+6.1-RELEASE&format=html#end

Modifications:

- Limit the maximum allowed timeout for `kevent()` to 24 hours.
- Skip scheduling a query timeout when the value is `Long.MAX_VALUE`

Result:

`kevent(..) failed: Invalid argument` no longer raises when a task is scheduled with a large value.

