### PR TITLE
Fix exception on HTTP chunk size overflow

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -903,12 +903,12 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
                 if (b == ';' || isControlOrWhitespaceAsciiChar(b)) {
                     if (i == 0) {
                         // empty case
-                        throw new NumberFormatException();
+                        throw new NumberFormatException("Empty chunk size");
                     }
                     return result;
                 }
                 // non-hex char fail-fast path
-                throw new NumberFormatException();
+                throw new NumberFormatException("Invalid character in chunk size");
             }
             result *= 16;
             result += digit;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -912,9 +912,9 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
             }
             result *= 16;
             result += digit;
-        }
-        if (result < 0) {
-            throw new NumberFormatException("Chunk size overflow: " + result);
+            if (result < 0) {
+                throw new NumberFormatException("Chunk size overflow: " + result);
+            }
         }
         return result;
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -905,7 +905,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
                         // empty case
                         throw new NumberFormatException();
                     }
-                    break;
+                    return result;
                 }
                 // non-hex char fail-fast path
                 throw new NumberFormatException();

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -914,7 +914,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
             result += digit;
         }
         if (result < 0) {
-            throw new NumberFormatException();
+            throw new NumberFormatException("Chunk size overflow: " + result);
         }
         return result;
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -913,6 +913,9 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
             result *= 16;
             result += digit;
         }
+        if (result < 0) {
+            throw new NumberFormatException();
+        }
         return result;
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -905,7 +905,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
                         // empty case
                         throw new NumberFormatException();
                     }
-                    return result;
+                    break;
                 }
                 // non-hex char fail-fast path
                 throw new NumberFormatException();

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -639,6 +639,20 @@ public class HttpRequestDecoderTest {
         assertFalse(channel.finish());
     }
 
+    @Test
+    public void testChunkSizeOverflow() {
+        String requestStr = "PUT /some/path HTTP/1.1\r\n" +
+                "Transfer-Encoding: chunked\r\n\r\n" +
+                "8ccccccc\r\n";
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder());
+        assertTrue(channel.writeInbound(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)));
+        HttpRequest request = channel.readInbound();
+        assertTrue(request.decoderResult().isSuccess());
+        HttpContent c = channel.readInbound();
+        c.release();
+        assertFalse(channel.finish());
+    }
+
     private static void testInvalidHeaders0(String requestStr) {
         testInvalidHeaders0(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII));
     }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -35,6 +35,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -650,6 +651,8 @@ public class HttpRequestDecoderTest {
         assertTrue(request.decoderResult().isSuccess());
         HttpContent c = channel.readInbound();
         c.release();
+        assertTrue(c.decoderResult().isFailure());
+        assertInstanceOf(NumberFormatException.class, c.decoderResult().cause());
         assertFalse(channel.finish());
     }
 
@@ -664,6 +667,8 @@ public class HttpRequestDecoderTest {
         assertTrue(request.decoderResult().isSuccess());
         HttpContent c = channel.readInbound();
         c.release();
+        assertTrue(c.decoderResult().isFailure());
+        assertInstanceOf(NumberFormatException.class, c.decoderResult().cause());
         assertFalse(channel.finish());
     }
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -653,6 +653,20 @@ public class HttpRequestDecoderTest {
         assertFalse(channel.finish());
     }
 
+    @Test
+    public void testChunkSizeOverflow2() {
+        String requestStr = "PUT /some/path HTTP/1.1\r\n" +
+                "Transfer-Encoding: chunked\r\n\r\n" +
+                "bbbbbbbe;\n\r\n";
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder());
+        assertTrue(channel.writeInbound(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)));
+        HttpRequest request = channel.readInbound();
+        assertTrue(request.decoderResult().isSuccess());
+        HttpContent c = channel.readInbound();
+        c.release();
+        assertFalse(channel.finish());
+    }
+
     private static void testInvalidHeaders0(String requestStr) {
         testInvalidHeaders0(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII));
     }


### PR DESCRIPTION
Motivation:

If there is an overflow in the chunk size calculation, it would throw an exception on the pipeline instead of an invalid chunk like other number format errors. In particular:

```
Caused by: java.lang.IllegalArgumentException: minimumReadableBytes : -1932735284 (expected: >= 0)
	at io.netty.util.internal.ObjectUtil.checkPositiveOrZero(ObjectUtil.java:144)
	at io.netty.buffer.AbstractByteBuf.checkReadableBytes(AbstractByteBuf.java:1428)
	at io.netty.buffer.AbstractByteBuf.readRetainedSlice(AbstractByteBuf.java:887)
	at io.netty.handler.codec.http.HttpObjectDecoder.decode(HttpObjectDecoder.java:480)
	at io.netty.handler.codec.http.HttpServerCodec$HttpServerRequestDecoder.decode(HttpServerCodec.java:167)
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:529)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:468)
	... 134 common frames omitted
```

Modification:

Check for negative chunk size, and throw a NumberFormatException early.

Result:

This invalid input is treated like any other invalid chunk.