### PR TITLE
Deprecate disabling HTTP header validation

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/CombinedHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/CombinedHttpHeaders.java
@@ -16,6 +16,8 @@
 package io.netty.handler.codec.http;
 
 import io.netty.handler.codec.DefaultHeaders;
+import io.netty.handler.codec.DefaultHeaders.NameValidator;
+import io.netty.handler.codec.DefaultHeaders.ValueValidator;
 import io.netty.handler.codec.Headers;
 import io.netty.handler.codec.ValueConverter;
 import io.netty.util.HashingStrategy;
@@ -28,6 +30,7 @@ import java.util.Map;
 
 import static io.netty.handler.codec.http.HttpHeaderNames.SET_COOKIE;
 import static io.netty.util.AsciiString.CASE_INSENSITIVE_HASHER;
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import static io.netty.util.internal.StringUtil.COMMA;
 import static io.netty.util.internal.StringUtil.unescapeCsvFields;
 
@@ -37,9 +40,26 @@ import static io.netty.util.internal.StringUtil.unescapeCsvFields;
  * Please refer to section <a href="https://tools.ietf.org/html/rfc7230#section-3.2.2">RFC 7230, 3.2.2</a>.
  */
 public class CombinedHttpHeaders extends DefaultHttpHeaders {
+    /**
+     * Create a combined HTTP header object, with optional validation.
+     *
+     * @param validate Should Netty validate header values to ensure they aren't malicious.
+     * @deprecated Prefer instead to configuring a {@link HttpHeadersFactory}
+     * by calling {@link HttpHeadersBuilder#withCombiningHeaders(boolean) withCombiningHeaders(true)}
+     * on {@link HttpHeaders#DEFAULT_HEADER_FACTORY}.
+     */
+    @Deprecated
     public CombinedHttpHeaders(boolean validate) {
         super(new CombinedHttpHeadersImpl(CASE_INSENSITIVE_HASHER, valueConverter(), nameValidator(validate),
                 valueValidator(validate)));
+    }
+
+    CombinedHttpHeaders(NameValidator<CharSequence> nameValidator, ValueValidator<CharSequence> valueValidator) {
+        super(new CombinedHttpHeadersImpl(
+                CASE_INSENSITIVE_HASHER,
+                valueConverter(),
+                checkNotNull(nameValidator, "nameValidator"),
+                checkNotNull(valueValidator, "valueValidator")));
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/CombinedHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/CombinedHttpHeaders.java
@@ -62,6 +62,16 @@ public class CombinedHttpHeaders extends DefaultHttpHeaders {
                 checkNotNull(valueValidator, "valueValidator")));
     }
 
