### PR TITLE
Use primitive integer instead of class wrapper

### DIFF
--- a/transport/src/main/java/io/netty/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalChannel.java
@@ -315,7 +315,7 @@ public class LocalChannel extends AbstractChannel {
         }
 
         final InternalThreadLocalMap threadLocals = InternalThreadLocalMap.get();
-        final Integer stackDepth = threadLocals.localChannelReaderStackDepth();
+        final int stackDepth = threadLocals.localChannelReaderStackDepth();
         if (stackDepth < MAX_READER_STACK_DEPTH) {
             threadLocals.setLocalChannelReaderStackDepth(stackDepth + 1);
             try {


### PR DESCRIPTION
Motivation:
As IDE complains, let's use a primitive integer instead of a wrapper class unless needed.

Modification:
Converted wrapper Integer to int.

Result:
No more wrapper class overhead.
