### PR TITLE
Also set MAX_MESSAGES_PER_READ to 16 by default in EpollDomainDatagra…

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainDatagramChannel.java
@@ -44,7 +44,7 @@ import static io.netty.channel.epoll.LinuxSocket.newSocketDomainDgram;
 @UnstableApi
 public final class EpollDomainDatagramChannel extends AbstractEpollChannel implements DomainDatagramChannel {
 
-    private static final ChannelMetadata METADATA = new ChannelMetadata(true);
+    private static final ChannelMetadata METADATA = new ChannelMetadata(true, 16);
 
     private static final String EXPECTED_TYPES =
             " (expected: " +


### PR DESCRIPTION
…mChannel

Motivation:

7800070656daf4728a91ce3d527651334d0c7745 did changed the default MAX_MESSAGES_PER_READ to 16 for various DatagramChannel implementations. Unfortunally I missed EpollDomainDatagramChannel.

Modifications:

Also change EpollDomainDatagramChannel

Result:

Consistent default value