### PR TITLE
Disable DNS query timeout with zero

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -280,7 +280,8 @@ public class DnsNameResolver extends InetNameResolver {
      * @param authoritativeDnsServerCache the cache used to find the authoritative DNS server for a domain
      * @param dnsQueryLifecycleObserverFactory used to generate new instances of {@link DnsQueryLifecycleObserver} which
      *                                         can be used to track metrics for DNS servers.
-     * @param queryTimeoutMillis timeout of each DNS query in millis
+     * @param queryTimeoutMillis timeout of each DNS query in millis. {@code 0} disables the timeout. If not set or a
+     *                           negative number is set, the default timeout is used.
      * @param resolvedAddressTypes the preferred address types
      * @param recursionDesired if recursion desired flag must be set
      * @param maxQueriesPerResolve the maximum allowed number of DNS queries for a given name resolution
@@ -332,7 +333,8 @@ public class DnsNameResolver extends InetNameResolver {
      * @param authoritativeDnsServerCache the cache used to find the authoritative DNS server for a domain
      * @param dnsQueryLifecycleObserverFactory used to generate new instances of {@link DnsQueryLifecycleObserver} which
      *                                         can be used to track metrics for DNS servers.
-     * @param queryTimeoutMillis timeout of each DNS query in millis
+     * @param queryTimeoutMillis timeout of each DNS query in millis. {@code 0} disables the timeout. If not set or a
+     *                           negative number is set, the default timeout is used.
      * @param resolvedAddressTypes the preferred address types
      * @param recursionDesired if recursion desired flag must be set
      * @param maxQueriesPerResolve the maximum allowed number of DNS queries for a given name resolution
@@ -426,7 +428,7 @@ public class DnsNameResolver extends InetNameResolver {
             boolean completeOncePreferredResolved,
             int maxNumConsolidation) {
         super(eventLoop);
-        this.queryTimeoutMillis = queryTimeoutMillis > 0
+        this.queryTimeoutMillis = queryTimeoutMillis >= 0
             ? queryTimeoutMillis
             : TimeUnit.SECONDS.toMillis(DEFAULT_OPTIONS.timeout());
         this.resolvedAddressTypes = resolvedAddressTypes != null ? resolvedAddressTypes : DEFAULT_RESOLVE_ADDRESS_TYPES;

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
@@ -252,6 +252,7 @@ public final class DnsNameResolverBuilder {
 
     /**
      * Sets the timeout of each DNS query performed by this resolver (in milliseconds).
+     * {@code 0} disables the timeout. If not set or a negative number is set, the default timeout is used.
      *
      * @param queryTimeoutMillis the query timeout
      * @return {@code this}

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverBuilderTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverBuilderTest.java
@@ -144,6 +144,12 @@ class DnsNameResolverBuilderTest {
         assertThat(resolver.authoritativeDnsServerCache()).isSameAs(testAuthoritativeDnsServerCache);
     }
 
+    @Test
+    void disableQueryTimeoutWithZero() {
+        resolver = builder.queryTimeoutMillis(0).build();
+        assertThat(resolver.queryTimeoutMillis()).isEqualTo(0);
+    }
+
     private static void checkDefaultDnsCache(DefaultDnsCache dnsCache,
             int expectedMaxTtl, int expectedMinTtl, int expectedNegativeTtl) {
         assertThat(dnsCache.maxTtl()).isEqualTo(expectedMaxTtl);


### PR DESCRIPTION
Motivation:

There is no explicit way to disable DNS query timeout. A positive number schedules a timeout and the default timeout is used for non-positive numbers.

Modifications:

- Use the default query timeout only when `queryTimeoutMillis` is a negative number.
  - 0 is used to mean no query timeout.

Result:

Users can now disable a query timeout of `DnsNameResolver` with `0`.
