### PR TITLE
Make SizeClasses as composition with PoolArena instead of inheritance to reduce memory usage

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolChunkList.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunkList.java
@@ -97,7 +97,7 @@ final class PoolChunkList<T> implements PoolChunkListMetric {
     }
 
     boolean allocate(PooledByteBuf<T> buf, int reqCapacity, int sizeIdx, PoolThreadCache threadCache) {
-        int normCapacity = arena.sizeIdx2size(sizeIdx);
+        int normCapacity = arena.sizeClass.sizeIdx2size(sizeIdx);
         if (normCapacity > maxCapacity) {
             // Either this PoolChunkList is empty or the requested capacity is larger then the capacity which can
             // be handled by the PoolChunks that are contained in this PoolChunkList.

--- a/buffer/src/main/java/io/netty/buffer/PoolThreadCache.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolThreadCache.java
@@ -74,12 +74,8 @@ final class PoolThreadCache {
         this.heapArena = heapArena;
         this.directArena = directArena;
         if (directArena != null) {
-            smallSubPageDirectCaches = createSubPageCaches(
-                    smallCacheSize, directArena.numSmallSubpagePools);
-
-            normalDirectCaches = createNormalCaches(
-                    normalCacheSize, maxCachedBufferCapacity, directArena);
-
+            smallSubPageDirectCaches = createSubPageCaches(smallCacheSize, directArena.sizeClass.nSubpages);
+            normalDirectCaches = createNormalCaches(normalCacheSize, maxCachedBufferCapacity, directArena);
             directArena.numThreadCaches.getAndIncrement();
         } else {
             // No directArea is configured so just null out all caches
@@ -88,12 +84,8 @@ final class PoolThreadCache {
         }
         if (heapArena != null) {
             // Create the caches for the heap allocations
-            smallSubPageHeapCaches = createSubPageCaches(
-                    smallCacheSize, heapArena.numSmallSubpagePools);
-
-            normalHeapCaches = createNormalCaches(
-                    normalCacheSize, maxCachedBufferCapacity, heapArena);
-
+            smallSubPageHeapCaches = createSubPageCaches(smallCacheSize, heapArena.sizeClass.nSubpages);
+            normalHeapCaches = createNormalCaches(normalCacheSize, maxCachedBufferCapacity, heapArena);
             heapArena.numThreadCaches.getAndIncrement();
         } else {
             // No heapArea is configured so just null out all caches
@@ -130,11 +122,12 @@ final class PoolThreadCache {
     private static <T> MemoryRegionCache<T>[] createNormalCaches(
             int cacheSize, int maxCachedBufferCapacity, PoolArena<T> area) {
         if (cacheSize > 0 && maxCachedBufferCapacity > 0) {
-            int max = Math.min(area.chunkSize, maxCachedBufferCapacity);
+            int max = Math.min(area.sizeClass.chunkSize, maxCachedBufferCapacity);
             // Create as many normal caches as we support based on how many sizeIdx we have and what the upper
             // bound is that we want to cache in general.
             List<MemoryRegionCache<T>> cache = new ArrayList<MemoryRegionCache<T>>() ;
-            for (int idx = area.numSmallSubpagePools; idx < area.nSizes && area.sizeIdx2size(idx) <= max ; idx++) {
+            for (int idx = area.sizeClass.nSubpages; idx < area.sizeClass.nSizes &&
+                    area.sizeClass.sizeIdx2size(idx) <= max; idx++) {
                 cache.add(new NormalMemoryRegionCache<T>(cacheSize));
             }
             return cache.toArray(new MemoryRegionCache[0]);
@@ -183,7 +176,7 @@ final class PoolThreadCache {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     boolean add(PoolArena<?> area, PoolChunk chunk, ByteBuffer nioBuffer,
                 long handle, int normCapacity, SizeClass sizeClass) {
-        int sizeIdx = area.size2SizeIdx(normCapacity);
+        int sizeIdx = area.sizeClass.size2SizeIdx(normCapacity);
         MemoryRegionCache<?> cache = cache(area, sizeIdx, sizeClass);
         if (cache == null) {
             return false;
@@ -297,8 +290,8 @@ final class PoolThreadCache {
     }
 
     private MemoryRegionCache<?> cacheForNormal(PoolArena<?> area, int sizeIdx) {
-        // We need to substract area.numSmallSubpagePools as sizeIdx is the overall index for all sizes.
-        int idx = sizeIdx - area.numSmallSubpagePools;
+        // We need to subtract area.sizeClass.nSubpages as sizeIdx is the overall index for all sizes.
+        int idx = sizeIdx - area.sizeClass.nSubpages;
         if (area.isDirect()) {
             return cache(normalDirectCaches, idx);
         }

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
@@ -60,7 +60,8 @@ abstract class PooledByteBuf<T> extends AbstractReferenceCountedByteBuf {
                        long handle, int offset, int length, int maxLength, PoolThreadCache cache) {
         assert handle >= 0;
         assert chunk != null;
-        assert !PoolChunk.isSubpage(handle) || chunk.arena.size2SizeIdx(maxLength) <= chunk.arena.smallMaxSizeIdx:
+        assert !PoolChunk.isSubpage(handle) ||
+                chunk.arena.sizeClass.size2SizeIdx(maxLength) <= chunk.arena.sizeClass.smallMaxSizeIdx:
                 "Allocated small sub-page handle for a buffer size that isn't \"small.\"";
 
         chunk.incrementPinnedMemory(maxLength);

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -300,8 +300,9 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
         if (nHeapArena > 0) {
             heapArenas = newArenaArray(nHeapArena);
             List<PoolArenaMetric> metrics = new ArrayList<PoolArenaMetric>(heapArenas.length);
+            final SizeClasses sizeClasses = new SizeClasses(pageSize, pageShifts, chunkSize, 0);
             for (int i = 0; i < heapArenas.length; i ++) {
-                PoolArena.HeapArena arena = new PoolArena.HeapArena(this, pageSize, pageShifts, chunkSize);
+                PoolArena.HeapArena arena = new PoolArena.HeapArena(this, sizeClasses);
                 heapArenas[i] = arena;
                 metrics.add(arena);
             }
@@ -314,9 +315,10 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
         if (nDirectArena > 0) {
             directArenas = newArenaArray(nDirectArena);
             List<PoolArenaMetric> metrics = new ArrayList<PoolArenaMetric>(directArenas.length);
+            final SizeClasses sizeClasses = new SizeClasses(pageSize, pageShifts, chunkSize,
+                    directMemoryCacheAlignment);
             for (int i = 0; i < directArenas.length; i ++) {
-                PoolArena.DirectArena arena = new PoolArena.DirectArena(
-                        this, pageSize, pageShifts, chunkSize, directMemoryCacheAlignment);
+                PoolArena.DirectArena arena = new PoolArena.DirectArena(this, sizeClasses);
                 directArenas[i] = arena;
                 metrics.add(arena);
             }

--- a/buffer/src/main/java/io/netty/buffer/SizeClasses.java
+++ b/buffer/src/main/java/io/netty/buffer/SizeClasses.java
@@ -78,7 +78,7 @@ import static io.netty.buffer.PoolThreadCache.*;
  * <p>
  *   ( 76,    24,       22,        1,       yes,            no,        no)
  */
-class SizeClasses implements SizeClassesMetric {
+final class SizeClasses implements SizeClassesMetric {
 
     static final int LOG2_QUANTUM = 4;
 

--- a/buffer/src/main/java/io/netty/buffer/SizeClasses.java
+++ b/buffer/src/main/java/io/netty/buffer/SizeClasses.java
@@ -78,14 +78,13 @@ import static io.netty.buffer.PoolThreadCache.*;
  * <p>
  *   ( 76,    24,       22,        1,       yes,            no,        no)
  */
-abstract class SizeClasses implements SizeClassesMetric {
+class SizeClasses implements SizeClassesMetric {
 
     static final int LOG2_QUANTUM = 4;
 
     private static final int LOG2_SIZE_CLASS_GROUP = 2;
     private static final int LOG2_MAX_LOOKUP_SIZE = 12;
 
-    private static final int INDEX_IDX = 0;
     private static final int LOG2GROUP_IDX = 1;
     private static final int LOG2DELTA_IDX = 2;
     private static final int NDELTA_IDX = 3;
@@ -95,10 +94,10 @@ abstract class SizeClasses implements SizeClassesMetric {
 
     private static final byte no = 0, yes = 1;
 
-    protected final int pageSize;
-    protected final int pageShifts;
-    protected final int chunkSize;
-    protected final int directMemoryCacheAlignment;
+    final int pageSize;
+    final int pageShifts;
+    final int chunkSize;
+    final int directMemoryCacheAlignment;
 
     final int nSizes;
     final int nSubpages;
@@ -115,7 +114,7 @@ abstract class SizeClasses implements SizeClassesMetric {
     // spacing is 1 << LOG2_QUANTUM, so the size of array is lookupMaxClass >> LOG2_QUANTUM
     private final int[] size2idxTab;
 
-    protected SizeClasses(int pageSize, int pageShifts, int chunkSize, int directMemoryCacheAlignment) {
+    SizeClasses(int pageSize, int pageShifts, int chunkSize, int directMemoryCacheAlignment) {
         int group = log2(chunkSize) - LOG2_QUANTUM - LOG2_SIZE_CLASS_GROUP + 1;
 
         //generate size classes
@@ -181,9 +180,9 @@ abstract class SizeClasses implements SizeClassesMetric {
         this.directMemoryCacheAlignment = directMemoryCacheAlignment;
 
         //generate lookup tables
-        sizeIdx2sizeTab = newIdx2SizeTab(sizeClasses, nSizes, directMemoryCacheAlignment);
-        pageIdx2sizeTab = newPageIdx2sizeTab(sizeClasses, nSizes, nPSizes, directMemoryCacheAlignment);
-        size2idxTab = newSize2idxTab(lookupMaxSize, sizeClasses);
+        this.sizeIdx2sizeTab = newIdx2SizeTab(sizeClasses, nSizes, directMemoryCacheAlignment);
+        this.pageIdx2sizeTab = newPageIdx2sizeTab(sizeClasses, nSizes, nPSizes, directMemoryCacheAlignment);
+        this.size2idxTab = newSize2idxTab(lookupMaxSize, sizeClasses);
     }
 
     //calculate size class

--- a/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
@@ -33,33 +33,38 @@ public class PoolArenaTest {
 
     @Test
     public void testNormalizeCapacity() {
-        PoolArena<ByteBuffer> arena = new PoolArena.DirectArena(null, PAGE_SIZE, PAGE_SHIFTS, CHUNK_SIZE, 0);
+        SizeClasses sc = new SizeClasses(PAGE_SIZE, PAGE_SHIFTS, CHUNK_SIZE, 0);
+        PoolArena<ByteBuffer> arena = new PoolArena.DirectArena(null, sc);
         int[] reqCapacities = {0, 15, 510, 1024, 1023, 1025};
         int[] expectedResult = {16, 16, 512, 1024, 1024, 1280};
         for (int i = 0; i < reqCapacities.length; i ++) {
-            assertEquals(expectedResult[i], arena.sizeIdx2size(arena.size2SizeIdx(reqCapacities[i])));
+            assertEquals(expectedResult[i],
+                    arena.sizeClass.sizeIdx2size(arena.sizeClass.size2SizeIdx(reqCapacities[i])));
         }
     }
 
     @Test
     public void testNormalizeAlignedCapacity() {
-        PoolArena<ByteBuffer> arena = new PoolArena.DirectArena(null, PAGE_SIZE, PAGE_SHIFTS, CHUNK_SIZE, 64);
+        SizeClasses sc = new SizeClasses(PAGE_SIZE, PAGE_SHIFTS, CHUNK_SIZE, 64);
+        PoolArena<ByteBuffer> arena = new PoolArena.DirectArena(null, sc);
         int[] reqCapacities = {0, 15, 510, 1024, 1023, 1025};
         int[] expectedResult = {64, 64, 512, 1024, 1024, 1280};
         for (int i = 0; i < reqCapacities.length; i ++) {
-            assertEquals(expectedResult[i], arena.sizeIdx2size(arena.size2SizeIdx(reqCapacities[i])));
+            assertEquals(expectedResult[i],
+                    arena.sizeClass.sizeIdx2size(arena.sizeClass.size2SizeIdx(reqCapacities[i])));
         }
     }
 
     @Test
     public void testSize2SizeIdx() {
-        PoolArena<ByteBuffer> arena = new PoolArena.DirectArena(null, PAGE_SIZE, PAGE_SHIFTS, CHUNK_SIZE, 0);
+        SizeClasses sc = new SizeClasses(PAGE_SIZE, PAGE_SHIFTS, CHUNK_SIZE, 0);
+        PoolArena<ByteBuffer> arena = new PoolArena.DirectArena(null, sc);
 
         for (int sz = 0; sz <= CHUNK_SIZE; sz++) {
-            int sizeIdx = arena.size2SizeIdx(sz);
-            assertTrue(sz <= arena.sizeIdx2size(sizeIdx));
+            int sizeIdx = arena.sizeClass.size2SizeIdx(sz);
+            assertTrue(sz <= arena.sizeClass.sizeIdx2size(sizeIdx));
             if (sizeIdx > 0) {
-                assertTrue(sz > arena.sizeIdx2size(sizeIdx - 1));
+                assertTrue(sz > arena.sizeClass.sizeIdx2size(sizeIdx - 1));
             }
         }
     }
@@ -67,38 +72,40 @@ public class PoolArenaTest {
     @Test
     public void testPages2PageIdx() {
         int pageShifts = PAGE_SHIFTS;
-
-        PoolArena<ByteBuffer> arena = new PoolArena.DirectArena(null, PAGE_SIZE, PAGE_SHIFTS, CHUNK_SIZE, 0);
+        SizeClasses sc = new SizeClasses(PAGE_SIZE, PAGE_SHIFTS, CHUNK_SIZE, 0);
+        PoolArena<ByteBuffer> arena = new PoolArena.DirectArena(null, sc);
 
         int maxPages = CHUNK_SIZE >> pageShifts;
         for (int pages = 1; pages <= maxPages; pages++) {
-            int pageIdxFloor = arena.pages2pageIdxFloor(pages);
-            assertTrue(pages << pageShifts >= arena.pageIdx2size(pageIdxFloor));
+            int pageIdxFloor = arena.sizeClass.pages2pageIdxFloor(pages);
+            assertTrue(pages << pageShifts >= arena.sizeClass.pageIdx2size(pageIdxFloor));
             if (pageIdxFloor > 0 && pages < maxPages) {
-                assertTrue(pages << pageShifts < arena.pageIdx2size(pageIdxFloor + 1));
+                assertTrue(pages << pageShifts < arena.sizeClass.pageIdx2size(pageIdxFloor + 1));
             }
 
-            int pageIdxCeiling = arena.pages2pageIdx(pages);
-            assertTrue(pages << pageShifts <= arena.pageIdx2size(pageIdxCeiling));
+            int pageIdxCeiling = arena.sizeClass.pages2pageIdx(pages);
+            assertTrue(pages << pageShifts <= arena.sizeClass.pageIdx2size(pageIdxCeiling));
             if (pageIdxCeiling > 0) {
-                assertTrue(pages << pageShifts > arena.pageIdx2size(pageIdxCeiling - 1));
+                assertTrue(pages << pageShifts > arena.sizeClass.pageIdx2size(pageIdxCeiling - 1));
             }
         }
     }
 
     @Test
     public void testSizeIdx2size() {
-        PoolArena<ByteBuffer> arena = new PoolArena.DirectArena(null, PAGE_SIZE, PAGE_SHIFTS, CHUNK_SIZE, 0);
-        for (int i = 0; i < arena.nSizes; i++) {
-            assertEquals(arena.sizeIdx2sizeCompute(i), arena.sizeIdx2size(i));
+        SizeClasses sc = new SizeClasses(PAGE_SIZE, PAGE_SHIFTS, CHUNK_SIZE, 0);
+        PoolArena<ByteBuffer> arena = new PoolArena.DirectArena(null, sc);
+        for (int i = 0; i < arena.sizeClass.nSizes; i++) {
+            assertEquals(arena.sizeClass.sizeIdx2sizeCompute(i), arena.sizeClass.sizeIdx2size(i));
         }
     }
 
     @Test
     public void testPageIdx2size() {
-        PoolArena<ByteBuffer> arena = new PoolArena.DirectArena(null, PAGE_SIZE, PAGE_SHIFTS, CHUNK_SIZE, 0);
-        for (int i = 0; i < arena.nPSizes; i++) {
-            assertEquals(arena.pageIdx2sizeCompute(i), arena.pageIdx2size(i));
+        SizeClasses sc = new SizeClasses(PAGE_SIZE, PAGE_SHIFTS, CHUNK_SIZE, 0);
+        PoolArena<ByteBuffer> arena = new PoolArena.DirectArena(null, sc);
+        for (int i = 0; i < arena.sizeClass.nPSizes; i++) {
+            assertEquals(arena.sizeClass.pageIdx2sizeCompute(i), arena.sizeClass.pageIdx2size(i));
         }
     }
 


### PR DESCRIPTION
Motivation:

For one `PooledByteBufAllocator` instance, the array `PooledByteBufAllocator.heapArenas[]` only needs one `SizeClasses` instance, so does the `PooledByteBufAllocator.directArenas[]`, this will reduce memory usage.

Take the `PooledByteBufAllocator.DEFAULT` as an example, on my laptop, after `PooledByteBufAllocator.DEFAULT` initialized,  there are `heapArenas[16]` and `directArenas[16]` arrays created, every element of the arrays created following `int[]` array by `SizeClasses`'s constructor:
```
int[] pageIdx2sizeTab; // Length is 32 on my laptop
int[] sizeIdx2sizeTab; // Length is 68 on my laptop
int[] size2idxTab; // Length is 256 on my laptop
```
After `PooledByteBufAllocator.DEFAULT` initialized, there are 32 `int[] pageIdx2sizeTab`, 32 `int[] sizeIdx2sizeTab`, and 32 `int[] size2idxTab` arrays created. 

This is not necessary, because the `PooledByteBufAllocator.heapArenas[]` can share one `SizeClasses` instance, so does the `PooledByteBufAllocator.directArenas[]`. 

After the PR change, the `PooledByteBufAllocator.DEFAULT` only needs 2 `int[] pageIdx2sizeTab`, 2 `int[] sizeIdx2sizeTab` and 2 `int[] size2idxTab` arrays. 

It reduced at least 42720 bytes memory usage when use `PooledByteBufAllocator.DEFAULT`:
4 * (30 * 32 + 30 * 68 + 30 * 256) = 42720 bytes. 

So we make `SizeClasses` as composition with `PoolArena` instead of inheritance.
And it still reserves the ability to create `SizeClasses` per `PoolArena` for possible different implementation in the future.

Modification:

Make `SizeClasses` as composition with `PoolArena` instead of inheritance.

Result:

Reduced memory footprint.
