### PR TITLE
Optimize code in method PoolChunk.free(...)

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolChunk.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunk.java
@@ -474,7 +474,6 @@ final class PoolChunk<T> implements PoolChunkMetric {
      * @param handle handle to free
      */
     void free(long handle, int normCapacity, ByteBuffer nioBuffer) {
-        int runSize = runSize(pageShifts, handle);
         if (isSubpage(handle)) {
             int sizeIdx = arena.size2SizeIdx(normCapacity);
             PoolSubpage<T> head = arena.findSubpagePoolHead(sizeIdx);
@@ -499,6 +498,7 @@ final class PoolChunk<T> implements PoolChunkMetric {
             }
         }
 
+        int runSize = runSize(pageShifts, handle);
         //start free run
         runsAvailLock.lock();
         try {


### PR DESCRIPTION
Motivation:

The `runSize` may not be used if `PoolSubpage` does not need to be freed, so it's better to calculate `runSize` after the `if(...)` block.

Modification:

Calculate `runSize` after the `if(...)` block.

Result:

Avoid calculating`runSize` if `PoolSubpage` does not need to be freed.
