### PR TITLE
Enable client side session cache when using native SSL by default

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -115,10 +115,8 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
 
     static final boolean SERVER_ENABLE_SESSION_CACHE =
             SystemPropertyUtil.getBoolean("io.netty.handler.ssl.openssl.sessionCacheServer", true);
-    // session caching is disabled by default on the client side due a JDK bug:
-    // https://mail.openjdk.java.net/pipermail/security-dev/2021-March/024758.html
     static final boolean CLIENT_ENABLE_SESSION_CACHE =
-            SystemPropertyUtil.getBoolean("io.netty.handler.ssl.openssl.sessionCacheClient", false);
+            SystemPropertyUtil.getBoolean("io.netty.handler.ssl.openssl.sessionCacheClient", true);
 
     /**
      * The OpenSSL SSL_CTX object.


### PR DESCRIPTION
Motivation:

When we introduced support for client side session caching for our native SSL implementation we disabled it by default as some java versions had a bug that could result in a NPE. This was fixed for all java versions >= 8 for a while. Let's enable it by default so people will receive the performance gains with the need to adjust properties.

Related JDK ticket:
https://bugs.openjdk.org/browse/JDK-8241248

Modifications:

Set io.netty.handler.ssl.openssl.sessionCacheClient to true by default

Result:

Enable client session caching by default.
