### PR TITLE
Prevent classloader leak via JNI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -702,7 +702,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-jni-util</artifactId>
-        <version>0.0.7.Final</version>
+        <version>0.0.8.Final</version>
         <classifier>sources</classifier>
         <optional>true</optional>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -702,7 +702,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-jni-util</artifactId>
-        <version>0.0.8.Final</version>
+        <version>0.0.9.Final</version>
         <classifier>sources</classifier>
         <optional>true</optional>
       </dependency>

--- a/resolver-dns-native-macos/src/main/c/netty_resolver_dns_macos.c
+++ b/resolver-dns-native-macos/src/main/c/netty_resolver_dns_macos.c
@@ -129,15 +129,13 @@ static jobjectArray netty_resolver_dns_macos_resolvers(JNIEnv* env, jclass clazz
     }
 
     dns_configuration_free(config);
-    (*env)->DeleteLocalRef(env, dnsResolverClass);
+    NETTY_JNI_UTIL_DELETE_LOCAL(env, dnsResolverClass);
     return array;
 error:
     if (config != NULL) {
         dns_configuration_free(config);
     }
-    if (dnsResolverClass != NULL) {
-        (*env)->DeleteLocalRef(env, dnsResolverClass);
-    }
+    NETTY_JNI_UTIL_DELETE_LOCAL(env, dnsResolverClass);
     return NULL;
 }
 
@@ -212,9 +210,9 @@ done:
     }
     netty_jni_util_free_dynamic_methods_table(dynamicMethods, 0, 1);
     free(nettyClassName);
-    if (dnsResolverClass != NULL) {
-        (*env)->DeleteLocalRef(env, dnsResolverClass);
-    }
+
+    NETTY_JNI_UTIL_DELETE_LOCAL(env, dnsResolverClass);
+
     return ret;
 }
 

--- a/resolver-dns-native-macos/src/main/c/netty_resolver_dns_macos.c
+++ b/resolver-dns-native-macos/src/main/c/netty_resolver_dns_macos.c
@@ -32,7 +32,7 @@
 
 #define STREAM_CLASSNAME "io/netty/resolver/dns/macos/MacOSDnsServerAddressStreamProvider"
 
-static jclass dnsResolverClass = NULL;
+static jweak dnsResolverClassWeak = NULL;
 static jclass byteArrayClass = NULL;
 static jclass stringClass = NULL;
 static jmethodID dnsResolverMethodId = NULL;
