### PR TITLE
Added check for pseudo-headers in trailers

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2ConnectionHandlerBuilder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2ConnectionHandlerBuilder.java
@@ -566,7 +566,7 @@ public abstract class AbstractHttp2ConnectionHandlerBuilder<T extends Http2Conne
         }
 
         DefaultHttp2ConnectionDecoder decoder = new DefaultHttp2ConnectionDecoder(connection, encoder, reader,
-                promisedRequestVerifier(), isAutoAckSettingsFrame(), isAutoAckPingFrame());
+            promisedRequestVerifier(), isAutoAckSettingsFrame(), isAutoAckPingFrame(), isValidateHeaders());
         return buildFromCodec(decoder, encoder);
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -405,8 +405,8 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
             } else {
                 // Need to check trailers don't contain pseudo headers. According to RFC
                 // "Pseudo-header fields MUST NOT appear in trailers"
-                for (Entry<CharSequence, CharSequence> entry : headers) {
-                    if (entry.getKey().charAt(0) == ':') {
+                for (CharSequence name : headers.names()) {
+                    if (Http2Headers.PseudoHeaderName.hasPseudoHeaderFormat(name)) {
                         throw streamError(stream.id(), PROTOCOL_ERROR,
                                 "Found invalid Pseudo-Header in trailers");
                     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -25,6 +25,7 @@ import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.util.List;
+import java.util.Map.Entry;
 
 import static io.netty.handler.codec.http.HttpStatusClass.INFORMATIONAL;
 import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_PRIORITY_WEIGHT;
@@ -399,6 +400,15 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
                     } catch (IllegalArgumentException e) {
                         throw streamError(stream.id(), PROTOCOL_ERROR, e,
                                 "Multiple content-length headers received");
+                    }
+                }
+            } else {
+                // Need to check trailers don't contain pseudo headers. According to RFC
+                // "Pseudo-header fields MUST NOT appear in trailers"
+                for (Entry<CharSequence, CharSequence> entry : headers) {
+                    if (entry.getKey().charAt(0) == ':') {
+                        throw streamError(stream.id(), PROTOCOL_ERROR,
+                                "Found invalid Pseudo-Header in trailers");
                     }
                 }
             }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -64,7 +64,7 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
     private final Http2SettingsReceivedConsumer settingsReceivedConsumer;
     private final boolean autoAckPing;
     private final Http2Connection.PropertyKey contentLengthKey;
-    private boolean validateHeaders;
+    private final boolean validateHeaders;
 
     public DefaultHttp2ConnectionDecoder(Http2Connection connection,
                                          Http2ConnectionEncoder encoder,
@@ -209,10 +209,6 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
     @Override
     public void close() {
         frameReader.close();
-    }
-
-    public void validateHeaders(boolean validateHeaders) {
-        this.validateHeaders = checkNotNull(validateHeaders, "validateHeaders");
     }
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -421,9 +421,10 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
                 // Trailers MUST NOT include pseudo-header fields (Section 8.3).
                 for (Iterator<Entry<CharSequence, CharSequence>> iterator =
                     headers.iterator(); iterator.hasNext();) {
-                    if (Http2Headers.PseudoHeaderName.hasPseudoHeaderFormat(iterator.next().getKey())) {
+                    CharSequence name = iterator.next().getKey();
+                    if (Http2Headers.PseudoHeaderName.hasPseudoHeaderFormat(name)) {
                         throw streamError(stream.id(), PROTOCOL_ERROR,
-                                "Found invalid Pseudo-Header in trailers");
+                                "Found invalid Pseudo-Header in trailers: %s", name);
                     }
                 }
             }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodecBuilder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodecBuilder.java
@@ -218,7 +218,7 @@ public class Http2FrameCodecBuilder extends
                 encoder = new StreamBufferingEncoder(encoder);
             }
             Http2ConnectionDecoder decoder = new DefaultHttp2ConnectionDecoder(connection, encoder, frameReader,
-                    promisedRequestVerifier(), isAutoAckSettingsFrame(), isAutoAckPingFrame());
+                    promisedRequestVerifier(), isAutoAckSettingsFrame(), isAutoAckPingFrame(), isValidateHeaders());
             int maxConsecutiveEmptyDataFrames = decoderEnforceMaxConsecutiveEmptyDataFrames();
             if (maxConsecutiveEmptyDataFrames > 0) {
                 decoder = new Http2EmptyDataFrameConnectionDecoder(decoder, maxConsecutiveEmptyDataFrames);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodecBuilder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodecBuilder.java
@@ -232,8 +232,7 @@ public class Http2MultiplexCodecBuilder
                 encoder = new StreamBufferingEncoder(encoder);
             }
             Http2ConnectionDecoder decoder = new DefaultHttp2ConnectionDecoder(connection, encoder, frameReader,
-                    promisedRequestVerifier(), isAutoAckSettingsFrame(), isAutoAckPingFrame());
-
+                    promisedRequestVerifier(), isAutoAckSettingsFrame(), isAutoAckPingFrame(), isValidateHeaders());
             int maxConsecutiveEmptyDataFrames = decoderEnforceMaxConsecutiveEmptyDataFrames();
             if (maxConsecutiveEmptyDataFrames > 0) {
                 decoder = new Http2EmptyDataFrameConnectionDecoder(decoder, maxConsecutiveEmptyDataFrames);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
@@ -50,6 +50,7 @@ import static io.netty.handler.codec.http2.Http2Stream.State.RESERVED_REMOTE;
 import static io.netty.util.CharsetUtil.UTF_8;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 
@@ -581,7 +582,7 @@ public class DefaultHttp2ConnectionDecoderTest {
 
     @ParameterizedTest
     @ValueSource(strings = {":scheme", ":custom-pseudo-header"})
-    public void trailersWithPseudoHeadersThrows(CharSequence pseudoHeader) throws Exception {
+    public void trailersWithPseudoHeadersThrows(String pseudoHeader) throws Exception {
         decode().onHeadersRead(ctx, STREAM_ID, EmptyHttp2Headers.INSTANCE, 0, false);
 
         final Http2Headers trailers = new DefaultHttp2Headers(false);
@@ -593,6 +594,7 @@ public class DefaultHttp2ConnectionDecoderTest {
             }
         });
         assertEquals(PROTOCOL_ERROR, ex.error());
+        assertThat(ex.getMessage(), containsString(pseudoHeader));
     }
 
     @Test

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -1029,6 +1029,7 @@ public class Http2ConnectionRoundtripTest {
     @Test
     public void flowControlProperlyChunksLargeMessage() throws Exception {
         final Http2Headers headers = dummyHeaders();
+        final Http2Headers trailers = dummyTrailers();
 
         // Create a large message to send.
         final int length = 10485760; // 10MB
@@ -1061,7 +1062,7 @@ public class Http2ConnectionRoundtripTest {
                     http2Client.encoder().writeData(ctx(), 3, data.retainedDuplicate(), 0, false, newPromise());
 
                     // Write trailers.
-                    http2Client.encoder().writeHeaders(ctx(), 3, headers, 0, (short) 16, false, 0,
+                    http2Client.encoder().writeHeaders(ctx(), 3, trailers, 0, (short) 16, false, 0,
                             true, newPromise());
                     http2Client.flush(ctx());
                 }
@@ -1074,7 +1075,7 @@ public class Http2ConnectionRoundtripTest {
             // Verify that headers and trailers were received.
             verify(serverListener).onHeadersRead(any(ChannelHandlerContext.class), eq(3), eq(headers), eq(0),
                     eq((short) 16), eq(false), eq(0), eq(false));
-            verify(serverListener).onHeadersRead(any(ChannelHandlerContext.class), eq(3), eq(headers), eq(0),
+            verify(serverListener).onHeadersRead(any(ChannelHandlerContext.class), eq(3), eq(trailers), eq(0),
                     eq((short) 16), eq(false), eq(0), eq(true));
 
             // Verify we received all the bytes.
@@ -1093,6 +1094,7 @@ public class Http2ConnectionRoundtripTest {
     @Test
     public void stressTest() throws Exception {
         final Http2Headers headers = dummyHeaders();
+        final Http2Headers trailers = dummyTrailers();
         int length = 10;
         final ByteBuf data = randomBytes(length);
         final String dataAsHex = ByteBufUtil.hexDump(data);
@@ -1147,7 +1149,7 @@ public class Http2ConnectionRoundtripTest {
                         http2Client.encoder().writeData(ctx(), streamId, data.retainedSlice(), 0,
                                                         false, newPromise());
                         // Write trailers.
-                        http2Client.encoder().writeHeaders(ctx(), streamId, headers, 0, (short) 16,
+                        http2Client.encoder().writeHeaders(ctx(), streamId, trailers, 0, (short) 16,
                                 false, 0, true, newPromise());
                         http2Client.flush(ctx());
                     }
@@ -1159,7 +1161,7 @@ public class Http2ConnectionRoundtripTest {
             verify(serverListener, times(numStreams)).onHeadersRead(any(ChannelHandlerContext.class), anyInt(),
                     eq(headers), eq(0), eq((short) 16), eq(false), eq(0), eq(false));
             verify(serverListener, times(numStreams)).onHeadersRead(any(ChannelHandlerContext.class), anyInt(),
-                    eq(headers), eq(0), eq((short) 16), eq(false), eq(0), eq(true));
+                    eq(trailers), eq(0), eq((short) 16), eq(false), eq(0), eq(true));
             verify(serverListener, times(numStreams)).onPingRead(any(ChannelHandlerContext.class),
                     any(long.class));
             verify(serverListener, never()).onDataRead(any(ChannelHandlerContext.class),
@@ -1269,6 +1271,11 @@ public class Http2ConnectionRoundtripTest {
     private static Http2Headers dummyHeaders() {
         return new DefaultHttp2Headers(false).method(new AsciiString("GET")).scheme(new AsciiString("https"))
         .authority(new AsciiString("example.org")).path(new AsciiString("/some/path/resource2"))
+        .add(randomString(), randomString());
+    }
+
+    private static Http2Headers dummyTrailers() {
+        return new DefaultHttp2Headers(false)
         .add(randomString(), randomString());
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -1276,7 +1276,7 @@ public class Http2ConnectionRoundtripTest {
 
     private static Http2Headers dummyTrailers() {
         return new DefaultHttp2Headers(false)
-        .add(randomString(), randomString());
+        .add("header-" + randomString(), randomString());
     }
 
     private static void mockFlowControl(Http2FrameListener listener) throws Http2Exception {


### PR DESCRIPTION
Motivation:
According to the RFC for HTTP2 on Section 8.1.2.1, 'Pseudo-header fields MUST NOT appear in trailers. Endpoints MUST treat a request or response that contains undefined or invalid pseudo-header fields as malformed (Section 8.1.2.6).'

Modifications:
Updated Http2Decoder to check trailers for Pseudo-Headers and treat them as invalid requests according to RFC 7540 Section 8.1.2.6

Result:
After this change, requests with Pseudo-Headers sent inside trailers will be treated as malformed and a stream error is thrown.
Fixes: #13602 