### PR TITLE
Make initializer as `static`

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoopGroup.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoopGroup.java
@@ -35,7 +35,8 @@ import java.util.concurrent.ThreadFactory;
  * it only works on linux.
  */
 public final class EpollEventLoopGroup extends MultithreadEventLoopGroup {
-    {
+
+    static {
         // Ensure JNI is initialized by the time this class is loaded.
         Epoll.ensureAvailability();
     }

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoopGroup.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoopGroup.java
@@ -32,10 +32,12 @@ import java.util.concurrent.ThreadFactory;
 
 @UnstableApi
 public final class KQueueEventLoopGroup extends MultithreadEventLoopGroup {
-    {
+
+    static {
         // Ensure JNI is initialized by the time this class is loaded by this time!
         KQueue.ensureAvailability();
     }
+
     /**
      * Create a new instance using the default number of threads and the default {@link ThreadFactory}.
      */


### PR DESCRIPTION
Motivation:
I went through native transport and found that we don't explicitly mark class initializers as `static`. We should mark them as `static`.

Modification:
Made initializers as `static`

Result:
Clean code and no more IDE warning pings.
