### PR TITLE
Adds topicFilter method to MqttTopicSubscription and deprecate topicName

### DIFF
--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttTopicSubscription.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttTopicSubscription.java
@@ -37,7 +37,15 @@ public final class MqttTopicSubscription {
         this.option = option;
     }
 
+    /**
+     * @deprecated use topicFilter
+     * */
+    @Deprecated
     public String topicName() {
+        return topicFilter;
+    }
+
+    public String topicFilter() {
         return topicFilter;
     }
 


### PR DESCRIPTION
Motivation:

MQTT specification when refers to subscriptions always speak about topic filters. Topic filters are string (like topic names) but that could contain wildcard characters to subscribe to multiple topic names.
Topic names are used only during the publish request.

Modification:

This PR deprecates the existing topicName and adds topicFilter because it's more adherent to MQTT specification jargon.


Result:

Fixes #<GitHub issue number>. 

If there is no issue then describe the changes introduced by this PR.
