### PR TITLE
Reduce PoolChunk's metadata size: change LongPriorityQueue to IntPriorityQueue

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/IntPriorityQueue.java
+++ b/buffer/src/main/java/io/netty/buffer/IntPriorityQueue.java
@@ -21,12 +21,12 @@ import java.util.Arrays;
  * Internal primitive priority queue, used by {@link PoolChunk}.
  * The implementation is based on the binary heap, as described in Algorithms by Sedgewick and Wayne.
  */
-final class LongPriorityQueue {
+final class IntPriorityQueue {
     public static final int NO_VALUE = -1;
-    private long[] array = new long[9];
+    private int[] array = new int[9];
     private int size;
 
-    public void offer(long handle) {
+    public void offer(int handle) {
         if (handle == NO_VALUE) {
             throw new IllegalArgumentException("The NO_VALUE (" + NO_VALUE + ") cannot be added to the queue.");
         }
@@ -39,7 +39,7 @@ final class LongPriorityQueue {
         lift(size);
     }
 
-    public void remove(long value) {
+    public void remove(int value) {
         for (int i = 1; i <= size; i++) {
             if (array[i] == value) {
                 array[i] = array[size--];
@@ -50,18 +50,18 @@ final class LongPriorityQueue {
         }
     }
 
-    public long peek() {
+    public int peek() {
         if (size == 0) {
             return NO_VALUE;
         }
         return array[1];
     }
 
-    public long poll() {
+    public int poll() {
         if (size == 0) {
             return NO_VALUE;
         }
-        long val = array[1];
+        int val = array[1];
         array[1] = array[size];
         array[size] = 0;
         size--;
@@ -100,7 +100,7 @@ final class LongPriorityQueue {
     }
 
     private void swap(int a, int b) {
-        long value = array[a];
+        int value = array[a];
         array[a] = array[b];
         array[b] = value;
     }

--- a/buffer/src/main/java/io/netty/buffer/PoolChunk.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunk.java
@@ -157,7 +157,7 @@ final class PoolChunk<T> implements PoolChunkMetric {
     /**
      * manage all avail runs
      */
-    private final LongPriorityQueue[] runsAvail;
+    private final IntPriorityQueue[] runsAvail;
 
     private final ReentrantLock runsAvailLock;
 
@@ -231,18 +231,18 @@ final class PoolChunk<T> implements PoolChunkMetric {
         cachedNioBuffers = null;
     }
 
-    private static LongPriorityQueue[] newRunsAvailqueueArray(int size) {
-        LongPriorityQueue[] queueArray = new LongPriorityQueue[size];
+    private static IntPriorityQueue[] newRunsAvailqueueArray(int size) {
+        IntPriorityQueue[] queueArray = new IntPriorityQueue[size];
         for (int i = 0; i < queueArray.length; i++) {
-            queueArray[i] = new LongPriorityQueue();
+            queueArray[i] = new IntPriorityQueue();
         }
         return queueArray;
     }
 
     private void insertAvailRun(int runOffset, int pages, long handle) {
         int pageIdxFloor = arena.pages2pageIdxFloor(pages);
-        LongPriorityQueue queue = runsAvail[pageIdxFloor];
-        queue.offer(handle);
+        IntPriorityQueue queue = runsAvail[pageIdxFloor];
+        queue.offer((int) (handle >> BITMAP_IDX_BIT_LENGTH));
 
         //insert first page of run
         insertAvailRun0(runOffset, handle);
@@ -259,7 +259,7 @@ final class PoolChunk<T> implements PoolChunkMetric {
 
     private void removeAvailRun(long handle) {
         int pageIdxFloor = arena.pages2pageIdxFloor(runPages(handle));
-        runsAvail[pageIdxFloor].remove(handle);
+        runsAvail[pageIdxFloor].remove((int) (handle >> BITMAP_IDX_BIT_LENGTH));
         removeAvailRun0(handle);
     }
 
@@ -348,16 +348,15 @@ final class PoolChunk<T> implements PoolChunkMetric {
             }
 
             //get run with min offset in this queue
-            LongPriorityQueue queue = runsAvail[queueIdx];
+            IntPriorityQueue queue = runsAvail[queueIdx];
             long handle = queue.poll();
-
-            assert handle != LongPriorityQueue.NO_VALUE && !isUsed(handle) : "invalid handle: " + handle;
+            assert handle != IntPriorityQueue.NO_VALUE;
+            handle <<= BITMAP_IDX_BIT_LENGTH;
+            assert !isUsed(handle) : "invalid handle: " + handle;
 
             removeAvailRun0(handle);
 
-            if (handle != -1) {
-                handle = splitLargeRun(handle, pages);
-            }
+            handle = splitLargeRun(handle, pages);
 
             int pinnedSize = runSize(pageShifts, handle);
             freeBytes -= pinnedSize;
@@ -397,7 +396,7 @@ final class PoolChunk<T> implements PoolChunkMetric {
             return arena.nPSizes - 1;
         }
         for (int i = pageIdx; i < arena.nPSizes; i++) {
-            LongPriorityQueue queue = runsAvail[i];
+            IntPriorityQueue queue = runsAvail[i];
             if (queue != null && !queue.isEmpty()) {
                 return i;
             }

--- a/buffer/src/main/java/io/netty/buffer/PoolChunk.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunk.java
@@ -242,6 +242,7 @@ final class PoolChunk<T> implements PoolChunkMetric {
     private void insertAvailRun(int runOffset, int pages, long handle) {
         int pageIdxFloor = arena.pages2pageIdxFloor(pages);
         IntPriorityQueue queue = runsAvail[pageIdxFloor];
+        assert isRun(handle);
         queue.offer((int) (handle >> BITMAP_IDX_BIT_LENGTH));
 
         //insert first page of run

--- a/buffer/src/test/java/io/netty/buffer/IntPriorityQueueTest.java
+++ b/buffer/src/test/java/io/netty/buffer/IntPriorityQueueTest.java
@@ -26,14 +26,14 @@ import java.util.ListIterator;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
-class LongPriorityQueueTest {
+class IntPriorityQueueTest {
     @Test
     public void mustThrowWhenAddingNoValue() {
-        final LongPriorityQueue pq = new LongPriorityQueue();
+        final IntPriorityQueue pq = new IntPriorityQueue();
         assertThrows(IllegalArgumentException.class, new Executable() {
             @Override
             public void execute() {
-                pq.offer(LongPriorityQueue.NO_VALUE);
+                pq.offer(IntPriorityQueue.NO_VALUE);
             }
         });
     }
@@ -42,18 +42,18 @@ class LongPriorityQueueTest {
     public void mustReturnValuesInOrder() {
         ThreadLocalRandom tlr = ThreadLocalRandom.current();
         int initialValues = tlr.nextInt(5, 30);
-        ArrayList<Long> values = new ArrayList<Long>();
+        ArrayList<Integer> values = new ArrayList<Integer>();
         for (int i = 0; i < initialValues; i++) {
-            values.add(tlr.nextLong(0, Long.MAX_VALUE));
+            values.add(tlr.nextInt(0, Integer.MAX_VALUE));
         }
-        LongPriorityQueue pq = new LongPriorityQueue();
+        IntPriorityQueue pq = new IntPriorityQueue();
         assertTrue(pq.isEmpty());
-        for (Long value : values) {
+        for (Integer value : values) {
             pq.offer(value);
         }
         Collections.sort(values);
         int valuesToRemove = initialValues / 2;
-        ListIterator<Long> itr = values.listIterator();
+        ListIterator<Integer> itr = values.listIterator();
         for (int i = 0; i < valuesToRemove; i++) {
             assertTrue(itr.hasNext());
             assertThat(pq.poll()).isEqualTo(itr.next());
@@ -61,7 +61,7 @@ class LongPriorityQueueTest {
         }
         int moreValues = tlr.nextInt(5, 30);
         for (int i = 0; i < moreValues; i++) {
-            long value = tlr.nextLong(0, Long.MAX_VALUE);
+            int value = tlr.nextInt(0, Integer.MAX_VALUE);
             pq.offer(value);
             values.add(value);
         }
@@ -71,54 +71,54 @@ class LongPriorityQueueTest {
             assertThat(pq.poll()).isEqualTo(itr.next());
         }
         assertTrue(pq.isEmpty());
-        assertThat(pq.poll()).isEqualTo(LongPriorityQueue.NO_VALUE);
+        assertThat(pq.poll()).isEqualTo(IntPriorityQueue.NO_VALUE);
     }
 
     @Test
     public void internalRemoveOfAllElements() {
         ThreadLocalRandom tlr = ThreadLocalRandom.current();
         int initialValues = tlr.nextInt(5, 30);
-        ArrayList<Long> values = new ArrayList<Long>();
-        LongPriorityQueue pq = new LongPriorityQueue();
+        ArrayList<Integer> values = new ArrayList<Integer>();
+        IntPriorityQueue pq = new IntPriorityQueue();
         for (int i = 0; i < initialValues; i++) {
-            long value = tlr.nextLong(0, Long.MAX_VALUE);
+            int value = tlr.nextInt(0, Integer.MAX_VALUE);
             pq.offer(value);
             values.add(value);
         }
-        for (Long value : values) {
+        for (Integer value : values) {
             pq.remove(value);
         }
         assertTrue(pq.isEmpty());
-        assertThat(pq.poll()).isEqualTo(LongPriorityQueue.NO_VALUE);
+        assertThat(pq.poll()).isEqualTo(IntPriorityQueue.NO_VALUE);
     }
 
     @Test
     public void internalRemoveMustPreserveOrder() {
         ThreadLocalRandom tlr = ThreadLocalRandom.current();
         int initialValues = tlr.nextInt(1, 30);
-        ArrayList<Long> values = new ArrayList<Long>();
-        LongPriorityQueue pq = new LongPriorityQueue();
+        ArrayList<Integer> values = new ArrayList<Integer>();
+        IntPriorityQueue pq = new IntPriorityQueue();
         for (int i = 0; i < initialValues; i++) {
-            long value = tlr.nextLong(0, Long.MAX_VALUE);
+            int value = tlr.nextInt(0, Integer.MAX_VALUE);
             pq.offer(value);
             values.add(value);
         }
 
-        long toRemove = values.get(values.size() / 2);
+        Integer toRemove = values.get(values.size() / 2);
         values.remove(toRemove);
         pq.remove(toRemove);
 
         Collections.sort(values);
-        for (Long value : values) {
+        for (Integer value : values) {
             assertThat(pq.poll()).isEqualTo(value);
         }
         assertTrue(pq.isEmpty());
-        assertThat(pq.poll()).isEqualTo(LongPriorityQueue.NO_VALUE);
+        assertThat(pq.poll()).isEqualTo(IntPriorityQueue.NO_VALUE);
     }
 
     @Test
     public void mustSupportDuplicateValues() {
-        LongPriorityQueue pq = new LongPriorityQueue();
+        IntPriorityQueue pq = new IntPriorityQueue();
         pq.offer(10);
         pq.offer(5);
         pq.offer(6);
@@ -141,7 +141,7 @@ class LongPriorityQueueTest {
         assertThat(pq.poll()).isEqualTo(10);
         assertThat(pq.poll()).isEqualTo(10);
         assertTrue(pq.isEmpty());
-        assertThat(pq.poll()).isEqualTo(LongPriorityQueue.NO_VALUE);
-        assertThat(pq.peek()).isEqualTo(LongPriorityQueue.NO_VALUE);
+        assertThat(pq.poll()).isEqualTo(IntPriorityQueue.NO_VALUE);
+        assertThat(pq.peek()).isEqualTo(IntPriorityQueue.NO_VALUE);
     }
 }


### PR DESCRIPTION
Motivation:

`LongPriorityQueue[]` is used by `PoolChunk` to store available run information of all page classes.
This information (i.e., `handle`) contains page offset,  page count, isUsed, isSubpage, and bitmapIdx of subpage.

* Handle is inserted to `LongPriorityQueue` and `LongLongHashMap` when some memory is freed back to the chunk.
* Handle is removed from `LongPriorityQueue` and `LongLongHashMap` when some memory is allocated.
* One Handle can be split to two handles, and two continuous handles can be collapsed to one handle.

All the `LongPriorityQueue` operations are only related to page offset and page count. The low 32bit `bitmapIdx` is not used at all. So the high 32bit of handle is enough.

Modification:

1) Change `LongPriorityQueue` to `IntPriorityQueue`
2) Store high 32bit handle in `IntPriorityQueue`

Result:

PoolChunk's metadata is smaller.
