### PR TITLE
Separate encode methods for CookiePair and SetCookie

### DIFF
--- a/codec-http/src/main/java/io/netty5/handler/codec/http/headers/DefaultHttpCookiePair.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/headers/DefaultHttpCookiePair.java
@@ -133,7 +133,7 @@ public final class DefaultHttpCookiePair implements HttpCookiePair {
     }
 
     @Override
-    public CharSequence encoded() {
+    public CharSequence encodedCookie() {
         StringBuilder sb = new StringBuilder(name.length() + value.length() + 1 + (isWrapped ? 2 : 0));
         sb.append(name).append('=');
         if (isWrapped) {

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/headers/DefaultHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/headers/DefaultHttpHeaders.java
@@ -263,7 +263,7 @@ public class DefaultHttpHeaders extends MultiMap<CharSequence, CharSequence> imp
     public HttpHeaders addCookie(final HttpCookiePair cookie) {
         // HTTP/1.x requires that all cookies/crumbs are combined into a single Cookie header.
         // https://tools.ietf.org/html/rfc6265#section-5.4
-        CharSequence encoded = cookie.encoded();
+        CharSequence encoded = cookie.encodedCookie();
         final int keyHash = hashCode(COOKIE);
         final BucketHead<CharSequence, CharSequence> bucketHead = entries[index(keyHash)];
         if (bucketHead != null) {
@@ -283,7 +283,7 @@ public class DefaultHttpHeaders extends MultiMap<CharSequence, CharSequence> imp
 
     @Override
     public HttpHeaders addSetCookie(final HttpSetCookie cookie) {
-        put(SET_COOKIE, cookie.encoded());
+        put(SET_COOKIE, cookie.encodedSetCookie());
         return this;
     }
 

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/headers/DefaultHttpSetCookie.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/headers/DefaultHttpSetCookie.java
@@ -454,7 +454,12 @@ public final class DefaultHttpSetCookie implements HttpSetCookie {
     }
 
     @Override
-    public CharSequence encoded() {
+    public CharSequence encodedCookie() {
+        return new DefaultHttpCookiePair(name, value, wrapped).encodedCookie();
+    }
+
+    @Override
+    public CharSequence encodedSetCookie() {
         StringBuilder sb = new StringBuilder(1 + name.length() + value.length() +
                 (wrapped ? 2 : 0) +
                 (domain != null ? ENCODED_LABEL_DOMAIN.length() + domain.length() : 0) +

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/headers/HttpCookiePair.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/headers/HttpCookiePair.java
@@ -57,9 +57,9 @@ public interface HttpCookiePair {
     boolean isWrapped();
 
     /**
-     * Get the encoded value of this {@link HttpCookiePair}.
+     * Get the encoded value of this {@link HttpCookiePair} for the {@code Cookie} HTTP header.
      *
      * @return the encoded value of this {@link HttpCookiePair}.
      */
-    CharSequence encoded();
+    CharSequence encodedCookie();
 }

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/headers/HttpSetCookie.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/headers/HttpSetCookie.java
@@ -123,6 +123,13 @@ public interface HttpSetCookie extends HttpCookiePair {
     boolean isHttpOnly();
 
     /**
+     * Get the encoded value of this {@link HttpSetCookie} for the {@code Set-Cookie} HTTP header.
+     *
+     * @return the encoded value of this {@link HttpSetCookie}.
+     */
+    CharSequence encodedSetCookie();
+
+    /**
      * Represents
      * <a href="https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-05#section-4.1.1">samesite-value</a>
      * for the

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/headers/DefaultHttpCookiePairTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/headers/DefaultHttpCookiePairTest.java
@@ -32,6 +32,8 @@ package io.netty5.handler.codec.http.headers;
 import io.netty5.util.AsciiString;
 import org.junit.jupiter.api.Test;
 
+import java.util.Iterator;
+
 import static io.netty5.handler.codec.http.headers.HttpHeaders.newHeaders;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -139,5 +141,16 @@ class DefaultHttpCookiePairTest {
         Exception e = assertThrows(IllegalArgumentException.class, () -> headers.getCookies().forEach(c -> { }));
         assertThat(e).hasMessageContaining("no cookie value found after")
                 .hasMessageContaining("no previous cookie");
+    }
+
+    @Test
+    void setCookieAsCookie() {
+        final HttpHeaders headers = newHeaders();
+        // HttpSetCookie also implements HttpCookiePair
+        headers.addCookie(new DefaultHttpSetCookie("k", "v", false, true, true));
+        Iterator<HttpCookiePair> itr = headers.getCookiesIterator();
+        assertThat(itr.hasNext()).isTrue();
+        assertThat(itr.next()).isEqualTo(new DefaultHttpCookiePair("k", "v"));
+        assertThat(itr.hasNext()).isFalse();
     }
 }

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/headers/DefaultHttpSetCookiesTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/headers/DefaultHttpSetCookiesTest.java
@@ -132,21 +132,21 @@ class DefaultHttpSetCookiesTest {
         HttpSetCookie next = cookieItr.next();
         assertTrue(areSetCookiesEqual(new TestSetCookie(
                 "foo", "12345", "/", "somecompany.co.uk", null, null, SameSite.Lax, false, false, true), next));
-        assertThat(next.encoded()).containsIgnoringCase("samesite=lax");
+        assertThat(next.encodedSetCookie()).containsIgnoringCase("samesite=lax");
         assertFalse(cookieItr.hasNext());
         cookieItr = headers.getSetCookiesIterator("bar");
         assertTrue(cookieItr.hasNext());
         next = cookieItr.next();
         assertTrue(areSetCookiesEqual(new TestSetCookie("bar", "abcd", "/2", "somecompany.co.uk", null,
                 3000L, SameSite.None, false, false, false), next));
-        assertThat(next.encoded()).containsIgnoringCase("samesite=none");
+        assertThat(next.encodedSetCookie()).containsIgnoringCase("samesite=none");
         assertFalse(cookieItr.hasNext());
         cookieItr = headers.getSetCookiesIterator("baz");
         assertTrue(cookieItr.hasNext());
         next = cookieItr.next();
         assertTrue(areSetCookiesEqual(new TestSetCookie("baz", "xyz", "/3", "somecompany.co.uk", null,
                 null, SameSite.Strict, false, true, false), next));
-        assertThat(next.encoded()).containsIgnoringCase("samesite=strict");
+        assertThat(next.encodedSetCookie()).containsIgnoringCase("samesite=strict");
         assertFalse(cookieItr.hasNext());
     }
 
@@ -888,9 +888,15 @@ class DefaultHttpSetCookiesTest {
         }
 
         @Override
-        public CharSequence encoded() {
+        public CharSequence encodedCookie() {
             return new DefaultHttpSetCookie(name, value, path, domain, expires, maxAge, sameSite, isWrapped, isSecure,
-                    isHttpOnly).encoded();
+                    isHttpOnly).encodedCookie();
+        }
+
+        @Override
+        public CharSequence encodedSetCookie() {
+            return new DefaultHttpSetCookie(name, value, path, domain, expires, maxAge, sameSite, isWrapped, isSecure,
+                    isHttpOnly).encodedSetCookie();
         }
 
         @Override


### PR DESCRIPTION
Motivation:

Before this patch, the `HttpCookiePair.encoded()` would return the `Cookie` syntax for `HttpCookiePair`, but the `Set-Cookie` syntax for `HttpSetCookie`. `DefaultHttpHeaders.addCookie` trusts this value, so passing a `HttpSetCookie` to the method would produce and invalid `Cookie` header.

There is really no need for these two formats to use the same method.

Modification:

Replace the `encoded` method with separate `encodedCookie` and `encodedSetCookie` methods for the respective header formats.

Result:

`HttpSetCookie` instances can now be used with `addCookie` without issue.