### PR TITLE
Replace empty array initialization with constants

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
@@ -1720,7 +1720,7 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
                 i ++;
             }
 
-            return buffers.toArray(new ByteBuffer[0]);
+            return buffers.toArray(EmptyArrays.EMPTY_BYTE_BUFFERS);
         } finally {
             buffers.recycle();
         }

--- a/buffer/src/main/java/io/netty/buffer/FixedCompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/FixedCompositeByteBuf.java
@@ -593,7 +593,7 @@ final class FixedCompositeByteBuf extends AbstractReferenceCountedByteBuf {
                 s = buffer(++i);
             }
 
-            return array.toArray(new ByteBuffer[0]);
+            return array.toArray(EmptyArrays.EMPTY_BYTE_BUFFERS);
         } finally {
             array.recycle();
         }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
@@ -30,6 +30,7 @@ import io.netty.handler.codec.http.multipart.HttpPostRequestDecoder.ErrorDataDec
 import io.netty.handler.codec.http.multipart.HttpPostRequestDecoder.MultiPartStatus;
 import io.netty.handler.codec.http.multipart.HttpPostRequestDecoder.NotEnoughDataDecoderException;
 import io.netty.util.CharsetUtil;
+import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.InternalThreadLocalMap;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
@@ -1377,7 +1378,7 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
             }
         }
         values.add(svalue.substring(start));
