### PR TITLE
Add service-loaded extension points for channel initialization

### DIFF
--- a/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspClient.java
+++ b/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspClient.java
@@ -18,8 +18,6 @@ package io.netty.handler.ssl.ocsp;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.channel.Channel;
-import io.netty.channel.ChannelFactory;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelInitializer;
@@ -32,11 +30,7 @@ import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpClientCodec;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpObjectAggregator;
-import io.netty.resolver.AddressResolver;
-import io.netty.resolver.AddressResolverGroup;
-import io.netty.resolver.InetSocketAddressResolver;
 import io.netty.resolver.dns.DnsNameResolver;
-import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.GenericFutureListener;
@@ -62,8 +56,6 @@ import org.bouncycastle.operator.jcajce.JcaContentVerifierProviderBuilder;
 import org.bouncycastle.operator.jcajce.JcaDigestCalculatorProviderBuilder;
 
 import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.SocketAddress;
 import java.net.URL;
 import java.security.SecureRandom;
 import java.security.cert.CertificateEncodingException;
@@ -142,7 +134,7 @@ final class OcspClient {
                         path = "/";
                     } else {
                         if (uri.getQuery() != null) {
-                            path = path + "?" + uri.getQuery();
+                            path = path + '?' + uri.getQuery();
                         }
                     }
 
