### PR TITLE
Fix issue with unrecognized JVM option while running with Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -631,7 +631,7 @@
       -dsa -da -ea:io.netty...
       -XX:+HeapDumpOnOutOfMemoryError
     </argLine.common>
-    <argLine.jni>-D</argLine.jni>
+    <argLine.jni>-D_</argLine.jni>
     <!-- Default to ALPN. See forcenpn profile to force NPN -->
     <argLine.alpnAgent>-javaagent:${jetty.alpnAgent.path}=${jetty.alpnAgent.option}</argLine.alpnAgent>
     <argLine.leak>-D_</argLine.leak> <!-- Overridden when 'leak' profile is active -->


### PR DESCRIPTION
Motivation:

While running with Java 11, hit the following issue
```
# Created at 2023-10-03T16:18:21.784
JVMJ9VM007E Command-line option unrecognised: -D

# Created at 2023-10-03T16:18:21.786
Error: Could not create the Java Virtual Machine.

# Created at 2023-10-03T16:18:21.786
Error: A fatal exception has occurred. Program will exit.
```

Modification:

Update pom.xml to change new JVM option to default to -D_

Result:

Runs now don't hit this issue on JDKs other than 21
