### PR TITLE
Make WebSocketDecoderConfig not final

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketDecoderConfig.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketDecoderConfig.java
@@ -20,10 +20,9 @@ import io.netty.util.internal.ObjectUtil;
 /**
  * Frames decoder configuration.
  */
-public final class WebSocketDecoderConfig {
+public class WebSocketDecoderConfig {
 
-    static final WebSocketDecoderConfig DEFAULT =
-        new WebSocketDecoderConfig(65536, true, false, false, true, true);
+    static final WebSocketDecoderConfig DEFAULT = new WebSocketDecoderConfig();
 
     private final int maxFramePayloadLength;
     private final boolean expectMaskedFrames;
@@ -31,6 +30,13 @@ public final class WebSocketDecoderConfig {
     private final boolean allowExtensions;
     private final boolean closeOnProtocolViolation;
     private final boolean withUTF8Validator;
+
+    /**
+     * Default Constructor
+     */
+    protected WebSocketDecoderConfig() {
+        this(65536, true, false, false, true, true);
+    }
 
     /**
      * Constructor


### PR DESCRIPTION
Motivation:

WebSocketDecoderConfig is currently final, which means that some aspects (eg `maxFramePayloadLength`) cannot be changed as a result of - for example - an `Authorization` header sent with the initial handshake, or with some sort of initial "login" websocket message.

I can't see any reason why this field in particular has to be final; it's not like the value for one received frame has to be identical to a frame received for a different message.

Modification:

I've made the class non-final so it can be extended, but - because there is a builder class - I've made the new zero-argument constructor protected, so it can only be called by someone explicitly subclassing this class.

Result:

Addresses https://github.com/netty/netty/issues/13600