@@ -194,6 +186,7 @@ final class OcspClient {
                     .group(ioTransport.eventLoop())
                     .option(ChannelOption.TCP_NODELAY, true)
                     .channelFactory(ioTransport.socketChannel())
+                    .attr(OcspServerCertificateValidator.OCSP_PIPELINE_ATTRIBUTE, Boolean.TRUE)
                     .handler(new Initializer(responsePromise));
 
             dnsNameResolver.resolve(host).addListener(new FutureListener<InetAddress>() {

--- a/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspServerCertificateValidator.java
+++ b/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspServerCertificateValidator.java
@@ -21,6 +21,7 @@ import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
 import io.netty.resolver.dns.DnsNameResolver;
 import io.netty.resolver.dns.DnsNameResolverBuilder;
+import io.netty.util.AttributeKey;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import io.netty.util.concurrent.Promise;
@@ -41,6 +42,11 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
  * will perform certificate validation using OCSP over HTTP/1.1 with the server's certificate issuer OCSP responder.
  */
 public class OcspServerCertificateValidator extends ChannelInboundHandlerAdapter {
+    /**
+     * An attribute used to mark all channels created by the {@link OcspServerCertificateValidator}.
+     */
+    public static final AttributeKey<Boolean> OCSP_PIPELINE_ATTRIBUTE =
+            AttributeKey.newInstance("io.netty.handler.ssl.ocsp.pipeline");
 
     private final boolean closeAndThrowIfNotValid;
     private final boolean validateNonce;

--- a/pom.xml
+++ b/pom.xml
@@ -1560,7 +1560,7 @@
             <nativeImage.handlerMetadataGroupId>${project.groupId}</nativeImage.handlerMetadataGroupId>
             <nativeimage.handlerMetadataArtifactId>${project.artifactId}</nativeimage.handlerMetadataArtifactId>
           </systemPropertyVariables>
-          <argLine>${argLine.common} ${argLine.printGC} ${argLine.alpnAgent} ${argLine.leak} ${argLine.coverage} ${argLine.noUnsafe} ${argLine.jni} ${argLine.java9} ${argLine.javaProperties}</argLine>
+          <argLine>${argLine.common} ${argLine.printGC} ${argLine.alpnAgent} ${argLine.leak} ${argLine.coverage} ${argLine.noUnsafe} ${argLine.jni} ${argLine.java9} ${argLine.javaProperties} -Dio.netty.bootstrap.extensions=serviceload</argLine>
           <properties>
             <property>
               <name>listener</name>

--- a/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
@@ -66,7 +66,6 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
     // purposes.
     private final Map<ChannelOption<?>, Object> options = new LinkedHashMap<ChannelOption<?>, Object>();
     private final Map<AttributeKey<?>, Object> attrs = new ConcurrentHashMap<AttributeKey<?>, Object>();
-    private volatile boolean disableExtensions;
     private volatile ChannelHandler handler;
 
     AbstractBootstrap() {
@@ -82,7 +81,6 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
             options.putAll(bootstrap.options);
         }
         attrs.putAll(bootstrap.attrs);
-        disableExtensions = bootstrap.disableExtensions;
     }
 
     /**
@@ -138,17 +136,6 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
     @SuppressWarnings({ "unchecked", "deprecation" })
     public B channelFactory(io.netty.channel.ChannelFactory<? extends C> channelFactory) {
         return channelFactory((ChannelFactory<C>) channelFactory);
-    }
-
-    /**
-     * Disable calling out to any {@link ChannelInitializerExtension}s for the channels created by this bootstrap.
-     * <p>
-     * Channel initializer extensions are loaded and installed by default, but can be selectively disabled per bootstrap
-     * by calling this method.
-     */
-    public B disableChannelInitializerExtensions() {
-        disableExtensions = true;
-        return self();
     }
 
     /**
@@ -358,8 +345,8 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
     abstract void init(Channel channel) throws Exception;
 
     Collection<ChannelInitializerExtension> getInitializerExtensions() {
-        ChannelInitializerExtensions extensions;
-        if (disableExtensions || (extensions = ChannelInitializerExtensions.getExtensions()).isEmpty()) {
+        ChannelInitializerExtensions extensions = ChannelInitializerExtensions.getExtensions();
+        if (extensions.isEmpty()) {
             // Skip building ApplicableInfo.
             return Collections.emptyList();
         }

--- a/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
@@ -345,15 +345,7 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
     abstract void init(Channel channel) throws Exception;
 
     Collection<ChannelInitializerExtension> getInitializerExtensions() {
-        ChannelInitializerExtensions extensions = ChannelInitializerExtensions.getExtensions();
-        if (extensions.isEmpty()) {
-            // Skip building ApplicableInfo.
-            return Collections.emptyList();
-        }
-
-        ChannelInitializerExtension.ApplicableInfo info =
-                new ChannelInitializerExtension.ApplicableInfo(getClass());
-        return extensions.extensions(info);
+        return ChannelInitializerExtensions.getExtensions().extensions();
     }
 
     private static void doBind0(

--- a/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
@@ -37,9 +37,12 @@ import io.netty.util.internal.logging.InternalLogger;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -65,6 +68,7 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
     // purposes.
     private final Map<ChannelOption<?>, Object> options = new LinkedHashMap<ChannelOption<?>, Object>();
     private final Map<AttributeKey<?>, Object> attrs = new ConcurrentHashMap<AttributeKey<?>, Object>();
+    private volatile boolean disableExtensions;
     private volatile ChannelHandler handler;
 
     AbstractBootstrap() {
@@ -80,6 +84,7 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
             options.putAll(bootstrap.options);
         }
         attrs.putAll(bootstrap.attrs);
+        disableExtensions = bootstrap.disableExtensions;
     }
 
     /**
@@ -135,6 +140,17 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
     @SuppressWarnings({ "unchecked", "deprecation" })
     public B channelFactory(io.netty.channel.ChannelFactory<? extends C> channelFactory) {
         return channelFactory((ChannelFactory<C>) channelFactory);
+    }
+
+    /**
+     * Disable calling out to any {@link ChannelInitializerExtension}s for the channels created by this bootstrap.
+     * <p>
+     * Channel initializer extensions are loaded and installed by default, but can be selectively disabled per bootstrap
+     * by calling this method.
+     */
+    public B disableChannelInitializerExtensions() {
+        disableExtensions = true;
+        return self();
     }
 
     /**
@@ -342,6 +358,33 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
     }
 
     abstract void init(Channel channel) throws Exception;
+
+    Collection<ChannelInitializerExtension> getInitializerExtensions() {
+        if (disableExtensions) {
+            return ChannelInitializerExtensions.empty().extensions();
+        }
+        List<ChannelInitializerExtension> extensions = ChannelInitializerExtensions.getExtensions().extensions();
+        if (extensions.isEmpty()) {
+            return extensions;
+        }
+
+        ChannelInitializerExtension.ApplicableInfo info =
+                new ChannelInitializerExtension.ApplicableInfo(getClass());
+        List<ChannelInitializerExtension> filteredExtensions = null;
+        for (int i = 0, len = extensions.size(); i < len; i++) {
+            ChannelInitializerExtension extension = extensions.get(i);
+            boolean applicable = extension.isApplicable(info);
+            if (filteredExtensions == null && !applicable) {
+                filteredExtensions = new ArrayList<ChannelInitializerExtension>();
+                for (int j = 0; j < i; j++) {
+                    filteredExtensions.add(extensions.get(j));
+                }
+            } else if (filteredExtensions != null && applicable) {
+                filteredExtensions.add(extension);
+            }
+        }
+        return filteredExtensions != null ? filteredExtensions : extensions;
+    }
 
     private static void doBind0(
             final ChannelFuture regFuture, final Channel channel,

--- a/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
@@ -23,9 +23,9 @@ import io.netty.channel.ChannelPromise;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.resolver.AddressResolver;
+import io.netty.resolver.AddressResolverGroup;
 import io.netty.resolver.DefaultAddressResolverGroup;
 import io.netty.resolver.NameResolver;
-import io.netty.resolver.AddressResolverGroup;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import io.netty.util.internal.ObjectUtil;
@@ -35,6 +35,7 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.Collection;
 
 /**
  * A {@link Bootstrap} that makes it easy to bootstrap a {@link Channel} to use
@@ -70,9 +71,8 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
      *
      * @see io.netty.resolver.DefaultAddressResolverGroup
      */
-    @SuppressWarnings("unchecked")
     public Bootstrap resolver(AddressResolverGroup<?> resolver) {
-        this.externalResolver = resolver == null ? null : new ExternalAddressResolver(resolver);
+        externalResolver = resolver == null ? null : new ExternalAddressResolver(resolver);
         disableResolver = false;
         return this;
     }
@@ -277,6 +277,12 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
 
         setChannelOptions(channel, newOptionsArray(), logger);
         setAttributes(channel, newAttributesArray());
+        Collection<ChannelInitializerExtension> extensions = getInitializerExtensions();
+        if (!extensions.isEmpty()) {
+            for (ChannelInitializerExtension extension : extensions) {
+                extension.postInitializeClientChannel(channel);
+            }
+        }
     }
 
     @Override

--- a/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
@@ -280,7 +280,11 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
         Collection<ChannelInitializerExtension> extensions = getInitializerExtensions();
         if (!extensions.isEmpty()) {
             for (ChannelInitializerExtension extension : extensions) {
-                extension.postInitializeClientChannel(channel);
+                try {
+                    extension.postInitializeClientChannel(channel);
+                } catch (Exception e) {
+                    logger.warn("Exception thrown from postInitializeClientChannel", e);
+                }
             }
         }
     }

--- a/transport/src/main/java/io/netty/bootstrap/ChannelInitializerExtension.java
+++ b/transport/src/main/java/io/netty/bootstrap/ChannelInitializerExtension.java
@@ -16,6 +16,7 @@
 package io.netty.bootstrap;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ServerChannel;
 
 /**
  * A channel initializer extension make it possible to enforce rules and apply modifications across multiple,
@@ -80,7 +81,7 @@ public interface ChannelInitializerExtension {
      *
      * @param channel The channel that was initialized.
      */
-    void postInitializeServerListenerChannel(Channel channel);
+    void postInitializeServerListenerChannel(ServerChannel channel);
 
     /**
      * Called by {@link ServerBootstrap} after the initialization of the given child channel.

--- a/transport/src/main/java/io/netty/bootstrap/ChannelInitializerExtension.java
+++ b/transport/src/main/java/io/netty/bootstrap/ChannelInitializerExtension.java
@@ -31,7 +31,7 @@ import io.netty.channel.ServerChannel;
  * unless the extensions are explicitly disabled on the given bootstrap instance with a call to
  * {@link AbstractBootstrap#disableChannelInitializerExtensions()}.
  */
-public interface ChannelInitializerExtension {
+public abstract class ChannelInitializerExtension {
     /**
      * Inspect the information in the given {@link ApplicableInfo} object, and determine if this extension is applicable
      * for the given context.
@@ -44,7 +44,7 @@ public interface ChannelInitializerExtension {
      * @return {@code true} if this extension is interested in getting called in the given context,
      * otherwise {@code false}.
      */
-    boolean isApplicable(ApplicableInfo info);
+    public abstract boolean isApplicable(ApplicableInfo info);
 
     /**
      * Get the "priority" of this extension. If multiple extensions are
@@ -59,7 +59,9 @@ public interface ChannelInitializerExtension {
      *
      * @return The priority.
      */
-    double priority();
+    public double priority() {
+        return 0;
+    }
 
     /**
      * Called by {@link Bootstrap} after the initialization of the given client channel.
@@ -69,7 +71,7 @@ public interface ChannelInitializerExtension {
      *
      * @param channel The channel that was initialized.
      */
-    void postInitializeClientChannel(Channel channel);
+    public abstract void postInitializeClientChannel(Channel channel);
 
     /**
      * Called by {@link ServerBootstrap} after the initialization of the given server listener channel.
@@ -81,7 +83,7 @@ public interface ChannelInitializerExtension {
      *
      * @param channel The channel that was initialized.
      */
-    void postInitializeServerListenerChannel(ServerChannel channel);
+    public abstract void postInitializeServerListenerChannel(ServerChannel channel);
 
     /**
      * Called by {@link ServerBootstrap} after the initialization of the given child channel.
@@ -92,7 +94,7 @@ public interface ChannelInitializerExtension {
      *
      * @param channel The channel that was initialized.
      */
-    void postInitializeServerChildChannel(Channel channel);
+    public abstract void postInitializeServerChildChannel(Channel channel);
 
     /**
      * Provides information about the context where an extension might be used.
@@ -101,7 +103,7 @@ public interface ChannelInitializerExtension {
      * This class is a parameter-object, and is {@code final} so that additional information can be made available in
      * the future, without breaking backwards compatibility.
      */
-    final class ApplicableInfo {
+    public static final class ApplicableInfo {
         private final Class<?> bootstrapClass;
 
         ApplicableInfo(Class<?> bootstrapClass) {

--- a/transport/src/main/java/io/netty/bootstrap/ChannelInitializerExtension.java
+++ b/transport/src/main/java/io/netty/bootstrap/ChannelInitializerExtension.java
@@ -39,12 +39,17 @@ public abstract class ChannelInitializerExtension {
      * If the extension is not applicable, then it won't be called.
      * <p>
      * This method may be called multiple times with different parameters for different contexts.
+     * <p>
+     * Override this method to apply your own logic to this decision.
+     * The default implementation just returns {@code true}.
      *
      * @param info An object carrying information about the context of where and how this extension would be used.
      * @return {@code true} if this extension is interested in getting called in the given context,
      * otherwise {@code false}.
      */
-    public abstract boolean isApplicable(ApplicableInfo info);
+    public boolean isApplicable(ApplicableInfo info) {
+        return true;
+    }
 
     /**
      * Get the "priority" of this extension. If multiple extensions are
@@ -56,6 +61,13 @@ public abstract class ChannelInitializerExtension {
      * <p>
      * Extensions with lower priority will get called first, while extensions with greater priority may be able to
      * observe the effects of extensions with lesser priority.
+     * <p>
+     * Note that if multiple extensions have the same priority, then their relative order will be unpredictable.
+     * As such, implementations should always take into consideration that other extensions might be called before
+     * or after them.
+     * <p>
+     * Override this method to specify your own priority.
+     * The default implementation just returns {@code 0}.
      *
      * @return The priority.
      */
@@ -68,10 +80,14 @@ public abstract class ChannelInitializerExtension {
      * <p>
      * The method is allowed to modify the handlers in the pipeline, the channel attributes, or the channel options.
      * The method must refrain from doing any I/O, or from closing the channel.
+     * <p>
+     * Override this method to add your own callback logic.
+     * The default implementation does nothing.
      *
      * @param channel The channel that was initialized.
      */
-    public abstract void postInitializeClientChannel(Channel channel);
+    public void postInitializeClientChannel(Channel channel) {
+    }
 
     /**
      * Called by {@link ServerBootstrap} after the initialization of the given server listener channel.
@@ -80,10 +96,14 @@ public abstract class ChannelInitializerExtension {
      * <p>
      * The method is allowed to modify the handlers in the pipeline, the channel attributes, or the channel options.
      * The method must refrain from doing any I/O, or from closing the channel.
+     * <p>
+     * Override this method to add your own callback logic.
+     * The default implementation does nothing.
      *
      * @param channel The channel that was initialized.
      */
-    public abstract void postInitializeServerListenerChannel(ServerChannel channel);
+    public void postInitializeServerListenerChannel(ServerChannel channel) {
+    }
 
     /**
      * Called by {@link ServerBootstrap} after the initialization of the given child channel.
@@ -91,10 +111,14 @@ public abstract class ChannelInitializerExtension {
      * <p>
      * The method is allowed to modify the handlers in the pipeline, the channel attributes, or the channel options.
      * The method must refrain from doing any I/O, or from closing the channel.
+     * <p>
+     * Override this method to add your own callback logic.
+     * The default implementation does nothing.
      *
      * @param channel The channel that was initialized.
      */
-    public abstract void postInitializeServerChildChannel(Channel channel);
+    public void postInitializeServerChildChannel(Channel channel) {
+    }
 
     /**
      * Provides information about the context where an extension might be used.

--- a/transport/src/main/java/io/netty/bootstrap/ChannelInitializerExtension.java
+++ b/transport/src/main/java/io/netty/bootstrap/ChannelInitializerExtension.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.bootstrap;
+
+import io.netty.channel.Channel;
+
+/**
+ * A channel initializer extension make it possible to enforce rules and apply modifications across multiple,
+ * disconnected uses of Netty within the same JVM process.
+ * <p>
+ * For instance, application-level firewall rules can be injected into all uses of Netty within an application,
+ * without making changes to such uses that are otherwise outside the purview of the application code,
+ * such as 3rd-party libraries.
+ * <p>
+ * All channel initializer extensions that are available on the classpath will be
+ * {@linkplain java.util.ServiceLoader#load(Class) service-loaded} and used by all {@link AbstractBootstrap} subclasses,
+ * unless the extensions are explicitly disabled on the given bootstrap instance with a call to
+ * {@link AbstractBootstrap#disableChannelInitializerExtensions()}.
+ */
+public interface ChannelInitializerExtension {
+    /**
+     * Inspect the information in the given {@link ApplicableInfo} object, and determine if this extension is applicable
+     * for the given context.
+     * <p>
+     * If the extension is not applicable, then it won't be called.
+     * <p>
+     * This method may be called multiple times with different parameters for different contexts.
+     *
+     * @param info An object carrying information about the context of where and how this extension would be used.
+     * @return {@code true} if this extension is interested in getting called in the given context,
+     * otherwise {@code false}.
+     */
+    boolean isApplicable(ApplicableInfo info);
+
+    /**
+     * Get the "priority" of this extension. If multiple extensions are
+     * {@linkplain #isApplicable(ApplicableInfo) applicable} to a given context, then they will be called in their
+     * priority order, from lowest to highest.
+     * <p>
+     * Implementers are encouraged to pick a number between {@code -100.0} and {@code 100.0}, where extensions that have
+     * no particular opinion on their priority are encouraged to return {@code 0.0}.
+     * <p>
+     * Extensions with lower priority will get called first, while extensions with greater priority may be able to
+     * observe the effects of extensions with lesser priority.
+     *
+     * @return The priority.
+     */
+    double priority();
+
+    /**
+     * Called by {@link Bootstrap} after the initialization of the given client channel.
+     * <p>
+     * The method is allowed to modify the handlers in the pipeline, the channel attributes, or the channel options.
+     * The method must refrain from doing any I/O, or from closing the channel.
+     *
+     * @param channel The channel that was initialized.
+     */
+    void postInitializeClientChannel(Channel channel);
+
+    /**
+     * Called by {@link ServerBootstrap} after the initialization of the given server listener channel.
+     * The listener channel is responsible for invoking the {@code accept(2)} system call,
+     * and for producing child channels.
+     * <p>
+     * The method is allowed to modify the handlers in the pipeline, the channel attributes, or the channel options.
+     * The method must refrain from doing any I/O, or from closing the channel.
+     *
+     * @param channel The channel that was initialized.
+     */
+    void postInitializeServerListenerChannel(Channel channel);
+
+    /**
+     * Called by {@link ServerBootstrap} after the initialization of the given child channel.
+     * A child channel is a newly established connection from a client to the server.
+     * <p>
+     * The method is allowed to modify the handlers in the pipeline, the channel attributes, or the channel options.
+     * The method must refrain from doing any I/O, or from closing the channel.
+     *
+     * @param channel The channel that was initialized.
+     */
+    void postInitializeServerChildChannel(Channel channel);
+
+    /**
+     * Provides information about the context where an extension might be used.
+     * Extensions are given instances of this class through the {@link #isApplicable(ApplicableInfo)} method.
+     * <p>
+     * This class is a parameter-object, and is {@code final} so that additional information can be made available in
+     * the future, without breaking backwards compatibility.
+     */
+    final class ApplicableInfo {
+        private final Class<?> bootstrapClass;
+
+        ApplicableInfo(Class<?> bootstrapClass) {
+            this.bootstrapClass = bootstrapClass;
+        }
+
+        /**
+         * Get the concrete {@link AbstractBootstrap} subclass that is interested in using this extension.
+         */
+        @SuppressWarnings("unchecked")
+        public <C extends Channel, B extends AbstractBootstrap<B, C>> Class<? extends B> getBootstrapClass() {
+            return (Class<? extends B>) bootstrapClass;
+        }
+    }
+}

--- a/transport/src/main/java/io/netty/bootstrap/ChannelInitializerExtension.java
+++ b/transport/src/main/java/io/netty/bootstrap/ChannelInitializerExtension.java
@@ -28,7 +28,7 @@ import io.netty.channel.ServerChannel;
  * <p>
  * Channel initializer extensions are <em>not</em> enabled by default, because of their power to influence Netty
  * pipelines across libraries, frameworks, and use-cases.
- * Extensions must be explicitly enabled by setting the {@link #EXTENSIONS_SYSTEM_PROPERTY} to {@code serviceload}.
+ * Extensions must be explicitly enabled by setting the {@value #EXTENSIONS_SYSTEM_PROPERTY} to {@code serviceload}.
  * <p>
  * All channel initializer extensions that are available on the classpath will be
  * {@linkplain java.util.ServiceLoader#load(Class) service-loaded} and used by all {@link AbstractBootstrap} subclasses.

--- a/transport/src/main/java/io/netty/bootstrap/ChannelInitializerExtension.java
+++ b/transport/src/main/java/io/netty/bootstrap/ChannelInitializerExtension.java
@@ -27,9 +27,7 @@ import io.netty.channel.ServerChannel;
  * such as 3rd-party libraries.
  * <p>
  * All channel initializer extensions that are available on the classpath will be
- * {@linkplain java.util.ServiceLoader#load(Class) service-loaded} and used by all {@link AbstractBootstrap} subclasses,
- * unless the extensions are explicitly disabled on the given bootstrap instance with a call to
- * {@link AbstractBootstrap#disableChannelInitializerExtensions()}.
+ * {@linkplain java.util.ServiceLoader#load(Class) service-loaded} and used by all {@link AbstractBootstrap} subclasses.
  */
 public abstract class ChannelInitializerExtension {
     /**

--- a/transport/src/main/java/io/netty/bootstrap/ChannelInitializerExtension.java
+++ b/transport/src/main/java/io/netty/bootstrap/ChannelInitializerExtension.java
@@ -28,6 +28,10 @@ import io.netty.channel.ServerChannel;
  * <p>
  * All channel initializer extensions that are available on the classpath will be
  * {@linkplain java.util.ServiceLoader#load(Class) service-loaded} and used by all {@link AbstractBootstrap} subclasses.
+ * <p>
+ * Note that this feature will not work for Netty uses that are shaded <em>and relocated</em> into other libraries.
+ * The classes in a relocated Netty library are technically distinct and incompatible types. This means the
+ * service-loader in non-relocated Netty will not see types from a relocated Netty, and vice versa.
  */
 public abstract class ChannelInitializerExtension {
     /**

--- a/transport/src/main/java/io/netty/bootstrap/ChannelInitializerExtensions.java
+++ b/transport/src/main/java/io/netty/bootstrap/ChannelInitializerExtensions.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.bootstrap;
+
+import io.netty.util.internal.SystemPropertyUtil;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.ServiceLoader;
+
+/**
+ * The configurable facade that decides what {@link ChannelInitializerExtension}s to load and where to find them.
+ */
+abstract class ChannelInitializerExtensions {
+    private static volatile ChannelInitializerExtensions implementation;
+
+    private ChannelInitializerExtensions() {
+    }
+
+    /**
+     * Get the implementation where we have no extensions.
+     */
+    static ChannelInitializerExtensions empty() {
+        return EmptyExtensions.EMPTY;
+    }
+
+    /**
+     * Get the configuration extensions, which may be the same as {@link #empty()} if the
+     * {@code io.netty.bootstrap.extensions} system property is {@code empty} or {@code false}.
+     * <p>
+     * By default, we pick an implementation that finds extensions through
+     * {@linkplain ServiceLoader#load(Class) service loading}.
+     */
+    static ChannelInitializerExtensions getExtensions() {
+        ChannelInitializerExtensions impl = implementation;
+        if (impl == null) {
+            synchronized (ChannelInitializerExtensions.class) {
+                impl = implementation;
+                if (impl != null) {
+                    return impl;
+                }
+                String extensionProp = SystemPropertyUtil.get("io.netty.bootstrap.extensions");
+                if ("empty".equalsIgnoreCase(extensionProp) || "false".equalsIgnoreCase(extensionProp)) {
+                    impl = empty();
+                } else {
+                    impl = new ServiceLoadingExtensions();
+                }
+                implementation = impl;
+            }
+        }
+        return impl;
+    }
+
+    /**
+     * Get the list of available extensions. The list is unmodifiable.
+     */
+    abstract List<ChannelInitializerExtension> extensions();
+
+    private static final class EmptyExtensions extends ChannelInitializerExtensions {
+        private static final EmptyExtensions EMPTY = new EmptyExtensions();
+
+        @Override
+        List<ChannelInitializerExtension> extensions() {
+            return Collections.emptyList();
+        }
+    }
+
+    private static final class ServiceLoadingExtensions extends ChannelInitializerExtensions {
+        private final List<ChannelInitializerExtension> extensionList;
+
+        private ServiceLoadingExtensions() {
+            ServiceLoader<ChannelInitializerExtension> loader = ServiceLoader.load(ChannelInitializerExtension.class);
+            ArrayList<ChannelInitializerExtension> extensions = new ArrayList<ChannelInitializerExtension>();
+            for (ChannelInitializerExtension extension : loader) {
+                extensions.add(extension);
+            }
+            if (!extensions.isEmpty()) {
+                Collections.sort(extensions, new Comparator<ChannelInitializerExtension>() {
+                    @Override
+                    public int compare(ChannelInitializerExtension a, ChannelInitializerExtension b) {
+                        return Double.compare(a.priority(), b.priority());
+                    }
+                });
+                extensionList = Collections.unmodifiableList(extensions);
+            } else {
+                extensionList = Collections.emptyList();
+            }
+        }
+
+        @Override
+        List<ChannelInitializerExtension> extensions() {
+            return extensionList;
+        }
+    }
+}

--- a/transport/src/main/java/io/netty/bootstrap/ChannelInitializerExtensions.java
+++ b/transport/src/main/java/io/netty/bootstrap/ChannelInitializerExtensions.java
@@ -92,16 +92,9 @@ abstract class ChannelInitializerExtensions {
         @SuppressWarnings("AssignmentOrReturnOfFieldWithMutableType")
         @Override
         synchronized Collection<ChannelInitializerExtension> extensions(ClassLoader cl) {
-            ClassLoader context = Thread.currentThread().getContextClassLoader();
             ClassLoader configured = classLoader == null ? null : classLoader.get();
-            if (configured == null || configured != cl && configured != context) {
+            if (configured == null || configured != cl) {
                 Collection<ChannelInitializerExtension> loaded = serviceLoadExtensions(logLevel, cl);
-                if (loaded.isEmpty()) {
-                    // If we found no extensions, then try the context-specific class loader as well.
-                    // Frameworks like https://aries.apache.org/modules/spi-fly.html use the context class loader.
-                    cl = context;
-                    loaded = serviceLoadExtensions(logLevel, cl);
-                }
                 classLoader = new WeakReference<ClassLoader>(cl);
                 extensions = loadAndCache ? loaded : Collections.<ChannelInitializerExtension>emptyList();
             }

--- a/transport/src/main/java/io/netty/bootstrap/ChannelInitializerExtensions.java
+++ b/transport/src/main/java/io/netty/bootstrap/ChannelInitializerExtensions.java
@@ -16,6 +16,8 @@
 package io.netty.bootstrap;
 
 import io.netty.util.internal.SystemPropertyUtil;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -27,6 +29,7 @@ import java.util.ServiceLoader;
  * The configurable facade that decides what {@link ChannelInitializerExtension}s to load and where to find them.
  */
 abstract class ChannelInitializerExtensions {
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(ChannelInitializerExtensions.class);
     private static volatile ChannelInitializerExtensions implementation;
 
     private ChannelInitializerExtensions() {
@@ -55,6 +58,7 @@ abstract class ChannelInitializerExtensions {
                     return impl;
                 }
                 String extensionProp = SystemPropertyUtil.get("io.netty.bootstrap.extensions");
+                logger.debug("-Dio.netty.bootstrap.extensions: {}", extensionProp);
                 if ("serviceload".equalsIgnoreCase(extensionProp)) {
                     impl = new ServiceLoadingExtensions();
                 } else {
@@ -87,6 +91,7 @@ abstract class ChannelInitializerExtensions {
             ServiceLoader<ChannelInitializerExtension> loader = ServiceLoader.load(ChannelInitializerExtension.class);
             ArrayList<ChannelInitializerExtension> extensions = new ArrayList<ChannelInitializerExtension>();
             for (ChannelInitializerExtension extension : loader) {
+                logger.debug("Loaded extension: {}", extension.getClass());
                 extensions.add(extension);
             }
             if (!extensions.isEmpty()) {

--- a/transport/src/main/java/io/netty/bootstrap/ChannelInitializerExtensions.java
+++ b/transport/src/main/java/io/netty/bootstrap/ChannelInitializerExtensions.java
@@ -55,10 +55,10 @@ abstract class ChannelInitializerExtensions {
                     return impl;
                 }
                 String extensionProp = SystemPropertyUtil.get("io.netty.bootstrap.extensions");
-                if ("empty".equalsIgnoreCase(extensionProp) || "false".equalsIgnoreCase(extensionProp)) {
-                    impl = empty();
-                } else {
+                if ("serviceload".equalsIgnoreCase(extensionProp)) {
                     impl = new ServiceLoadingExtensions();
+                } else {
+                    impl = empty();
                 }
                 implementation = impl;
             }

--- a/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
@@ -161,8 +161,13 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
             }
         });
         if (!extensions.isEmpty() && channel instanceof ServerChannel) {
+            ServerChannel serverChannel = (ServerChannel) channel;
             for (ChannelInitializerExtension extension : extensions) {
-                extension.postInitializeServerListenerChannel((ServerChannel) channel);
+                try {
+                    extension.postInitializeServerListenerChannel(serverChannel);
+                } catch (Exception e) {
+                    logger.warn("Exception thrown from postInitializeServerListenerChannel", e);
+                }
             }
         }
     }
@@ -224,7 +229,11 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
 
             if (!extensions.isEmpty()) {
                 for (ChannelInitializerExtension extension : extensions) {
-                    extension.postInitializeServerChildChannel(child);
+                    try {
+                        extension.postInitializeServerChildChannel(child);
+                    } catch (Exception e) {
+                        logger.warn("Exception thrown from postInitializeServerChildChannel", e);
+                    }
                 }
             }
 

--- a/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
@@ -32,6 +32,7 @@ import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -138,6 +139,7 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
         final ChannelHandler currentChildHandler = childHandler;
         final Entry<ChannelOption<?>, Object>[] currentChildOptions = newOptionsArray(childOptions);
         final Entry<AttributeKey<?>, Object>[] currentChildAttrs = newAttributesArray(childAttrs);
+        final Collection<ChannelInitializerExtension> extensions = getInitializerExtensions();
 
         p.addLast(new ChannelInitializer<Channel>() {
             @Override
@@ -152,11 +154,17 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
                     @Override
                     public void run() {
                         pipeline.addLast(new ServerBootstrapAcceptor(
-                                ch, currentChildGroup, currentChildHandler, currentChildOptions, currentChildAttrs));
+                                ch, currentChildGroup, currentChildHandler, currentChildOptions, currentChildAttrs,
+                                extensions));
                     }
                 });
             }
         });
+        if (!extensions.isEmpty()) {
+            for (ChannelInitializerExtension extension : extensions) {
+                extension.postInitializeServerListenerChannel(channel);
+            }
+        }
     }
 
     @Override
@@ -179,14 +187,17 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
         private final Entry<ChannelOption<?>, Object>[] childOptions;
         private final Entry<AttributeKey<?>, Object>[] childAttrs;
         private final Runnable enableAutoReadTask;
+        private final Collection<ChannelInitializerExtension> extensions;
 
         ServerBootstrapAcceptor(
                 final Channel channel, EventLoopGroup childGroup, ChannelHandler childHandler,
-                Entry<ChannelOption<?>, Object>[] childOptions, Entry<AttributeKey<?>, Object>[] childAttrs) {
+                Entry<ChannelOption<?>, Object>[] childOptions, Entry<AttributeKey<?>, Object>[] childAttrs,
+                Collection<ChannelInitializerExtension> extensions) {
             this.childGroup = childGroup;
             this.childHandler = childHandler;
             this.childOptions = childOptions;
             this.childAttrs = childAttrs;
+            this.extensions = extensions;
 
             // Task which is scheduled to re-enable auto-read.
             // It's important to create this Runnable before we try to submit it as otherwise the URLClassLoader may
@@ -210,6 +221,12 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
 
             setChannelOptions(child, childOptions, logger);
             setAttributes(child, childAttrs);
+
+            if (!extensions.isEmpty()) {
+                for (ChannelInitializerExtension extension : extensions) {
+                    extension.postInitializeServerChildChannel(child);
+                }
+            }
 
             try {
                 childGroup.register(child).addListener(new ChannelFutureListener() {

--- a/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
@@ -160,9 +160,9 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
                 });
             }
         });
-        if (!extensions.isEmpty()) {
+        if (!extensions.isEmpty() && channel instanceof ServerChannel) {
             for (ChannelInitializerExtension extension : extensions) {
-                extension.postInitializeServerListenerChannel(channel);
+                extension.postInitializeServerListenerChannel((ServerChannel) channel);
             }
         }
     }

--- a/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
+++ b/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
@@ -504,23 +504,6 @@ public class BootstrapTest {
         assertNull(StubChannelInitializerExtension.lastSeenListenerChannel.get());
     }
 
-    @Test
-    void mustNotCallInitializerExtensionsWhenDisabled() throws Exception {
-        final Bootstrap cb = new Bootstrap();
-        cb.group(groupA);
-        cb.handler(dummyHandler);
-        cb.channel(LocalChannel.class);
-        cb.disableChannelInitializerExtensions();
-
-        StubChannelInitializerExtension.clearThreadLocals();
-
-        cb.register().sync();
-
-        assertNull(StubChannelInitializerExtension.lastSeenClientChannel.get());
-        assertNull(StubChannelInitializerExtension.lastSeenChildChannel.get());
-        assertNull(StubChannelInitializerExtension.lastSeenListenerChannel.get());
-    }
-
     private static final class DelayedEventLoopGroup extends DefaultEventLoop {
         @Override
         public ChannelFuture register(final Channel channel, final ChannelPromise promise) {

--- a/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
+++ b/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
@@ -485,6 +485,7 @@ public class BootstrapTest {
         assertSame(expectedChannel, StubChannelInitializerExtension.lastSeenClientChannel.get());
         assertNull(StubChannelInitializerExtension.lastSeenChildChannel.get());
         assertNull(StubChannelInitializerExtension.lastSeenListenerChannel.get());
+        expectedChannel.close().sync();
     }
 
     private static final class DelayedEventLoopGroup extends DefaultEventLoop {

--- a/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
+++ b/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
@@ -470,7 +470,7 @@ public class BootstrapTest {
     }
 
     @Test
-    void mustCallInitializerExtensionsByDefault() throws Exception {
+    void mustCallInitializerExtensions() throws Exception {
         final Bootstrap cb = new Bootstrap();
         cb.group(groupA);
         cb.handler(dummyHandler);
@@ -483,23 +483,6 @@ public class BootstrapTest {
         final Channel expectedChannel = future.channel();
 
         assertSame(expectedChannel, StubChannelInitializerExtension.lastSeenClientChannel.get());
-        assertNull(StubChannelInitializerExtension.lastSeenChildChannel.get());
-        assertNull(StubChannelInitializerExtension.lastSeenListenerChannel.get());
-    }
-
-    @Test
-    void mustNotCallInitializerExtensionsNotApplicable() throws Exception {
-        final Bootstrap cb = new Bootstrap();
-        cb.group(groupA);
-        cb.handler(dummyHandler);
-        cb.channel(LocalChannel.class);
-
-        StubChannelInitializerExtension.clearThreadLocals();
-        StubChannelInitializerExtension.isApplicable.set(Boolean.FALSE);
-
-        cb.register().sync();
-
-        assertNull(StubChannelInitializerExtension.lastSeenClientChannel.get());
         assertNull(StubChannelInitializerExtension.lastSeenChildChannel.get());
         assertNull(StubChannelInitializerExtension.lastSeenListenerChannel.get());
     }

--- a/transport/src/test/java/io/netty/bootstrap/ServerBootstrapTest.java
+++ b/transport/src/test/java/io/netty/bootstrap/ServerBootstrapTest.java
@@ -277,40 +277,4 @@ public class ServerBootstrapTest {
         clientChannel.close().syncUninterruptibly();
         group.shutdownGracefully();
     }
-
-    @Test
-    void mustNotCallInitializerExtensionsWhenDisabled() throws Exception {
-        LocalAddress addr = new LocalAddress(ServerBootstrapTest.class);
-        LocalEventLoopGroup group = new LocalEventLoopGroup(1);
-        final ServerBootstrap sb = new ServerBootstrap();
-        sb.group(group);
-        sb.handler(new ChannelInboundHandlerAdapter());
-        sb.channel(LocalServerChannel.class);
-        sb.childHandler(new ChannelInboundHandlerAdapter());
-        sb.disableChannelInitializerExtensions();
-
-        StubChannelInitializerExtension.clearThreadLocals();
-        group.submit(new Runnable() {
-            @Override
-            public void run() {
-                StubChannelInitializerExtension.clearThreadLocals();
-            }
-        }).sync();
-
-        Channel serverChannel = sb.bind(addr).syncUninterruptibly().channel();
-
-        Bootstrap cb = new Bootstrap();
-        cb.group(group)
-                .channel(LocalChannel.class)
-                .handler(new ChannelInboundHandlerAdapter());
-        Channel clientChannel = cb.connect(addr).syncUninterruptibly().channel();
-
-        assertSame(clientChannel, StubChannelInitializerExtension.lastSeenClientChannel.get());
-        assertNull(StubChannelInitializerExtension.lastSeenChildChannel.get());
-        assertNull(StubChannelInitializerExtension.lastSeenListenerChannel.get());
-
-        serverChannel.close().syncUninterruptibly();
-        clientChannel.close().syncUninterruptibly();
-        group.shutdownGracefully();
-    }
 }

--- a/transport/src/test/java/io/netty/bootstrap/ServerBootstrapTest.java
+++ b/transport/src/test/java/io/netty/bootstrap/ServerBootstrapTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import java.util.UUID;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -40,6 +41,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ServerBootstrapTest {
@@ -178,5 +180,137 @@ public class ServerBootstrapTest {
         clientChannel.close().syncUninterruptibly();
         group.shutdownGracefully();
         assertTrue(requestServed.get());
+    }
+
+    @Test
+    void mustCallInitializerExtensionsByDefault() throws Exception {
+        LocalAddress addr = new LocalAddress(ServerBootstrapTest.class);
+        final AtomicReference<Channel> expectedServerChannel = new AtomicReference<Channel>();
+        final AtomicReference<Channel> expectedChildChannel = new AtomicReference<Channel>();
+        LocalEventLoopGroup group = new LocalEventLoopGroup(1);
+        final ServerBootstrap sb = new ServerBootstrap();
+        sb.group(group);
+        sb.channel(LocalServerChannel.class);
+        sb.handler(new ChannelInitializer<Channel>() {
+            @Override
+            protected void initChannel(Channel ch) throws Exception {
+                expectedServerChannel.set(ch);
+            }
+        });
+        sb.childHandler(new ChannelInitializer<Channel>() {
+            @Override
+            protected void initChannel(Channel ch) throws Exception {
+                expectedChildChannel.set(ch);
+            }
+        });
+
+        StubChannelInitializerExtension.clearThreadLocals();
+        group.submit(new Runnable() {
+            @Override
+            public void run() {
+                StubChannelInitializerExtension.clearThreadLocals();
+            }
+        }).sync();
+
+        Channel serverChannel = sb.bind(addr).syncUninterruptibly().channel();
+
+        assertNull(StubChannelInitializerExtension.lastSeenClientChannel.get());
+        assertNull(StubChannelInitializerExtension.lastSeenChildChannel.get());
+        assertSame(expectedServerChannel.get(), StubChannelInitializerExtension.lastSeenListenerChannel.get());
+        assertSame(serverChannel, StubChannelInitializerExtension.lastSeenListenerChannel.get());
+
+        Bootstrap cb = new Bootstrap();
+        cb.group(group)
+                .channel(LocalChannel.class)
+                .handler(new ChannelInboundHandlerAdapter());
+        Channel clientChannel = cb.connect(addr).syncUninterruptibly().channel();
+
+        assertSame(clientChannel, StubChannelInitializerExtension.lastSeenClientChannel.get());
+        group.submit(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                assertSame(expectedChildChannel.get(), StubChannelInitializerExtension.lastSeenChildChannel.get());
+                return null;
+            }
+        }).sync();
+        assertSame(expectedServerChannel.get(), StubChannelInitializerExtension.lastSeenListenerChannel.get());
+        assertSame(serverChannel, StubChannelInitializerExtension.lastSeenListenerChannel.get());
+
+        serverChannel.close().syncUninterruptibly();
+        clientChannel.close().syncUninterruptibly();
+        group.shutdownGracefully();
+    }
+
+    @Test
+    void mustNotCallInitializerExtensionsNotApplicable() throws Exception {
+        LocalAddress addr = new LocalAddress(ServerBootstrapTest.class);
+        LocalEventLoopGroup group = new LocalEventLoopGroup(1);
+        final ServerBootstrap sb = new ServerBootstrap();
+        sb.group(group);
+        sb.handler(new ChannelInboundHandlerAdapter());
+        sb.channel(LocalServerChannel.class);
+        sb.childHandler(new ChannelInboundHandlerAdapter());
+
+        StubChannelInitializerExtension.clearThreadLocals();
+        StubChannelInitializerExtension.isApplicable.set(Boolean.FALSE);
+        group.submit(new Runnable() {
+            @Override
+            public void run() {
+                StubChannelInitializerExtension.clearThreadLocals();
+                StubChannelInitializerExtension.isApplicable.set(Boolean.FALSE);
+            }
+        }).sync();
+
+        Channel serverChannel = sb.bind(addr).syncUninterruptibly().channel();
+
+        Bootstrap cb = new Bootstrap();
+        cb.group(group)
+                .channel(LocalChannel.class)
+                .handler(new ChannelInboundHandlerAdapter());
+        Channel clientChannel = cb.connect(addr).syncUninterruptibly().channel();
+
+        assertNull(StubChannelInitializerExtension.lastSeenClientChannel.get());
+        assertNull(StubChannelInitializerExtension.lastSeenChildChannel.get());
+        assertNull(StubChannelInitializerExtension.lastSeenListenerChannel.get());
+
+        serverChannel.close().syncUninterruptibly();
+        clientChannel.close().syncUninterruptibly();
+        group.shutdownGracefully();
+    }
+
+    @Test
+    void mustNotCallInitializerExtensionsWhenDisabled() throws Exception {
+        LocalAddress addr = new LocalAddress(ServerBootstrapTest.class);
+        LocalEventLoopGroup group = new LocalEventLoopGroup(1);
+        final ServerBootstrap sb = new ServerBootstrap();
+        sb.group(group);
+        sb.handler(new ChannelInboundHandlerAdapter());
+        sb.channel(LocalServerChannel.class);
+        sb.childHandler(new ChannelInboundHandlerAdapter());
+        sb.disableChannelInitializerExtensions();
+
+        StubChannelInitializerExtension.clearThreadLocals();
+        group.submit(new Runnable() {
+            @Override
+            public void run() {
+                StubChannelInitializerExtension.clearThreadLocals();
+            }
+        }).sync();
+
+        Channel serverChannel = sb.bind(addr).syncUninterruptibly().channel();
+
+        Bootstrap cb = new Bootstrap();
+        cb.group(group)
+                .channel(LocalChannel.class)
+                .handler(new ChannelInboundHandlerAdapter());
+        Channel clientChannel = cb.connect(addr).syncUninterruptibly().channel();
+
+        assertSame(clientChannel, StubChannelInitializerExtension.lastSeenClientChannel.get());
+        assertNull(StubChannelInitializerExtension.lastSeenChildChannel.get());
+        assertNull(StubChannelInitializerExtension.lastSeenListenerChannel.get());
+
+        serverChannel.close().syncUninterruptibly();
+        clientChannel.close().syncUninterruptibly();
+        group.shutdownGracefully();
     }
 }

--- a/transport/src/test/java/io/netty/bootstrap/ServerBootstrapTest.java
+++ b/transport/src/test/java/io/netty/bootstrap/ServerBootstrapTest.java
@@ -183,7 +183,7 @@ public class ServerBootstrapTest {
     }
 
     @Test
-    void mustCallInitializerExtensionsByDefault() throws Exception {
+    void mustCallInitializerExtensions() throws Exception {
         LocalAddress addr = new LocalAddress(ServerBootstrapTest.class);
         final AtomicReference<Channel> expectedServerChannel = new AtomicReference<Channel>();
         final AtomicReference<Channel> expectedChildChannel = new AtomicReference<Channel>();
@@ -235,43 +235,6 @@ public class ServerBootstrapTest {
         }).sync();
         assertSame(expectedServerChannel.get(), StubChannelInitializerExtension.lastSeenListenerChannel.get());
         assertSame(serverChannel, StubChannelInitializerExtension.lastSeenListenerChannel.get());
-
-        serverChannel.close().syncUninterruptibly();
-        clientChannel.close().syncUninterruptibly();
-        group.shutdownGracefully();
-    }
-
-    @Test
-    void mustNotCallInitializerExtensionsNotApplicable() throws Exception {
-        LocalAddress addr = new LocalAddress(ServerBootstrapTest.class);
-        LocalEventLoopGroup group = new LocalEventLoopGroup(1);
-        final ServerBootstrap sb = new ServerBootstrap();
-        sb.group(group);
-        sb.handler(new ChannelInboundHandlerAdapter());
-        sb.channel(LocalServerChannel.class);
-        sb.childHandler(new ChannelInboundHandlerAdapter());
-
-        StubChannelInitializerExtension.clearThreadLocals();
-        StubChannelInitializerExtension.isApplicable.set(Boolean.FALSE);
-        group.submit(new Runnable() {
-            @Override
-            public void run() {
-                StubChannelInitializerExtension.clearThreadLocals();
-                StubChannelInitializerExtension.isApplicable.set(Boolean.FALSE);
-            }
-        }).sync();
-
-        Channel serverChannel = sb.bind(addr).syncUninterruptibly().channel();
-
-        Bootstrap cb = new Bootstrap();
-        cb.group(group)
-                .channel(LocalChannel.class)
-                .handler(new ChannelInboundHandlerAdapter());
-        Channel clientChannel = cb.connect(addr).syncUninterruptibly().channel();
-
-        assertNull(StubChannelInitializerExtension.lastSeenClientChannel.get());
-        assertNull(StubChannelInitializerExtension.lastSeenChildChannel.get());
-        assertNull(StubChannelInitializerExtension.lastSeenListenerChannel.get());
 
         serverChannel.close().syncUninterruptibly();
         clientChannel.close().syncUninterruptibly();

--- a/transport/src/test/java/io/netty/bootstrap/StubChannelInitializerExtension.java
+++ b/transport/src/test/java/io/netty/bootstrap/StubChannelInitializerExtension.java
@@ -20,12 +20,6 @@ import io.netty.channel.ServerChannel;
 import io.netty.util.concurrent.FastThreadLocal;
 
 public class StubChannelInitializerExtension extends ChannelInitializerExtension {
-    static final FastThreadLocal<Boolean> isApplicable = new FastThreadLocal<Boolean>() {
-        @Override
-        protected Boolean initialValue() throws Exception {
-            return Boolean.TRUE;
-        }
-    };
     static final FastThreadLocal<Channel> lastSeenClientChannel = new FastThreadLocal<Channel>();
     static final FastThreadLocal<Channel> lastSeenListenerChannel = new FastThreadLocal<Channel>();
     static final FastThreadLocal<Channel> lastSeenChildChannel = new FastThreadLocal<Channel>();
@@ -34,17 +28,6 @@ public class StubChannelInitializerExtension extends ChannelInitializerExtension
         lastSeenChildChannel.remove();
         lastSeenClientChannel.remove();
         lastSeenListenerChannel.remove();
-        isApplicable.set(Boolean.TRUE);
-    }
-
-    @Override
-    public boolean isApplicable(ApplicableInfo info) {
-        return isApplicable.get();
-    }
-
-    @Override
-    public double priority() {
-        return 0;
     }
 
     @Override

--- a/transport/src/test/java/io/netty/bootstrap/StubChannelInitializerExtension.java
+++ b/transport/src/test/java/io/netty/bootstrap/StubChannelInitializerExtension.java
@@ -19,7 +19,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ServerChannel;
 import io.netty.util.concurrent.FastThreadLocal;
 
-public class StubChannelInitializerExtension implements ChannelInitializerExtension {
+public class StubChannelInitializerExtension extends ChannelInitializerExtension {
     static final FastThreadLocal<Boolean> isApplicable = new FastThreadLocal<Boolean>() {
         @Override
         protected Boolean initialValue() throws Exception {

--- a/transport/src/test/java/io/netty/bootstrap/StubChannelInitializerExtension.java
+++ b/transport/src/test/java/io/netty/bootstrap/StubChannelInitializerExtension.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.bootstrap;
+
+import io.netty.channel.Channel;
+import io.netty.util.concurrent.FastThreadLocal;
+
+public class StubChannelInitializerExtension implements ChannelInitializerExtension {
+    static final FastThreadLocal<Boolean> isApplicable = new FastThreadLocal<Boolean>() {
+        @Override
+        protected Boolean initialValue() throws Exception {
+            return Boolean.TRUE;
+        }
+    };
+    static final FastThreadLocal<Channel> lastSeenClientChannel = new FastThreadLocal<Channel>();
+    static final FastThreadLocal<Channel> lastSeenListenerChannel = new FastThreadLocal<Channel>();
+    static final FastThreadLocal<Channel> lastSeenChildChannel = new FastThreadLocal<Channel>();
+
+    public static void clearThreadLocals() {
+        lastSeenChildChannel.remove();
+        lastSeenClientChannel.remove();
+        lastSeenListenerChannel.remove();
+        isApplicable.set(Boolean.TRUE);
+    }
+
+    @Override
+    public boolean isApplicable(ApplicableInfo info) {
+        return isApplicable.get();
+    }
+
+    @Override
+    public double priority() {
+        return 0;
+    }
+
+    @Override
+    public void postInitializeClientChannel(Channel channel) {
+        lastSeenClientChannel.set(channel);
+    }
+
+    @Override
+    public void postInitializeServerListenerChannel(Channel channel) {
+        lastSeenListenerChannel.set(channel);
+    }
+
+    @Override
+    public void postInitializeServerChildChannel(Channel channel) {
+        lastSeenChildChannel.set(channel);
+    }
+}

--- a/transport/src/test/java/io/netty/bootstrap/StubChannelInitializerExtension.java
+++ b/transport/src/test/java/io/netty/bootstrap/StubChannelInitializerExtension.java
@@ -16,6 +16,7 @@
 package io.netty.bootstrap;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ServerChannel;
 import io.netty.util.concurrent.FastThreadLocal;
 
 public class StubChannelInitializerExtension implements ChannelInitializerExtension {
@@ -52,7 +53,7 @@ public class StubChannelInitializerExtension implements ChannelInitializerExtens
     }
 
     @Override
-    public void postInitializeServerListenerChannel(Channel channel) {
+    public void postInitializeServerListenerChannel(ServerChannel channel) {
         lastSeenListenerChannel.set(channel);
     }
 

--- a/transport/src/test/resources/META-INF/services/io.netty.bootstrap.ChannelInitializerExtension
+++ b/transport/src/test/resources/META-INF/services/io.netty.bootstrap.ChannelInitializerExtension
@@ -1,0 +1,1 @@
+io.netty.bootstrap.StubChannelInitializerExtension


### PR DESCRIPTION
**Motivation:**

Netty is used by many libraries and frameworks that (reasonably) hide the fact that they use Netty under the covers. When Netty is hidden, it is hard, or sometimes impossible, to modify the channel pipelines, attributes, or options, from the outside. It might not even be clear if a framework or library makes use of Netty at all. However, we sometimes want to apply some changes, or make some checks, to most or all channels that are initialized by Netty, regardless of the framework or library that is using Netty in the given case.

Some examples of use-cases are:
- Web application firewalls.
- Server-side request forgery filters.
- Intrusion detection.
- Metrics gathering.

To address these use-cases in a way that don't require integrators to somehow find every Netty usage in a process, we introduce a service-loaded extension point that hooks into the channel initialization process.

**Modification:**

A new abstract class, `ChannelInitializerExtension`, is added. Implementations of this interface can be found and service-loaded at runtime by `AbstractBootstrap`, with the help of the `ChannelInitializerExtensions` utility class.

The `ChannelInitializerExtension` class offers three callback methods, one for the initialization of each of the different "kinds" of channels:
- Server listener channels.
- Server child channels.
- Client channels.

The extensions are disabled by default for security reasons, and require opt in by setting the `io.netty.bootstrap.extensions` system property to `serviceload`.
To see what extensions are available, the system property can be set to `log`, and we will load and log (at INFO level) what extensions are available, but not actually run them.

**Result:**

We have extension points for use cases that are cutting-across different Netty uses, and require low-level Netty access. This makes it relatively easy to implement such use cases without requiring deep access to the Netty internals of arbitrary libraries and frameworks, and without even needing to know which libraries and frameworks are actually using Netty. The only restriction to this, is the use of shading with class-relocation, which in each case would require their own `META-INF/services` file. Thankfully, most libraries and frameworks that shade Netty, also offer non-shading versions.
