### PR TITLE
Change read-only behavior of composite buffers for netty 5

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/BufferAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/BufferAllocator.java
@@ -174,6 +174,49 @@ public interface BufferAllocator extends SafeCloseable {
     }
 
     /**
+     * Compose the send of a buffer and present them as a single buffer.
+     * <p>
+     * When a composite buffer is closed, all of its constituent component buffers are closed as well.
+     * <p>
+     * See the class documentation for more information on how buffers compose, and what is required of the given
+     * buffers for composition to be allowed.
+     *
+     * @param send The sent buffer to compose into a single buffer view.
+     * @return A buffer composed of, and backed by, the given buffers.
+     * @throws IllegalStateException if one of the sends have already been received. The remaining buffers and sends
+     * will be closed and discarded, respectively.
+     */
+    default CompositeBuffer composeReadOnly(Send<Buffer> send) {
+        return DefaultCompositeBuffer.composeReadOnly(this, Collections.singleton(send));
+    }
+
+    /**
+     * Compose the given sequence of sends of buffers and present them as a single buffer.
+     * <p>
+     * When a composite buffer is closed, all of its constituent component buffers are closed as well.
+     * <p>
+     * See the class documentation for more information on how buffers compose, and what is required of the given
+     * buffers for composition to be allowed.
+     *
+     * @param sends The sent buffers to compose into a single buffer view.
+     * @return A buffer composed of, and backed by, the given buffers.
+     * @throws IllegalStateException if one of the sends have already been received. The remaining buffers and sends
+     * will be closed and discarded, respectively.
+     */
+    default CompositeBuffer composeReadOnly(Iterable<Send<Buffer>> sends) {
+        return DefaultCompositeBuffer.composeReadOnly(this, sends);
+    }
+
+    /**
+     * Create an empty composite buffer, that has no components. The buffer can be extended with components using either
+     * {@link CompositeBuffer#ensureWritable(int)} or {@link CompositeBuffer#extendWith(Send)}.
+     * @return A composite buffer that has no components, and has a capacity of zero.
+     */
+    default CompositeBuffer composeReadOnly() {
+        return DefaultCompositeBuffer.composeReadOnly(this);
+    }
+
+    /**
      * Create a supplier of "constant" {@linkplain Buffer Buffers} from this allocator, that all have the given
      * byte contents. The buffer has the same capacity as the byte array length, and its write offset is placed at the
      * end, and its read offset is at the beginning, such that the entire buffer contents are readable.

--- a/buffer/src/main/java/io/netty5/buffer/CompositeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/CompositeBuffer.java
@@ -118,6 +118,18 @@ public interface CompositeBuffer extends Buffer {
     }
 
     /**
+     * Create an empty composite buffer, that has no components. The buffer can be extended with components using either
+     * {@link #ensureWritable(int)} or {@link #extendWith(Send)}.
+     *
+     * @param allocator The allocator for the composite buffer. This allocator will be used e.g. to service
+     * {@link #ensureWritable(int)} calls.
+     * @return A composite buffer that has no components, and has a capacity of zero.
+     */
+    static CompositeBuffer composeReadOnly(BufferAllocator allocator) {
+        return DefaultCompositeBuffer.composeReadOnly(allocator);
+    }
+
+    /**
      * Check if the given buffer is a composite buffer or not.
      * @param composite The buffer to check.
      * @return {@code true} if the given buffer was created with {@link BufferAllocator#compose()},

--- a/buffer/src/test/java/io/netty5/buffer/tests/BufferCompositionTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/tests/BufferCompositionTest.java
@@ -270,7 +270,7 @@ public class BufferCompositionTest extends BufferTestSupport {
     @Test
     public void emptyCompositeBufferMustAllowExtendingWithReadOnlyBuffer() {
         try (BufferAllocator allocator = BufferAllocator.onHeapUnpooled()) {
-            try (CompositeBuffer composite = allocator.compose()) {
+            try (CompositeBuffer composite = allocator.composeReadOnly()) {
                 try (Buffer b = allocator.allocate(8).makeReadOnly()) {
                     composite.extendWith(b.send());
                     assertTrue(composite.readOnly());
@@ -447,7 +447,7 @@ public class BufferCompositionTest extends BufferTestSupport {
         try (BufferAllocator allocator = BufferAllocator.onHeapUnpooled();
              Buffer a = allocator.allocate(4).makeReadOnly();
              Buffer b = allocator.allocate(4).makeReadOnly();
-             Buffer composite = allocator.compose(asList(a.send(), b.send()))) {
+             Buffer composite = allocator.composeReadOnly(asList(a.send(), b.send()))) {
             assertTrue(composite.readOnly());
             verifyWriteInaccessible(composite, BufferReadOnlyException.class);
         }
@@ -492,12 +492,13 @@ public class BufferCompositionTest extends BufferTestSupport {
     }
 
     @Test
-    public void compositeReadOnlyBufferCannotBeExtendedWithWritableBuffer() {
+    public void compositeReadOnlyBufferCanBeExtendedWithWritableBuffer() {
         try (BufferAllocator allocator = BufferAllocator.onHeapUnpooled();
-             CompositeBuffer composite = allocator.compose(allocator.allocate(8).makeReadOnly().send())) {
+             CompositeBuffer composite = allocator.composeReadOnly(allocator.allocate(8).makeReadOnly().send())) {
             try (Buffer b = allocator.allocate(8)) {
-                assertThrows(IllegalArgumentException.class, () -> composite.extendWith(b.send()));
+                composite.extendWith(b.send());
             }
+            assertThat(composite.readOnly()).isTrue();
         }
     }
 


### PR DESCRIPTION
Prototype. @chrisvest thoughts?

**Motivation:**

A common use case for composite buffers is to aggregate data and then send it on, without copying. One example is `HttpObjectAggregator`, which combines multiple `HttpContent` objects into a single composite buffer, and then sends it on as a `FullHttpMessage`. In these use cases, the composite buffer is essentially treated as an equivalent but copy-less alternative to repeated `writeBytes` calls to a normal buffer.

When it comes to read-only buffers however, the composite buffer has a worse interaction with the buffers "written to it" than a normal buffer has. A composite buffer "guesses" its RO state from its first component, and any further components have to match that RO state.

For `HttpObjectAggregator`, this essentially means that you cannot send RO `HttpContent` objects, because netty generates RW buffers in most places, and RW and RO cannot be mixed. This is despite the fact that downstream consumers of the `FullHttpMessage` are unlikely to actually write to the `HttpContent`, and would be fine with an RO composite.

In netty 4, this restriction on mixing did not exist, and it would only blow up when a write attempt was made.

A workaround in netty 5 is to explicitly make any inputs read-only on extendWith. However since this aggregation pattern is so common, it is easy to miss this step and create code that is incompatible with RO buffers when it doesn't need to be, as is the case for `HttpObjectAggregator`.

**Modification:**

This PR explores a different approach. Composites do not infer their RO state from the first component anymore, and are instead constructed explicitly in RO or RW state. RO composites can now accept RW buffers, and make them RO on extend. RW composites retain the old behavior and will fail when an RO buffer is added. The `compose` method creates an RW composite by default (will now fail if the input or first extend call is RO), and there is a new `composeReadOnly` method to create an RO composite.

**Result:**

Classes like `HttpObjectAggregator` could now use `composeReadOnly` and become compatible with both RO and RW inputs without further changes. This also removes some of the "magic" of the automatic RO state detection. However it still requires a change in all the classes that use this pattern, and for more generic use cases (`CoalescingBufferQueue`), removes the ability to create RW composites when the developer knows all inputs are RW.

**Further work:**

A further change could be to allow extending RW composites with RO buffers, but making the composite (and its earlier components) RO when this happens. This would allow us to remove the `compositeReadOnly` methods again. For the aggregation use case, it would be very useful, because RO buffers can be used but if the developers control all inputs and ensure they're RW, they can still rely on the output being RW. It would also make the transition from netty 4 easier.

The big downside of allowing this is that it moves potential errors from the site that causes them. It might not be easy to tell which code adds an RO buffer and "pollutes" the composite causing it to become RO, and then causing code further downstream to break.

In my opinion however, since this aggregation use case is quite common, this would be a worthwhile tradeoff.