### PR TITLE
Reduce HTTP 1.1 Full msg pipeline traversals

### DIFF
--- a/microbench/src/main/java/io/netty/microbench/http/HttpRequestEncoderBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/http/HttpRequestEncoderBenchmark.java
@@ -70,9 +70,12 @@ public class HttpRequestEncoderBenchmark extends AbstractMicrobenchmark {
     @Param({ "false", "true" })
     public boolean typePollution;
 
+    @Param({ "128" })
+    private int contentBytes;
+
     @Setup(Level.Trial)
     public void setup() throws Exception {
-        byte[] bytes = new byte[256];
+        byte[] bytes = new byte[contentBytes];
         content = Unpooled.buffer(bytes.length);
         content.writeBytes(bytes);
         ByteBuf testContent = Unpooled.unreleasableBuffer(content.asReadOnly());
@@ -112,27 +115,34 @@ public class HttpRequestEncoderBenchmark extends AbstractMicrobenchmark {
 
     @Benchmark
     public void fullMessage() throws Exception {
+        fullRequest.content().setIndex(0, contentBytes);
         encoder.write(context, fullRequest, newPromise());
     }
 
     @Benchmark
     public void contentLength() throws Exception {
         encoder.write(context, contentLengthRequest, newPromise());
+        lastContent.content().setIndex(0, contentBytes);
         encoder.write(context, lastContent, newPromise());
     }
 
     @Benchmark
     public void chunked() throws Exception {
         encoder.write(context, chunkedRequest, newPromise());
+        lastContent.content().setIndex(0, contentBytes);
         encoder.write(context, lastContent, newPromise());
     }
 
     @Benchmark
     public void differentTypes() throws Exception {
         encoder.write(context, contentLengthRequest, newPromise());
+        lastContent.content().setIndex(0, contentBytes);
         encoder.write(context, lastContent, newPromise());
+        content.setIndex(0, contentBytes);
+        fullRequest.content().setIndex(0, contentBytes);
         encoder.write(context, fullRequest, newPromise());
         encoder.write(context, chunkedRequest, newPromise());
+        lastContent.content().setIndex(0, contentBytes);
         encoder.write(context, lastContent, newPromise());
     }
 


### PR DESCRIPTION
Reduce HTTP 1.1 Full msg pipeline traversals

Motivation:

HttpObjectEncoder can already embed the data into the header buffer, enabling MessageToMessageEncoder to save allocating promise combiners and reducing the number of pipeline traversal. Sadly this happens only if the header estimation leave enough room in the header buffer.

Modifications:

Enhance the ability to embed the full msg content into the header buffer if under specific thresholds or for heap buffers, which will likely be copied into direct ones regardless, later one, anticipating the copy.

Result:

Faster small or heap data's writes