### PR TITLE
removable judgment('else')

### DIFF
--- a/handler/src/main/java/io/netty/handler/timeout/IdleStateHandler.java
+++ b/handler/src/main/java/io/netty/handler/timeout/IdleStateHandler.java
@@ -242,10 +242,9 @@ public class IdleStateHandler extends ChannelDuplexHandler {
             // channelActive() event has been fired already, which means this.channelActive() will
             // not be invoked. We have to initialize here instead.
             initialize(ctx);
-        } else {
-            // channelActive() event has not been fired yet.  this.channelActive() will be invoked
-            // and initialization will occur there.
         }
+        // channelActive() event has not been fired yet.  this.channelActive() will be invoked
+        // and initialization will occur there.
     }
 
     @Override


### PR DESCRIPTION
Motivation:
` if (ctx.channel().isActive() && ctx.channel().isRegistered()) {`
         ` // channelActive() event has been fired already, which means this.channelActive() will`
         ` // not be invoked. We have to initialize here instead.`
        ` initialize(ctx);`
   `} else {`
         ` // channelActive() event has not been fired yet.  this.channelActive() will be invoked`
        ` // and initialization will occur there.`
    `}`
Modification:

removable judgment, and removal will not change the original semantics, but it can make the code more concise

Result:
It can make the code more concise