-        return values.toArray(new String[0]);
+        return values.toArray(EmptyArrays.EMPTY_STRINGS);
     }
 
     /**

--- a/common/src/main/java/io/netty/util/AsciiString.java
+++ b/common/src/main/java/io/netty/util/AsciiString.java
@@ -1117,7 +1117,7 @@ public final class AsciiString implements CharSequence, Comparable<CharSequence>
             }
         }
 
-        return res.toArray(new AsciiString[0]);
+        return res.toArray(EmptyArrays.EMPTY_ASCII_STRINGS);
     }
 
     /**

--- a/example/src/main/java/io/netty/example/ocsp/OcspServerExample.java
+++ b/example/src/main/java/io/netty/example/ocsp/OcspServerExample.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import io.netty.util.internal.EmptyArrays;
 import org.bouncycastle.asn1.ocsp.OCSPResponseStatus;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
@@ -204,6 +205,6 @@ public class OcspServerExample {
             parser.close();
         }
 
-        return dst.toArray(new X509Certificate[0]);
+        return dst.toArray(EmptyArrays.EMPTY_X509_CERTIFICATES);
     }
 }

--- a/handler/src/main/java/io/netty/handler/ssl/ConscryptAlpnSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ConscryptAlpnSslEngine.java
@@ -31,6 +31,7 @@ import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLEngineResult;
 import javax.net.ssl.SSLException;
 
+import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.SystemPropertyUtil;
 import org.conscrypt.AllocatedBuffer;
 import org.conscrypt.BufferAllocator;
@@ -71,7 +72,7 @@ abstract class ConscryptAlpnSslEngine extends JdkSslEngine {
         }
 
         // Set the list of supported ALPN protocols on the engine.
-        Conscrypt.setApplicationProtocols(engine, protocols.toArray(new String[0]));
+        Conscrypt.setApplicationProtocols(engine, protocols.toArray(EmptyArrays.EMPTY_STRINGS));
     }
 
     /**

--- a/handler/src/main/java/io/netty/handler/ssl/IdentityCipherSuiteFilter.java
+++ b/handler/src/main/java/io/netty/handler/ssl/IdentityCipherSuiteFilter.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.ssl;
 
+import io.netty.util.internal.EmptyArrays;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -46,8 +48,8 @@ public final class IdentityCipherSuiteFilter implements CipherSuiteFilter {
             Set<String> supportedCiphers) {
         if (ciphers == null) {
             return defaultToDefaultCiphers ?
-                    defaultCiphers.toArray(new String[0]) :
-                    supportedCiphers.toArray(new String[0]);
+                    defaultCiphers.toArray(EmptyArrays.EMPTY_STRINGS) :
+                    supportedCiphers.toArray(EmptyArrays.EMPTY_STRINGS);
         } else {
             List<String> newCiphers = new ArrayList<String>(supportedCiphers.size());
             for (String c : ciphers) {
@@ -56,7 +58,7 @@ public final class IdentityCipherSuiteFilter implements CipherSuiteFilter {
                 }
                 newCiphers.add(c);
             }
-            return newCiphers.toArray(new String[0]);
+            return newCiphers.toArray(EmptyArrays.EMPTY_STRINGS);
         }
     }
 }

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
@@ -708,7 +708,7 @@ public final class OpenSsl {
         libNames.add(staticLibName);
 
         NativeLibraryLoader.loadFirstAvailable(PlatformDependent.getClassLoader(SSLContext.class),
-            libNames.toArray(new String[0]));
+            libNames.toArray(EmptyArrays.EMPTY_STRINGS));
     }
 
     private static boolean initializeTcNative(String engine) throws Exception {
@@ -766,7 +766,7 @@ public final class OpenSsl {
                 protocols.add(proto);
             }
         }
-        return protocols.toArray(new String[0]);
+        return protocols.toArray(EmptyArrays.EMPTY_STRINGS);
     }
 
     static boolean isBoringSSL() {

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslClientContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslClientContext.java
@@ -16,6 +16,7 @@
 package io.netty.handler.ssl;
 
 import io.netty.internal.tcnative.CertificateCallback;
+import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.SuppressJava6Requirement;
 import io.netty.internal.tcnative.SSL;
 import io.netty.internal.tcnative.SSLContext;
@@ -253,7 +254,7 @@ public final class ReferenceCountedOpenSslClientContext extends ReferenceCounted
             }
             try {
                 final Set<String> keyTypesSet = supportedClientKeyTypes(keyTypeBytes);
-                final String[] keyTypes = keyTypesSet.toArray(new String[0]);
+                final String[] keyTypes = keyTypesSet.toArray(EmptyArrays.EMPTY_STRINGS);
                 final X500Principal[] issuers;
                 if (asn1DerEncodedPrincipals == null) {
                     issuers = null;

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -32,6 +32,7 @@ import io.netty.util.ResourceLeakDetectorFactory;
 import io.netty.util.ResourceLeakTracker;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
+import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.SuppressJava6Requirement;
@@ -368,7 +369,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
             List<String> nextProtoList = apn.protocols();
             /* Set next protocols for next protocol negotiation extension, if specified */
             if (!nextProtoList.isEmpty()) {
-                String[] appProtocols = nextProtoList.toArray(new String[0]);
+                String[] appProtocols = nextProtoList.toArray(EmptyArrays.EMPTY_STRINGS);
                 int selectorBehavior = opensslSelectorFailureBehavior(apn.selectorFailureBehavior());
 
                 switch (apn.protocol()) {

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -67,6 +67,7 @@ import javax.security.cert.X509Certificate;
 
 import static io.netty.handler.ssl.OpenSsl.memoryAddress;
 import static io.netty.handler.ssl.SslUtils.SSL_RECORD_HEADER_LENGTH;
+import static io.netty.util.internal.EmptyArrays.EMPTY_STRINGS;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import static io.netty.util.internal.ObjectUtil.checkNotNullArrayParam;
 import static io.netty.util.internal.ObjectUtil.checkNotNullWithIAE;
@@ -273,11 +274,11 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                     synchronized (ReferenceCountedOpenSslEngine.this) {
                         if (peerSupportedSignatureAlgorithms == null) {
                             if (isDestroyed()) {
-                                peerSupportedSignatureAlgorithms = EmptyArrays.EMPTY_STRINGS;
+                                peerSupportedSignatureAlgorithms = EMPTY_STRINGS;
                             } else {
                                 String[] algs = SSL.getSigAlgs(ssl);
                                 if (algs == null) {
-                                    peerSupportedSignatureAlgorithms = EmptyArrays.EMPTY_STRINGS;
+                                    peerSupportedSignatureAlgorithms = EMPTY_STRINGS;
                                 } else {
                                     Set<String> algorithmList = new LinkedHashSet<String>(algs.length);
                                     for (String alg: algs) {
@@ -287,7 +288,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                                             algorithmList.add(converted);
                                         }
                                     }
-                                    peerSupportedSignatureAlgorithms = algorithmList.toArray(new String[0]);
+                                    peerSupportedSignatureAlgorithms = algorithmList.toArray(EMPTY_STRINGS);
                                 }
                             }
                         }
@@ -410,7 +411,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
 
     final synchronized String[] authMethods() {
         if (isDestroyed()) {
-            return EmptyArrays.EMPTY_STRINGS;
+            return EMPTY_STRINGS;
         }
         return SSL.authenticationMethods(ssl);
     }
@@ -1619,7 +1620,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
 
     @Override
     public final String[] getSupportedCipherSuites() {
-        return OpenSsl.AVAILABLE_CIPHER_SUITES.toArray(new String[0]);
+        return OpenSsl.AVAILABLE_CIPHER_SUITES.toArray(EMPTY_STRINGS);
     }
 
     @Override
@@ -1635,15 +1636,15 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                     extraCiphers = OpenSsl.EXTRA_SUPPORTED_TLS_1_3_CIPHERS;
                     tls13Enabled = true;
                 } else {
-                    extraCiphers = EmptyArrays.EMPTY_STRINGS;
+                    extraCiphers = EMPTY_STRINGS;
                     tls13Enabled = false;
                 }
             } else {
-                return EmptyArrays.EMPTY_STRINGS;
+                return EMPTY_STRINGS;
             }
         }
         if (enabled == null) {
-            return EmptyArrays.EMPTY_STRINGS;
+            return EMPTY_STRINGS;
         } else {
             Set<String> enabledSet = new LinkedHashSet<String>(enabled.length + extraCiphers.length);
             synchronized (this) {
@@ -1657,7 +1658,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                 }
                 Collections.addAll(enabledSet, extraCiphers);
             }
