### PR TITLE
Only enable the RST limit for servers by default

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2ConnectionHandlerBuilder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2ConnectionHandlerBuilder.java
@@ -77,6 +77,8 @@ public abstract class AbstractHttp2ConnectionHandlerBuilder<T extends Http2Conne
 
     private static final SensitivityDetector DEFAULT_HEADER_SENSITIVITY_DETECTOR = Http2HeadersEncoder.NEVER_SENSITIVE;
 
+    private static final int DEFAULT_MAX_RST_FRAMES_PER_CONNECTION_FOR_SERVER = 200;
+
     // The properties that can always be set.
     private Http2Settings initialSettings = Http2Settings.defaultSettings();
     private Http2FrameListener frameListener;
@@ -109,7 +111,7 @@ public abstract class AbstractHttp2ConnectionHandlerBuilder<T extends Http2Conne
     private boolean autoAckPingFrame = true;
     private int maxQueuedControlFrames = Http2CodecUtil.DEFAULT_MAX_QUEUED_CONTROL_FRAMES;
     private int maxConsecutiveEmptyFrames = 2;
-    private int maxRstFramesPerWindow = 200;
+    private Integer maxRstFramesPerWindow;
     private int secondsPerWindow = 30;
 
     /**
@@ -592,7 +594,18 @@ public abstract class AbstractHttp2ConnectionHandlerBuilder<T extends Http2Conne
         if (maxConsecutiveEmptyDataFrames > 0) {
             decoder = new Http2EmptyDataFrameConnectionDecoder(decoder, maxConsecutiveEmptyDataFrames);
         }
-        if (maxRstFramesPerWindow > 0 && secondsPerWindow > 0) {
+        final int maxRstFrames;
+        if (maxRstFramesPerWindow == null) {
+            // Only enable by default on the server.
+            if (isServer()) {
+                maxRstFrames = DEFAULT_MAX_RST_FRAMES_PER_CONNECTION_FOR_SERVER;
+            } else {
+                maxRstFrames = 0;
+            }
+        } else {
+            maxRstFrames = maxRstFramesPerWindow;
+        }
+        if (maxRstFrames > 0 && secondsPerWindow > 0) {
             decoder = new Http2MaxRstFrameDecoder(decoder, maxRstFramesPerWindow, secondsPerWindow);
         }
         final T handler;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2ConnectionHandlerBuilder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2ConnectionHandlerBuilder.java
@@ -606,7 +606,7 @@ public abstract class AbstractHttp2ConnectionHandlerBuilder<T extends Http2Conne
             maxRstFrames = maxRstFramesPerWindow;
         }
         if (maxRstFrames > 0 && secondsPerWindow > 0) {
-            decoder = new Http2MaxRstFrameDecoder(decoder, maxRstFramesPerWindow, secondsPerWindow);
+            decoder = new Http2MaxRstFrameDecoder(decoder, maxRstFrames, secondsPerWindow);
         }
         final T handler;
         try {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodecBuilder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodecBuilder.java
@@ -196,8 +196,8 @@ public class Http2FrameCodecBuilder extends
 
     @Override
     public Http2FrameCodecBuilder decoderEnforceMaxRstFramesPerWindow(
-            int maxConsecutiveEmptyFrames, int secondsPerWindow) {
-        return super.decoderEnforceMaxRstFramesPerWindow(maxConsecutiveEmptyFrames, secondsPerWindow);
+            int maxRstFramesPerWindow, int secondsPerWindow) {
+        return super.decoderEnforceMaxRstFramesPerWindow(maxRstFramesPerWindow, secondsPerWindow);
     }
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodecBuilder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodecBuilder.java
@@ -213,8 +213,8 @@ public class Http2MultiplexCodecBuilder
 
     @Override
     public Http2MultiplexCodecBuilder decoderEnforceMaxRstFramesPerWindow(
-            int maxConsecutiveEmptyFrames, int secondsPerWindow) {
-        return super.decoderEnforceMaxRstFramesPerWindow(maxConsecutiveEmptyFrames, secondsPerWindow);
+            int maxRstFramesPerWindow, int secondsPerWindow) {
+        return super.decoderEnforceMaxRstFramesPerWindow(maxRstFramesPerWindow, secondsPerWindow);
     }
 
     @Override


### PR DESCRIPTION
Motivation:

We dont need to limit the number of RST frames per connection when we are bulding a codec for the client side.

Modifications:

Dont limit the numbers of RST frames per connection when building a codec for the client side.

Result:

Only add limit where needed
