### PR TITLE
Add support for snappy http content encoding

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
@@ -465,7 +465,7 @@ public class HttpContentCompressor extends HttpContentEncoder {
      * Compression Encoder Factory for create {@link SnappyFrameEncoder}
      * used to compress http content for snappy content encoding
      */
-    private final class SnappyEncoderFactory implements CompressionEncoderFactory {
+    private static final class SnappyEncoderFactory implements CompressionEncoderFactory {
 
         @Override
         public MessageToByteEncoder<ByteBuf> createEncoder() {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
@@ -198,7 +198,7 @@ public class HttpContentCompressor extends HttpContentEncoder {
                     deflateOptions = (DeflateOptions) compressionOption;
                 } else if (compressionOption instanceof ZstdOptions) {
                     zstdOptions = (ZstdOptions) compressionOption;
-                } else if(compressionOption instanceof  SnappyOptions) {
+                } else if (compressionOption instanceof SnappyOptions) {
                     snappyOptions = (SnappyOptions) compressionOption;
                 } else {
                     throw new IllegalArgumentException("Unsupported " + CompressionOptions.class.getSimpleName() +

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
@@ -22,7 +22,21 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.MessageToByteEncoder;
-import io.netty.handler.codec.compression.*;
+import io.netty.handler.codec.compression.Brotli;
+import io.netty.handler.codec.compression.BrotliEncoder;
+import io.netty.handler.codec.compression.BrotliOptions;
+import io.netty.handler.codec.compression.CompressionOptions;
+import io.netty.handler.codec.compression.DeflateOptions;
+import io.netty.handler.codec.compression.GzipOptions;
+import io.netty.handler.codec.compression.StandardCompressionOptions;
+import io.netty.handler.codec.compression.ZlibCodecFactory;
+import io.netty.handler.codec.compression.ZlibEncoder;
+import io.netty.handler.codec.compression.ZlibWrapper;
+import io.netty.handler.codec.compression.Zstd;
+import io.netty.handler.codec.compression.ZstdEncoder;
+import io.netty.handler.codec.compression.ZstdOptions;
+import io.netty.handler.codec.compression.SnappyFrameEncoder;
+import io.netty.handler.codec.compression.SnappyOptions;
 import io.netty.util.internal.ObjectUtil;
 
 /**

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentCompressorOptionsTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentCompressorOptionsTest.java
@@ -43,7 +43,8 @@ class HttpContentCompressorOptionsTest {
             StandardCompressionOptions.gzip(),
             StandardCompressionOptions.deflate(),
             StandardCompressionOptions.brotli(),
-            StandardCompressionOptions.zstd()
+            StandardCompressionOptions.zstd(),
+            StandardCompressionOptions.snappy()
         );
 
         String[] tests = {
@@ -70,7 +71,8 @@ class HttpContentCompressorOptionsTest {
             StandardCompressionOptions.gzip(),
             StandardCompressionOptions.deflate(),
             StandardCompressionOptions.brotli(),
-            StandardCompressionOptions.zstd()
+            StandardCompressionOptions.zstd(),
+            StandardCompressionOptions.snappy()
         );
 
         String[] tests = {
@@ -81,6 +83,33 @@ class HttpContentCompressorOptionsTest {
                 "compress, zstd;q=0.5", "zstd",
                 "zstd; q=0.5, identity", "zstd",
                 "zstd; q=0, deflate", "zstd",
+        };
+        for (int i = 0; i < tests.length; i += 2) {
+            String acceptEncoding = tests[i];
+            String contentEncoding = tests[i + 1];
+            String targetEncoding = compressor.determineEncoding(acceptEncoding);
+            assertEquals(contentEncoding, targetEncoding);
+        }
+    }
+
+    @Test
+    void testGetSnappyTargetContentEncoding() {
+        HttpContentCompressor compressor = new HttpContentCompressor(
+                StandardCompressionOptions.gzip(),
+                StandardCompressionOptions.deflate(),
+                StandardCompressionOptions.brotli(),
+                StandardCompressionOptions.zstd(),
+                StandardCompressionOptions.snappy()
+        );
+
+        String[] tests = {
+                // Accept-Encoding -> Content-Encoding
+                "", null,
+                "*;q=0.0", null,
+                "snappy", "snappy",
+                "compress, snappy;q=0.5", "snappy",
+                "snappy; q=0.5, identity", "snappy",
+                "snappy; q=0, deflate", "snappy",
         };
         for (int i = 0; i < tests.length; i += 2) {
             String acceptEncoding = tests[i];
@@ -122,7 +151,7 @@ class HttpContentCompressorOptionsTest {
 
     private static FullHttpRequest newRequest() {
         FullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
-        req.headers().set(HttpHeaderNames.ACCEPT_ENCODING, "br, zstd, gzip, deflate");
+        req.headers().set(HttpHeaderNames.ACCEPT_ENCODING, "br, zstd, snappy, gzip, deflate");
         return req;
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/CompressorHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/CompressorHttp2ConnectionEncoder.java
@@ -21,14 +21,33 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.ByteToMessageDecoder;
-import io.netty.handler.codec.compression.*;
+import io.netty.handler.codec.compression.BrotliEncoder;
+import io.netty.handler.codec.compression.ZlibCodecFactory;
+import io.netty.handler.codec.compression.ZlibWrapper;
+import io.netty.handler.codec.compression.Brotli;
+import io.netty.handler.codec.compression.BrotliOptions;
+import io.netty.handler.codec.compression.CompressionOptions;
+import io.netty.handler.codec.compression.DeflateOptions;
+import io.netty.handler.codec.compression.GzipOptions;
+import io.netty.handler.codec.compression.StandardCompressionOptions;
+import io.netty.handler.codec.compression.ZstdEncoder;
+import io.netty.handler.codec.compression.ZstdOptions;
+import io.netty.handler.codec.compression.SnappyFrameEncoder;
+import io.netty.handler.codec.compression.SnappyOptions;
 import io.netty.util.concurrent.PromiseCombiner;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.UnstableApi;
 
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_ENCODING;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
-import static io.netty.handler.codec.http.HttpHeaderValues.*;
+import static io.netty.handler.codec.http.HttpHeaderValues.BR;
+import static io.netty.handler.codec.http.HttpHeaderValues.DEFLATE;
+import static io.netty.handler.codec.http.HttpHeaderValues.GZIP;
+import static io.netty.handler.codec.http.HttpHeaderValues.IDENTITY;
+import static io.netty.handler.codec.http.HttpHeaderValues.X_DEFLATE;
+import static io.netty.handler.codec.http.HttpHeaderValues.X_GZIP;
+import static io.netty.handler.codec.http.HttpHeaderValues.ZSTD;
+import static io.netty.handler.codec.http.HttpHeaderValues.SNAPPY;
 
 /**
  * A decorating HTTP2 encoder that will compress data frames according to the {@code content-encoding} header for each

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
@@ -339,6 +339,54 @@ public class DataCompressionHttp2Test {
     }
 
     @Test
+    public void snappyEncodingSingleEmptyMessage() throws Exception {
+        final String text = "";
+        final ByteBuf data = Unpooled.copiedBuffer(text.getBytes());
+        bootstrapEnv(data.readableBytes());
+        try {
+            final Http2Headers headers = new DefaultHttp2Headers().method(POST).path(PATH)
+                    .set(HttpHeaderNames.CONTENT_ENCODING, HttpHeaderValues.SNAPPY);
+
+            runInChannel(clientChannel, new Http2Runnable() {
+                @Override
+                public void run() throws Http2Exception {
+                    clientEncoder.writeHeaders(ctxClient(), 3, headers, 0, false, newPromiseClient());
+                    clientEncoder.writeData(ctxClient(), 3, data.retain(), 0, true, newPromiseClient());
+                    clientHandler.flush(ctxClient());
+                }
+            });
+            awaitServer();
+            assertEquals(text, serverOut.toString(CharsetUtil.UTF_8.name()));
+        } finally {
+            data.release();
+        }
+    }
+
+    @Test
+    public void snappyEncodingSingleMessage() throws Exception {
+        final String text = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbccccccccccccccccccccccc";
+        final ByteBuf data = Unpooled.copiedBuffer(text.getBytes(CharsetUtil.UTF_8.name()));
+        bootstrapEnv(data.readableBytes());
+        try {
+            final Http2Headers headers = new DefaultHttp2Headers().method(POST).path(PATH)
+                    .set(HttpHeaderNames.CONTENT_ENCODING, HttpHeaderValues.SNAPPY);
+
+            runInChannel(clientChannel, new Http2Runnable() {
+                @Override
+                public void run() throws Http2Exception {
+                    clientEncoder.writeHeaders(ctxClient(), 3, headers, 0, false, newPromiseClient());
+                    clientEncoder.writeData(ctxClient(), 3, data.retain(), 0, true, newPromiseClient());
+                    clientHandler.flush(ctxClient());
+                }
+            });
+            awaitServer();
+            assertEquals(text, serverOut.toString(CharsetUtil.UTF_8.name()));
+        } finally {
+            data.release();
+        }
+    }
+
+    @Test
     public void deflateEncodingWriteLargeMessage() throws Exception {
         final int BUFFER_SIZE = 1 << 12;
         final byte[] bytes = new byte[BUFFER_SIZE];

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
@@ -341,7 +341,7 @@ public class DataCompressionHttp2Test {
     @Test
     public void snappyEncodingSingleEmptyMessage() throws Exception {
         final String text = "";
-        final ByteBuf data = Unpooled.copiedBuffer(text.getBytes());
+        final ByteBuf data = Unpooled.copiedBuffer(text.getBytes(CharsetUtil.US_ASCII));
         bootstrapEnv(data.readableBytes());
         try {
             final Http2Headers headers = new DefaultHttp2Headers().method(POST).path(PATH)
@@ -365,7 +365,7 @@ public class DataCompressionHttp2Test {
     @Test
     public void snappyEncodingSingleMessage() throws Exception {
         final String text = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbccccccccccccccccccccccc";
-        final ByteBuf data = Unpooled.copiedBuffer(text.getBytes(CharsetUtil.UTF_8.name()));
+        final ByteBuf data = Unpooled.copiedBuffer(text.getBytes(CharsetUtil.US_ASCII));
         bootstrapEnv(data.readableBytes());
         try {
             final Http2Headers headers = new DefaultHttp2Headers().method(POST).path(PATH)

--- a/codec/src/main/java/io/netty/handler/codec/compression/SnappyOptions.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/SnappyOptions.java
@@ -1,0 +1,9 @@
+package io.netty.handler.codec.compression;
+
+/**
+ * {@link SnappyOptions} holds config for
+ * Snappy compression.
+ */
+public class SnappyOptions implements CompressionOptions {
+    // Will add config if Snappy supports this
+}

--- a/codec/src/main/java/io/netty/handler/codec/compression/SnappyOptions.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/SnappyOptions.java
@@ -19,6 +19,6 @@ package io.netty.handler.codec.compression;
  * {@link SnappyOptions} holds config for
  * Snappy compression.
  */
-public class SnappyOptions implements CompressionOptions {
+public final class SnappyOptions implements CompressionOptions {
     // Will add config if Snappy supports this
 }

--- a/codec/src/main/java/io/netty/handler/codec/compression/SnappyOptions.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/SnappyOptions.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package io.netty.handler.codec.compression;
 
 /**

--- a/codec/src/main/java/io/netty/handler/codec/compression/StandardCompressionOptions.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/StandardCompressionOptions.java
@@ -68,6 +68,14 @@ public final class StandardCompressionOptions {
         return new ZstdOptions(compressionLevel, blockSize, maxEncodeSize);
     }
 
+    /**
+     * Create a new {@link SnappyOptions}
+     *
+     */
+    public static SnappyOptions snappy() {
+        return new SnappyOptions();
+    }
+
      /**
      * Default implementation of {@link GzipOptions} with
      * {@code compressionLevel()} set to 6, {@code windowBits()} set to 15 and {@code memLevel()} set to 8.


### PR DESCRIPTION
Motivation:

Since netty already supports the decompression of snappy's http content encoding, it should also consider supporting snappy's http content compression

Modification:

Add support for snappy http content encoding

Result:

Netty supports snappy http content encoding