@@ -45,10 +45,13 @@ static char const* staticPackagePrefix = NULL;
 //     https://src.chromium.org/viewvc/chrome?revision=218617&view=revision
 //     https://opensource.apple.com/tarballs/mDNSResponder/
 static jobjectArray netty_resolver_dns_macos_resolvers(JNIEnv* env, jclass clazz) {
+    jclass dnsResolverClass = NULL;
     dns_config_t* config = dns_configuration_copy();
     if (config == NULL) {
         goto error;
     }
+    NETTY_JNI_UTIL_NEW_LOCAL_FROM_WEAK(env, dnsResolverClass, dnsResolverClassWeak, error);
+
     jobjectArray array = (*env)->NewObjectArray(env, config->n_resolver, dnsResolverClass, NULL);
     if (array == NULL) {
         goto error;
@@ -126,10 +129,14 @@ static jobjectArray netty_resolver_dns_macos_resolvers(JNIEnv* env, jclass clazz
     }
 
     dns_configuration_free(config);
+    (*env)->DeleteLocalRef(env, dnsResolverClass);
     return array;
 error:
     if (config != NULL) {
         dns_configuration_free(config);
+    }
+    if (dnsResolverClass != NULL) {
+        (*env)->DeleteLocalRef(env, dnsResolverClass);
     }
     return NULL;
 }
@@ -154,7 +161,7 @@ static JNINativeMethod* createDynamicMethodsTable(const char* packagePrefix) {
 static void netty_resolver_dns_native_macos_JNI_OnUnLoad(JNIEnv* env) {
     NETTY_JNI_UTIL_UNLOAD_CLASS(env, byteArrayClass);
     NETTY_JNI_UTIL_UNLOAD_CLASS(env, stringClass);
-    NETTY_JNI_UTIL_UNLOAD_CLASS(env, dnsResolverClass);
+    NETTY_JNI_UTIL_UNLOAD_CLASS_WEAK(env, dnsResolverClassWeak);
     netty_jni_util_unregister_natives(env, staticPackagePrefix, STREAM_CLASSNAME);
 
     if (staticPackagePrefix != NULL) {
@@ -169,6 +176,7 @@ static jint netty_resolver_dns_native_macos_JNI_OnLoad(JNIEnv* env, char const* 
     int ret = JNI_ERR;
     int providerRegistered = 0;
     char* nettyClassName = NULL;
+    jclass dnsResolverClass = NULL;
 
     // Register the methods which are not referenced by static member variables
     JNINativeMethod* dynamicMethods = createDynamicMethodsTable(packagePrefix);
@@ -184,9 +192,10 @@ static jint netty_resolver_dns_native_macos_JNI_OnLoad(JNIEnv* env, char const* 
     providerRegistered = 1;
 
     nettyClassName = netty_jni_util_prepend(packagePrefix, "io/netty/resolver/dns/macos/DnsResolver");
-    NETTY_JNI_UTIL_LOAD_CLASS(env, dnsResolverClass, nettyClassName, done);
+    NETTY_JNI_UTIL_LOAD_CLASS_WEAK(env, dnsResolverClassWeak, nettyClassName, done);
     netty_jni_util_free_dynamic_name(&nettyClassName);
 
+    NETTY_JNI_UTIL_NEW_LOCAL_FROM_WEAK(env, dnsResolverClass, dnsResolverClassWeak, done);
     NETTY_JNI_UTIL_GET_METHOD(env, dnsResolverClass, dnsResolverMethodId, "<init>", "(Ljava/lang/String;[[BI[Ljava/lang/String;Ljava/lang/String;II)V", done);
 
     NETTY_JNI_UTIL_LOAD_CLASS(env, byteArrayClass, "[B", done);
@@ -203,6 +212,9 @@ done:
     }
     netty_jni_util_free_dynamic_methods_table(dynamicMethods, 0, 1);
     free(nettyClassName);
+    if (dnsResolverClass != NULL) {
+        (*env)->DeleteLocalRef(env, dnsResolverClass);
+    }
     return ret;
 }
 

--- a/transport-native-epoll/src/main/c/netty_epoll_linuxsocket.c
+++ b/transport-native-epoll/src/main/c/netty_epoll_linuxsocket.c
@@ -703,9 +703,8 @@ static jobject netty_epoll_linuxsocket_getPeerCredentials(JNIEnv *env, jclass cl
      NETTY_JNI_UTIL_NEW_LOCAL_FROM_WEAK(env, peerCredentialsClass, peerCredentialsClassWeak, error);
 
      jobject creds = (*env)->NewObject(env, peerCredentialsClass, peerCredentialsMethodId, credentials.pid, credentials.uid, gids);
-     if (peerCredentialsClass != NULL) {
-         (*env)->DeleteLocalRef(env, peerCredentialsClass);
-     }
+
+     NETTY_JNI_UTIL_DELETE_LOCAL(env, peerCredentialsClass);
      return creds;
  error:
      return NULL;
@@ -899,9 +898,8 @@ jint netty_epoll_linuxsocket_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) 
 done:
     netty_jni_util_free_dynamic_methods_table(dynamicMethods, fixed_method_table_size, dynamicMethodsTableSize());
     free(nettyClassName);
-    if (peerCredentialsClass != NULL) {
-        (*env)->DeleteLocalRef(env, peerCredentialsClass);
-    }
+
+    NETTY_JNI_UTIL_DELETE_LOCAL(env, peerCredentialsClass);
     return ret;
 }
 

--- a/transport-native-epoll/src/main/c/netty_epoll_linuxsocket.c
+++ b/transport-native-epoll/src/main/c/netty_epoll_linuxsocket.c
@@ -706,6 +706,7 @@ static jobject netty_epoll_linuxsocket_getPeerCredentials(JNIEnv *env, jclass cl
      if (peerCredentialsClass != NULL) {
          (*env)->DeleteLocalRef(env, peerCredentialsClass);
      }
+     return creds;
  error:
      return NULL;
 }

--- a/transport-native-epoll/src/main/c/netty_epoll_linuxsocket.c
+++ b/transport-native-epoll/src/main/c/netty_epoll_linuxsocket.c
@@ -63,7 +63,7 @@
 #define UDP_GRO 104
 #endif
 
-static jclass peerCredentialsClass = NULL;
+static jweak peerCredentialsClassWeak = NULL;
 static jmethodID peerCredentialsMethodId = NULL;
 
 static jfieldID fileChannelFieldId = NULL;
@@ -693,12 +693,21 @@ static jint netty_epoll_linuxsocket_getTcpNotSentLowAt(JNIEnv* env, jclass clazz
 
 static jobject netty_epoll_linuxsocket_getPeerCredentials(JNIEnv *env, jclass clazz, jint fd) {
      struct ucred credentials;
+     jclass peerCredentialsClass = NULL;
      if(netty_unix_socket_getOption(env,fd, SOL_SOCKET, SO_PEERCRED, &credentials, sizeof (credentials)) == -1) {
          return NULL;
      }
      jintArray gids = (*env)->NewIntArray(env, 1);
      (*env)->SetIntArrayRegion(env, gids, 0, 1, (jint*) &credentials.gid);
-     return (*env)->NewObject(env, peerCredentialsClass, peerCredentialsMethodId, credentials.pid, credentials.uid, gids);
+
+     NETTY_JNI_UTIL_NEW_LOCAL_FROM_WEAK(env, peerCredentialsClass, peerCredentialsClassWeak, error);
+
+     jobject creds = (*env)->NewObject(env, peerCredentialsClass, peerCredentialsMethodId, credentials.pid, credentials.uid, gids);
+     if (peerCredentialsClass != NULL) {
+         (*env)->DeleteLocalRef(env, peerCredentialsClass);
+     }
+ error:
+     return NULL;
 }
 
 static jint netty_epoll_linuxsocket_isUdpGro(JNIEnv* env, jclass clazz, jint fd) {
@@ -845,6 +854,7 @@ jint netty_epoll_linuxsocket_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) 
     jclass fileRegionCls = NULL;
     jclass fileChannelCls = NULL;
     jclass fileDescriptorCls = NULL;
+    jclass peerCredentialsClass = NULL;
     // Register the methods which are not referenced by static member variables
     JNINativeMethod* dynamicMethods = createDynamicMethodsTable(packagePrefix);
     if (dynamicMethods == NULL) {
@@ -859,6 +869,10 @@ jint netty_epoll_linuxsocket_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) 
     }
 
     NETTY_JNI_UTIL_PREPEND(packagePrefix, "io/netty/channel/unix/PeerCredentials", nettyClassName, done);
+
+    NETTY_JNI_UTIL_LOAD_CLASS_WEAK(env, peerCredentialsClassWeak, nettyClassName, done);
+    NETTY_JNI_UTIL_NEW_LOCAL_FROM_WEAK(env, peerCredentialsClass, peerCredentialsClassWeak, done);
+
     NETTY_JNI_UTIL_LOAD_CLASS(env, peerCredentialsClass, nettyClassName, done);
     netty_jni_util_free_dynamic_name(&nettyClassName);
 
@@ -884,12 +898,14 @@ jint netty_epoll_linuxsocket_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) 
 done:
     netty_jni_util_free_dynamic_methods_table(dynamicMethods, fixed_method_table_size, dynamicMethodsTableSize());
     free(nettyClassName);
-
+    if (peerCredentialsClass != NULL) {
+        (*env)->DeleteLocalRef(env, peerCredentialsClass);
+    }
     return ret;
 }
 
 void netty_epoll_linuxsocket_JNI_OnUnLoad(JNIEnv* env, const char* packagePrefix) {
-    NETTY_JNI_UTIL_UNLOAD_CLASS(env, peerCredentialsClass);
+    NETTY_JNI_UTIL_UNLOAD_CLASS_WEAK(env, peerCredentialsClassWeak);
 
     netty_jni_util_unregister_natives(env, packagePrefix, LINUXSOCKET_CLASSNAME);
 }

--- a/transport-native-kqueue/src/main/c/netty_kqueue_bsdsocket.c
+++ b/transport-native-kqueue/src/main/c/netty_kqueue_bsdsocket.c
@@ -367,9 +367,7 @@ done:
     netty_jni_util_free_dynamic_methods_table(dynamicMethods, fixed_method_table_size, dynamicMethodsTableSize());
     free(nettyClassName);
 
-    if (peerCredentialsClass != NULL) {
-        (*env)->DeleteLocalRef(env, peerCredentialsClass);
-    }
+    NETTY_JNI_UTIL_DELETE_LOCAL(env, peerCredentialsClass);
 
     return ret;
 }

