### PR TITLE
SSLSession.getPeerCertificateChain() should throw UnsupportedOperatio…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
@@ -73,6 +73,8 @@ public final class OpenSsl {
     static final String EXTRA_SUPPORTED_TLS_1_3_CIPHERS_STRING;
     static final String[] NAMED_GROUPS;
 
+    static final boolean JAVAX_CERTIFICATE_CREATION_SUPPORTED;
+
     // Use default that is supported in java 11 and earlier and also in OpenSSL / BoringSSL.
     // See https://github.com/netty/netty-tcnative/issues/567
     // See https://www.java.com/en/configure_crypto.html for ordering
@@ -442,6 +444,18 @@ public final class OpenSsl {
                 logger.debug("Supported protocols (OpenSSL): {} ", SUPPORTED_PROTOCOLS_SET);
                 logger.debug("Default cipher suites (OpenSSL): {}", DEFAULT_CIPHERS);
             }
+
+            // Check if we can create a javax.security.cert.X509Certificate from our cert. This might fail on
+            // JDK17 and above. In this case we will later throw an UnsupportedOperationException if someone
+            // tries to access these via SSLSession. See https://github.com/netty/netty/issues/13560.
+            boolean javaxCertificateCreationSupported;
+            try {
+                javax.security.cert.X509Certificate.getInstance(CERT.getBytes(CharsetUtil.US_ASCII));
+                javaxCertificateCreationSupported = true;
+            } catch (javax.security.cert.CertificateException ex) {
+                javaxCertificateCreationSupported = false;
+            }
+            JAVAX_CERTIFICATE_CREATION_SUPPORTED = javaxCertificateCreationSupported;
         } else {
             DEFAULT_CIPHERS = Collections.emptyList();
             AVAILABLE_OPENSSL_CIPHER_SUITES = Collections.emptySet();
@@ -456,6 +470,7 @@ public final class OpenSsl {
             EXTRA_SUPPORTED_TLS_1_3_CIPHERS = EmptyArrays.EMPTY_STRINGS;
             EXTRA_SUPPORTED_TLS_1_3_CIPHERS_STRING = StringUtil.EMPTY_STRING;
             NAMED_GROUPS = DEFAULT_NAMED_GROUPS;
+            JAVAX_CERTIFICATE_CREATION_SUPPORTED = false;
         }
     }
 


### PR DESCRIPTION
…nException if javax.security.cert.X509Certificate can bot be created

Motivation:

SSLSession.getPeerCertificateChain() is allowed to throw UnsupportedOperationException if the implementation does not support it. We should do exactly this if the JDK that is used can not create a cert from a byte array. Otherwise we will produce an exception much later which is confusing.

Modifications:

Check if we can create such a cert and so support it, if not throw an UnuspportedOperationException as soon as the user tries to use the method.

Result:

Fixes https://github.com/netty/netty/issues/13560
