### PR TITLE
Upgrade to maven 3.9.4

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/apache-maven/3.9.1/apache-maven-3.9.1-bin.zip
+distributionUrl=https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/apache-maven/3.9.4/apache-maven-3.9.4-bin.zip


### PR DESCRIPTION
Motivation:

There was a new maven release

Modifications:

Upgrade to 3.9.4

Result:

Use latest maven release via maven wrapper
