### PR TITLE
add reflection configuration for java.nio.channels.spi.SelectorProvider

### DIFF
--- a/transport/src/main/resources/META-INF/native-image/io.netty/netty-transport/reflection-config.json
+++ b/transport/src/main/resources/META-INF/native-image/io.netty/netty-transport/reflection-config.json
@@ -29,5 +29,21 @@
                 "parameterTypes": []
             }
         ]
+    },
+    {
+        "name": "java.nio.channels.spi.SelectorProvider",
+        "condition": {
+            "typeReachable": "java.nio.channels.spi.SelectorProvider"
+        },
+        "methods": [
+            {
+                "name": "openSocketChannel",
+                "parameterTypes": ["java.net.ProtocolFamily"]
+            },
+            {
+                "name": "openServerSocketChannel",
+                "parameterTypes": ["java.net.ProtocolFamily"]
+            }
+        ]
     }
 ]


### PR DESCRIPTION
Motivation:

This PR add the reflection configurations(graalvm native image) for `java.nio.channels.spi.SelectorProvider` which is used in `io.netty.channel.socket.nio.SelectorProviderUtil`

Modification:

more configs in `transport/src/main/resources/META-INF/native-image/io.netty/netty-transport/reflection-config.json`

Result:

Fixes https://github.com/netty/netty/issues/13575
