### PR TITLE
Speedup pseudoheader lookup

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackStaticTable.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackStaticTable.java
@@ -31,6 +31,10 @@
  */
 package io.netty.handler.codec.http2;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http2.Http2Headers.PseudoHeaderName;
 import io.netty.util.AsciiString;
 import io.netty.util.internal.PlatformDependent;
 
@@ -46,75 +50,95 @@ final class HpackStaticTable {
     // Appendix A: Static Table
     // https://tools.ietf.org/html/rfc7541#appendix-A
     private static final List<HpackHeaderField> STATIC_TABLE = Arrays.asList(
-    /*  1 */ newEmptyHeaderField(":authority"),
-    /*  2 */ newHeaderField(":method", "GET"),
-    /*  3 */ newHeaderField(":method", "POST"),
-    /*  4 */ newHeaderField(":path", "/"),
-    /*  5 */ newHeaderField(":path", "/index.html"),
-    /*  6 */ newHeaderField(":scheme", "http"),
-    /*  7 */ newHeaderField(":scheme", "https"),
-    /*  8 */ newHeaderField(":status", "200"),
-    /*  9 */ newHeaderField(":status", "204"),
-    /* 10 */ newHeaderField(":status", "206"),
-    /* 11 */ newHeaderField(":status", "304"),
-    /* 12 */ newHeaderField(":status", "400"),
-    /* 13 */ newHeaderField(":status", "404"),
-    /* 14 */ newHeaderField(":status", "500"),
-    /* 15 */ newEmptyHeaderField("accept-charset"),
-    /* 16 */ newHeaderField("accept-encoding", "gzip, deflate"),
-    /* 17 */ newEmptyHeaderField("accept-language"),
-    /* 18 */ newEmptyHeaderField("accept-ranges"),
-    /* 19 */ newEmptyHeaderField("accept"),
-    /* 20 */ newEmptyHeaderField("access-control-allow-origin"),
-    /* 21 */ newEmptyHeaderField("age"),
-    /* 22 */ newEmptyHeaderField("allow"),
-    /* 23 */ newEmptyHeaderField("authorization"),
-    /* 24 */ newEmptyHeaderField("cache-control"),
-    /* 25 */ newEmptyHeaderField("content-disposition"),
-    /* 26 */ newEmptyHeaderField("content-encoding"),
-    /* 27 */ newEmptyHeaderField("content-language"),
-    /* 28 */ newEmptyHeaderField("content-length"),
-    /* 29 */ newEmptyHeaderField("content-location"),
-    /* 30 */ newEmptyHeaderField("content-range"),
-    /* 31 */ newEmptyHeaderField("content-type"),
-    /* 32 */ newEmptyHeaderField("cookie"),
-    /* 33 */ newEmptyHeaderField("date"),
-    /* 34 */ newEmptyHeaderField("etag"),
-    /* 35 */ newEmptyHeaderField("expect"),
-    /* 36 */ newEmptyHeaderField("expires"),
-    /* 37 */ newEmptyHeaderField("from"),
-    /* 38 */ newEmptyHeaderField("host"),
-    /* 39 */ newEmptyHeaderField("if-match"),
-    /* 40 */ newEmptyHeaderField("if-modified-since"),
-    /* 41 */ newEmptyHeaderField("if-none-match"),
-    /* 42 */ newEmptyHeaderField("if-range"),
-    /* 43 */ newEmptyHeaderField("if-unmodified-since"),
-    /* 44 */ newEmptyHeaderField("last-modified"),
+    /*  1 */ newEmptyPseudoHeaderField(PseudoHeaderName.AUTHORITY),
+    /*  2 */ newPseudoHeaderMethodField(HttpMethod.GET),
+    /*  3 */ newPseudoHeaderMethodField(HttpMethod.POST),
+    /*  4 */ newPseudoHeaderField(PseudoHeaderName.PATH, "/"),
+    /*  5 */ newPseudoHeaderField(PseudoHeaderName.PATH, "/index.html"),
+    /*  6 */ newPseudoHeaderField(PseudoHeaderName.SCHEME, "http"),
+    /*  7 */ newPseudoHeaderField(PseudoHeaderName.SCHEME, "https"),
+    /*  8 */ newPseudoHeaderField(PseudoHeaderName.STATUS, HttpResponseStatus.OK.codeAsText()),
+    /*  9 */ newPseudoHeaderField(PseudoHeaderName.STATUS, HttpResponseStatus.NO_CONTENT.codeAsText()),
+    /* 10 */ newPseudoHeaderField(PseudoHeaderName.STATUS, HttpResponseStatus.PARTIAL_CONTENT.codeAsText()),
+    /* 11 */ newPseudoHeaderField(PseudoHeaderName.STATUS, HttpResponseStatus.NOT_MODIFIED.codeAsText()),
+    /* 12 */ newPseudoHeaderField(PseudoHeaderName.STATUS, HttpResponseStatus.BAD_REQUEST.codeAsText()),
+    /* 13 */ newPseudoHeaderField(PseudoHeaderName.STATUS, HttpResponseStatus.NOT_FOUND.codeAsText()),
+    /* 14 */ newPseudoHeaderField(PseudoHeaderName.STATUS, HttpResponseStatus.INTERNAL_SERVER_ERROR.codeAsText()),
+    /* 15 */ newEmptyHeaderField(HttpHeaderNames.ACCEPT_CHARSET),
+    /* 16 */ newHeaderField(HttpHeaderNames.ACCEPT_ENCODING, "gzip, deflate"),
+    /* 17 */ newEmptyHeaderField(HttpHeaderNames.ACCEPT_LANGUAGE),
+    /* 18 */ newEmptyHeaderField(HttpHeaderNames.ACCEPT_RANGES),
+    /* 19 */ newEmptyHeaderField(HttpHeaderNames.ACCEPT),
+    /* 20 */ newEmptyHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN),
+    /* 21 */ newEmptyHeaderField(HttpHeaderNames.AGE),
+    /* 22 */ newEmptyHeaderField(HttpHeaderNames.ALLOW),
+    /* 23 */ newEmptyHeaderField(HttpHeaderNames.AUTHORIZATION),
+    /* 24 */ newEmptyHeaderField(HttpHeaderNames.CACHE_CONTROL),
+    /* 25 */ newEmptyHeaderField(HttpHeaderNames.CONTENT_DISPOSITION),
+    /* 26 */ newEmptyHeaderField(HttpHeaderNames.CONTENT_ENCODING),
+    /* 27 */ newEmptyHeaderField(HttpHeaderNames.CONTENT_LANGUAGE),
+    /* 28 */ newEmptyHeaderField(HttpHeaderNames.CONTENT_LENGTH),
+    /* 29 */ newEmptyHeaderField(HttpHeaderNames.CONTENT_LOCATION),
+    /* 30 */ newEmptyHeaderField(HttpHeaderNames.CONTENT_RANGE),
+    /* 31 */ newEmptyHeaderField(HttpHeaderNames.CONTENT_TYPE),
+    /* 32 */ newEmptyHeaderField(HttpHeaderNames.COOKIE),
+    /* 33 */ newEmptyHeaderField(HttpHeaderNames.DATE),
+    /* 34 */ newEmptyHeaderField(HttpHeaderNames.ETAG),
+    /* 35 */ newEmptyHeaderField(HttpHeaderNames.EXPECT),
+    /* 36 */ newEmptyHeaderField(HttpHeaderNames.EXPIRES),
+    /* 37 */ newEmptyHeaderField(HttpHeaderNames.FROM),
+    /* 38 */ newEmptyHeaderField(HttpHeaderNames.HOST),
+    /* 39 */ newEmptyHeaderField(HttpHeaderNames.IF_MATCH),
+    /* 40 */ newEmptyHeaderField(HttpHeaderNames.IF_MODIFIED_SINCE),
+    /* 41 */ newEmptyHeaderField(HttpHeaderNames.IF_NONE_MATCH),
+    /* 42 */ newEmptyHeaderField(HttpHeaderNames.IF_RANGE),
+    /* 43 */ newEmptyHeaderField(HttpHeaderNames.IF_UNMODIFIED_SINCE),
+    /* 44 */ newEmptyHeaderField(HttpHeaderNames.LAST_MODIFIED),
     /* 45 */ newEmptyHeaderField("link"),
-    /* 46 */ newEmptyHeaderField("location"),
-    /* 47 */ newEmptyHeaderField("max-forwards"),
-    /* 48 */ newEmptyHeaderField("proxy-authenticate"),
-    /* 49 */ newEmptyHeaderField("proxy-authorization"),
-    /* 50 */ newEmptyHeaderField("range"),
-    /* 51 */ newEmptyHeaderField("referer"),
+    /* 46 */ newEmptyHeaderField(HttpHeaderNames.LOCATION),
+    /* 47 */ newEmptyHeaderField(HttpHeaderNames.MAX_FORWARDS),
+    /* 48 */ newEmptyHeaderField(HttpHeaderNames.PROXY_AUTHENTICATE),
+    /* 49 */ newEmptyHeaderField(HttpHeaderNames.PROXY_AUTHORIZATION),
+    /* 50 */ newEmptyHeaderField(HttpHeaderNames.RANGE),
+    /* 51 */ newEmptyHeaderField(HttpHeaderNames.REFERER),
     /* 52 */ newEmptyHeaderField("refresh"),
-    /* 53 */ newEmptyHeaderField("retry-after"),
-    /* 54 */ newEmptyHeaderField("server"),
-    /* 55 */ newEmptyHeaderField("set-cookie"),
+    /* 53 */ newEmptyHeaderField(HttpHeaderNames.RETRY_AFTER),
+    /* 54 */ newEmptyHeaderField(HttpHeaderNames.SERVER),
+    /* 55 */ newEmptyHeaderField(HttpHeaderNames.SET_COOKIE),
     /* 56 */ newEmptyHeaderField("strict-transport-security"),
-    /* 57 */ newEmptyHeaderField("transfer-encoding"),
-    /* 58 */ newEmptyHeaderField("user-agent"),
-    /* 59 */ newEmptyHeaderField("vary"),
-    /* 60 */ newEmptyHeaderField("via"),
-    /* 61 */ newEmptyHeaderField("www-authenticate")
+    /* 57 */ newEmptyHeaderField(HttpHeaderNames.TRANSFER_ENCODING),
+    /* 58 */ newEmptyHeaderField(HttpHeaderNames.USER_AGENT),
+    /* 59 */ newEmptyHeaderField(HttpHeaderNames.VARY),
+    /* 60 */ newEmptyHeaderField(HttpHeaderNames.VIA),
+    /* 61 */ newEmptyHeaderField(HttpHeaderNames.WWW_AUTHENTICATE)
     );
