### PR TITLE
Lazily allocate ChunkedWriteHandler#queue

### DIFF
--- a/handler/src/main/java/io/netty/handler/stream/ChunkedWriteHandler.java
+++ b/handler/src/main/java/io/netty/handler/stream/ChunkedWriteHandler.java
@@ -251,13 +251,9 @@ public class ChunkedWriteHandler extends ChannelDuplexHandler {
                 try {
                     message = chunks.readChunk(allocator);
                     endOfInput = chunks.isEndOfInput();
+                    // No need to suspend when reached at the end.
+                    suspend = message == null && !endOfInput;
 
-                    if (message == null) {
-                        // No need to suspend when reached at the end.
-                        suspend = !endOfInput;
-                    } else {
-                        suspend = false;
-                    }
                 } catch (final Throwable t) {
                     queue.remove();
 

--- a/handler/src/main/java/io/netty/handler/stream/ChunkedWriteHandler.java
+++ b/handler/src/main/java/io/netty/handler/stream/ChunkedWriteHandler.java
@@ -183,9 +183,7 @@ public class ChunkedWriteHandler extends ChannelDuplexHandler {
                 } catch (Exception e) {
                     closeInput(in);
                     currentWrite.fail(e);
-                    if (logger.isWarnEnabled()) {
-                        logger.warn(ChunkedInput.class.getSimpleName() + " failed", e);
-                    }
+                    logger.warn("ChunkedInput failed", e);
                     continue;
                 }
 
@@ -363,9 +361,7 @@ public class ChunkedWriteHandler extends ChannelDuplexHandler {
         try {
             chunks.close();
         } catch (Throwable t) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("Failed to close a chunked input.", t);
-            }
+            logger.warn("Failed to close a ChunkedInput.", t);
         }
     }
 

--- a/handler/src/main/java/io/netty/handler/stream/ChunkedWriteHandler.java
+++ b/handler/src/main/java/io/netty/handler/stream/ChunkedWriteHandler.java
@@ -72,7 +72,7 @@ public class ChunkedWriteHandler extends ChannelDuplexHandler {
     private static final InternalLogger logger =
         InternalLoggerFactory.getInstance(ChunkedWriteHandler.class);
 
-    private Queue<PendingWrite> queue = null;
+    private Queue<PendingWrite> queue;
     private volatile ChannelHandlerContext ctx;
 
     public ChunkedWriteHandler() {
@@ -229,7 +229,7 @@ public class ChunkedWriteHandler extends ChannelDuplexHandler {
 
             if (currentWrite.promise.isDone()) {
                 // This might happen e.g. in the case when a write operation
-                // failed, but there're still unconsumed chunks left.
+                // failed, but there are still unconsumed chunks left.
                 // Most chunked input sources would stop generating chunks
                 // and report end of input, but this doesn't work with any
                 // source wrapped in HttpChunkedInput.
@@ -296,7 +296,7 @@ public class ChunkedWriteHandler extends ChannelDuplexHandler {
                     } else {
                         // Register a listener which will close the input once the write is complete.
                         // This is needed because the Chunk may have some resource bound that can not
-                        // be closed before its not written.
+                        // be closed before it's not written.
                         //
                         // See https://github.com/netty/netty/issues/303
                         f.addListener(new ChannelFutureListener() {


### PR DESCRIPTION
Motivation:

When building an HTTP client, a `ChunkedWriteHandler` might be added to the pipeline just in case a `ChunkedInput` might be written, but that might never happen.
In this case, we don't need the extra queue allocation and ChunkedWriteHandler should just behave as a pass-through.

Modifications:

* lazily initialize the queue
* bypass work when the queue is empty