### PR TITLE
Change pageShifts from int to byte, to reduce memory usage

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -75,7 +75,7 @@ abstract class PoolArena<T> extends SizeClasses implements PoolArenaMetric {
     private final ReentrantLock lock = new ReentrantLock();
 
     protected PoolArena(PooledByteBufAllocator parent, int pageSize,
-          int pageShifts, int chunkSize, int cacheAlignment) {
+          byte pageShifts, int chunkSize, int cacheAlignment) {
         super(pageSize, pageShifts, chunkSize, cacheAlignment);
         this.parent = parent;
         directMemoryCacheAlignment = cacheAlignment;
@@ -540,7 +540,7 @@ abstract class PoolArena<T> extends SizeClasses implements PoolArenaMetric {
         return max(0, val);
     }
 
-    protected abstract PoolChunk<T> newChunk(int pageSize, int maxPageIdx, int pageShifts, int chunkSize);
+    protected abstract PoolChunk<T> newChunk(int pageSize, int maxPageIdx, byte pageShifts, int chunkSize);
     protected abstract PoolChunk<T> newUnpooledChunk(int capacity);
     protected abstract PooledByteBuf<T> newByteBuf(int maxCapacity);
     protected abstract void memoryCopy(T src, int srcOffset, PooledByteBuf<T> dst, int length);
@@ -629,7 +629,7 @@ abstract class PoolArena<T> extends SizeClasses implements PoolArenaMetric {
 
     static final class HeapArena extends PoolArena<byte[]> {
 
-        HeapArena(PooledByteBufAllocator parent, int pageSize, int pageShifts,
+        HeapArena(PooledByteBufAllocator parent, int pageSize, byte pageShifts,
                   int chunkSize) {
             super(parent, pageSize, pageShifts, chunkSize,
                   0);
@@ -645,7 +645,7 @@ abstract class PoolArena<T> extends SizeClasses implements PoolArenaMetric {
         }
 
         @Override
-        protected PoolChunk<byte[]> newChunk(int pageSize, int maxPageIdx, int pageShifts, int chunkSize) {
+        protected PoolChunk<byte[]> newChunk(int pageSize, int maxPageIdx, byte pageShifts, int chunkSize) {
             return new PoolChunk<byte[]>(
                     this, null, newByteArray(chunkSize), pageSize, pageShifts, chunkSize, maxPageIdx);
         }
@@ -678,7 +678,7 @@ abstract class PoolArena<T> extends SizeClasses implements PoolArenaMetric {
 
     static final class DirectArena extends PoolArena<ByteBuffer> {
 
-        DirectArena(PooledByteBufAllocator parent, int pageSize, int pageShifts,
+        DirectArena(PooledByteBufAllocator parent, int pageSize, byte pageShifts,
                     int chunkSize, int directMemoryCacheAlignment) {
             super(parent, pageSize, pageShifts, chunkSize,
                   directMemoryCacheAlignment);
@@ -691,7 +691,7 @@ abstract class PoolArena<T> extends SizeClasses implements PoolArenaMetric {
 
         @Override
         protected PoolChunk<ByteBuffer> newChunk(int pageSize, int maxPageIdx,
-            int pageShifts, int chunkSize) {
+            byte pageShifts, int chunkSize) {
             if (directMemoryCacheAlignment == 0) {
                 ByteBuffer memory = allocateDirect(chunkSize);
                 return new PoolChunk<ByteBuffer>(this, memory, memory, pageSize, pageShifts,

--- a/buffer/src/main/java/io/netty/buffer/PoolChunk.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunk.java
@@ -172,7 +172,7 @@ final class PoolChunk<T> implements PoolChunkMetric {
     private final LongCounter pinnedBytes = PlatformDependent.newLongCounter();
 
     private final int pageSize;
-    private final int pageShifts;
+    private final byte pageShifts;
     private final int chunkSize;
 
     // Use as cache for ByteBuffer created from the memory. These are just duplicates and so are only a container
@@ -192,7 +192,7 @@ final class PoolChunk<T> implements PoolChunkMetric {
     //private long pad0, pad1, pad2, pad3, pad4, pad5, pad6, pad7;
 
     @SuppressWarnings("unchecked")
-    PoolChunk(PoolArena<T> arena, Object base, T memory, int pageSize, int pageShifts, int chunkSize, int maxPageIdx) {
+    PoolChunk(PoolArena<T> arena, Object base, T memory, int pageSize, byte pageShifts, int chunkSize, int maxPageIdx) {
         unpooled = false;
         this.arena = arena;
         this.base = base;
@@ -684,7 +684,7 @@ final class PoolChunk<T> implements PoolChunkMetric {
         return (int) (handle >> RUN_OFFSET_SHIFT);
     }
 
-    static int runSize(int pageShifts, long handle) {
+    static int runSize(byte pageShifts, long handle) {
         return runPages(handle) << pageShifts;
     }
 

--- a/buffer/src/main/java/io/netty/buffer/PoolSubpage.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolSubpage.java
@@ -27,7 +27,7 @@ final class PoolSubpage<T> implements PoolSubpageMetric {
 
     final PoolChunk<T> chunk;
     final int elemSize;
-    private final int pageShifts;
+    private final byte pageShifts;
     private final int runOffset;
     private final int runSize;
     private final long[] bitmap;
@@ -59,7 +59,7 @@ final class PoolSubpage<T> implements PoolSubpageMetric {
         maxNumElems = 0;
     }
 
-    PoolSubpage(PoolSubpage<T> head, PoolChunk<T> chunk, int pageShifts, int runOffset, int runSize, int elemSize) {
+    PoolSubpage(PoolSubpage<T> head, PoolChunk<T> chunk, byte pageShifts, int runOffset, int runSize, int elemSize) {
         this.chunk = chunk;
         this.pageShifts = pageShifts;
         this.runOffset = runOffset;

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -295,7 +295,7 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
                     + directMemoryCacheAlignment + " (expected: power of two)");
         }
 
-        int pageShifts = validateAndCalculatePageShifts(pageSize, directMemoryCacheAlignment);
+        byte pageShifts = validateAndCalculatePageShifts(pageSize, directMemoryCacheAlignment);
 
         if (nHeapArena > 0) {
             heapArenas = newArenaArray(nHeapArena);
@@ -334,7 +334,7 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
         return new PoolArena[size];
     }
 
-    private static int validateAndCalculatePageShifts(int pageSize, int alignment) {
+    private static byte validateAndCalculatePageShifts(int pageSize, int alignment) {
         if (pageSize < MIN_PAGE_SIZE) {
             throw new IllegalArgumentException("pageSize: " + pageSize + " (expected: " + MIN_PAGE_SIZE + ')');
         }
@@ -349,7 +349,7 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
         }
 
         // Logarithm base 2. At this point we know that pageSize is a power of two.
-        return Integer.SIZE - 1 - Integer.numberOfLeadingZeros(pageSize);
+        return (byte) (Integer.SIZE - 1 - Integer.numberOfLeadingZeros(pageSize));
     }
 
     private static int validateAndCalculateChunkSize(int pageSize, int maxOrder) {

--- a/buffer/src/main/java/io/netty/buffer/SizeClasses.java
+++ b/buffer/src/main/java/io/netty/buffer/SizeClasses.java
@@ -96,7 +96,7 @@ abstract class SizeClasses implements SizeClassesMetric {
     private static final byte no = 0, yes = 1;
 
     protected final int pageSize;
-    protected final int pageShifts;
+    protected final byte pageShifts;
     protected final int chunkSize;
     protected final int directMemoryCacheAlignment;
 
@@ -115,7 +115,7 @@ abstract class SizeClasses implements SizeClassesMetric {
     // spacing is 1 << LOG2_QUANTUM, so the size of array is lookupMaxClass >> LOG2_QUANTUM
     private final int[] size2idxTab;
 
-    protected SizeClasses(int pageSize, int pageShifts, int chunkSize, int directMemoryCacheAlignment) {
+    protected SizeClasses(int pageSize, byte pageShifts, int chunkSize, int directMemoryCacheAlignment) {
         int group = log2(chunkSize) - LOG2_QUANTUM - LOG2_SIZE_CLASS_GROUP + 1;
 
         //generate size classes
@@ -187,7 +187,7 @@ abstract class SizeClasses implements SizeClassesMetric {
     }
 
     //calculate size class
-    private static short[] newSizeClass(int index, int log2Group, int log2Delta, int nDelta, int pageShifts) {
+    private static short[] newSizeClass(int index, int log2Group, int log2Delta, int nDelta, byte pageShifts) {
         short isMultiPageSize;
         if (log2Delta >= pageShifts) {
             isMultiPageSize = yes;

--- a/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class PoolArenaTest {
 
     private static final int PAGE_SIZE = 8192;
-    private static final int PAGE_SHIFTS = 11;
+    private static final byte PAGE_SHIFTS = 11;
     //chunkSize = pageSize * (2 ^ pageShifts)
     private static final int CHUNK_SIZE = 16777216;
 
@@ -66,7 +66,7 @@ public class PoolArenaTest {
 
     @Test
     public void testPages2PageIdx() {
-        int pageShifts = PAGE_SHIFTS;
+        byte pageShifts = PAGE_SHIFTS;
 
         PoolArena<ByteBuffer> arena = new PoolArena.DirectArena(null, PAGE_SIZE, PAGE_SHIFTS, CHUNK_SIZE, 0);
 


### PR DESCRIPTION
Motivation:

Change `int pageShifts` to `byte pageShifts` to reduce memory usage, because the `byte` range is enough for `pageShifts`.

Modification:

Change `int pageShifts` to `byte`.

Result:

Reduce memory footprint.
