### PR TITLE
Add reset API to IdleStateHandler

### DIFF
--- a/handler/src/main/java/io/netty/handler/timeout/IdleStateHandler.java
+++ b/handler/src/main/java/io/netty/handler/timeout/IdleStateHandler.java
@@ -305,6 +305,25 @@ public class IdleStateHandler extends ChannelDuplexHandler {
         }
     }
 
+    /**
+     * Reset the read timeout. As this handler is not thread-safe, this method <b>must</b> be called on the event loop.
+     */
+    public final void resetReadTimeout() {
+        if (readerIdleTimeNanos > 0 || allIdleTimeNanos > 0) {
+            lastReadTime = ticksInNanos();
+            reading = false;
+        }
+    }
+
+    /**
+     * Reset the write timeout. As this handler is not thread-safe, this method <b>must</b> be called on the event loop.
+     */
+    public final void resetWriteTimeout() {
+        if (writerIdleTimeNanos > 0 || allIdleTimeNanos > 0) {
+            lastWriteTime = ticksInNanos();
+        }
+    }
+
     private void initialize(ChannelHandlerContext ctx) {
         // Avoid the case where destroy() is called before scheduling timeouts.
         // See: https://github.com/netty/netty/issues/143

--- a/handler/src/main/java/io/netty/handler/timeout/IdleStateHandler.java
+++ b/handler/src/main/java/io/netty/handler/timeout/IdleStateHandler.java
@@ -308,7 +308,7 @@ public class IdleStateHandler extends ChannelDuplexHandler {
     /**
      * Reset the read timeout. As this handler is not thread-safe, this method <b>must</b> be called on the event loop.
      */
-    public final void resetReadTimeout() {
+    public void resetReadTimeout() {
         if (readerIdleTimeNanos > 0 || allIdleTimeNanos > 0) {
             lastReadTime = ticksInNanos();
             reading = false;
@@ -318,7 +318,7 @@ public class IdleStateHandler extends ChannelDuplexHandler {
     /**
      * Reset the write timeout. As this handler is not thread-safe, this method <b>must</b> be called on the event loop.
      */
-    public final void resetWriteTimeout() {
+    public void resetWriteTimeout() {
         if (writerIdleTimeNanos > 0 || allIdleTimeNanos > 0) {
             lastWriteTime = ticksInNanos();
         }


### PR DESCRIPTION
Motivation:

Sometimes it is useful to reset the read/write timeout of an IdleStateHandler without an actual read/write event. At the moment, this requires a complicated dance of sending a manual read/write event and then intercepting it again to avoid triggering downstream handlers.

Modification:

Add API methods to explicitly reset the timeouts. Add tests for the new API. Fix the `anyNotIdle` test utility method, because it turns out it did not actually confirm the action reset the timeout.

Result:

The timeouts can be reset manually by the developer without resorting to workarounds.