### PR TITLE
Enable build with JDK21 (#13627)

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -220,9 +220,9 @@ jobs:
           - setup: linux-x86_64-java17
             docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-7.117.yaml build"
             docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-7.117.yaml run build-leak"
-          - setup: linux-x86_64-java20
-            docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.20.yaml build"
-            docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.20.yaml run build-leak"
+          - setup: linux-x86_64-java21
+            docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.21.yaml build"
+            docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.21.yaml run build-leak"
           - setup: linux-x86_64-java11-boringssl
             docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.111.yaml build"
             docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.111.yaml run build-leak-boringssl-static"

--- a/buffer-memory-segment/pom.xml
+++ b/buffer-memory-segment/pom.xml
@@ -33,9 +33,9 @@
   <properties>
     <javaModuleName>io.netty5.buffer.memseg</javaModuleName>
     <!-- Java version for bytecode compatibility. -->
-    <java.compatibility>20</java.compatibility>
+    <java.compatibility>21</java.compatibility>
     <!-- Java version actually used to perform the build; compiling and testing. -->
-    <java.version>20</java.version>
+    <java.version>21</java.version>
     <surefire.version>3.0.0-M5</surefire.version>
     <jmh.version>1.33</jmh.version>
   </properties>

--- a/buffer-memory-segment/src/main/java/io/netty5/buffer/memseg/MemSegBuffer.java
+++ b/buffer-memory-segment/src/main/java/io/netty5/buffer/memseg/MemSegBuffer.java
@@ -49,25 +49,25 @@ import static io.netty5.util.internal.PlatformDependent.roundToPowerOfTwo;
 class MemSegBuffer extends AdaptableBuffer<MemSegBuffer>
         implements BufferComponent, ComponentIterator<MemSegBuffer>, ComponentIterator.Next {
     private static final ValueLayout.OfByte JAVA_BYTE =
-            ValueLayout.JAVA_BYTE.withOrder(ByteOrder.BIG_ENDIAN).withBitAlignment(Byte.SIZE);
+            ValueLayout.JAVA_BYTE.withOrder(ByteOrder.BIG_ENDIAN).withByteAlignment(Byte.BYTES);
     private static final ValueLayout.OfChar JAVA_CHAR =
-            ValueLayout.JAVA_CHAR.withOrder(ByteOrder.BIG_ENDIAN).withBitAlignment(Byte.SIZE);
+            ValueLayout.JAVA_CHAR.withOrder(ByteOrder.BIG_ENDIAN).withByteAlignment(Byte.BYTES);
     private static final ValueLayout.OfShort JAVA_SHORT =
-            ValueLayout.JAVA_SHORT.withOrder(ByteOrder.BIG_ENDIAN).withBitAlignment(Byte.SIZE);
+            ValueLayout.JAVA_SHORT.withOrder(ByteOrder.BIG_ENDIAN).withByteAlignment(Byte.BYTES);
     private static final ValueLayout.OfInt JAVA_INT =
-            ValueLayout.JAVA_INT.withOrder(ByteOrder.BIG_ENDIAN).withBitAlignment(Byte.SIZE);
+            ValueLayout.JAVA_INT.withOrder(ByteOrder.BIG_ENDIAN).withByteAlignment(Byte.BYTES);
     private static final ValueLayout.OfFloat JAVA_FLOAT =
-            ValueLayout.JAVA_FLOAT.withOrder(ByteOrder.BIG_ENDIAN).withBitAlignment(Byte.SIZE);
+            ValueLayout.JAVA_FLOAT.withOrder(ByteOrder.BIG_ENDIAN).withByteAlignment(Byte.BYTES);
     private static final ValueLayout.OfLong JAVA_LONG =
-            ValueLayout.JAVA_LONG.withOrder(ByteOrder.BIG_ENDIAN).withBitAlignment(Byte.SIZE);
+            ValueLayout.JAVA_LONG.withOrder(ByteOrder.BIG_ENDIAN).withByteAlignment(Byte.BYTES);
     private static final ValueLayout.OfDouble JAVA_DOUBLE =
-            ValueLayout.JAVA_DOUBLE.withOrder(ByteOrder.BIG_ENDIAN).withBitAlignment(Byte.SIZE);
+            ValueLayout.JAVA_DOUBLE.withOrder(ByteOrder.BIG_ENDIAN).withByteAlignment(Byte.BYTES);
 
     private static final MemorySegment CLOSED_SEGMENT;
 
     static {
-        try (Arena arena = Arena.openShared()) {
-            CLOSED_SEGMENT = MemorySegment.allocateNative(0, arena.scope());
+        try (Arena arena = Arena.ofShared()) {
+            CLOSED_SEGMENT = arena.allocate(0);
         }
     }
 

--- a/buffer-memory-segment/src/main/java/io/netty5/buffer/memseg/SegmentMemoryManager.java
+++ b/buffer-memory-segment/src/main/java/io/netty5/buffer/memseg/SegmentMemoryManager.java
@@ -39,9 +39,9 @@ public class SegmentMemoryManager implements MemoryManager {
 
     private static Buffer createNativeBuffer(
             long size, Function<Drop<Buffer>, Drop<Buffer>> adaptor, AllocatorControl control) {
-        Arena arena = Arena.openShared();
+        Arena arena = Arena.ofShared();
         InternalBufferUtils.MEM_USAGE_NATIVE.add(size);
-        var segment = MemorySegment.allocateNative(size, arena.scope());
+        var segment = arena.allocate(size);
         var drop = adaptor.apply(drop(arena, size));
         return createBuffer(segment, drop, control);
     }

--- a/buffer-memory-segment/src/test/java/io/netty5/buffer/memseg/benchmarks/MemorySegmentCloseBenchmark.java
+++ b/buffer-memory-segment/src/test/java/io/netty5/buffer/memseg/benchmarks/MemorySegmentCloseBenchmark.java
@@ -67,15 +67,15 @@ public class MemorySegmentCloseBenchmark {
 
     @Benchmark
     public MemorySegment nativeConfined() {
-        try (Arena arena = Arena.openConfined()) {
-            return MemorySegment.allocateNative(size, arena.scope());
+        try (Arena arena = Arena.ofConfined()) {
+            return arena.allocate(size);
         }
     }
 
     @Benchmark
     public MemorySegment nativeShared() {
-        try (Arena arena = Arena.openShared()) {
-            return MemorySegment.allocateNative(size, arena.scope());
+        try (Arena arena = Arena.ofShared()) {
+            return arena.allocate(size);
         }
     }
 }

--- a/docker/Dockerfile.panama_foreign
+++ b/docker/Dockerfile.panama_foreign
@@ -12,7 +12,7 @@ RUN yum install -y alsa-lib-devel cups-devel fontconfig-devel libXtst-devel libX
 # Downloading and installing SDKMAN!
 RUN curl -s  "https://get.sdkman.io" | bash
 
-ENV BOOTSTRAP_JAVA 20.0.1-zulu
+ENV BOOTSTRAP_JAVA 21-zulu
 
 # Installing Java removing some unnecessary SDKMAN files
 RUN bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && \

--- a/docker/docker-compose.centos-6.21.yaml
+++ b/docker/docker-compose.centos-6.21.yaml
@@ -1,0 +1,24 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: netty:centos-6-21
+    build:
+      args:
+        java_version : "21-zulu"
+
+  build:
+    image: netty:centos-6-21
+
+  build-leak:
+    image: netty:centos-6-21
+
+  build-boringssl-static:
+    image: netty:centos-6-21
+
+  build-leak-boringssl-static:
+    image: netty:centos-6-21
+
+  shell:
+    image: netty:centos-6-21

--- a/pom.xml
+++ b/pom.xml
@@ -217,6 +217,23 @@
       </properties>
     </profile>
     <profile>
+      <id>java20</id>
+      <activation>
+        <jdk>20</jdk>
+      </activation>
+      <properties>
+        <!-- Not use alpn agent as Java11+ supports alpn out of the box -->
+        <argLine.alpnAgent />
+        <argLine.java9.extras />
+        <!-- Export some stuff which is used during our tests -->
+        <argLine.java9>--illegal-access=deny ${argLine.java9.extras}</argLine.java9>
+        <forbiddenapis.skip>true</forbiddenapis.skip>
+        <!-- pax-exam does not work on latest Java12 EA 22 build -->
+        <skipOsgiTestsuite>true</skipOsgiTestsuite>
+        <revapi.skip>true</revapi.skip>
+      </properties>
+    </profile>
+    <profile>
       <id>java19</id>
       <activation>
         <jdk>19</jdk>

--- a/pom.xml
+++ b/pom.xml
@@ -217,26 +217,6 @@
       </properties>
     </profile>
     <profile>
-      <id>java20</id>
-      <activation>
-        <jdk>20</jdk>
-      </activation>
-      <modules>
-        <module>buffer-memory-segment</module>
-      </modules>
-      <properties>
-        <!-- Not use alpn agent as Java11+ supports alpn out of the box -->
-        <argLine.alpnAgent />
-        <argLine.java9.extras />
-        <!-- Export some stuff which is used during our tests -->
-        <argLine.java9>--illegal-access=deny ${argLine.java9.extras}</argLine.java9>
-        <forbiddenapis.skip>true</forbiddenapis.skip>
-        <!-- pax-exam does not work on latest Java12 EA 22 build -->
-        <skipOsgiTestsuite>true</skipOsgiTestsuite>
-        <revapi.skip>true</revapi.skip>
-      </properties>
-    </profile>
-    <profile>
       <id>java19</id>
       <activation>
         <jdk>19</jdk>

--- a/transport-blockhound-tests/pom.xml
+++ b/transport-blockhound-tests/pom.xml
@@ -104,6 +104,15 @@
         <argLine.common>-XX:+AllowRedefinitionToAddDeleteMethods</argLine.common>
       </properties>
     </profile>
+    <profile>
+      <id>java21</id>
+      <activation>
+        <jdk>21</jdk>
+      </activation>
+      <properties>
+        <argLine.common>-XX:+AllowRedefinitionToAddDeleteMethods</argLine.common>
+      </properties>
+    </profile>
   </profiles>
 
   <properties>


### PR DESCRIPTION
Motivation:

Now that JDK21 is released we should also build with it on our CI

Modifications:

Add docker-compose config for JDK21 and use it in the PR workflow

Result:

Test with latest LTS release
