### PR TITLE
Marks lazily-initialized 'codeClass' field as volatile to fix TSAN da…

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseStatus.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseStatus.java
@@ -527,7 +527,7 @@ public class HttpResponseStatus implements Comparable<HttpResponseStatus> {
 
     private final int code;
     private final AsciiString codeAsText;
-    private HttpStatusClass codeClass;
+    private final HttpStatusClass codeClass;
 
     private final String reasonPhrase;
     private final byte[] bytes;
@@ -562,6 +562,7 @@ public class HttpResponseStatus implements Comparable<HttpResponseStatus> {
         }
 
         this.code = code;
+        this.codeClass = HttpStatusClass.valueOf(code);
         String codeString = Integer.toString(code);
         codeAsText = new AsciiString(codeString);
         this.reasonPhrase = reasonPhrase;
@@ -597,11 +598,7 @@ public class HttpResponseStatus implements Comparable<HttpResponseStatus> {
      * Returns the class of this {@link HttpResponseStatus}
      */
     public HttpStatusClass codeClass() {
-        HttpStatusClass type = this.codeClass;
-        if (type == null) {
-            this.codeClass = type = HttpStatusClass.valueOf(code);
-        }
-        return type;
+        return this.codeClass;
     }
 
     @Override


### PR DESCRIPTION
…ta race.

Motivation:

HttpStatusClass has only final fields so it's safe to do an unsynchronized write to codeClass in the Java memory model, but TSAN complains about unsafe writes without marking the field as volatile.

Modifications:

Marks lazily-initialized 'codeClass' field as volatile to fix TSAN data race.

Result:

TSAN checks will be happy.