### PR TITLE
Change the default value of maxMessagePerRead to 16 in ChannelMetadata

### DIFF
--- a/transport/src/main/java/io/netty/channel/ChannelMetadata.java
+++ b/transport/src/main/java/io/netty/channel/ChannelMetadata.java
@@ -35,7 +35,7 @@ public final class ChannelMetadata {
      *                          again, such as UDP/IP.
      */
     public ChannelMetadata(boolean hasDisconnect) {
-        this(hasDisconnect, 1);
+        this(hasDisconnect, 16);
     }
 
     /**


### PR DESCRIPTION
Motivation:

We used 1 as the default value for maxMessagesPerRead in ChannelMetadata which is a very bad default for performance reasons. Because of this we usually explicit use 16 when constructing it. To eliminate problems when we forgot to do so let's use 16 as default.

Modifications:

Change default to 16

Result:

Better performance by default
