### PR TITLE
Fix bug in the IOUringHandler where events can be written to a close event file descriptor

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/IOUringHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/IOUringHandler.java
@@ -51,6 +51,7 @@ final class IOUringHandler implements IoHandler, CompletionCallback {
     private final long eventfdReadBuf;
     private long eventfdReadSubmitted;
 
+    private boolean eventFdClosing;
     private volatile boolean shuttingDown;
     private boolean closeCompleted;
 
@@ -149,7 +150,7 @@ final class IOUringHandler implements IoHandler, CompletionCallback {
 
     private void handleEventFdRead() {
         eventfdReadSubmitted = 0;
-        if (!shuttingDown) {
+        if (!eventFdClosing) {
             eventfdAsyncNotify.set(false);
             submitEventFdRead();
         }
@@ -168,7 +169,6 @@ final class IOUringHandler implements IoHandler, CompletionCallback {
     @Override
     public void prepareToDestroy() {
         shuttingDown = true;
-        drainEventFd();
         CompletionQueue completionQueue = ringBuffer.ioUringCompletionQueue();
         SubmissionQueue submissionQueue = ringBuffer.ioUringSubmissionQueue();
         AbstractIOUringChannel<?>[] chs = channels.values().toArray(AbstractIOUringChannel[]::new);
@@ -191,10 +191,7 @@ final class IOUringHandler implements IoHandler, CompletionCallback {
     public void destroy() {
         SubmissionQueue submissionQueue = ringBuffer.ioUringSubmissionQueue();
         CompletionQueue completionQueue = ringBuffer.ioUringCompletionQueue();
-        if (eventfdReadSubmitted != 0) {
-            submissionQueue.addCancel(eventfd.intValue(), eventfdReadSubmitted);
-            eventfdReadSubmitted = 0;
-        }
+        drainEventFd();
         if (submissionQueue.remaining() < 2) {
             // We need to submit 2 linked operations. Since they are linked, we cannot allow a submit-call to
             // separate them. We don't have enough room (< 2) in the queue, so we submit now to make more room.
@@ -208,9 +205,7 @@ final class IOUringHandler implements IoHandler, CompletionCallback {
         submissionQueue.addLinkTimeout(ringBuffer.fd(), TimeUnit.MILLISECONDS.toNanos(200), (short) 0);
         submissionQueue.submitAndWait();
         completionQueue.process(this);
-        if (!closeCompleted) {
-            completeRingClose();
-        }
+        completeRingClose();
     }
 
     // We need to prevent the race condition where a wakeup event is submitted to a file descriptor that has
@@ -218,42 +213,52 @@ final class IOUringHandler implements IoHandler, CompletionCallback {
     // `eventfdAsyncNotify` flag we can close the gate but may need to read any outstanding events that have
     // (or will) be written.
     private void drainEventFd() {
-        assert shuttingDown;
-        boolean eventPending = eventfdAsyncNotify.getAndSet(true);
-        if (!eventPending) {
-            // No event pending so nothing to do.
-            return;
-        }
-        // We must wait for the event.
         CompletionQueue completionQueue = ringBuffer.ioUringCompletionQueue();
         SubmissionQueue submissionQueue = ringBuffer.ioUringSubmissionQueue();
-        // Make sure we're actually listening for writes to the event fd.
-        while (eventfdReadSubmitted == 0) {
-            submitEventFdRead();
-            submissionQueue.submit();
-        }
-        // Now drain the eventfd read.
-        class DrainFdEventCallback implements CompletionCallback {
-            boolean eventFdDrained;
-            @Override
-            public void handle(int fd, int res, int flags, long udata) {
-                if (fd == eventfd.intValue()) {
-                    eventFdDrained = true;
+        assert !eventFdClosing;
+        eventFdClosing = true;
+        boolean eventPending = eventfdAsyncNotify.getAndSet(true);
+        if (eventPending) {
+            // There is an event that has been or will be written by another thread, so we must wait for the event.
+            // Make sure we're actually listening for writes to the event fd.
+            while (eventfdReadSubmitted == 0) {
+                submitEventFdRead();
+                submissionQueue.submit();
+            }
+            // Drain the eventfd of the pending wakup.
+            class DrainFdEventCallback implements CompletionCallback {
+                boolean eventFdDrained;
+
+                @Override
+                public void handle(int fd, int res, int flags, long udata) {
+                    if (fd == eventfd.intValue()) {
+                        eventFdDrained = true;
+                    }
+                    IOUringHandler.this.handle(fd, res, flags, udata);
                 }
-                IOUringHandler.this.handle(fd, res, flags, udata);
+            }
+            final DrainFdEventCallback handler = new DrainFdEventCallback();
+            completionQueue.process(handler);
+            while (!handler.eventFdDrained) {
+                submissionQueue.submitAndWait();
+                completionQueue.process(handler);
             }
         }
-        final DrainFdEventCallback handler = new DrainFdEventCallback();
-        completionQueue.process(handler);
-        while (!handler.eventFdDrained) {
-            submissionQueue.submitAndWait();
-            completionQueue.process(handler);
-        }
-        // We've consumed the pending eventfd read and `eventfdAsyncNotify` should never
+        // We've consumed any pending eventfd read and `eventfdAsyncNotify` should never
         // transition back to false, thus we should never have any more events written.
+        // So, if we have a read event pending, we can cancel it.
+        if (eventfdReadSubmitted != 0) {
+            submissionQueue.addCancel(eventfd.intValue(), eventfdReadSubmitted);
+            eventfdReadSubmitted = 0;
+            submissionQueue.submit();
+        }
     }
 
     private void completeRingClose() {
+        if (closeCompleted) {
+            // already done.
+            return;
+        }
         closeCompleted = true;
         ringBuffer.close();
         try {

--- a/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/IOUringHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/IOUringHandler.java
@@ -218,6 +218,7 @@ final class IOUringHandler implements IoHandler, CompletionCallback {
     // `eventfdAsyncNotify` flag we can close the gate but may need to read any outstanding events that have
     // (or will) be written.
     private void drainEventFd() {
+        assert shuttingDown;
         boolean eventPending = eventfdAsyncNotify.getAndSet(true);
         if (!eventPending) {
             // No event pending so nothing to do.


### PR DESCRIPTION
Motivation:

It's possible for the event FD to be released an
yet have a new submission write to the FD, which
may be reallocated by the OS in the meantime.

Modifications:

- Properly shutdown the wakeup pathway and drain any pending/future writes to the event fd.

Result:

An IOUring event loop will no longer be able to
(wrongly) write an event to a fd which has already been closed, and potentially reallocated.

## Testing

Without the changes the `shutdownNotSoGracefully` test fails with
```
[ERROR] shutdownNotSoGracefully[21]  Time elapsed: 0.015 s  <<< ERROR!
io.netty5.channel.ChannelException: eventfd_write(...) failed: Bad file descriptor
	at io.netty5.channel.uring.Native.eventFdWrite(Native Method)
	at io.netty5.channel.uring.IOUringHandler.wakeup(IOUringHandler.java:269)
	at io.netty5.channel.SingleThreadEventLoop.wakeup(SingleThreadEventLoop.java:256)
	at io.netty5.util.concurrent.SingleThreadEventExecutor.shutdownGracefully(SingleThreadEventExecutor.java:553)
	at io.netty5.util.concurrent.MultithreadEventExecutorGroup.shutdownGracefully(MultithreadEventExecutorGroup.java:228)
	at io.netty5.channel.uring.IOUringEventLoopTest.shutdownNotSoGracefully(IOUringEventLoopTest.java:75)
	at jdk.internal.reflect.GeneratedMethodAccessor1.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
```
 but seem to succeed after many retries with the patch.
