### PR TITLE
Fix datagram channel to correctly handle non blocking reading

### DIFF
--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioDatagramChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioDatagramChannel.java
@@ -393,7 +393,7 @@ public final class NioDatagramChannel
             }
             if (remoteAddress == null) {
                 readSink.processRead(attemptedBytesRead, 0, null);
-                return -1;
+                return 0;
             }
             data.skipWritableBytes(actualBytesRead);
             readSink.processRead(attemptedBytesRead, actualBytesRead,


### PR DESCRIPTION
Motivation:

We had a bug in how we signaled back that there are no more dtagrams to read, which did cause the NioDatagramChannel to be closed

Modifications:

Correctly return 0

Result:

Correctly handle non-blocking reading