### PR TITLE
Implement packet coalescing in the local transport

### DIFF
--- a/transport/src/main/java/io/netty/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalChannel.java
@@ -15,6 +15,7 @@
  */
 package io.netty.channel.local;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.channel.AbstractChannel;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
@@ -296,6 +297,29 @@ public class LocalChannel extends AbstractChannel {
             if (received == null) {
                 break;
             }
+            if (received instanceof ByteBuf) {
+                ByteBuf msg = (ByteBuf) received;
+                ByteBuf output = handle.allocate(alloc());
+                if (msg.readableBytes() < output.writableBytes()) {
+                    // We have an opportunity to coalesce buffers.
+                    output.writeBytes(msg, msg.readerIndex(), msg.readableBytes());
+                    msg.release();
+                    while ((received = inboundBuffer.peek()) instanceof ByteBuf &&
+                            ((ByteBuf) received).readableBytes() < output.writableBytes()) {
+                        inboundBuffer.poll();
+                        msg = (ByteBuf) received;
+                        output.writeBytes(msg, msg.readerIndex(), msg.readableBytes());
+                        msg.release();
+                    }
+                    handle.lastBytesRead(output.readableBytes());
+                    received = output; // Send the coalesced buffer down the pipeline.
+                } else {
+                    // It won't be profitable to coalesce buffers this time around.
+                    handle.lastBytesRead(output.capacity());
+                    output.release();
+                }
+            }
+            handle.incMessagesRead(1);
             pipeline.fireChannelRead(received);
         } while (handle.continueReading());
         handle.readComplete();

--- a/transport/src/main/java/io/netty/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalChannel.java
@@ -297,7 +297,7 @@ public class LocalChannel extends AbstractChannel {
             if (received == null) {
                 break;
             }
-            if (received instanceof ByteBuf) {
+            if (received instanceof ByteBuf && inboundBuffer.peek() instanceof ByteBuf) {
                 ByteBuf msg = (ByteBuf) received;
                 ByteBuf output = handle.allocate(alloc());
                 if (msg.readableBytes() < output.writableBytes()) {


### PR DESCRIPTION
Motivation:
It is much more efficient to process data in batches, and this is true as well for data passing through the local transport, i.e. LocalChannel. Applications often write many small buffers to their channels, but expect to process fewer, larger buffers when receiving data from the network. In fact, when the SslHandler is in the pipeline, we can observe an orders of magnitude difference in performance when coalescing packets into bigger buffers before processing, compared to processing packets individually. The real transports, like NIO and the native transports, all operate like this.

Modification:
The LocalChannel will now inspect incoming messages, and opportunistically coalesce small Buffers into bigger ones before sending them down the pipeline.

Result:
The local transport now sees improved batch processing behaviour.

This is a back port of #13568
