### PR TITLE
Optimize method HttpStatusClass.valueOf(int)

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpStatusClass.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpStatusClass.java
@@ -68,7 +68,15 @@ public enum HttpStatusClass {
         if (UNKNOWN.contains(code)) {
             return UNKNOWN;
         }
-        return statusArray[code / 100];
+        return statusArray[fast_div100(code)];
+    }
+
+    /**
+     * @param dividend Must >= 0
+     * @return dividend/100
+     */
+    private static int fast_div100(int dividend) {
+        return (int) ((dividend * 1374389535L) >> 37);
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpStatusClass.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpStatusClass.java
@@ -52,24 +52,24 @@ public enum HttpStatusClass {
         }
     };
 
+    private static final HttpStatusClass[] statusArray = new HttpStatusClass[5];
+
+    static {
+        statusArray[0] = INFORMATIONAL;
+        statusArray[1] = SUCCESS;
+        statusArray[2] = REDIRECTION;
+        statusArray[3] = CLIENT_ERROR;
+        statusArray[4] = SERVER_ERROR;
+    }
+
     /**
      * Returns the class of the specified HTTP status code.
      */
     public static HttpStatusClass valueOf(int code) {
-        switch (code / 100) {
-            // 1xx
-            case 1: return INFORMATIONAL;
-            // 2xx
-            case 2: return SUCCESS;
-            // 3xx
-            case 3: return REDIRECTION;
-            // 4xx
-            case 4: return CLIENT_ERROR;
-            // 5xx
-            case 5: return SERVER_ERROR;
-            // others
-            default: return UNKNOWN;
+        if (UNKNOWN.contains(code)) {
+            return UNKNOWN;
         }
+        return statusArray[(code / 100) - 1];
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpStatusClass.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpStatusClass.java
@@ -52,24 +52,24 @@ public enum HttpStatusClass {
         }
     };
 
-    private static final HttpStatusClass[] statusArray = new HttpStatusClass[5];
-
-    static {
-        statusArray[0] = INFORMATIONAL;
-        statusArray[1] = SUCCESS;
-        statusArray[2] = REDIRECTION;
-        statusArray[3] = CLIENT_ERROR;
-        statusArray[4] = SERVER_ERROR;
-    }
-
     /**
      * Returns the class of the specified HTTP status code.
      */
     public static HttpStatusClass valueOf(int code) {
-        if (UNKNOWN.contains(code)) {
-            return UNKNOWN;
+        switch (code / 100) {
+            // 1xx
+            case 1: return INFORMATIONAL;
+            // 2xx
+            case 2: return SUCCESS;
+            // 3xx
+            case 3: return REDIRECTION;
+            // 4xx
+            case 4: return CLIENT_ERROR;
+            // 5xx
+            case 5: return SERVER_ERROR;
+            // others
+            default: return UNKNOWN;
         }
-        return statusArray[(code / 100) - 1];
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpStatusClass.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpStatusClass.java
@@ -56,22 +56,20 @@ public enum HttpStatusClass {
      * Returns the class of the specified HTTP status code.
      */
     public static HttpStatusClass valueOf(int code) {
-        if (INFORMATIONAL.contains(code)) {
-            return INFORMATIONAL;
+        switch (code / 100) {
+            // 1xx
+            case 1: return INFORMATIONAL;
+            // 2xx
+            case 2: return SUCCESS;
+            // 3xx
+            case 3: return REDIRECTION;
+            // 4xx
+            case 4: return CLIENT_ERROR;
+            // 5xx
+            case 5: return SERVER_ERROR;
+            // others
+            default: return UNKNOWN;
         }
-        if (SUCCESS.contains(code)) {
-            return SUCCESS;
-        }
-        if (REDIRECTION.contains(code)) {
-            return REDIRECTION;
-        }
-        if (CLIENT_ERROR.contains(code)) {
-            return CLIENT_ERROR;
-        }
-        if (SERVER_ERROR.contains(code)) {
-            return SERVER_ERROR;
-        }
-        return UNKNOWN;
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpStatusClass.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpStatusClass.java
@@ -52,24 +52,23 @@ public enum HttpStatusClass {
         }
     };
 
+    private static final HttpStatusClass[] statusArray = new HttpStatusClass[6];
+    static {
+        statusArray[1] = INFORMATIONAL;
+        statusArray[2] = SUCCESS;
+        statusArray[3] = REDIRECTION;
+        statusArray[4] = CLIENT_ERROR;
+        statusArray[5] = SERVER_ERROR;
+    }
+
     /**
      * Returns the class of the specified HTTP status code.
      */
     public static HttpStatusClass valueOf(int code) {
-        switch (code / 100) {
-            // 1xx
-            case 1: return INFORMATIONAL;
-            // 2xx
-            case 2: return SUCCESS;
-            // 3xx
-            case 3: return REDIRECTION;
-            // 4xx
-            case 4: return CLIENT_ERROR;
-            // 5xx
-            case 5: return SERVER_ERROR;
-            // others
-            default: return UNKNOWN;
+        if (UNKNOWN.contains(code)) {
+            return UNKNOWN;
         }
+        return statusArray[code / 100];
     }
 
     /**

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseStatusTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseStatusTest.java
@@ -21,8 +21,10 @@ import org.junit.jupiter.api.function.Executable;
 
 import static io.netty.handler.codec.http.HttpResponseStatus.parseLine;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class HttpResponseStatusTest {
     @Test
@@ -109,5 +111,37 @@ public class HttpResponseStatusTest {
                 parseLine(new AsciiString("200a foo"));
             }
         });
+    }
+
+    @Test
+    public void testHttpStatusClassValueOf() {
+        // status scope: [100, 600).
+        for (int code = 100; code < 600; code ++) {
+            HttpStatusClass httpStatusClass = HttpStatusClass.valueOf(code);
+            assertNotSame(HttpStatusClass.UNKNOWN, httpStatusClass);
+            if (HttpStatusClass.INFORMATIONAL.contains(code)) {
+                assertEquals(HttpStatusClass.INFORMATIONAL, httpStatusClass);
+            } else if (HttpStatusClass.SUCCESS.contains(code)) {
+                assertEquals(HttpStatusClass.SUCCESS, httpStatusClass);
+            } else if (HttpStatusClass.REDIRECTION.contains(code)) {
+                assertEquals(HttpStatusClass.REDIRECTION, httpStatusClass);
+            } else if (HttpStatusClass.CLIENT_ERROR.contains(code)) {
+                assertEquals(HttpStatusClass.CLIENT_ERROR, httpStatusClass);
+            } else if (HttpStatusClass.SERVER_ERROR.contains(code)) {
+                assertEquals(HttpStatusClass.SERVER_ERROR, httpStatusClass);
+            } else {
+                fail("At least one of the if-branches above must be true");
+            }
+        }
+        // status scope: [Integer.MIN_VALUE, 100).
+        for (int code = Integer.MIN_VALUE; code < 100; code ++) {
+            HttpStatusClass httpStatusClass = HttpStatusClass.valueOf(code);
+            assertEquals(HttpStatusClass.UNKNOWN, httpStatusClass);
+        }
+        // status scope: [600, Integer.MAX_VALUE].
+        for (int code = 600; code > 0; code ++) {
+            HttpStatusClass httpStatusClass = HttpStatusClass.valueOf(code);
+            assertEquals(HttpStatusClass.UNKNOWN, httpStatusClass);
+        }
     }
 }

--- a/microbench/src/main/java/io/netty/handler/codec/http/HttpStatusValueOfBenchmark.java
+++ b/microbench/src/main/java/io/netty/handler/codec/http/HttpStatusValueOfBenchmark.java
@@ -15,7 +15,6 @@
  */
 package io.netty.handler.codec.http;
 import io.netty.microbench.util.AbstractMicrobenchmark;
-import io.netty.util.internal.SuppressJava6Requirement;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Level;
@@ -25,33 +24,183 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import io.netty.util.internal.SuppressJava6Requirement;
+import org.openjdk.jmh.profile.LinuxPerfNormProfiler;
+import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
+
+import java.math.BigDecimal;
+import java.text.DecimalFormat;
 import java.util.SplittableRandom;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.Throughput)
-@Warmup(iterations = 3, time = 1)
-@Measurement(iterations = 3, time = 1)
-@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 10, time = 1)
+@Measurement(iterations = 10, time = 1)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class HttpStatusValueOfBenchmark extends AbstractMicrobenchmark {
-
     private int[] data;
     private HttpStatusClass[] result;
-    @Param({ "25", "32", "63", "95" })
-    public int size;
+    @Param({"1300", "2600", "5300", "11000", "23000"})
+    private int size;
+    private final BigDecimal bdZero = new BigDecimal("0.00");
+    private final BigDecimal bdOne = new BigDecimal("1.00");
+    private final BigDecimal bdLowest = new BigDecimal("0.01");
+    private final DecimalFormat df = new DecimalFormat("##.##%");
+    public HttpStatusValueOfBenchmark() {
+        // disable assertion
+        super(true);
+    }
 
     @Setup(Level.Iteration)
     @SuppressJava6Requirement(reason = "suppress")
-    public void setup() {
+    public void setup(Blackhole bh) {
+        if (size < 100) {
+            throw new IllegalArgumentException("The size MUST > 100");
+        }
         final SplittableRandom random = new SplittableRandom();
+        // Equal the branch predictor.
+        int equalDistributedArraySize = 16000;
+        int[] dataSwitchCase = new int[equalDistributedArraySize];
+        initDistributedData("dataSwitchCase", dataSwitchCase, random, 0.166, 0.166, 0.166,
+                0.166, 0.166, 0.166, 0.0);
+        for (int i = 0; i < equalDistributedArraySize; i++) {
+            HttpStatusClass rs = HttpStatusClass.valueOf(dataSwitchCase[i]);
+            bh.consume(rs);
+        }
         data = new int[size];
         result = new HttpStatusClass[size];
-        for (int j = 0; j < size; j++) {
-            data[j] = random.nextInt(100, 700);
+        // Generate bench mark data.
+        initDistributedData("data", data, random, 0.38, 0.30, 0.15,
+                0.10, 0.05, 0.02, 0.0);
+    }
+
+    @SuppressJava6Requirement(reason = "suppress")
+    private void initDistributedData(String desc, int[] setUpData, SplittableRandom random, double informationalRatio,
+                                     double successRatio, double redirectionRatio, double clientErrorRatio,
+                                     double serverErrorRatio, double unknownRatio, double negativeRatio) {
+        BigDecimal[] bdArray = { BigDecimal.valueOf(informationalRatio), BigDecimal.valueOf(successRatio),
+                BigDecimal.valueOf(redirectionRatio), BigDecimal.valueOf(clientErrorRatio),
+                BigDecimal.valueOf(serverErrorRatio), BigDecimal.valueOf(unknownRatio),
+                BigDecimal.valueOf(negativeRatio) };
+        validateRatios(bdArray);
+
+        int totalCount = 0;
+        int informationalCount = (int) (setUpData.length * informationalRatio);
+        totalCount += informationalCount;
+        int successCount = (int) (setUpData.length * successRatio);
+        totalCount += successCount;
+        int redirectionCount = (int) (setUpData.length * redirectionRatio);
+        totalCount += redirectionCount;
+        int clientErrorCount = (int) (setUpData.length * clientErrorRatio);
+        totalCount += clientErrorCount;
+        int serverErrorCount = (int) (setUpData.length * serverErrorRatio);
+        totalCount += serverErrorCount;
+        int unknownCount = (int) (setUpData.length * unknownRatio);
+        totalCount += unknownCount;
+        int negativeCount = (int) (setUpData.length * negativeRatio);
+        totalCount += negativeCount;
+
+        double c1x = 0, c2x = 0, c3x = 0, c4x = 0, c5x = 0, c6x = 0, c7x = 0;
+        for (int i = 0; i < totalCount;) {
+            int code = random.nextInt(100, 800);
+            if (HttpStatusClass.INFORMATIONAL.contains(code) && informationalCount-- > 0) {
+                setUpData[i++] = code;
+                ++c1x;
+            }
+            if (HttpStatusClass.SUCCESS.contains(code) && successCount-- > 0) {
+                setUpData[i++] = code;
+                ++c2x;
+            }
+            if (HttpStatusClass.REDIRECTION.contains(code) && redirectionCount-- > 0) {
+                setUpData[i++] = code;
+                ++c3x;
+            }
+            if (HttpStatusClass.CLIENT_ERROR.contains(code) && clientErrorCount-- > 0) {
+                setUpData[i++] = code;
+                ++c4x;
+            }
+            if (HttpStatusClass.SERVER_ERROR.contains(code) && serverErrorCount-- > 0) {
+                setUpData[i++] = code;
+                ++c5x;
+            }
+            // UNKNOWN:[600,700)
+            if (code >= 600 && code < 700 && unknownCount-- > 0) {
+                int origin = BigDecimal.valueOf(negativeRatio).compareTo(bdZero) > 0 ? 0 : Integer.MIN_VALUE;
+                // Re-generate 'UNKNOWN' code.
+                do {
+                    code = random.nextInt(origin, Integer.MAX_VALUE);
+                } while (code >= 100 && code < 600);
+                setUpData[i++] = code;
+                ++c6x;
+            }
+            // Negative:[700,800)
+            if (code >= 700 && negativeCount-- > 0) {
+                // Re-generate Negative code.
+                code = random.nextInt(Integer.MIN_VALUE, 0);
+                setUpData[i++] = code;
+                ++c7x;
+            }
+        }
+
+        for (int i = (totalCount - 1); i < setUpData.length; i++) {
+            // Generate remaining elements from scope 1xx to 5xx
+            int code = random.nextInt(100, 600);
+            setUpData[i] = code;
+            if (HttpStatusClass.INFORMATIONAL.contains(code)) {
+                ++c1x;
+            }
+            if (HttpStatusClass.SUCCESS.contains(code)) {
+                ++c2x;
+            }
+            if (HttpStatusClass.REDIRECTION.contains(code)) {
+                ++c3x;
+            }
+            if (HttpStatusClass.CLIENT_ERROR.contains(code)) {
+                ++c4x;
+            }
+            if (HttpStatusClass.SERVER_ERROR.contains(code)) {
+                ++c5x;
+            }
+        }
+//        printCodePercentage(desc, setUpData.length, c1x, c2x, c3x, c4x, c5x, c6x, c7x);
+    }
+
+    private void validateRatios(BigDecimal[] bdArray ) {
+        BigDecimal bdSum = new BigDecimal("0.00");
+        for (BigDecimal bdParam : bdArray) {
+            if (bdParam.compareTo(bdZero) < 0) {
+                throw new IllegalArgumentException("Ratio can NOT be negative");
+            }
+            if (bdParam.compareTo(bdZero) > 0 && bdParam.compareTo(bdLowest) < 0) {
+                throw new IllegalArgumentException("If ratio != 0, then the ratio MUST >= 0.01");
+            }
+            bdSum = bdSum.add(bdParam);
+        }
+        if (bdSum.compareTo(bdOne) > 0) {
+            throw new IllegalArgumentException("Sum of ratios MUST <= 1");
         }
     }
 
+    private void printCodePercentage(String desc, int length, double c1x, double c2x, double c3x, double c4x, double c5x, double c6x, double c7x) {
+        System.out.println("\n" + desc + "===>"
+                +"INFORMATIONAL:" + df.format(c1x / length)
+                + ", SUCCESS:" + df.format(c2x / length)
+                + ", REDIRECTION:" + df.format(c3x / length)
+                + ", CLIENT_ERROR:" + df.format(c4x / length)
+                + ", SERVER_ERROR:" + df.format(c5x / length)
+                + ", UNKNOWN:" + df.format(c6x / length)
+                + ", NEGATIVE:" + df.format(c7x / length)
+        );
+    }
+
+    @Override
+    protected ChainedOptionsBuilder newOptionsBuilder() throws Exception {
+        return super.newOptionsBuilder().addProfiler(LinuxPerfNormProfiler.class);
+    }
+
     @Benchmark
-    public HttpStatusClass[] ofValue() {
+    public HttpStatusClass[] valueOf() {
         for (int i = 0; i < size; ++i) {
             result[i] = HttpStatusClass.valueOf(data[i]);
         }

--- a/microbench/src/main/java/io/netty/handler/codec/http/HttpStatusValueOfBenchmark.java
+++ b/microbench/src/main/java/io/netty/handler/codec/http/HttpStatusValueOfBenchmark.java
@@ -26,7 +26,9 @@ import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
-import org.openjdk.jmh.profile.*;
+import org.openjdk.jmh.profile.LinuxPerfNormProfiler;
+import org.openjdk.jmh.profile.ProfilerException;
+import org.openjdk.jmh.profile.ProfilerFactory;
 import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
 import org.openjdk.jmh.runner.options.ProfilerConfig;
 import java.text.DecimalFormat;
@@ -183,7 +185,7 @@ public class HttpStatusValueOfBenchmark extends AbstractMicrobenchmark {
     }
 
     private static final class CircularLink {
-        private CircularLink next = null;
+        private CircularLink next;
         private int value;
     }
 

--- a/microbench/src/main/java/io/netty/handler/codec/http/HttpStatusValueOfBenchmark.java
+++ b/microbench/src/main/java/io/netty/handler/codec/http/HttpStatusValueOfBenchmark.java
@@ -61,11 +61,12 @@ public class HttpStatusValueOfBenchmark extends AbstractMicrobenchmark {
         final SplittableRandom random = new SplittableRandom();
         // Equal the branch predictor.
         int equalDistributedArraySize = 16000;
-        int[] dataSwitchCase = new int[equalDistributedArraySize];
-        initDistributedData("dataSwitchCase", dataSwitchCase, random, 0.166, 0.166, 0.166,
-                0.166, 0.166, 0.166, 0.0);
+        int[] dataArrayIndex = new int[equalDistributedArraySize];
+        initDistributedData("dataArrayIndex", dataArrayIndex, random,
+                0.166, 0.166, 0.166, 0.166,
+                0.166, 0.166, 0.0);
         for (int i = 0; i < equalDistributedArraySize; i++) {
-            HttpStatusClass rs = HttpStatusClass.valueOf(dataSwitchCase[i]);
+            HttpStatusClass rs = HttpStatusClass.valueOf(dataArrayIndex[i]);
             bh.consume(rs);
         }
         data = new int[size];

--- a/microbench/src/main/java/io/netty/handler/codec/http/HttpStatusValueOfBenchmark.java
+++ b/microbench/src/main/java/io/netty/handler/codec/http/HttpStatusValueOfBenchmark.java
@@ -15,6 +15,7 @@
  */
 package io.netty.handler.codec.http;
 import io.netty.microbench.util.AbstractMicrobenchmark;
+import io.netty.util.internal.SuppressJava6Requirement;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Level;
@@ -25,12 +26,12 @@ import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
-import io.netty.util.internal.SuppressJava6Requirement;
-import org.openjdk.jmh.profile.LinuxPerfNormProfiler;
+import org.openjdk.jmh.profile.*;
 import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
-
-import java.math.BigDecimal;
+import org.openjdk.jmh.runner.options.ProfilerConfig;
 import java.text.DecimalFormat;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.SplittableRandom;
 import java.util.concurrent.TimeUnit;
 
@@ -38,153 +39,168 @@ import java.util.concurrent.TimeUnit;
 @Warmup(iterations = 10, time = 1)
 @Measurement(iterations = 10, time = 1)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
+@SuppressJava6Requirement(reason = "suppress")
 public class HttpStatusValueOfBenchmark extends AbstractMicrobenchmark {
-    private int[] data;
-    private HttpStatusClass[] result;
     @Param({"1300", "2600", "5300", "11000", "23000"})
     private int size;
-    private final BigDecimal bdZero = new BigDecimal("0.00");
-    private final BigDecimal bdOne = new BigDecimal("1.00");
-    private final BigDecimal bdLowest = new BigDecimal("0.01");
-    private final DecimalFormat df = new DecimalFormat("##.##%");
+    private static final SplittableRandom random = new SplittableRandom();
+    private static final DecimalFormat df = new DecimalFormat("##.##%");
+    private CircularLink head;
+    private static final CircularLink polluteDistributeHead;
+    private static final Map<Integer, CircularLink> sizeMap = new HashMap<Integer, CircularLink>();
+
+    static {
+        sizeMap.put(1300, initCircularLink(1300));
+        sizeMap.put(2600, initCircularLink(2600));
+        sizeMap.put(5300, initCircularLink(5300));
+        sizeMap.put(11000, initCircularLink(11000));
+        sizeMap.put(23000, initCircularLink(23000));
+        polluteDistributeHead = initCircularLink(16000);
+        fillPolluteDistributeData(16000, polluteDistributeHead);
+    }
+
+    @Setup(Level.Invocation)
+    public void setup(Blackhole bh) {
+        // Pollute the branch predictor.
+        CircularLink cl = polluteDistributeHead;
+        do {
+            bh.consume(HttpStatusClass.valueOf(cl.value));
+        } while ((cl = cl.next) != polluteDistributeHead);
+
+        head = sizeMap.get(size);
+        // Fill benchmark data.
+        fillBenchMarkData(size, head);
+    }
+
+    @Benchmark
+    public void valueOf(Blackhole bh) {
+        CircularLink cl = head;
+        do {
+            bh.consume(HttpStatusClass.valueOf(cl.value));
+        } while ((cl = cl.next) != head);
+    }
+
     public HttpStatusValueOfBenchmark() {
         // disable assertion
         super(true);
     }
 
-    @Setup(Level.Iteration)
-    @SuppressJava6Requirement(reason = "suppress")
-    public void setup(Blackhole bh) {
-        if (size < 100) {
-            throw new IllegalArgumentException("The size MUST > 100");
-        }
-        final SplittableRandom random = new SplittableRandom();
-        // Equal the branch predictor.
-        int equalDistributedArraySize = 16000;
-        int[] dataArrayIndex = new int[equalDistributedArraySize];
-        initDistributedData("dataArrayIndex", dataArrayIndex, random,
-                0.166, 0.166, 0.166, 0.166,
-                0.166, 0.166, 0.0);
-        for (int i = 0; i < equalDistributedArraySize; i++) {
-            HttpStatusClass rs = HttpStatusClass.valueOf(dataArrayIndex[i]);
-            bh.consume(rs);
-        }
-        data = new int[size];
-        result = new HttpStatusClass[size];
-        // Generate bench mark data.
-        initDistributedData("data", data, random, 0.38, 0.30, 0.15,
-                0.10, 0.05, 0.02, 0.0);
-    }
-
-    @SuppressJava6Requirement(reason = "suppress")
-    private void initDistributedData(String desc, int[] setUpData, SplittableRandom random, double informationalRatio,
-                                     double successRatio, double redirectionRatio, double clientErrorRatio,
-                                     double serverErrorRatio, double unknownRatio, double negativeRatio) {
-        BigDecimal[] bdArray = { BigDecimal.valueOf(informationalRatio), BigDecimal.valueOf(successRatio),
-                BigDecimal.valueOf(redirectionRatio), BigDecimal.valueOf(clientErrorRatio),
-                BigDecimal.valueOf(serverErrorRatio), BigDecimal.valueOf(unknownRatio),
-                BigDecimal.valueOf(negativeRatio) };
-        validateRatios(bdArray);
-
-        int totalCount = 0;
-        int informationalCount = (int) (setUpData.length * informationalRatio);
-        totalCount += informationalCount;
-        int successCount = (int) (setUpData.length * successRatio);
-        totalCount += successCount;
-        int redirectionCount = (int) (setUpData.length * redirectionRatio);
-        totalCount += redirectionCount;
-        int clientErrorCount = (int) (setUpData.length * clientErrorRatio);
-        totalCount += clientErrorCount;
-        int serverErrorCount = (int) (setUpData.length * serverErrorRatio);
-        totalCount += serverErrorCount;
-        int unknownCount = (int) (setUpData.length * unknownRatio);
-        totalCount += unknownCount;
-        int negativeCount = (int) (setUpData.length * negativeRatio);
-        totalCount += negativeCount;
-
-        double c1x = 0, c2x = 0, c3x = 0, c4x = 0, c5x = 0, c6x = 0, c7x = 0;
-        for (int i = 0; i < totalCount;) {
-            int code = random.nextInt(100, 800);
-            if (HttpStatusClass.INFORMATIONAL.contains(code) && informationalCount-- > 0) {
-                setUpData[i++] = code;
+    private static void fillBenchMarkData(int size, CircularLink head) {
+        double c1x = 0, c2x = 0, c3x = 0, c4x = 0, c5x = 0, c6x = 0;
+        CircularLink cl = head;
+        do {
+            // [0, 100)
+            int code = random.nextInt(0, 100);
+            // 38%
+            if (code < 38) {
+                cl.value = random.nextInt(100, 200);
                 ++c1x;
+                continue;
             }
-            if (HttpStatusClass.SUCCESS.contains(code) && successCount-- > 0) {
-                setUpData[i++] = code;
+            // 30%
+            if (code < 68) {
+                cl.value = random.nextInt(200, 300);
                 ++c2x;
+                continue;
             }
-            if (HttpStatusClass.REDIRECTION.contains(code) && redirectionCount-- > 0) {
-                setUpData[i++] = code;
+            // 15%
+            if (code < 83) {
+                cl.value = random.nextInt(300, 400);
                 ++c3x;
+                continue;
             }
-            if (HttpStatusClass.CLIENT_ERROR.contains(code) && clientErrorCount-- > 0) {
-                setUpData[i++] = code;
+            // 10%
+            if (code < 93) {
+                cl.value = random.nextInt(400, 500);
                 ++c4x;
+                continue;
             }
-            if (HttpStatusClass.SERVER_ERROR.contains(code) && serverErrorCount-- > 0) {
-                setUpData[i++] = code;
+            // 5%
+            if (code < 98) {
+                cl.value = random.nextInt(500, 600);
                 ++c5x;
+                continue;
             }
-            // UNKNOWN:[600,700)
-            if (code >= 600 && code < 700 && unknownCount-- > 0) {
-                int origin = BigDecimal.valueOf(negativeRatio).compareTo(bdZero) > 0 ? 0 : Integer.MIN_VALUE;
-                // Re-generate 'UNKNOWN' code.
-                do {
-                    code = random.nextInt(origin, Integer.MAX_VALUE);
-                } while (code >= 100 && code < 600);
-                setUpData[i++] = code;
-                ++c6x;
-            }
-            // Negative:[700,800)
-            if (code >= 700 && negativeCount-- > 0) {
-                // Re-generate Negative code.
-                code = random.nextInt(Integer.MIN_VALUE, 0);
-                setUpData[i++] = code;
-                ++c7x;
-            }
-        }
+            // 2%
+            cl.value = random.nextInt(-50, 50);
+            ++c6x;
+        } while (head != (cl = cl.next));
+//        printCodePercentage("initBenchMarkData", size, c1x, c2x, c3x, c4x, c5x, c6x);
+    }
 
-        for (int i = totalCount - 1; i < setUpData.length; i++) {
-            // Generate remaining elements from scope 1xx to 5xx
-            int code = random.nextInt(100, 600);
-            setUpData[i] = code;
-            if (HttpStatusClass.INFORMATIONAL.contains(code)) {
+    private static void fillPolluteDistributeData(int size, CircularLink head) {
+        double c1x = 0, c2x = 0, c3x = 0, c4x = 0, c5x = 0, c6x = 0;
+        CircularLink cl = head;
+        do {
+            // [0, 96)
+            int code = random.nextInt(0, 96);
+            // (100/6) %
+            if (code < 16) {
+                cl.value = random.nextInt(100, 200);
                 ++c1x;
+                continue;
             }
-            if (HttpStatusClass.SUCCESS.contains(code)) {
+            // (100/6) %
+            if (code < 32) {
+                cl.value = random.nextInt(200, 300);
                 ++c2x;
+                continue;
             }
-            if (HttpStatusClass.REDIRECTION.contains(code)) {
+            // (100/6) %
+            if (code < 48) {
+                cl.value = random.nextInt(300, 400);
                 ++c3x;
+                continue;
             }
-            if (HttpStatusClass.CLIENT_ERROR.contains(code)) {
+            // (100/6) %
+            if (code < 64) {
+                cl.value = random.nextInt(400, 500);
                 ++c4x;
+                continue;
             }
-            if (HttpStatusClass.SERVER_ERROR.contains(code)) {
+            // (100/6) %
+            if (code < 80) {
+                cl.value = random.nextInt(500, 600);
                 ++c5x;
+                continue;
             }
-        }
-//        printCodePercentage(desc, setUpData.length, c1x, c2x, c3x, c4x, c5x, c6x, c7x);
+            // (100/6) %
+            cl.value = random.nextInt(-50, 50);
+            ++c6x;
+        } while (head != (cl = cl.next));
+//        printCodePercentage("fillEqualDistributeData", size, c1x, c2x, c3x, c4x, c5x, c6x);
     }
 
-    private void validateRatios(BigDecimal[] bdArray) {
-        BigDecimal bdSum = new BigDecimal("0.00");
-        for (BigDecimal bdParam : bdArray) {
-            if (bdParam.compareTo(bdZero) < 0) {
-                throw new IllegalArgumentException("Ratio can NOT be negative");
-            }
-            if (bdParam.compareTo(bdZero) > 0 && bdParam.compareTo(bdLowest) < 0) {
-                throw new IllegalArgumentException("If ratio != 0, then the ratio MUST >= 0.01");
-            }
-            bdSum = bdSum.add(bdParam);
+    private static CircularLink initCircularLink(int size) {
+        CircularLink cl = new CircularLink();
+        CircularLink head = cl;
+        for (int i = 0 ; i < size - 1; i++) {
+            cl.next = new CircularLink();
+            cl = cl.next;
         }
-        if (bdSum.compareTo(bdOne) > 0) {
-            throw new IllegalArgumentException("Sum of ratios MUST <= 1");
-        }
+        cl.next = head;
+        return head;
     }
 
-    private void printCodePercentage(String desc, int length, double c1x, double c2x, double c3x, double c4x,
-                                     double c5x, double c6x, double c7x) {
+    private static final class CircularLink {
+        private CircularLink next = null;
+        private int value;
+    }
+
+    @Override
+    protected ChainedOptionsBuilder newOptionsBuilder() throws Exception {
+        Class<LinuxPerfNormProfiler> profilerClass = LinuxPerfNormProfiler.class;
+        try {
+            ProfilerFactory.getProfilerOrException(new ProfilerConfig(profilerClass.getCanonicalName()));
+        } catch (ProfilerException t) {
+            // Fall back to default.
+            return super.newOptionsBuilder();
+        }
+        return super.newOptionsBuilder().addProfiler(profilerClass);
+    }
+
+    private static void printCodePercentage(String desc, int length, double c1x, double c2x, double c3x, double c4x,
+                                            double c5x, double c6x) {
         System.out.println("\n" + desc + "===>"
                 + "INFORMATIONAL:" + df.format(c1x / length)
                 + ", SUCCESS:" + df.format(c2x / length)
@@ -192,20 +208,6 @@ public class HttpStatusValueOfBenchmark extends AbstractMicrobenchmark {
                 + ", CLIENT_ERROR:" + df.format(c4x / length)
                 + ", SERVER_ERROR:" + df.format(c5x / length)
                 + ", UNKNOWN:" + df.format(c6x / length)
-                + ", NEGATIVE:" + df.format(c7x / length)
         );
-    }
-
-    @Override
-    protected ChainedOptionsBuilder newOptionsBuilder() throws Exception {
-        return super.newOptionsBuilder().addProfiler(LinuxPerfNormProfiler.class);
-    }
-
-    @Benchmark
-    public HttpStatusClass[] valueOf() {
-        for (int i = 0; i < size; ++i) {
-            result[i] = HttpStatusClass.valueOf(data[i]);
-        }
-        return result;
     }
 }

--- a/microbench/src/main/java/io/netty/handler/codec/http/HttpStatusValueOfBenchmark.java
+++ b/microbench/src/main/java/io/netty/handler/codec/http/HttpStatusValueOfBenchmark.java
@@ -21,10 +21,11 @@ import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
-import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.BenchmarkParams;
 import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.profile.LinuxPerfNormProfiler;
 import org.openjdk.jmh.profile.ProfilerException;
@@ -32,48 +33,86 @@ import org.openjdk.jmh.profile.ProfilerFactory;
 import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
 import org.openjdk.jmh.runner.options.ProfilerConfig;
 import java.text.DecimalFormat;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.SplittableRandom;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.Throughput)
 @Warmup(iterations = 10, time = 1)
 @Measurement(iterations = 10, time = 1)
-@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
 @SuppressJava6Requirement(reason = "suppress")
 public class HttpStatusValueOfBenchmark extends AbstractMicrobenchmark {
-    @Param({"1300", "2600", "5300", "11000", "23000"})
-    private int size;
     private static final SplittableRandom random = new SplittableRandom();
     private static final DecimalFormat df = new DecimalFormat("##.##%");
-    private int[] benchmarkData;
-    private static final int[] polluteData;
-    private static final Map<Integer, int[]> sizeMap = new HashMap<Integer, int[]>();
-
-    static {
-        sizeMap.put(1300, new int[1300]);
-        sizeMap.put(2600, new int[2600]);
-        sizeMap.put(5300, new int[5300]);
-        sizeMap.put(11000, new int[11000]);
-        sizeMap.put(23000, new int[23000]);
-        polluteData = new int[16000];
-        fillPolluteData(polluteData);
-    }
+    private static final int[] data_1300 = new int[1300];
+    private static final int[] data_2600 = new int[2600];
+    private static final int[] data_5300 = new int[5300];
+    private static final int[] data_11000 = new int[11000];
+    private static final int[] data_23000 = new int[23000];
+    private static final boolean ENABLE_POLLUTE = false;
 
     @Setup(Level.Invocation)
-    public void setup(Blackhole bh) {
-        // Pollute the branch predictor.
-        for (int code : polluteData) {
-            bh.consume(HttpStatusClass.valueOf(code));
+    public void setup(Blackhole bh, BenchmarkParams benchmarkParams) {
+        switch (benchmarkParams.getOpsPerInvocation()) {
+            case 1300 :
+                polluteBranchIfEnabled(bh, data_1300);
+                fillBenchMarkData(data_1300);
+                break;
+            case 2600 :
+                polluteBranchIfEnabled(bh, data_2600);
+                fillBenchMarkData(data_2600);
+                break;
+            case 5300 :
+                polluteBranchIfEnabled(bh, data_5300);
+                fillBenchMarkData(data_5300);
+                break;
+            case 11000 :
+                polluteBranchIfEnabled(bh, data_11000);
+                fillBenchMarkData(data_11000);
+                break;
+            case 23000 :
+                polluteBranchIfEnabled(bh, data_23000);
+                fillBenchMarkData(data_23000);
+                break;
         }
-        benchmarkData = sizeMap.get(size);
-        fillBenchMarkData(benchmarkData);
     }
 
     @Benchmark
-    public void valueOf(Blackhole bh) {
-        for (int code : benchmarkData) {
+    @OperationsPerInvocation(1300)
+    public void valueOf_1300(Blackhole bh) {
+        for (int code : data_1300) {
+            bh.consume(HttpStatusClass.valueOf(code));
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(2600)
+    public void valueOf_2600(Blackhole bh) {
+        for (int code : data_2600) {
+            bh.consume(HttpStatusClass.valueOf(code));
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(5300)
+    public void valueOf_5300(Blackhole bh) {
+        for (int code : data_5300) {
+            bh.consume(HttpStatusClass.valueOf(code));
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(11000)
+    public void valueOf_11000(Blackhole bh) {
+        for (int code : data_11000) {
+            bh.consume(HttpStatusClass.valueOf(code));
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(23000)
+    public void valueOf_23000(Blackhole bh) {
+        for (int code : data_23000) {
             bh.consume(HttpStatusClass.valueOf(code));
         }
     }
@@ -81,6 +120,15 @@ public class HttpStatusValueOfBenchmark extends AbstractMicrobenchmark {
     public HttpStatusValueOfBenchmark() {
         // disable assertion
         super(true);
+    }
+
+    private static void polluteBranchIfEnabled(Blackhole bh, int[] polluteData) {
+        if (ENABLE_POLLUTE) {
+            fillPolluteData(polluteData);
+            for (int code : polluteData) {
+                bh.consume(HttpStatusClass.valueOf(code));
+            }
+        }
     }
 
     private static void fillBenchMarkData(int[] benchMarkData) {

--- a/microbench/src/main/java/io/netty/handler/codec/http/HttpStatusValueOfBenchmark.java
+++ b/microbench/src/main/java/io/netty/handler/codec/http/HttpStatusValueOfBenchmark.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package io.netty.handler.codec.http;
 import io.netty.microbench.util.AbstractMicrobenchmark;
 import io.netty.util.internal.SuppressJava6Requirement;
@@ -42,5 +57,4 @@ public class HttpStatusValueOfBenchmark extends AbstractMicrobenchmark {
         }
         return result;
     }
-
 }

--- a/microbench/src/main/java/io/netty/handler/codec/http/HttpStatusValueOfBenchmark.java
+++ b/microbench/src/main/java/io/netty/handler/codec/http/HttpStatusValueOfBenchmark.java
@@ -144,7 +144,7 @@ public class HttpStatusValueOfBenchmark extends AbstractMicrobenchmark {
             }
         }
 
-        for (int i = (totalCount - 1); i < setUpData.length; i++) {
+        for (int i = totalCount - 1; i < setUpData.length; i++) {
             // Generate remaining elements from scope 1xx to 5xx
             int code = random.nextInt(100, 600);
             setUpData[i] = code;
@@ -167,7 +167,7 @@ public class HttpStatusValueOfBenchmark extends AbstractMicrobenchmark {
 //        printCodePercentage(desc, setUpData.length, c1x, c2x, c3x, c4x, c5x, c6x, c7x);
     }
 
-    private void validateRatios(BigDecimal[] bdArray ) {
+    private void validateRatios(BigDecimal[] bdArray) {
         BigDecimal bdSum = new BigDecimal("0.00");
         for (BigDecimal bdParam : bdArray) {
             if (bdParam.compareTo(bdZero) < 0) {
@@ -183,9 +183,10 @@ public class HttpStatusValueOfBenchmark extends AbstractMicrobenchmark {
         }
     }
 
-    private void printCodePercentage(String desc, int length, double c1x, double c2x, double c3x, double c4x, double c5x, double c6x, double c7x) {
+    private void printCodePercentage(String desc, int length, double c1x, double c2x, double c3x, double c4x,
+                                     double c5x, double c6x, double c7x) {
         System.out.println("\n" + desc + "===>"
-                +"INFORMATIONAL:" + df.format(c1x / length)
+                + "INFORMATIONAL:" + df.format(c1x / length)
                 + ", SUCCESS:" + df.format(c2x / length)
                 + ", REDIRECTION:" + df.format(c3x / length)
                 + ", CLIENT_ERROR:" + df.format(c4x / length)

--- a/microbench/src/main/java/io/netty/handler/codec/http/HttpStatusValueOfBenchmark.java
+++ b/microbench/src/main/java/io/netty/handler/codec/http/HttpStatusValueOfBenchmark.java
@@ -1,0 +1,46 @@
+package io.netty.handler.codec.http;
+import io.netty.microbench.util.AbstractMicrobenchmark;
+import io.netty.util.internal.SuppressJava6Requirement;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.Warmup;
+import java.util.SplittableRandom;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 3, time = 1)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class HttpStatusValueOfBenchmark extends AbstractMicrobenchmark {
+
+    private int[] data;
+    private HttpStatusClass[] result;
+    @Param({ "25", "32", "63", "95" })
+    public int size;
+
+    @Setup(Level.Iteration)
+    @SuppressJava6Requirement(reason = "suppress")
+    public void setup() {
+        final SplittableRandom random = new SplittableRandom();
+        data = new int[size];
+        result = new HttpStatusClass[size];
+        for (int j = 0; j < size; j++) {
+            data[j] = random.nextInt(100, 700);
+        }
+    }
+
+    @Benchmark
+    public HttpStatusClass[] ofValue() {
+        for (int i = 0; i < size; ++i) {
+            result[i] = HttpStatusClass.valueOf(data[i]);
+        }
+        return result;
+    }
+
+}


### PR DESCRIPTION
Motivation:

The method `HttpStatusClass.valueOf(int)` can be optimized by replacing 'if branches' with 'switch cases'.
The 'switch cases' can be optimized by JIT to run faster than 'if branches'.
Refer https://stackoverflow.com/a/98024.

Modification:

Replace 'if-branches' with 'switch case'.

Result:

Remove the 'if-branches'.

