### PR TITLE
Only coalesce when there is more than one inbound buffer

### DIFF
--- a/transport/src/main/java/io/netty5/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty5/channel/local/LocalChannel.java
@@ -214,7 +214,7 @@ public class LocalChannel extends AbstractChannel<LocalServerChannel, LocalAddre
     @Override
     protected boolean doReadNow(ReadSink readSink) {
         Object received = inboundBuffer.poll();
-        if (received instanceof Buffer) {
+        if (received instanceof Buffer && inboundBuffer.peek() instanceof Buffer) {
             Buffer msg = (Buffer) received;
             Buffer buffer = readSink.allocateBuffer();
             if (buffer != null) {
@@ -411,7 +411,7 @@ public class LocalChannel extends AbstractChannel<LocalServerChannel, LocalAddre
         if (state != State.BOUND) {
             // Not bound yet and no localAddress specified - get one.
             if (localAddress == null) {
-                localAddress = new LocalAddress(LocalChannel.this);
+                localAddress = new LocalAddress(this);
             }
         }
 
@@ -432,13 +432,13 @@ public class LocalChannel extends AbstractChannel<LocalServerChannel, LocalAddre
         }
 
         LocalServerChannel serverChannel = (LocalServerChannel) boundChannel;
-        peer = serverChannel.serve(LocalChannel.this);
+        peer = serverChannel.serve(this);
         return false;
     }
 
     @Override
     protected boolean doFinishConnect(LocalAddress requestedRemoteAddress) throws Exception {
-        final LocalChannel peer = LocalChannel.this.peer;
+        final LocalChannel peer = this.peer;
         if (peer == null) {
             return false;
         }


### PR DESCRIPTION
Motivation:
In #13568 we added packet coalescing to the local transport. This will try to coalesce every time we observe a Buffer in the inboundBuffer queue. We should, however, only try to coalesce when there is at least two buffers in a row in the inbound buffer queue. Otherwise, we will end up doing an allocation and memory copy without actually reducing the number of buffers sent down the pipeline.

Modification:
Only go down the coalescing code path if we not only poll a buffer from the queue, but peek tells us that we have another buffer waiting after the first.

Result:
Avoid useless coalescing work when we only have one buffer in the inbound buffer queue.
