### PR TITLE
Fixing `AsciiString#lastIndexOf` To Respect The `offset`

### DIFF
--- a/common/src/main/java/io/netty/util/AsciiString.java
+++ b/common/src/main/java/io/netty/util/AsciiString.java
@@ -775,7 +775,7 @@ public final class AsciiString implements CharSequence, Comparable<CharSequence>
             return INDEX_NOT_FOUND;
         }
         final byte firstCharAsByte = c2b0(firstChar);
-        for (int i = offset + start; i >= 0; --i) {
+        for (int i = offset + start; i >= offset; --i) {
             if (value[i] == firstCharAsByte) {
                 int o1 = i, o2 = 0;
                 while (++o2 < subCount && b2c(value[++o1]) == subString.charAt(o2)) {

--- a/common/src/test/java/io/netty/util/AsciiStringCharacterTest.java
+++ b/common/src/test/java/io/netty/util/AsciiStringCharacterTest.java
@@ -364,6 +364,9 @@ public class AsciiStringCharacterTest {
 
     @Test
     public void testLastIndexOfCharSequence() {
+        final byte[] bytes = {'a', 'b', 'c', 'd', 'e'};
+        final AsciiString ascii = new AsciiString(bytes, 2, 3, false);
+
         assertEquals(0, new AsciiString("abcd").lastIndexOf("abcd", 0));
         assertEquals(0, new AsciiString("abcd").lastIndexOf("abc", 4));
         assertEquals(1, new AsciiString("abcd").lastIndexOf("bcd", 4));
@@ -374,11 +377,14 @@ public class AsciiStringCharacterTest {
         assertEquals(1, new AsciiString("abcdabcd", 4, 4).lastIndexOf("bcd", 4));
         assertEquals(3, new AsciiString("012345").lastIndexOf("345", 3));
         assertEquals(3, new AsciiString("012345").lastIndexOf("345", 6));
+        assertEquals(1, ascii.lastIndexOf("de", 3));
+        assertEquals(0, ascii.lastIndexOf("cde", 3));
 
         // Test with empty string
         assertEquals(0, new AsciiString("abcd").lastIndexOf("", 0));
         assertEquals(1, new AsciiString("abcd").lastIndexOf("", 1));
         assertEquals(3, new AsciiString("abcd", 1, 3).lastIndexOf("", 4));
+        assertEquals(3, ascii.lastIndexOf("", 3));
 
         // Test not found
         assertEquals(-1, new AsciiString("abcd").lastIndexOf("abcde", 0));
@@ -390,6 +396,9 @@ public class AsciiStringCharacterTest {
         assertEquals(-1, new AsciiString("012345").lastIndexOf("abc", 0));
         assertEquals(-1, new AsciiString("012345").lastIndexOf("abcdefghi", 0));
         assertEquals(-1, new AsciiString("012345").lastIndexOf("abcdefghi", 4));
+        assertEquals(-1, ascii.lastIndexOf("a", 3));
+        assertEquals(-1, ascii.lastIndexOf("abc", 3));
+        assertEquals(-1, ascii.lastIndexOf("ce", 3));
     }
 
     @Test


### PR DESCRIPTION
Motivation:
The current `AsciiString#lastIndexOf` implementation does not consider the offset.

Modification:
Fix it to respect the `offset`.

Result:
`AsciiString#lastIndexOf` now accurately finds the index.