### PR TITLE
Make Epoll UDS channel extensible by removing `final`.

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannel.java
@@ -30,7 +30,7 @@ import java.net.SocketAddress;
 
 import static io.netty.channel.epoll.LinuxSocket.newSocketDomain;
 
-public final class EpollDomainSocketChannel extends AbstractEpollStreamChannel implements DomainSocketChannel {
+public class EpollDomainSocketChannel extends AbstractEpollStreamChannel implements DomainSocketChannel {
     private final EpollDomainSocketChannelConfig config = new EpollDomainSocketChannelConfig(this);
 
     private volatile DomainSocketAddress local;


### PR DESCRIPTION
Motivation:

We'd like to override Epoll UDS channels - in particular, setting a custom channel id. There is no way to do that with the current 4.1 channel API. In addition, the `Epoll*` channels are not extensible, but e.g. `NioSocketChannel` is, which is inconsistent.

Google sends remote debug logs to a server over UDS, so any logs in the path of creating UDS channels (e.g. [`MacAddressUtil`](https://github.com/netty/netty/blob/4.1/common/src/main/java/io/netty/util/internal/MacAddressUtil.java#L133-L135) called from `DefaultChannelId`) cause a deadlock. Hence, wrapping/adapting `EpollDomainSocketChannel` does not work because we still hit the deadlock. Overriding `EpollDomainSocketChannel.newId()` avoids the issue.

Modifications:

Make Epoll UDS channel extensible by removing `final`.

Result:

Epoll UDS channels will be extensible.