### PR TITLE
Avoid virtual calls in http 2 stream notifications

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/UniformStreamByteDistributor.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/UniformStreamByteDistributor.java
@@ -53,17 +53,7 @@ public final class UniformStreamByteDistributor implements StreamByteDistributor
         connectionStream.setProperty(stateKey, new State(connectionStream));
 
         // Register for notification of new streams.
-        connection.addListener(new Http2ConnectionAdapter() {
-            @Override
-            public void onStreamAdded(Http2Stream stream) {
-                stream.setProperty(stateKey, new State(stream));
-            }
-
-            @Override
-            public void onStreamClosed(Http2Stream stream) {
-                state(stream).close();
-            }
-        });
+        connection.addListener(new StreamListener());
     }
 
     /**
@@ -200,6 +190,18 @@ public final class UniformStreamByteDistributor implements StreamByteDistributor
 
             // Clear the streamable bytes.
             updateStreamableBytes(0, false, 0);
+        }
+    }
+
+    final class StreamListener extends Http2ConnectionAdapter {
+        @Override
+        public void onStreamAdded(Http2Stream stream) {
+            stream.setProperty(stateKey, new State(stream));
+        }
+
+        @Override
+        public void onStreamClosed(Http2Stream stream) {
+            state(stream).close();
         }
     }
 }


### PR DESCRIPTION
Motivation:

relying on Http2 Listener's invokeinterface always cause megamorphic calls

Modifications:

Peel-off Listener's invokeinterface call-site(s) by using known implementors

Result:

No megamorphic http 2 stream notifications