### PR TITLE
Update to Brotli4j v1.14.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -880,7 +880,7 @@
         <artifactId>brotli4j</artifactId>
         <version>${brotli4j.version}</version>
       </dependency>
-     <dependency>
+      <dependency>
         <groupId>com.aayushatharva.brotli4j</groupId>
         <artifactId>native-linux-ppc64le</artifactId>
         <version>${brotli4j.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -666,7 +666,7 @@
     <skipAutobahnTestsuite>false</skipAutobahnTestsuite>
     <skipHttp2Testsuite>false</skipHttp2Testsuite>
     <graalvm.version>19.3.6</graalvm.version>
-    <brotli4j.version>1.13.0</brotli4j.version>
+    <brotli4j.version>1.14.0</brotli4j.version>
     <!-- By default skip native testsuite as it requires a custom environment with graalvm installed -->
     <skipNativeImageTestsuite>true</skipNativeImageTestsuite>
     <skipShadingTestsuite>false</skipShadingTestsuite>
@@ -880,6 +880,11 @@
         <artifactId>brotli4j</artifactId>
         <version>${brotli4j.version}</version>
       </dependency>
+     <dependency>
+        <groupId>com.aayushatharva.brotli4j</groupId>
+        <artifactId>native-linux-ppc64le</artifactId>
+        <version>${brotli4j.version}</version>
+      </dependency>
       <dependency>
         <groupId>com.aayushatharva.brotli4j</groupId>
         <artifactId>native-linux-x86_64</artifactId>
@@ -913,6 +918,11 @@
       <dependency>
         <groupId>com.aayushatharva.brotli4j</groupId>
         <artifactId>native-windows-x86_64</artifactId>
+        <version>${brotli4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.aayushatharva.brotli4j</groupId>
+        <artifactId>native-windows-aarch64</artifactId>
         <version>${brotli4j.version}</version>
       </dependency>
 


### PR DESCRIPTION
Motivation:
Brotli4j v1.14.0 is available with Windows ARM support.

Modification:
Upgraded Brotli4j to v1.14.0 and added Windows ARM module and PPC64le module.

Result:
Latest version of Brotli4j
