### PR TITLE
Honor SslHandler.setWrapDataSize greater than SSL packet length

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ConscryptAlpnSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ConscryptAlpnSslEngine.java
@@ -85,8 +85,7 @@ abstract class ConscryptAlpnSslEngine extends JdkSslEngine {
      */
     final int calculateOutNetBufSize(int plaintextBytes, int numBuffers) {
         // Assuming a max of one frame per component in a composite buffer.
-        long maxOverhead = (long) Conscrypt.maxSealOverhead(getWrappedEngine()) * numBuffers;
-        return (int) min(Integer.MAX_VALUE, plaintextBytes + maxOverhead);
+        return calculateSpace(plaintextBytes, numBuffers, Integer.MAX_VALUE);
     }
 
     /**
@@ -98,8 +97,12 @@ abstract class ConscryptAlpnSslEngine extends JdkSslEngine {
      * @return the maximum size of the encrypted output buffer required for the wrap operation.
      */
     final int calculateRequiredOutBufSpace(int plaintextBytes, int numBuffers) {
-        long maxOverhead = (long) Conscrypt.maxSealOverhead(getWrappedEngine()) * numBuffers;
-        return (int) min(Conscrypt.maxEncryptedPacketLength(), plaintextBytes + maxOverhead);
+        return calculateSpace(plaintextBytes, numBuffers, Conscrypt.maxEncryptedPacketLength());
+    }
+
+    private int calculateSpace(int plaintextBytes, int numBuffers, long maxPacketLength) {
+         long maxOverhead = (long) Conscrypt.maxSealOverhead(getWrappedEngine()) * numBuffers;
+         return (int) min(maxPacketLength, plaintextBytes + maxOverhead);
     }
 
     final SSLEngineResult unwrap(ByteBuffer[] srcs, ByteBuffer[] dests) throws SSLException {

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -705,8 +705,22 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
      * This method is intentionally not synchronized, only use if you know you are in the EventLoop
      * thread and visibility on {@link #maxWrapBufferSize} and {@link #maxWrapOverhead} is achieved
      * via other synchronized blocks.
+     * <br>
+     * Calculates the max size of a single wrap operation for the given plaintextLength and
+     * numComponents.
      */
-    final int calculateOutboundBufferLength(int plaintextLength, int numComponents) {
+    final int calculateMaxLengthForWrap(int plaintextLength, int numComponents) {
+        return (int) min(maxWrapBufferSize, plaintextLength + (long) maxWrapOverhead * numComponents);
+    }
+
+    /**
+     * This method is intentionally not synchronized, only use if you know you are in the EventLoop
+     * thread and visibility on {@link #maxWrapOverhead} is achieved via other synchronized blocks.
+     * <br>
+     * Calculates the size of the out net buf to create for the given plaintextLength and numComponents.
+     * This is not related to the max size per wrap, as we can wrap chunks at a time into one out net buf.
+     */
+    final int calculateOutNetBufSize(int plaintextLength, int numComponents) {
         return (int) min(MAX_VALUE, plaintextLength + (long) maxWrapOverhead * numComponents);
     }
 

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -72,6 +72,7 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import static io.netty.util.internal.ObjectUtil.checkNotNullArrayParam;
 import static io.netty.util.internal.ObjectUtil.checkNotNullWithIAE;
 import static java.lang.Integer.MAX_VALUE;
+import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static javax.net.ssl.SSLEngineResult.HandshakeStatus.FINISHED;
 import static javax.net.ssl.SSLEngineResult.HandshakeStatus.NEED_TASK;
@@ -705,8 +706,8 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
      * thread and visibility on {@link #maxWrapBufferSize} and {@link #maxWrapOverhead} is achieved
      * via other synchronized blocks.
      */
-    final int calculateMaxLengthForWrap(int plaintextLength, int numComponents) {
-        return (int) min(maxWrapBufferSize, plaintextLength + (long) maxWrapOverhead * numComponents);
+    final int calculateOutboundBufferLength(int plaintextLength, int numComponents) {
+        return (int) min(MAX_VALUE, plaintextLength + (long) maxWrapOverhead * numComponents);
     }
 
     final synchronized int sslPending() {

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
@@ -433,7 +433,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
         SSLEngine clientEngine = null;
         try {
             clientEngine = clientSslCtx.newEngine(UnpooledByteBufAllocator.DEFAULT);
-            int value = ((ReferenceCountedOpenSslEngine) clientEngine).calculateMaxLengthForWrap(MAX_VALUE, 1);
+            int value = ((ReferenceCountedOpenSslEngine) clientEngine).calculateOutboundBufferLength(MAX_VALUE, 1);
             assertTrue(value > 0);
         } finally {
             cleanupClientSslEngine(clientEngine);
@@ -452,7 +452,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
         SSLEngine clientEngine = null;
         try {
             clientEngine = clientSslCtx.newEngine(UnpooledByteBufAllocator.DEFAULT);
-            assertTrue(((ReferenceCountedOpenSslEngine) clientEngine).calculateMaxLengthForWrap(0, 1) > 0);
+            assertTrue(((ReferenceCountedOpenSslEngine) clientEngine).calculateOutboundBufferLength(0, 1) > 0);
         } finally {
             cleanupClientSslEngine(clientEngine);
         }

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
@@ -433,7 +433,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
         SSLEngine clientEngine = null;
         try {
             clientEngine = clientSslCtx.newEngine(UnpooledByteBufAllocator.DEFAULT);
-            int value = ((ReferenceCountedOpenSslEngine) clientEngine).calculateOutboundBufferLength(MAX_VALUE, 1);
+            int value = ((ReferenceCountedOpenSslEngine) clientEngine).calculateOutNetBufSize(MAX_VALUE, 1);
             assertTrue(value > 0);
         } finally {
             cleanupClientSslEngine(clientEngine);
@@ -452,7 +452,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
         SSLEngine clientEngine = null;
         try {
             clientEngine = clientSslCtx.newEngine(UnpooledByteBufAllocator.DEFAULT);
-            assertTrue(((ReferenceCountedOpenSslEngine) clientEngine).calculateOutboundBufferLength(0, 1) > 0);
+            assertTrue(((ReferenceCountedOpenSslEngine) clientEngine).calculateOutNetBufSize(0, 1) > 0);
         } finally {
             cleanupClientSslEngine(clientEngine);
         }

--- a/transport/src/main/java/io/netty/channel/AbstractCoalescingBufferQueue.java
+++ b/transport/src/main/java/io/netty/channel/AbstractCoalescingBufferQueue.java
@@ -160,8 +160,9 @@ public abstract class AbstractCoalescingBufferQueue {
                 }
 
                 entryBuffer = (ByteBuf) entry;
+                int bufferBytes = entryBuffer.readableBytes();
 
-                if (entryBuffer.readableBytes() > bytes) {
+                if (bufferBytes > bytes) {
                     // Add the buffer back to the queue as we can't consume all of it.
                     bufAndListenerPairs.addFirst(entryBuffer);
                     if (bytes > 0) {
@@ -175,10 +176,10 @@ public abstract class AbstractCoalescingBufferQueue {
                     break;
                 }
 
-                bytes -= entryBuffer.readableBytes();
+                bytes -= bufferBytes;
                 if (toReturn == null) {
                     // if there are no more bytes in the queue after this, there's no reason to compose
-                    toReturn = entryBuffer.readableBytes() == readableBytes
+                    toReturn = bufferBytes == readableBytes
                             ? entryBuffer
                             : composeFirst(alloc, entryBuffer);
                 } else {


### PR DESCRIPTION
**NOTE**: The idea is sound and has been tested in my environment, but the implementation varies from my original POC. I think this approach fits better into the ecosystem, but I have not fully run all the tests locally or validated this approach yet. I wanted to post this in case anyone happens to see my issue #13549 and wanted to see an example of my idea.

Motivation:

When processing large responses, chunking them into many 16kb chunks causes excessive load on PoolArena which slows down AbstractUnsafe.flush0.

Modifications:

Allocate an outNetBuf based on setWrapDataSize. If setWrapDataSize is larger than SSL packet length, iteratively slice the data buffer, encrypting chunks into the one larger output buffer.

Reduce unnecessary composition in AbstractCoalescingBufferQueue when a call to remove() only needs to process one buffer.

Result:

Eliminate contention in PoolArena relative to splitting large responses, thus increasing overall throughput and reducing overall memory pressure.

Relates to #13549 