### PR TITLE
Add support for the Partitioned attribute in cookies

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ClientCookieDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ClientCookieDecoder.java
@@ -156,6 +156,7 @@ public final class ClientCookieDecoder extends CookieDecoder {
         private boolean secure;
         private boolean httpOnly;
         private SameSite sameSite;
+        private boolean partitioned;
 
         CookieBuilder(DefaultCookie cookie, String header) {
             this.cookie = cookie;
@@ -183,6 +184,7 @@ public final class ClientCookieDecoder extends CookieDecoder {
             cookie.setSecure(secure);
             cookie.setHttpOnly(httpOnly);
             cookie.setSameSite(sameSite);
+            cookie.setPartitioned(partitioned);
             return cookie;
         }
 
@@ -210,6 +212,8 @@ public final class ClientCookieDecoder extends CookieDecoder {
                 parse7(keyStart, valueStart, valueEnd);
             } else if (length == 8) {
                 parse8(keyStart, valueStart, valueEnd);
+            } else if (length == 11) {
+                parse11(keyStart);
             }
         }
 
@@ -249,6 +253,12 @@ public final class ClientCookieDecoder extends CookieDecoder {
                 httpOnly = true;
             } else if (header.regionMatches(true, nameStart, CookieHeaderNames.SAMESITE, 0, 8)) {
                 sameSite = SameSite.of(computeValue(valueStart, valueEnd));
+            }
+        }
+
+        private void parse11(int nameStart) {
+            if (header.regionMatches(true, nameStart, CookieHeaderNames.PARTITIONED, 0, 11)) {
+                partitioned = true;
             }
         }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/CookieHeaderNames.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/CookieHeaderNames.java
@@ -30,6 +30,8 @@ public final class CookieHeaderNames {
 
     public static final String SAMESITE = "SameSite";
 
+    public static final String PARTITIONED = "Partitioned";
+
     /**
      * Possible values for the SameSite attribute.
      * See <a href="https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-05">changes to RFC6265bis</a>

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/DefaultCookie.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/DefaultCookie.java
@@ -36,6 +36,7 @@ public class DefaultCookie implements Cookie {
     private boolean secure;
     private boolean httpOnly;
     private SameSite sameSite;
+    private boolean partitioned;
 
     /**
      * Creates a new cookie with the specified name and value.
@@ -138,6 +139,24 @@ public class DefaultCookie implements Cookie {
      */
     public void setSameSite(SameSite sameSite) {
         this.sameSite = sameSite;
+    }
+
+    /**
+     * Checks to see if this {@link Cookie} is partitioned
+     *
+     * @return True if this {@link Cookie} is partitioned, otherwise false
+     */
+    public boolean isPartitioned() {
+        return partitioned;
+    }
+
+    /**
+     * Sets the {@code Partitioned} attribute of this {@link Cookie}
+     *
+     * @param partitioned True if this {@link Cookie} is to be partitioned, otherwise false
+     */
+    public void setPartitioned(boolean partitioned) {
+        this.partitioned = partitioned;
     }
 
     @Override
@@ -255,6 +274,9 @@ public class DefaultCookie implements Cookie {
         }
         if (sameSite() != null) {
             buf.append(", SameSite=").append(sameSite());
+        }
+        if (isPartitioned()) {
+            buf.append(", Partitioned");
         }
         return buf.toString();
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ServerCookieEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ServerCookieEncoder.java
@@ -129,6 +129,9 @@ public final class ServerCookieEncoder extends CookieEncoder {
             if (c.sameSite() != null) {
                 add(buf, CookieHeaderNames.SAMESITE, c.sameSite().name());
             }
+            if (c.isPartitioned()) {
+                add(buf, CookieHeaderNames.PARTITIONED);
+            }
         }
 
         return stripTrailingSeparator(buf);

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cookie/ClientCookieDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cookie/ClientCookieDecoderTest.java
@@ -41,7 +41,7 @@ public class ClientCookieDecoderTest {
     public void testDecodingSingleCookieV0() {
         String cookieString = "myCookie=myValue;expires="
                 + DateFormatter.format(new Date(System.currentTimeMillis() + 50000))
-                + ";path=/apathsomewhere;domain=.adomainsomewhere;secure;SameSite=None";
+                + ";path=/apathsomewhere;domain=.adomainsomewhere;secure;SameSite=None;Partitioned";
 
         Cookie cookie = ClientCookieDecoder.STRICT.decode(cookieString);
         assertNotNull(cookie);
@@ -55,7 +55,9 @@ public class ClientCookieDecoderTest {
         assertTrue(cookie.isSecure());
 
         assertThat(cookie, is(instanceOf(DefaultCookie.class)));
-        assertEquals(SameSite.None, ((DefaultCookie) cookie).sameSite());
+        DefaultCookie c = (DefaultCookie) cookie;
+        assertEquals(SameSite.None, c.sameSite());
+        assertTrue(c.isPartitioned());
     }
 
     @Test

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cookie/ServerCookieEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cookie/ServerCookieEncoderTest.java
@@ -44,13 +44,14 @@ public class ServerCookieEncoderTest {
         int maxAge = 50;
 
         String result = "myCookie=myValue; Max-Age=50; Expires=(.+?); Path=/apathsomewhere;" +
-                " Domain=.adomainsomewhere; Secure; SameSite=Lax";
+                " Domain=.adomainsomewhere; Secure; SameSite=Lax; Partitioned";
         DefaultCookie cookie = new DefaultCookie("myCookie", "myValue");
         cookie.setDomain(".adomainsomewhere");
         cookie.setMaxAge(maxAge);
         cookie.setPath("/apathsomewhere");
         cookie.setSecure(true);
         cookie.setSameSite(SameSite.Lax);
+        cookie.setPartitioned(true);
 
         String encodedCookie = ServerCookieEncoder.STRICT.encode(cookie);
 


### PR DESCRIPTION
Motivation:

Netty currently does not support the `Partitioned` attribute for response cookies. 
https://developers.google.com/privacy-sandbox/3pcd/chips

Modifications:

Since adding new methods to the `Cookie` interface is backwards-incompatible, the attribute has been solely added to the `DefaultCookie` class. Moreover, the `Partitioned` attribute is not included in the current `RFC6265`. `ServerCookieEncoder` and `ClientCookieDecoder` have been updated accordingly to process this value.

Result:

Response cookies with the `Partitioned` attribute set can be read or written by Netty. 
Fixes #13740