### PR TITLE
Prevent classloader leak via JNI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -639,7 +639,7 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>netty-jni-util</artifactId>
-        <version>0.0.7.Final</version>
+        <version>0.0.9.Final</version>
         <classifier>sources</classifier>
         <optional>true</optional>
       </dependency>

--- a/resolver-dns-native-macos/src/main/c/netty5_resolver_dns_macos.c
+++ b/resolver-dns-native-macos/src/main/c/netty5_resolver_dns_macos.c
@@ -32,7 +32,7 @@
 
 #define STREAM_CLASSNAME "io/netty5/resolver/dns/macos/MacOSDnsServerAddressStreamProvider"
 
-static jclass dnsResolverClass = NULL;
+static jweak dnsResolverClassWeak = NULL;
 static jclass byteArrayClass = NULL;
 static jclass stringClass = NULL;
 static jmethodID dnsResolverMethodId = NULL;
@@ -45,10 +45,13 @@ static char const* staticPackagePrefix = NULL;
 //     https://src.chromium.org/viewvc/chrome?revision=218617&view=revision
 //     https://opensource.apple.com/tarballs/mDNSResponder/
 static jobjectArray netty5_resolver_dns_macos_resolvers(JNIEnv* env, jclass clazz) {
+    jclass dnsResolverClass = NULL;
     dns_config_t* config = dns_configuration_copy();
     if (config == NULL) {
         goto error;
     }
+    NETTY_JNI_UTIL_NEW_LOCAL_FROM_WEAK(env, dnsResolverClass, dnsResolverClassWeak, error);
+
     jobjectArray array = (*env)->NewObjectArray(env, config->n_resolver, dnsResolverClass, NULL);
     if (array == NULL) {
         goto error;
@@ -126,11 +129,13 @@ static jobjectArray netty5_resolver_dns_macos_resolvers(JNIEnv* env, jclass claz
     }
 
     dns_configuration_free(config);
+    NETTY_JNI_UTIL_DELETE_LOCAL(env, dnsResolverClass);
     return array;
 error:
     if (config != NULL) {
         dns_configuration_free(config);
     }
+    NETTY_JNI_UTIL_DELETE_LOCAL(env, dnsResolverClass);
     return NULL;
 }
 
@@ -154,7 +159,7 @@ static JNINativeMethod* createDynamicMethodsTable(const char* packagePrefix) {
 static void netty5_resolver_dns_native_macos_JNI_OnUnLoad(JNIEnv* env) {
     NETTY_JNI_UTIL_UNLOAD_CLASS(env, byteArrayClass);
     NETTY_JNI_UTIL_UNLOAD_CLASS(env, stringClass);
-    NETTY_JNI_UTIL_UNLOAD_CLASS(env, dnsResolverClass);
+    NETTY_JNI_UTIL_UNLOAD_CLASS_WEAK(env, dnsResolverClassWeak);
     netty_jni_util_unregister_natives(env, staticPackagePrefix, STREAM_CLASSNAME);
 
     if (staticPackagePrefix != NULL) {
@@ -169,6 +174,7 @@ static jint netty5_resolver_dns_native_macos_JNI_OnLoad(JNIEnv* env, char const*
     int ret = JNI_ERR;
     int providerRegistered = 0;
     char* nettyClassName = NULL;
+    jclass dnsResolverClass = NULL;
 
     // Register the methods which are not referenced by static member variables
     JNINativeMethod* dynamicMethods = createDynamicMethodsTable(packagePrefix);
@@ -184,9 +190,10 @@ static jint netty5_resolver_dns_native_macos_JNI_OnLoad(JNIEnv* env, char const*
     providerRegistered = 1;
 
     nettyClassName = netty_jni_util_prepend(packagePrefix, "io/netty5/resolver/dns/macos/DnsResolver");
-    NETTY_JNI_UTIL_LOAD_CLASS(env, dnsResolverClass, nettyClassName, done);
+    NETTY_JNI_UTIL_LOAD_CLASS_WEAK(env, dnsResolverClassWeak, nettyClassName, done);
     netty_jni_util_free_dynamic_name(&nettyClassName);
 
+    NETTY_JNI_UTIL_NEW_LOCAL_FROM_WEAK(env, dnsResolverClass, dnsResolverClassWeak, done);
     NETTY_JNI_UTIL_GET_METHOD(env, dnsResolverClass, dnsResolverMethodId, "<init>", "(Ljava/lang/String;[[BI[Ljava/lang/String;Ljava/lang/String;II)V", done);
 
     NETTY_JNI_UTIL_LOAD_CLASS(env, byteArrayClass, "[B", done);
@@ -203,6 +210,9 @@ done:
     }
     netty_jni_util_free_dynamic_methods_table(dynamicMethods, 0, 1);
     free(nettyClassName);
+
+    NETTY_JNI_UTIL_DELETE_LOCAL(env, dnsResolverClass);
+
     return ret;
 }
 

--- a/transport-native-epoll/src/main/c/netty5_epoll_linuxsocket.c
+++ b/transport-native-epoll/src/main/c/netty5_epoll_linuxsocket.c
@@ -63,7 +63,7 @@
 #define UDP_GRO 104
 #endif
 
-static jclass peerCredentialsClass = NULL;
+static jweak peerCredentialsClassWeak = NULL;
 static jmethodID peerCredentialsMethodId = NULL;
 
 static jfieldID fileChannelFieldId = NULL;
@@ -694,12 +694,21 @@ static jint netty5_epoll_linuxsocket_getTcpNotSentLowAt(JNIEnv* env, jclass claz
 
 static jobject netty5_epoll_linuxsocket_getPeerCredentials(JNIEnv *env, jclass clazz, jint fd) {
      struct ucred credentials;
+     jclass peerCredentialsClass = NULL;
      if(netty5_unix_socket_getOption(env,fd, SOL_SOCKET, SO_PEERCRED, &credentials, sizeof (credentials)) == -1) {
          return NULL;
      }
      jintArray gids = (*env)->NewIntArray(env, 1);
      (*env)->SetIntArrayRegion(env, gids, 0, 1, (jint*) &credentials.gid);
-     return (*env)->NewObject(env, peerCredentialsClass, peerCredentialsMethodId, credentials.pid, credentials.uid, gids);
+
+     NETTY_JNI_UTIL_NEW_LOCAL_FROM_WEAK(env, peerCredentialsClass, peerCredentialsClassWeak, error);
+
+     jobject creds = (*env)->NewObject(env, peerCredentialsClass, peerCredentialsMethodId, credentials.pid, credentials.uid, gids);
+
+     NETTY_JNI_UTIL_DELETE_LOCAL(env, peerCredentialsClass);
+     return creds;
+ error:
+     return NULL;
 }
 
 static jint netty5_epoll_linuxsocket_isUdpGro(JNIEnv* env, jclass clazz, jint fd) {
@@ -846,6 +855,7 @@ jint netty5_epoll_linuxsocket_JNI_OnLoad(JNIEnv* env, const char* packagePrefix)
     jclass fileRegionCls = NULL;
     jclass fileChannelCls = NULL;
     jclass fileDescriptorCls = NULL;
+    jclass peerCredentialsClass = NULL;
     // Register the methods which are not referenced by static member variables
     JNINativeMethod* dynamicMethods = createDynamicMethodsTable(packagePrefix);
     if (dynamicMethods == NULL) {
@@ -860,6 +870,9 @@ jint netty5_epoll_linuxsocket_JNI_OnLoad(JNIEnv* env, const char* packagePrefix)
     }
 
     NETTY_JNI_UTIL_PREPEND(packagePrefix, "io/netty5/channel/unix/PeerCredentials", nettyClassName, done);
+    NETTY_JNI_UTIL_LOAD_CLASS_WEAK(env, peerCredentialsClassWeak, nettyClassName, done);
+    NETTY_JNI_UTIL_NEW_LOCAL_FROM_WEAK(env, peerCredentialsClass, peerCredentialsClassWeak, done);
+
     NETTY_JNI_UTIL_LOAD_CLASS(env, peerCredentialsClass, nettyClassName, done);
     netty_jni_util_free_dynamic_name(&nettyClassName);
 
@@ -886,11 +899,12 @@ done:
     netty_jni_util_free_dynamic_methods_table(dynamicMethods, fixed_method_table_size, dynamicMethodsTableSize());
     free(nettyClassName);
 
+    NETTY_JNI_UTIL_DELETE_LOCAL(env, peerCredentialsClass);
     return ret;
 }
 
 void netty5_epoll_linuxsocket_JNI_OnUnLoad(JNIEnv* env, const char* packagePrefix) {
-    NETTY_JNI_UTIL_UNLOAD_CLASS(env, peerCredentialsClass);
+    NETTY_JNI_UTIL_UNLOAD_CLASS_WEAK(env, peerCredentialsClassWeak);
 
     netty_jni_util_unregister_natives(env, packagePrefix, LINUXSOCKET_CLASSNAME);
 }

--- a/transport-native-kqueue/src/main/c/netty5_kqueue_bsdsocket.c
+++ b/transport-native-kqueue/src/main/c/netty5_kqueue_bsdsocket.c
@@ -37,7 +37,7 @@
 
 // Those are initialized in the init(...) method and cached for performance reasons
 static jclass stringClass = NULL;
-static jclass peerCredentialsClass = NULL;
+static jweak peerCredentialsClassWeak = NULL;
 static jfieldID fileChannelFieldId = NULL;
 static jfieldID transferredFieldId = NULL;
 static jfieldID fdFieldId = NULL;
@@ -225,6 +225,8 @@ static jint netty5_kqueue_bsdsocket_isTcpFastOpen(JNIEnv* env, jclass clazz, jin
 
 static jobject netty5_kqueue_bsdsocket_getPeerCredentials(JNIEnv *env, jclass clazz, jint fd) {
     struct xucred credentials;
+    jclass peerCredentialsClass = NULL;
+
     // It has been observed on MacOS that this method can complete successfully but not set all fields of xucred.
     credentials.cr_ngroups = 0;
     if(netty5_unix_socket_getOption(env,fd, SOL_SOCKET, LOCAL_PEERCRED, &credentials, sizeof (credentials)) == -1) {
@@ -253,7 +255,13 @@ static jobject netty5_kqueue_bsdsocket_getPeerCredentials(JNIEnv *env, jclass cl
     }
 #endif
 
-    return (*env)->NewObject(env, peerCredentialsClass, peerCredentialsMethodId, pid, credentials.cr_uid, gids);
+    NETTY_JNI_UTIL_NEW_LOCAL_FROM_WEAK(env, peerCredentialsClass, peerCredentialsClassWeak, error);
+
+    jobject creds = (*env)->NewObject(env, peerCredentialsClass, peerCredentialsMethodId, pid, credentials.cr_uid, gids);
+    NETTY_JNI_UTIL_DELETE_LOCAL(env, peerCredentialsClass);
+    return creds;
+ error:
+    return NULL;
 }
 // JNI Registered Methods End
 
@@ -317,6 +325,7 @@ jint netty5_kqueue_bsdsocket_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) 
     jclass fileRegionCls = NULL;
     jclass fileChannelCls = NULL;
     jclass fileDescriptorCls = NULL;
+    jclass peerCredentialsClass = NULL;
     // Register the methods which are not referenced by static member variables
     JNINativeMethod* dynamicMethods = createDynamicMethodsTable(packagePrefix);
     if (dynamicMethods == NULL) {
@@ -347,7 +356,8 @@ jint netty5_kqueue_bsdsocket_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) 
     NETTY_JNI_UTIL_LOAD_CLASS(env, stringClass, "java/lang/String", done);
 
     NETTY_JNI_UTIL_PREPEND(packagePrefix, "io/netty5/channel/unix/PeerCredentials", nettyClassName, done);
-    NETTY_JNI_UTIL_LOAD_CLASS(env, peerCredentialsClass, nettyClassName, done);
+    NETTY_JNI_UTIL_LOAD_CLASS_WEAK(env, peerCredentialsClassWeak, nettyClassName, done);
+    NETTY_JNI_UTIL_NEW_LOCAL_FROM_WEAK(env, peerCredentialsClass, peerCredentialsClassWeak, done);
     netty_jni_util_free_dynamic_name(&nettyClassName);
   
     NETTY_JNI_UTIL_GET_METHOD(env, peerCredentialsClass, peerCredentialsMethodId, "<init>", "(II[I)V", done);
@@ -356,11 +366,13 @@ done:
     netty_jni_util_free_dynamic_methods_table(dynamicMethods, fixed_method_table_size, dynamicMethodsTableSize());
     free(nettyClassName);
 
+    NETTY_JNI_UTIL_DELETE_LOCAL(env, peerCredentialsClass);
+
     return ret;
 }
 
 void netty5_kqueue_bsdsocket_JNI_OnUnLoad(JNIEnv* env, const char* packagePrefix) {
-    NETTY_JNI_UTIL_UNLOAD_CLASS(env, peerCredentialsClass);
+    NETTY_JNI_UTIL_UNLOAD_CLASS_WEAK(env, peerCredentialsClassWeak);
     NETTY_JNI_UTIL_UNLOAD_CLASS(env, stringClass);
 
     netty_jni_util_unregister_natives(env, packagePrefix, BSDSOCKET_CLASSNAME);

--- a/transport-native-unix-common/src/main/c/netty5_unix_errors.c
+++ b/transport-native-unix-common/src/main/c/netty5_unix_errors.c
@@ -24,9 +24,9 @@
 
 #define ERRORS_CLASSNAME "io/netty5/channel/unix/ErrorsStaticallyReferencedJniMethods"
 
+static jweak channelExceptionClassWeak = NULL;
 static jclass oomErrorClass = NULL;
 static jclass runtimeExceptionClass = NULL;
-static jclass channelExceptionClass = NULL;
 static jclass ioExceptionClass = NULL;
 static jclass portUnreachableExceptionClass = NULL;
 static jclass closedChannelExceptionClass = NULL;
@@ -102,11 +102,18 @@ void netty5_unix_errors_throwRuntimeExceptionErrorNo(JNIEnv* env, char* message,
 }
 
 void netty5_unix_errors_throwChannelExceptionErrorNo(JNIEnv* env, char* message, int errorNumber) {
+    jclass channelExceptionClass = NULL;
     char* allocatedMessage = exceptionMessage(message, errorNumber);
     if (allocatedMessage == NULL) {
         return;
     }
+
+    NETTY_JNI_UTIL_NEW_LOCAL_FROM_WEAK(env, channelExceptionClass, channelExceptionClassWeak, done);
+
     (*env)->ThrowNew(env, channelExceptionClass, allocatedMessage);
+done:
+
+    NETTY_JNI_UTIL_DELETE_LOCAL(env, channelExceptionClass);
     free(allocatedMessage);
 }
 
@@ -221,6 +228,7 @@ static const jint statically_referenced_fixed_method_table_size = sizeof(statica
 //            Unix to reflect that.
 jint netty5_unix_errors_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     char* nettyClassName = NULL;
+    jclass channelExceptionClass = NULL;
     // We must register the statically referenced methods first!
     if (netty_jni_util_register_natives(env,
             packagePrefix,
@@ -235,7 +243,9 @@ jint netty5_unix_errors_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     NETTY_JNI_UTIL_LOAD_CLASS(env, runtimeExceptionClass, "java/lang/RuntimeException", error);
 
     NETTY_JNI_UTIL_PREPEND(packagePrefix, "io/netty5/channel/ChannelException", nettyClassName, error);
-    NETTY_JNI_UTIL_LOAD_CLASS(env, channelExceptionClass, nettyClassName, error);
+    NETTY_JNI_UTIL_LOAD_CLASS_WEAK(env, channelExceptionClassWeak, nettyClassName, error);
+    NETTY_JNI_UTIL_NEW_LOCAL_FROM_WEAK(env, channelExceptionClass, channelExceptionClassWeak, error);
+
     netty_jni_util_free_dynamic_name(&nettyClassName);
 
     NETTY_JNI_UTIL_LOAD_CLASS(env, closedChannelExceptionClass, "java/nio/channels/ClosedChannelException", error);
@@ -245,9 +255,14 @@ jint netty5_unix_errors_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
 
     NETTY_JNI_UTIL_LOAD_CLASS(env, portUnreachableExceptionClass, "java/net/PortUnreachableException", error);
 
+
+    NETTY_JNI_UTIL_DELETE_LOCAL(env, channelExceptionClass);
     return NETTY_JNI_UTIL_JNI_VERSION;
 error:
     free(nettyClassName);
+
+    NETTY_JNI_UTIL_DELETE_LOCAL(env, channelExceptionClass);
+
     return JNI_ERR;
 }
 
@@ -255,7 +270,7 @@ void netty5_unix_errors_JNI_OnUnLoad(JNIEnv* env, const char* packagePrefix) {
     // delete global references so the GC can collect them
     NETTY_JNI_UTIL_UNLOAD_CLASS(env, oomErrorClass);
     NETTY_JNI_UTIL_UNLOAD_CLASS(env, runtimeExceptionClass);
-    NETTY_JNI_UTIL_UNLOAD_CLASS(env, channelExceptionClass);
+    NETTY_JNI_UTIL_UNLOAD_CLASS_WEAK(env, channelExceptionClassWeak);
     NETTY_JNI_UTIL_UNLOAD_CLASS(env, ioExceptionClass);
     NETTY_JNI_UTIL_UNLOAD_CLASS(env, portUnreachableExceptionClass);
     NETTY_JNI_UTIL_UNLOAD_CLASS(env, closedChannelExceptionClass);


### PR DESCRIPTION
Motivation:

We should use weak references to hold global references to our own classes as otherwise it will be not possible to unload the classloader.

Modifications:

Use weak references for the classes in JNI.

Result:
Fixes https://github.com/netty/netty/issues/13480

