### PR TITLE
Automatically close `Http2StreamChannel` when `Http2FrameStreamExcept…

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexHandler.java
@@ -47,7 +47,7 @@ import static io.netty.handler.codec.http2.Http2Exception.connectionError;
  * An HTTP/2 handler that creates child channels for each stream. This handler must be used in combination
  * with {@link Http2FrameCodec}.
  *
- * <p>When a new stream is created, a new {@link Channel} is created for it. Applications send and
+ * <p>When a new stream is created, a new {@link Http2StreamChannel} is created for it. Applications send and
  * receive {@link Http2StreamFrame}s on the created channel. {@link ByteBuf}s cannot be processed by the channel;
  * all writes that reach the head of the pipeline must be an instance of {@link Http2StreamFrame}. Writes that reach
  * the head of the pipeline are processed directly by this handler and cannot be intercepted.
@@ -71,7 +71,7 @@ import static io.netty.handler.codec.http2.Http2Exception.connectionError;
  * reference counted objects (e.g. {@link ByteBuf}s). The multiplex codec will call {@link ReferenceCounted#retain()}
  * before propagating a reference counted object through the pipeline, and thus an application handler needs to release
  * such an object after having consumed it. For more information on reference counting take a look at
- * https://netty.io/wiki/reference-counted-objects.html
+ * <a href="https://netty.io/wiki/reference-counted-objects.html">the reference counted docs.</a>
  *
  * <h3>Channel Events</h3>
  *
@@ -88,6 +88,14 @@ import static io.netty.handler.codec.http2.Http2Exception.connectionError;
  * window. {@link ChannelHandler}s are free to ignore the channel's writability, in which case the excessive writes will
  * be buffered by the parent channel. It's important to note that only {@link Http2DataFrame}s are subject to
  * HTTP/2 flow control.
+ *
+ * <h3>Closing a {@link Http2StreamChannel}</h3>
+ *
+ * Once you close a {@link Http2StreamChannel} a {@link Http2ResetFrame} will be send to the remote peer with
+ * {@link Http2Error#CANCEL} if needed. If you want to close the stream with another {@link Http2Error} (due
+ * errors / limits) you should propagate a {@link Http2FrameStreamException} through the {@link ChannelPipeline}.
+ * Once it reaches the end of the {@link ChannelPipeline} it will automatically close the {@link Http2StreamChannel}
+ * and send a {@link Http2ResetFrame} with the unwrapped {@link Http2Error} set.
  */
 @UnstableApi
 public final class Http2MultiplexHandler extends Http2ChannelDuplexHandler {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexHandler.java
@@ -91,11 +91,12 @@ import static io.netty.handler.codec.http2.Http2Exception.connectionError;
  *
  * <h3>Closing a {@link Http2StreamChannel}</h3>
  *
- * Once you close a {@link Http2StreamChannel} a {@link Http2ResetFrame} will be send to the remote peer with
+ * Once you close a {@link Http2StreamChannel} a {@link Http2ResetFrame} will be sent to the remote peer with
  * {@link Http2Error#CANCEL} if needed. If you want to close the stream with another {@link Http2Error} (due
  * errors / limits) you should propagate a {@link Http2FrameStreamException} through the {@link ChannelPipeline}.
  * Once it reaches the end of the {@link ChannelPipeline} it will automatically close the {@link Http2StreamChannel}
- * and send a {@link Http2ResetFrame} with the unwrapped {@link Http2Error} set.
+ * and send a {@link Http2ResetFrame} with the unwrapped {@link Http2Error} set. Another possibility is to just
+ * directly write a {@link Http2ResetFrame} to the {@link Http2StreamChannel}l.
  */
 @UnstableApi
 public final class Http2MultiplexHandler extends Http2ChannelDuplexHandler {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
@@ -364,6 +364,17 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
     }
 
     @Test
+    public void streamExceptionCauseRstStreamWithProtocolError() {
+        request.addLong(HttpHeaderNames.CONTENT_LENGTH, 10);
+        Http2StreamChannel channel = newInboundStream(3, false, new ChannelInboundHandlerAdapter());
+        channel.pipeline().fireExceptionCaught(new Http2FrameStreamException(channel.stream(),
+                Http2Error.PROTOCOL_ERROR, new IllegalArgumentException()));
+        assertFalse(channel.isActive());
+        verify(frameWriter).writeRstStream(eqCodecCtx(), eq(3),
+                eq(Http2Error.PROTOCOL_ERROR.code()), anyChannelPromise());
+    }
+
+    @Test
     public void contentLengthNotMatchRstStreamWithProtocolError() {
         final LastInboundHandler inboundHandler = new LastInboundHandler();
         request.addLong(HttpHeaderNames.CONTENT_LENGTH, 10);


### PR DESCRIPTION
…ion` reaches end of `ChannelPipeline`

Motivation:

Sometimes the end-user might want to do extra validation and so reset a stream with a specific `Http2Error`.

Modifications:

Unwrap `Http2Error` and use it to close the `Http2StreamChannel` if it reaches the end of the `ChannelPipeline`

Result:

More flexible handling for `Http2ResetFrame`s.