+
+    private static HpackHeaderField newEmptyHeaderField(AsciiString name) {
+        return new HpackHeaderField(name, AsciiString.EMPTY_STRING);
+    }
 
     private static HpackHeaderField newEmptyHeaderField(String name) {
         return new HpackHeaderField(AsciiString.cached(name), AsciiString.EMPTY_STRING);
     }
 
-    private static HpackHeaderField newHeaderField(String name, String value) {
-        return new HpackHeaderField(AsciiString.cached(name), AsciiString.cached(value));
+    private static HpackHeaderField newHeaderField(AsciiString name, String value) {
+        return new HpackHeaderField(name, AsciiString.cached(value));
+    }
+
+    private static HpackHeaderField newPseudoHeaderMethodField(HttpMethod method) {
+        return new HpackHeaderField(PseudoHeaderName.METHOD.value(), method.asciiName());
+    }
+
+    private static HpackHeaderField newPseudoHeaderField(PseudoHeaderName name, AsciiString value) {
+        return new HpackHeaderField(name.value(), value);
+    }
+
+    private static HpackHeaderField newPseudoHeaderField(PseudoHeaderName name, String value) {
+        return new HpackHeaderField(name.value(), AsciiString.cached(value));
+    }
+
+    private static HpackHeaderField newEmptyPseudoHeaderField(PseudoHeaderName name) {
+        return new HpackHeaderField(name.value(), AsciiString.EMPTY_STRING);
     }
 
     // The table size and bit shift are chosen so that each hash bucket contains a single header name.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Headers.java
@@ -68,13 +68,6 @@ public interface Http2Headers extends Headers<CharSequence, CharSequence, Http2H
 
         private final AsciiString value;
         private final boolean requestOnly;
-        private static final CharSequenceMap<PseudoHeaderName> PSEUDO_HEADERS = new CharSequenceMap<PseudoHeaderName>();
-
-        static {
-            for (PseudoHeaderName pseudoHeader : values()) {
-                PSEUDO_HEADERS.add(pseudoHeader.value(), pseudoHeader);
-            }
-        }
 
         PseudoHeaderName(String value, boolean requestOnly) {
             this.value = AsciiString.cached(value);
@@ -104,7 +97,21 @@ public interface Http2Headers extends Headers<CharSequence, CharSequence, Http2H
          * Indicates whether the given header name is a valid HTTP/2 pseudo header.
          */
         public static boolean isPseudoHeader(CharSequence header) {
-            return PSEUDO_HEADERS.contains(header);
+            return getPseudoHeader(header) != null;
+        }
+
+        /**
+         * Indicates whether the given header name is a valid HTTP/2 pseudo header.
+         */
+        public static boolean isPseudoHeader(AsciiString header) {
+            return getPseudoHeader(header) != null;
+        }
+
+        /**
+         * Indicates whether the given header name is a valid HTTP/2 pseudo header.
+         */
+        public static boolean isPseudoHeader(String header) {
+            return getPseudoHeader(header) != null;
         }
 
         /**
@@ -113,7 +120,89 @@ public interface Http2Headers extends Headers<CharSequence, CharSequence, Http2H
          * @return corresponding {@link PseudoHeaderName} if any, {@code null} otherwise.
          */
         public static PseudoHeaderName getPseudoHeader(CharSequence header) {
-            return PSEUDO_HEADERS.get(header);
+            if (header instanceof AsciiString) {
+                return getPseudoHeader((AsciiString) header);
+            }
+            return getPseudoHeaderName(header);
+        }
+
+        private static PseudoHeaderName getPseudoHeaderName(CharSequence header) {
+            if (header.length() > 0 && header.charAt(0) == PSEUDO_HEADER_PREFIX) {
+                switch (header.length()) {
+                case 5:
+                    // :path
+                    return ":path".contentEquals(header)? PATH : null;
+                case 7:
+                    // :method, :scheme, :status
+                    if (":method" == header) {
+                        return METHOD;
+                    }
+                    if (":scheme" == header) {
+                        return SCHEME;
+                    }
+                    if (":status" == header) {
+                        return STATUS;
+                    }
+                    if (":method".contentEquals(header)) {
+                        return METHOD;
+                    }
+                    if (":scheme".contentEquals(header)) {
+                        return SCHEME;
+                    }
+                    return ":status".contentEquals(header)? STATUS : null;
+                case 9:
+                    // :protocol
+                    return ":protocol".contentEquals(header)? PROTOCOL : null;
+                case 10:
+                    // :authority
+                    return ":authority".contentEquals(header)? AUTHORITY : null;
+                }
+            }
+            return null;
+        }
+
+        /**
+         * Returns the {@link PseudoHeaderName} corresponding to the specified header name.
+         *
+         * @return corresponding {@link PseudoHeaderName} if any, {@code null} otherwise.
+         */
+        public static PseudoHeaderName getPseudoHeader(AsciiString header) {
+            int length = header.length();
+            if (length == 0) {
+                return null;
+            }
+            if (header.charAt(0) == PSEUDO_HEADER_PREFIX_BYTE) {
+                switch (length) {
+                case 5:
+                    // :path
+                    return PATH.value().equals(header) ? PATH : null;
+                case 7:
+                    if (header == METHOD.value()) {
+                        return METHOD;
+                    }
+                    if (header == SCHEME.value()) {
+                        return SCHEME;
+                    }
+                    if (header == STATUS.value()) {
+                        return STATUS;
+                    }
+                    // :method, :scheme, :status
+                    if (METHOD.value().equals(header)) {
+                        return METHOD;
+                    }
+                    if (SCHEME.value().equals(header)) {
+                        return SCHEME;
+                    }
+                    return STATUS.value().equals(header)? STATUS : null;
+                case 9:
+                    // :protocol
+                    return PROTOCOL.value().equals(header)? PROTOCOL : null;
+                case 10:
+                    // :authority
+                    return AUTHORITY.value().equals(header)? AUTHORITY : null;
+                }
+            }
+            return null;
         }
 
         /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Headers.java
@@ -127,8 +127,9 @@ public interface Http2Headers extends Headers<CharSequence, CharSequence, Http2H
         }
 
         private static PseudoHeaderName getPseudoHeaderName(CharSequence header) {
-            if (header.length() > 0 && header.charAt(0) == PSEUDO_HEADER_PREFIX) {
-                switch (header.length()) {
+            int length = header.length();
+            if (length > 0 && header.charAt(0) == PSEUDO_HEADER_PREFIX) {
+                switch (length) {
                 case 5:
                     // :path
                     return ":path".contentEquals(header)? PATH : null;
@@ -168,10 +169,7 @@ public interface Http2Headers extends Headers<CharSequence, CharSequence, Http2H
          */
         public static PseudoHeaderName getPseudoHeader(AsciiString header) {
             int length = header.length();
-            if (length == 0) {
-                return null;
-            }
-            if (header.charAt(0) == PSEUDO_HEADER_PREFIX_BYTE) {
+            if (length > 0 && header.charAt(0) == PSEUDO_HEADER_PREFIX) {
                 switch (length) {
                 case 5:
                     // :path

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2HeadersTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2HeadersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 The Netty Project
+ * Copyright 2024 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2HeadersTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2HeadersTest.java
@@ -37,6 +37,17 @@ public class Http2HeadersTest {
     }
 
     @Test
+    public void pseudoHeaderNamesAreLiterals() {
+        // despite is an implementation details. is a relevant optimization
+        assertSame(":authority", PseudoHeaderName.AUTHORITY.value().toString());
+        assertSame(":method", PseudoHeaderName.METHOD.value().toString());
+        assertSame(":path", PseudoHeaderName.PATH.value().toString());
+        assertSame(":scheme", PseudoHeaderName.SCHEME.value().toString());
+        assertSame(":status", PseudoHeaderName.STATUS.value().toString());
+        assertSame(":protocol", PseudoHeaderName.PROTOCOL.value().toString());
+    }
+
+    @Test
     public void testIsPseudoHeader() {
         // same as before but for isPseudoHeader
         for (PseudoHeaderName pseudoHeaderName : PseudoHeaderName.values()) {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2HeadersTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2HeadersTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.handler.codec.http2;
+
+import io.netty.handler.codec.http2.Http2Headers.PseudoHeaderName;
+import io.netty.util.AsciiString;
+import org.junit.jupiter.api.Test;
+
+import static io.netty.handler.codec.http2.Http2Headers.PseudoHeaderName.getPseudoHeader;
+import static io.netty.handler.codec.http2.Http2Headers.PseudoHeaderName.isPseudoHeader;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Http2HeadersTest {
+
+    @Test
+    public void testGetPseudoHeader() {
+        for (PseudoHeaderName pseudoHeaderName : PseudoHeaderName.values()) {
+            assertSame(pseudoHeaderName, getPseudoHeader(pseudoHeaderName.value()));
+            assertSame(pseudoHeaderName, getPseudoHeader(new AsciiString(pseudoHeaderName.value().array())));
+            assertSame(pseudoHeaderName, getPseudoHeader(pseudoHeaderName.value().toString()));
+            assertSame(pseudoHeaderName, getPseudoHeader(new String(pseudoHeaderName.value().toCharArray())));
+            assertSame(pseudoHeaderName, getPseudoHeader(new StringBuilder(pseudoHeaderName.value())));
+        }
+    }
+
+    @Test
+    public void testIsPseudoHeader() {
+        // same as before but for isPseudoHeader
+        for (PseudoHeaderName pseudoHeaderName : PseudoHeaderName.values()) {
+            assertTrue(isPseudoHeader(pseudoHeaderName.value()));
+            assertTrue(isPseudoHeader(new AsciiString(pseudoHeaderName.value().array())));
+            assertTrue(isPseudoHeader(pseudoHeaderName.value().toString()));
+            assertTrue(isPseudoHeader(new String(pseudoHeaderName.value().toCharArray())));
+            assertTrue(isPseudoHeader(new StringBuilder(pseudoHeaderName.value())));
+        }
+    }
+}

--- a/microbench/src/main/java/io/netty/handler/codec/http2/Http2PseudoHeadersLookupBenchmark.java
+++ b/microbench/src/main/java/io/netty/handler/codec/http2/Http2PseudoHeadersLookupBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 The Netty Project
+ * Copyright 2024 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/microbench/src/main/java/io/netty/handler/codec/http2/Http2PseudoHeadersLookupBenchmark.java
+++ b/microbench/src/main/java/io/netty/handler/codec/http2/Http2PseudoHeadersLookupBenchmark.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http2;
+
+import io.netty.handler.codec.http2.Http2Headers.PseudoHeaderName;
+import io.netty.microbench.util.AbstractMicrobenchmark;
+import io.netty.util.AsciiString;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.concurrent.TimeUnit;
+
+
+@State(Scope.Benchmark)
+@Warmup(iterations = 10, time = 200, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 200, timeUnit = TimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class Http2PseudoHeadersLookupBenchmark extends AbstractMicrobenchmark {
+
+    @Param({ "true", "false" })
+    public boolean same;
+
+    private AsciiString[] asciiStrings;
+    private String[] strings;
+
+    private DefaultHttp2Headers headers;
+    @Setup
+    public void init() {
+        // this benchmark is assuming a good happy path:
+        // 1. ascii strings have hashCode cached
+        // 2. String doesn't have AsciiString::hashCode cached -> cannot be compared directly with AsciiStrings!
+        // 3. the call-sites are never observing the 2 types together
+        PseudoHeaderName[] pseudoHeaderNames = PseudoHeaderName.values();
+        asciiStrings = new AsciiString[pseudoHeaderNames.length];
+        strings = new String[pseudoHeaderNames.length];
+        for (int i = 0; i < pseudoHeaderNames.length; i++) {
+            PseudoHeaderName pseudoHeaderName = pseudoHeaderNames[i];
+            asciiStrings[i] = same? pseudoHeaderName.value() : new AsciiString(pseudoHeaderName.value().array(), true);
+            byte[] chars = asciiStrings[i].array();
+            strings[i] = same? pseudoHeaderName.value().toString() : new String(chars, 0, 0, chars.length);
+            // force hashCode caching
+            asciiStrings[i].hashCode();
+            pseudoHeaderName.hashCode();
+            pseudoHeaderName.toString().hashCode();
+            strings[i].hashCode();
+        }
+        this.headers = new DefaultHttp2Headers();
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public void getAsciiStringPseudoHeader(Blackhole bh) {
+        for (AsciiString asciiString : asciiStrings) {
+            bh.consume(PseudoHeaderName.getPseudoHeader(asciiString));
+        }
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public void getStringPseudoHeader(Blackhole bh) {
+        for (String string : strings) {
+            bh.consume(PseudoHeaderName.getPseudoHeader(string));
+        }
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public void addAsciiStringInHttp2Headers(Blackhole bh) {
+        DefaultHttp2Headers headers = this.headers;
+        for (AsciiString asciiString : asciiStrings) {
+            boolean hasPrefix = PseudoHeaderName.hasPseudoHeaderFormat(asciiString);
+            if (hasPrefix) {
+                boolean isPseudoHeader = PseudoHeaderName.isPseudoHeader(asciiString);
+                if (isPseudoHeader) {
+                    bh.consume(headers.add(asciiString, "0"));
+                    headers.clear();
+                }
+            }
+        }
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public void addStringInHttp2Headers(Blackhole bh) {
+        DefaultHttp2Headers headers = this.headers;
+        for (String asciiString : strings) {
+            boolean hasPrefix = PseudoHeaderName.hasPseudoHeaderFormat(asciiString);
+            if (hasPrefix) {
+                boolean isPseudoHeader = PseudoHeaderName.isPseudoHeader(asciiString);
+                if (isPseudoHeader) {
+                    bh.consume(headers.add(asciiString, "0"));
+                    headers.clear();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

Pseudoheader's could be cached within Hpack static table, but when they are added into Http2HeadersSink they are validated, verifying if they are pseudo-headers. Given that the AsciiStrings used within PseudoHeaderName and HpackStaticTable, it always requires to perform `AsciiString's equality.
For the same reason, if user code lookup those pseudo-headers using (as expected) PseudoHeaderName, the same equality check will always be performed.

Modification:

Speed-up pseudo-header lookup algorithm using a simple switch and ensuring that PseudoHeader's name are used to populate HpackStaticTable, to remove the need of a content equality check.

Result:

Faster pseudo-header lookup