-            return enabledSet.toArray(new String[0]);
+            return enabledSet.toArray(EMPTY_STRINGS);
         }
     }
 
@@ -1706,7 +1707,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                     }
                     // Update the protocols but not cache the value. We only cache when we call it from the user
                     // code or when we construct the engine.
-                    setEnabledProtocols0(protocols.toArray(EmptyArrays.EMPTY_STRINGS), false);
+                    setEnabledProtocols0(protocols.toArray(EMPTY_STRINGS), false);
                 } catch (Exception e) {
                     throw new IllegalStateException("failed to enable cipher suites: " + cipherSuiteSpec, e);
                 }
@@ -1718,7 +1719,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
 
     @Override
     public final String[] getSupportedProtocols() {
-        return OpenSsl.SUPPORTED_PROTOCOLS_SET.toArray(new String[0]);
+        return OpenSsl.SUPPORTED_PROTOCOLS_SET.toArray(EMPTY_STRINGS);
     }
 
     @Override
@@ -1732,7 +1733,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
             if (!isDestroyed()) {
                 opts = SSL.getOptions(ssl);
             } else {
-                return enabled.toArray(new String[0]);
+                return enabled.toArray(EMPTY_STRINGS);
             }
         }
         if (isProtocolEnabled(opts, SSL.SSL_OP_NO_TLSv1, SslProtocols.TLS_v1)) {
@@ -1753,7 +1754,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
         if (isProtocolEnabled(opts, SSL.SSL_OP_NO_SSLv3, SslProtocols.SSL_v3)) {
             enabled.add(SslProtocols.SSL_v3);
         }
-        return enabled.toArray(new String[0]);
+        return enabled.toArray(EMPTY_STRINGS);
     }
 
     private static boolean isProtocolEnabled(int opts, int disableMask, String protocolString) {
@@ -2487,9 +2488,9 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
             synchronized (this) {
                 Map<String, Object> values = this.values;
                 if (values == null || values.isEmpty()) {
-                    return EmptyArrays.EMPTY_STRINGS;
+                    return EMPTY_STRINGS;
                 }
-                return values.keySet().toArray(new String[0]);
+                return values.keySet().toArray(EMPTY_STRINGS);
             }
         }
 

--- a/handler/src/main/java/io/netty/handler/ssl/SupportedCipherSuiteFilter.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SupportedCipherSuiteFilter.java
@@ -15,6 +15,7 @@
  */
 package io.netty.handler.ssl;
 
+import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.ObjectUtil;
 
 import javax.net.ssl.SSLEngine;
@@ -51,7 +52,7 @@ public final class SupportedCipherSuiteFilter implements CipherSuiteFilter {
                 newCiphers.add(c);
             }
         }
-        return newCiphers.toArray(new String[0]);
+        return newCiphers.toArray(EmptyArrays.EMPTY_STRINGS);
     }
 
 }

--- a/microbench/src/main/java/io/netty/microbench/util/AbstractMicrobenchmarkBase.java
+++ b/microbench/src/main/java/io/netty/microbench/util/AbstractMicrobenchmarkBase.java
@@ -16,6 +16,7 @@
 package io.netty.microbench.util;
 
 import io.netty.util.ResourceLeakDetector;
+import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.SystemPropertyUtil;
 
 import java.io.File;
@@ -93,7 +94,7 @@ public abstract class AbstractMicrobenchmarkBase {
             }
         }
         if (jvmArgs.length != customArgs.size()) {
-            jvmArgs = customArgs.toArray(new String[0]);
+            jvmArgs = customArgs.toArray(EmptyArrays.EMPTY_STRINGS);
         }
         return jvmArgs;
     }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -149,7 +149,7 @@ public class DnsNameResolver extends InetNameResolver {
             List<String> list = PlatformDependent.isWindows()
                     ? getSearchDomainsHack()
                     : UnixResolverDnsServerAddressStreamProvider.parseEtcResolverSearchDomains();
-            searchDomains = list.toArray(new String[0]);
+            searchDomains = list.toArray(EmptyArrays.EMPTY_STRINGS);
         } catch (Exception ignore) {
             // Failed to get the system name search domain list.
             searchDomains = EmptyArrays.EMPTY_STRINGS;

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
@@ -24,6 +24,7 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.resolver.HostsFileEntriesResolver;
 import io.netty.resolver.ResolvedAddressTypes;
 import io.netty.util.concurrent.Future;
+import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -426,7 +427,7 @@ public final class DnsNameResolverBuilder {
             list.add(f);
         }
 
-        this.searchDomains = list.toArray(new String[0]);
+        this.searchDomains = list.toArray(EmptyArrays.EMPTY_STRINGS);
         return this;
     }
 


### PR DESCRIPTION
Motivation:
We should consider reducing memory footprint by reusing an empty array instead of initializing an empty array for every operation.

Modification:
Re-used already declared Empty Array objects.

Result:
Reduced memory overhead
