### PR TITLE
Optimize time wheel algorithm

### DIFF
--- a/common/src/main/java/io/netty5/util/HashedWheelTimer.java
+++ b/common/src/main/java/io/netty5/util/HashedWheelTimer.java
@@ -343,11 +343,13 @@ public class HashedWheelTimer implements Timer {
     }
 
     private static int normalizeTicksPerWheel(int ticksPerWheel) {
-        int normalizedTicksPerWheel = 1;
-        while (normalizedTicksPerWheel < ticksPerWheel) {
-            normalizedTicksPerWheel <<= 1;
-        }
-        return normalizedTicksPerWheel;
+        int n = ticksPerWheel - 1;
+        n |= n >>> 1;
+        n |= n >>> 2;
+        n |= n >>> 4;
+        n |= n >>> 8;
+        n |= n >>> 16;
+        return (n < 0) ? 1 : (n >= 1073741824) ? 1073741824 : n + 1;
     }
 
     /**


### PR DESCRIPTION
Motivation:

In HashedWheelTimer.normalizeTicksPerWheel, The inefficiency problem caused by multiple loops may occur in the time wheel algorithm

Modification:

Fixed calculation process to avoid low efficiency in multiple loops

Result:

optimize HashedWheelTimer.normalizeTicksPerWheel
