### PR TITLE
Revert "HttpHeaderValidationUtil should reject chars past the 1 byte range"

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderValidationUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderValidationUtil.java
@@ -151,13 +151,13 @@ public final class HttpHeaderValidationUtil {
         //  See: https://datatracker.ietf.org/doc/html/rfc7230#section-3.2
         //  And: https://datatracker.ietf.org/doc/html/rfc5234#appendix-B.1
         int b = value.charAt(0);
-        if (b < 0x21 || b == 0x7F || 0xFF < b) {
+        if (b < 0x21 || b == 0x7F) {
             return 0;
         }
         int length = value.length();
         for (int i = 1; i < length; i++) {
             b = value.charAt(i);
-            if (b < 0x20 && b != 0x09 || b == 0x7F || 0xFF < b) {
+            if (b < 0x20 && b != 0x09 || b == 0x7F) {
                 return i;
             }
         }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpHeaderValidationUtilTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpHeaderValidationUtilTest.java
@@ -235,11 +235,6 @@ public class HttpHeaderValidationUtilTest {
         assertEquals(0, validateValidHeaderValue(asCharSequence(value)));
     }
 
-    @Test
-    void decodingInvalidHeaderValuesMustFailIfFirstCharIsIllegalAsciiString() {
-        assertEquals(0, validateValidHeaderValue("" + (char) (0xFF + 1)));
-    }
-
     public static List<AsciiString> legalFirstChar() {
         List<AsciiString> list = new ArrayList<AsciiString>();
 
@@ -289,11 +284,6 @@ public class HttpHeaderValidationUtilTest {
     @MethodSource("illegalNotFirstChar")
     void decodingInvalidHeaderValuesMustFailIfNotFirstCharIsIllegalCharSequence(AsciiString value) {
         assertEquals(1, validateValidHeaderValue(asCharSequence(value)));
-    }
-
-    @Test
-    void decodingInvalidHeaderValuesMustFailIfNotFirstCharIsIllegalCharSequence() {
-        assertEquals(1, validateValidHeaderValue("a" + (char) (0xFF + 1)));
     }
 
     public static List<AsciiString> legalNotFirstChar() {


### PR DESCRIPTION
Motivation:
[RFC 9110 Section 5.5-4](https://datatracker.ietf.org/doc/html/rfc9110#section-5.5-4) says we _should_ constrain ourselves to only putting US-ASCII in header values, _but_ encodings beyond that are technically allowed as long as they are ASCII-compatible (e.g. ISO-8859-1 or UTF-8).
In such a case, some of their characters will fall into the "obs-text" clause.

One complication with our header validation is that we don't at that point know if we're the recipient or the sender.
And we also don't at that point know what encoding is used.

The Netty header encoder clobbers non-ASCII characters, but people may have custom header encoders that permit more characters.

Modification:
This reverts #13541, so we no longer enforce that `String` header values only contain US-ASCII characters.

Result:
Restore the "support" for non-ASCII header encodings that we had previously.