### PR TITLE
Support DTLS headers when parsing encrypted packet lengths #2

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -73,6 +73,7 @@ import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLSession;
 
 import static io.netty.buffer.ByteBufUtil.ensureWritableSuccess;
+import static io.netty.handler.ssl.SslUtils.NOT_ENOUGH_DATA;
 import static io.netty.handler.ssl.SslUtils.getEncryptedPacketLength;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
@@ -1318,6 +1319,9 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
                 setHandshakeFailure(ctx, e);
 
                 throw e;
+            }
+            if (packetLength == NOT_ENOUGH_DATA) {
+                return;
             }
             assert packetLength > 0;
             if (packetLength > readableBytes) {

--- a/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
@@ -56,6 +56,11 @@ final class SslUtils {
                           "TLS_AES_128_GCM_SHA256", "TLS_AES_128_CCM_8_SHA256",
                           "TLS_AES_128_CCM_SHA256")));
 
+    static final short DTLS_1_0 = (short) 0xFEFF;
+    static final short DTLS_1_2 = (short) 0xFEFD;
+    static final short DTLS_1_3 = (short) 0xFEFC;
+    static final short DTLS_RECORD_HEADER_LENGTH = 13;
+
     /**
      * GMSSL Protocol Version
      */
@@ -293,6 +298,7 @@ final class SslUtils {
         if (tls) {
             // SSLv3 or TLS or GMSSLv1.0 or GMSSLv1.1 - Check ProtocolVersion
             int majorVersion = buffer.getUnsignedByte(offset + 1);
+            int version = buffer.getShort(offset + 1);
             if (majorVersion == 3 || buffer.getShort(offset + 1) == GMSSL_PROTOCOL_VERSION) {
                 // SSLv3 or TLS or GMSSLv1.0 or GMSSLv1.1
                 packetLength = unsignedShortBE(buffer, offset + 3) + SSL_RECORD_HEADER_LENGTH;
@@ -300,6 +306,9 @@ final class SslUtils {
                     // Neither SSLv3 or TLSv1 (i.e. SSLv2 or bad data)
                     tls = false;
                 }
+            } else if (version == DTLS_1_0 || version == DTLS_1_2 || version == DTLS_1_3) {
+                // length is the last 2 bytes in the 13 byte header. 13 - 2 = 11
+                packetLength = unsignedShortBE(buffer, offset + 11) + DTLS_RECORD_HEADER_LENGTH;
             } else {
                 // Neither SSLv3 or TLSv1 (i.e. SSLv2 or bad data)
                 tls = false;

--- a/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
@@ -299,7 +299,7 @@ final class SslUtils {
             // SSLv3 or TLS or GMSSLv1.0 or GMSSLv1.1 - Check ProtocolVersion
             int majorVersion = buffer.getUnsignedByte(offset + 1);
             int version = buffer.getShort(offset + 1);
-            if (majorVersion == 3 || buffer.getShort(offset + 1) == GMSSL_PROTOCOL_VERSION) {
+            if (majorVersion == 3 || version == GMSSL_PROTOCOL_VERSION) {
                 // SSLv3 or TLS or GMSSLv1.0 or GMSSLv1.1
                 packetLength = unsignedShortBE(buffer, offset + 3) + SSL_RECORD_HEADER_LENGTH;
                 if (packetLength <= SSL_RECORD_HEADER_LENGTH) {

--- a/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
@@ -265,17 +265,12 @@ final class SslUtils {
      * the readerIndex of the given {@link ByteBuf}.
      *
      * @param   buffer
-     *                  The {@link ByteBuf} to read from. Be aware that it must have at least
-     *                  {@link #SSL_RECORD_HEADER_LENGTH} bytes to read,
-     *                  otherwise it will throw an {@link IllegalArgumentException}.
+     *                  The {@link ByteBuf} to read from.
      * @return length
      *                  The length of the encrypted packet that is included in the buffer or
      *                  {@link #SslUtils#NOT_ENOUGH_DATA} if not enough data is present in the
      *                  {@link ByteBuf}. This will return {@link SslUtils#NOT_ENCRYPTED} if
      *                  the given {@link ByteBuf} is not encrypted at all.
-     * @throws IllegalArgumentException
-     *                  Is thrown if the given {@link ByteBuf} has not at least {@link #SSL_RECORD_HEADER_LENGTH}
-     *                  bytes to read.
      */
     static int getEncryptedPacketLength(ByteBuf buffer, int offset) {
         int packetLength = 0;
@@ -310,8 +305,9 @@ final class SslUtils {
                 if (buffer.readableBytes() < offset + DTLS_RECORD_HEADER_LENGTH) {
                     return NOT_ENOUGH_DATA;
                 }
-                // length is the last 2 bytes in the 13 byte header. 13 - 2 = 11
-                packetLength = unsignedShortBE(buffer, offset + 11) + DTLS_RECORD_HEADER_LENGTH;
+                // length is the last 2 bytes in the 13 byte header.
+                packetLength = unsignedShortBE(buffer, offset + DTLS_RECORD_HEADER_LENGTH - 2) +
+                        DTLS_RECORD_HEADER_LENGTH;
             } else {
                 // Neither SSLv3 or TLSv1 (i.e. SSLv2 or bad data)
                 tls = false;

--- a/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
@@ -307,6 +307,9 @@ final class SslUtils {
                     tls = false;
                 }
             } else if (version == DTLS_1_0 || version == DTLS_1_2 || version == DTLS_1_3) {
+                if (buffer.readableBytes() < offset + DTLS_RECORD_HEADER_LENGTH) {
+                    return NOT_ENOUGH_DATA;
+                }
                 // length is the last 2 bytes in the 13 byte header. 13 - 2 = 11
                 packetLength = unsignedShortBE(buffer, offset + 11) + DTLS_RECORD_HEADER_LENGTH;
             } else {

--- a/handler/src/test/java/io/netty/handler/ssl/SslUtilsTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslUtilsTest.java
@@ -18,6 +18,8 @@ package io.netty.handler.ssl;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
@@ -26,6 +28,9 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.security.NoSuchAlgorithmException;
 
+import static io.netty.handler.ssl.SslUtils.DTLS_1_0;
+import static io.netty.handler.ssl.SslUtils.DTLS_1_2;
+import static io.netty.handler.ssl.SslUtils.DTLS_1_3;
 import static io.netty.handler.ssl.SslUtils.getEncryptedPacketLength;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -98,6 +103,45 @@ public class SslUtilsTest {
 
         int packetLength = getEncryptedPacketLength(new ByteBuffer[] { buf.nioBuffer() }, 0);
         assertEquals(bodyLength + SslUtils.SSL_RECORD_HEADER_LENGTH, packetLength);
+        buf.release();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {DTLS_1_0, DTLS_1_2, DTLS_1_3}) // six numbers
+    public void shouldGetPacketLengthOfDtlsProtocolFromByteBuf(int dtlsVersion) {
+        int bodyLength = 65;
+        ByteBuf buf = Unpooled.buffer()
+                .writeByte(SslUtils.SSL_CONTENT_TYPE_HANDSHAKE)
+                .writeShort(dtlsVersion)
+                .writeShort(0) // epoch
+                .writeBytes(new byte[6]) // sequence number
+                .writeShort(bodyLength);
+
+        int packetLength = getEncryptedPacketLength(buf, 0);
+        assertEquals(bodyLength + SslUtils.DTLS_RECORD_HEADER_LENGTH, packetLength);
+        buf.release();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {DTLS_1_0, DTLS_1_2, DTLS_1_3}) // six numbers
+    public void shouldGetPacketLengthOfMultipleDtlsFromByteBuf(int dtlsVersion) {
+        int bodyLength = 65;
+        ByteBuf buf = Unpooled.buffer()
+                .writeByte(SslUtils.SSL_CONTENT_TYPE_HANDSHAKE)
+                .writeShort(dtlsVersion)
+                .writeShort(0) // epoch
+                .writeBytes(new byte[6]) // sequence number
+                .writeShort(bodyLength)
+                .writeBytes(new byte[65])
+                .writeByte(SslUtils.SSL_CONTENT_TYPE_HANDSHAKE)
+                .writeShort(dtlsVersion)
+                .writeShort(0) // epoch
+                .writeBytes(new byte[6]) // sequence number
+                .writeShort(bodyLength)
+                .writeBytes(new byte[65]);
+
+        int packetLength = getEncryptedPacketLength(buf, 0);
+        assertEquals((bodyLength + SslUtils.DTLS_RECORD_HEADER_LENGTH) * 2, packetLength);
         buf.release();
     }
 


### PR DESCRIPTION
Motivation:

Supporting DTLS headers allows users to use a DTLS SSLContext to build a SSLEngine for a SslHandler. There are probably more changes that need to be added to handle edge cases in DTLS, but this appears to work and starts the process of supporting DTLS.

Modifications:

Checks for the DTLS version after failing to find the TLS version. If DTLS version is found, we read the length of each DTLS record until there are no more records.

Result:

Users can create a SslHandler with a DTLS SSLContext and connect to a simple server using DTLS.


While trying to update this PR, I seem to have broken the previous PR. Sorry about that. I hate branches and tried to just amend the commit instead of needing a merge branch. Turns out that was not a good idea with github lol.