### PR TITLE
Default value of MAX_MESSAGES_PER_READ not used for native DatagramCh…

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannelConfig.java
@@ -36,8 +36,7 @@ public final class EpollDatagramChannelConfig extends EpollChannelConfig impleme
     private volatile int maxDatagramSize;
 
     EpollDatagramChannelConfig(EpollDatagramChannel channel) {
-        super(channel);
-        setRecvByteBufAllocator(new FixedRecvByteBufAllocator(2048));
+        super(channel, new FixedRecvByteBufAllocator(2048));
     }
 
     @Override

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainDatagramChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainDatagramChannelConfig.java
@@ -37,8 +37,7 @@ public final class EpollDomainDatagramChannelConfig extends EpollChannelConfig i
     private boolean activeOnOpen;
 
     EpollDomainDatagramChannelConfig(EpollDomainDatagramChannel channel) {
-        super(channel);
-        setRecvByteBufAllocator(new FixedRecvByteBufAllocator(2048));
+        super(channel, new FixedRecvByteBufAllocator(2048));
     }
 
     @Override

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannelConfig.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannelConfig.java
@@ -47,8 +47,7 @@ public final class KQueueDatagramChannelConfig extends KQueueChannelConfig imple
     private boolean activeOnOpen;
 
     KQueueDatagramChannelConfig(KQueueDatagramChannel channel) {
-        super(channel);
-        setRecvByteBufAllocator(new FixedRecvByteBufAllocator(2048));
+        super(channel, new FixedRecvByteBufAllocator(2048));
     }
 
     @Override

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainDatagramChannelConfig.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainDatagramChannelConfig.java
@@ -38,8 +38,7 @@ public final class KQueueDomainDatagramChannelConfig
     private boolean activeOnOpen;
 
     KQueueDomainDatagramChannelConfig(KQueueDomainDatagramChannel channel) {
-        super(channel);
-        setRecvByteBufAllocator(new FixedRecvByteBufAllocator(2048));
+        super(channel, new FixedRecvByteBufAllocator(2048));
     }
 
     @Override

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramChannelTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramChannelTest.java
@@ -44,6 +44,13 @@ public class EpollDatagramChannelTest {
     }
 
     @Test
+    public void testDefaultMaxMessagePerRead() {
+        EpollDatagramChannel channel = new EpollDatagramChannel();
+        assertEquals(16, channel.config().getMaxMessagesPerRead());
+        channel.unsafe().closeForcibly();
+    }
+
+    @Test
     public void testNotActiveNoLocalRemoteAddress() throws IOException {
         checkNotActiveNoLocalRemoteAddress(new EpollDatagramChannel());
         checkNotActiveNoLocalRemoteAddress(new EpollDatagramChannel(InternetProtocolFamily.IPv4));

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainDatagramChannelTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainDatagramChannelTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.epoll;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class EpollDomainDatagramChannelTest {
+
+    @BeforeEach
+    public void setUp() {
+        Epoll.ensureAvailability();
+    }
+
+    @Test
+    public void testDefaultMaxMessagePerRead() {
+        EpollDomainDatagramChannel channel = new EpollDomainDatagramChannel();
+        assertEquals(16, channel.config().getMaxMessagesPerRead());
+        channel.unsafe().closeForcibly();
+    }
+}

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KqueueDatagramChannelTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KqueueDatagramChannelTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.kqueue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class KqueueDatagramChannelTest {
+
+    @BeforeEach
+    public void setUp() {
+        KQueue.ensureAvailability();
+    }
+
+    @Test
+    public void testDefaultMaxMessagePerRead() {
+        KQueueDatagramChannel channel = new KQueueDatagramChannel();
+        assertEquals(16, channel.config().getMaxMessagesPerRead());
+        channel.unsafe().closeForcibly();
+    }
+}

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KqueueDomainDatagramChannelTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KqueueDomainDatagramChannelTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.kqueue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class KqueueDomainDatagramChannelTest {
+
+    @BeforeEach
+    public void setUp() {
+        KQueue.ensureAvailability();
+    }
+
+    @Test
+    public void testDefaultMaxMessagePerRead() {
+        KQueueDomainDatagramChannel channel = new KQueueDomainDatagramChannel();
+        assertEquals(16, channel.config().getMaxMessagesPerRead());
+        channel.unsafe().closeForcibly();
+    }
+}


### PR DESCRIPTION
…anne

Motivation:

Due of how we did set up the RecvByteBufAllocator we did not set the correct default value for the max message per read.

Modifications:

Pass the RecvByteBufAllocator in the constructor so its setup correctly.

Result:

Fix https://github.com/netty/netty/issues/13733
