### PR TITLE
Enable validation for HttpHeaders.emptyHeaders()

### DIFF
--- a/codec-http/src/main/java/io/netty5/handler/codec/http/headers/HttpHeaders.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/headers/HttpHeaders.java
@@ -52,7 +52,7 @@ public interface HttpHeaders extends Iterable<Entry<CharSequence, CharSequence>>
      * @return A new headers instance that use up as few resources as possible.
      */
     static HttpHeaders emptyHeaders() {
-        return newHeaders(2, false, false, false);
+        return newHeaders(2, true, true, true);
     }
 
     /**

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/headers/EmptyHttpHeadersTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/headers/EmptyHttpHeadersTest.java
@@ -1,0 +1,17 @@
+package io.netty5.handler.codec.http.headers;
+
+import org.junit.jupiter.api.Assumptions;
+
+public class EmptyHttpHeadersTest extends AbstractHttpHeadersTest {
+    // this basically tests that emptyHeaders() behaves like a normal header map, including validation
+
+    @Override
+    protected HttpHeaders newHeaders() {
+        return HttpHeaders.emptyHeaders();
+    }
+
+    @Override
+    protected HttpHeaders newHeaders(int initialSizeHint) {
+        return Assumptions.abort("Empty headers have a fixed size hint");
+    }
+}

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/headers/EmptyHttpHeadersTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/headers/EmptyHttpHeadersTest.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.netty5.handler.codec.http.headers;
 
 import org.junit.jupiter.api.Assumptions;


### PR DESCRIPTION
Motivation:

While `emptyHeaders()` should usually stay empty, this is not enforced in netty 5. Thus, it is preferable to enable validation by default, in case the header map *is* modified.

Modification:

Enable validation for `emptyHeaders()`.

Result:

If the `emptyHeaders()` instance is wrongly modified, the values will be validated properly. This should have no performance impact, as validation is only done on modification, which ideally doesn't happen for `emptyHeaders()`.