### PR TITLE
Make use of relaxed*() methods in PoolThreadCache.MemoryRegionCache when possible

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolThreadCache.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolThreadCache.java
@@ -369,7 +369,7 @@ final class PoolThreadCache {
         @SuppressWarnings("unchecked")
         public final boolean add(PoolChunk<T> chunk, ByteBuffer nioBuffer, long handle, int normCapacity) {
             Entry<T> entry = newEntry(chunk, nioBuffer, handle, normCapacity);
-            boolean queued = queue.relaxedOffer(entry);
+            boolean queued = queue.offer(entry);
             if (!queued) {
                 // If it was not possible to cache the chunk, immediately recycle the entry
                 entry.unguardedRecycle();

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -89,8 +89,8 @@ public final class PlatformDependent {
     private static final boolean DIRECT_BUFFER_PREFERRED;
     private static final long MAX_DIRECT_MEMORY = estimateMaxDirectMemory();
 
-    private static final int MPSC_CHUNK_SIZE =  1024;
-    private static final int MIN_MAX_MPSC_CAPACITY =  MPSC_CHUNK_SIZE * 2;
+    private static final int MPSC_CHUNK_SIZE = 1024;
+    private static final int MIN_MAX_MPSC_CAPACITY = MPSC_CHUNK_SIZE * 2;
     private static final int MAX_ALLOWED_MPSC_CAPACITY = Pow2.MAX_POW2;
 
     private static final long BYTE_ARRAY_BASE_OFFSET = byteArrayBaseOffset0();


### PR DESCRIPTION
Motivation:

This is inspired by https://github.com/netty/netty/pull/11960.
We should be able to make use of `MessagePassingQueue.relaxedPoll()` methods in `PoolThreadCache.MemoryRegionCache` to reduce the overhead.

Modification:

Use `MessagePassingQueue.relaxedPoll(...)`.

Result:

Less overhead.