### PR TITLE
HttpHeaderValidationUtil should reject chars past the 1 byte range

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderValidationUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderValidationUtil.java
@@ -151,13 +151,13 @@ public final class HttpHeaderValidationUtil {
         //  See: https://datatracker.ietf.org/doc/html/rfc7230#section-3.2
         //  And: https://datatracker.ietf.org/doc/html/rfc5234#appendix-B.1
         int b = value.charAt(0);
-        if (b < 0x21 || b == 0x7F) {
+        if (b < 0x21 || b == 0x7F || 0xFF < b) {
             return 0;
         }
         int length = value.length();
         for (int i = 1; i < length; i++) {
             b = value.charAt(i);
-            if (b < 0x20 && b != 0x09 || b == 0x7F) {
+            if (b < 0x20 && b != 0x09 || b == 0x7F || 0xFF < b) {
                 return i;
             }
         }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpHeaderValidationUtilTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpHeaderValidationUtilTest.java
@@ -236,6 +236,11 @@ public class HttpHeaderValidationUtilTest {
         assertEquals(0, validateValidHeaderValue(asCharSequence(value)));
     }
 
+    @Test
+    void decodingInvalidHeaderValuesMustFailIfFirstCharIsIllegalAsciiString() {
+        assertEquals(0, validateValidHeaderValue("" + (char) (0xFF + 1)));
+    }
+
     public static List<AsciiString> legalFirstChar() {
         List<AsciiString> list = new ArrayList<AsciiString>();
 
@@ -285,6 +290,11 @@ public class HttpHeaderValidationUtilTest {
     @MethodSource("illegalNotFirstChar")
     void decodingInvalidHeaderValuesMustFailIfNotFirstCharIsIllegalCharSequence(AsciiString value) {
         assertEquals(1, validateValidHeaderValue(asCharSequence(value)));
+    }
+
+    @Test
+    void decodingInvalidHeaderValuesMustFailIfNotFirstCharIsIllegalCharSequence() {
+        assertEquals(1, validateValidHeaderValue("a" + (char) (0xFF + 1)));
     }
 
     public static List<AsciiString> legalNotFirstChar() {


### PR DESCRIPTION
Motivation:

When we use HttpHeaderValidationUtil to validate a non-AsciiString CharSequence we check each byte but don't consider whether it is larger than the max value of 0xFF of obs-text.

Modification:

Check is the value is larger than 0xFF.

Result:

We reject more illegal characters.

Relates to #13540.