### PR TITLE
Allow to supply custom matcher to any class with TypeParameterMatcher

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/ByteToMessageCodec.java
+++ b/codec/src/main/java/io/netty/handler/codec/ByteToMessageCodec.java
@@ -63,6 +63,13 @@ public abstract class ByteToMessageCodec<I> extends ChannelDuplexHandler {
     }
 
     /**
+     * see {@link #ByteToMessageCodec(TypeParameterMatcher, boolean)} with {@code true} as boolean value.
+     */
+    protected ByteToMessageCodec(TypeParameterMatcher matcher) {
+        this(matcher, true);
+    }
+
+    /**
      * Create a new instance which will try to detect the types to match out of the type parameter of the class.
      *
      * @param preferDirect          {@code true} if a direct {@link ByteBuf} should be tried to be used as target for
@@ -84,8 +91,20 @@ public abstract class ByteToMessageCodec<I> extends ChannelDuplexHandler {
      *                              {@link ByteBuf}, which is backed by an byte array.
      */
     protected ByteToMessageCodec(Class<? extends I> outboundMessageType, boolean preferDirect) {
+        this(TypeParameterMatcher.get(outboundMessageType), preferDirect);
+    }
+
+    /**
+     * Create a new instance
+     *
+     * @param outboundMsgMatcher    The matcher of messages that are compatible with I
+     * @param preferDirect          {@code true} if a direct {@link ByteBuf} should be tried to be used as target for
+     *                              the encoded messages. If {@code false} is used it will allocate a heap
+     *                              {@link ByteBuf}, which is backed by an byte array.
+     */
+    protected ByteToMessageCodec(TypeParameterMatcher outboundMsgMatcher, boolean preferDirect) {
         ensureNotSharable();
-        outboundMsgMatcher = TypeParameterMatcher.get(outboundMessageType);
+        this.outboundMsgMatcher = outboundMsgMatcher;
         encoder = new Encoder(preferDirect);
     }
 

--- a/codec/src/main/java/io/netty/handler/codec/MessageToByteEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/MessageToByteEncoder.java
@@ -63,6 +63,13 @@ public abstract class MessageToByteEncoder<I> extends ChannelOutboundHandlerAdap
     }
 
     /**
+     * see {@link #MessageToByteEncoder(TypeParameterMatcher, boolean)} with {@code true} as boolean value.
+     */
+    protected MessageToByteEncoder(TypeParameterMatcher matcher) {
+        this(matcher, true);
+    }
+
+    /**
      * Create a new instance which will try to detect the types to match out of the type parameter of the class.
      *
      * @param preferDirect          {@code true} if a direct {@link ByteBuf} should be tried to be used as target for
@@ -83,7 +90,19 @@ public abstract class MessageToByteEncoder<I> extends ChannelOutboundHandlerAdap
      *                              {@link ByteBuf}, which is backed by an byte array.
      */
     protected MessageToByteEncoder(Class<? extends I> outboundMessageType, boolean preferDirect) {
-        matcher = TypeParameterMatcher.get(outboundMessageType);
+        this(TypeParameterMatcher.get(outboundMessageType), preferDirect);
+    }
+
+    /**
+     * Create a new instance
+     *
+     * @param matcher               The matcher of messages that are compatible with I
+     * @param preferDirect          {@code true} if a direct {@link ByteBuf} should be tried to be used as target for
+     *                              the encoded messages. If {@code false} is used it will allocate a heap
+     *                              {@link ByteBuf}, which is backed by an byte array.
+     */
+    protected MessageToByteEncoder(TypeParameterMatcher matcher, boolean preferDirect) {
+        this.matcher = matcher;
         this.preferDirect = preferDirect;
     }
 

