### PR TITLE
Deprecate disabling HTTP header validation

### DIFF
--- a/codec-http/src/main/java/io/netty5/handler/codec/http/DefaultFullHttpRequest.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/DefaultFullHttpRequest.java
@@ -17,9 +17,13 @@ package io.netty5.handler.codec.http;
 
 import io.netty5.buffer.Buffer;
 import io.netty5.buffer.BufferClosedException;
+import io.netty5.handler.codec.http.headers.DefaultHttpHeadersFactory;
 import io.netty5.handler.codec.http.headers.HttpHeaders;
+import io.netty5.handler.codec.http.headers.HttpHeadersFactory;
 import io.netty5.util.Send;
 
+import static io.netty5.handler.codec.http.headers.DefaultHttpHeadersFactory.headersFactory;
+import static io.netty5.handler.codec.http.headers.DefaultHttpHeadersFactory.trailersFactory;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -34,17 +38,30 @@ public class DefaultFullHttpRequest extends DefaultHttpRequest implements FullHt
      */
     private int hash;
 
+    /**
+     * Create a full HTTP response with the given HTTP version, method, URI, and contents.
+     */
     public DefaultFullHttpRequest(HttpVersion httpVersion, HttpMethod method, String uri, Buffer payload) {
-        this(httpVersion, method, uri, payload, true);
+        this(httpVersion, method, uri, payload, headersFactory(), trailersFactory());
     }
 
