### PR TITLE
Add javadoc for `ProxyHandler` and its implementations

### DIFF
--- a/handler-proxy/src/main/java/io/netty/handler/proxy/HttpProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/handler/proxy/HttpProxyHandler.java
@@ -42,6 +42,15 @@ import io.netty.util.internal.ObjectUtil;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 
+/**
+ * Handler that establishes a blind forwarding proxy tunnel using
+ * <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.6">HTTP/1.1 CONNECT</a> request. It can be used to
+ * establish plaintext or secure tunnels.
+ * <p>
+ * HTTP users who need to connect to a
+ * <a href="https://datatracker.ietf.org/doc/html/rfc7230#page-10">message-forwarding HTTP proxy agent</a> instead of a
+ * tunneling proxy should not use this handler.
+ */
 public final class HttpProxyHandler extends ProxyHandler {
 
     private static final String PROTOCOL = "http";

--- a/handler-proxy/src/main/java/io/netty/handler/proxy/ProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/handler/proxy/ProxyHandler.java
@@ -35,6 +35,9 @@ import java.net.SocketAddress;
 import java.nio.channels.ConnectionPendingException;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * A common abstraction for protocols that establish blind forwarding proxy tunnels.
+ */
 public abstract class ProxyHandler extends ChannelDuplexHandler {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(ProxyHandler.class);

--- a/handler-proxy/src/main/java/io/netty/handler/proxy/Socks4ProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/handler/proxy/Socks4ProxyHandler.java
@@ -28,6 +28,10 @@ import io.netty.handler.codec.socksx.v4.Socks4CommandType;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 
+/**
+ * Handler that establishes a blind forwarding proxy tunnel using
+ * <a href="https://www.openssh.com/txt/socks4.protocol">SOCKS4</a> protocol.
+ */
 public final class Socks4ProxyHandler extends ProxyHandler {
 
     private static final String PROTOCOL = "socks4";

--- a/handler-proxy/src/main/java/io/netty/handler/proxy/Socks5ProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/handler/proxy/Socks5ProxyHandler.java
@@ -42,6 +42,10 @@ import java.net.SocketAddress;
 import java.util.Arrays;
 import java.util.Collections;
 
+/**
+ * Handler that establishes a blind forwarding proxy tunnel using
+ * <a href="https://www.rfc-editor.org/rfc/rfc1928">SOCKS Protocol Version 5</a>.
+ */
 public final class Socks5ProxyHandler extends ProxyHandler {
 
     private static final String PROTOCOL = "socks5";


### PR DESCRIPTION
Motivation:

Clarify purpose of `ProxyHandler`, `HttpProxyHandler`, `Socks4ProxyHandler`, and `Socks5ProxyHandler`.
