### PR TITLE
Handle wildcard addresses in PcapWriteHandler

### DIFF
--- a/handler/src/test/java/io/netty/handler/pcap/PcapWriteHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/pcap/PcapWriteHandlerTest.java
@@ -28,20 +28,31 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ChannelPromise;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.embedded.CustomChannelId;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.DatagramChannel;
+import io.netty.channel.socket.DatagramChannelConfig;
 import io.netty.channel.socket.DatagramPacket;
+import io.netty.channel.socket.DefaultDatagramChannelConfig;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.channel.unix.DatagramSocketAddress;
 import io.netty.util.CharsetUtil;
 import io.netty.util.NetUtil;
 import io.netty.util.concurrent.Promise;
 
 import java.io.OutputStream;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketAddress;
+import java.net.SocketException;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
@@ -137,6 +148,29 @@ public class PcapWriteHandlerTest {
 
         // Verify the capture data
         verifyUdpCapture(true, pcapBuffer, serverAddr, clientAddr);
+
+        assertFalse(embeddedChannel.finishAndReleaseAll());
+    }
+
+    @Test
+    public void udpMixedAddress() throws SocketException {
+        final ByteBuf pcapBuffer = Unpooled.buffer();
+        final ByteBuf payload = Unpooled.wrappedBuffer("Meow".getBytes());
+
+        InetSocketAddress serverAddr = new InetSocketAddress("1.1.1.1", 1234);
+        // for ipv6 ::, it's allowed to connect to ipv4 on some systems
+        InetSocketAddress clientAddr = new InetSocketAddress("::", 3456);
+
+        // We fake a client
+        EmbeddedChannel embeddedChannel = new EmbeddedDatagramChannel(clientAddr, serverAddr);
+        embeddedChannel.pipeline().addLast(PcapWriteHandler.builder()
+                .build(new ByteBufOutputStream(pcapBuffer)));
+
+        assertTrue(embeddedChannel.writeOutbound(payload));
+        assertEquals(payload, embeddedChannel.readOutbound());
+
+        // Verify the capture data
+        verifyUdpCapture(true, pcapBuffer, serverAddr, new InetSocketAddress("0.0.0.0", 3456));
 
         assertFalse(embeddedChannel.finishAndReleaseAll());
     }