-    public DefaultFullHttpRequest(HttpVersion httpVersion, HttpMethod method, String uri,
-                                  Buffer payload, boolean validateHeaders) {
-        super(httpVersion, method, uri, validateHeaders);
+    /**
+     * Create a full HTTP response with the given HTTP version, method, URI, contents,
+     * and factories for creating headers and trailers.
+     * <p>
+     * The recommended default header factory is {@link DefaultHttpHeadersFactory#headersFactory()},
+     * and the recommended default trailer factory is {@link DefaultHttpHeadersFactory#trailersFactory()}.
+     */
+    public DefaultFullHttpRequest(HttpVersion httpVersion, HttpMethod method, String uri, Buffer payload,
+                                  HttpHeadersFactory headersFactory, HttpHeadersFactory trailersFactory) {
+        super(httpVersion, method, uri, headersFactory);
         this.payload = requireNonNull(payload, "payload");
-        trailingHeader = HttpHeaders.newHeaders(validateHeaders);
+        trailingHeader = trailersFactory.newHeaders();
     }
 
+    /**
+     * Create a full HTTP response with the given HTTP version, method, URI, contents, and header and trailer objects.
+     */
     public DefaultFullHttpRequest(HttpVersion httpVersion, HttpMethod method, String uri,
                                   Buffer payload, HttpHeaders headers, HttpHeaders trailingHeader) {
         super(httpVersion, method, uri, headers);

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/DefaultFullHttpResponse.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/DefaultFullHttpResponse.java
@@ -17,7 +17,9 @@ package io.netty5.handler.codec.http;
 
 import io.netty5.buffer.Buffer;
 import io.netty5.buffer.BufferClosedException;
+import io.netty5.handler.codec.http.headers.DefaultHttpHeadersFactory;
 import io.netty5.handler.codec.http.headers.HttpHeaders;
+import io.netty5.handler.codec.http.headers.HttpHeadersFactory;
 import io.netty5.util.Send;
 
 import static java.util.Objects.requireNonNull;
@@ -35,17 +37,31 @@ public class DefaultFullHttpResponse extends DefaultHttpResponse implements Full
      */
     private int hash;
 
+    /**
+     * Create an HTTP response with the given HTTP version, status, and contents.
+     */
     public DefaultFullHttpResponse(HttpVersion version, HttpResponseStatus status, Buffer payload) {
-        this(version, status, payload, true);
+        this(version, status, payload, DefaultHttpHeadersFactory.headersFactory(),
+                DefaultHttpHeadersFactory.trailersFactory());
     }
 
-    public DefaultFullHttpResponse(HttpVersion version, HttpResponseStatus status,
-                                   Buffer payload, boolean validateHeaders) {
-        super(version, status, validateHeaders);
+    /**
+     * Create an HTTP response with the given HTTP version, status, contents,
+     * and with headers and trailers created by the given header factories.
+     * <p>
+     * The recommended header factory is {@link DefaultHttpHeadersFactory#headersFactory()},
+     * and the recommended trailer factory is {@link DefaultHttpHeadersFactory#trailersFactory()}.
+     */
+    public DefaultFullHttpResponse(HttpVersion version, HttpResponseStatus status, Buffer payload,
+                                   HttpHeadersFactory headersFactory, HttpHeadersFactory trailersFactory) {
+        super(version, status, headersFactory);
         this.payload = requireNonNull(payload, "payload");
-        trailingHeaders = HttpHeaders.newHeaders(validateHeaders);
+        trailingHeaders = trailersFactory.newHeaders();
     }
 
+    /**
+     * Create an HTTP response with the given HTTP version, status, contents, headers and trailers.
+     */
     public DefaultFullHttpResponse(HttpVersion version, HttpResponseStatus status,
                                    Buffer payload, HttpHeaders headers, HttpHeaders trailingHeaders) {
         super(version, status, headers);

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/DefaultHttpMessage.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/DefaultHttpMessage.java
@@ -15,7 +15,9 @@
  */
 package io.netty5.handler.codec.http;
 
+import io.netty5.handler.codec.http.headers.DefaultHttpHeadersFactory;
 import io.netty5.handler.codec.http.headers.HttpHeaders;
+import io.netty5.handler.codec.http.headers.HttpHeadersFactory;
 
 import static java.util.Objects.requireNonNull;
 
@@ -31,14 +33,14 @@ public abstract class DefaultHttpMessage extends DefaultHttpObject implements Ht
      * Creates a new instance.
      */
     protected DefaultHttpMessage(final HttpVersion version) {
-        this(version, true);
+        this(version, DefaultHttpHeadersFactory.headersFactory());
     }
 
     /**
      * Creates a new instance.
      */
-    protected DefaultHttpMessage(final HttpVersion version, boolean validateHeaders) {
-        this(version, HttpHeaders.newHeaders(validateHeaders));
+    protected DefaultHttpMessage(final HttpVersion version, HttpHeadersFactory factory) {
+        this(version, factory.newHeaders());
     }
 
     /**

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/DefaultHttpRequest.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/DefaultHttpRequest.java
@@ -15,7 +15,9 @@
  */
 package io.netty5.handler.codec.http;
 
+import io.netty5.handler.codec.http.headers.DefaultHttpHeadersFactory;
 import io.netty5.handler.codec.http.headers.HttpHeaders;
+import io.netty5.handler.codec.http.headers.HttpHeadersFactory;
 
 import static java.util.Objects.requireNonNull;
 
@@ -35,7 +37,7 @@ public class DefaultHttpRequest extends DefaultHttpMessage implements HttpReques
      * @param uri         the URI or path of the request
      */
     public DefaultHttpRequest(HttpVersion httpVersion, HttpMethod method, String uri) {
-        this(httpVersion, method, uri, true);
+        this(httpVersion, method, uri, DefaultHttpHeadersFactory.headersFactory());
     }
 
     /**
@@ -44,10 +46,11 @@ public class DefaultHttpRequest extends DefaultHttpMessage implements HttpReques
      * @param httpVersion       the HTTP version of the request
      * @param method            the HTTP method of the request
      * @param uri               the URI or path of the request
-     * @param validateHeaders   validate the header names and values when adding them to the {@link HttpHeaders}
+     * @param factory the factory used to create the {@link HttpHeaders}.
+     * The recommended default is {@link DefaultHttpHeadersFactory#headersFactory()}.
      */
-    public DefaultHttpRequest(HttpVersion httpVersion, HttpMethod method, String uri, boolean validateHeaders) {
-        super(httpVersion, validateHeaders);
+    public DefaultHttpRequest(HttpVersion httpVersion, HttpMethod method, String uri, HttpHeadersFactory factory) {
+        super(httpVersion, factory);
         this.method = requireNonNull(method, "method");
         this.uri = requireNonNull(uri, "uri");
     }

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/DefaultHttpResponse.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/DefaultHttpResponse.java
@@ -15,7 +15,9 @@
  */
 package io.netty5.handler.codec.http;
 
+import io.netty5.handler.codec.http.headers.DefaultHttpHeadersFactory;
 import io.netty5.handler.codec.http.headers.HttpHeaders;
+import io.netty5.handler.codec.http.headers.HttpHeadersFactory;
 
 import static java.util.Objects.requireNonNull;
 
@@ -33,7 +35,7 @@ public class DefaultHttpResponse extends DefaultHttpMessage implements HttpRespo
      * @param status  the status of this response
      */
     public DefaultHttpResponse(HttpVersion version, HttpResponseStatus status) {
-        this(version, status, true);
+        this(version, status, DefaultHttpHeadersFactory.headersFactory());
     }
 
     /**
@@ -41,10 +43,11 @@ public class DefaultHttpResponse extends DefaultHttpMessage implements HttpRespo
      *
      * @param version           the HTTP version of this response
      * @param status            the status of this response
-     * @param validateHeaders   validate the header names and values when adding them to the {@link HttpHeaders}
+     * @param factory the factory used to create the {@link HttpHeaders}.
+     * The recommended default is {@link DefaultHttpHeadersFactory#headersFactory()}.
      */
-    public DefaultHttpResponse(HttpVersion version, HttpResponseStatus status, boolean validateHeaders) {
-        super(version, validateHeaders);
+    public DefaultHttpResponse(HttpVersion version, HttpResponseStatus status, HttpHeadersFactory factory) {
+        super(version, factory);
         this.status = requireNonNull(status, "status");
     }
 

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/HttpDecoderConfig.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/HttpDecoderConfig.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.handler.codec.http;
+
+import io.netty5.handler.codec.http.headers.DefaultHttpHeadersFactory;
+import io.netty5.handler.codec.http.headers.HttpHeadersFactory;
+
+import static io.netty5.util.internal.ObjectUtil.checkPositive;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A configuration object for specifying the behaviour of {@link HttpObjectDecoder} and its subclasses.
+ * <p>
+ * The {@link HttpDecoderConfig} objects are mutable to reduce allocation,
+ * but also {@link Cloneable} in case a defensive copy is needed.
+ */
+public class HttpDecoderConfig implements Cloneable {
+    private boolean chunkedSupported = HttpObjectDecoder.DEFAULT_CHUNKED_SUPPORTED;
+    private HttpHeadersFactory headersFactory = DefaultHttpHeadersFactory.headersFactory();
+    private HttpHeadersFactory trailersFactory = DefaultHttpHeadersFactory.trailersFactory();
+    private boolean allowDuplicateContentLengths = HttpObjectDecoder.DEFAULT_ALLOW_DUPLICATE_CONTENT_LENGTHS;
+    private int maxInitialLineLength = HttpObjectDecoder.DEFAULT_MAX_INITIAL_LINE_LENGTH;
+    private int maxHeaderSize = HttpObjectDecoder.DEFAULT_MAX_HEADER_SIZE;
+    private int initialBufferSize = HttpObjectDecoder.DEFAULT_INITIAL_BUFFER_SIZE;
+
+    public int getInitialBufferSize() {
+        return initialBufferSize;
+    }
+
+    /**
+     * Set the initial size of the temporary buffer used when parsing the lines of the HTTP headers.
+     *
+     * @param initialBufferSize The buffer size in bytes.
+     * @return This decoder config.
+     */
+    public HttpDecoderConfig setInitialBufferSize(int initialBufferSize) {
+        checkPositive(initialBufferSize, "initialBufferSize");
+        this.initialBufferSize = initialBufferSize;
+        return this;
+    }
+
+    public int getMaxInitialLineLength() {
+        return maxInitialLineLength;
+    }
+
+    /**
+     * Set the maximum length of the first line of the HTTP header.
+     * This limits how much memory Netty will use when parsed the initial HTTP header line.
+     * You would typically set this to the same value as {@link #setMaxHeaderSize(int)}.
+     *
+     * @param maxInitialLineLength The maximum length, in bytes.
+     * @return This decoder config.
+     */
+    public HttpDecoderConfig setMaxInitialLineLength(int maxInitialLineLength) {
+        checkPositive(maxInitialLineLength, "maxInitialLineLength");
+        this.maxInitialLineLength = maxInitialLineLength;
+        return this;
+    }
+
+    public int getMaxHeaderSize() {
+        return maxHeaderSize;
+    }
+
+    /**
+     * Set the maximum line length of header lines.
+     * This limits how much memory Netty will use when parsing HTTP header key-value pairs.
+     * You would typically set this to the same value as {@link #setMaxInitialLineLength(int)}.
+     *
+     * @param maxHeaderSize The maximum length, in bytes.
+     * @return This decoder config.
+     */
+    public HttpDecoderConfig setMaxHeaderSize(int maxHeaderSize) {
+        checkPositive(maxHeaderSize, "maxHeaderSize");
+        this.maxHeaderSize = maxHeaderSize;
+        return this;
+    }
+
+    public boolean isChunkedSupported() {
+        return chunkedSupported;
+    }
+
+    /**
+     * Set whether {@code Transfer-Encoding: Chunked} should be supported.
+     *
+     * @param chunkedSupported if {@code false}, then a {@code Transfer-Encoding: Chunked} header will produce an error,
+     * instead of a stream of chunks.
+     * @return This decoder config.
+     */
+    public HttpDecoderConfig setChunkedSupported(boolean chunkedSupported) {
+        this.chunkedSupported = chunkedSupported;
+        return this;
+    }
+
+    public HttpHeadersFactory getHeadersFactory() {
+        return headersFactory;
+    }
+
+    /**
+     * Set the {@link HttpHeadersFactory} to use when creating new HTTP headers objects.
+     * The default headers factory is {@link DefaultHttpHeadersFactory#headersFactory()}.
+     * <p>
+     * For the purpose of {@link #clone()}, it is assumed that the factory is either immutable, or can otherwise be
+     * shared across different decoders and decoder configs.
+     *
+     * @param headersFactory The header factory to use.
+     * @return This decoder config.
+     */
+    public HttpDecoderConfig setHeadersFactory(HttpHeadersFactory headersFactory) {
+        requireNonNull(headersFactory, "headersFactory");
+        this.headersFactory = headersFactory;
+        return this;
+    }
+
+    public boolean isAllowDuplicateContentLengths() {
+        return allowDuplicateContentLengths;
+    }
+
+    /**
+     * Set whether more than one {@code Content-Length} header is allowed.
+     * You usually want to disallow this (which is the default) as multiple {@code Content-Length} headers can indicate
+     * a request- or response-splitting attack.
+     *
+     * @param allowDuplicateContentLengths set to {@code true} to allow multiple content length headers.
+     * @return This decoder config.
+     */
+    public HttpDecoderConfig setAllowDuplicateContentLengths(boolean allowDuplicateContentLengths) {
+        this.allowDuplicateContentLengths = allowDuplicateContentLengths;
+        return this;
+    }
+
+    /**
+     * Set whether header validation should be enabled or not.
+     * This works by changing the configured {@linkplain #setHeadersFactory(HttpHeadersFactory) header factory}
+     * and {@linkplain #setTrailersFactory(HttpHeadersFactory) trailer factory}.
+     * <p>
+     * You usually want header validation enabled (which is the default) in order to prevent request-/response-splitting
+     * attacks.
+     *
+     * @param validateHeaders set to {@code false} to disable header validation.
+     * @return This decoder config.
+     */
+    public HttpDecoderConfig setValidateHeaders(boolean validateHeaders) {
+        headersFactory = withValidation(DefaultHttpHeadersFactory.headersFactory(), validateHeaders);
+        trailersFactory = withValidation(DefaultHttpHeadersFactory.trailersFactory(), validateHeaders);
+        return this;
+    }
+
+    private static HttpHeadersFactory withValidation(DefaultHttpHeadersFactory factory, boolean validateHeaders) {
+        return factory.withNameValidation(validateHeaders)
+                .withValueValidation(validateHeaders)
+                .withCookieValidation(validateHeaders);
+    }
+
+    public HttpHeadersFactory getTrailersFactory() {
+        return trailersFactory;
+    }
+
+    /**
+     * Set the {@link HttpHeadersFactory} used to create HTTP trailers.
+     * This differs from {@link #setHeadersFactory(HttpHeadersFactory)} in that trailers have different validation
+     * requirements.
+     * The default trailer factory is {@link DefaultHttpHeadersFactory#headersFactory()}.
+     * <p>
+     * For the purpose of {@link #clone()}, it is assumed that the factory is either immutable, or can otherwise be
+     * shared across different decoders and decoder configs.
+     *
+     * @param trailersFactory The headers factory to use for creating trailers.
+     * @return This decoder config.
+     */
+    public HttpDecoderConfig setTrailersFactory(HttpHeadersFactory trailersFactory) {
+        requireNonNull(trailersFactory, "trailersFactory");
+        this.trailersFactory = trailersFactory;
+        return this;
+    }
+
+    @Override
+    public HttpDecoderConfig clone() {
+        try {
+            return (HttpDecoderConfig) super.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new AssertionError();
+        }
+    }
+}

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/HttpRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/HttpRequestDecoder.java
@@ -50,13 +50,26 @@ import io.netty5.channel.ChannelPipeline;
  *     after this decoder in the {@link ChannelPipeline}.</td>
  * </tr>
  * </table>
+ *
+ * <h3>Header Validation</h3>
+ *
+ * It is recommended to always enable header validation.
+ * <p>
+ * Without header validation, your system can become vulnerable to
+ * <a href="https://cwe.mitre.org/data/definitions/113.html">
+ *     CWE-113: Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
+ * </a>.
+ * <p>
+ * This recommendation stands even when both peers in the HTTP exchange are trusted,
+ * as it helps with defence-in-depth.
  */
 public class HttpRequestDecoder extends HttpObjectDecoder {
 
     /**
      * Creates a new instance with the default
-     * {@code maxInitialLineLength (4096)}, {@code maxHeaderSize (8192)}, and
-     * {@code maxChunkSize (8192)}.
+     * {@code maxInitialLineLength} ({@value DEFAULT_MAX_INITIAL_LINE_LENGTH}),
+     * {@code maxHeaderSize} ({@value DEFAULT_MAX_HEADER_SIZE}),
+     * and {@code chunkedSupported} ({@value DEFAULT_CHUNKED_SUPPORTED}).
      */
     public HttpRequestDecoder() {
     }
@@ -66,38 +79,30 @@ public class HttpRequestDecoder extends HttpObjectDecoder {
      */
     public HttpRequestDecoder(
             int maxInitialLineLength, int maxHeaderSize) {
-        super(maxInitialLineLength, maxHeaderSize, DEFAULT_CHUNKED_SUPPORTED);
+        super(new HttpDecoderConfig()
+                .setMaxInitialLineLength(maxInitialLineLength)
+                .setMaxHeaderSize(maxHeaderSize));
     }
 
-    public HttpRequestDecoder(
-            int maxInitialLineLength, int maxHeaderSize, boolean validateHeaders) {
-        super(maxInitialLineLength, maxHeaderSize, DEFAULT_CHUNKED_SUPPORTED, validateHeaders);
-    }
-
-    public HttpRequestDecoder(
-            int maxInitialLineLength, int maxHeaderSize, boolean validateHeaders,
-            int initialBufferSize) {
-        super(maxInitialLineLength, maxHeaderSize, DEFAULT_CHUNKED_SUPPORTED, validateHeaders, initialBufferSize);
-    }
-
-    public HttpRequestDecoder(
-            int maxInitialLineLength, int maxHeaderSize, boolean validateHeaders,
-            int initialBufferSize, boolean allowDuplicateContentLengths) {
-        super(maxInitialLineLength, maxHeaderSize, DEFAULT_CHUNKED_SUPPORTED, validateHeaders,
-              initialBufferSize, allowDuplicateContentLengths);
+    /**
+     * Create a new instance with the specified configuration.
+     * @param config The configuration for the request decoder.
+     */
+    public HttpRequestDecoder(HttpDecoderConfig config) {
+        super(config);
     }
 
     @Override
     protected HttpMessage createMessage(String[] initialLine) throws Exception {
         return new DefaultHttpRequest(
                 HttpVersion.valueOf(initialLine[2]),
-                HttpMethod.valueOf(initialLine[0]), initialLine[1], validateHeaders);
+                HttpMethod.valueOf(initialLine[0]), initialLine[1], headersFactory);
     }
 
     @Override
     protected HttpMessage createInvalidMessage(ChannelHandlerContext ctx) {
         return new DefaultFullHttpRequest(HttpVersion.HTTP_1_0, HttpMethod.GET, "/bad-request",
-                ctx.bufferAllocator().allocate(0), validateHeaders);
+                ctx.bufferAllocator().allocate(0), headersFactory, trailersFactory);
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/cors/CorsHandler.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/cors/CorsHandler.java
@@ -24,6 +24,7 @@ import io.netty5.handler.codec.http.HttpHeaderValues;
 import io.netty5.handler.codec.http.HttpRequest;
 import io.netty5.handler.codec.http.HttpResponse;
 import io.netty5.handler.codec.http.HttpUtil;
+import io.netty5.handler.codec.http.headers.DefaultHttpHeadersFactory;
 import io.netty5.handler.codec.http.headers.HttpHeaders;
 import io.netty5.util.AsciiString;
 import io.netty5.util.concurrent.Future;
@@ -99,7 +100,9 @@ public class CorsHandler implements ChannelHandler {
 
     private void handlePreflight(final ChannelHandlerContext ctx, final HttpRequest request) throws Exception {
         final HttpResponse response = new DefaultFullHttpResponse(request.protocolVersion(), OK,
-                ctx.bufferAllocator().allocate(0), true);
+                ctx.bufferAllocator().allocate(0),
+                DefaultHttpHeadersFactory.headersFactory(),
+                DefaultHttpHeadersFactory.trailersFactory());
         if (setOrigin(response)) {
             setAllowMethods(response);
             setAllowHeaders(response);

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/headers/DefaultHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/headers/DefaultHttpHeaders.java
@@ -69,6 +69,15 @@ public class DefaultHttpHeaders extends MultiMap<CharSequence, CharSequence> imp
 
     /**
      * Create a new instance.
+     * <p>
+     * <b>Warning!</b> Setting any of the validation parameters to {@code false} will mean that Netty won't
+     * validate & protect against user-supplied headers that are malicious.
+     * This can leave your server implementation vulnerable to
+     * <a href="https://cwe.mitre.org/data/definitions/113.html">
+     *     CWE-113: Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
+     * </a>.
+     * When disabling this validation, it is the responsibility of the caller to ensure that the values supplied
+     * do not contain a non-url-escaped carriage return (CR) and/or line feed (LF) characters.
      *
      * @param arraySizeHint A hint as to how large the hash data structure should be.
      *                      The next positive power of two will be used. An upper bound may be enforced.
@@ -606,6 +615,22 @@ public class DefaultHttpHeaders extends MultiMap<CharSequence, CharSequence> imp
         }
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * <b>Warning!</b> It is strongly recommended that the name validator implement validation that is at least as
+     * strict as {@link HttpHeaderValidationUtil#validateToken(CharSequence)}.
+     * <p>
+     * Without these validations in place, your code can be susceptible to
+     * <a href="https://cwe.mitre.org/data/definitions/113.html">
+     *     CWE-113: Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
+     * </a>.
+     *
+     * @param name The key which will be inserted.
+     * @param forAdd {@code true} if this validation is for adding to the headers, or {@code false} if this is for
+     * setting (overwriting) the given header.
+     * @return The validated header name.
+     */
     @Override
     protected CharSequence validateKey(@Nullable final CharSequence name, boolean forAdd) {
         if (name == null || name.length() == 0) {
@@ -617,6 +642,21 @@ public class DefaultHttpHeaders extends MultiMap<CharSequence, CharSequence> imp
         return name;
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * <b>Warning!</b> It is strongly recommended that the name validator implement validation that is at least as
+     * strict as {@link HttpHeaderValidationUtil#validateValidHeaderValue(CharSequence)}.
+     * <p>
+     * Without these validations in place, your code can be susceptible to
+     * <a href="https://cwe.mitre.org/data/definitions/113.html">
+     *     CWE-113: Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
+     * </a>.
+     *
+     * @param key The key for which the value is being inserted, for reference.
+     * @param value The value which will be inserted.
+     * @return The validated value.
+     */
     @Override
     protected CharSequence validateValue(CharSequence key, final CharSequence value) {
         if (validateValues) {

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/headers/DefaultHttpHeadersFactory.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/headers/DefaultHttpHeadersFactory.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.handler.codec.http.headers;
+
+import io.netty5.handler.codec.http.HttpHeaderNames;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * A builder of {@link HttpHeadersFactory} instances, that itself implements {@link HttpHeadersFactory}.
+ * The builder is immutable, and every {@code with-} method produce a new, modified instance.
+ * <p>
+ * The default builder you most likely want to start with is {@link DefaultHttpHeadersFactory#headersFactory()}.
+ */
+public final class DefaultHttpHeadersFactory implements HttpHeadersFactory {
+    private static final int SIZE_HINT = 16;
+    private static final DefaultHttpHeadersFactory FOR_HEADER =
+            new DefaultHttpHeadersFactory(SIZE_HINT, true, true, true, false);
+    private static final DefaultHttpHeadersFactory FOR_TRAILER =
+            new DefaultHttpHeadersFactory(SIZE_HINT, true, true, true, true);
+    private static final int MIN_SIZE_HINT = 2;
+
+    private final int sizeHint;
+    private final boolean validateNames;
+    private final boolean validateValues;
+    private final boolean validateCookies;
+    private final boolean validateAsTrailer;
+
+    /**
+     * Create a header factory with the given settings.
+     *
+     * @param sizeHint A hint as to how large the hash data structure should be.
+     * The next positive power of two will be used. An upper bound may be enforced.
+     * @param validateNames {@code true} to validate header names.
+     * @param validateValues {@code true} to validate header values.
+     * @param validateCookies {@code true} to validate cookie contents when parsing.
+     * @param validateAsTrailer {@code true} to do the name validation in a way that's specific to trailers.
+     */
+    private DefaultHttpHeadersFactory(int sizeHint, boolean validateNames, boolean validateValues,
+                                      boolean validateCookies, boolean validateAsTrailer) {
+        this.sizeHint = Math.max(MIN_SIZE_HINT, sizeHint); // Size hint should be at least 2, always.
+        this.validateNames = validateNames;
+        this.validateValues = validateValues;
+        this.validateCookies = validateCookies;
+        this.validateAsTrailer = validateAsTrailer;
+    }
+
+    /**
+     * Get the default implementation of {@link HttpHeadersFactory} for creating headers.
+     * <p>
+     * This {@link DefaultHttpHeadersFactory} creates {@link HttpHeaders} instances that has the
+     * recommended header validation enabled.
+     */
+    public static DefaultHttpHeadersFactory headersFactory() {
+        return FOR_HEADER;
+    }
+
+    /**
+     * Get the implementation of {@link HttpHeadersFactory} for creating trailers for
+     * {@link io.netty5.handler.codec.http.LastHttpContent}.
+     * <p>
+     * This {@link DefaultHttpHeadersFactory} creates {@link HttpHeaders} instances that has the
+     * recommended header validation enabled.
+     */
+    public static DefaultHttpHeadersFactory trailersFactory() {
+        return FOR_TRAILER;
+    }
+
+    @Override
+    public HttpHeaders newHeaders() {
+        if (validateAsTrailer) {
+            return new TrailingHttpHeaders(sizeHint, validateNames, validateCookies, validateValues);
+        }
+        return HttpHeaders.newHeaders(sizeHint, validateNames, validateCookies, validateValues);
+    }
+
+    @Override
+    public HttpHeaders newEmptyHeaders() {
+        if (validateAsTrailer) {
+            return new TrailingHttpHeaders(MIN_SIZE_HINT, validateNames, validateCookies, validateValues);
+        }
+        return HttpHeaders.newHeaders(MIN_SIZE_HINT, validateNames, validateCookies, validateValues);
+    }
+    /**
+     * Create a new factory that has HTTP header name validation enabled or disabled.
+     * <p>
+     * <b>Warning!</b> Setting {@code checkNames} to {@code false} will mean that Netty won't
+     * validate & protect against user-supplied headers that are malicious.
+     * This can leave your server implementation vulnerable to
+     * <a href="https://cwe.mitre.org/data/definitions/113.html">
+     *     CWE-113: Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
+     * </a>.
+     * When disabling this validation, it is the responsibility of the caller to ensure that the values supplied
+     * do not contain a non-url-escaped carriage return (CR) and/or line feed (LF) characters.
+     *
+     * @param validateNames If validation should be enabled or disabled.
+     * @return The new factory.
+     */
+    public DefaultHttpHeadersFactory withNameValidation(boolean validateNames) {
+        if (sizeHint == SIZE_HINT && validateNames && validateValues && validateCookies) {
+            return validateAsTrailer ? FOR_TRAILER : FOR_HEADER;
+        }
+        return new DefaultHttpHeadersFactory(
+                sizeHint, validateNames, validateValues, validateCookies, validateAsTrailer);
+    }
+
+    /**
+     * Create a new factory that has HTTP header value validation enabled or disabled.
+     * <p>
+     * <b>Warning!</b> Setting {@code checkValues} to {@code false} will mean that Netty won't
+     * validate & protect against user-supplied headers that are malicious.
+     * This can leave your server implementation vulnerable to
+     * <a href="https://cwe.mitre.org/data/definitions/113.html">
+     *     CWE-113: Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
+     * </a>.
+     * When disabling this validation, it is the responsibility of the caller to ensure that the values supplied
+     * do not contain a non-url-escaped carriage return (CR) and/or line feed (LF) characters.
+     *
+     * @param validateValues If validation should be enabled or disabled.
+     * @return The new factory.
+     */
+    public DefaultHttpHeadersFactory withValueValidation(boolean validateValues) {
+        if (sizeHint == SIZE_HINT && validateNames && validateValues && validateCookies) {
+            return validateAsTrailer ? FOR_TRAILER : FOR_HEADER;
+        }
+        return new DefaultHttpHeadersFactory(
+                sizeHint, validateNames, validateValues, validateCookies, validateAsTrailer);
+    }
+
+    /**
+     * Create a new factory that has HTTP header value validation enabled or disabled.
+     * <p>
+     * <b>Warning!</b> Setting {@code checkCookies} to {@code false} will mean that Netty won't
+     * validate & protect against user-supplied headers that are malicious.
+     * This can leave your server implementation vulnerable to
+     * <a href="https://cwe.mitre.org/data/definitions/113.html">
+     *     CWE-113: Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
+     * </a>.
+     * When disabling this validation, it is the responsibility of the caller to ensure that the values supplied
+     * do not contain a non-url-escaped carriage return (CR) and/or line feed (LF) characters.
+     *
+     * @param validateCookies If validation should be enabled or disabled.
+     * @return The new factory.
+     */
+    public DefaultHttpHeadersFactory withCookieValidation(boolean validateCookies) {
+        if (sizeHint == SIZE_HINT && validateNames && validateValues && validateCookies) {
+            return validateAsTrailer ? FOR_TRAILER : FOR_HEADER;
+        }
+        return new DefaultHttpHeadersFactory(
+                sizeHint, validateNames, validateValues, validateCookies, validateAsTrailer);
+    }
+
+    /**
+     * Create a new factory that has the given size hint.
+     *
+     * @param sizeHint A hint about the anticipated number of header entries.
+     * @return The new factory.
+     */
+    public DefaultHttpHeadersFactory withSizeHint(int sizeHint) {
+        if (sizeHint == SIZE_HINT && validateNames && validateValues && validateCookies) {
+            return validateAsTrailer ? FOR_TRAILER : FOR_HEADER;
+        }
+        return new DefaultHttpHeadersFactory(
+                sizeHint, validateNames, validateValues, validateCookies, validateAsTrailer);
+    }
+
+    @Override
+    public int getSizeHint() {
+        return sizeHint;
+    }
+
+    @Override
+    public boolean isValidatingNames() {
+        return validateNames;
+    }
+
+    @Override
+    public boolean isValidatingValues() {
+        return validateValues;
+    }
+
+    @Override
+    public boolean isValidatingCookies() {
+        return validateCookies;
+    }
+
+    private static final class TrailingHttpHeaders extends DefaultHttpHeaders {
+        TrailingHttpHeaders(
+                int arraySizeHint, boolean validateNames, boolean validateCookies, boolean validateValues) {
+            super(arraySizeHint, validateNames, validateCookies, validateValues);
+        }
+
+        @Override
+        protected CharSequence validateKey(@Nullable CharSequence name, boolean forAdd) {
+            if (HttpHeaderNames.CONTENT_LENGTH.contentEqualsIgnoreCase(name)
+                    || HttpHeaderNames.TRANSFER_ENCODING.contentEqualsIgnoreCase(name)
+                    || HttpHeaderNames.TRAILER.contentEqualsIgnoreCase(name)) {
+                throw new IllegalArgumentException("Prohibited trailing header: " + name);
+            }
+            return super.validateKey(name, forAdd);
+        }
+    }
+}

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/headers/DefaultHttpSetCookie.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/headers/DefaultHttpSetCookie.java
@@ -198,7 +198,7 @@ public final class DefaultHttpSetCookie implements HttpSetCookie {
                             if (index != -1) {
                                 throw new HeaderValidationException(
                                         "a cookie name can only contain \"token\" characters, " +
-                                        "but found invalid character 0x" + Integer.toHexString(c) +
+                                        "but found invalid character 0x" + toHexString(c) +
                                         " at index " + index + " of header '" + name + "'.");
                             }
                         }

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/headers/HttpHeaders.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/headers/HttpHeaders.java
@@ -44,6 +44,10 @@ import java.util.function.BiFunction;
  * <p>
  * All header field names are compared in a
  * <a href="https://tools.ietf.org/html/rfc7230#section-3.2">case-insensitive manner</a>.
+ * <p>
+ * Concrete instances of this interface can be obtained from the {@link #newHeaders()} or {@link #emptyHeaders()}
+ * family of methods, or they can be obtained from a {@link HttpHeadersFactory}.
+ * The default header factory instance is obtained from {@link DefaultHttpHeadersFactory#headersFactory()}.
  */
 public interface HttpHeaders extends Iterable<Entry<CharSequence, CharSequence>> {
     /**

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/headers/HttpHeadersFactory.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/headers/HttpHeadersFactory.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.handler.codec.http.headers;
+
+/**
+ * An interface for creating {@link HttpHeaders} instances.
+ * <p>
+ * These objects encapsulate a configuration for a call to the static factory methods in {@link HttpHeaders}.
+ * <p>
+ * The default implementation is {@link DefaultHttpHeadersFactory},
+ * and the default instance is {@link DefaultHttpHeadersFactory#headersFactory()}.
+ */
+public interface HttpHeadersFactory {
+    /**
+     * Create a new {@link HttpHeaders} instance.
+     */
+    HttpHeaders newHeaders();
+
+    /**
+     * Create a new {@link HttpHeaders} instance, but sized to be as small an object as possible.
+     */
+    HttpHeaders newEmptyHeaders();
+
+    /**
+     * Get the configured size hint.
+     *
+     * @return The current size hint.
+     */
+    int getSizeHint();
+
+    /**
+     * Check whether header name validation is enabled.
+     *
+     * @return {@code true} if header name validation is enabled, otherwise {@code false}.
+     */
+    boolean isValidatingNames();
+
+    /**
+     * Check whether header value validation is enabled.
+     *
+     * @return {@code true} if header value validation is enabled, otherwise {@code false}.
+     */
+    boolean isValidatingValues();
+
+    /**
+     * Check whether cookie validation is enabled.
+     *
+     * @return {@code true} if cookie validation is enabled, otherwise {@code false}.
+     */
+    boolean isValidatingCookies();
+}

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpClientCodecTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpClientCodecTest.java
@@ -71,7 +71,7 @@ public class HttpClientCodecTest {
 
     @Test
     public void testConnectWithResponseContent() {
-        HttpClientCodec codec = new HttpClientCodec(4096, 8192, true);
+        HttpClientCodec codec = new HttpClientCodec(new HttpDecoderConfig(), true);
         EmbeddedChannel ch = new EmbeddedChannel(codec);
 
         sendRequestAndReadResponse(ch, HttpMethod.CONNECT, RESPONSE);
@@ -80,7 +80,7 @@ public class HttpClientCodecTest {
 
     @Test
     public void testFailsNotOnRequestResponseChunked() {
-        HttpClientCodec codec = new HttpClientCodec(4096, 8192, true);
+        HttpClientCodec codec = new HttpClientCodec(new HttpDecoderConfig(), true);
         EmbeddedChannel ch = new EmbeddedChannel(codec);
 
         sendRequestAndReadResponse(ch, HttpMethod.GET, CHUNKED_RESPONSE);
@@ -89,7 +89,7 @@ public class HttpClientCodecTest {
 
     @Test
     public void testFailsOnMissingResponse() {
-        HttpClientCodec codec = new HttpClientCodec(4096, 8192, true);
+        HttpClientCodec codec = new HttpClientCodec(new HttpDecoderConfig(), true);
         EmbeddedChannel ch = new EmbeddedChannel(codec);
 
         assertTrue(ch.writeOutbound(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET,
@@ -107,7 +107,7 @@ public class HttpClientCodecTest {
 
     @Test
     public void testFailsOnIncompleteChunkedResponse() {
-        HttpClientCodec codec = new HttpClientCodec(4096, 8192, true);
+        HttpClientCodec codec = new HttpClientCodec(new HttpDecoderConfig(), true);
         EmbeddedChannel ch = new EmbeddedChannel(codec);
 
         ch.writeOutbound(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "http://localhost/",
@@ -139,7 +139,7 @@ public class HttpClientCodecTest {
                 @Override
                 protected void initChannel(Channel ch) {
                     // Don't use the HttpServerCodec, because we don't want to have content-length or anything added.
-                    ch.pipeline().addLast(new HttpRequestDecoder(4096, 8192, true));
+                    ch.pipeline().addLast(new HttpRequestDecoder());
                     ch.pipeline().addLast(new HttpObjectAggregator<DefaultHttpContent>(4096));
                     ch.pipeline().addLast(new SimpleChannelInboundHandler<FullHttpRequest>() {
                         @Override
@@ -177,7 +177,7 @@ public class HttpClientCodecTest {
             cb.handler(new ChannelInitializer<>() {
                 @Override
                 protected void initChannel(Channel ch) {
-                    ch.pipeline().addLast(new HttpClientCodec(4096, 8192, true, true));
+                    ch.pipeline().addLast(new HttpClientCodec(new HttpDecoderConfig(), true));
                     ch.pipeline().addLast(new HttpObjectAggregator<DefaultHttpContent>(4096));
                     ch.pipeline().addLast(new SimpleChannelInboundHandler<FullHttpResponse>() {
                         @Override
@@ -215,7 +215,7 @@ public class HttpClientCodecTest {
     }
 
     private static void testAfterConnect(final boolean parseAfterConnect) {
-        EmbeddedChannel ch = new EmbeddedChannel(new HttpClientCodec(4096, 8192, true, true, parseAfterConnect));
+        EmbeddedChannel ch = new EmbeddedChannel(new HttpClientCodec(new HttpDecoderConfig(), true, parseAfterConnect));
 
         Consumer connectResponseConsumer = new Consumer();
         sendRequestAndReadResponse(ch, HttpMethod.CONNECT, EMPTY_RESPONSE, connectResponseConsumer);
@@ -288,7 +288,7 @@ public class HttpClientCodecTest {
                 "Connection: Upgrade\r\n" +
                 "Upgrade: TLS/1.2, HTTP/1.1\r\n\r\n";
 
-        HttpClientCodec codec = new HttpClientCodec(4096, 8192, true);
+        HttpClientCodec codec = new HttpClientCodec(new HttpDecoderConfig(), true);
         EmbeddedChannel ch = new EmbeddedChannel(codec, new HttpObjectAggregator<DefaultHttpContent>(1024));
 
         HttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "http://localhost/",
@@ -403,7 +403,7 @@ public class HttpClientCodecTest {
         String response = "HTTP/1.1 200 OK\r\n" +
                 "Content-Length: 0\r\n\r\n";
 
-        HttpClientCodec codec = new HttpClientCodec(4096, 8192, true);
+        HttpClientCodec codec = new HttpClientCodec(new HttpDecoderConfig(), true);
         EmbeddedChannel ch = new EmbeddedChannel(codec, new HttpObjectAggregator<DefaultHttpContent>(1024));
 
         HttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "http://localhost/",

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpRequestDecoderTest.java
@@ -27,8 +27,6 @@ import org.junit.jupiter.api.Test;
 import java.util.Iterator;
 
 import static io.netty5.handler.codec.http.HttpHeaderNames.HOST;
-import static io.netty5.handler.codec.http.HttpObjectDecoder.DEFAULT_MAX_HEADER_SIZE;
-import static io.netty5.handler.codec.http.HttpObjectDecoder.DEFAULT_MAX_INITIAL_LINE_LENGTH;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -76,7 +74,7 @@ public class HttpRequestDecoderTest {
     }
 
     void setUpNoValidation() {
-        setUpDecoder(new HttpRequestDecoder(DEFAULT_MAX_INITIAL_LINE_LENGTH, DEFAULT_MAX_HEADER_SIZE, false));
+        setUpDecoder(new HttpRequestDecoder(new HttpDecoderConfig().setValidateHeaders(false)));
     }
 
     void setUpDecoder(HttpRequestDecoder decoder) {

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpResponseDecoderTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpResponseDecoderTest.java
@@ -33,8 +33,6 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;
 
-import static io.netty5.handler.codec.http.HttpObjectDecoder.DEFAULT_MAX_HEADER_SIZE;
-import static io.netty5.handler.codec.http.HttpObjectDecoder.DEFAULT_MAX_INITIAL_LINE_LENGTH;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -56,7 +54,7 @@ public class HttpResponseDecoderTest {
     }
 
     private void setUpNoValidation() {
-        setUpDecoder(new HttpResponseDecoder(DEFAULT_MAX_INITIAL_LINE_LENGTH, DEFAULT_MAX_HEADER_SIZE, false));
+        setUpDecoder(new HttpResponseDecoder(new HttpDecoderConfig().setValidateHeaders(false)));
     }
 
     private void setUpDecoder(HttpResponseDecoder decoder) {

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/MultipleContentLengthHeadersTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/MultipleContentLengthHeadersTest.java
@@ -23,10 +23,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.Arrays;
 import java.util.Collection;
 
-import static io.netty5.handler.codec.http.HttpObjectDecoder.DEFAULT_INITIAL_BUFFER_SIZE;
-import static io.netty5.handler.codec.http.HttpObjectDecoder.DEFAULT_MAX_HEADER_SIZE;
-import static io.netty5.handler.codec.http.HttpObjectDecoder.DEFAULT_MAX_INITIAL_LINE_LENGTH;
-import static io.netty5.handler.codec.http.HttpObjectDecoder.DEFAULT_VALIDATE_HEADERS;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
@@ -51,11 +47,7 @@ public class MultipleContentLengthHeadersTest {
 
     private static EmbeddedChannel newChannel(boolean allowDuplicateContentLengths) {
         HttpRequestDecoder decoder = new HttpRequestDecoder(
-                DEFAULT_MAX_INITIAL_LINE_LENGTH,
-                DEFAULT_MAX_HEADER_SIZE,
-                DEFAULT_VALIDATE_HEADERS,
-                DEFAULT_INITIAL_BUFFER_SIZE,
-                allowDuplicateContentLengths);
+                new HttpDecoderConfig().setAllowDuplicateContentLengths(allowDuplicateContentLengths));
         return new EmbeddedChannel(decoder);
     }
 

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/cors/CorsHandlerTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/cors/CorsHandlerTest.java
@@ -597,7 +597,7 @@ public class CorsHandlerTest {
         @Override
         public void messageReceived(ChannelHandlerContext ctx, Object msg) throws Exception {
             ctx.writeAndFlush(new DefaultFullHttpResponse(
-                    HTTP_1_1, OK, preferredAllocator().allocate(0), true));
+                    HTTP_1_1, OK, preferredAllocator().allocate(0)));
         }
     }
 

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/HttpToHttp2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/HttpToHttp2ConnectionHandler.java
@@ -114,7 +114,8 @@ public class HttpToHttp2ConnectionHandler extends Http2ConnectionHandler {
                 }
 
                 // Convert and write the headers.
-                Http2Headers http2Headers = HttpConversionUtil.toHttp2Headers(httpMsg, validateHeaders);
+                Http2Headers http2Headers = HttpConversionUtil.toHttp2Headers(
+                        httpMsg, validateHeaders, validateHeaders, validateHeaders);
                 endStream = msg instanceof FullHttpMessage && ((FullHttpMessage<?>) msg).payload().readableBytes() == 0;
                 writeHeaders(ctx, encoder, currentStreamId, httpMsg.headers(), http2Headers,
                         endStream).cascadeTo(promiseAggregator.newPromise());
@@ -130,7 +131,8 @@ public class HttpToHttp2ConnectionHandler extends Http2ConnectionHandler {
                     // Convert any trailing headers.
                     final LastHttpContent<?> lastContent = (LastHttpContent<?>) msg;
                     trailers = lastContent.trailingHeaders();
-                    http2Trailers = HttpConversionUtil.toHttp2Headers(trailers, validateHeaders);
+                    http2Trailers = HttpConversionUtil.toHttp2Headers(trailers,
+                            validateHeaders, validateHeaders, validateHeaders);
                 }
 
                 // Write the data

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/InboundHttp2ToHttpAdapterBuilder.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/InboundHttp2ToHttpAdapterBuilder.java
@@ -14,6 +14,7 @@
  */
 package io.netty5.handler.codec.http2;
 
+import io.netty5.handler.codec.http.headers.HttpHeadersFactory;
 import io.netty5.util.internal.UnstableApi;
 
 /**
@@ -39,8 +40,13 @@ public final class InboundHttp2ToHttpAdapterBuilder
     }
 
     @Override
-    public InboundHttp2ToHttpAdapterBuilder validateHttpHeaders(boolean validate) {
-        return super.validateHttpHeaders(validate);
+    protected InboundHttp2ToHttpAdapterBuilder headersFactory(HttpHeadersFactory headersFactory) {
+        return super.headersFactory(headersFactory);
+    }
+
+    @Override
+    protected InboundHttp2ToHttpAdapterBuilder trailersFactory(HttpHeadersFactory trailersFactory) {
+        return super.trailersFactory(trailersFactory);
     }
 
     @Override
@@ -54,12 +60,10 @@ public final class InboundHttp2ToHttpAdapterBuilder
     }
 
     @Override
-    protected InboundHttp2ToHttpAdapter build(Http2Connection connection,
-                                              int maxContentLength,
-                                              boolean validateHttpHeaders,
-                                              boolean propagateSettings) throws Exception {
-
-        return new InboundHttp2ToHttpAdapter(connection, maxContentLength,
-                                             validateHttpHeaders, propagateSettings);
+    protected InboundHttp2ToHttpAdapter build(
+            Http2Connection connection, int maxContentLength, boolean propagateSettings,
+            HttpHeadersFactory headersFactory, HttpHeadersFactory trailersFactory) throws Exception {
+        return new InboundHttp2ToHttpAdapter(
+                connection, maxContentLength, propagateSettings, headersFactory, trailersFactory);
     }
 }

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/InboundHttpToHttp2Adapter.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/InboundHttpToHttp2Adapter.java
@@ -68,7 +68,7 @@ public class InboundHttpToHttp2Adapter implements ChannelHandler {
             stream = connection.remote().createStream(streamId, false);
         }
         message.headers().set(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), HttpScheme.HTTP.name());
-        Http2Headers messageHeaders = HttpConversionUtil.toHttp2Headers(message, true);
+        Http2Headers messageHeaders = HttpConversionUtil.toHttp2Headers(message, true, true, true);
         boolean hasContent = message.payload().readableBytes() > 0;
         boolean hasTrailers = !message.trailingHeaders().isEmpty();
         listener.onHeadersRead(
@@ -78,7 +78,7 @@ public class InboundHttpToHttp2Adapter implements ChannelHandler {
             listener.onDataRead(ctx, streamId, payload, 0, !hasTrailers);
         }
         if (hasTrailers) {
-            Http2Headers headers = HttpConversionUtil.toHttp2Headers(message.trailingHeaders(), true);
+            Http2Headers headers = HttpConversionUtil.toHttp2Headers(message.trailingHeaders(), true, true, true);
             listener.onHeadersRead(ctx, streamId, headers, 0, true);
         }
         stream.closeRemoteSide();

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2StreamFrameToHttpObjectCodecTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2StreamFrameToHttpObjectCodecTest.java
@@ -231,7 +231,7 @@ public class Http2StreamFrameToHttpObjectCodecTest {
     public void testUpgradeDataEnd() {
         EmbeddedChannel ch = new EmbeddedChannel(new Http2StreamFrameToHttpObjectCodec(true));
         Buffer hello = preferredAllocator().allocate(16).writeCharSequence("hello world", UTF_8);
-        LastHttpContent<?> end = new DefaultLastHttpContent(hello, true);
+        LastHttpContent<?> end = new DefaultLastHttpContent(hello);
         assertTrue(ch.writeOutbound(end));
 
         try (Http2DataFrame dataFrame = ch.readOutbound()) {
@@ -247,7 +247,7 @@ public class Http2StreamFrameToHttpObjectCodecTest {
     @Test
     public void testUpgradeTrailers() {
         EmbeddedChannel ch = new EmbeddedChannel(new Http2StreamFrameToHttpObjectCodec(true));
-        LastHttpContent<?> trailers = new DefaultLastHttpContent(preferredAllocator().allocate(0), true);
+        LastHttpContent<?> trailers = new DefaultLastHttpContent(preferredAllocator().allocate(0));
         HttpHeaders headers = trailers.trailingHeaders();
         headers.set("key", "value");
         assertTrue(ch.writeOutbound(trailers));
@@ -265,7 +265,7 @@ public class Http2StreamFrameToHttpObjectCodecTest {
     public void testUpgradeDataEndWithTrailers() {
         EmbeddedChannel ch = new EmbeddedChannel(new Http2StreamFrameToHttpObjectCodec(true));
         Buffer hello = preferredAllocator().allocate(16).writeCharSequence("hello world", UTF_8);
-        LastHttpContent<?> trailers = new DefaultLastHttpContent(hello, true);
+        LastHttpContent<?> trailers = new DefaultLastHttpContent(hello);
         HttpHeaders headers = trailers.trailingHeaders();
         headers.set("key", "value");
         assertTrue(ch.writeOutbound(trailers));
@@ -605,7 +605,7 @@ public class Http2StreamFrameToHttpObjectCodecTest {
     public void testEncodeDataEndAsClient() {
         EmbeddedChannel ch = new EmbeddedChannel(new Http2StreamFrameToHttpObjectCodec(false));
         Buffer hello = preferredAllocator().allocate(16).writeCharSequence("hello world", UTF_8);
-        LastHttpContent<?> end = new DefaultLastHttpContent(hello, true);
+        LastHttpContent<?> end = new DefaultLastHttpContent(hello);
         assertTrue(ch.writeOutbound(end));
 
         try (Http2DataFrame dataFrame = ch.readOutbound()) {
@@ -621,7 +621,7 @@ public class Http2StreamFrameToHttpObjectCodecTest {
     public void testEncodeTrailersAsClient() {
         EmbeddedChannel ch = new EmbeddedChannel(new Http2StreamFrameToHttpObjectCodec(false));
         LastHttpContent<?> trailers = new DefaultLastHttpContent(
-                preferredAllocator().allocate(0), true);
+                preferredAllocator().allocate(0));
         HttpHeaders headers = trailers.trailingHeaders();
         headers.set("key", "value");
         assertTrue(ch.writeOutbound(trailers));
@@ -638,7 +638,7 @@ public class Http2StreamFrameToHttpObjectCodecTest {
     public void testEncodeDataEndWithTrailersAsClient() {
         EmbeddedChannel ch = new EmbeddedChannel(new Http2StreamFrameToHttpObjectCodec(false));
         Buffer hello = preferredAllocator().allocate(16).writeCharSequence("hello world", UTF_8);
-        LastHttpContent<?> trailers = new DefaultLastHttpContent(hello, true);
+        LastHttpContent<?> trailers = new DefaultLastHttpContent(hello);
         HttpHeaders headers = trailers.trailingHeaders();
         headers.set("key", "value");
         assertTrue(ch.writeOutbound(trailers));
@@ -742,7 +742,7 @@ public class Http2StreamFrameToHttpObjectCodecTest {
         assertFalse(ch.finish());
     }
 
-    @ParameterizedTest()
+    @ParameterizedTest
     @ValueSource(strings = {"204", "304"})
     public void testDecodeResponseHeadersContentAlwaysEmpty(String statusCode) {
         EmbeddedChannel ch = new EmbeddedChannel(new Http2StreamFrameToHttpObjectCodec(false));
@@ -772,7 +772,7 @@ public class Http2StreamFrameToHttpObjectCodecTest {
         testDecodeFullResponseHeaders(true);
     }
 
-    private void testDecodeFullResponseHeaders(boolean withStreamId) {
+    private static void testDecodeFullResponseHeaders(boolean withStreamId) {
         EmbeddedChannel ch = new EmbeddedChannel(new Http2StreamFrameToHttpObjectCodec(false));
         Http2Headers headers = Http2Headers.newHeaders();
         headers.scheme(HttpScheme.HTTP.name());

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/HttpConversionUtilTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/HttpConversionUtilTest.java
@@ -19,6 +19,7 @@ import io.netty5.handler.codec.http.DefaultHttpRequest;
 import io.netty5.handler.codec.http.HttpMethod;
 import io.netty5.handler.codec.http.HttpRequest;
 import io.netty5.handler.codec.http.HttpVersion;
+import io.netty5.handler.codec.http.headers.DefaultHttpHeadersFactory;
 import io.netty5.handler.codec.http.headers.HeaderValidationException;
 import io.netty5.handler.codec.http.headers.HttpHeaders;
 import io.netty5.handler.codec.http2.headers.Http2Headers;
@@ -52,7 +53,7 @@ public class HttpConversionUtilTest {
         Http2Headers headers = Http2Headers.newHeaders();
         headers.authority(authority);
         headers.method(HttpMethod.CONNECT.asciiName());
-        HttpRequest request = HttpConversionUtil.toHttpRequest(0, headers, true);
+        HttpRequest request = HttpConversionUtil.toHttpRequest(0, headers, DefaultHttpHeadersFactory.headersFactory());
         assertNotNull(request);
         assertEquals(authority, request.uri());
         assertEquals(of(authority), request.headers().get(HOST));
@@ -182,13 +183,12 @@ public class HttpConversionUtilTest {
 
     @Test
     public void handlesRequest() throws Exception {
-        boolean validateHeaders = true;
         HttpRequest msg = new DefaultHttpRequest(
-                HttpVersion.HTTP_1_1, HttpMethod.GET, "http://example.com/path/to/something", validateHeaders);
+                HttpVersion.HTTP_1_1, HttpMethod.GET, "http://example.com/path/to/something");
         HttpHeaders inHeaders = msg.headers();
         inHeaders.add(CONNECTION, "foo,  bar");
         inHeaders.add("hello", "world");
-        Http2Headers out = HttpConversionUtil.toHttp2Headers(msg, validateHeaders);
+        Http2Headers out = HttpConversionUtil.toHttp2Headers(msg, true, true, true);
         assertEquals(new AsciiString("/path/to/something"), out.path());
         assertEquals(new AsciiString("http"), out.scheme());
         assertEquals(new AsciiString("example.com"), out.authority());
@@ -198,15 +198,14 @@ public class HttpConversionUtilTest {
 
     @Test
     public void handlesRequestWithDoubleSlashPath() throws Exception {
-        boolean validateHeaders = true;
         HttpRequest msg = new DefaultHttpRequest(
-                HttpVersion.HTTP_1_1, HttpMethod.GET, "//path/to/something", validateHeaders);
+                HttpVersion.HTTP_1_1, HttpMethod.GET, "//path/to/something");
         HttpHeaders inHeaders = msg.headers();
         inHeaders.add(CONNECTION, "foo,  bar");
         inHeaders.add(HOST, "example.com");
         inHeaders.add(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), "http");
         inHeaders.add("hello", "world");
-        Http2Headers out = HttpConversionUtil.toHttp2Headers(msg, validateHeaders);
+        Http2Headers out = HttpConversionUtil.toHttp2Headers(msg, true, true, true);
         assertEquals(new AsciiString("//path/to/something"), out.path());
         assertEquals(new AsciiString("http"), out.scheme());
         assertEquals(new AsciiString("example.com"), out.authority());

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
@@ -135,7 +135,7 @@ public class InboundHttp2ToHttpAdapterTest {
     public void clientRequestSingleHeaderNoDataFrames() throws Exception {
         boostrapEnv(1, 1, 1);
         try (FullHttpRequest request = new DefaultFullHttpRequest(
-                HTTP_1_1, GET, "/some/path/resource2", preferredAllocator().allocate(0), true)) {
+                HTTP_1_1, GET, "/some/path/resource2", preferredAllocator().allocate(0))) {
             HttpHeaders httpHeaders = request.headers();
             httpHeaders.set(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), "https");
             httpHeaders.set(HttpHeaderNames.HOST, "example.org");
@@ -160,7 +160,7 @@ public class InboundHttp2ToHttpAdapterTest {
     public void clientRequestSingleHeaderCookieSplitIntoMultipleEntries() throws Exception {
         boostrapEnv(1, 1, 1);
         try (FullHttpRequest request = new DefaultFullHttpRequest(
-                HTTP_1_1, GET, "/some/path/resource2", preferredAllocator().allocate(0), true)) {
+                HTTP_1_1, GET, "/some/path/resource2", preferredAllocator().allocate(0))) {
             HttpHeaders httpHeaders = request.headers();
             httpHeaders.set(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), "https");
             httpHeaders.set(HttpHeaderNames.HOST, "example.org");
@@ -188,7 +188,7 @@ public class InboundHttp2ToHttpAdapterTest {
     public void clientRequestSingleHeaderCookieSplitIntoMultipleEntries2() throws Exception {
         boostrapEnv(1, 1, 1);
         try (FullHttpRequest request = new DefaultFullHttpRequest(
-                HTTP_1_1, GET, "/some/path/resource2", preferredAllocator().allocate(0), true)) {
+                HTTP_1_1, GET, "/some/path/resource2", preferredAllocator().allocate(0))) {
             HttpHeaders httpHeaders = request.headers();
             httpHeaders.set(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), "https");
             httpHeaders.set(HttpHeaderNames.HOST, "example.org");
@@ -236,7 +236,7 @@ public class InboundHttp2ToHttpAdapterTest {
         boostrapEnv(1, 1, 1);
         final String text = "hello world";
         Buffer hello = preferredAllocator().allocate(16).writeCharSequence(text, UTF_8);
-        try (FullHttpRequest request = new DefaultFullHttpRequest(HTTP_1_1, GET, "/some/path/resource2", hello, true)) {
+        try (FullHttpRequest request = new DefaultFullHttpRequest(HTTP_1_1, GET, "/some/path/resource2", hello)) {
             HttpHeaders httpHeaders = request.headers();
             httpHeaders.set(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), "3");
             httpHeaders.set(HttpHeaderNames.CONTENT_LENGTH, String.valueOf(text.length()));
@@ -261,7 +261,7 @@ public class InboundHttp2ToHttpAdapterTest {
         final String text = "hello world big time data!";
         try (Buffer content = preferredAllocator().allocate(32).writeCharSequence(text, UTF_8);
              FullHttpRequest request = new DefaultFullHttpRequest(
-                     HTTP_1_1, GET, "/some/path/resource2", content.copy(), true)) {
+                     HTTP_1_1, GET, "/some/path/resource2", content.copy())) {
             HttpHeaders httpHeaders = request.headers();
             httpHeaders.set(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), "3");
             httpHeaders.set(HttpHeaderNames.CONTENT_LENGTH, String.valueOf(text.length()));
@@ -290,7 +290,7 @@ public class InboundHttp2ToHttpAdapterTest {
         final String text = "";
         final Buffer content = preferredAllocator().allocate(0);
         try (FullHttpRequest request = new DefaultFullHttpRequest(
-                HTTP_1_1, GET, "/some/path/resource2", content, true)) {
+                HTTP_1_1, GET, "/some/path/resource2", content)) {
             HttpHeaders httpHeaders = request.headers();
             httpHeaders.set(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), "3");
             httpHeaders.set(HttpHeaderNames.CONTENT_LENGTH, String.valueOf(text.length()));
@@ -316,7 +316,7 @@ public class InboundHttp2ToHttpAdapterTest {
         final String text = "some data";
         Buffer content = preferredAllocator().allocate(16).writeCharSequence(text, UTF_8);
         try (FullHttpRequest request = new DefaultFullHttpRequest(
-                HTTP_1_1, GET, "/some/path/resource2", content, true)) {
+                HTTP_1_1, GET, "/some/path/resource2", content)) {
             HttpHeaders httpHeaders = request.headers();
             httpHeaders.set(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), "3");
             httpHeaders.set(HttpHeaderNames.CONTENT_LENGTH, String.valueOf(text.length()));
@@ -352,9 +352,9 @@ public class InboundHttp2ToHttpAdapterTest {
         final String text2 = "hello world big time data...number 2!!";
         Buffer content2 = preferredAllocator().allocate(64).writeCharSequence(text2, UTF_8);
         try (FullHttpRequest request = new DefaultFullHttpRequest(
-                HTTP_1_1, HttpMethod.PUT, "/some/path/resource", content, true);
+                HTTP_1_1, HttpMethod.PUT, "/some/path/resource", content);
              FullHttpMessage<?> request2 = new DefaultFullHttpRequest(
-                     HTTP_1_1, HttpMethod.PUT, "/some/path/resource2", content2, true)) {
+                     HTTP_1_1, HttpMethod.PUT, "/some/path/resource2", content2)) {
             HttpHeaders httpHeaders = request.headers();
             httpHeaders.set(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), "3");
             httpHeaders.set(HttpHeaderNames.CONTENT_LENGTH, String.valueOf(text.length()));
@@ -390,11 +390,11 @@ public class InboundHttp2ToHttpAdapterTest {
         final String text2 = "hello world smaller data?";
         Buffer content2 = preferredAllocator().allocate(32).writeCharSequence(text2, UTF_8);
         try (FullHttpMessage<?> response = new DefaultFullHttpResponse(
-                HTTP_1_1, HttpResponseStatus.OK, content, true);
+                HTTP_1_1, HttpResponseStatus.OK, content);
              FullHttpMessage<?> response2 = new DefaultFullHttpResponse(
-                     HTTP_1_1, HttpResponseStatus.CREATED, content2, true);
+                     HTTP_1_1, HttpResponseStatus.CREATED, content2);
              FullHttpMessage<?> request = new DefaultFullHttpRequest(
-                     HTTP_1_1, GET, "/push/test", preferredAllocator().allocate(0), true)) {
+                     HTTP_1_1, GET, "/push/test", preferredAllocator().allocate(0))) {
             HttpHeaders httpHeaders = response.headers();
             httpHeaders.set(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), "3");
             httpHeaders.set(HttpHeaderNames.CONTENT_LENGTH, String.valueOf(text.length()));
@@ -446,7 +446,7 @@ public class InboundHttp2ToHttpAdapterTest {
     public void serverResponseHeaderInformational() throws Exception {
         boostrapEnv(1, 2, 1, 2, 1);
         final FullHttpRequest request = new DefaultFullHttpRequest(
-                HTTP_1_1, HttpMethod.PUT, "/info/test", preferredAllocator().allocate(0), true);
+                HTTP_1_1, HttpMethod.PUT, "/info/test", preferredAllocator().allocate(0));
         HttpHeaders httpHeaders = request.headers();
         httpHeaders.set(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), "3");
         httpHeaders.set(HttpHeaderNames.EXPECT, HttpHeaderValues.CONTINUE);
@@ -570,7 +570,6 @@ public class InboundHttp2ToHttpAdapterTest {
                 serverHandler = new Http2ConnectionHandlerBuilder().frameListener(
                         new InboundHttp2ToHttpAdapterBuilder(connection)
                            .maxContentLength(maxContentLength)
-                           .validateHttpHeaders(true)
                            .propagateSettings(true)
                            .build())
                    .connection(connection)

--- a/example/src/main/java/io/netty5/example/http2/tiles/Http2OrHttpHandler.java
+++ b/example/src/main/java/io/netty5/example/http2/tiles/Http2OrHttpHandler.java
@@ -56,7 +56,7 @@ public class Http2OrHttpHandler extends ApplicationProtocolNegotiationHandler {
     private static void configureHttp2(ChannelHandlerContext ctx) {
         DefaultHttp2Connection connection = new DefaultHttp2Connection(true);
         InboundHttp2ToHttpAdapter listener = new InboundHttp2ToHttpAdapterBuilder(connection)
-                .propagateSettings(true).validateHttpHeaders(false)
+                .propagateSettings(true)
                 .maxContentLength(MAX_CONTENT_LENGTH).build();
 
         ctx.pipeline().addLast(new HttpToHttp2ConnectionHandlerBuilder()

--- a/microbench/src/main/java/io/netty5/microbench/http/HttpObjectEncoderBenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/http/HttpObjectEncoderBenchmark.java
@@ -29,7 +29,9 @@ import io.netty5.handler.codec.http.HttpRequest;
 import io.netty5.handler.codec.http.HttpRequestEncoder;
 import io.netty5.handler.codec.http.HttpVersion;
 import io.netty5.handler.codec.http.LastHttpContent;
+import io.netty5.handler.codec.http.headers.DefaultHttpHeadersFactory;
 import io.netty5.handler.codec.http.headers.HttpHeaders;
+import io.netty5.handler.codec.http.headers.HttpHeadersFactory;
 import io.netty5.handler.codec.http2.headers.Http2Headers;
 import io.netty5.microbench.channel.EmbeddedChannelWriteReleaseHandlerContext;
 import io.netty5.microbench.util.AbstractMicrobenchmark;
@@ -81,7 +83,9 @@ public class HttpObjectEncoderBenchmark extends AbstractMicrobenchmark {
         contentLengthRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/index",
                 headersWithContentLength);
         chunkedRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/index", headersWithChunked);
-        lastContent = new DefaultLastHttpContent(testContent, false);
+        HttpHeadersFactory trailerFactory = DefaultHttpHeadersFactory.trailersFactory()
+                .withNameValidation(false).withValueValidation(false).withCookieValidation(false);
+        lastContent = new DefaultLastHttpContent(testContent, trailerFactory);
 
         encoder = new HttpRequestEncoder();
         context = new EmbeddedChannelWriteReleaseHandlerContext(allocator, encoder) {


### PR DESCRIPTION
This is a forward port of #13609, aka 84a13a92e1d757965438dc41a5611b19dd47ec44.

Motivation:
HTTP request/response splitting is a serious vulnerability, which is mitigated by enabling HTTP header validation. We already do header validation by default, but we have many constructors in our HTTP codec that permit turning it off. We should discourage all our down-stream users from turning header validation off.

Modification:
- Remove many constructors in our HTTP codec, that allow header validation to be turned off.
- Offer alternative constructors to all the newly removed ones, where header validation is enabled.
- Offer alternative constructors, that take HttpDecoderConfig or HttpHeadersFactory instances.
- Trailer validation in `DefaultLastHttpContent` is now enabled by default in the `DefaultLastHttpContent(Buffer, HttpHeaders)`
- Add more guidance in the javadocs.

Result:
We hopefully encourage integrators to validate headers. And we hopefully get fewer issues reported about disabled header validation when people run security scanners on their code.
