### PR TITLE
DnsNameResolver: Limit connect timeout to query timeout

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -466,6 +466,11 @@ public class DnsNameResolver extends InetNameResolver {
                     .channelFactory(socketChannelFactory)
                     .attr(DNS_PIPELINE_ATTRIBUTE, Boolean.TRUE)
                     .handler(TCP_ENCODER);
+            if (queryTimeoutMillis > 0 && queryTimeoutMillis <= Integer.MAX_VALUE) {
+                // Set the connect timeout to the same as queryTimeout as otherwise it might take a long
+                // time for the query to fail in case of a connection timeout.
+                socketBootstrap.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, (int) queryTimeoutMillis);
+            }
         }
         switch (this.resolvedAddressTypes) {
             case IPV4_ONLY:


### PR DESCRIPTION
Motivation:

We should not use the default connect timeout (10s) but better use the query timeout as the limit

Modifications:

Use query timeout as connect timeout if any is configured

Result:

Faster failing connect timeouts when using TCP fallback