+    CombinedHttpHeaders(
+            NameValidator<CharSequence> nameValidator, ValueValidator<CharSequence> valueValidator, int sizeHint) {
+        super(new CombinedHttpHeadersImpl(
+                CASE_INSENSITIVE_HASHER,
+                valueConverter(),
+                checkNotNull(nameValidator, "nameValidator"),
+                checkNotNull(valueValidator, "valueValidator"),
+                sizeHint));
+    }
+
     @Override
     public boolean containsValue(CharSequence name, CharSequence value, boolean ignoreCase) {
         return super.containsValue(name, StringUtil.trimOws(value), ignoreCase);
@@ -111,7 +121,15 @@ public class CombinedHttpHeaders extends DefaultHttpHeaders {
                                 ValueConverter<CharSequence> valueConverter,
                                 NameValidator<CharSequence> nameValidator,
                                 ValueValidator<CharSequence> valueValidator) {
-            super(nameHashingStrategy, valueConverter, nameValidator, 16, valueValidator);
+            this(nameHashingStrategy, valueConverter, nameValidator, valueValidator, 16);
+        }
+
+        CombinedHttpHeadersImpl(HashingStrategy<CharSequence> nameHashingStrategy,
+                                ValueConverter<CharSequence> valueConverter,
+                                NameValidator<CharSequence> nameValidator,
+                                ValueValidator<CharSequence> valueValidator,
+                                int sizeHint) {
+            super(nameHashingStrategy, valueConverter, nameValidator, sizeHint, valueValidator);
         }
 
         @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/CombinedHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/CombinedHttpHeaders.java
@@ -45,8 +45,8 @@ public class CombinedHttpHeaders extends DefaultHttpHeaders {
      *
      * @param validate Should Netty validate header values to ensure they aren't malicious.
      * @deprecated Prefer instead to configuring a {@link HttpHeadersFactory}
-     * by calling {@link HttpHeadersBuilder#withCombiningHeaders(boolean) withCombiningHeaders(true)}
-     * on {@link HttpHeaders#DEFAULT_HEADER_FACTORY}.
+     * by calling {@link DefaultHttpHeadersFactory#withCombiningHeaders(boolean) withCombiningHeaders(true)}
+     * on {@link DefaultHttpHeadersFactory#headersFactory()}.
      */
     @Deprecated
     public CombinedHttpHeaders(boolean validate) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultFullHttpRequest.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultFullHttpRequest.java
@@ -19,6 +19,9 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.util.IllegalReferenceCountException;
+
+import static io.netty.handler.codec.http.DefaultHttpHeadersFactory.headersFactory;
+import static io.netty.handler.codec.http.DefaultHttpHeadersFactory.trailersFactory;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
@@ -37,16 +40,14 @@ public class DefaultFullHttpRequest extends DefaultHttpRequest implements FullHt
      * Create a full HTTP response with the given HTTP version, method, and URI.
      */
     public DefaultFullHttpRequest(HttpVersion httpVersion, HttpMethod method, String uri) {
-        this(httpVersion, method, uri, Unpooled.buffer(0),
-                HttpHeadersBuilder.DEFAULT, HttpHeadersBuilder.DEFAULT_TRAILER);
+        this(httpVersion, method, uri, Unpooled.buffer(0), headersFactory(), trailersFactory());
     }
 
     /**
      * Create a full HTTP response with the given HTTP version, method, URI, and contents.
      */
     public DefaultFullHttpRequest(HttpVersion httpVersion, HttpMethod method, String uri, ByteBuf content) {
-        this(httpVersion, method, uri, content,
-                HttpHeadersBuilder.DEFAULT, HttpHeadersBuilder.DEFAULT_TRAILER);
+        this(httpVersion, method, uri, content, headersFactory(), trailersFactory());
     }
 
     /**
@@ -57,8 +58,8 @@ public class DefaultFullHttpRequest extends DefaultHttpRequest implements FullHt
     @Deprecated
     public DefaultFullHttpRequest(HttpVersion httpVersion, HttpMethod method, String uri, boolean validateHeaders) {
         this(httpVersion, method, uri, Unpooled.buffer(0),
-                HttpHeaders.DEFAULT_HEADER_FACTORY.withValidation(validateHeaders),
-                HttpHeaders.DEFAULT_TRAILER_FACTORY.withValidation(validateHeaders));
+                headersFactory().withValidation(validateHeaders),
+                trailersFactory().withValidation(validateHeaders));
     }
 
     /**
@@ -70,20 +71,20 @@ public class DefaultFullHttpRequest extends DefaultHttpRequest implements FullHt
     public DefaultFullHttpRequest(HttpVersion httpVersion, HttpMethod method, String uri,
                                   ByteBuf content, boolean validateHeaders) {
         this(httpVersion, method, uri, content,
-                HttpHeaders.DEFAULT_HEADER_FACTORY.withValidation(validateHeaders),
-                HttpHeaders.DEFAULT_TRAILER_FACTORY.withValidation(validateHeaders));
+                headersFactory().withValidation(validateHeaders),
+                trailersFactory().withValidation(validateHeaders));
     }
 
     /**
      * Create a full HTTP response with the given HTTP version, method, URI, contents,
      * and factories for creating headers and trailers.
      * <p>
-     * The recommended default header factory is {@link HttpHeaders#DEFAULT_HEADER_FACTORY},
-     * and the recommended default trailer factory is {@link HttpHeaders#DEFAULT_TRAILER_FACTORY}.
+     * The recommended default header factory is {@link DefaultHttpHeadersFactory#headersFactory()},
+     * and the recommended default trailer factory is {@link DefaultHttpHeadersFactory#trailersFactory()}.
      */
     public DefaultFullHttpRequest(HttpVersion httpVersion, HttpMethod method, String uri,
             ByteBuf content, HttpHeadersFactory headersFactory, HttpHeadersFactory trailersFactory) {
-        this(httpVersion, method, uri, content, headersFactory.createHeaders(), trailersFactory.createHeaders());
+        this(httpVersion, method, uri, content, headersFactory.newHeaders(), trailersFactory.newHeaders());
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultFullHttpRequest.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultFullHttpRequest.java
@@ -33,25 +33,62 @@ public class DefaultFullHttpRequest extends DefaultHttpRequest implements FullHt
      */
     private int hash;
 
+    /**
+     * Create a full HTTP response with the given HTTP version, method, and URI.
+     */
     public DefaultFullHttpRequest(HttpVersion httpVersion, HttpMethod method, String uri) {
-        this(httpVersion, method, uri, Unpooled.buffer(0));
+        this(httpVersion, method, uri, Unpooled.buffer(0),
+                HttpHeadersBuilder.DEFAULT, HttpHeadersBuilder.DEFAULT_TRAILER);
     }
 
+    /**
+     * Create a full HTTP response with the given HTTP version, method, URI, and contents.
+     */
     public DefaultFullHttpRequest(HttpVersion httpVersion, HttpMethod method, String uri, ByteBuf content) {
-        this(httpVersion, method, uri, content, true);
+        this(httpVersion, method, uri, content,
+                HttpHeadersBuilder.DEFAULT, HttpHeadersBuilder.DEFAULT_TRAILER);
     }
 
+    /**
+     * Create a full HTTP response with the given HTTP version, method, URI, and optional validation.
+     * @deprecated Use the {@link #DefaultFullHttpRequest(HttpVersion, HttpMethod, String, ByteBuf,
+     * HttpHeadersFactory, HttpHeadersFactory)} constructor instead.
+     */
+    @Deprecated
     public DefaultFullHttpRequest(HttpVersion httpVersion, HttpMethod method, String uri, boolean validateHeaders) {
-        this(httpVersion, method, uri, Unpooled.buffer(0), validateHeaders);
+        this(httpVersion, method, uri, Unpooled.buffer(0),
+                HttpHeaders.DEFAULT_HEADER_FACTORY.withValidation(validateHeaders),
+                HttpHeaders.DEFAULT_TRAILER_FACTORY.withValidation(validateHeaders));
     }
 
+    /**
+     * Create a full HTTP response with the given HTTP version, method, URI, contents, and optional validation.
+     * @deprecated Use the {@link #DefaultFullHttpRequest(HttpVersion, HttpMethod, String, ByteBuf,
+     * HttpHeadersFactory, HttpHeadersFactory)} constructor instead.
+     */
+    @Deprecated
     public DefaultFullHttpRequest(HttpVersion httpVersion, HttpMethod method, String uri,
                                   ByteBuf content, boolean validateHeaders) {
-        super(httpVersion, method, uri, validateHeaders);
-        this.content = checkNotNull(content, "content");
-        trailingHeader = new DefaultHttpHeaders(validateHeaders);
+        this(httpVersion, method, uri, content,
+                HttpHeaders.DEFAULT_HEADER_FACTORY.withValidation(validateHeaders),
+                HttpHeaders.DEFAULT_TRAILER_FACTORY.withValidation(validateHeaders));
     }
 
+    /**
+     * Create a full HTTP response with the given HTTP version, method, URI, contents,
+     * and factories for creating headers and trailers.
+     * <p>
+     * The recommended default header factory is {@link HttpHeaders#DEFAULT_HEADER_FACTORY},
+     * and the recommended default trailer factory is {@link HttpHeaders#DEFAULT_TRAILER_FACTORY}.
+     */
+    public DefaultFullHttpRequest(HttpVersion httpVersion, HttpMethod method, String uri,
+            ByteBuf content, HttpHeadersFactory headersFactory, HttpHeadersFactory trailersFactory) {
+        this(httpVersion, method, uri, content, headersFactory.createHeaders(), trailersFactory.createHeaders());
+    }
+
+    /**
+     * Create a full HTTP response with the given HTTP version, method, URI, contents, and header and trailer objects.
+     */
     public DefaultFullHttpRequest(HttpVersion httpVersion, HttpMethod method, String uri,
             ByteBuf content, HttpHeaders headers, HttpHeaders trailingHeader) {
         super(httpVersion, method, uri, headers);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultFullHttpResponse.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultFullHttpResponse.java
@@ -20,8 +20,8 @@ import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.util.IllegalReferenceCountException;
 
-import static io.netty.handler.codec.http.HttpHeaders.DEFAULT_HEADER_FACTORY;
-import static io.netty.handler.codec.http.HttpHeaders.DEFAULT_TRAILER_FACTORY;
+import static io.netty.handler.codec.http.DefaultHttpHeadersFactory.headersFactory;
+import static io.netty.handler.codec.http.DefaultHttpHeadersFactory.trailersFactory;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
@@ -41,14 +41,14 @@ public class DefaultFullHttpResponse extends DefaultHttpResponse implements Full
      * Create an empty HTTP response with the given HTTP version and status.
      */
     public DefaultFullHttpResponse(HttpVersion version, HttpResponseStatus status) {
-        this(version, status, Unpooled.buffer(0), DEFAULT_HEADER_FACTORY, DEFAULT_TRAILER_FACTORY);
+        this(version, status, Unpooled.buffer(0), headersFactory(), trailersFactory());
     }
 
     /**
      * Create an HTTP response with the given HTTP version, status, and contents.
      */
     public DefaultFullHttpResponse(HttpVersion version, HttpResponseStatus status, ByteBuf content) {
-        this(version, status, content, DEFAULT_HEADER_FACTORY, DEFAULT_TRAILER_FACTORY);
+        this(version, status, content, headersFactory(), trailersFactory());
     }
 
     /**
@@ -60,8 +60,8 @@ public class DefaultFullHttpResponse extends DefaultHttpResponse implements Full
     @Deprecated
     public DefaultFullHttpResponse(HttpVersion version, HttpResponseStatus status, boolean validateHeaders) {
         this(version, status, Unpooled.buffer(0),
-                DEFAULT_HEADER_FACTORY.withValidation(validateHeaders),
-                DEFAULT_TRAILER_FACTORY.withValidation(validateHeaders));
+                headersFactory().withValidation(validateHeaders),
+                trailersFactory().withValidation(validateHeaders));
     }
 
     /**
@@ -75,8 +75,8 @@ public class DefaultFullHttpResponse extends DefaultHttpResponse implements Full
     public DefaultFullHttpResponse(HttpVersion version, HttpResponseStatus status, boolean validateHeaders,
                                    boolean singleFieldHeaders) {
         this(version, status, Unpooled.buffer(0),
-                DEFAULT_HEADER_FACTORY.withValidation(validateHeaders).withCombiningHeaders(singleFieldHeaders),
-                DEFAULT_TRAILER_FACTORY.withValidation(validateHeaders).withCombiningHeaders(singleFieldHeaders));
+                headersFactory().withValidation(validateHeaders).withCombiningHeaders(singleFieldHeaders),
+                trailersFactory().withValidation(validateHeaders).withCombiningHeaders(singleFieldHeaders));
     }
 
     /**
@@ -89,8 +89,8 @@ public class DefaultFullHttpResponse extends DefaultHttpResponse implements Full
     public DefaultFullHttpResponse(HttpVersion version, HttpResponseStatus status,
                                    ByteBuf content, boolean validateHeaders) {
         this(version, status, content,
-                DEFAULT_HEADER_FACTORY.withValidation(validateHeaders),
-                DEFAULT_TRAILER_FACTORY.withValidation(validateHeaders));
+                headersFactory().withValidation(validateHeaders),
+                trailersFactory().withValidation(validateHeaders));
     }
 
     /**
@@ -104,20 +104,20 @@ public class DefaultFullHttpResponse extends DefaultHttpResponse implements Full
     public DefaultFullHttpResponse(HttpVersion version, HttpResponseStatus status,
                                    ByteBuf content, boolean validateHeaders, boolean singleFieldHeaders) {
         this(version, status, content,
-                DEFAULT_HEADER_FACTORY.withValidation(validateHeaders).withCombiningHeaders(singleFieldHeaders),
-                DEFAULT_TRAILER_FACTORY.withValidation(validateHeaders).withCombiningHeaders(singleFieldHeaders));
+                headersFactory().withValidation(validateHeaders).withCombiningHeaders(singleFieldHeaders),
+                trailersFactory().withValidation(validateHeaders).withCombiningHeaders(singleFieldHeaders));
     }
 
     /**
      * Create an HTTP response with the given HTTP version, status, contents,
      * and with headers and trailers created by the given header factories.
      * <p>
-     * The recommended header factory is {@link HttpHeaders#DEFAULT_HEADER_FACTORY},
-     * and the recommended trailer factory is {@link HttpHeaders#DEFAULT_TRAILER_FACTORY}.
+     * The recommended header factory is {@link DefaultHttpHeadersFactory#headersFactory()},
+     * and the recommended trailer factory is {@link DefaultHttpHeadersFactory#trailersFactory()}.
      */
     public DefaultFullHttpResponse(HttpVersion version, HttpResponseStatus status, ByteBuf content,
                                    HttpHeadersFactory headersFactory, HttpHeadersFactory trailersFactory) {
-        this(version, status, content, headersFactory.createHeaders(), trailersFactory.createHeaders());
+        this(version, status, content, headersFactory.newHeaders(), trailersFactory.newHeaders());
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultFullHttpResponse.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultFullHttpResponse.java
@@ -20,6 +20,8 @@ import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.util.IllegalReferenceCountException;
 
+import static io.netty.handler.codec.http.HttpHeaders.DEFAULT_HEADER_FACTORY;
+import static io.netty.handler.codec.http.HttpHeaders.DEFAULT_TRAILER_FACTORY;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
@@ -35,36 +37,92 @@ public class DefaultFullHttpResponse extends DefaultHttpResponse implements Full
      */
     private int hash;
 
+    /**
+     * Create an empty HTTP response with the given HTTP version and status.
+     */
     public DefaultFullHttpResponse(HttpVersion version, HttpResponseStatus status) {
-        this(version, status, Unpooled.buffer(0));
+        this(version, status, Unpooled.buffer(0), DEFAULT_HEADER_FACTORY, DEFAULT_TRAILER_FACTORY);
     }
 
+    /**
+     * Create an HTTP response with the given HTTP version, status, and contents.
+     */
     public DefaultFullHttpResponse(HttpVersion version, HttpResponseStatus status, ByteBuf content) {
-        this(version, status, content, true);
+        this(version, status, content, DEFAULT_HEADER_FACTORY, DEFAULT_TRAILER_FACTORY);
     }
 
+    /**
+     * Create an empty HTTP response with the given HTTP version, status, and optional header validation.
+     *
+     * @deprecated Prefer the {@link #DefaultFullHttpResponse(HttpVersion, HttpResponseStatus, ByteBuf,
+     * HttpHeadersFactory, HttpHeadersFactory)} constructor instead.
+     */
+    @Deprecated
     public DefaultFullHttpResponse(HttpVersion version, HttpResponseStatus status, boolean validateHeaders) {
-        this(version, status, Unpooled.buffer(0), validateHeaders, false);
+        this(version, status, Unpooled.buffer(0),
+                DEFAULT_HEADER_FACTORY.withValidation(validateHeaders),
+                DEFAULT_TRAILER_FACTORY.withValidation(validateHeaders));
     }
 
+    /**
+     * Create an empty HTTP response with the given HTTP version, status, optional header validation,
+     * and optional header combining.
+     *
+     * @deprecated Prefer the {@link #DefaultFullHttpResponse(HttpVersion, HttpResponseStatus, ByteBuf,
+     * HttpHeadersFactory, HttpHeadersFactory)} constructor instead.
+     */
+    @Deprecated
     public DefaultFullHttpResponse(HttpVersion version, HttpResponseStatus status, boolean validateHeaders,
                                    boolean singleFieldHeaders) {
-        this(version, status, Unpooled.buffer(0), validateHeaders, singleFieldHeaders);
+        this(version, status, Unpooled.buffer(0),
+                DEFAULT_HEADER_FACTORY.withValidation(validateHeaders).withCombiningHeaders(singleFieldHeaders),
+                DEFAULT_TRAILER_FACTORY.withValidation(validateHeaders).withCombiningHeaders(singleFieldHeaders));
     }
 
+    /**
+     * Create an HTTP response with the given HTTP version, status, contents, and optional header validation.
+     *
+     * @deprecated Prefer the {@link #DefaultFullHttpResponse(HttpVersion, HttpResponseStatus, ByteBuf,
+     * HttpHeadersFactory, HttpHeadersFactory)} constructor instead.
+     */
+    @Deprecated
     public DefaultFullHttpResponse(HttpVersion version, HttpResponseStatus status,
                                    ByteBuf content, boolean validateHeaders) {
-        this(version, status, content, validateHeaders, false);
+        this(version, status, content,
+                DEFAULT_HEADER_FACTORY.withValidation(validateHeaders),
+                DEFAULT_TRAILER_FACTORY.withValidation(validateHeaders));
     }
 
+    /**
+     * Create an HTTP response with the given HTTP version, status, contents, optional header validation,
+     * and optional header combining.
+     *
+     * @deprecated Prefer the {@link #DefaultFullHttpResponse(HttpVersion, HttpResponseStatus, ByteBuf,
+     * HttpHeadersFactory, HttpHeadersFactory)} constructor instead.
+     */
+    @Deprecated
     public DefaultFullHttpResponse(HttpVersion version, HttpResponseStatus status,
                                    ByteBuf content, boolean validateHeaders, boolean singleFieldHeaders) {
-        super(version, status, validateHeaders, singleFieldHeaders);
-        this.content = checkNotNull(content, "content");
-        this.trailingHeaders = singleFieldHeaders ? new CombinedHttpHeaders(validateHeaders)
-                                                  : new DefaultHttpHeaders(validateHeaders);
+        this(version, status, content,
+                DEFAULT_HEADER_FACTORY.withValidation(validateHeaders).withCombiningHeaders(singleFieldHeaders),
+                DEFAULT_TRAILER_FACTORY.withValidation(validateHeaders).withCombiningHeaders(singleFieldHeaders));
     }
 
+    /**
+     * Create an HTTP response with the given HTTP version, status, contents,
+     * and with headers and trailers created by the given header factories.
+     * <p>
+     * The recommended header factory is {@link HttpHeaders#DEFAULT_HEADER_FACTORY},
+     * and the recommended trailer factory is {@link HttpHeaders#DEFAULT_TRAILER_FACTORY}.
+     */
+    public DefaultFullHttpResponse(HttpVersion version, HttpResponseStatus status, ByteBuf content,
+                                   HttpHeadersFactory headersFactory, HttpHeadersFactory trailersFactory) {
+        this(version, status, content, headersFactory.createHeaders(), trailersFactory.createHeaders());
+    }
+
+    /**
+     * Create an HTTP response with the given HTTP version, status, contents, headers and trailers.
+     */
     public DefaultFullHttpResponse(HttpVersion version, HttpResponseStatus status,
             ByteBuf content, HttpHeaders headers, HttpHeaders trailingHeaders) {
         super(version, status, headers);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
@@ -391,11 +391,13 @@ public class DefaultHttpHeaders extends HttpHeaders {
     }
 
     static ValueValidator<CharSequence> valueValidator(boolean validate) {
-        return validate ? HttpHeadersBuilder.DEFAULT_VALUE_VALIDATOR : HttpHeadersBuilder.NO_VALUE_VALIDATOR;
+        return validate ? DefaultHttpHeadersFactory.headersFactory().getValueValidator() :
+                DefaultHttpHeadersFactory.headersFactory().withValidation(false).getValueValidator();
     }
 
     static NameValidator<CharSequence> nameValidator(boolean validate) {
-        return validate ? HttpHeadersBuilder.DEFAULT_NAME_VALIDATOR : HttpHeadersBuilder.NO_NAME_VALIDATOR;
+        return validate ? DefaultHttpHeadersFactory.headersFactory().getNameValidator() :
+                DefaultHttpHeadersFactory.headersFactory().withNameValidation(false).getNameValidator();
     }
 
     private static class HeaderValueConverter extends CharSequenceValueConverter {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
@@ -113,11 +113,37 @@ public class DefaultHttpHeaders extends HttpHeaders {
     protected DefaultHttpHeaders(
             NameValidator<CharSequence> nameValidator,
             ValueValidator<CharSequence> valueValidator) {
+        this(nameValidator, valueValidator, 16);
+    }
+
+    /**
+     * Create an HTTP headers object with the given name and value validators.
+     * <p>
+     * <b>Warning!</b> It is strongly recommended that the name validator implement validation that is at least as
+     * strict as {@link HttpHeaderValidationUtil#validateToken(CharSequence)}.
+     * And that the value validator is at least as strict as
+     * {@link HttpHeaderValidationUtil#validateValidHeaderValue(CharSequence)}.
+     * <p>
+     * Without these validations in place, your code can be susceptible to
+     * <a href="https://cwe.mitre.org/data/definitions/113.html">
+     *     CWE-113: Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
+     * </a>.
+     * It is the responsibility of the caller to ensure that the values supplied
+     * do not contain a non-url-escaped carriage return (CR) and/or line feed (LF) characters.
+     *
+     * @param nameValidator The {@link NameValidator} to use, never {@code null}.
+     * @param valueValidator The {@link ValueValidator} to use, never {@code null}.
+     * @param sizeHint A hint about the anticipated number of entries.
+     */
+    protected DefaultHttpHeaders(
+            NameValidator<CharSequence> nameValidator,
+            ValueValidator<CharSequence> valueValidator,
+            int sizeHint) {
         this(new DefaultHeadersImpl<CharSequence, CharSequence>(
                 CASE_INSENSITIVE_HASHER,
                 HeaderValueConverter.INSTANCE,
                 nameValidator,
-                16,
+                sizeHint,
                 valueValidator));
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
@@ -41,21 +41,6 @@ import static io.netty.util.AsciiString.CASE_SENSITIVE_HASHER;
  * Default implementation of {@link HttpHeaders}.
  */
 public class DefaultHttpHeaders extends HttpHeaders {
-    static final NameValidator<CharSequence> HttpNameValidator = new NameValidator<CharSequence>() {
-        @Override
-        public void validateName(CharSequence name) {
-            if (name == null || name.length() == 0) {
-                throw new IllegalArgumentException("empty headers are not allowed [" + name + ']');
-            }
-            int index = HttpHeaderValidationUtil.validateToken(name);
-            if (index != -1) {
-                throw new IllegalArgumentException("a header name can only contain \"token\" characters, " +
-                        "but found invalid character 0x" + Integer.toHexString(name.charAt(index)) +
-                        " at index " + index + " of header '" + name + "'.");
-            }
-        }
-    };
-
     private final DefaultHeaders<CharSequence, CharSequence, ?> headers;
 
     /**
@@ -405,15 +390,12 @@ public class DefaultHttpHeaders extends HttpHeaders {
         return HeaderValueConverter.INSTANCE;
     }
 
-    @SuppressWarnings("unchecked")
     static ValueValidator<CharSequence> valueValidator(boolean validate) {
-        return validate ? HeaderValueValidator.INSTANCE :
-                (ValueValidator<CharSequence>) ValueValidator.NO_VALIDATION;
+        return validate ? HttpHeadersBuilder.DEFAULT_VALUE_VALIDATOR : HttpHeadersBuilder.NO_VALUE_VALIDATOR;
     }
 
-    @SuppressWarnings("unchecked")
     static NameValidator<CharSequence> nameValidator(boolean validate) {
-        return validate ? HttpNameValidator : NameValidator.NOT_NULL;
+        return validate ? HttpHeadersBuilder.DEFAULT_NAME_VALIDATOR : HttpHeadersBuilder.NO_NAME_VALIDATOR;
     }
 
     private static class HeaderValueConverter extends CharSequenceValueConverter {
@@ -431,19 +413,6 @@ public class DefaultHttpHeaders extends HttpHeaders {
                 return DateFormatter.format(((Calendar) value).getTime());
             }
             return value.toString();
-        }
-    }
-
-    private static final class HeaderValueValidator implements ValueValidator<CharSequence> {
-        static final HeaderValueValidator INSTANCE = new HeaderValueValidator();
-
-        @Override
-        public void validate(CharSequence value) {
-            int index = HttpHeaderValidationUtil.validateValidHeaderValue(value);
-            if (index != -1) {
-                throw new IllegalArgumentException("a header value contains prohibited character 0x" +
-                        Integer.toHexString(value.charAt(index)) + " at index " + index + '.');
-            }
         }
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpMessage.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpMessage.java
@@ -15,8 +15,6 @@
  */
 package io.netty.handler.codec.http;
 
-import io.netty.util.internal.ObjectUtil;
-
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
@@ -31,16 +29,27 @@ public abstract class DefaultHttpMessage extends DefaultHttpObject implements Ht
      * Creates a new instance.
      */
     protected DefaultHttpMessage(final HttpVersion version) {
-        this(version, true, false);
+        this(version, HttpHeaders.DEFAULT_HEADER_FACTORY);
+    }
+
+    /**
+     * Creates a new instance.
+     * <p>
+     * @deprecated Use the {@link #DefaultHttpMessage(HttpVersion, HttpHeadersFactory)} constructor instead,
+     * ideally using the {@link HttpHeaders#DEFAULT_HEADER_FACTORY}, or a factory that otherwise has validation enabled.
+     */
+    @Deprecated
+    protected DefaultHttpMessage(final HttpVersion version, boolean validateHeaders, boolean singleFieldHeaders) {
+        this(version, HttpHeaders.DEFAULT_HEADER_FACTORY
+                .withValidation(validateHeaders)
+                .withCombiningHeaders(singleFieldHeaders));
     }
 
     /**
      * Creates a new instance.
      */
-    protected DefaultHttpMessage(final HttpVersion version, boolean validateHeaders, boolean singleFieldHeaders) {
-        this(version,
-                singleFieldHeaders ? new CombinedHttpHeaders(validateHeaders)
-                                   : new DefaultHttpHeaders(validateHeaders));
+    protected DefaultHttpMessage(HttpVersion version, HttpHeadersFactory headersFactory) {
+        this(version, headersFactory.createHeaders());
     }
 
     /**
@@ -91,7 +100,7 @@ public abstract class DefaultHttpMessage extends DefaultHttpObject implements Ht
 
     @Override
     public HttpMessage setProtocolVersion(HttpVersion version) {
-        this.version = ObjectUtil.checkNotNull(version, "version");
+        this.version = checkNotNull(version, "version");
         return this;
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpMessage.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpMessage.java
@@ -29,18 +29,19 @@ public abstract class DefaultHttpMessage extends DefaultHttpObject implements Ht
      * Creates a new instance.
      */
     protected DefaultHttpMessage(final HttpVersion version) {
-        this(version, HttpHeaders.DEFAULT_HEADER_FACTORY);
+        this(version, DefaultHttpHeadersFactory.headersFactory());
     }
 
     /**
      * Creates a new instance.
      * <p>
      * @deprecated Use the {@link #DefaultHttpMessage(HttpVersion, HttpHeadersFactory)} constructor instead,
-     * ideally using the {@link HttpHeaders#DEFAULT_HEADER_FACTORY}, or a factory that otherwise has validation enabled.
+     * ideally using the {@link DefaultHttpHeadersFactory#headersFactory()},
+     * or a factory that otherwise has validation enabled.
      */
     @Deprecated
     protected DefaultHttpMessage(final HttpVersion version, boolean validateHeaders, boolean singleFieldHeaders) {
-        this(version, HttpHeaders.DEFAULT_HEADER_FACTORY
+        this(version, DefaultHttpHeadersFactory.headersFactory()
                 .withValidation(validateHeaders)
                 .withCombiningHeaders(singleFieldHeaders));
     }
@@ -49,7 +50,7 @@ public abstract class DefaultHttpMessage extends DefaultHttpObject implements Ht
      * Creates a new instance.
      */
     protected DefaultHttpMessage(HttpVersion version, HttpHeadersFactory headersFactory) {
-        this(version, headersFactory.createHeaders());
+        this(version, headersFactory.newHeaders());
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpRequest.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpRequest.java
@@ -35,7 +35,7 @@ public class DefaultHttpRequest extends DefaultHttpMessage implements HttpReques
      * @param uri         the URI or path of the request
      */
     public DefaultHttpRequest(HttpVersion httpVersion, HttpMethod method, String uri) {
-        this(httpVersion, method, uri, true);
+        this(httpVersion, method, uri, HttpHeadersBuilder.DEFAULT.createHeaders());
     }
 
     /**
@@ -45,11 +45,26 @@ public class DefaultHttpRequest extends DefaultHttpMessage implements HttpReques
      * @param method            the HTTP method of the request
      * @param uri               the URI or path of the request
      * @param validateHeaders   validate the header names and values when adding them to the {@link HttpHeaders}
+     * @deprecated Prefer the {@link #DefaultHttpRequest(HttpVersion, HttpMethod, String)} constructor instead,
+     * to always have header validation enabled.
      */
+    @Deprecated
     public DefaultHttpRequest(HttpVersion httpVersion, HttpMethod method, String uri, boolean validateHeaders) {
-        super(httpVersion, validateHeaders, false);
-        this.method = checkNotNull(method, "method");
-        this.uri = checkNotNull(uri, "uri");
+        this(httpVersion, method, uri, HttpHeadersBuilder.DEFAULT.withValidation(validateHeaders));
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param httpVersion       the HTTP version of the request
+     * @param method            the HTTP method of the request
+     * @param uri               the URI or path of the request
+     * @param headersFactory    the {@link HttpHeadersFactory} used to create the headers for this Request.
+     * The recommended default is {@link HttpHeaders#DEFAULT_HEADER_FACTORY}.
+     */
+    public DefaultHttpRequest(HttpVersion httpVersion, HttpMethod method, String uri,
+                              HttpHeadersFactory headersFactory) {
+        this(httpVersion, method, uri, headersFactory.createHeaders());
     }
 
     /**
@@ -90,13 +105,13 @@ public class DefaultHttpRequest extends DefaultHttpMessage implements HttpReques
 
     @Override
     public HttpRequest setMethod(HttpMethod method) {
-        this.method = ObjectUtil.checkNotNull(method, "method");
+        this.method = checkNotNull(method, "method");
         return this;
     }
 
     @Override
     public HttpRequest setUri(String uri) {
-        this.uri = ObjectUtil.checkNotNull(uri, "uri");
+        this.uri = checkNotNull(uri, "uri");
         return this;
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpRequest.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpRequest.java
@@ -15,8 +15,7 @@
  */
 package io.netty.handler.codec.http;
 
-import io.netty.util.internal.ObjectUtil;
-
+import static io.netty.handler.codec.http.DefaultHttpHeadersFactory.headersFactory;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
@@ -35,7 +34,7 @@ public class DefaultHttpRequest extends DefaultHttpMessage implements HttpReques
      * @param uri         the URI or path of the request
      */
     public DefaultHttpRequest(HttpVersion httpVersion, HttpMethod method, String uri) {
-        this(httpVersion, method, uri, HttpHeadersBuilder.DEFAULT.createHeaders());
+        this(httpVersion, method, uri, headersFactory().newHeaders());
     }
 
     /**
@@ -50,7 +49,7 @@ public class DefaultHttpRequest extends DefaultHttpMessage implements HttpReques
      */
     @Deprecated
     public DefaultHttpRequest(HttpVersion httpVersion, HttpMethod method, String uri, boolean validateHeaders) {
-        this(httpVersion, method, uri, HttpHeadersBuilder.DEFAULT.withValidation(validateHeaders));
+        this(httpVersion, method, uri, headersFactory().withValidation(validateHeaders));
     }
 
     /**
@@ -60,11 +59,11 @@ public class DefaultHttpRequest extends DefaultHttpMessage implements HttpReques
      * @param method            the HTTP method of the request
      * @param uri               the URI or path of the request
      * @param headersFactory    the {@link HttpHeadersFactory} used to create the headers for this Request.
-     * The recommended default is {@link HttpHeaders#DEFAULT_HEADER_FACTORY}.
+     * The recommended default is {@link DefaultHttpHeadersFactory#headersFactory()}.
      */
     public DefaultHttpRequest(HttpVersion httpVersion, HttpMethod method, String uri,
                               HttpHeadersFactory headersFactory) {
-        this(httpVersion, method, uri, headersFactory.createHeaders());
+        this(httpVersion, method, uri, headersFactory.newHeaders());
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpResponse.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpResponse.java
@@ -17,6 +17,7 @@ package io.netty.handler.codec.http;
 
 import io.netty.util.internal.ObjectUtil;
 
+import static io.netty.handler.codec.http.DefaultHttpHeadersFactory.headersFactory;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
@@ -33,7 +34,7 @@ public class DefaultHttpResponse extends DefaultHttpMessage implements HttpRespo
      * @param status  the status of this response
      */
     public DefaultHttpResponse(HttpVersion version, HttpResponseStatus status) {
-        this(version, status, HttpHeadersBuilder.DEFAULT);
+        this(version, status, headersFactory());
     }
 
     /**
@@ -47,7 +48,7 @@ public class DefaultHttpResponse extends DefaultHttpMessage implements HttpRespo
      */
     @Deprecated
     public DefaultHttpResponse(HttpVersion version, HttpResponseStatus status, boolean validateHeaders) {
-        this(version, status, HttpHeadersBuilder.DEFAULT.withValidation(validateHeaders));
+        this(version, status, headersFactory().withValidation(validateHeaders));
     }
 
     /**
@@ -67,8 +68,7 @@ public class DefaultHttpResponse extends DefaultHttpMessage implements HttpRespo
     @Deprecated
     public DefaultHttpResponse(HttpVersion version, HttpResponseStatus status, boolean validateHeaders,
                                boolean singleFieldHeaders) {
-        this(version, status, HttpHeadersBuilder.DEFAULT
-                .withValidation(validateHeaders)
+        this(version, status, headersFactory().withValidation(validateHeaders)
                 .withCombiningHeaders(singleFieldHeaders));
     }
 
@@ -78,10 +78,10 @@ public class DefaultHttpResponse extends DefaultHttpMessage implements HttpRespo
      * @param version           the HTTP version of this response
      * @param status            the status of this response
      * @param headersFactory    the {@link HttpHeadersFactory} used to create the headers for this HTTP Response.
-     * The recommended default is {@link HttpHeaders#DEFAULT_HEADER_FACTORY}.
+     * The recommended default is {@link DefaultHttpHeadersFactory#headersFactory()}.
      */
     public DefaultHttpResponse(HttpVersion version, HttpResponseStatus status, HttpHeadersFactory headersFactory) {
-        this(version, status, headersFactory.createHeaders());
+        this(version, status, headersFactory.newHeaders());
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpResponse.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpResponse.java
@@ -33,7 +33,7 @@ public class DefaultHttpResponse extends DefaultHttpMessage implements HttpRespo
      * @param status  the status of this response
      */
     public DefaultHttpResponse(HttpVersion version, HttpResponseStatus status) {
-        this(version, status, true, false);
+        this(version, status, HttpHeadersBuilder.DEFAULT);
     }
 
     /**
@@ -42,9 +42,12 @@ public class DefaultHttpResponse extends DefaultHttpMessage implements HttpRespo
      * @param version           the HTTP version of this response
      * @param status            the status of this response
      * @param validateHeaders   validate the header names and values when adding them to the {@link HttpHeaders}
+     * @deprecated Use the {@link #DefaultHttpResponse(HttpVersion, HttpResponseStatus, HttpHeadersFactory)} constructor
+     * instead.
      */
+    @Deprecated
     public DefaultHttpResponse(HttpVersion version, HttpResponseStatus status, boolean validateHeaders) {
-        this(version, status, validateHeaders, false);
+        this(version, status, HttpHeadersBuilder.DEFAULT.withValidation(validateHeaders));
     }
 
     /**
@@ -58,11 +61,27 @@ public class DefaultHttpResponse extends DefaultHttpMessage implements HttpRespo
      * See <a href="https://tools.ietf.org/html/rfc7230#section-3.2.2">RFC 7230, 3.2.2</a>.
      * {@code false} to allow multiple header entries with the same name to
      * coexist.
+     * @deprecated Use the {@link #DefaultHttpResponse(HttpVersion, HttpResponseStatus, HttpHeadersFactory)} constructor
+     * instead.
      */
+    @Deprecated
     public DefaultHttpResponse(HttpVersion version, HttpResponseStatus status, boolean validateHeaders,
                                boolean singleFieldHeaders) {
-        super(version, validateHeaders, singleFieldHeaders);
-        this.status = checkNotNull(status, "status");
+        this(version, status, HttpHeadersBuilder.DEFAULT
+                .withValidation(validateHeaders)
+                .withCombiningHeaders(singleFieldHeaders));
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param version           the HTTP version of this response
+     * @param status            the status of this response
+     * @param headersFactory    the {@link HttpHeadersFactory} used to create the headers for this HTTP Response.
+     * The recommended default is {@link HttpHeaders#DEFAULT_HEADER_FACTORY}.
+     */
+    public DefaultHttpResponse(HttpVersion version, HttpResponseStatus status, HttpHeadersFactory headersFactory) {
+        this(version, status, headersFactory.createHeaders());
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultLastHttpContent.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultLastHttpContent.java
@@ -17,7 +17,6 @@ package io.netty.handler.codec.http;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.handler.codec.DefaultHeaders.NameValidator;
 import io.netty.util.internal.StringUtil;
 
 import java.util.Map.Entry;
@@ -29,26 +28,55 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
  */
 public class DefaultLastHttpContent extends DefaultHttpContent implements LastHttpContent {
     private final HttpHeaders trailingHeaders;
-    private final boolean validateHeaders;
 
+    /**
+     * Create a new empty, last HTTP content message.
+     */
     public DefaultLastHttpContent() {
         this(Unpooled.buffer(0));
     }
 
+    /**
+     * Create a new last HTTP content message with the given contents.
+     */
     public DefaultLastHttpContent(ByteBuf content) {
-        this(content, true);
+        this(content, HttpHeadersBuilder.DEFAULT_TRAILER);
     }
 
+    /**
+     * Create a new last HTTP content message with the given contents, and optional trailing header validation.
+     * <p>
+     * <b>Warning!</b> Setting {@code validateHeaders} to {@code false} will mean that Netty won't
+     * validate & protect against user-supplied header values that are malicious.
+     * This can leave your server implementation vulnerable to
+     * <a href="https://cwe.mitre.org/data/definitions/113.html">
+     *     CWE-113: Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
+     * </a>.
+     * When disabling this validation, it is the responsibility of the caller to ensure that the values supplied
+     * do not contain a non-url-escaped carriage return (CR) and/or line feed (LF) characters.
+     *
+     * @deprecated Prefer the {@link #DefaultLastHttpContent(ByteBuf)} constructor instead, to always have header
+     * validation enabled.
+     */
+    @Deprecated
     public DefaultLastHttpContent(ByteBuf content, boolean validateHeaders) {
-        super(content);
-        trailingHeaders = new TrailingHttpHeaders(validateHeaders);
-        this.validateHeaders = validateHeaders;
+        this(content, HttpHeadersBuilder.DEFAULT_TRAILER.withValidation(validateHeaders));
     }
 
+    /**
+     * Create a new last HTTP content message with the given contents, and trailing headers from the given factory.
+     */
+    public DefaultLastHttpContent(ByteBuf content, HttpHeadersFactory trailersFactory) {
+        super(content);
+        trailingHeaders = trailersFactory.createHeaders();
+    }
+
+    /**
+     * Create a new last HTTP content message with the given contents, and trailing headers.
+     */
     public DefaultLastHttpContent(ByteBuf content, HttpHeaders trailingHeaders) {
         super(content);
         this.trailingHeaders = checkNotNull(trailingHeaders, "trailingHeaders");
-        this.validateHeaders = false;
     }
 
     @Override
@@ -68,9 +96,7 @@ public class DefaultLastHttpContent extends DefaultHttpContent implements LastHt
 
     @Override
     public LastHttpContent replace(ByteBuf content) {
-        final DefaultLastHttpContent dup = new DefaultLastHttpContent(content, validateHeaders);
-        dup.trailingHeaders().set(trailingHeaders());
-        return dup;
+        return new DefaultLastHttpContent(content, trailingHeaders().copy());
     }
 
     @Override
@@ -119,25 +145,6 @@ public class DefaultLastHttpContent extends DefaultHttpContent implements LastHt
             buf.append(": ");
             buf.append(e.getValue());
             buf.append(StringUtil.NEWLINE);
-        }
-    }
-
-    private static final class TrailingHttpHeaders extends DefaultHttpHeaders {
-        private static final NameValidator<CharSequence> TrailerNameValidator = new NameValidator<CharSequence>() {
-            @Override
-            public void validateName(CharSequence name) {
-                DefaultHttpHeaders.HttpNameValidator.validateName(name);
-                if (HttpHeaderNames.CONTENT_LENGTH.contentEqualsIgnoreCase(name)
-                        || HttpHeaderNames.TRANSFER_ENCODING.contentEqualsIgnoreCase(name)
-                        || HttpHeaderNames.TRAILER.contentEqualsIgnoreCase(name)) {
-                    throw new IllegalArgumentException("prohibited trailing header: " + name);
-                }
-            }
-        };
-
-        @SuppressWarnings({ "unchecked" })
-        TrailingHttpHeaders(boolean validate) {
-            super(validate, validate ? TrailerNameValidator : NameValidator.NOT_NULL);
         }
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultLastHttpContent.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultLastHttpContent.java
@@ -21,6 +21,7 @@ import io.netty.util.internal.StringUtil;
 
 import java.util.Map.Entry;
 
+import static io.netty.handler.codec.http.DefaultHttpHeadersFactory.trailersFactory;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
@@ -40,7 +41,7 @@ public class DefaultLastHttpContent extends DefaultHttpContent implements LastHt
      * Create a new last HTTP content message with the given contents.
      */
     public DefaultLastHttpContent(ByteBuf content) {
-        this(content, HttpHeadersBuilder.DEFAULT_TRAILER);
+        this(content, trailersFactory());
     }
 
     /**
@@ -60,7 +61,7 @@ public class DefaultLastHttpContent extends DefaultHttpContent implements LastHt
      */
     @Deprecated
     public DefaultLastHttpContent(ByteBuf content, boolean validateHeaders) {
-        this(content, HttpHeadersBuilder.DEFAULT_TRAILER.withValidation(validateHeaders));
+        this(content, trailersFactory().withValidation(validateHeaders));
     }
 
     /**
@@ -68,7 +69,7 @@ public class DefaultLastHttpContent extends DefaultHttpContent implements LastHt
      */
     public DefaultLastHttpContent(ByteBuf content, HttpHeadersFactory trailersFactory) {
         super(content);
-        trailingHeaders = trailersFactory.createHeaders();
+        trailingHeaders = trailersFactory.newHeaders();
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientCodec.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientCodec.java
@@ -42,9 +42,21 @@ import static io.netty.handler.codec.http.HttpObjectDecoder.DEFAULT_VALIDATE_HEA
  * {@link HttpResponseDecoder} to learn what additional state management needs
  * to be done for <tt>HEAD</tt> and <tt>CONNECT</tt> and why
  * {@link HttpResponseDecoder} can not handle it by itself.
- *
+ * <p>
  * If the {@link Channel} is closed and there are missing responses,
  * a {@link PrematureChannelClosureException} is thrown.
+ *
+ * <h3>Header Validation</h3>
+ *
+ * It is recommended to always enable header validation.
+ * <p>
+ * Without header validation, your system can become vulnerable to
+ * <a href="https://cwe.mitre.org/data/definitions/113.html">
+ *     CWE-113: Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
+ * </a>.
+ * <p>
+ * This recommendation stands even when both peers in the HTTP exchange are trusted,
+ * as it helps with defence-in-depth.
  *
  * @see HttpServerCodec
  */
@@ -69,15 +81,21 @@ public final class HttpClientCodec extends CombinedChannelDuplexHandler<HttpResp
      * {@code maxChunkSize (8192)}).
      */
     public HttpClientCodec() {
-        this(DEFAULT_MAX_INITIAL_LINE_LENGTH, DEFAULT_MAX_HEADER_SIZE, DEFAULT_MAX_CHUNK_SIZE,
-             DEFAULT_FAIL_ON_MISSING_RESPONSE);
+        this(new HttpDecoderConfig(),
+                DEFAULT_PARSE_HTTP_AFTER_CONNECT_REQUEST,
+                DEFAULT_FAIL_ON_MISSING_RESPONSE);
     }
 
     /**
      * Creates a new instance with the specified decoder options.
      */
     public HttpClientCodec(int maxInitialLineLength, int maxHeaderSize, int maxChunkSize) {
-        this(maxInitialLineLength, maxHeaderSize, maxChunkSize, DEFAULT_FAIL_ON_MISSING_RESPONSE);
+        this(new HttpDecoderConfig()
+                        .setMaxInitialLineLength(maxInitialLineLength)
+                        .setMaxHeaderSize(maxHeaderSize)
+                        .setMaxChunkSize(maxChunkSize),
+                DEFAULT_PARSE_HTTP_AFTER_CONNECT_REQUEST,
+                DEFAULT_FAIL_ON_MISSING_RESPONSE);
     }
 
     /**
@@ -85,72 +103,142 @@ public final class HttpClientCodec extends CombinedChannelDuplexHandler<HttpResp
      */
     public HttpClientCodec(
             int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean failOnMissingResponse) {
-        this(maxInitialLineLength, maxHeaderSize, maxChunkSize, failOnMissingResponse, DEFAULT_VALIDATE_HEADERS);
+        this(new HttpDecoderConfig()
+                        .setMaxInitialLineLength(maxInitialLineLength)
+                        .setMaxHeaderSize(maxHeaderSize)
+                        .setMaxChunkSize(maxChunkSize),
+                DEFAULT_PARSE_HTTP_AFTER_CONNECT_REQUEST,
+                failOnMissingResponse);
     }
 
     /**
      * Creates a new instance with the specified decoder options.
+     *
+     * @deprecated Prefer the {@link #HttpClientCodec(int, int, int, boolean)} constructor,
+     * to always enable header validation.
      */
+    @Deprecated
     public HttpClientCodec(
             int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean failOnMissingResponse,
             boolean validateHeaders) {
-        this(maxInitialLineLength, maxHeaderSize, maxChunkSize, failOnMissingResponse, validateHeaders,
-             DEFAULT_PARSE_HTTP_AFTER_CONNECT_REQUEST);
+        this(new HttpDecoderConfig()
+                        .setMaxInitialLineLength(maxInitialLineLength)
+                        .setMaxHeaderSize(maxHeaderSize)
+                        .setMaxChunkSize(maxChunkSize)
+                        .setValidateHeaders(validateHeaders),
+                DEFAULT_PARSE_HTTP_AFTER_CONNECT_REQUEST,
+                failOnMissingResponse);
     }
 
     /**
      * Creates a new instance with the specified decoder options.
+     *
+     * @deprecated Prefer the {@link #HttpClientCodec(HttpDecoderConfig, boolean, boolean)} constructor,
+     * to always enable header validation.
      */
+    @Deprecated
     public HttpClientCodec(
             int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean failOnMissingResponse,
             boolean validateHeaders, boolean parseHttpAfterConnectRequest) {
-        init(new Decoder(maxInitialLineLength, maxHeaderSize, maxChunkSize, validateHeaders), new Encoder());
-        this.failOnMissingResponse = failOnMissingResponse;
-        this.parseHttpAfterConnectRequest = parseHttpAfterConnectRequest;
+        this(new HttpDecoderConfig()
+                        .setMaxInitialLineLength(maxInitialLineLength)
+                        .setMaxHeaderSize(maxHeaderSize)
+                        .setMaxChunkSize(maxChunkSize)
+                        .setValidateHeaders(validateHeaders),
+                parseHttpAfterConnectRequest,
+                failOnMissingResponse);
     }
 
     /**
      * Creates a new instance with the specified decoder options.
+     *
+     * @deprecated Prefer the {@link #HttpClientCodec(HttpDecoderConfig, boolean, boolean)} constructor,
+     * to always enable header validation.
      */
+    @Deprecated
     public HttpClientCodec(
             int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean failOnMissingResponse,
             boolean validateHeaders, int initialBufferSize) {
-        this(maxInitialLineLength, maxHeaderSize, maxChunkSize, failOnMissingResponse, validateHeaders,
-             initialBufferSize, DEFAULT_PARSE_HTTP_AFTER_CONNECT_REQUEST);
+        this(new HttpDecoderConfig()
+                        .setMaxInitialLineLength(maxInitialLineLength)
+                        .setMaxHeaderSize(maxHeaderSize)
+                        .setMaxChunkSize(maxChunkSize)
+                        .setValidateHeaders(validateHeaders)
+                        .setInitialBufferSize(initialBufferSize),
+                DEFAULT_PARSE_HTTP_AFTER_CONNECT_REQUEST,
+                failOnMissingResponse);
     }
 
     /**
      * Creates a new instance with the specified decoder options.
+     *
+     * @deprecated Prefer the {@link #HttpClientCodec(HttpDecoderConfig, boolean, boolean)} constructor,
+     * to always enable header validation.
      */
+    @Deprecated
     public HttpClientCodec(
             int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean failOnMissingResponse,
             boolean validateHeaders, int initialBufferSize, boolean parseHttpAfterConnectRequest) {
-        this(maxInitialLineLength, maxHeaderSize, maxChunkSize, failOnMissingResponse, validateHeaders,
-             initialBufferSize, parseHttpAfterConnectRequest, DEFAULT_ALLOW_DUPLICATE_CONTENT_LENGTHS);
+        this(new HttpDecoderConfig()
+                        .setMaxInitialLineLength(maxInitialLineLength)
+                        .setMaxHeaderSize(maxHeaderSize)
+                        .setMaxChunkSize(maxChunkSize)
+                        .setValidateHeaders(validateHeaders)
+                        .setInitialBufferSize(initialBufferSize),
+                parseHttpAfterConnectRequest,
+                failOnMissingResponse);
     }
-
     /**
      * Creates a new instance with the specified decoder options.
+     *
+     * @deprecated Prefer the {@link #HttpClientCodec(HttpDecoderConfig, boolean, boolean)} constructor,
+     * to always enable header validation.
      */
+    @Deprecated
     public HttpClientCodec(
             int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean failOnMissingResponse,
             boolean validateHeaders, int initialBufferSize, boolean parseHttpAfterConnectRequest,
             boolean allowDuplicateContentLengths) {
-        this(maxInitialLineLength, maxHeaderSize, maxChunkSize, failOnMissingResponse, validateHeaders,
-            initialBufferSize, parseHttpAfterConnectRequest, allowDuplicateContentLengths,
-            DEFAULT_ALLOW_PARTIAL_CHUNKS);
+        this(new HttpDecoderConfig()
+                        .setMaxInitialLineLength(maxInitialLineLength)
+                        .setMaxHeaderSize(maxHeaderSize)
+                        .setMaxChunkSize(maxChunkSize)
+                        .setValidateHeaders(validateHeaders)
+                        .setInitialBufferSize(initialBufferSize)
+                        .setAllowDuplicateContentLengths(allowDuplicateContentLengths),
+                parseHttpAfterConnectRequest,
+                failOnMissingResponse);
+    }
+
+    /**
+     * Creates a new instance with the specified decoder options.
+     *
+     * @deprecated Prefer the {@link #HttpClientCodec(HttpDecoderConfig, boolean, boolean)}
+     * constructor, to always enable header validation.
+     */
+    @Deprecated
+    public HttpClientCodec(
+            int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean failOnMissingResponse,
+            boolean validateHeaders, int initialBufferSize, boolean parseHttpAfterConnectRequest,
+            boolean allowDuplicateContentLengths, boolean allowPartialChunks) {
+        this(new HttpDecoderConfig()
+                .setMaxInitialLineLength(maxInitialLineLength)
+                .setMaxHeaderSize(maxHeaderSize)
+                .setMaxChunkSize(maxChunkSize)
+                .setValidateHeaders(validateHeaders)
+                .setInitialBufferSize(initialBufferSize)
+                .setAllowDuplicateContentLengths(allowDuplicateContentLengths)
+                .setAllowPartialChunks(allowPartialChunks),
+                parseHttpAfterConnectRequest,
+                failOnMissingResponse);
     }
 
     /**
      * Creates a new instance with the specified decoder options.
      */
     public HttpClientCodec(
-            int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean failOnMissingResponse,
-            boolean validateHeaders, int initialBufferSize, boolean parseHttpAfterConnectRequest,
-            boolean allowDuplicateContentLengths, boolean allowPartialChunks) {
-        init(new Decoder(maxInitialLineLength, maxHeaderSize, maxChunkSize, validateHeaders, initialBufferSize,
-                         allowDuplicateContentLengths, allowPartialChunks),
-             new Encoder());
+            HttpDecoderConfig config, boolean parseHttpAfterConnectRequest, boolean failOnMissingResponse) {
+        init(new Decoder(config), new Encoder());
         this.parseHttpAfterConnectRequest = parseHttpAfterConnectRequest;
         this.failOnMissingResponse = failOnMissingResponse;
     }
@@ -212,14 +300,8 @@ public final class HttpClientCodec extends CombinedChannelDuplexHandler<HttpResp
     }
 
     private final class Decoder extends HttpResponseDecoder {
-        Decoder(int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean validateHeaders) {
-            super(maxInitialLineLength, maxHeaderSize, maxChunkSize, validateHeaders);
-        }
-
-        Decoder(int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean validateHeaders,
-                int initialBufferSize, boolean allowDuplicateContentLengths, boolean allowPartialChunks) {
-            super(maxInitialLineLength, maxHeaderSize, maxChunkSize, validateHeaders, initialBufferSize,
-                  allowDuplicateContentLengths, allowPartialChunks);
+        Decoder(HttpDecoderConfig config) {
+            super(config);
         }
 
         @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpDecoderConfig.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpDecoderConfig.java
@@ -28,8 +28,8 @@ public final class HttpDecoderConfig implements Cloneable {
     private int maxChunkSize = HttpObjectDecoder.DEFAULT_MAX_CHUNK_SIZE;
     private boolean chunkedSupported = HttpObjectDecoder.DEFAULT_CHUNKED_SUPPORTED;
     private boolean allowPartialChunks = HttpObjectDecoder.DEFAULT_ALLOW_PARTIAL_CHUNKS;
-    private HttpHeadersFactory headersFactory = HttpHeaders.DEFAULT_HEADER_FACTORY;
-    private HttpHeadersFactory trailersFactory = HttpHeadersBuilder.DEFAULT_TRAILER;
+    private HttpHeadersFactory headersFactory = DefaultHttpHeadersFactory.headersFactory();
+    private HttpHeadersFactory trailersFactory = DefaultHttpHeadersFactory.trailersFactory();
     private boolean allowDuplicateContentLengths = HttpObjectDecoder.DEFAULT_ALLOW_DUPLICATE_CONTENT_LENGTHS;
     private int maxInitialLineLength = HttpObjectDecoder.DEFAULT_MAX_INITIAL_LINE_LENGTH;
     private int maxHeaderSize = HttpObjectDecoder.DEFAULT_MAX_HEADER_SIZE;
@@ -143,7 +143,7 @@ public final class HttpDecoderConfig implements Cloneable {
 
     /**
      * Set the {@link HttpHeadersFactory} to use when creating new HTTP headers objects.
-     * The default headers factory is {@link HttpHeaders#DEFAULT_HEADER_FACTORY}.
+     * The default headers factory is {@link DefaultHttpHeadersFactory#headersFactory()}.
      * <p>
      * For the purpose of {@link #clone()}, it is assumed that the factory is either immutable, or can otherwise be
      * shared across different decoders and decoder configs.
@@ -186,9 +186,9 @@ public final class HttpDecoderConfig implements Cloneable {
      * @return This decoder config.
      */
     public HttpDecoderConfig setValidateHeaders(boolean validateHeaders) {
-        HttpHeadersBuilder noValidation = HttpHeadersBuilder.DEFAULT_NO_VALIDATION;
-        headersFactory = validateHeaders ? HttpHeadersBuilder.DEFAULT : noValidation;
-        trailersFactory = validateHeaders ? HttpHeadersBuilder.DEFAULT_TRAILER : noValidation;
+        DefaultHttpHeadersFactory noValidation = DefaultHttpHeadersFactory.headersFactory().withValidation(false);
+        headersFactory = validateHeaders ? DefaultHttpHeadersFactory.headersFactory() : noValidation;
+        trailersFactory = validateHeaders ? DefaultHttpHeadersFactory.trailersFactory() : noValidation;
         return this;
     }
 
@@ -200,7 +200,7 @@ public final class HttpDecoderConfig implements Cloneable {
      * Set the {@link HttpHeadersFactory} used to create HTTP trailers.
      * This differs from {@link #setHeadersFactory(HttpHeadersFactory)} in that trailers have different validation
      * requirements.
-     * The default trailer factory is {@link HttpHeaders#DEFAULT_TRAILER_FACTORY}.
+     * The default trailer factory is {@link DefaultHttpHeadersFactory#headersFactory()}.
      * <p>
      * For the purpose of {@link #clone()}, it is assumed that the factory is either immutable, or can otherwise be
      * shared across different decoders and decoder configs.

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpDecoderConfig.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpDecoderConfig.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http;
+
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import static io.netty.util.internal.ObjectUtil.checkPositive;
+
+/**
+ * A configuration object for specifying the behaviour of {@link HttpObjectDecoder} and its subclasses.
+ * <p>
+ * The {@link HttpDecoderConfig} objects are mutable to reduce allocation,
+ * but also {@link Cloneable} in case a defensive copy is needed.
+ */
+public final class HttpDecoderConfig implements Cloneable {
+    private int maxChunkSize = HttpObjectDecoder.DEFAULT_MAX_CHUNK_SIZE;
+    private boolean chunkedSupported = HttpObjectDecoder.DEFAULT_CHUNKED_SUPPORTED;
+    private boolean allowPartialChunks = HttpObjectDecoder.DEFAULT_ALLOW_PARTIAL_CHUNKS;
+    private HttpHeadersFactory headersFactory = HttpHeaders.DEFAULT_HEADER_FACTORY;
+    private HttpHeadersFactory trailersFactory = HttpHeadersBuilder.DEFAULT_TRAILER;
+    private boolean allowDuplicateContentLengths = HttpObjectDecoder.DEFAULT_ALLOW_DUPLICATE_CONTENT_LENGTHS;
+    private int maxInitialLineLength = HttpObjectDecoder.DEFAULT_MAX_INITIAL_LINE_LENGTH;
+    private int maxHeaderSize = HttpObjectDecoder.DEFAULT_MAX_HEADER_SIZE;
+    private int initialBufferSize = HttpObjectDecoder.DEFAULT_INITIAL_BUFFER_SIZE;
+
+    public int getInitialBufferSize() {
+        return initialBufferSize;
+    }
+
+    /**
+     * Set the initial size of the temporary buffer used when parsing the lines of the HTTP headers.
+     *
+     * @param initialBufferSize The buffer size in bytes.
+     * @return This decoder config.
+     */
+    public HttpDecoderConfig setInitialBufferSize(int initialBufferSize) {
+        checkPositive(initialBufferSize, "initialBufferSize");
+        this.initialBufferSize = initialBufferSize;
+        return this;
+    }
+
+    public int getMaxInitialLineLength() {
+        return maxInitialLineLength;
+    }
+
+    /**
+     * Set the maximum length of the first line of the HTTP header.
+     * This limits how much memory Netty will use when parsed the initial HTTP header line.
+     * You would typically set this to the same value as {@link #setMaxHeaderSize(int)}.
+     *
+     * @param maxInitialLineLength The maximum length, in bytes.
+     * @return This decoder config.
+     */
+    public HttpDecoderConfig setMaxInitialLineLength(int maxInitialLineLength) {
+        checkPositive(maxInitialLineLength, "maxInitialLineLength");
+        this.maxInitialLineLength = maxInitialLineLength;
+        return this;
+    }
+
+    public int getMaxHeaderSize() {
+        return maxHeaderSize;
+    }
+
+    /**
+     * Set the maximum line length of header lines.
+     * This limits how much memory Netty will use when parsing HTTP header key-value pairs.
+     * You would typically set this to the same value as {@link #setMaxInitialLineLength(int)}.
+     *
+     * @param maxHeaderSize The maximum length, in bytes.
+     * @return This decoder config.
+     */
+    public HttpDecoderConfig setMaxHeaderSize(int maxHeaderSize) {
+        checkPositive(maxHeaderSize, "maxHeaderSize");
+        this.maxHeaderSize = maxHeaderSize;
+        return this;
+    }
+
+    public int getMaxChunkSize() {
+        return maxChunkSize;
+    }
+
+    /**
+     * Set the maximum chunk size.
+     * HTTP requests and responses can be quite large, in which case it's better to process the data as a stream of
+     * chunks.
+     * This sets the limit, in bytes, at which Netty will send a chunk down the pipeline.
+     *
+     * @param maxChunkSize The maximum chunk size, in bytes.
+     * @return This decoder config.
+     */
+    public HttpDecoderConfig setMaxChunkSize(int maxChunkSize) {
+        checkPositive(maxChunkSize, "maxChunkSize");
+        this.maxChunkSize = maxChunkSize;
+        return this;
+    }
+
+    public boolean isChunkedSupported() {
+        return chunkedSupported;
+    }
+
+    /**
+     * Set whether {@code Transfer-Encoding: Chunked} should be supported.
+     *
+     * @param chunkedSupported if {@code false}, then a {@code Transfer-Encoding: Chunked} header will produce an error,
+     * instead of a stream of chunks.
+     * @return This decoder config.
+     */
+    public HttpDecoderConfig setChunkedSupported(boolean chunkedSupported) {
+        this.chunkedSupported = chunkedSupported;
+        return this;
+    }
+
+    public boolean isAllowPartialChunks() {
+        return allowPartialChunks;
+    }
+
+    /**
+     * Set whether chunks can be split into multiple messages, if their chunk size exceeds the size of the input buffer.
+     *
+     * @param allowPartialChunks set to {@code false} to only allow sending whole chunks down the pipeline.
+     * @return This decoder config.
+     */
+    public HttpDecoderConfig setAllowPartialChunks(boolean allowPartialChunks) {
+        this.allowPartialChunks = allowPartialChunks;
+        return this;
+    }
+
+    public HttpHeadersFactory getHeadersFactory() {
+        return headersFactory;
+    }
+
+    /**
+     * Set the {@link HttpHeadersFactory} to use when creating new HTTP headers objects.
+     * The default headers factory is {@link HttpHeaders#DEFAULT_HEADER_FACTORY}.
+     * <p>
+     * For the purpose of {@link #clone()}, it is assumed that the factory is either immutable, or can otherwise be
+     * shared across different decoders and decoder configs.
+     *
+     * @param headersFactory The header factory to use.
+     * @return This decoder config.
+     */
+    public HttpDecoderConfig setHeadersFactory(HttpHeadersFactory headersFactory) {
+        checkNotNull(headersFactory, "headersFactory");
+        this.headersFactory = headersFactory;
+        return this;
+    }
+
+    public boolean isAllowDuplicateContentLengths() {
+        return allowDuplicateContentLengths;
+    }
+
+    /**
+     * Set whether more than one {@code Content-Length} header is allowed.
+     * You usually want to disallow this (which is the default) as multiple {@code Content-Length} headers can indicate
+     * a request- or response-splitting attack.
+     *
+     * @param allowDuplicateContentLengths set to {@code true} to allow multiple content length headers.
+     * @return This decoder config.
+     */
+    public HttpDecoderConfig setAllowDuplicateContentLengths(boolean allowDuplicateContentLengths) {
+        this.allowDuplicateContentLengths = allowDuplicateContentLengths;
+        return this;
+    }
+
+    /**
+     * Set whether header validation should be enabled or not.
+     * This works by changing the configured {@linkplain #setHeadersFactory(HttpHeadersFactory) header factory}
+     * and {@linkplain #setTrailersFactory(HttpHeadersFactory) trailer factory}.
+     * <p>
+     * You usually want header validation enabled (which is the default) in order to prevent request-/response-splitting
+     * attacks.
+     *
+     * @param validateHeaders set to {@code false} to disable header validation.
+     * @return This decoder config.
+     */
+    public HttpDecoderConfig setValidateHeaders(boolean validateHeaders) {
+        HttpHeadersBuilder noValidation = HttpHeadersBuilder.DEFAULT_NO_VALIDATION;
+        headersFactory = validateHeaders ? HttpHeadersBuilder.DEFAULT : noValidation;
+        trailersFactory = validateHeaders ? HttpHeadersBuilder.DEFAULT_TRAILER : noValidation;
+        return this;
+    }
+
+    public HttpHeadersFactory getTrailersFactory() {
+        return trailersFactory;
+    }
+
+    /**
+     * Set the {@link HttpHeadersFactory} used to create HTTP trailers.
+     * This differs from {@link #setHeadersFactory(HttpHeadersFactory)} in that trailers have different validation
+     * requirements.
+     * The default trailer factory is {@link HttpHeaders#DEFAULT_TRAILER_FACTORY}.
+     * <p>
+     * For the purpose of {@link #clone()}, it is assumed that the factory is either immutable, or can otherwise be
+     * shared across different decoders and decoder configs.
+     *
+     * @param trailersFactory The headers factory to use for creating trailers.
+     * @return This decoder config.
+     */
+    public HttpDecoderConfig setTrailersFactory(HttpHeadersFactory trailersFactory) {
+        checkNotNull(trailersFactory, "trailersFactory");
+        this.trailersFactory = trailersFactory;
+        return this;
+    }
+
+    @Override
+    public HttpDecoderConfig clone() {
+        try {
+            return (HttpDecoderConfig) super.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new AssertionError();
+        }
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaders.java
@@ -46,16 +46,6 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
  */
 public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>> {
     /**
-     * @deprecated Use {@link EmptyHttpHeaders#INSTANCE}.
-     * <p>
-     * The instance is instantiated here to break the cyclic static initialization between {@link EmptyHttpHeaders} and
-     * {@link HttpHeaders}. The issue is that if someone accesses {@link EmptyHttpHeaders#INSTANCE} before
-     * {@link HttpHeaders#EMPTY_HEADERS} then {@link HttpHeaders#EMPTY_HEADERS} will be {@code null}.
-     */
-    @Deprecated
-    public static final HttpHeaders EMPTY_HEADERS = EmptyHttpHeaders.instance();
-
-    /**
      * Default implementation of {@link HttpHeadersFactory}, that creates an {@link HttpHeaders} instance that has the
      * recommended header validation enabled.
      */
@@ -66,6 +56,16 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
      * validation enabled that is recommended for trailers.
      */
     public static final HttpHeadersBuilder DEFAULT_TRAILER_FACTORY = HttpHeadersBuilder.DEFAULT_TRAILER;
+
+    /**
+     * @deprecated Use {@link EmptyHttpHeaders#INSTANCE}.
+     * <p>
+     * The instance is instantiated here to break the cyclic static initialization between {@link EmptyHttpHeaders} and
+     * {@link HttpHeaders}. The issue is that if someone accesses {@link EmptyHttpHeaders#INSTANCE} before
+     * {@link HttpHeaders#EMPTY_HEADERS} then {@link HttpHeaders#EMPTY_HEADERS} will be {@code null}.
+     */
+    @Deprecated
+    public static final HttpHeaders EMPTY_HEADERS = EmptyHttpHeaders.instance();
 
     /**
      * @deprecated Use {@link HttpHeaderNames} instead.

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaders.java
@@ -42,21 +42,10 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
  * Provides the constants for the standard HTTP header names and values and
  * commonly used utility methods that accesses an {@link HttpMessage}.
  * <p>
- * Concrete instances of this class are most easily obtained from its default factory: {@link #DEFAULT_HEADER_FACTORY}.
+ * Concrete instances of this class are most easily obtained from its default factory:
+ * {@link DefaultHttpHeadersFactory#headersFactory()}.
  */
 public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>> {
-    /**
-     * Default implementation of {@link HttpHeadersFactory}, that creates an {@link HttpHeaders} instance that has the
-     * recommended header validation enabled.
-     */
-    public static final HttpHeadersBuilder DEFAULT_HEADER_FACTORY = HttpHeadersBuilder.DEFAULT;
-
-    /**
-     * Default implementation of {@link HttpHeadersFactory}, that creates an {@link HttpHeaders} instance that has the
-     * validation enabled that is recommended for trailers.
-     */
-    public static final HttpHeadersBuilder DEFAULT_TRAILER_FACTORY = HttpHeadersBuilder.DEFAULT_TRAILER;
-
     /**
      * @deprecated Use {@link EmptyHttpHeaders#INSTANCE}.
      * <p>

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaders.java
@@ -41,6 +41,8 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
 /**
  * Provides the constants for the standard HTTP header names and values and
  * commonly used utility methods that accesses an {@link HttpMessage}.
+ * <p>
+ * Concrete instances of this class are most easily obtained from its default factory: {@link #DEFAULT_HEADER_FACTORY}.
  */
 public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>> {
     /**
@@ -52,6 +54,18 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
      */
     @Deprecated
     public static final HttpHeaders EMPTY_HEADERS = EmptyHttpHeaders.instance();
+
+    /**
+     * Default implementation of {@link HttpHeadersFactory}, that creates an {@link HttpHeaders} instance that has the
+     * recommended header validation enabled.
+     */
+    public static final HttpHeadersBuilder DEFAULT_HEADER_FACTORY = HttpHeadersBuilder.DEFAULT;
+
+    /**
+     * Default implementation of {@link HttpHeadersFactory}, that creates an {@link HttpHeaders} instance that has the
+     * validation enabled that is recommended for trailers.
+     */
+    public static final HttpHeadersBuilder DEFAULT_TRAILER_FACTORY = HttpHeadersBuilder.DEFAULT_TRAILER;
 
     /**
      * @deprecated Use {@link HttpHeaderNames} instead.

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeadersBuilder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeadersBuilder.java
@@ -240,7 +240,7 @@ public class HttpHeadersBuilder implements HttpHeadersFactory {
         if (notSubclassed()) {
             return validation ? DEFAULT : DEFAULT_NO_VALIDATION;
         }
-        return withNameValidation(false).withValueValidation(false);
+        return withNameValidation(validation).withValueValidation(validation);
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeadersBuilder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeadersBuilder.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http;
+
+import io.netty.handler.codec.DefaultHeaders.NameValidator;
+import io.netty.handler.codec.DefaultHeaders.ValueValidator;
+
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
+/**
+ * A builder of {@link HttpHeadersFactory} instances, that itself implements {@link HttpHeadersFactory}.
+ * The builder is immutable, and every {@code with-} method produce a new, modified instance.
+ * <p>
+ * The default builder you most likely want to start with is {@link HttpHeaders#DEFAULT_HEADER_FACTORY}.
+ */
+public class HttpHeadersBuilder implements HttpHeadersFactory {
+
+    private static final NameValidator<CharSequence> DEFAULT_NAME_VALIDATOR =
+            DefaultHttpHeaders.nameValidator(true);
+    private static final ValueValidator<CharSequence> DEFAULT_VALUE_VALIDATOR =
+            DefaultHttpHeaders.valueValidator(true);
+    private static final NameValidator<CharSequence> DEFAULT_TRAILER_NAME_VALIDATOR =
+            new NameValidator<CharSequence>() {
+                @Override
+                public void validateName(CharSequence name) {
+                    DefaultHttpHeaders.HttpNameValidator.validateName(name);
+                    if (HttpHeaderNames.CONTENT_LENGTH.contentEqualsIgnoreCase(name)
+                            || HttpHeaderNames.TRANSFER_ENCODING.contentEqualsIgnoreCase(name)
+                            || HttpHeaderNames.TRAILER.contentEqualsIgnoreCase(name)) {
+                        throw new IllegalArgumentException("prohibited trailing header: " + name);
+                    }
+                }
+            };
+
+    private static final NameValidator<CharSequence> NO_NAME_VALIDATOR =
+            DefaultHttpHeaders.nameValidator(false);
+    private static final ValueValidator<CharSequence> NO_VALUE_VALIDATOR =
+            DefaultHttpHeaders.valueValidator(false);
+
+    static final HttpHeadersBuilder DEFAULT = new HttpHeadersBuilder();
+    static final HttpHeadersBuilder DEFAULT_TRAILER =
+            new HttpHeadersBuilder(DEFAULT_TRAILER_NAME_VALIDATOR, DEFAULT_VALUE_VALIDATOR, false);
+    static final HttpHeadersBuilder DEFAULT_COMBINING =
+            new HttpHeadersBuilder(DEFAULT.nameValidator, DEFAULT.valueValidator, true);
+    static final HttpHeadersBuilder DEFAULT_NO_VALIDATION =
+            new HttpHeadersBuilder(NO_NAME_VALIDATOR, NO_VALUE_VALIDATOR, false);
+
+    private final NameValidator<CharSequence> nameValidator;
+    private final ValueValidator<CharSequence> valueValidator;
+    private final boolean combiningHeaders;
+
+    /**
+     * Create a header builder with the default settings.
+     */
+    protected HttpHeadersBuilder() {
+        this(DEFAULT_NAME_VALIDATOR, DEFAULT_VALUE_VALIDATOR, false);
+    }
+
+    /**
+     * Create a header builder with the given settings.
+     *
+     * @param nameValidator The name validator to use, not null.
+     * @param valueValidator The value validator to use, not null.
+     * @param combiningHeaders {@code true} if multi-valued headers should be combined into single lines.
+     */
+    protected HttpHeadersBuilder(
+            NameValidator<CharSequence> nameValidator,
+            ValueValidator<CharSequence> valueValidator,
+            boolean combiningHeaders) {
+        this.nameValidator = checkNotNull(nameValidator, "nameValidator");
+        this.valueValidator = checkNotNull(valueValidator, "valueValidator");
+        this.combiningHeaders = combiningHeaders;
+    }
+
+    private boolean notSubclassed() {
+        return getClass() == HttpHeadersBuilder.class;
+    }
+
+    /**
+     * Create a new header builder instance with the given overrides.
+     * This method is used by all other {@code with-} methods, for creating new builder instances.
+     *
+     * @param nameValidator The name validator to use, not null.
+     * @param valueValidator The value validator to use, not null.
+     * @param combiningHeaders {@code true} if multi-valued headers should be combined into single lines.
+     * @return The new header builder instance.
+     */
+    protected HttpHeadersBuilder with(
+            NameValidator<CharSequence> nameValidator,
+            ValueValidator<CharSequence> valueValidator,
+            boolean combiningHeaders) {
+        return new HttpHeadersBuilder(nameValidator, valueValidator, combiningHeaders);
+    }
+
+    @Override
+    public HttpHeaders createHeaders() {
+        if (isCombiningHeaders()) {
+            return new CombinedHttpHeaders(getNameValidator(), getValueValidator());
+        }
+        return new DefaultHttpHeaders(getNameValidator(), getValueValidator());
+    }
+
+    /**
+     * Create a new builder that has HTTP header name validation enabled or disabled.
+     * <p>
+     * <b>Warning!</b> Setting {@code validation} to {@code false} will mean that Netty won't
+     * validate & protect against user-supplied headers that are malicious.
+     * This can leave your server implementation vulnerable to
+     * <a href="https://cwe.mitre.org/data/definitions/113.html">
+     *     CWE-113: Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
+     * </a>.
+     * When disabling this validation, it is the responsibility of the caller to ensure that the values supplied
+     * do not contain a non-url-escaped carriage return (CR) and/or line feed (LF) characters.
+     *
+     * @param validation If validation should be enabled or disabled.
+     * @return The new builder.
+     */
+    public HttpHeadersBuilder withNameValidation(boolean validation) {
+        return withNameValidator(validation ? DEFAULT_NAME_VALIDATOR : NO_NAME_VALIDATOR);
+    }
+
+    /**
+     * Create a new builder that with the given {@link NameValidator}.
+     * <p>
+     * <b>Warning!</b> If the given validator does not check that the header names are standards compliant, Netty won't
+     * validate & protect against user-supplied headers that are malicious.
+     * This can leave your server implementation vulnerable to
+     * <a href="https://cwe.mitre.org/data/definitions/113.html">
+     *     CWE-113: Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
+     * </a>.
+     * When disabling this validation, it is the responsibility of the caller to ensure that the values supplied
+     * do not contain a non-url-escaped carriage return (CR) and/or line feed (LF) characters.
+     *
+     * @param validator The HTTP header name validator to use.
+     * @return The new builder.
+     */
+    public HttpHeadersBuilder withNameValidator(NameValidator<CharSequence> validator) {
+        if (nameValidator == checkNotNull(validator, "validator")) {
+            return this;
+        }
+        if (notSubclassed() && validator == DEFAULT_NAME_VALIDATOR && valueValidator == DEFAULT_VALUE_VALIDATOR) {
+            return combiningHeaders ? DEFAULT_COMBINING : DEFAULT;
+        }
+        return with(validator, valueValidator, combiningHeaders);
+    }
+
+    /**
+     * Create a new builder that has HTTP header value validation enabled or disabled.
+     * <p>
+     * <b>Warning!</b> Setting {@code validation} to {@code false} will mean that Netty won't
+     * validate & protect against user-supplied headers that are malicious.
+     * This can leave your server implementation vulnerable to
+     * <a href="https://cwe.mitre.org/data/definitions/113.html">
+     *     CWE-113: Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
+     * </a>.
+     * When disabling this validation, it is the responsibility of the caller to ensure that the values supplied
+     * do not contain a non-url-escaped carriage return (CR) and/or line feed (LF) characters.
+     *
+     * @param validation If validation should be enabled or disabled.
+     * @return The new builder.
+     */
+    public HttpHeadersBuilder withValueValidation(boolean validation) {
+        return withValueValidator(validation ? DEFAULT_VALUE_VALIDATOR : NO_VALUE_VALIDATOR);
+    }
+
+    /**
+     * Create a new builder that with the given {@link ValueValidator}.
+     * <p>
+     * <b>Warning!</b> If the given validator does not check that the header values are standards compliant, Netty won't
+     * validate & protect against user-supplied headers that are malicious.
+     * This can leave your server implementation vulnerable to
+     * <a href="https://cwe.mitre.org/data/definitions/113.html">
+     *     CWE-113: Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
+     * </a>.
+     * When disabling this validation, it is the responsibility of the caller to ensure that the values supplied
+     * do not contain a non-url-escaped carriage return (CR) and/or line feed (LF) characters.
+     *
+     * @param validator The HTTP header name validator to use.
+     * @return The new builder.
+     */
+    public HttpHeadersBuilder withValueValidator(ValueValidator<CharSequence> validator) {
+        if (valueValidator == checkNotNull(validator, "validator")) {
+            return this;
+        }
+        if (notSubclassed() && nameValidator == DEFAULT_NAME_VALIDATOR && validator == DEFAULT_VALUE_VALIDATOR) {
+            return combiningHeaders ? DEFAULT_COMBINING : DEFAULT;
+        }
+        return with(nameValidator, validator, combiningHeaders);
+    }
+
+    /**
+     * Create a new builder that has HTTP header validation enabled or disabled.
+     * <p>
+     * <b>Warning!</b> Setting {@code validation} to {@code false} will mean that Netty won't
+     * validate & protect against user-supplied headers that are malicious.
+     * This can leave your server implementation vulnerable to
+     * <a href="https://cwe.mitre.org/data/definitions/113.html">
+     *     CWE-113: Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
+     * </a>.
+     * When disabling this validation, it is the responsibility of the caller to ensure that the values supplied
+     * do not contain a non-url-escaped carriage return (CR) and/or line feed (LF) characters.
+     *
+     * @param validation If validation should be enabled or disabled.
+     * @return The new builder.
+     */
+    public HttpHeadersBuilder withValidation(boolean validation) {
+        if (notSubclassed()) {
+            return validation ? DEFAULT : DEFAULT_NO_VALIDATION;
+        }
+        return withNameValidation(false).withValueValidation(false);
+    }
+
+    /**
+     * Create a new builder that will build {@link HttpHeaders} objects that either combine
+     * multi-valued headers, or not.
+     *
+     * @param combiningHeaders {@code true} if multi-valued headers should be combined, otherwise {@code false}.
+     * @return The new builder.
+     */
+    public HttpHeadersBuilder withCombiningHeaders(boolean combiningHeaders) {
+        if (this.combiningHeaders == combiningHeaders) {
+            return this;
+        }
+        return with(nameValidator, valueValidator, combiningHeaders);
+    }
+
+    /**
+     * Get the currently configured {@link NameValidator}.
+     * <p>
+     * This method will be used by the {@link #createHeaders()} method.
+     *
+     * @return The configured name validator.
+     */
+    public NameValidator<CharSequence> getNameValidator() {
+        return nameValidator;
+    }
+
+    /**
+     * Get the currently configured {@link ValueValidator}.
+     * <p>
+     * This method will be used by the {@link #createHeaders()} method.
+     *
+     * @return The configured value validator.
+     */
+    public ValueValidator<CharSequence> getValueValidator() {
+        return valueValidator;
+    }
+
+    /**
+     * Check whether header combining is enabled or not.
+     *
+     * @return {@code true} if header value combining is enabled, otherwise {@code false}.
+     */
+    public boolean isCombiningHeaders() {
+        return combiningHeaders;
+    }
+
+    /**
+     * Check whether header name validation is enabled.
+     *
+     * @return {@code true} if header name validation is enabled, otherwise {@code false}.
+     */
+    public boolean isValidatingHeaderNames() {
+        return nameValidator != NO_NAME_VALIDATOR;
+    }
+
+    /**
+     * Check whether header value validation is enabled.
+     *
+     * @return {@code true} if header value validation is enabled, otherwise {@code false}.
+     */
+    public boolean isValidatingHeaderValues() {
+        return valueValidator != NO_VALUE_VALIDATOR;
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeadersBuilder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeadersBuilder.java
@@ -26,7 +26,7 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
  * <p>
  * The default builder you most likely want to start with is {@link HttpHeaders#DEFAULT_HEADER_FACTORY}.
  */
-public class HttpHeadersBuilder implements HttpHeadersFactory {
+public final class HttpHeadersBuilder implements HttpHeadersFactory {
 
     static final NameValidator<CharSequence> DEFAULT_NAME_VALIDATOR = new NameValidator<CharSequence>() {
         @Override
@@ -85,7 +85,7 @@ public class HttpHeadersBuilder implements HttpHeadersFactory {
     /**
      * Create a header builder with the default settings.
      */
-    protected HttpHeadersBuilder() {
+    private HttpHeadersBuilder() {
         this(DEFAULT_NAME_VALIDATOR, DEFAULT_VALUE_VALIDATOR, false);
     }
 
@@ -96,17 +96,13 @@ public class HttpHeadersBuilder implements HttpHeadersFactory {
      * @param valueValidator The value validator to use, not null.
      * @param combiningHeaders {@code true} if multi-valued headers should be combined into single lines.
      */
-    protected HttpHeadersBuilder(
+    private HttpHeadersBuilder(
             NameValidator<CharSequence> nameValidator,
             ValueValidator<CharSequence> valueValidator,
             boolean combiningHeaders) {
         this.nameValidator = checkNotNull(nameValidator, "nameValidator");
         this.valueValidator = checkNotNull(valueValidator, "valueValidator");
         this.combiningHeaders = combiningHeaders;
-    }
-
-    private boolean notSubclassed() {
-        return getClass() == HttpHeadersBuilder.class;
     }
 
     /**
@@ -118,7 +114,7 @@ public class HttpHeadersBuilder implements HttpHeadersFactory {
      * @param combiningHeaders {@code true} if multi-valued headers should be combined into single lines.
      * @return The new header builder instance.
      */
-    protected HttpHeadersBuilder with(
+    private static HttpHeadersBuilder with(
             NameValidator<CharSequence> nameValidator,
             ValueValidator<CharSequence> valueValidator,
             boolean combiningHeaders) {
@@ -171,7 +167,7 @@ public class HttpHeadersBuilder implements HttpHeadersFactory {
         if (nameValidator == checkNotNull(validator, "validator")) {
             return this;
         }
-        if (notSubclassed() && validator == DEFAULT_NAME_VALIDATOR && valueValidator == DEFAULT_VALUE_VALIDATOR) {
+        if (validator == DEFAULT_NAME_VALIDATOR && valueValidator == DEFAULT_VALUE_VALIDATOR) {
             return combiningHeaders ? DEFAULT_COMBINING : DEFAULT;
         }
         return with(validator, valueValidator, combiningHeaders);
@@ -215,7 +211,7 @@ public class HttpHeadersBuilder implements HttpHeadersFactory {
         if (valueValidator == checkNotNull(validator, "validator")) {
             return this;
         }
-        if (notSubclassed() && nameValidator == DEFAULT_NAME_VALIDATOR && validator == DEFAULT_VALUE_VALIDATOR) {
+        if (nameValidator == DEFAULT_NAME_VALIDATOR && validator == DEFAULT_VALUE_VALIDATOR) {
             return combiningHeaders ? DEFAULT_COMBINING : DEFAULT;
         }
         return with(nameValidator, validator, combiningHeaders);
@@ -237,9 +233,6 @@ public class HttpHeadersBuilder implements HttpHeadersFactory {
      * @return The new builder.
      */
     public HttpHeadersBuilder withValidation(boolean validation) {
-        if (notSubclassed()) {
-            return validation ? DEFAULT : DEFAULT_NO_VALIDATION;
-        }
         return withNameValidation(validation).withValueValidation(validation);
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeadersFactory.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeadersFactory.java
@@ -18,12 +18,12 @@ package io.netty.handler.codec.http;
 /**
  * An interface for creating {@link HttpHeaders} instances.
  * <p>
- * The default implementation is {@link HttpHeadersBuilder},
- * and the default instance is {@link HttpHeaders#DEFAULT_HEADER_FACTORY}.
+ * The default implementation is {@link DefaultHttpHeadersFactory},
+ * and the default instance is {@link DefaultHttpHeadersFactory#headersFactory()}.
  */
 public interface HttpHeadersFactory {
     /**
      * Create a new {@link HttpHeaders} instance.
      */
-    HttpHeaders createHeaders();
+    HttpHeaders newHeaders();
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeadersFactory.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeadersFactory.java
@@ -26,4 +26,9 @@ public interface HttpHeadersFactory {
      * Create a new {@link HttpHeaders} instance.
      */
     HttpHeaders newHeaders();
+
+    /**
+     * Create a new {@link HttpHeaders} instance, but sized to be as small an object as possible.
+     */
+    HttpHeaders newEmptyHeaders();
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeadersFactory.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeadersFactory.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http;
+
+/**
+ * An interface for creating {@link HttpHeaders} instances.
+ * <p>
+ * The default implementation is {@link HttpHeadersBuilder},
+ * and the default instance is {@link HttpHeaders#DEFAULT_HEADER_FACTORY}.
+ */
+public interface HttpHeadersFactory {
+    /**
+     * Create a new {@link HttpHeaders} instance.
+     */
+    HttpHeaders createHeaders();
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -324,8 +324,8 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
     }
 
     protected boolean isValidating(HttpHeadersFactory headersFactory) {
-        if (headersFactory instanceof HttpHeadersBuilder) {
-            HttpHeadersBuilder builder = (HttpHeadersBuilder) headersFactory;
+        if (headersFactory instanceof DefaultHttpHeadersFactory) {
+            DefaultHttpHeadersFactory builder = (DefaultHttpHeadersFactory) headersFactory;
             return builder.isValidatingHeaderNames() || builder.isValidatingHeaderValues();
         }
         return true; // We can't actually tell in this case, but we assume some validation is taking place.

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -15,8 +15,6 @@
  */
 package io.netty.handler.codec.http;
 
-import static io.netty.util.internal.ObjectUtil.checkPositive;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
@@ -31,6 +29,8 @@ import io.netty.util.internal.StringUtil;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
  * Decodes {@link ByteBuf}s into {@link HttpMessage}s and
@@ -129,6 +129,18 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * <a href="https://en.wikipedia.org/wiki/Internet_Content_Adaptation_Protocol">ICAP</a>.
  * To implement the decoder of such a derived protocol, extend this class and
  * implement all abstract methods properly.
+ *
+ * <h3>Header Validation</h3>
+ *
+ * It is recommended to always enable header validation.
+ * <p>
+ * Without header validation, your system can become vulnerable to
+ * <a href="https://cwe.mitre.org/data/definitions/113.html">
+ *     CWE-113: Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
+ * </a>.
+ * <p>
+ * This recommendation stands even when both peers in the HTTP exchange are trusted,
+ * as it helps with defence-in-depth.
  */
 public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
     public static final int DEFAULT_MAX_INITIAL_LINE_LENGTH = 4096;
@@ -142,7 +154,13 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
     private final int maxChunkSize;
     private final boolean chunkedSupported;
     private final boolean allowPartialChunks;
+    /**
+     * This field is no longer used. It is only kept around for backwards compatibility purpose.
+     */
+    @Deprecated
     protected final boolean validateHeaders;
+    protected final HttpHeadersFactory headersFactory;
+    protected final HttpHeadersFactory trailersFactory;
     private final boolean allowDuplicateContentLengths;
     private final ByteBuf parserScratchBuffer;
     private final HeaderParser headerParser;
@@ -193,68 +211,124 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
      * {@code maxChunkSize (8192)}.
      */
     protected HttpObjectDecoder() {
-        this(DEFAULT_MAX_INITIAL_LINE_LENGTH, DEFAULT_MAX_HEADER_SIZE, DEFAULT_MAX_CHUNK_SIZE,
-             DEFAULT_CHUNKED_SUPPORTED);
+        this(new HttpDecoderConfig());
     }
 
     /**
      * Creates a new instance with the specified parameters.
+     *
+     * @deprecated Use {@link #HttpObjectDecoder(HttpDecoderConfig)} instead.
      */
+    @Deprecated
     protected HttpObjectDecoder(
             int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean chunkedSupported) {
-        this(maxInitialLineLength, maxHeaderSize, maxChunkSize, chunkedSupported, DEFAULT_VALIDATE_HEADERS);
+        this(new HttpDecoderConfig()
+                .setMaxInitialLineLength(maxInitialLineLength)
+                .setMaxHeaderSize(maxHeaderSize)
+                .setMaxChunkSize(maxChunkSize)
+                .setChunkedSupported(chunkedSupported));
     }
 
     /**
      * Creates a new instance with the specified parameters.
+     *
+     * @deprecated Use {@link #HttpObjectDecoder(HttpDecoderConfig)} instead.
      */
+    @Deprecated
     protected HttpObjectDecoder(
             int maxInitialLineLength, int maxHeaderSize, int maxChunkSize,
             boolean chunkedSupported, boolean validateHeaders) {
-        this(maxInitialLineLength, maxHeaderSize, maxChunkSize, chunkedSupported, validateHeaders,
-             DEFAULT_INITIAL_BUFFER_SIZE);
+        this(new HttpDecoderConfig()
+                .setMaxInitialLineLength(maxInitialLineLength)
+                .setMaxHeaderSize(maxHeaderSize)
+                .setMaxChunkSize(maxChunkSize)
+                .setChunkedSupported(chunkedSupported)
+                .setValidateHeaders(validateHeaders));
     }
 
     /**
      * Creates a new instance with the specified parameters.
+     *
+     * @deprecated Use {@link #HttpObjectDecoder(HttpDecoderConfig)} instead.
      */
+    @Deprecated
     protected HttpObjectDecoder(
             int maxInitialLineLength, int maxHeaderSize, int maxChunkSize,
             boolean chunkedSupported, boolean validateHeaders, int initialBufferSize) {
-        this(maxInitialLineLength, maxHeaderSize, maxChunkSize, chunkedSupported, validateHeaders, initialBufferSize,
-             DEFAULT_ALLOW_DUPLICATE_CONTENT_LENGTHS);
+        this(new HttpDecoderConfig()
+                .setMaxInitialLineLength(maxInitialLineLength)
+                .setMaxHeaderSize(maxHeaderSize)
+                .setMaxChunkSize(maxChunkSize)
+                .setChunkedSupported(chunkedSupported)
+                .setValidateHeaders(validateHeaders)
+                .setInitialBufferSize(initialBufferSize));
     }
 
     /**
      * Creates a new instance with the specified parameters.
+     *
+     * @deprecated Use {@link #HttpObjectDecoder(HttpDecoderConfig)} instead.
      */
+    @Deprecated
     protected HttpObjectDecoder(
             int maxInitialLineLength, int maxHeaderSize, int maxChunkSize,
             boolean chunkedSupported, boolean validateHeaders, int initialBufferSize,
             boolean allowDuplicateContentLengths) {
-        this(maxInitialLineLength, maxHeaderSize, maxChunkSize, chunkedSupported, validateHeaders, initialBufferSize,
-            allowDuplicateContentLengths, DEFAULT_ALLOW_PARTIAL_CHUNKS);
+        this(new HttpDecoderConfig()
+                .setMaxInitialLineLength(maxInitialLineLength)
+                .setMaxHeaderSize(maxHeaderSize)
+                .setMaxChunkSize(maxChunkSize)
+                .setChunkedSupported(chunkedSupported)
+                .setValidateHeaders(validateHeaders)
+                .setInitialBufferSize(initialBufferSize)
+                .setAllowDuplicateContentLengths(allowDuplicateContentLengths));
     }
 
     /**
      * Creates a new instance with the specified parameters.
+     *
+     * @deprecated Use {@link #HttpObjectDecoder(HttpDecoderConfig)} instead.
      */
+    @Deprecated
     protected HttpObjectDecoder(
             int maxInitialLineLength, int maxHeaderSize, int maxChunkSize,
             boolean chunkedSupported, boolean validateHeaders, int initialBufferSize,
             boolean allowDuplicateContentLengths, boolean allowPartialChunks) {
-        checkPositive(maxInitialLineLength, "maxInitialLineLength");
-        checkPositive(maxHeaderSize, "maxHeaderSize");
-        checkPositive(maxChunkSize, "maxChunkSize");
+        this(new HttpDecoderConfig()
+                .setMaxInitialLineLength(maxInitialLineLength)
+                .setMaxHeaderSize(maxHeaderSize)
+                .setMaxChunkSize(maxChunkSize)
+                .setChunkedSupported(chunkedSupported)
+                .setValidateHeaders(validateHeaders)
+                .setInitialBufferSize(initialBufferSize)
+                .setAllowDuplicateContentLengths(allowDuplicateContentLengths)
+                .setAllowPartialChunks(allowPartialChunks));
+    }
 
-        parserScratchBuffer = Unpooled.buffer(initialBufferSize);
-        lineParser = new LineParser(parserScratchBuffer, maxInitialLineLength);
-        headerParser = new HeaderParser(parserScratchBuffer, maxHeaderSize);
-        this.maxChunkSize = maxChunkSize;
-        this.chunkedSupported = chunkedSupported;
-        this.validateHeaders = validateHeaders;
-        this.allowDuplicateContentLengths = allowDuplicateContentLengths;
-        this.allowPartialChunks = allowPartialChunks;
+    /**
+     * Creates a new instance with the specified configuration.
+     */
+    protected HttpObjectDecoder(HttpDecoderConfig config) {
+        checkNotNull(config, "config");
+
+        parserScratchBuffer = Unpooled.buffer(config.getInitialBufferSize());
+        lineParser = new LineParser(parserScratchBuffer, config.getMaxInitialLineLength());
+        headerParser = new HeaderParser(parserScratchBuffer, config.getMaxHeaderSize());
+        maxChunkSize = config.getMaxChunkSize();
+        chunkedSupported = config.isChunkedSupported();
+        headersFactory = config.getHeadersFactory();
+        trailersFactory = config.getTrailersFactory();
+        validateHeaders = isValidating(headersFactory);
+        allowDuplicateContentLengths = config.isAllowDuplicateContentLengths();
+        allowPartialChunks = config.isAllowPartialChunks();
+    }
+
+    protected boolean isValidating(HttpHeadersFactory headersFactory) {
+        if (headersFactory instanceof HttpHeadersBuilder) {
+            HttpHeadersBuilder builder = (HttpHeadersBuilder) headersFactory;
+            return builder.isValidatingHeaderNames() || builder.isValidatingHeaderValues();
+        }
+        return true; // We can't actually tell in this case, but we assume some validation is taking place.
     }
 
     @Override
@@ -303,10 +377,10 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
                 out.add(message);
                 return;
             default:
-                /**
-                 * <a href="https://tools.ietf.org/html/rfc7230#section-3.3.3">RFC 7230, 3.3.3</a> states that if a
+                /*
+                 * RFC 7230, 3.3.3 (https://tools.ietf.org/html/rfc7230#section-3.3.3) states that if a
                  * request does not have either a transfer-encoding or a content-length header then the message body
-                 * length is 0. However for a response the body length is the number of octets received prior to the
+                 * length is 0. However, for a response the body length is the number of octets received prior to the
                  * server closing the connection. So we treat this as variable length chunked encoding.
                  */
                 long contentLength = contentLength();
@@ -365,14 +439,14 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
 
             if (chunkSize == 0) {
                 // Read all content.
-                out.add(new DefaultLastHttpContent(content, validateHeaders));
+                out.add(new DefaultLastHttpContent(content, trailersFactory));
                 resetNow();
             } else {
                 out.add(new DefaultHttpContent(content));
             }
             return;
         }
-        /**
+        /*
          * everything else after this point takes care of reading chunked content. basically, read chunk size,
          * read chunk, read and ignore the CRLF and repeat until 0
          */
@@ -755,7 +829,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
 
         CharSequence lastHeader = null;
         if (trailer == null) {
-            trailer = this.trailer = new DefaultLastHttpContent(Unpooled.EMPTY_BUFFER, validateHeaders);
+            trailer = this.trailer = new DefaultLastHttpContent(Unpooled.EMPTY_BUFFER, trailersFactory);
         }
         while (lineLength > 0) {
             final byte[] lineContent = line.array();

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseDecoder.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.http;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelPipeline;
 
 /**
@@ -102,6 +103,18 @@ import io.netty.channel.ChannelPipeline;
  * use {@link HttpClientCodec} if you are writing an HTTP client that issues a
  * <tt>CONNECT</tt> request.
  * </p>
+ *
+ * <h3>Header Validation</h3>
+ *
+ * It is recommended to always enable header validation.
+ * <p>
+ * Without header validation, your system can become vulnerable to
+ * <a href="https://cwe.mitre.org/data/definitions/113.html">
+ *     CWE-113: Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
+ * </a>.
+ * <p>
+ * This recommendation stands even when both peers in the HTTP exchange are trusted,
+ * as it helps with defence-in-depth.
  */
 public class HttpResponseDecoder extends HttpObjectDecoder {
 
@@ -120,14 +133,25 @@ public class HttpResponseDecoder extends HttpObjectDecoder {
      */
     public HttpResponseDecoder(
             int maxInitialLineLength, int maxHeaderSize, int maxChunkSize) {
-        super(maxInitialLineLength, maxHeaderSize, maxChunkSize, DEFAULT_CHUNKED_SUPPORTED);
+        super(new HttpDecoderConfig()
+                .setMaxInitialLineLength(maxInitialLineLength)
+                .setMaxHeaderSize(maxHeaderSize)
+                .setMaxChunkSize(maxChunkSize));
     }
 
+    /**
+     * @deprecated Prefer the {@link #HttpResponseDecoder(HttpDecoderConfig)} constructor.
+     */
+    @Deprecated
     public HttpResponseDecoder(
             int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean validateHeaders) {
         super(maxInitialLineLength, maxHeaderSize, maxChunkSize, DEFAULT_CHUNKED_SUPPORTED, validateHeaders);
     }
 
+    /**
+     * @deprecated Prefer the {@link #HttpResponseDecoder(HttpDecoderConfig)} constructor.
+     */
+    @Deprecated
     public HttpResponseDecoder(
             int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean validateHeaders,
             int initialBufferSize) {
@@ -135,6 +159,10 @@ public class HttpResponseDecoder extends HttpObjectDecoder {
               initialBufferSize);
     }
 
+    /**
+     * @deprecated Prefer the {@link #HttpResponseDecoder(HttpDecoderConfig)} constructor.
+     */
+    @Deprecated
     public HttpResponseDecoder(
             int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean validateHeaders,
             int initialBufferSize, boolean allowDuplicateContentLengths) {
@@ -142,6 +170,10 @@ public class HttpResponseDecoder extends HttpObjectDecoder {
               initialBufferSize, allowDuplicateContentLengths);
     }
 
+    /**
+     * @deprecated Prefer the {@link #HttpResponseDecoder(HttpDecoderConfig)} constructor.
+     */
+    @Deprecated
     public HttpResponseDecoder(
             int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean validateHeaders,
             int initialBufferSize, boolean allowDuplicateContentLengths, boolean allowPartialChunks) {
@@ -149,16 +181,24 @@ public class HttpResponseDecoder extends HttpObjectDecoder {
               initialBufferSize, allowDuplicateContentLengths, allowPartialChunks);
     }
 
+    /**
+     * Creates a new instance with the specified configuration.
+     */
+    public HttpResponseDecoder(HttpDecoderConfig config) {
+        super(config);
+    }
+
     @Override
     protected HttpMessage createMessage(String[] initialLine) {
         return new DefaultHttpResponse(
                 HttpVersion.valueOf(initialLine[0]),
-                HttpResponseStatus.valueOf(Integer.parseInt(initialLine[1]), initialLine[2]), validateHeaders);
+                HttpResponseStatus.valueOf(Integer.parseInt(initialLine[1]), initialLine[2]), headersFactory);
     }
 
     @Override
     protected HttpMessage createInvalidMessage() {
-        return new DefaultFullHttpResponse(HttpVersion.HTTP_1_0, UNKNOWN_STATUS, validateHeaders);
+        return new DefaultFullHttpResponse(HttpVersion.HTTP_1_0, UNKNOWN_STATUS, Unpooled.buffer(0),
+                headersFactory, trailersFactory);
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerCodec.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerCodec.java
@@ -26,10 +26,23 @@ import java.util.Queue;
 import static io.netty.handler.codec.http.HttpObjectDecoder.DEFAULT_MAX_CHUNK_SIZE;
 import static io.netty.handler.codec.http.HttpObjectDecoder.DEFAULT_MAX_HEADER_SIZE;
 import static io.netty.handler.codec.http.HttpObjectDecoder.DEFAULT_MAX_INITIAL_LINE_LENGTH;
+import static io.netty.handler.codec.http.HttpObjectDecoder.DEFAULT_VALIDATE_HEADERS;
 
 /**
  * A combination of {@link HttpRequestDecoder} and {@link HttpResponseEncoder}
  * which enables easier server side HTTP implementation.
+ *
+ * <h3>Header Validation</h3>
+ *
+ * It is recommended to always enable header validation.
+ * <p>
+ * Without header validation, your system can become vulnerable to
+ * <a href="https://cwe.mitre.org/data/definitions/113.html">
+ *     CWE-113: Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
+ * </a>.
+ * <p>
+ * This recommendation stands even when both peers in the HTTP exchange are trusted,
+ * as it helps with defence-in-depth.
  *
  * @see HttpClientCodec
  */
@@ -52,47 +65,86 @@ public final class HttpServerCodec extends CombinedChannelDuplexHandler<HttpRequ
      * Creates a new instance with the specified decoder options.
      */
     public HttpServerCodec(int maxInitialLineLength, int maxHeaderSize, int maxChunkSize) {
-        init(new HttpServerRequestDecoder(maxInitialLineLength, maxHeaderSize, maxChunkSize),
-                new HttpServerResponseEncoder());
+        this(new HttpDecoderConfig()
+                .setMaxInitialLineLength(maxInitialLineLength)
+                .setMaxHeaderSize(maxHeaderSize)
+                .setMaxChunkSize(maxChunkSize));
     }
 
     /**
      * Creates a new instance with the specified decoder options.
+     *
+     * @deprecated Prefer the {@link #HttpServerCodec(HttpDecoderConfig)} constructor,
+     * to always enable header validation.
      */
+    @Deprecated
     public HttpServerCodec(int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean validateHeaders) {
-        init(new HttpServerRequestDecoder(maxInitialLineLength, maxHeaderSize, maxChunkSize, validateHeaders),
-                new HttpServerResponseEncoder());
+        this(new HttpDecoderConfig()
+                .setMaxInitialLineLength(maxInitialLineLength)
+                .setMaxHeaderSize(maxHeaderSize)
+                .setMaxChunkSize(maxChunkSize)
+                .setValidateHeaders(validateHeaders));
     }
 
     /**
      * Creates a new instance with the specified decoder options.
+     *
+     * @deprecated Prefer the {@link #HttpServerCodec(HttpDecoderConfig)} constructor, to always enable header
+     * validation.
      */
+    @Deprecated
     public HttpServerCodec(int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean validateHeaders,
                            int initialBufferSize) {
-        init(
-          new HttpServerRequestDecoder(maxInitialLineLength, maxHeaderSize, maxChunkSize,
-                  validateHeaders, initialBufferSize),
-          new HttpServerResponseEncoder());
+        this(new HttpDecoderConfig()
+                .setMaxInitialLineLength(maxInitialLineLength)
+                .setMaxHeaderSize(maxHeaderSize)
+                .setMaxChunkSize(maxChunkSize)
+                .setValidateHeaders(validateHeaders)
+                .setInitialBufferSize(initialBufferSize));
     }
 
     /**
      * Creates a new instance with the specified decoder options.
+     *
+     * @deprecated Prefer the {@link #HttpServerCodec(HttpDecoderConfig)} constructor,
+     * to always enable header validation.
      */
+    @Deprecated
     public HttpServerCodec(int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean validateHeaders,
                            int initialBufferSize, boolean allowDuplicateContentLengths) {
-        init(new HttpServerRequestDecoder(maxInitialLineLength, maxHeaderSize, maxChunkSize, validateHeaders,
-                                          initialBufferSize, allowDuplicateContentLengths),
-             new HttpServerResponseEncoder());
+        this(new HttpDecoderConfig()
+                .setMaxInitialLineLength(maxInitialLineLength)
+                .setMaxHeaderSize(maxHeaderSize)
+                .setMaxChunkSize(maxChunkSize)
+                .setValidateHeaders(validateHeaders)
+                .setInitialBufferSize(initialBufferSize)
+                .setAllowDuplicateContentLengths(allowDuplicateContentLengths));
     }
 
     /**
      * Creates a new instance with the specified decoder options.
+     *
+     * @deprecated Prefer the {@link #HttpServerCodec(HttpDecoderConfig)} constructor,
+     * to always enable header validation.
      */
+    @Deprecated
     public HttpServerCodec(int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean validateHeaders,
                            int initialBufferSize, boolean allowDuplicateContentLengths, boolean allowPartialChunks) {
-        init(new HttpServerRequestDecoder(maxInitialLineLength, maxHeaderSize, maxChunkSize, validateHeaders,
-                                          initialBufferSize, allowDuplicateContentLengths, allowPartialChunks),
-             new HttpServerResponseEncoder());
+        this(new HttpDecoderConfig()
+                .setMaxInitialLineLength(maxInitialLineLength)
+                .setMaxHeaderSize(maxHeaderSize)
+                .setMaxChunkSize(maxChunkSize)
+                .setValidateHeaders(validateHeaders)
+                .setInitialBufferSize(initialBufferSize)
+                .setAllowDuplicateContentLengths(allowDuplicateContentLengths)
+                .setAllowPartialChunks(allowPartialChunks));
+    }
+
+    /**
+     * Creates a new instance with the specified decoder configuration.
+     */
+    public HttpServerCodec(HttpDecoderConfig config) {
+        init(new HttpServerRequestDecoder(config), new HttpServerResponseEncoder());
     }
 
     /**
@@ -105,33 +157,8 @@ public final class HttpServerCodec extends CombinedChannelDuplexHandler<HttpRequ
     }
 
     private final class HttpServerRequestDecoder extends HttpRequestDecoder {
-
-        HttpServerRequestDecoder(int maxInitialLineLength, int maxHeaderSize, int maxChunkSize) {
-            super(maxInitialLineLength, maxHeaderSize, maxChunkSize);
-        }
-
-        HttpServerRequestDecoder(int maxInitialLineLength, int maxHeaderSize, int maxChunkSize,
-                                        boolean validateHeaders) {
-            super(maxInitialLineLength, maxHeaderSize, maxChunkSize, validateHeaders);
-        }
-
-        HttpServerRequestDecoder(int maxInitialLineLength, int maxHeaderSize, int maxChunkSize,
-
-                                        boolean validateHeaders, int initialBufferSize) {
-            super(maxInitialLineLength, maxHeaderSize, maxChunkSize, validateHeaders, initialBufferSize);
-        }
-
-        HttpServerRequestDecoder(int maxInitialLineLength, int maxHeaderSize, int maxChunkSize,
-                                 boolean validateHeaders, int initialBufferSize, boolean allowDuplicateContentLengths) {
-            super(maxInitialLineLength, maxHeaderSize, maxChunkSize, validateHeaders, initialBufferSize,
-                  allowDuplicateContentLengths);
-        }
-
-        HttpServerRequestDecoder(int maxInitialLineLength, int maxHeaderSize, int maxChunkSize,
-                                 boolean validateHeaders, int initialBufferSize, boolean allowDuplicateContentLengths,
-                                 boolean allowPartialChunks) {
-            super(maxInitialLineLength, maxHeaderSize, maxChunkSize, validateHeaders, initialBufferSize,
-                  allowDuplicateContentLengths, allowPartialChunks);
+        HttpServerRequestDecoder(HttpDecoderConfig config) {
+            super(config);
         }
 
         @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerUpgradeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerUpgradeHandler.java
@@ -189,7 +189,7 @@ public class HttpServerUpgradeHandler extends HttpObjectAggregator {
      */
     public HttpServerUpgradeHandler(SourceCodec sourceCodec, UpgradeCodecFactory upgradeCodecFactory) {
         this(sourceCodec, upgradeCodecFactory, 0,
-                HttpHeaders.DEFAULT_HEADER_FACTORY, HttpHeaders.DEFAULT_TRAILER_FACTORY);
+                DefaultHttpHeadersFactory.headersFactory(), DefaultHttpHeadersFactory.trailersFactory());
     }
 
     /**
@@ -203,7 +203,7 @@ public class HttpServerUpgradeHandler extends HttpObjectAggregator {
     public HttpServerUpgradeHandler(
             SourceCodec sourceCodec, UpgradeCodecFactory upgradeCodecFactory, int maxContentLength) {
         this(sourceCodec, upgradeCodecFactory, maxContentLength,
-                HttpHeaders.DEFAULT_HEADER_FACTORY, HttpHeaders.DEFAULT_TRAILER_FACTORY);
+                DefaultHttpHeadersFactory.headersFactory(), DefaultHttpHeadersFactory.trailersFactory());
     }
 
     /**
@@ -218,8 +218,8 @@ public class HttpServerUpgradeHandler extends HttpObjectAggregator {
     public HttpServerUpgradeHandler(SourceCodec sourceCodec, UpgradeCodecFactory upgradeCodecFactory,
                                     int maxContentLength, boolean validateHeaders) {
         this(sourceCodec, upgradeCodecFactory, maxContentLength,
-                HttpHeaders.DEFAULT_HEADER_FACTORY.withValidation(validateHeaders),
-                HttpHeaders.DEFAULT_TRAILER_FACTORY.withValidation(validateHeaders));
+                DefaultHttpHeadersFactory.headersFactory().withValidation(validateHeaders),
+                DefaultHttpHeadersFactory.trailersFactory().withValidation(validateHeaders));
     }
 
     /**
@@ -230,9 +230,9 @@ public class HttpServerUpgradeHandler extends HttpObjectAggregator {
      *                            for one of the requested upgrade protocols
      * @param maxContentLength the maximum length of the content of an upgrade request
      * @param headersFactory The {@link HttpHeadersFactory} to use for headers.
-     * The recommended default factory is {@link HttpHeaders#DEFAULT_HEADER_FACTORY}.
+     * The recommended default factory is {@link DefaultHttpHeadersFactory#headersFactory()}.
      * @param trailersFactory The {@link HttpHeadersFactory} to use for trailers.
-     * The recommended default factory is {@link HttpHeaders#DEFAULT_TRAILER_FACTORY}.
+     * The recommended default factory is {@link DefaultHttpHeadersFactory#trailersFactory()}.
      */
     public HttpServerUpgradeHandler(
             SourceCodec sourceCodec, UpgradeCodecFactory upgradeCodecFactory, int maxContentLength,

--- a/codec-http/src/main/java/io/netty/handler/codec/http/ReadOnlyHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/ReadOnlyHttpHeaders.java
@@ -68,7 +68,7 @@ public final class ReadOnlyHttpHeaders extends HttpHeaders {
 
     private static void validateHeaders(CharSequence... keyValuePairs) {
         for (int i = 0; i < keyValuePairs.length; i += 2) {
-            HttpHeadersBuilder.DEFAULT_NAME_VALIDATOR.validateName(keyValuePairs[i]);
+            DefaultHttpHeadersFactory.headersFactory().getNameValidator().validateName(keyValuePairs[i]);
         }
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/ReadOnlyHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/ReadOnlyHttpHeaders.java
@@ -29,7 +29,6 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 
 import static io.netty.handler.codec.CharSequenceValueConverter.INSTANCE;
-import static io.netty.handler.codec.http.DefaultHttpHeaders.HttpNameValidator;
 import static io.netty.util.AsciiString.contentEquals;
 import static io.netty.util.AsciiString.contentEqualsIgnoreCase;
 
@@ -69,7 +68,7 @@ public final class ReadOnlyHttpHeaders extends HttpHeaders {
 
     private static void validateHeaders(CharSequence... keyValuePairs) {
         for (int i = 0; i < keyValuePairs.length; i += 2) {
-            HttpNameValidator.validateName(keyValuePairs[i]);
+            HttpHeadersBuilder.DEFAULT_NAME_VALIDATOR.validateName(keyValuePairs[i]);
         }
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cors/CorsHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cors/CorsHandler.java
@@ -25,6 +25,7 @@ import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.DefaultHttpHeadersFactory;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpUtil;
@@ -101,8 +102,8 @@ public class CorsHandler extends ChannelDuplexHandler {
                 request.protocolVersion(),
                 OK,
                 Unpooled.buffer(0),
-                HttpHeaders.DEFAULT_HEADER_FACTORY.withCombiningHeaders(true),
-                HttpHeaders.DEFAULT_TRAILER_FACTORY.withCombiningHeaders(true));
+                DefaultHttpHeadersFactory.headersFactory().withCombiningHeaders(true),
+                DefaultHttpHeadersFactory.trailersFactory().withCombiningHeaders(true));
         if (setOrigin(response)) {
             setAllowMethods(response);
             setAllowHeaders(response);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cors/CorsHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cors/CorsHandler.java
@@ -15,6 +15,7 @@
  */
 package io.netty.handler.codec.http.cors;
 
+import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
@@ -96,7 +97,12 @@ public class CorsHandler extends ChannelDuplexHandler {
     }
 
     private void handlePreflight(final ChannelHandlerContext ctx, final HttpRequest request) {
-        final HttpResponse response = new DefaultFullHttpResponse(request.protocolVersion(), OK, true, true);
+        final HttpResponse response = new DefaultFullHttpResponse(
+                request.protocolVersion(),
+                OK,
+                Unpooled.buffer(0),
+                HttpHeaders.DEFAULT_HEADER_FACTORY.withCombiningHeaders(true),
+                HttpHeaders.DEFAULT_TRAILER_FACTORY.withCombiningHeaders(true));
         if (setOrigin(response)) {
             setAllowMethods(response);
             setAllowHeaders(response);

--- a/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspDecoder.java
@@ -17,10 +17,12 @@ package io.netty.handler.codec.rtsp;
 
 import java.util.regex.Pattern;
 
+import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.HttpDecoderConfig;
 import io.netty.handler.codec.http.HttpMessage;
 import io.netty.handler.codec.http.HttpObjectDecoder;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -96,7 +98,11 @@ public class RtspDecoder extends HttpObjectDecoder {
     public RtspDecoder(final int maxInitialLineLength,
                        final int maxHeaderSize,
                        final int maxContentLength) {
-        super(maxInitialLineLength, maxHeaderSize, maxContentLength * 2, false);
+        super(new HttpDecoderConfig()
+                .setMaxInitialLineLength(maxInitialLineLength)
+                .setMaxHeaderSize(maxHeaderSize)
+                .setMaxChunkSize(maxContentLength * 2)
+                .setChunkedSupported(false));
     }
 
     /**
@@ -105,16 +111,29 @@ public class RtspDecoder extends HttpObjectDecoder {
      * @param maxHeaderSize The max allowed size of header
      * @param maxContentLength The max allowed content length
      * @param validateHeaders Set to true if headers should be validated
+     * @deprecated Use the {@link #RtspDecoder(HttpDecoderConfig)} constructor instead,
+     * or the {@link #RtspDecoder(int, int, int)} to always enable header validation.
      */
+    @Deprecated
     public RtspDecoder(final int maxInitialLineLength,
                        final int maxHeaderSize,
                        final int maxContentLength,
                        final boolean validateHeaders) {
-        super(maxInitialLineLength,
-              maxHeaderSize,
-              maxContentLength * 2,
-              false,
-              validateHeaders);
+        super(new HttpDecoderConfig()
+                .setMaxInitialLineLength(maxInitialLineLength)
+                .setMaxHeaderSize(maxHeaderSize)
+                .setMaxChunkSize(maxContentLength * 2)
+                .setChunkedSupported(false)
+                .setValidateHeaders(validateHeaders));
+    }
+
+    /**
+     * Creates a new instance with the specified configuration.
+     */
+    public RtspDecoder(HttpDecoderConfig config) {
+        super(config.clone()
+                .setMaxChunkSize(2 * config.getMaxChunkSize())
+                .setChunkedSupported(false));
     }
 
     @Override
@@ -127,13 +146,13 @@ public class RtspDecoder extends HttpObjectDecoder {
             return new DefaultHttpResponse(RtspVersions.valueOf(initialLine[0]),
                 new HttpResponseStatus(Integer.parseInt(initialLine[1]),
                                        initialLine[2]),
-                validateHeaders);
+                headersFactory);
         } else {
             isDecodingRequest = true;
             return new DefaultHttpRequest(RtspVersions.valueOf(initialLine[2]),
                     RtspMethods.valueOf(initialLine[0]),
                     initialLine[1],
-                    validateHeaders);
+                    headersFactory);
         }
     }
 
@@ -148,11 +167,10 @@ public class RtspDecoder extends HttpObjectDecoder {
     protected HttpMessage createInvalidMessage() {
         if (isDecodingRequest) {
             return new DefaultFullHttpRequest(RtspVersions.RTSP_1_0,
-                       RtspMethods.OPTIONS, "/bad-request", validateHeaders);
+                       RtspMethods.OPTIONS, "/bad-request", Unpooled.buffer(0), headersFactory, trailersFactory);
         } else {
-            return new DefaultFullHttpResponse(RtspVersions.RTSP_1_0,
-                                               UNKNOWN_STATUS,
-                                               validateHeaders);
+            return new DefaultFullHttpResponse(
+                    RtspVersions.RTSP_1_0, UNKNOWN_STATUS, Unpooled.buffer(0), headersFactory, trailersFactory);
         }
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpCodec.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpCodec.java
@@ -16,6 +16,10 @@
 package io.netty.handler.codec.spdy;
 
 import io.netty.channel.CombinedChannelDuplexHandler;
+import io.netty.handler.codec.http.FullHttpMessage;
+import io.netty.handler.codec.http.HttpHeadersFactory;
+
+import java.util.HashMap;
 
 /**
  * A combination of {@link SpdyHttpDecoder} and {@link SpdyHttpEncoder}
@@ -31,7 +35,17 @@ public final class SpdyHttpCodec extends CombinedChannelDuplexHandler<SpdyHttpDe
     /**
      * Creates a new instance with the specified decoder options.
      */
+    @Deprecated
     public SpdyHttpCodec(SpdyVersion version, int maxContentLength, boolean validateHttpHeaders) {
         super(new SpdyHttpDecoder(version, maxContentLength, validateHttpHeaders), new SpdyHttpEncoder(version));
+    }
+
+    /**
+     * Creates a new instance with the specified decoder options.
+     */
+    public SpdyHttpCodec(SpdyVersion version, int maxContentLength,
+                         HttpHeadersFactory headersFactory, HttpHeadersFactory trailersFactory) {
+        super(new SpdyHttpDecoder(version, maxContentLength, new HashMap<Integer, FullHttpMessage>(),
+                headersFactory, trailersFactory), new SpdyHttpEncoder(version));
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpDecoder.java
@@ -26,6 +26,8 @@ import io.netty.handler.codec.http.FullHttpMessage;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpHeadersFactory;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -47,10 +49,11 @@ import static io.netty.util.internal.ObjectUtil.checkPositive;
  */
 public class SpdyHttpDecoder extends MessageToMessageDecoder<SpdyFrame> {
 
-    private final boolean validateHeaders;
     private final int spdyVersion;
     private final int maxContentLength;
     private final Map<Integer, FullHttpMessage> messageMap;
+    private final HttpHeadersFactory headersFactory;
+    private final HttpHeadersFactory trailersFactory;
 
     /**
      * Creates a new instance.
@@ -61,7 +64,8 @@ public class SpdyHttpDecoder extends MessageToMessageDecoder<SpdyFrame> {
      *        a {@link TooLongFrameException} will be raised.
      */
     public SpdyHttpDecoder(SpdyVersion version, int maxContentLength) {
-        this(version, maxContentLength, new HashMap<Integer, FullHttpMessage>(), true);
+        this(version, maxContentLength, new HashMap<Integer, FullHttpMessage>(),
+                HttpHeaders.DEFAULT_HEADER_FACTORY, HttpHeaders.DEFAULT_TRAILER_FACTORY);
     }
 
     /**
@@ -72,7 +76,10 @@ public class SpdyHttpDecoder extends MessageToMessageDecoder<SpdyFrame> {
      *        If the length of the message content exceeds this value,
      *        a {@link TooLongFrameException} will be raised.
      * @param validateHeaders {@code true} if http headers should be validated
+     * @deprecated Use the {@link #SpdyHttpDecoder(SpdyVersion, int, Map, HttpHeadersFactory, HttpHeadersFactory)}
+     * constructor instead.
      */
+    @Deprecated
     public SpdyHttpDecoder(SpdyVersion version, int maxContentLength, boolean validateHeaders) {
         this(version, maxContentLength, new HashMap<Integer, FullHttpMessage>(), validateHeaders);
     }
@@ -87,7 +94,8 @@ public class SpdyHttpDecoder extends MessageToMessageDecoder<SpdyFrame> {
      * @param messageMap the {@link Map} used to hold partially received messages.
      */
     protected SpdyHttpDecoder(SpdyVersion version, int maxContentLength, Map<Integer, FullHttpMessage> messageMap) {
-        this(version, maxContentLength, messageMap, true);
+        this(version, maxContentLength, messageMap,
+                HttpHeaders.DEFAULT_HEADER_FACTORY, HttpHeaders.DEFAULT_TRAILER_FACTORY);
     }
 
     /**
@@ -99,13 +107,35 @@ public class SpdyHttpDecoder extends MessageToMessageDecoder<SpdyFrame> {
      *        a {@link TooLongFrameException} will be raised.
      * @param messageMap the {@link Map} used to hold partially received messages.
      * @param validateHeaders {@code true} if http headers should be validated
+     * @deprecated Use the {@link #SpdyHttpDecoder(SpdyVersion, int, Map, HttpHeadersFactory, HttpHeadersFactory)}
+     * constructor instead.
      */
+    @Deprecated
     protected SpdyHttpDecoder(SpdyVersion version, int maxContentLength, Map<Integer,
             FullHttpMessage> messageMap, boolean validateHeaders) {
+        this(version, maxContentLength, messageMap,
+                HttpHeaders.DEFAULT_HEADER_FACTORY.withValidation(validateHeaders),
+                HttpHeaders.DEFAULT_TRAILER_FACTORY.withValidation(validateHeaders));
+    }
+
+    /**
+     * Creates a new instance with the specified parameters.
+     *
+     * @param version the protocol version
+     * @param maxContentLength the maximum length of the message content.
+     *        If the length of the message content exceeds this value,
+     *        a {@link TooLongFrameException} will be raised.
+     * @param messageMap the {@link Map} used to hold partially received messages.
+     * @param headersFactory The factory used for creating HTTP headers
+     * @param trailersFactory The factory used for creating HTTP trailers.
+     */
+    protected SpdyHttpDecoder(SpdyVersion version, int maxContentLength, Map<Integer,
+            FullHttpMessage> messageMap, HttpHeadersFactory headersFactory, HttpHeadersFactory trailersFactory) {
         spdyVersion = ObjectUtil.checkNotNull(version, "version").getVersion();
         this.maxContentLength = checkPositive(maxContentLength, "maxContentLength");
         this.messageMap = messageMap;
-        this.validateHeaders = validateHeaders;
+        this.headersFactory = headersFactory;
+        this.trailersFactory = trailersFactory;
     }
 
     @Override
@@ -242,7 +272,7 @@ public class SpdyHttpDecoder extends MessageToMessageDecoder<SpdyFrame> {
 
             try {
                 FullHttpResponse httpResponseWithEntity =
-                   createHttpResponse(spdySynReplyFrame, ctx.alloc(), validateHeaders);
+                   createHttpResponse(spdySynReplyFrame, ctx.alloc());
 
                 // Set the Stream-ID as a header
                 httpResponseWithEntity.headers().setInt(Names.STREAM_ID, streamId);
@@ -282,7 +312,7 @@ public class SpdyHttpDecoder extends MessageToMessageDecoder<SpdyFrame> {
                     }
 
                     try {
-                        fullHttpMessage = createHttpResponse(spdyHeadersFrame, ctx.alloc(), validateHeaders);
+                        fullHttpMessage = createHttpResponse(spdyHeadersFrame, ctx.alloc());
 
                         // Set the Stream-ID as a header
                         fullHttpMessage.headers().setInt(Names.STREAM_ID, streamId);
@@ -396,8 +426,8 @@ public class SpdyHttpDecoder extends MessageToMessageDecoder<SpdyFrame> {
         }
     }
 
-    private static FullHttpResponse createHttpResponse(SpdyHeadersFrame responseFrame, ByteBufAllocator alloc,
-                                                       boolean validateHeaders) throws Exception {
+    private FullHttpResponse createHttpResponse(SpdyHeadersFrame responseFrame, ByteBufAllocator alloc)
+            throws Exception {
 
         // Create the first line of the response from the name/value pairs
         SpdyHeaders headers = responseFrame.headers();
@@ -409,7 +439,8 @@ public class SpdyHttpDecoder extends MessageToMessageDecoder<SpdyFrame> {
         boolean release = true;
         ByteBuf buffer = alloc.buffer();
         try {
-            FullHttpResponse res = new DefaultFullHttpResponse(version, status, buffer, validateHeaders);
+            FullHttpResponse res = new DefaultFullHttpResponse(
+                    version, status, buffer, headersFactory, trailersFactory);
             for (Map.Entry<CharSequence, CharSequence> e: responseFrame.headers()) {
                 res.headers().add(e.getKey(), e.getValue());
             }

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpDecoder.java
@@ -26,7 +26,7 @@ import io.netty.handler.codec.http.FullHttpMessage;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.DefaultHttpHeadersFactory;
 import io.netty.handler.codec.http.HttpHeadersFactory;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpMethod;
@@ -65,7 +65,7 @@ public class SpdyHttpDecoder extends MessageToMessageDecoder<SpdyFrame> {
      */
     public SpdyHttpDecoder(SpdyVersion version, int maxContentLength) {
         this(version, maxContentLength, new HashMap<Integer, FullHttpMessage>(),
-                HttpHeaders.DEFAULT_HEADER_FACTORY, HttpHeaders.DEFAULT_TRAILER_FACTORY);
+                DefaultHttpHeadersFactory.headersFactory(), DefaultHttpHeadersFactory.trailersFactory());
     }
 
     /**
@@ -95,7 +95,7 @@ public class SpdyHttpDecoder extends MessageToMessageDecoder<SpdyFrame> {
      */
     protected SpdyHttpDecoder(SpdyVersion version, int maxContentLength, Map<Integer, FullHttpMessage> messageMap) {
         this(version, maxContentLength, messageMap,
-                HttpHeaders.DEFAULT_HEADER_FACTORY, HttpHeaders.DEFAULT_TRAILER_FACTORY);
+                DefaultHttpHeadersFactory.headersFactory(), DefaultHttpHeadersFactory.trailersFactory());
     }
 
     /**
@@ -114,8 +114,8 @@ public class SpdyHttpDecoder extends MessageToMessageDecoder<SpdyFrame> {
     protected SpdyHttpDecoder(SpdyVersion version, int maxContentLength, Map<Integer,
             FullHttpMessage> messageMap, boolean validateHeaders) {
         this(version, maxContentLength, messageMap,
-                HttpHeaders.DEFAULT_HEADER_FACTORY.withValidation(validateHeaders),
-                HttpHeaders.DEFAULT_TRAILER_FACTORY.withValidation(validateHeaders));
+                DefaultHttpHeadersFactory.headersFactory().withValidation(validateHeaders),
+                DefaultHttpHeadersFactory.trailersFactory().withValidation(validateHeaders));
     }
 
     /**

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cors/CorsHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cors/CorsHandlerTest.java
@@ -15,12 +15,14 @@
  */
 package io.netty.handler.codec.http.cors;
 
+import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpUtil;
@@ -574,7 +576,9 @@ public class CorsHandlerTest {
     private static class EchoHandler extends SimpleChannelInboundHandler<Object> {
         @Override
         public void channelRead0(ChannelHandlerContext ctx, Object msg) throws Exception {
-            ctx.writeAndFlush(new DefaultFullHttpResponse(HTTP_1_1, OK, true, true));
+            ctx.writeAndFlush(new DefaultFullHttpResponse(HTTP_1_1, OK, Unpooled.buffer(0),
+                    HttpHeaders.DEFAULT_HEADER_FACTORY.withCombiningHeaders(true),
+                    HttpHeaders.DEFAULT_TRAILER_FACTORY.withCombiningHeaders(true)));
         }
     }
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cors/CorsHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cors/CorsHandlerTest.java
@@ -22,7 +22,7 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpRequest;
-import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.DefaultHttpHeadersFactory;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpUtil;
@@ -577,8 +577,8 @@ public class CorsHandlerTest {
         @Override
         public void channelRead0(ChannelHandlerContext ctx, Object msg) throws Exception {
             ctx.writeAndFlush(new DefaultFullHttpResponse(HTTP_1_1, OK, Unpooled.buffer(0),
-                    HttpHeaders.DEFAULT_HEADER_FACTORY.withCombiningHeaders(true),
-                    HttpHeaders.DEFAULT_TRAILER_FACTORY.withCombiningHeaders(true)));
+                    DefaultHttpHeadersFactory.headersFactory().withCombiningHeaders(true),
+                    DefaultHttpHeadersFactory.trailersFactory().withCombiningHeaders(true)));
         }
     }
 

--- a/handler-proxy/src/main/java/io/netty/handler/proxy/HttpProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/handler/proxy/HttpProxyHandler.java
@@ -29,6 +29,7 @@ import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpClientCodec;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.DefaultHttpHeadersFactory;
 import io.netty.handler.codec.http.HttpHeadersFactory;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponse;
@@ -172,7 +173,7 @@ public final class HttpProxyHandler extends ProxyHandler {
                 hostString :
                 url;
 
-        HttpHeadersFactory headersFactory = HttpHeaders.DEFAULT_HEADER_FACTORY.withValidation(false);
+        HttpHeadersFactory headersFactory = DefaultHttpHeadersFactory.headersFactory().withValidation(false);
         FullHttpRequest req = new DefaultFullHttpRequest(
                 HttpVersion.HTTP_1_1, HttpMethod.CONNECT,
                 url,

--- a/handler-proxy/src/main/java/io/netty/handler/proxy/HttpProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/handler/proxy/HttpProxyHandler.java
@@ -29,6 +29,7 @@ import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpClientCodec;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpHeadersFactory;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -171,10 +172,11 @@ public final class HttpProxyHandler extends ProxyHandler {
                 hostString :
                 url;
 
+        HttpHeadersFactory headersFactory = HttpHeaders.DEFAULT_HEADER_FACTORY.withValidation(false);
         FullHttpRequest req = new DefaultFullHttpRequest(
                 HttpVersion.HTTP_1_1, HttpMethod.CONNECT,
                 url,
-                Unpooled.EMPTY_BUFFER, false);
+                Unpooled.EMPTY_BUFFER, headersFactory, headersFactory);
 
         req.headers().set(HttpHeaderNames.HOST, hostHeader);
 

--- a/microbench/src/main/java/io/netty/microbench/http/HttpRequestEncoderBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/http/HttpRequestEncoderBenchmark.java
@@ -22,7 +22,6 @@ import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
-import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.EmptyHttpHeaders;
@@ -30,6 +29,7 @@ import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpHeadersBuilder;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpRequestEncoder;
@@ -76,9 +76,10 @@ public class HttpRequestEncoderBenchmark extends AbstractMicrobenchmark {
         content = Unpooled.buffer(bytes.length);
         content.writeBytes(bytes);
         ByteBuf testContent = Unpooled.unreleasableBuffer(content.asReadOnly());
-        HttpHeaders headersWithChunked = new DefaultHttpHeaders(false);
+        HttpHeadersBuilder headersFactory = HttpHeaders.DEFAULT_HEADER_FACTORY.withValidation(false);
+        HttpHeaders headersWithChunked = headersFactory.createHeaders();
         headersWithChunked.add(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
-        HttpHeaders headersWithContentLength = new DefaultHttpHeaders(false);
+        HttpHeaders headersWithContentLength = headersFactory.createHeaders();
         headersWithContentLength.add(HttpHeaderNames.CONTENT_LENGTH, testContent.readableBytes());
 
         fullRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/index", testContent,
@@ -86,7 +87,7 @@ public class HttpRequestEncoderBenchmark extends AbstractMicrobenchmark {
         contentLengthRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/index",
                 headersWithContentLength);
         chunkedRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/index", headersWithChunked);
-        lastContent = new DefaultLastHttpContent(testContent, false);
+        lastContent = new DefaultLastHttpContent(testContent, headersFactory);
 
         encoder = new HttpRequestEncoder();
         context = new EmbeddedChannelWriteReleaseHandlerContext(pooledAllocator ? PooledByteBufAllocator.DEFAULT :

--- a/microbench/src/main/java/io/netty/microbench/http/HttpRequestEncoderBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/http/HttpRequestEncoderBenchmark.java
@@ -29,7 +29,7 @@ import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpHeaders;
-import io.netty.handler.codec.http.HttpHeadersBuilder;
+import io.netty.handler.codec.http.DefaultHttpHeadersFactory;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpRequestEncoder;
@@ -76,10 +76,10 @@ public class HttpRequestEncoderBenchmark extends AbstractMicrobenchmark {
         content = Unpooled.buffer(bytes.length);
         content.writeBytes(bytes);
         ByteBuf testContent = Unpooled.unreleasableBuffer(content.asReadOnly());
-        HttpHeadersBuilder headersFactory = HttpHeaders.DEFAULT_HEADER_FACTORY.withValidation(false);
-        HttpHeaders headersWithChunked = headersFactory.createHeaders();
+        DefaultHttpHeadersFactory headersFactory = DefaultHttpHeadersFactory.headersFactory().withValidation(false);
+        HttpHeaders headersWithChunked = headersFactory.newHeaders();
         headersWithChunked.add(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
-        HttpHeaders headersWithContentLength = headersFactory.createHeaders();
+        HttpHeaders headersWithContentLength = headersFactory.newHeaders();
         headersWithContentLength.add(HttpHeaderNames.CONTENT_LENGTH, testContent.readableBytes());
 
         fullRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/index", testContent,

--- a/microbench/src/main/java/io/netty/microbench/http/HttpRequestResponseBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/http/HttpRequestResponseBenchmark.java
@@ -27,6 +27,7 @@ import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.DefaultHttpHeadersFactory;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpRequestDecoder;
 import io.netty.handler.codec.http.HttpResponseEncoder;
@@ -235,8 +236,8 @@ public class HttpRequestResponseBenchmark extends AbstractMicrobenchmark {
                 // Build the response object.
                 FullHttpResponse response = new DefaultFullHttpResponse(
                         HttpVersion.HTTP_1_1, HttpResponseStatus.OK, buf,
-                        HttpHeaders.DEFAULT_HEADER_FACTORY.withValidation(false),
-                        HttpHeaders.DEFAULT_TRAILER_FACTORY.withValidation(false));
+                        DefaultHttpHeadersFactory.headersFactory().withValidation(false),
+                        DefaultHttpHeadersFactory.trailersFactory().withValidation(false));
                 HttpHeaders headers = response.headers();
                 headers.set(CONTENT_TYPE_ENTITY, contentType);
                 headers.set(SERVER_ENTITY, SERVER_NAME);

--- a/microbench/src/main/java/io/netty/microbench/http/HttpRequestResponseBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/http/HttpRequestResponseBenchmark.java
@@ -233,8 +233,10 @@ public class HttpRequestResponseBenchmark extends AbstractMicrobenchmark {
             private void writeResponse(ChannelHandlerContext ctx, ByteBuf buf, CharSequence contentType,
                                        CharSequence contentLength) {
                 // Build the response object.
-                FullHttpResponse response =
-                        new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK, buf, false);
+                FullHttpResponse response = new DefaultFullHttpResponse(
+                        HttpVersion.HTTP_1_1, HttpResponseStatus.OK, buf,
+                        HttpHeaders.DEFAULT_HEADER_FACTORY.withValidation(false),
+                        HttpHeaders.DEFAULT_TRAILER_FACTORY.withValidation(false));
                 HttpHeaders headers = response.headers();
                 headers.set(CONTENT_TYPE_ENTITY, contentType);
                 headers.set(SERVER_ENTITY, SERVER_NAME);


### PR DESCRIPTION
Motivation:
HTTP request/response splitting is a serious vulnerability, which is mitigated by enabling HTTP header validation. We already do header validation by default, but we have many constructors in our HTTP codec that permit turning it off. We should discourage all our down-stream users from turning header validation off.

Modification:
- Deprecate all constructors in our HTTP codec, that allow header validation to be turned off.
- Offer alternative constructors to all the newly deprecated ones, where header validation is enabled.
- Trailer validation in `DefaultLastHttpContent` is now enabled by default in the `DefaultLastHttpContent(ByteBuf, HttpHeaders)` constructor (Behavioral change!)
- Add better constructors, and more guidance in the javadocs, for `DefaultHttpHeaders` for those who want to use custom header validators.

Result:
We hopefully encourage integrators to validate headers. And we hopefully get fewer issues reported about disabled header validation when people run security scanners on their code.