--- a/codec/src/main/java/io/netty/handler/codec/MessageToMessageCodec.java
+++ b/codec/src/main/java/io/netty/handler/codec/MessageToMessageCodec.java
@@ -102,8 +102,18 @@ public abstract class MessageToMessageCodec<INBOUND_IN, OUTBOUND_IN> extends Cha
      */
     protected MessageToMessageCodec(
             Class<? extends INBOUND_IN> inboundMessageType, Class<? extends OUTBOUND_IN> outboundMessageType) {
-        inboundMsgMatcher = TypeParameterMatcher.get(inboundMessageType);
-        outboundMsgMatcher = TypeParameterMatcher.get(outboundMessageType);
+        this(TypeParameterMatcher.get(inboundMessageType), TypeParameterMatcher.get(outboundMessageType));
+    }
+
+    /**
+     * Create a new instance.
+     *
+     * @param inboundMsgMatcher    The matcher of messages to decode that are compatible with INBOUND_IN
+     * @param outboundMsgMatcher   The matcher of messages to encode that are compatible with OUTBOUND_IN
+     */
+    protected MessageToMessageCodec(TypeParameterMatcher inboundMsgMatcher, TypeParameterMatcher outboundMsgMatcher) {
+        this.inboundMsgMatcher = inboundMsgMatcher;
+        this.outboundMsgMatcher = outboundMsgMatcher;
     }
 
     @Override

--- a/codec/src/main/java/io/netty/handler/codec/MessageToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/MessageToMessageDecoder.java
@@ -66,7 +66,16 @@ public abstract class MessageToMessageDecoder<I> extends ChannelInboundHandlerAd
      * @param inboundMessageType    The type of messages to match and so decode
      */
     protected MessageToMessageDecoder(Class<? extends I> inboundMessageType) {
-        matcher = TypeParameterMatcher.get(inboundMessageType);
+        this(TypeParameterMatcher.get(inboundMessageType));
+    }
+
+    /**
+     * Create a new instance
+     *
+     * @param matcher    The matcher of messages to decode that are compatible with I
+     */
+    protected MessageToMessageDecoder(TypeParameterMatcher matcher) {
+        this.matcher = matcher;
     }
 
     /**

--- a/codec/src/main/java/io/netty/handler/codec/MessageToMessageEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/MessageToMessageEncoder.java
@@ -71,6 +71,15 @@ public abstract class MessageToMessageEncoder<I> extends ChannelOutboundHandlerA
     }
 
     /**
+     * Create a new instance
+     *
+     * @param matcher    The matcher of messages to encode that are compatible with I
+     */
+    protected MessageToMessageEncoder(TypeParameterMatcher matcher) {
+        this.matcher = matcher;
+    }
+
+    /**
      * Returns {@code true} if the given message should be handled. If {@code false} it will be passed to the next
      * {@link ChannelOutboundHandler} in the {@link ChannelPipeline}.
      */

