### PR TITLE
Use Http2Headers.size() instead of isEmpty()

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -416,7 +416,9 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
                                 "Multiple content-length headers received");
                     }
                 }
-            } else if (validateHeaders && !headers.isEmpty()) {
+                // Use size() instead of isEmpty() for backward compatibility with grpc-java prior to 1.59.1,
+                // see https://github.com/grpc/grpc-java/issues/10665
+            } else if (validateHeaders && headers.size() > 0) {
                 // Need to check trailers don't contain pseudo headers. According to RFC 9113
                 // Trailers MUST NOT include pseudo-header fields (Section 8.3).
                 for (Iterator<Entry<CharSequence, CharSequence>> iterator =


### PR DESCRIPTION
Motivation:

grpc-java prior to version 1.59.1 does not implement `Http2Headers.isEmpty()` method (it throws
`UnsupportedOperationException`). While the fix was released in 1.59.1, there is another issue with circular dependencies between `grpc-core` and `grpc-util` modules. To unblock Netty users that also depend on grpc-java, we can check the size.

Modifications:

- Use `Http2Headers.size()` instead of `Http2Headers.isEmpty()` in `DefaultHttp2ConnectionDecoder`;

Result:

Users of older grpc-java versions can independently bump Netty version.