### PR TITLE
Bump Brotli4j to v1.13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -666,7 +666,7 @@
     <skipAutobahnTestsuite>false</skipAutobahnTestsuite>
     <skipHttp2Testsuite>false</skipHttp2Testsuite>
     <graalvm.version>19.3.6</graalvm.version>
-    <brotli4j.version>1.12.0</brotli4j.version>
+    <brotli4j.version>1.13.0</brotli4j.version>
     <!-- By default skip native testsuite as it requires a custom environment with graalvm installed -->
     <skipNativeImageTestsuite>true</skipNativeImageTestsuite>
     <skipShadingTestsuite>false</skipShadingTestsuite>


### PR DESCRIPTION
Motivation:

Brotli4j v1.13.0 is out and we should upgrade to it.

Modification:

Update latest Brotli4j

Result:

Latest Brotli4j version