@@ -486,5 +520,162 @@ public class PcapWriteHandlerTest {
         assertTrue(ethernetPacket.release());
         assertTrue(ipv4Packet.release());
         assertTrue(udpPacket.release());
+    }
+
+    private static class EmbeddedDatagramChannel extends EmbeddedChannel implements DatagramChannel {
+        private final InetSocketAddress local;
+        private final InetSocketAddress remote;
+        private DatagramChannelConfig config;
+
+        EmbeddedDatagramChannel(InetSocketAddress local, InetSocketAddress remote) {
+            super(new CustomChannelId(1), false);
+            this.local = local;
+            this.remote = remote;
+        }
+
+        @Override
+        public boolean isConnected() {
+            return true;
+        }
+
+        @Override
+        public DatagramChannelConfig config() {
+            if (config == null) {
+                // ick! config() is called by the super constructor, so we need to do this.
+                try {
+                    config = new DefaultDatagramChannelConfig(this, new DatagramSocket());
+                } catch (SocketException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            return config;
+        }
+
+        @Override
+        public InetSocketAddress localAddress() {
+            return (InetSocketAddress) super.localAddress();
+        }
+
+        @Override
+        public InetSocketAddress remoteAddress() {
+            return (InetSocketAddress) super.remoteAddress();
+        }
+
+        @Override
+        protected SocketAddress localAddress0() {
+            return local;
+        }
+
+        @Override
+        protected SocketAddress remoteAddress0() {
+            return remote;
+        }
+
+        @Override
+        public ChannelFuture joinGroup(InetAddress multicastAddress) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture joinGroup(InetAddress multicastAddress, ChannelPromise future) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture joinGroup(InetSocketAddress multicastAddress, NetworkInterface networkInterface) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture joinGroup(
+                InetSocketAddress multicastAddress,
+                NetworkInterface networkInterface,
+                ChannelPromise future) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture joinGroup(
+                InetAddress multicastAddress,
+                NetworkInterface networkInterface,
+                InetAddress source) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture joinGroup(
+                InetAddress multicastAddress,
+                NetworkInterface networkInterface,
+                InetAddress source,
+                ChannelPromise future) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture leaveGroup(InetAddress multicastAddress) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture leaveGroup(InetAddress multicastAddress, ChannelPromise future) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture leaveGroup(InetSocketAddress multicastAddress, NetworkInterface networkInterface) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture leaveGroup(
+                InetSocketAddress multicastAddress,
+                NetworkInterface networkInterface,
+                ChannelPromise future) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture leaveGroup(
+                InetAddress multicastAddress,
+                NetworkInterface networkInterface,
+                InetAddress source) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture leaveGroup(
+                InetAddress multicastAddress,
+                NetworkInterface networkInterface,
+                InetAddress source,
+                ChannelPromise future) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture block(
+                InetAddress multicastAddress,
+                NetworkInterface networkInterface,
+                InetAddress sourceToBlock) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture block(
+                InetAddress multicastAddress,
+                NetworkInterface networkInterface,
+                InetAddress sourceToBlock,
+                ChannelPromise future) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture block(InetAddress multicastAddress, InetAddress sourceToBlock) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelFuture block(InetAddress multicastAddress, InetAddress sourceToBlock, ChannelPromise future) {
+            throw new UnsupportedOperationException();
+        }
     }
 }

--- a/handler/src/test/java/io/netty/handler/pcap/PcapWriteHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/pcap/PcapWriteHandlerTest.java
@@ -29,9 +29,9 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
+import io.netty.channel.DefaultChannelId;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.SimpleChannelInboundHandler;
-import io.netty.channel.embedded.CustomChannelId;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.DatagramChannel;
@@ -42,7 +42,6 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
-import io.netty.channel.unix.DatagramSocketAddress;
 import io.netty.util.CharsetUtil;
 import io.netty.util.NetUtil;
 import io.netty.util.concurrent.Promise;
@@ -528,7 +527,7 @@ public class PcapWriteHandlerTest {
         private DatagramChannelConfig config;
 
         EmbeddedDatagramChannel(InetSocketAddress local, InetSocketAddress remote) {
-            super(new CustomChannelId(1), false);
+            super(DefaultChannelId.newInstance(), false);
             this.local = local;
             this.remote = remote;
         }

--- a/transport/src/test/java/io/netty/channel/embedded/CustomChannelId.java
+++ b/transport/src/test/java/io/netty/channel/embedded/CustomChannelId.java
@@ -24,7 +24,7 @@ public class CustomChannelId implements ChannelId {
 
     private final int id;
 
-    CustomChannelId(int id) {
+    public CustomChannelId(int id) {
         this.id = id;
     }
 

--- a/transport/src/test/java/io/netty/channel/embedded/CustomChannelId.java
+++ b/transport/src/test/java/io/netty/channel/embedded/CustomChannelId.java
@@ -24,7 +24,7 @@ public class CustomChannelId implements ChannelId {
 
     private final int id;
 
-    public CustomChannelId(int id) {
+    CustomChannelId(int id) {
         this.id = id;
     }
 


### PR DESCRIPTION
Motivation:

If a UDP socket is bound to :: or 0.0.0.0, on some systems, it can still send packets to addresses of the other address family. This leads to a mismatch between the local and remote address families, that PcapWriteHandler cannot handle.

Modification:

In this scenario, coerce the local wildcard address to the wildcard address of the proper family.

Result:

Local wildcard address is handled properly and packets are logged as expected.