### PR TITLE
Sanitize all multibyte chars in HpackHuffmanEncoder

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackEncoder.java
@@ -305,7 +305,7 @@ final class HpackEncoder {
                 AsciiString asciiString = (AsciiString) string;
                 out.writeBytes(asciiString.array(), asciiString.arrayOffset(), asciiString.length());
             } else {
-                // Only ASCII is allowed in http2 headers, so It's fine to use this.
+                // Only ASCII is allowed in http2 headers, so it is fine to use this.
                 // https://tools.ietf.org/html/rfc7540#section-8.1.2
                 out.writeCharSequence(string, CharsetUtil.ISO_8859_1);
             }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackEncoder.java
@@ -305,7 +305,7 @@ final class HpackEncoder {
                 AsciiString asciiString = (AsciiString) string;
                 out.writeBytes(asciiString.array(), asciiString.arrayOffset(), asciiString.length());
             } else {
-                // Only ASCII is allowed in http2 headers, so its fine to use this.
+                // Only ASCII is allowed in http2 headers, so It's fine to use this.
                 // https://tools.ietf.org/html/rfc7540#section-8.1.2
                 out.writeCharSequence(string, CharsetUtil.ISO_8859_1);
             }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackHuffmanEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackHuffmanEncoder.java
@@ -87,7 +87,7 @@ final class HpackHuffmanEncoder {
         int n = 0;
 
         for (int i = 0; i < data.length(); i++) {
-            int b = sanitizeChar(data.charAt(i));
+            int b = AsciiString.c2b(data.charAt(i)) & 0xFF;
             int code = codes[b];
             int nbits = lengths[b];
 
@@ -133,21 +133,9 @@ final class HpackHuffmanEncoder {
     private int getEncodedLengthSlowPath(CharSequence data) {
         long len = 0;
         for (int i = 0; i < data.length(); i++) {
-            len += lengths[sanitizeChar(data.charAt(i))];
+            len += lengths[AsciiString.c2b(data.charAt(i)) & 0xFF];
         }
         return (int) (len + 7 >> 3);
-    }
-
-    /**
-     * Sanitize a character in a way that is similar to what {@link AsciiString#c2b} does. The difference is that it
-     * does not cast the sanitized character to a {@code byte}, instead it simply returns the sanitized character as a
-     * {@code char}.
-     *
-     * @param c input character to sanitize.
-     * @return '?' if the character is sanitized or the same input character is returned.
-     */
-    private char sanitizeChar(char c) {
-        return (c > 255) ? '?' : c; // 255 is max character value.
     }
 
     private final class EncodeProcessor implements ByteProcessor {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackHuffmanEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackHuffmanEncoder.java
@@ -87,7 +87,7 @@ final class HpackHuffmanEncoder {
         int n = 0;
 
         for (int i = 0; i < data.length(); i++) {
-            int b = AsciiString.c2b(data.charAt(i));
+            int b = sanitizeChar(data.charAt(i));
             int code = codes[b];
             int nbits = lengths[b];
 
@@ -133,9 +133,21 @@ final class HpackHuffmanEncoder {
     private int getEncodedLengthSlowPath(CharSequence data) {
         long len = 0;
         for (int i = 0; i < data.length(); i++) {
-            len += lengths[AsciiString.c2b(data.charAt(i))];
+            len += lengths[sanitizeChar(data.charAt(i))];
         }
         return (int) (len + 7 >> 3);
+    }
+
+    /**
+     * Sanitize a character in a way that is similar to what {@link AsciiString#c2b} does. The difference is that it
+     * does not cast the sanitized character to a {@code byte}, instead it simply returns the sanitized character as a
+     * {@code char}.
+     *
+     * @param c input character to sanitize.
+     * @return '?' if the character is sanitized or the same input character is returned.
+     */
+    private char sanitizeChar(char c) {
+        return (c > 255) ? '?' : c; // 255 is max character value.
     }
 
     private final class EncodeProcessor implements ByteProcessor {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackHuffmanEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackHuffmanEncoder.java
@@ -87,7 +87,7 @@ final class HpackHuffmanEncoder {
         int n = 0;
 
         for (int i = 0; i < data.length(); i++) {
-            int b = data.charAt(i) & 0xFF;
+            int b = AsciiString.c2b(data.charAt(i));
             int code = codes[b];
             int nbits = lengths[b];
 
@@ -133,7 +133,7 @@ final class HpackHuffmanEncoder {
     private int getEncodedLengthSlowPath(CharSequence data) {
         long len = 0;
         for (int i = 0; i < data.length(); i++) {
-            len += lengths[data.charAt(i) & 0xFF];
+            len += lengths[AsciiString.c2b(data.charAt(i))];
         }
         return (int) (len + 7 >> 3);
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackEncoderTest.java
@@ -206,40 +206,44 @@ public class HpackEncoderTest {
 
     @Test
     public void testSanitization() throws Http2Exception {
-        int smallHeaderValueSize = 10;
-        int mediumHeaderValueSize = 300;
-        int largeHeaderValueSize = 2000;
-        verifyHeaderValueSanitization(smallHeaderValueSize);
-        verifyHeaderValueSanitization(mediumHeaderValueSize);
-        verifyHeaderValueSanitization(largeHeaderValueSize);
+        final int headerValueSize = 300;
+        StringBuilder actualHeaderValueBuilder = new StringBuilder();
+        StringBuilder expectedHeaderValueBuilder = new StringBuilder();
+
+        for (int i = 0; i < headerValueSize; i++) {
+            actualHeaderValueBuilder.append((char) i); // Use the index as the code point value of the character.
+            if (i <= 255) {
+                expectedHeaderValueBuilder.append((char) i);
+            } else {
+                expectedHeaderValueBuilder.append('?'); // Expect this character to be sanitized.
+            }
+        }
+        String actualHeaderValue = actualHeaderValueBuilder.toString();
+        String expectedHeaderValue = expectedHeaderValueBuilder.toString();
+        HpackEncoder encoderWithHuffmanEncoding =
+                new HpackEncoder(false, 64, 0); // Low Huffman code threshold.
+        HpackEncoder encoderWithoutHuffmanEncoding =
+                new HpackEncoder(false, 64, Integer.MAX_VALUE); // High Huffman code threshold.
+
+        // Expect the same decoded header value regardless of whether Huffman encoding is enabled or not.
+        verifyHeaderValueSanitization(encoderWithHuffmanEncoding, actualHeaderValue, expectedHeaderValue);
+        verifyHeaderValueSanitization(encoderWithoutHuffmanEncoding, actualHeaderValue, expectedHeaderValue);
     }
 
-    private void verifyHeaderValueSanitization(int headerValueSize) throws Http2Exception {
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < headerValueSize; i++) {
-            sb.append((char) i); // Use the index as the code point value of the character.
-        }
-        String headerValue = sb.toString();
-        String headerKey = "some-key";
-        Http2Headers toBeEncodedHeaders = new DefaultHttp2Headers().add(headerKey, headerValue);
+    private void verifyHeaderValueSanitization(
+            HpackEncoder encoder,
+            String actualHeaderValue,
+            String expectedHeaderValue
+    ) throws Http2Exception {
 
-        hpackEncoder.encodeHeaders(0, buf, toBeEncodedHeaders, Http2HeadersEncoder.NEVER_SENSITIVE);
+        String headerKey = "some-key";
+        Http2Headers toBeEncodedHeaders = new DefaultHttp2Headers().add(headerKey, actualHeaderValue);
+        encoder.encodeHeaders(0, buf, toBeEncodedHeaders, Http2HeadersEncoder.NEVER_SENSITIVE);
         DefaultHttp2Headers decodedHeaders = new DefaultHttp2Headers();
         hpackDecoder.decode(0, buf, decodedHeaders, true);
         buf.clear();
-
-        CharSequence decodedHeaderValue = decodedHeaders.get(headerKey);
-        System.out.println(decodedHeaderValue);
-        for (int i = 0; i < headerValueSize; i++) {
-            char c = decodedHeaderValue.charAt(i);
-            if (i > 255) {
-                // All characters outside the range should be sanitized.
-                Assertions.assertEquals('?', c, "Should be sanitized.");
-            } else {
-                char expectedChar = (char) i;
-                Assertions.assertEquals(expectedChar, c, "Should not be sanitized.");
-            }
-        }
+        String decodedHeaderValue = decodedHeaders.get(headerKey).toString();
+        Assertions.assertEquals(expectedHeaderValue, decodedHeaderValue);
     }
 
     private void setMaxTableSize(int maxHeaderTableSize) throws Http2Exception {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackHuffmanTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackHuffmanTest.java
@@ -37,9 +37,11 @@ import io.netty.util.AsciiString;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
+import java.util.Arrays;
 import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -160,6 +162,39 @@ public class HpackHuffmanTest {
                 decode(buf);
             }
         });
+    }
+
+    @Test
+    public void testEncoderSanitizingMultiByteCharacters() throws Http2Exception {
+        final int inputLen = 500;
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < inputLen; i++) {
+            // Starts with 0x4E01 because certain suboptimal sanitization could cause some problem with this input. For
+            // example, if a multibyte character C is sanitized by doing (C & OxFF), if C == 0x4E01, then (0x4E01 & OxFF)
+            // is greater than zero which indicates insufficient sanitization.
+            sb.append((char) (0x4E01 + i));
+        }
+        HpackHuffmanEncoder encoder = new HpackHuffmanEncoder();
+        String toBeEncoded = sb.toString();
+        ByteBuf buffer = Unpooled.buffer();
+        byte[] bytes;
+        try {
+            encoder.encode(buffer, toBeEncoded);
+            bytes = new byte[buffer.readableBytes()];
+            buffer.readBytes(bytes);
+        } finally {
+            buffer.release(); // Release as soon as possible.
+        }
+        byte[] actualBytes = decode(bytes);
+        String actualDecoded = new String(actualBytes);
+        char[] charArray = new char[inputLen];
+        Arrays.fill(charArray, '?');
+        String expectedDecoded = new String(charArray);
+        assertEquals(
+                expectedDecoded,
+                actualDecoded,
+                "Expect the decoded string to be sanitized and contains only '?' characters."
+        );
     }
 
     private static byte[] makeBuf(int ... bytes) {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackHuffmanTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackHuffmanTest.java
@@ -169,9 +169,9 @@ public class HpackHuffmanTest {
         final int inputLen = 500;
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < inputLen; i++) {
-            // Starts with 0x4E01 because certain suboptimal sanitization could cause some problem with this input. For
-            // example, if a multibyte character C is sanitized by doing (C & OxFF), if C == 0x4E01, then (0x4E01 & OxFF)
-            // is greater than zero which indicates insufficient sanitization.
+            // Starts with 0x4E01 because certain suboptimal sanitization could cause some problem with this input.
+            // For example, if a multibyte character C is sanitized by doing (C & OxFF), if C == 0x4E01, then
+            // (0x4E01 & OxFF) is greater than zero which indicates insufficient sanitization.
             sb.append((char) (0x4E01 + i));
         }
         HpackHuffmanEncoder encoder = new HpackHuffmanEncoder();


### PR DESCRIPTION
Motivation:

To fix the following problem: during encoding, Huffman encoded headers are sanitized differently compared to non-Huffman encoded headers in `HpackEncoder`. As a result, characters with code point values higher than 0xFF which could be decoded to an unexpected control chars instead of `'?'`.

Modification:

Change how each character is sanitized in `HpackHuffmanEncoder`. Specifically, use the new approach [1] to replace the old approach [2].

[1] `AsciiString.c2b(aChar) & 0xFF`
[2] `aChar & 0xFF`

Expected output is `0` if `aChar > 0xFF`. But with the old approach, if `aChar == 0x4E01`, `0x4E01 & 0xFF == 1` which is incorrect.

Result:
All characters with code point values higher than 0xFF are decoded to `?`s regardless of whether Huffman encoding was used during encoding.

Fixes #13540