### PR TITLE
[feat] Introduce MemoryStateListener 

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
@@ -1455,6 +1455,22 @@ public abstract class AbstractByteBuf extends ByteBuf {
         }
     }
 
+    protected void notifyUnpooledMemoryReleased(int released) {
+        ByteBufAllocator alloc = alloc();
+        if (alloc instanceof AbstractByteBufAllocator) {
+            AbstractByteBufAllocator aalloc = (AbstractByteBufAllocator) alloc;
+            aalloc.notifyMemoryReleased0(released, isDirect());
+        }
+    }
+
+    protected void notifyUnpooledMemoryAllocated(int allocated) {
+        ByteBufAllocator alloc = alloc();
+        if (alloc instanceof AbstractByteBufAllocator) {
+            AbstractByteBufAllocator aalloc = (AbstractByteBufAllocator) alloc;
+            aalloc.notifyMemoryAllocated0(allocated, isDirect());
+        }
+    }
+
     final void setIndex0(int readerIndex, int writerIndex) {
         this.readerIndex = readerIndex;
         this.writerIndex = writerIndex;

--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBufAllocator.java
@@ -83,6 +83,7 @@ public abstract class AbstractByteBufAllocator implements ByteBufAllocator {
 
     private final boolean directByDefault;
     private final ByteBuf emptyBuf;
+    private MemoryStateListener listener;
 
     /**
      * Instance use heap buffers by default
@@ -242,6 +243,32 @@ public abstract class AbstractByteBufAllocator implements ByteBufAllocator {
      * Create a direct {@link ByteBuf} with the given initialCapacity and maxCapacity.
      */
     protected abstract ByteBuf newDirectBuffer(int initialCapacity, int maxCapacity);
+
+    protected void setMemoryStateListener(MemoryStateListener listener) {
+        this.listener = listener;
+    }
+
+    void notifyMemoryReleased0(int released, boolean direct) {
+        if (null == listener) {
+            return;
+        }
+        try {
+            listener.memoryReleased(released, direct);
+        } catch (Exception ex) {
+            // ignore
+        }
+    }
+
+    void notifyMemoryAllocated0(int allocated, boolean direct) {
+        if (null == listener) {
+            return;
+        }
+        try {
+            listener.memoryAllocated(allocated, direct);
+        } catch (Exception ex) {
+            // ignore
+        }
+    }
 
     @Override
     public String toString() {

--- a/buffer/src/main/java/io/netty/buffer/MemoryStateListener.java
+++ b/buffer/src/main/java/io/netty/buffer/MemoryStateListener.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package io.netty.buffer;
 
 public interface MemoryStateListener {

--- a/buffer/src/main/java/io/netty/buffer/MemoryStateListener.java
+++ b/buffer/src/main/java/io/netty/buffer/MemoryStateListener.java
@@ -1,0 +1,7 @@
+package io.netty.buffer;
+
+public interface MemoryStateListener {
+    void memoryReleased(int released, boolean direct);
+
+    void memoryAllocated(int allocated, boolean direct);
+}

--- a/buffer/src/main/java/io/netty/buffer/PoolChunk.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunk.java
@@ -617,12 +617,14 @@ final class PoolChunk<T> implements PoolChunkMetric {
     }
 
     void incrementPinnedMemory(int delta) {
+        arena.parent.notifyMemoryAllocated0(delta, arena.isDirect());
         assert delta > 0;
         pinnedBytes.add(delta);
     }
 
     void decrementPinnedMemory(int delta) {
         assert delta > 0;
+        arena.parent.notifyMemoryReleased0(delta, arena.isDirect());
         pinnedBytes.add(-delta);
     }
 

--- a/buffer/src/main/java/io/netty/buffer/UnpooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledByteBufAllocator.java
@@ -140,16 +140,16 @@ public final class UnpooledByteBufAllocator extends AbstractByteBufAllocator imp
         }
 
         @Override
-        protected byte[] allocateArray(int initialCapacity) {
-            byte[] bytes = super.allocateArray(initialCapacity);
+        protected byte[] doAllocateArray(int initialCapacity) {
+            byte[] bytes = super.doAllocateArray(initialCapacity);
             ((UnpooledByteBufAllocator) alloc()).incrementHeap(bytes.length);
             return bytes;
         }
 
         @Override
-        protected void freeArray(byte[] array) {
+        protected void doFreeArray(byte[] array) {
             int length = array.length;
-            super.freeArray(array);
+            super.doFreeArray(array);
             ((UnpooledByteBufAllocator) alloc()).decrementHeap(length);
         }
     }
@@ -160,16 +160,16 @@ public final class UnpooledByteBufAllocator extends AbstractByteBufAllocator imp
         }
 
         @Override
-        protected byte[] allocateArray(int initialCapacity) {
-            byte[] bytes = super.allocateArray(initialCapacity);
+        protected byte[] doAllocateArray(int initialCapacity) {
+            byte[] bytes = super.doAllocateArray(initialCapacity);
             ((UnpooledByteBufAllocator) alloc()).incrementHeap(bytes.length);
             return bytes;
         }
 
         @Override
-        protected void freeArray(byte[] array) {
+        protected void doFreeArray(byte[] array) {
             int length = array.length;
-            super.freeArray(array);
+            super.doFreeArray(array);
             ((UnpooledByteBufAllocator) alloc()).decrementHeap(length);
         }
     }
@@ -182,24 +182,24 @@ public final class UnpooledByteBufAllocator extends AbstractByteBufAllocator imp
         }
 
         @Override
-        protected ByteBuffer allocateDirect(int initialCapacity) {
-            ByteBuffer buffer = super.allocateDirect(initialCapacity);
+        protected ByteBuffer doAllocateDirect(int initialCapacity) {
+            ByteBuffer buffer = super.doAllocateDirect(initialCapacity);
             ((UnpooledByteBufAllocator) alloc()).incrementDirect(buffer.capacity());
             return buffer;
         }
 
         @Override
-        ByteBuffer reallocateDirect(ByteBuffer oldBuffer, int initialCapacity) {
+        protected ByteBuffer doReallocateDirect(ByteBuffer oldBuffer, int initialCapacity) {
             int capacity = oldBuffer.capacity();
-            ByteBuffer buffer = super.reallocateDirect(oldBuffer, initialCapacity);
+            ByteBuffer buffer = super.doReallocateDirect(oldBuffer, initialCapacity);
             ((UnpooledByteBufAllocator) alloc()).incrementDirect(buffer.capacity() - capacity);
             return buffer;
         }
 
         @Override
-        protected void freeDirect(ByteBuffer buffer) {
+        protected void doFreeDirect(ByteBuffer buffer) {
             int capacity = buffer.capacity();
-            super.freeDirect(buffer);
+            super.doFreeDirect(buffer);
             ((UnpooledByteBufAllocator) alloc()).decrementDirect(capacity);
         }
     }
@@ -211,16 +211,16 @@ public final class UnpooledByteBufAllocator extends AbstractByteBufAllocator imp
         }
 
         @Override
-        protected ByteBuffer allocateDirect(int initialCapacity) {
-            ByteBuffer buffer = super.allocateDirect(initialCapacity);
+        protected ByteBuffer doAllocateDirect(int initialCapacity) {
+            ByteBuffer buffer = super.doAllocateDirect(initialCapacity);
             ((UnpooledByteBufAllocator) alloc()).incrementDirect(buffer.capacity());
             return buffer;
         }
 
         @Override
-        protected void freeDirect(ByteBuffer buffer) {
+        protected void doFreeDirect(ByteBuffer buffer) {
             int capacity = buffer.capacity();
-            super.freeDirect(buffer);
+            super.doFreeDirect(buffer);
             ((UnpooledByteBufAllocator) alloc()).decrementDirect(capacity);
         }
     }
@@ -232,16 +232,16 @@ public final class UnpooledByteBufAllocator extends AbstractByteBufAllocator imp
         }
 
         @Override
-        protected ByteBuffer allocateDirect(int initialCapacity) {
-            ByteBuffer buffer = super.allocateDirect(initialCapacity);
+        protected ByteBuffer doAllocateDirect(int initialCapacity) {
+            ByteBuffer buffer = super.doAllocateDirect(initialCapacity);
             ((UnpooledByteBufAllocator) alloc()).incrementDirect(buffer.capacity());
             return buffer;
         }
 
         @Override
-        protected void freeDirect(ByteBuffer buffer) {
+        protected void doFreeDirect(ByteBuffer buffer) {
             int capacity = buffer.capacity();
-            super.freeDirect(buffer);
+            super.doFreeDirect(buffer);
             ((UnpooledByteBufAllocator) alloc()).decrementDirect(capacity);
         }
     }

--- a/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
@@ -112,21 +112,13 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     private ByteBuffer allocateDirect(int initialCapacity) {
-        ByteBufAllocator alloc = alloc();
-        if (alloc instanceof AbstractByteBufAllocator) {
-            AbstractByteBufAllocator alloc0 = (AbstractByteBufAllocator) alloc;
-            alloc0.notifyMemoryAllocated0(initialCapacity, true);
-        }
+        notifyUnpooledMemoryAllocated(initialCapacity);
         return doAllocateDirect(initialCapacity);
     }
 
     private void freeDirect(ByteBuffer buffer) {
-        ByteBufAllocator alloc = alloc();
-        if (alloc instanceof AbstractByteBufAllocator) {
-            AbstractByteBufAllocator alloc0 = (AbstractByteBufAllocator) alloc;
-            alloc0.notifyMemoryReleased0(buffer.capacity(), true);
-        }
         doFreeDirect(buffer);
+        notifyUnpooledMemoryReleased(buffer.capacity());
     }
 
     void setByteBuffer(ByteBuffer buffer, boolean tryFree) {

--- a/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
@@ -100,15 +100,33 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
     /**
      * Allocate a new direct {@link ByteBuffer} with the given initialCapacity.
      */
-    protected ByteBuffer allocateDirect(int initialCapacity) {
+    protected ByteBuffer doAllocateDirect(int initialCapacity) {
         return ByteBuffer.allocateDirect(initialCapacity);
     }
 
     /**
      * Free a direct {@link ByteBuffer}
      */
-    protected void freeDirect(ByteBuffer buffer) {
+    protected void doFreeDirect(ByteBuffer buffer) {
         PlatformDependent.freeDirectBuffer(buffer);
+    }
+
+    private ByteBuffer allocateDirect(int initialCapacity) {
+        ByteBufAllocator alloc = alloc();
+        if (alloc instanceof AbstractByteBufAllocator) {
+            AbstractByteBufAllocator alloc0 = (AbstractByteBufAllocator) alloc;
+            alloc0.notifyMemoryAllocated0(initialCapacity, true);
+        }
+        return doAllocateDirect(initialCapacity);
+    }
+
+    private void freeDirect(ByteBuffer buffer) {
+        ByteBufAllocator alloc = alloc();
+        if (alloc instanceof AbstractByteBufAllocator) {
+            AbstractByteBufAllocator alloc0 = (AbstractByteBufAllocator) alloc;
+            alloc0.notifyMemoryReleased0(buffer.capacity(), true);
+        }
+        doFreeDirect(buffer);
     }
 
     void setByteBuffer(ByteBuffer buffer, boolean tryFree) {

--- a/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
@@ -90,21 +90,13 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     private byte[] allocateArray(int initialCapacity) {
-        ByteBufAllocator alloc = alloc();
-        if (alloc instanceof AbstractByteBufAllocator) {
-            AbstractByteBufAllocator alloc0 = (AbstractByteBufAllocator) alloc;
-            alloc0.notifyMemoryAllocated0(initialCapacity, false);
-        }
+        notifyUnpooledMemoryAllocated(initialCapacity);
         return doAllocateArray(initialCapacity);
     }
 
     private void freeArray(byte[] array) {
-        ByteBufAllocator alloc = alloc();
-        if (alloc instanceof AbstractByteBufAllocator && null != array) {
-            AbstractByteBufAllocator alloc0 = (AbstractByteBufAllocator) alloc;
-            alloc0.notifyMemoryReleased0(array.length, false);
-        }
         doFreeArray(array);
+        notifyUnpooledMemoryReleased(array.length);
     }
 
     private void setArray(byte[] initialArray) {

--- a/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
@@ -81,12 +81,30 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
         setIndex(0, initialArray.length);
     }
 
-    protected byte[] allocateArray(int initialCapacity) {
+    protected byte[] doAllocateArray(int initialCapacity) {
         return new byte[initialCapacity];
     }
 
-    protected void freeArray(byte[] array) {
+    protected void doFreeArray(byte[] array) {
         // NOOP
+    }
+
+    private byte[] allocateArray(int initialCapacity) {
+        ByteBufAllocator alloc = alloc();
+        if (alloc instanceof AbstractByteBufAllocator) {
+            AbstractByteBufAllocator alloc0 = (AbstractByteBufAllocator) alloc;
+            alloc0.notifyMemoryAllocated0(initialCapacity, false);
+        }
+        return doAllocateArray(initialCapacity);
+    }
+
+    private void freeArray(byte[] array) {
+        ByteBufAllocator alloc = alloc();
+        if (alloc instanceof AbstractByteBufAllocator && null != array) {
+            AbstractByteBufAllocator alloc0 = (AbstractByteBufAllocator) alloc;
+            alloc0.notifyMemoryReleased0(array.length, false);
+        }
+        doFreeArray(array);
     }
 
     private void setArray(byte[] initialArray) {

--- a/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeHeapByteBuf.java
@@ -35,7 +35,7 @@ public class UnpooledUnsafeHeapByteBuf extends UnpooledHeapByteBuf {
     }
 
     @Override
-    protected byte[] allocateArray(int initialCapacity) {
+    protected byte[] doAllocateArray(int initialCapacity) {
         return PlatformDependent.allocateUninitializedArray(initialCapacity);
     }
 

--- a/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeNoCleanerDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeNoCleanerDirectByteBuf.java
@@ -26,16 +26,26 @@ class UnpooledUnsafeNoCleanerDirectByteBuf extends UnpooledUnsafeDirectByteBuf {
     }
 
     @Override
-    protected ByteBuffer allocateDirect(int initialCapacity) {
+    protected ByteBuffer doAllocateDirect(int initialCapacity) {
         return PlatformDependent.allocateDirectNoCleaner(initialCapacity);
     }
 
-    ByteBuffer reallocateDirect(ByteBuffer oldBuffer, int initialCapacity) {
+    private ByteBuffer reallocateDirect(ByteBuffer oldBuffer, int initialCapacity) {
+        ByteBufAllocator alloc = alloc();
+        if (alloc instanceof AbstractByteBufAllocator) {
+            AbstractByteBufAllocator alloc0 = (AbstractByteBufAllocator) alloc;
+            alloc0.notifyMemoryReleased0(buffer.capacity(), true);
+            alloc0.notifyMemoryAllocated0(initialCapacity, true);
+        }
+        return doReallocateDirect(oldBuffer, initialCapacity);
+    }
+
+    protected ByteBuffer doReallocateDirect(ByteBuffer oldBuffer, int initialCapacity) {
         return PlatformDependent.reallocateDirectNoCleaner(oldBuffer, initialCapacity);
     }
 
     @Override
-    protected void freeDirect(ByteBuffer buffer) {
+    protected void doFreeDirect(ByteBuffer buffer) {
         PlatformDependent.freeDirectNoCleaner(buffer);
     }
 

--- a/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeNoCleanerDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeNoCleanerDirectByteBuf.java
@@ -31,13 +31,10 @@ class UnpooledUnsafeNoCleanerDirectByteBuf extends UnpooledUnsafeDirectByteBuf {
     }
 
     private ByteBuffer reallocateDirect(ByteBuffer oldBuffer, int initialCapacity) {
-        ByteBufAllocator alloc = alloc();
-        if (alloc instanceof AbstractByteBufAllocator) {
-            AbstractByteBufAllocator alloc0 = (AbstractByteBufAllocator) alloc;
-            alloc0.notifyMemoryReleased0(buffer.capacity(), true);
-            alloc0.notifyMemoryAllocated0(initialCapacity, true);
-        }
-        return doReallocateDirect(oldBuffer, initialCapacity);
+        notifyUnpooledMemoryAllocated(initialCapacity);
+        ByteBuffer buffer = doReallocateDirect(oldBuffer, initialCapacity);
+        notifyUnpooledMemoryReleased(oldBuffer.capacity());
+        return buffer;
     }
 
     protected ByteBuffer doReallocateDirect(ByteBuffer oldBuffer, int initialCapacity) {

--- a/buffer/src/main/java/io/netty/buffer/WrappedUnpooledUnsafeDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/WrappedUnpooledUnsafeDirectByteBuf.java
@@ -26,7 +26,7 @@ final class WrappedUnpooledUnsafeDirectByteBuf extends UnpooledUnsafeDirectByteB
     }
 
     @Override
-    protected void freeDirect(ByteBuffer buffer) {
+    protected void doFreeDirect(ByteBuffer buffer) {
         PlatformDependent.freeMemory(memoryAddress);
     }
 }


### PR DESCRIPTION
Motivation:

Introduce `MemoryStateListener`, it is for the purpose of memory usage control. Of course, we can also use it more gracefully for flow control.
With this feature, we can easy to control memory usage, this is an example for message usage control:
```
public class BlockingPooledByteBufAllocator extends PooledByteBufAllocator {

    public BlockingPooledByteBufAllocator(int maxMemoryAllowed) {
        super();
        setMemoryStateListener(new BlockingMemoryStateListener(maxMemoryAllowed));
    }

    private static class BlockingMemoryStateListener implements MemoryStateListener {

        private final Semaphore semaphore;
        BlockingMemoryStateListener(int maxMemoryAllowed) {
            this.semaphore = new Semaphore(maxMemoryAllowed);
        }

        @Override
        public void memoryReleased(int released, boolean direct) {
            this.semaphore.release(released);
        }

        @Override
        public void memoryAllocated(int allocated, boolean direct) {
            this.semaphore.acquireUninterruptibly(allocated);
        }
    }
}
```
If there is no more memory allowed, current thread will be blocked until some other memory released.
We can use this feature to protect our applications, instead of handle `OutOfMemoryError`.

This is an immature idea of mine, and I'm wondering if it is reasonable, looking forward to your feedback, thanks.

Modification:

Describe the modifications you've done.

Result:

Fixes #<GitHub issue number>. 

If there is no issue then describe the changes introduced by this PR.
