### PR TITLE
`DefaultDnsCache`: apply `MAX_SUPPORTED_TTL_SECS` cap for `negativeTtl`

### DIFF
--- a/resolver-dns/src/main/java/io/netty5/resolver/dns/DefaultDnsCache.java
+++ b/resolver-dns/src/main/java/io/netty5/resolver/dns/DefaultDnsCache.java
@@ -84,7 +84,7 @@ public class DefaultDnsCache implements DnsCache {
             throw new IllegalArgumentException(
                     "minTtl: " + minTtl + ", maxTtl: " + maxTtl + " (expected: 0 <= minTtl <= maxTtl)");
         }
-        this.negativeTtl = checkPositiveOrZero(negativeTtl, "negativeTtl");
+        this.negativeTtl = Math.min(Cache.MAX_SUPPORTED_TTL_SECS, checkPositiveOrZero(negativeTtl, "negativeTtl"));
     }
 
     /**


### PR DESCRIPTION
Motivation:

`DefaultDnsCache` already applies `MAX_SUPPORTED_TTL_SECS` as a cap for `minTtl`/`maxTtl`, but does not apply it for `negativeTtl` that may suffer from the same problem of scheduling tasks with too big delay on the `EventLoop`. See

https://github.com/netty/netty/commit/b47fb817991b42ec8808c7d26538f3f2464e1fa6

Modifications:

- Apply `MAX_SUPPORTED_TTL_SECS` cap for `negativeTtl` in ctor;

Result:

`negativeTtl` is capped by `MAX_SUPPORTED_TTL_SECS`.

---

Cherry-pick of #13637 for main branch.
