### PR TITLE
Change default value of MAX_MESSAGES_PER_READ for DatagramChannel imp…

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -54,7 +54,7 @@ import static io.netty.channel.epoll.LinuxSocket.newSocketDgram;
  * maximal performance.
  */
 public final class EpollDatagramChannel extends AbstractEpollChannel implements DatagramChannel {
-    private static final ChannelMetadata METADATA = new ChannelMetadata(true);
+    private static final ChannelMetadata METADATA = new ChannelMetadata(true, 16);
     private static final String EXPECTED_TYPES =
             " (expected: " + StringUtil.simpleClassName(DatagramPacket.class) + ", " +
             StringUtil.simpleClassName(AddressedEnvelope.class) + '<' +

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueDatagramChannel.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 
 abstract class AbstractKQueueDatagramChannel extends AbstractKQueueChannel {
 
-    private static final ChannelMetadata METADATA = new ChannelMetadata(true);
+    private static final ChannelMetadata METADATA = new ChannelMetadata(true, 16);
 
     AbstractKQueueDatagramChannel(Channel parent, BsdSocket fd, boolean active) {
         super(parent, fd, active);

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
@@ -65,7 +65,7 @@ import java.util.Map;
 public final class NioDatagramChannel
         extends AbstractNioMessageChannel implements io.netty.channel.socket.DatagramChannel {
 
-    private static final ChannelMetadata METADATA = new ChannelMetadata(true);
+    private static final ChannelMetadata METADATA = new ChannelMetadata(true, 16);
     private static final SelectorProvider DEFAULT_SELECTOR_PROVIDER = SelectorProvider.provider();
     private static final String EXPECTED_TYPES =
             " (expected: " + StringUtil.simpleClassName(DatagramPacket.class) + ", " +


### PR DESCRIPTION
…lementations

Motivation:

All our DatagramChannel implementations used a MAX_MESSAGES_PER_READ of 1 due the fact of how they used the ChannelMetaData constructor. This makes no sense and hurts performance a lot as it will basically result in have fireChannelRead(...) only called once and then direct fireChannelReadComplete(...).

For example in a QUIC benchmark I did observe receiving a 1 GB file did take 14 seconds. After chaning the default to 16 (which is also what other Channels use) this dropped to 6 seconds for the specific benchmark.

Modifications:

Use a default of 16 messages per read when using DatagramChannels

Result:

Better performance with default settings