### PR TITLE
Revert "Make initializer as `static` (#13506)"

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoopGroup.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoopGroup.java
@@ -36,7 +36,9 @@ import java.util.concurrent.ThreadFactory;
  */
 public final class EpollEventLoopGroup extends MultithreadEventLoopGroup {
 
-    static {
+    // This does not use static by design to ensure the class can be loaded and only do the check when its actually
+    // instanced.
+    {
         // Ensure JNI is initialized by the time this class is loaded.
         Epoll.ensureAvailability();
     }

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoopGroup.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoopGroup.java
@@ -33,11 +33,12 @@ import java.util.concurrent.ThreadFactory;
 @UnstableApi
 public final class KQueueEventLoopGroup extends MultithreadEventLoopGroup {
 
-    static {
+    // This does not use static by design to ensure the class can be loaded and only do the check when its actually
+    // instanced.
+    {
         // Ensure JNI is initialized by the time this class is loaded by this time!
         KQueue.ensureAvailability();
     }
-
     /**
      * Create a new instance using the default number of threads and the default {@link ThreadFactory}.
      */


### PR DESCRIPTION
Motivations:

By changing the code to use a static block we did remove the ability to load the class at all. This is sort of a regression as it may break existing code.

Modifications:

This reverts commit 1c7f0faac060313bfd313d0a50fdf83a2fd2c9c9.

Result:

It's possible again to at least load the class all the time as before.