### PR TITLE
Add check for JAVA8_HOME to release script

### DIFF
--- a/scripts/finish_release.sh
+++ b/scripts/finish_release.sh
@@ -16,6 +16,11 @@
 # ----------------------------------------------------------------------------
 set -e
 
+if [ -z "$JAVA8_HOME" ]; then
+    echo "The JAVA8_HOME environment variable needs to be set"
+    exit 1
+fi
+
 if [ "$#" -ne 2 ]; then
     echo "Expected staging profile id and branch name, login into oss.sonatype.org to retrieve it"
     exit 1
@@ -23,7 +28,6 @@ fi
 
 OS=$(uname)
 ARCH=$(uname -p)
-
 
 if [ "$OS" != "Darwin" ]; then
     echo "Needs to be executed on macOS"


### PR DESCRIPTION
Motivation:
This environment variable is required.
If it's not set, the Netty release will end up being built wrong bytecode version and incompatible ABI.

Modification:
Add a check that the JAVA8_HOME environment variable does not resolve to the empty string.

Result:
We're less likely to get a broken release from mistakes in the manual steps.