--- a/transport-native-kqueue/src/main/c/netty_kqueue_bsdsocket.c
+++ b/transport-native-kqueue/src/main/c/netty_kqueue_bsdsocket.c
@@ -258,9 +258,7 @@ static jobject netty_kqueue_bsdsocket_getPeerCredentials(JNIEnv *env, jclass cla
     NETTY_JNI_UTIL_NEW_LOCAL_FROM_WEAK(env, peerCredentialsClass, peerCredentialsClassWeak, error);
 
     jobject creds = (*env)->NewObject(env, peerCredentialsClass, peerCredentialsMethodId, pid, credentials.cr_uid, gids);
-    if (peerCredentialsClass != NULL) {
-        (*env)->DeleteLocalRef(env, peerCredentialsClass);
-    }
+    NETTY_JNI_UTIL_DELETE_LOCAL(env, peerCredentialsClass);
     return creds;
  error:
     return NULL;

--- a/transport-native-kqueue/src/main/c/netty_kqueue_bsdsocket.c
+++ b/transport-native-kqueue/src/main/c/netty_kqueue_bsdsocket.c
@@ -37,7 +37,7 @@
 
 // Those are initialized in the init(...) method and cached for performance reasons
 static jclass stringClass = NULL;
-static jclass peerCredentialsClass = NULL;
+static jweak peerCredentialsClassWeak = NULL;
 static jfieldID fileChannelFieldId = NULL;
 static jfieldID transferredFieldId = NULL;
 static jfieldID fdFieldId = NULL;
@@ -225,6 +225,8 @@ static jint netty_kqueue_bsdsocket_isTcpFastOpen(JNIEnv* env, jclass clazz, jint
 
 static jobject netty_kqueue_bsdsocket_getPeerCredentials(JNIEnv *env, jclass clazz, jint fd) {
     struct xucred credentials;
+    jclass peerCredentialsClass = NULL;
+
     // It has been observed on MacOS that this method can complete successfully but not set all fields of xucred.
     credentials.cr_ngroups = 0;
     if(netty_unix_socket_getOption(env,fd, SOL_SOCKET, LOCAL_PEERCRED, &credentials, sizeof (credentials)) == -1) {
@@ -253,7 +255,15 @@ static jobject netty_kqueue_bsdsocket_getPeerCredentials(JNIEnv *env, jclass cla
     }
 #endif
 
-    return (*env)->NewObject(env, peerCredentialsClass, peerCredentialsMethodId, pid, credentials.cr_uid, gids);
+    NETTY_JNI_UTIL_NEW_LOCAL_FROM_WEAK(env, peerCredentialsClass, peerCredentialsClassWeak, error);
+
+    jobject creds = (*env)->NewObject(env, peerCredentialsClass, peerCredentialsMethodId, pid, credentials.cr_uid, gids);
+    if (peerCredentialsClass != NULL) {
+        (*env)->DeleteLocalRef(env, peerCredentialsClass);
+    }
+    return creds;
+ error:
+    return NULL;
 }
 // JNI Registered Methods End
 
@@ -317,6 +327,7 @@ jint netty_kqueue_bsdsocket_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     jclass fileRegionCls = NULL;
     jclass fileChannelCls = NULL;
     jclass fileDescriptorCls = NULL;
+    jclass peerCredentialsClass = NULL;
     // Register the methods which are not referenced by static member variables
     JNINativeMethod* dynamicMethods = createDynamicMethodsTable(packagePrefix);
     if (dynamicMethods == NULL) {
@@ -347,7 +358,9 @@ jint netty_kqueue_bsdsocket_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     NETTY_JNI_UTIL_LOAD_CLASS(env, stringClass, "java/lang/String", done);
 
     NETTY_JNI_UTIL_PREPEND(packagePrefix, "io/netty/channel/unix/PeerCredentials", nettyClassName, done);
-    NETTY_JNI_UTIL_LOAD_CLASS(env, peerCredentialsClass, nettyClassName, done);
+
+    NETTY_JNI_UTIL_LOAD_CLASS_WEAK(env, peerCredentialsClassWeak, nettyClassName, done);
+    NETTY_JNI_UTIL_NEW_LOCAL_FROM_WEAK(env, peerCredentialsClass, peerCredentialsClassWeak, done);
     netty_jni_util_free_dynamic_name(&nettyClassName);
   
     NETTY_JNI_UTIL_GET_METHOD(env, peerCredentialsClass, peerCredentialsMethodId, "<init>", "(II[I)V", done);
@@ -356,11 +369,15 @@ done:
     netty_jni_util_free_dynamic_methods_table(dynamicMethods, fixed_method_table_size, dynamicMethodsTableSize());
     free(nettyClassName);
 
+    if (peerCredentialsClass != NULL) {
+        (*env)->DeleteLocalRef(env, peerCredentialsClass);
+    }
+
     return ret;
 }
 
 void netty_kqueue_bsdsocket_JNI_OnUnLoad(JNIEnv* env, const char* packagePrefix) {
-    NETTY_JNI_UTIL_UNLOAD_CLASS(env, peerCredentialsClass);
+    NETTY_JNI_UTIL_UNLOAD_CLASS_WEAK(env, peerCredentialsClassWeak);
     NETTY_JNI_UTIL_UNLOAD_CLASS(env, stringClass);
 
     netty_jni_util_unregister_natives(env, packagePrefix, BSDSOCKET_CLASSNAME);

--- a/transport-native-unix-common/src/main/c/netty_unix_errors.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_errors.c
@@ -24,9 +24,9 @@
 
 #define ERRORS_CLASSNAME "io/netty/channel/unix/ErrorsStaticallyReferencedJniMethods"
 
+static jweak channelExceptionClassWeak = NULL;
 static jclass oomErrorClass = NULL;
 static jclass runtimeExceptionClass = NULL;
-static jclass channelExceptionClass = NULL;
 static jclass ioExceptionClass = NULL;
 static jclass portUnreachableExceptionClass = NULL;
 static jclass closedChannelExceptionClass = NULL;
@@ -102,11 +102,19 @@ void netty_unix_errors_throwRuntimeExceptionErrorNo(JNIEnv* env, char* message, 
 }
 
 void netty_unix_errors_throwChannelExceptionErrorNo(JNIEnv* env, char* message, int errorNumber) {
+    jclass channelExceptionClass = NULL;
     char* allocatedMessage = exceptionMessage(message, errorNumber);
     if (allocatedMessage == NULL) {
         return;
     }
+
+    NETTY_JNI_UTIL_NEW_LOCAL_FROM_WEAK(env, channelExceptionClass, channelExceptionClassWeak, done);
+
     (*env)->ThrowNew(env, channelExceptionClass, allocatedMessage);
+done:
+    if (channelExceptionClass != NULL) {
+        (*env)->DeleteLocalRef(env, channelExceptionClass);
+    }
     free(allocatedMessage);
 }
 
@@ -221,6 +229,7 @@ static const jint statically_referenced_fixed_method_table_size = sizeof(statica
 //            Unix to reflect that.
 jint netty_unix_errors_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     char* nettyClassName = NULL;
+    jclass channelExceptionClass = NULL;
     // We must register the statically referenced methods first!
     if (netty_jni_util_register_natives(env,
             packagePrefix,
@@ -235,7 +244,11 @@ jint netty_unix_errors_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     NETTY_JNI_UTIL_LOAD_CLASS(env, runtimeExceptionClass, "java/lang/RuntimeException", error);
 
     NETTY_JNI_UTIL_PREPEND(packagePrefix, "io/netty/channel/ChannelException", nettyClassName, error);
-    NETTY_JNI_UTIL_LOAD_CLASS(env, channelExceptionClass, nettyClassName, error);
+
+
+    NETTY_JNI_UTIL_LOAD_CLASS_WEAK(env, channelExceptionClassWeak, nettyClassName, error);
+    NETTY_JNI_UTIL_NEW_LOCAL_FROM_WEAK(env, channelExceptionClass, channelExceptionClassWeak, error);
+
     netty_jni_util_free_dynamic_name(&nettyClassName);
 
     NETTY_JNI_UTIL_LOAD_CLASS(env, closedChannelExceptionClass, "java/nio/channels/ClosedChannelException", error);
@@ -245,9 +258,18 @@ jint netty_unix_errors_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
 
     NETTY_JNI_UTIL_LOAD_CLASS(env, portUnreachableExceptionClass, "java/net/PortUnreachableException", error);
 
+
+    if (channelExceptionClass != NULL) {
+        (*env)->DeleteLocalRef(env, channelExceptionClass);
+    }
+
     return NETTY_JNI_UTIL_JNI_VERSION;
 error:
     free(nettyClassName);
+
+    if (channelExceptionClass != NULL) {
+        (*env)->DeleteLocalRef(env, channelExceptionClass);
+    }
     return JNI_ERR;
 }
 
@@ -255,7 +277,7 @@ void netty_unix_errors_JNI_OnUnLoad(JNIEnv* env, const char* packagePrefix) {
     // delete global references so the GC can collect them
     NETTY_JNI_UTIL_UNLOAD_CLASS(env, oomErrorClass);
     NETTY_JNI_UTIL_UNLOAD_CLASS(env, runtimeExceptionClass);
-    NETTY_JNI_UTIL_UNLOAD_CLASS(env, channelExceptionClass);
+    NETTY_JNI_UTIL_UNLOAD_CLASS_WEAK(env, channelExceptionClassWeak);
     NETTY_JNI_UTIL_UNLOAD_CLASS(env, ioExceptionClass);
     NETTY_JNI_UTIL_UNLOAD_CLASS(env, portUnreachableExceptionClass);
     NETTY_JNI_UTIL_UNLOAD_CLASS(env, closedChannelExceptionClass);

--- a/transport-native-unix-common/src/main/c/netty_unix_errors.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_errors.c
@@ -112,9 +112,8 @@ void netty_unix_errors_throwChannelExceptionErrorNo(JNIEnv* env, char* message, 
 
     (*env)->ThrowNew(env, channelExceptionClass, allocatedMessage);
 done:
-    if (channelExceptionClass != NULL) {
-        (*env)->DeleteLocalRef(env, channelExceptionClass);
-    }
+
+    NETTY_JNI_UTIL_DELETE_LOCAL(env, channelExceptionClass);
     free(allocatedMessage);
 }
 
@@ -259,17 +258,13 @@ jint netty_unix_errors_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     NETTY_JNI_UTIL_LOAD_CLASS(env, portUnreachableExceptionClass, "java/net/PortUnreachableException", error);
 
 
-    if (channelExceptionClass != NULL) {
-        (*env)->DeleteLocalRef(env, channelExceptionClass);
-    }
-
+    NETTY_JNI_UTIL_DELETE_LOCAL(env, channelExceptionClass);
     return NETTY_JNI_UTIL_JNI_VERSION;
 error:
     free(nettyClassName);
 
-    if (channelExceptionClass != NULL) {
-        (*env)->DeleteLocalRef(env, channelExceptionClass);
-    }
+    NETTY_JNI_UTIL_DELETE_LOCAL(env, channelExceptionClass);
+
     return JNI_ERR;
 }
 

--- a/transport-native-unix-common/src/main/c/netty_unix_socket.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_socket.c
@@ -44,8 +44,8 @@
 #define MSG_FASTOPEN 0x20000000
 #endif
 
-static jclass datagramSocketAddressClass = NULL;
-static jclass domainDatagramSocketAddressClass = NULL;
+static jweak datagramSocketAddressClassWeak = NULL;
+static jweak domainDatagramSocketAddressClassWeak = NULL;
 static jmethodID datagramSocketAddrMethodId = NULL;
 static jmethodID domainDatagramSocketAddrMethodId = NULL;
 static jmethodID inetSocketAddrMethodId = NULL;
@@ -90,6 +90,8 @@ int netty_unix_socket_ipAddressLength(const struct sockaddr_storage* addr) {
 }
 
 static jobject createDatagramSocketAddress(JNIEnv* env, const struct sockaddr_storage* addr, int len, jobject local) {
+    jclass datagramSocketAddressClass = NULL;
+    jobject obj  = NULL;
     int port;
     int scopeId;
     int ipLength = netty_unix_socket_ipAddressLength(addr);
@@ -117,14 +119,24 @@ static jobject createDatagramSocketAddress(JNIEnv* env, const struct sockaddr_st
         jbyte* addr = (jbyte*) &s->sin6_addr.s6_addr;
         (*env)->SetByteArrayRegion(env, addressBytes, 0, ipLength, addr + offset);
     }
-    jobject obj = (*env)->NewObject(env, datagramSocketAddressClass, datagramSocketAddrMethodId, addressBytes, scopeId, port, len, local);
+
+    NETTY_JNI_UTIL_NEW_LOCAL_FROM_WEAK(env, datagramSocketAddressClass, datagramSocketAddressClassWeak, done);
+
+    obj = (*env)->NewObject(env, datagramSocketAddressClass, datagramSocketAddrMethodId, addressBytes, scopeId, port, len, local);
     if ((*env)->ExceptionCheck(env) == JNI_TRUE) {
-        return NULL;
+        obj = NULL;
+        goto done;
+    }
+done:
+    if (datagramSocketAddressClass != NULL) {
+        (*env)->DeleteLocalRef(env, datagramSocketAddressClass);
     }
     return obj;
 }
 
 static jobject createDomainDatagramSocketAddress(JNIEnv* env, const struct sockaddr_storage* addr, int len, jobject local) {
+    jclass domainDatagramSocketAddressClass = NULL;
+    jobject obj  = NULL;
     struct sockaddr_un* s = (struct sockaddr_un*) addr;
     int pathLength = strlen(s->sun_path);
     jbyteArray pathBytes = (*env)->NewByteArray(env, pathLength);
@@ -133,9 +145,16 @@ static jobject createDomainDatagramSocketAddress(JNIEnv* env, const struct socka
     }
 
     (*env)->SetByteArrayRegion(env, pathBytes, 0, pathLength, (jbyte*) &s->sun_path);
-    jobject obj = (*env)->NewObject(env, domainDatagramSocketAddressClass, domainDatagramSocketAddrMethodId, pathBytes, len, local);
+
+    NETTY_JNI_UTIL_NEW_LOCAL_FROM_WEAK(env, domainDatagramSocketAddressClass, domainDatagramSocketAddressClassWeak, done);
+
+    obj = (*env)->NewObject(env, domainDatagramSocketAddressClass, domainDatagramSocketAddrMethodId, pathBytes, len, local);
     if ((*env)->ExceptionCheck(env) == JNI_TRUE) {
         return NULL;
+    }
+done:
+    if (domainDatagramSocketAddressClass != NULL) {
+        (*env)->DeleteLocalRef(env, domainDatagramSocketAddressClass);
     }
     return obj;
 }
@@ -1296,6 +1315,9 @@ jint netty_unix_socket_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     int ret = JNI_ERR;
     char* nettyClassName = NULL;
     void* mem = NULL;
+    jclass datagramSocketAddressClass = NULL;
+    jclass domainDatagramSocketAddressClass = NULL;
+
     JNINativeMethod* dynamicMethods = createDynamicMethodsTable(packagePrefix);
     if (dynamicMethods == NULL) {
         goto done;
@@ -1309,7 +1331,9 @@ jint netty_unix_socket_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     }
   
     NETTY_JNI_UTIL_PREPEND(packagePrefix, "io/netty/channel/unix/DatagramSocketAddress", nettyClassName, done);
-    NETTY_JNI_UTIL_LOAD_CLASS(env, datagramSocketAddressClass, nettyClassName, done);
+
+    NETTY_JNI_UTIL_LOAD_CLASS_WEAK(env, datagramSocketAddressClassWeak, nettyClassName, done);
+    NETTY_JNI_UTIL_NEW_LOCAL_FROM_WEAK(env, datagramSocketAddressClass, datagramSocketAddressClassWeak, done);
 
     // Respect shading...
     char parameters[1024] = {0};
@@ -1318,7 +1342,9 @@ jint netty_unix_socket_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     NETTY_JNI_UTIL_GET_METHOD(env, datagramSocketAddressClass, datagramSocketAddrMethodId, "<init>", parameters, done);
 
     NETTY_JNI_UTIL_PREPEND(packagePrefix, "io/netty/channel/unix/DomainDatagramSocketAddress", nettyClassName, done);
-    NETTY_JNI_UTIL_LOAD_CLASS(env, domainDatagramSocketAddressClass, nettyClassName, done);
+
+    NETTY_JNI_UTIL_LOAD_CLASS_WEAK(env, domainDatagramSocketAddressClassWeak, nettyClassName, done);
+    NETTY_JNI_UTIL_NEW_LOCAL_FROM_WEAK(env, domainDatagramSocketAddressClass, domainDatagramSocketAddressClassWeak, done);
 
     char parameters1[1024] = {0};
     snprintf(parameters1, sizeof(parameters1), "([BIL%s;)V", nettyClassName);
@@ -1345,12 +1371,20 @@ done:
     netty_jni_util_free_dynamic_methods_table(dynamicMethods, fixed_method_table_size, dynamicMethodsTableSize());
     free(nettyClassName);
     free(mem);
+
+    if (datagramSocketAddressClass != NULL) {
+        (*env)->DeleteLocalRef(env, datagramSocketAddressClass);
+    }
+
+    if (domainDatagramSocketAddressClass != NULL) {
+        (*env)->DeleteLocalRef(env, domainDatagramSocketAddressClass);
+    }
     return ret;
 }
 
 void netty_unix_socket_JNI_OnUnLoad(JNIEnv* env, const char* packagePrefix) {
-    NETTY_JNI_UTIL_UNLOAD_CLASS(env, datagramSocketAddressClass);
-    NETTY_JNI_UTIL_UNLOAD_CLASS(env, domainDatagramSocketAddressClass);
+    NETTY_JNI_UTIL_UNLOAD_CLASS_WEAK(env, datagramSocketAddressClassWeak);
+    NETTY_JNI_UTIL_UNLOAD_CLASS_WEAK(env, domainDatagramSocketAddressClassWeak);
     NETTY_JNI_UTIL_UNLOAD_CLASS(env, inetSocketAddressClass);
 
     netty_jni_util_unregister_natives(env, packagePrefix, SOCKET_CLASSNAME);

--- a/transport-native-unix-common/src/main/c/netty_unix_socket.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_socket.c
@@ -128,9 +128,8 @@ static jobject createDatagramSocketAddress(JNIEnv* env, const struct sockaddr_st
         goto done;
     }
 done:
-    if (datagramSocketAddressClass != NULL) {
-        (*env)->DeleteLocalRef(env, datagramSocketAddressClass);
-    }
+    NETTY_JNI_UTIL_DELETE_LOCAL(env, datagramSocketAddressClass);
+
     return obj;
 }
 
@@ -153,9 +152,8 @@ static jobject createDomainDatagramSocketAddress(JNIEnv* env, const struct socka
         return NULL;
     }
 done:
-    if (domainDatagramSocketAddressClass != NULL) {
-        (*env)->DeleteLocalRef(env, domainDatagramSocketAddressClass);
-    }
+    NETTY_JNI_UTIL_DELETE_LOCAL(env, domainDatagramSocketAddressClass);
+
     return obj;
 }
 
@@ -1372,13 +1370,9 @@ done:
     free(nettyClassName);
     free(mem);
 
-    if (datagramSocketAddressClass != NULL) {
-        (*env)->DeleteLocalRef(env, datagramSocketAddressClass);
-    }
+    NETTY_JNI_UTIL_DELETE_LOCAL(env, datagramSocketAddressClass);
+    NETTY_JNI_UTIL_DELETE_LOCAL(env, domainDatagramSocketAddressClass);
 
-    if (domainDatagramSocketAddressClass != NULL) {
-        (*env)->DeleteLocalRef(env, domainDatagramSocketAddressClass);
-    }
     return ret;
 }
 


### PR DESCRIPTION
Motivation:

We should use weak references to hold global references to our own classes as otherwise it will be not possible to unload the classloader.

Modifications:

Use weak references for the classes in JNI.

Result:
Fixes https://github.com/netty/netty/issues/13480