--- a/resolver/src/main/java/io/netty/resolver/AbstractAddressResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/AbstractAddressResolver.java
@@ -51,8 +51,17 @@ public abstract class AbstractAddressResolver<T extends SocketAddress> implement
      * @param addressType the type of the {@link SocketAddress} supported by this resolver
      */
     protected AbstractAddressResolver(EventExecutor executor, Class<? extends T> addressType) {
+        this(executor, TypeParameterMatcher.get(addressType));
+    }
+
+    /**
+     * @param executor the {@link EventExecutor} which is used to notify the listeners of the {@link Future} returned
+     *                 by {@link #resolve(SocketAddress)}
+     * @param matcher  The matcher of messages that are compatible with T
+     */
+    protected AbstractAddressResolver(EventExecutor executor, TypeParameterMatcher matcher) {
         this.executor = checkNotNull(executor, "executor");
-        this.matcher = TypeParameterMatcher.get(addressType);
+        this.matcher = matcher;
     }
 
     /**

--- a/transport/src/main/java/io/netty/channel/SimpleChannelInboundHandler.java
+++ b/transport/src/main/java/io/netty/channel/SimpleChannelInboundHandler.java
@@ -70,6 +70,13 @@ public abstract class SimpleChannelInboundHandler<I> extends ChannelInboundHandl
     }
 
     /**
+     * see {@link #SimpleChannelInboundHandler(TypeParameterMatcher, boolean)} with {@code true} as boolean value.
+     */
+    protected SimpleChannelInboundHandler(TypeParameterMatcher matcher) {
+        this(matcher, true);
+    }
+
+    /**
      * Create a new instance
      *
      * @param inboundMessageType    The type of messages to match
@@ -77,7 +84,18 @@ public abstract class SimpleChannelInboundHandler<I> extends ChannelInboundHandl
      *                              {@link ReferenceCountUtil#release(Object)}.
      */
     protected SimpleChannelInboundHandler(Class<? extends I> inboundMessageType, boolean autoRelease) {
-        matcher = TypeParameterMatcher.get(inboundMessageType);
+        this(TypeParameterMatcher.get(inboundMessageType), autoRelease);
+    }
+
+    /**
+     * Create a new instance
+     *
+     * @param matcher               The matcher of messages that are compatible with I
+     * @param autoRelease           {@code true} if handled messages should be released automatically by passing them to
+     *                              {@link ReferenceCountUtil#release(Object)}.
+     */
+    protected SimpleChannelInboundHandler(TypeParameterMatcher matcher, boolean autoRelease) {
+        this.matcher = matcher;
         this.autoRelease = autoRelease;
     }
 

--- a/transport/src/main/java/io/netty/channel/SimpleUserEventChannelHandler.java
+++ b/transport/src/main/java/io/netty/channel/SimpleUserEventChannelHandler.java
@@ -70,6 +70,13 @@ public abstract class SimpleUserEventChannelHandler<I> extends ChannelInboundHan
     }
 
     /**
+     * see {@link #SimpleUserEventChannelHandler(TypeParameterMatcher, boolean)} with {@code true} as boolean value.
+     */
+    protected SimpleUserEventChannelHandler(TypeParameterMatcher matcher) {
+        this(matcher, true);
+    }
+
+    /**
      * Create a new instance
      *
      * @param eventType      The type of events to match
@@ -77,7 +84,18 @@ public abstract class SimpleUserEventChannelHandler<I> extends ChannelInboundHan
      *                       {@link ReferenceCountUtil#release(Object)}.
      */
     protected SimpleUserEventChannelHandler(Class<? extends I> eventType, boolean autoRelease) {
-        matcher = TypeParameterMatcher.get(eventType);
+        this(TypeParameterMatcher.get(eventType), autoRelease);
+    }
+
+    /**
+     * Create a new instance
+     *
+     * @param matcher        The matcher of messages that are compatible with I
+     * @param autoRelease    {@code true} if handled events should be released automatically by passing them to
+     *                       {@link ReferenceCountUtil#release(Object)}.
+     */
+    protected SimpleUserEventChannelHandler(TypeParameterMatcher matcher, boolean autoRelease) {
+        this.matcher = matcher;
         this.autoRelease = autoRelease;
     }
 


### PR DESCRIPTION
Motivation:

When you implementing subclass of MessageToByteEncoder\<I\> it's usefull to define your own matcher. Because when your subclass allow generic 'union' like \<OutputMessage extends BaseMessage & Encodable\> where BaseMessage are an astract class representing message without encoding or decoding and Encodable are an interface require implementation of some method like 'encode', isn't possible to allow that without create an abstract class to have single abstract class or interface to supply to MessageToByteEncoder. 
Purpose of this commit and PR it's allow that.

Modifications:

Addition of constructors allow to provide custom TypeParameterMatcher inside : 
 * ByteToMessageCodec
 * MessageToByteEncoder
 * MessageToMessageCodec
 * MessageToMessageDecoder
 * MessageToMessageEncoder
 * AbstractAddressResolver
 * SimpleChannelInboundHandler
 * SimpleUserEventChannelHandler

Result:

Now you can provide custom TypeParameterMatcher to allow union type