### PR TITLE
Remove redundant casts

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
@@ -676,14 +676,14 @@ public abstract class AbstractByteBuf extends ByteBuf {
             // Not need to update the index as we not will use it after this.
         } else if (nBytes < 4) {
             for (int i = nBytes; i > 0; i --) {
-                _setByte(index, (byte) 0);
+                _setByte(index, 0);
                 index ++;
             }
         } else {
             _setInt(index, 0);
             index += 4;
             for (int i = nBytes - 4; i > 0; i --) {
-                _setByte(index, (byte) 0);
+                _setByte(index, 0);
                 index ++;
             }
         }
@@ -1167,14 +1167,14 @@ public abstract class AbstractByteBuf extends ByteBuf {
             wIndex += 4;
         } else if (nBytes < 4) {
             for (int i = nBytes; i > 0; i --) {
-                _setByte(wIndex, (byte) 0);
+                _setByte(wIndex, 0);
                 wIndex++;
             }
         } else {
             _setInt(wIndex, 0);
             wIndex += 4;
             for (int i = nBytes - 4; i > 0; i --) {
-                _setByte(wIndex, (byte) 0);
+                _setByte(wIndex, 0);
                 wIndex++;
             }
         }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket00FrameEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket00FrameEncoder.java
@@ -32,11 +32,11 @@ import java.util.List;
 @Sharable
 public class WebSocket00FrameEncoder extends MessageToMessageEncoder<WebSocketFrame> implements WebSocketFrameEncoder {
     private static final ByteBuf _0X00 = Unpooled.unreleasableBuffer(
-            Unpooled.directBuffer(1, 1).writeByte((byte) 0x00)).asReadOnly();
+            Unpooled.directBuffer(1, 1).writeByte(0x00)).asReadOnly();
     private static final ByteBuf _0XFF = Unpooled.unreleasableBuffer(
             Unpooled.directBuffer(1, 1).writeByte((byte) 0xFF)).asReadOnly();
     private static final ByteBuf _0XFF_0X00 = Unpooled.unreleasableBuffer(
-            Unpooled.directBuffer(2, 2).writeByte((byte) 0xFF).writeByte((byte) 0x00)).asReadOnly();
+            Unpooled.directBuffer(2, 2).writeByte((byte) 0xFF).writeByte(0x00)).asReadOnly();
 
     @Override
     protected void encode(ChannelHandlerContext ctx, WebSocketFrame msg, List<Object> out) throws Exception {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameDecoder.java
@@ -397,7 +397,7 @@ public class WebSocket08FrameDecoder extends ByteToMessageDecoder
 
         int intMask = mask;
         // Avoid sign extension on widening primitive conversion
-        long longMask = (long) intMask & 0xFFFFFFFFL;
+        long longMask = intMask & 0xFFFFFFFFL;
         longMask |= longMask << 32;
 
         for (int lim = end - 7; i < lim; i += 8) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameEncoder.java
@@ -187,7 +187,7 @@ public class WebSocket08FrameEncoder extends MessageToMessageEncoder<WebSocketFr
                     if (srcOrder == dstOrder) {
                         // Use the optimized path only when byte orders match.
                         // Avoid sign extension on widening primitive conversion
-                        long longMask = (long) mask & 0xFFFFFFFFL;
+                        long longMask = mask & 0xFFFFFFFFL;
                         longMask |= longMask << 32;
 
                         // If the byte order of our buffers it little endian we have to bring our mask

--- a/common/src/main/java/io/netty/util/internal/StringUtil.java
+++ b/common/src/main/java/io/netty/util/internal/StringUtil.java
@@ -61,28 +61,28 @@ public final class StringUtil {
         // if a char type is used as an index.
         HEX2B = new byte[Character.MAX_VALUE + 1];
         Arrays.fill(HEX2B, (byte) -1);
-        HEX2B['0'] = (byte) 0;
-        HEX2B['1'] = (byte) 1;
-        HEX2B['2'] = (byte) 2;
-        HEX2B['3'] = (byte) 3;
-        HEX2B['4'] = (byte) 4;
-        HEX2B['5'] = (byte) 5;
-        HEX2B['6'] = (byte) 6;
-        HEX2B['7'] = (byte) 7;
-        HEX2B['8'] = (byte) 8;
-        HEX2B['9'] = (byte) 9;
-        HEX2B['A'] = (byte) 10;
-        HEX2B['B'] = (byte) 11;
-        HEX2B['C'] = (byte) 12;
-        HEX2B['D'] = (byte) 13;
-        HEX2B['E'] = (byte) 14;
-        HEX2B['F'] = (byte) 15;
-        HEX2B['a'] = (byte) 10;
-        HEX2B['b'] = (byte) 11;
-        HEX2B['c'] = (byte) 12;
-        HEX2B['d'] = (byte) 13;
-        HEX2B['e'] = (byte) 14;
-        HEX2B['f'] = (byte) 15;
+        HEX2B['0'] = 0;
+        HEX2B['1'] = 1;
+        HEX2B['2'] = 2;
+        HEX2B['3'] = 3;
+        HEX2B['4'] = 4;
+        HEX2B['5'] = 5;
+        HEX2B['6'] = 6;
+        HEX2B['7'] = 7;
+        HEX2B['8'] = 8;
+        HEX2B['9'] = 9;
+        HEX2B['A'] = 10;
+        HEX2B['B'] = 11;
+        HEX2B['C'] = 12;
+        HEX2B['D'] = 13;
+        HEX2B['E'] = 14;
+        HEX2B['F'] = 15;
+        HEX2B['a'] = 10;
+        HEX2B['b'] = 11;
+        HEX2B['c'] = 12;
+        HEX2B['d'] = 13;
+        HEX2B['e'] = 14;
+        HEX2B['f'] = 15;
     }
 
     private StringUtil() {

--- a/example/src/main/java/io/netty/example/ocsp/OcspUtils.java
+++ b/example/src/main/java/io/netty/example/ocsp/OcspUtils.java
@@ -82,7 +82,7 @@ public final class OcspUtils {
         }
 
         byte[] encoded = taggedObject.getEncoded();
-        int length = (int) encoded[1] & 0xFF;
+        int length = encoded[1] & 0xFF;
         String uri = new String(encoded, 2, length, CharsetUtil.UTF_8);
         return URI.create(uri);
     }

--- a/microbench/src/main/java/io/netty/handler/codec/http/DecodeHexBenchmark.java
+++ b/microbench/src/main/java/io/netty/handler/codec/http/DecodeHexBenchmark.java
@@ -140,32 +140,32 @@ public class DecodeHexBenchmark extends AbstractMicrobenchmark {
     static {
         HEX2B = new byte['f' + 1];
         Arrays.fill(HEX2B, (byte) -1);
-        HEX2B['0'] = (byte) 0;
-        HEX2B['1'] = (byte) 1;
-        HEX2B['2'] = (byte) 2;
-        HEX2B['3'] = (byte) 3;
-        HEX2B['4'] = (byte) 4;
-        HEX2B['5'] = (byte) 5;
-        HEX2B['6'] = (byte) 6;
-        HEX2B['7'] = (byte) 7;
-        HEX2B['8'] = (byte) 8;
-        HEX2B['9'] = (byte) 9;
-        HEX2B['A'] = (byte) 10;
-        HEX2B['B'] = (byte) 11;
-        HEX2B['C'] = (byte) 12;
-        HEX2B['D'] = (byte) 13;
-        HEX2B['E'] = (byte) 14;
-        HEX2B['F'] = (byte) 15;
-        HEX2B['a'] = (byte) 10;
-        HEX2B['b'] = (byte) 11;
-        HEX2B['c'] = (byte) 12;
-        HEX2B['d'] = (byte) 13;
-        HEX2B['e'] = (byte) 14;
-        HEX2B['f'] = (byte) 15;
+        HEX2B['0'] = 0;
+        HEX2B['1'] = 1;
+        HEX2B['2'] = 2;
+        HEX2B['3'] = 3;
+        HEX2B['4'] = 4;
+        HEX2B['5'] = 5;
+        HEX2B['6'] = 6;
+        HEX2B['7'] = 7;
+        HEX2B['8'] = 8;
+        HEX2B['9'] = 9;
+        HEX2B['A'] = 10;
+        HEX2B['B'] = 11;
+        HEX2B['C'] = 12;
+        HEX2B['D'] = 13;
+        HEX2B['E'] = 14;
+        HEX2B['F'] = 15;
+        HEX2B['a'] = 10;
+        HEX2B['b'] = 11;
+        HEX2B['c'] = 12;
+        HEX2B['d'] = 13;
+        HEX2B['e'] = 14;
+        HEX2B['f'] = 15;
     }
 
     private static int decodeHexNibbleWithCheck(final char c) {
-        if ((int) c >= HEX2B.length) {
+        if (c >= HEX2B.length) {
             return -1;
         }
         if (PlatformDependent.hasUnsafe()) {

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollEventArray.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollEventArray.java
@@ -111,7 +111,7 @@ public final class EpollEventArray {
 
     private int getInt(int index, int offset) {
         if (PlatformDependent.hasUnsafe()) {
-            long n = (long) index * (long) EPOLL_EVENT_SIZE;
+            long n = (long) index * EPOLL_EVENT_SIZE;
             return PlatformDependent.getInt(memoryAddress + n + offset);
         }
         return memory.getInt(index * EPOLL_EVENT_SIZE + offset);


### PR DESCRIPTION
Motivation:
We should remove unnecessary redundant type casing for primitive types of byte, int and long.

Modification:
Removed unnecessary redundant type casing

Result:
No more redundant casting
