### PR TITLE
Use entry.unguardedRecycle() instead of entry.recycle() in method MemoryRegionCache.freeEntry(...)

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolThreadCache.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolThreadCache.java
@@ -428,7 +428,7 @@ final class PoolThreadCache {
         }
 
         @SuppressWarnings({ "unchecked", "rawtypes" })
-        private  void freeEntry(Entry entry, boolean finalizer) {
+        private void freeEntry(Entry entry, boolean finalizer) {
             // Capture entry state before we recycle the entry object.
             PoolChunk chunk = entry.chunk;
             long handle = entry.handle;
@@ -438,7 +438,7 @@ final class PoolThreadCache {
             if (!finalizer) {
                 // recycle now so PoolChunk can be GC'ed. This will only be done if this is not freed because of
                 // a finalizer.
-                entry.recycle();
+                entry.unguardedRecycle();
             }
 
             chunk.arena.freeChunk(chunk, handle, normCapacity, sizeClass, nioBuffer, finalizer);


### PR DESCRIPTION
Motivation:

This is related to https://github.com/netty/netty/pull/13220, I think we should use `entry.unguardedRecycle()` instead of `entry.recycle()` in method `MemoryRegionCache.freeEntry(...)`, to make the 'recycle' operation cheaper.

Modification:

Use `entry.unguardedRecycle()` instead of `entry.recycle()` in method `MemoryRegionCache.freeEntry(...)`.

Result:

Make the 'recycle' operation cheaper.
