### PR TITLE
Inline duplicate variable declaration

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtensionHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtensionHandler.java
@@ -205,11 +205,9 @@ public class WebSocketServerExtensionHandler extends ChannelDuplexHandler {
     protected void onHttpResponseWrite(ChannelHandlerContext ctx, HttpResponse response, ChannelPromise promise)
             throws Exception {
         List<WebSocketServerExtension> validExtensionsList = validExtensions.poll();
-        HttpResponse httpResponse = response;
-        //checking the status is faster than looking at headers
-        //so we do this first
-        if (HttpResponseStatus.SWITCHING_PROTOCOLS.equals(httpResponse.status())) {
-            handlePotentialUpgrade(ctx, promise, httpResponse, validExtensionsList);
+        // checking the status is faster than looking at headers so we do this first
+        if (HttpResponseStatus.SWITCHING_PROTOCOLS.equals(response.status())) {
+            handlePotentialUpgrade(ctx, promise, response, validExtensionsList);
         }
         super.write(ctx, response, promise);
     }


### PR DESCRIPTION
Motivation:
I was going through the WebSocket code and found that a new `HttpResponse` variable was declared referring to the same instance.

Modification:
Inlined duplicate variable declaration

Result:
Minor nit and comment cleanup
