### PR TITLE
Java 9 introduced Arrays:equals intrinsics

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -870,6 +870,9 @@ public final class PlatformDependent {
      * by the caller.
      */
     public static boolean equals(byte[] bytes1, int startPos1, byte[] bytes2, int startPos2, int length) {
+        if (javaVersion() > 8 && (startPos2 | startPos1 | (bytes1.length - length) | bytes2.length - length) == 0) {
+            return Arrays.equals(bytes1, bytes2);
+        }
         return !hasUnsafe() || !unalignedAccess() ?
                   equalsSafe(bytes1, startPos1, bytes2, startPos2, length) :
                   PlatformDependent0.equals(bytes1, startPos1, bytes2, startPos2, length);


### PR DESCRIPTION
Motivation:

AsciiStrings and others are heavy users of byte[] equality checks

Modifications:

Leverage existing Arrays::equals(byte[]) intrinsics

Result:

Faster equality matches on hit(s)