### PR TITLE
Save HTTP 2 pseudo-header lower-case validation

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
@@ -24,8 +24,8 @@ import io.netty.util.internal.UnstableApi;
 
 import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
 import static io.netty.handler.codec.http2.Http2Exception.connectionError;
-import static io.netty.handler.codec.http2.Http2Headers.PseudoHeaderName.getPseudoHeader;
 import static io.netty.handler.codec.http2.Http2Headers.PseudoHeaderName.hasPseudoHeaderFormat;
+import static io.netty.handler.codec.http2.Http2Headers.PseudoHeaderName.isPseudoHeader;
 import static io.netty.util.AsciiString.CASE_INSENSITIVE_HASHER;
 import static io.netty.util.AsciiString.CASE_SENSITIVE_HASHER;
 import static io.netty.util.AsciiString.isUpperCase;
@@ -45,6 +45,15 @@ public class DefaultHttp2Headers
             if (name == null || name.length() == 0) {
                 PlatformDependent.throwException(connectionError(PROTOCOL_ERROR,
                         "empty headers are not allowed [%s]", name));
+            }
+
+            if (hasPseudoHeaderFormat(name)) {
+                if (!isPseudoHeader(name)) {
+                    PlatformDependent.throwException(connectionError(
+                            PROTOCOL_ERROR, "Invalid HTTP/2 pseudo-header '%s' encountered.", name));
+                }
+                // no need for lower-case validation, we trust our own pseudo header constants
+                return;
             }
 
             if (name instanceof AsciiString) {
@@ -70,14 +79,6 @@ public class DefaultHttp2Headers
                         PlatformDependent.throwException(connectionError(PROTOCOL_ERROR,
                                 "invalid header name [%s]", name));
                     }
-                }
-            }
-
-            if (hasPseudoHeaderFormat(name)) {
-                final Http2Headers.PseudoHeaderName pseudoHeader = getPseudoHeader(name);
-                if (pseudoHeader == null) {
-                    PlatformDependent.throwException(connectionError(
-                            PROTOCOL_ERROR, "Invalid HTTP/2 pseudo-header '%s' encountered.", name));
                 }
             }
         }


### PR DESCRIPTION
Motivation:

pseudo-header constants doesn't requires any further validation

Modifications:

anticipate pseudoheader lookup on http 2 header name validation, saving any further validation, if positive

Result:

Faster validations over known pseudo-headers