### PR TITLE
Draft: Remove PoolSubpage array from PoolChunk to reduce memory usage

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -161,9 +161,9 @@ abstract class PoolArena<T> extends SizeClasses implements PoolArenaMetric {
         final boolean needsNormalAllocation;
         head.lock();
         try {
-            final PoolSubpage<T> s = head.next;
-            needsNormalAllocation = s == head || s.numAvailable() <= 0 || !s.doNotDestroy;
+            needsNormalAllocation = !head.isAllocatable();
             if (!needsNormalAllocation) {
+                final PoolSubpage<T> s = head.next;
                 assert s.elemSize == sizeIdx2size(sizeIdx) : "doNotDestroy=" +
                         s.doNotDestroy + ", elemSize=" + s.elemSize + ", sizeIdx=" + sizeIdx;
                 long handle = s.allocate();

--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -161,7 +161,7 @@ abstract class PoolArena<T> extends SizeClasses implements PoolArenaMetric {
         final boolean needsNormalAllocation;
         head.lock();
         try {
-            needsNormalAllocation = !head.isPoolAllocatable(head);
+            needsNormalAllocation = !head.next.isAllocatable();
             if (!needsNormalAllocation) {
                 final PoolSubpage<T> s = head.next;
                 assert s.elemSize == sizeIdx2size(sizeIdx) : "doNotDestroy=" +

--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -161,7 +161,7 @@ abstract class PoolArena<T> extends SizeClasses implements PoolArenaMetric {
         final boolean needsNormalAllocation;
         head.lock();
         try {
-            needsNormalAllocation = !head.isAllocatable();
+            needsNormalAllocation = !head.isPoolAllocatable();
             if (!needsNormalAllocation) {
                 final PoolSubpage<T> s = head.next;
                 assert s.elemSize == sizeIdx2size(sizeIdx) : "doNotDestroy=" +

--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -114,6 +114,7 @@ abstract class PoolArena<T> extends SizeClasses implements PoolArenaMetric {
         PoolSubpage<T> head = new PoolSubpage<T>();
         head.prev = head;
         head.next = head;
+        head.tail = head;
         return head;
     }
 
@@ -162,7 +163,7 @@ abstract class PoolArena<T> extends SizeClasses implements PoolArenaMetric {
         head.lock();
         try {
             final PoolSubpage<T> s = head.next;
-            needsNormalAllocation = s == head;
+            needsNormalAllocation = s == head || s.numAvailable() <= 0;
             if (!needsNormalAllocation) {
                 assert s.doNotDestroy && s.elemSize == sizeIdx2size(sizeIdx) : "doNotDestroy=" +
                         s.doNotDestroy + ", elemSize=" + s.elemSize + ", sizeIdx=" + sizeIdx;

--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -161,7 +161,7 @@ abstract class PoolArena<T> extends SizeClasses implements PoolArenaMetric {
         final boolean needsNormalAllocation;
         head.lock();
         try {
-            needsNormalAllocation = !head.isPoolAllocatable();
+            needsNormalAllocation = !head.isPoolAllocatable(head);
             if (!needsNormalAllocation) {
                 final PoolSubpage<T> s = head.next;
                 assert s.elemSize == sizeIdx2size(sizeIdx) : "doNotDestroy=" +

--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -162,9 +162,9 @@ abstract class PoolArena<T> extends SizeClasses implements PoolArenaMetric {
         head.lock();
         try {
             final PoolSubpage<T> s = head.next;
-            needsNormalAllocation = s == head || s.numAvailable() <= 0;
+            needsNormalAllocation = s == head || s.numAvailable() <= 0 || !s.doNotDestroy;
             if (!needsNormalAllocation) {
-                assert s.doNotDestroy && s.elemSize == sizeIdx2size(sizeIdx) : "doNotDestroy=" +
+                assert s.elemSize == sizeIdx2size(sizeIdx) : "doNotDestroy=" +
                         s.doNotDestroy + ", elemSize=" + s.elemSize + ", sizeIdx=" + sizeIdx;
                 long handle = s.allocate();
                 assert handle >= 0;

--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -114,7 +114,6 @@ abstract class PoolArena<T> extends SizeClasses implements PoolArenaMetric {
         PoolSubpage<T> head = new PoolSubpage<T>();
         head.prev = head;
         head.next = head;
-        head.tail = head;
         return head;
     }
 

--- a/buffer/src/main/java/io/netty/buffer/PoolChunk.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunk.java
@@ -133,7 +133,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * 4) save the merged run
  *
  */
-final class PoolChunk<T> implements PoolChunkMetric, PoolChunkSubPageWrapper {
+final class PoolChunk<T> implements PoolChunkMetric, PoolChunkSubPageWrapper<T> {
     private static final int SIZE_BIT_LENGTH = 15;
     private static final int INUSED_BIT_LENGTH = 1;
     private static final int SUBPAGE_BIT_LENGTH = 1;

--- a/buffer/src/main/java/io/netty/buffer/PoolChunk.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunk.java
@@ -690,9 +690,9 @@ final class PoolChunk<T> implements PoolChunkMetric, PoolChunkSubPageWrapper<T> 
 
     @Override
     public PoolSubpage<T> getPoolSubpage() {
-        // PoolChunk VS PoolSubpage is 1 on N.
+        // PoolChunk on PoolSubpage is 1 on N.
         // Can not determine which PoolSubpage instance should be returned.
-        // So return null
+        // So return null.
         return null;
     }
 

--- a/buffer/src/main/java/io/netty/buffer/PoolChunk.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunk.java
@@ -316,8 +316,8 @@ final class PoolChunk<T> implements PoolChunkMetric, PoolChunkSubPageWrapper<T> 
             head.lock();
             try {
                 nextSub = head.next;
-                if (nextSub != head && nextSub.numAvailable() > 0) {
-                    assert nextSub.doNotDestroy && nextSub.elemSize == arena.sizeIdx2size(sizeIdx) : "doNotDestroy=" +
+                if (nextSub != head && nextSub.numAvailable() > 0 && nextSub.doNotDestroy) {
+                    assert nextSub.elemSize == arena.sizeIdx2size(sizeIdx) : "doNotDestroy=" +
                             nextSub.doNotDestroy + ", elemSize=" + nextSub.elemSize + ", sizeIdx=" + sizeIdx;
                     handle = nextSub.allocate();
                     assert handle >= 0;

--- a/buffer/src/main/java/io/netty/buffer/PoolChunk.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunk.java
@@ -315,7 +315,7 @@ final class PoolChunk<T> implements PoolChunkMetric, PoolChunkSubPageWrapper<T> 
             PoolSubpage<T> head = arena.smallSubpagePools[sizeIdx];
             head.lock();
             try {
-                if (head.isPoolAllocatable()) {
+                if (head.isPoolAllocatable(head)) {
                     nextSub = head.next;
                     assert nextSub.elemSize == arena.sizeIdx2size(sizeIdx) : "doNotDestroy=" +
                             nextSub.doNotDestroy + ", elemSize=" + nextSub.elemSize + ", sizeIdx=" + sizeIdx;

--- a/buffer/src/main/java/io/netty/buffer/PoolChunk.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunk.java
@@ -315,7 +315,7 @@ final class PoolChunk<T> implements PoolChunkMetric, PoolChunkSubPageWrapper<T> 
             PoolSubpage<T> head = arena.smallSubpagePools[sizeIdx];
             head.lock();
             try {
-                if (head.isPoolAllocatable(head)) {
+                if (head.next.isAllocatable()) {
                     nextSub = head.next;
                     assert nextSub.elemSize == arena.sizeIdx2size(sizeIdx) : "doNotDestroy=" +
                             nextSub.doNotDestroy + ", elemSize=" + nextSub.elemSize + ", sizeIdx=" + sizeIdx;

--- a/buffer/src/main/java/io/netty/buffer/PoolChunk.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunk.java
@@ -315,8 +315,8 @@ final class PoolChunk<T> implements PoolChunkMetric, PoolChunkSubPageWrapper<T> 
             PoolSubpage<T> head = arena.smallSubpagePools[sizeIdx];
             head.lock();
             try {
-                nextSub = head.next;
-                if (nextSub != head && nextSub.numAvailable() > 0 && nextSub.doNotDestroy) {
+                if (head.isAllocatable()) {
+                    nextSub = head.next;
                     assert nextSub.elemSize == arena.sizeIdx2size(sizeIdx) : "doNotDestroy=" +
                             nextSub.doNotDestroy + ", elemSize=" + nextSub.elemSize + ", sizeIdx=" + sizeIdx;
                     handle = nextSub.allocate();

--- a/buffer/src/main/java/io/netty/buffer/PoolChunk.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunk.java
@@ -316,7 +316,7 @@ final class PoolChunk<T> implements PoolChunkMetric, PoolChunkSubPageWrapper {
             head.lock();
             try {
                 nextSub = head.next;
-                if (nextSub != head) {
+                if (nextSub != head && nextSub.numAvailable() > 0) {
                     assert nextSub.doNotDestroy && nextSub.elemSize == arena.sizeIdx2size(sizeIdx) : "doNotDestroy=" +
                             nextSub.doNotDestroy + ", elemSize=" + nextSub.elemSize + ", sizeIdx=" + sizeIdx;
                     handle = nextSub.allocate();

--- a/buffer/src/main/java/io/netty/buffer/PoolChunk.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunk.java
@@ -315,7 +315,7 @@ final class PoolChunk<T> implements PoolChunkMetric, PoolChunkSubPageWrapper<T> 
             PoolSubpage<T> head = arena.smallSubpagePools[sizeIdx];
             head.lock();
             try {
-                if (head.isAllocatable()) {
+                if (head.isPoolAllocatable()) {
                     nextSub = head.next;
                     assert nextSub.elemSize == arena.sizeIdx2size(sizeIdx) : "doNotDestroy=" +
                             nextSub.doNotDestroy + ", elemSize=" + nextSub.elemSize + ", sizeIdx=" + sizeIdx;

--- a/buffer/src/main/java/io/netty/buffer/PoolChunkList.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunkList.java
@@ -116,8 +116,8 @@ final class PoolChunkList<T> implements PoolChunkListMetric {
         return false;
     }
 
-    boolean free(PoolChunk<T> chunk, long handle, int normCapacity, ByteBuffer nioBuffer) {
-        chunk.free(handle, normCapacity, nioBuffer);
+    boolean free(PoolChunk<T> chunk, long handle, int normCapacity, ByteBuffer nioBuffer, PoolSubpage<T> subpage) {
+        chunk.free(handle, normCapacity, nioBuffer, subpage);
         if (chunk.freeBytes > freeMaxThreshold) {
             remove(chunk);
             // Move the PoolChunk down the PoolChunkList linked-list.

--- a/buffer/src/main/java/io/netty/buffer/PoolChunkSubPageWrapper.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunkSubPageWrapper.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+interface PoolChunkSubPageWrapper<T> {
+
+    /**
+     * @return The wrapped PoolSubpage instance, otherwise return null.
+     */
+    PoolSubpage<T> getPoolSubpage();
+
+    /**
+     * @return The wrapped PoolChunk instance, or the wrapped PoolSubpage instance's parent PoolChunk instance.
+     */
+    PoolChunk<T> getPoolChunk();
+}

--- a/buffer/src/main/java/io/netty/buffer/PoolSubpage.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolSubpage.java
@@ -23,7 +23,7 @@ import static io.netty.buffer.PoolChunk.SIZE_SHIFT;
 import static io.netty.buffer.PoolChunk.IS_USED_SHIFT;
 import static io.netty.buffer.PoolChunk.IS_SUBPAGE_SHIFT;
 
-final class PoolSubpage<T> implements PoolSubpageMetric {
+final class PoolSubpage<T> implements PoolSubpageMetric, PoolChunkSubPageWrapper<T> {
 
     final PoolChunk<T> chunk;
     final int elemSize;
@@ -278,5 +278,15 @@ final class PoolSubpage<T> implements PoolSubpageMetric {
 
     void unlock() {
         lock.unlock();
+    }
+
+    @Override
+    public PoolSubpage<T> getPoolSubpage() {
+        return this;
+    }
+
+    @Override
+    public PoolChunk<T> getPoolChunk() {
+        return this.chunk;
     }
 }

--- a/buffer/src/main/java/io/netty/buffer/PoolSubpage.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolSubpage.java
@@ -330,8 +330,7 @@ final class PoolSubpage<T> implements PoolSubpageMetric, PoolChunkSubPageWrapper
             // It's the head.
             return false;
         }
-        PoolSubpage<T> head = chunk.arena.smallSubpagePools[headIndex];
-        assert head.lock.isHeldByCurrentThread();
+        assert chunk.arena.smallSubpagePools[headIndex].lock.isHeldByCurrentThread();
         return numAvail > 0 && doNotDestroy;
     }
 

--- a/buffer/src/main/java/io/netty/buffer/PoolSubpage.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolSubpage.java
@@ -322,12 +322,10 @@ final class PoolSubpage<T> implements PoolSubpageMetric, PoolChunkSubPageWrapper
 
     /**
      * The head subpage's lock must be held by current thread before call this method.
-     * @return true if the first subpage of the pool is not null, and 'numAvail' > 0, and 'doNotDestroy' is true.
-     *         otherwise return false.
      */
     boolean isPoolAllocatable(PoolSubpage<T> head) {
         assert head.lock.isHeldByCurrentThread();
-        return head.next != null && head.next.numAvail > 0 && head.next.doNotDestroy;
+        return head.next != head && head.next.numAvail > 0 && head.next.doNotDestroy;
     }
 
     void destroy() {

--- a/buffer/src/main/java/io/netty/buffer/PoolSubpage.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolSubpage.java
@@ -132,16 +132,17 @@ final class PoolSubpage<T> implements PoolSubpageMetric, PoolChunkSubPageWrapper
         setNextAvail(bitmapIdx);
 
         numAvail ++;
-        // If this subpage's state is valid('doNotDestroy' is true).
-        if (doNotDestroy) {
-            // If this subpage changed from full to non-full('numAvail' is 1),
-            if (1 == numAvail) {
+        // If this subpage's state is valid('doNotDestroy' is true),
+        // and this subpage changed from full to non-full('numAvail' is 1),
+        if (doNotDestroy && numAvail == 1) {
+            if (maxNumElems > 1 || !head.next.isAllocatable()) {
                 moveToFirst(head);
-            }
-            // If it is not empty: maxNumElems > numAvail.
-            if (maxNumElems > numAvail) {
                 return true;
             }
+            // Remove this subpage from the pool.
+            doNotDestroy = false;
+            removeFromPool();
+            return false;
         }
         // If this subpage becomes empty.
         if (numAvail == maxNumElems) {

--- a/buffer/src/main/java/io/netty/buffer/PoolSubpage.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolSubpage.java
@@ -101,6 +101,7 @@ final class PoolSubpage<T> implements PoolSubpageMetric, PoolChunkSubPageWrapper
             // Mark the 'doNotDestroy' as false to prohibit subsequent allocation from this subpage.
             doNotDestroy = false;
             // Move this subpage to tail.
+            // We do not remove this subpage from pool, because it may still have other elements in use.
             moveToTail(this.prev);
             throw new AssertionError("No next available bitmap index found (bitmapIdx = " + bitmapIdx + "), " +
                     "even though there are supposed to be (numAvail = " + numAvail + ") " +

--- a/buffer/src/main/java/io/netty/buffer/PoolSubpage.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolSubpage.java
@@ -149,8 +149,6 @@ final class PoolSubpage<T> implements PoolSubpageMetric, PoolChunkSubPageWrapper
         next = head.next;
         next.prev = this;
         head.next = this;
-        // Make the subpage link as a ring.
-        head.prev = head.prev == head ? this : head.prev;
     }
 
     private void moveToTail(PoolSubpage<T> head) {
@@ -171,7 +169,7 @@ final class PoolSubpage<T> implements PoolSubpageMetric, PoolChunkSubPageWrapper
 
     private void moveToFirst(PoolSubpage<T> head) {
         // If already on first.
-        if (head.next == this) {
+        if (prev == head) {
             return;
         }
         assert prev != null && next != null;

--- a/buffer/src/main/java/io/netty/buffer/PoolSubpage.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolSubpage.java
@@ -320,7 +320,7 @@ final class PoolSubpage<T> implements PoolSubpageMetric, PoolChunkSubPageWrapper
         }
     }
 
-    boolean isAllocatable() {
+    boolean isPoolAllocatable() {
         final PoolSubpage<T> head;
         if (chunk == null) {
             // It's the head.

--- a/buffer/src/main/java/io/netty/buffer/PoolSubpage.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolSubpage.java
@@ -131,7 +131,7 @@ final class PoolSubpage<T> implements PoolSubpageMetric, PoolChunkSubPageWrapper
         setNextAvail(bitmapIdx);
 
         numAvail ++;
-        // If this subpage's status is valid('doNotDestroy' is true).
+        // If this subpage's state is valid('doNotDestroy' is true).
         if (doNotDestroy) {
             // If this subpage changed from full to non-full('numAvail' is 1),
             // and it is not empty: maxNumElems > numAvail.
@@ -142,7 +142,7 @@ final class PoolSubpage<T> implements PoolSubpageMetric, PoolChunkSubPageWrapper
         }
         // If this subpage becomes empty.
         if (numAvail == maxNumElems) {
-            // If this subpage's status is valid('doNotDestroy' is true),
+            // If this subpage's state is valid('doNotDestroy' is true),
             // and it's the only one left in the pool,
             if (doNotDestroy && prev == next) {
                 // Do not remove this subpage from the pool.

--- a/buffer/src/main/java/io/netty/buffer/PoolSubpage.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolSubpage.java
@@ -136,9 +136,10 @@ final class PoolSubpage<T> implements PoolSubpageMetric, PoolChunkSubPageWrapper
                 // Do not remove if this subpage is the only one left in the pool.
                 return true;
             }
-            // Remove this subpage from the pool if there are other subpages left in the pool.
             doNotDestroy = false;
-            removeFromPool(head);
+            // Remove this subpage from the pool if there are other subpages left in the pool.
+            // This subpage will be GC-ed, and we should not use it anymore.
+            removeFromPool();
             return false;
         }
     }
@@ -181,7 +182,7 @@ final class PoolSubpage<T> implements PoolSubpageMetric, PoolChunkSubPageWrapper
         head.next = this;
     }
 
-    private void removeFromPool(PoolSubpage<T> head) {
+    private void removeFromPool() {
         // Assert current subpage is not the only one in the pool.
         assert prev != null && next != null;
         prev.next = next;

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
@@ -176,7 +176,6 @@ abstract class PooledByteBuf<T> extends AbstractReferenceCountedByteBuf {
             PoolChunk<T> chunk = chunkOrSub.getPoolChunk();
             chunk.arena.free(chunk, tmpNioBuf, handle, maxLength, cache, chunkOrSub.getPoolSubpage());
             tmpNioBuf = null;
-            chunk = null;
             cache = null;
             this.recyclerHandle.unguardedRecycle(this);
         }

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
@@ -176,6 +176,7 @@ abstract class PooledByteBuf<T> extends AbstractReferenceCountedByteBuf {
             PoolChunk<T> chunk = chunkOrSub.getPoolChunk();
             chunk.arena.free(chunk, tmpNioBuf, handle, maxLength, cache, chunkOrSub.getPoolSubpage());
             tmpNioBuf = null;
+            chunkOrSub = null;
             cache = null;
             this.recyclerHandle.unguardedRecycle(this);
         }

--- a/buffer/src/main/java/io/netty/buffer/PooledUnsafeDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledUnsafeDirectByteBuf.java
@@ -48,9 +48,9 @@ final class PooledUnsafeDirectByteBuf extends PooledByteBuf<ByteBuffer> {
     }
 
     @Override
-    void init(PoolChunk<ByteBuffer> chunk, ByteBuffer nioBuffer,
+    void init(PoolChunkSubPageWrapper<ByteBuffer> chunkOrSub, ByteBuffer nioBuffer,
               long handle, int offset, int length, int maxLength, PoolThreadCache cache) {
-        super.init(chunk, nioBuffer, handle, offset, length, maxLength, cache);
+        super.init(chunkOrSub, nioBuffer, handle, offset, length, maxLength, cache);
         initMemoryAddress();
     }
 

--- a/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
@@ -152,7 +152,7 @@ public class PoolArenaTest {
         // This causes the internal reused ByteBuffer duplicate limit to be set to 128
         pooledDst.writeBytes(ByteBuffer.allocate(128));
         // Ensure internal ByteBuffer duplicate limit is properly reset (used in memoryCopy non-Unsafe case)
-        pooledDst.chunk.arena.memoryCopy(pooledSrc.memory, 0, pooledDst, 512);
+        pooledDst.chunkOrSub.getPoolChunk().arena.memoryCopy(pooledSrc.memory, 0, pooledDst, 512);
 
         src.release();
         dst.release();

--- a/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
@@ -688,7 +688,7 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
         for (int i = 0; i < length; i++) {
             byteBufs[i] = allocator.heapBuffer(elemSize, elemSize);
         }
-        PoolChunk<Object> chunk = unwrapIfNeeded(byteBufs[0]).chunk;
+        PoolChunk<Object> chunk = unwrapIfNeeded(byteBufs[0]).chunkOrSub.getPoolChunk();
 
         int beforeFreeBytes = chunk.freeBytes();
         for (int i = 0; i < length; i++) {


### PR DESCRIPTION
Motivation:

Every time we new a `PoolChunk` instance, it will also new a `PoolSubpage` array: `new PoolSubpage[chunkSize >> pageShifts]`, this will consume considerable memory even though this array is not used yet at all. 

For example, for the `PooledByteBufAllocator.DEFAULT` allocator, the size of the `PoolSubpage` array is 512 per `PoolChunk` on my laptop, which means it will consume 512 * 64 = 32768 bytes per `PoolChunk`.

The `PoolSubpage` array in every `PoolChunk` is mainly used for `byteBuf` releasing, to locate the `byteBuf`'s corresponding `PoolSubpage` instance.

We can store the `PoolSubpage` reference inside `byteBuf`, just like the `chunk` field in `byteBuf`, but we do not want to introduce one more reference field into `byteBuf`, so we can let the `chunk` field play both as `PoolSubpage`/`PoolChunk`.

To make this happen, we let the `PoolSubpage` and `PoolChunk` implement a new `PoolChunkSubPageWrapper` interface.

Each `PoolSubpage` pool is a doubly circular link list:

<img width="1188" alt="sub-5" src="https://github.com/netty/netty/assets/29225782/0a4e7b91-af4f-4bc4-b2ca-d66507fc690d">


 After this PR:
1. When doing the byteBuf allocation, always allocate at the first subpage, if there is no first subpage or the first subpage is not allocatable, then create a new subpage and add it to the first; if the first subpage becomes full after allocation, then move it to the tail.
2. When doing the byteBuf de-allocation, after de-allocation, if the subpage becomes not full, then move this subpage to the first, if the subpage becomes empty and its next subpage is allocatable, then remove this subpage from the list and it will be GC'ed.

Result:

Remove `PoolSubpage` array from `PoolChunk` to reduce memory footprint.
