### PR TITLE
Updated HTTP2 Reader to fix missing header state

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2FrameReaderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2FrameReaderTest.java
@@ -393,6 +393,11 @@ public class DefaultHttp2FrameReaderTest {
         try {
             // Write a malformed priority header causing a stream exception in reader
             writeFrameHeader(input, 4, PRIORITY, new Http2Flags(), priorityStreamId);
+            // Fill buffer with dummy payload to be properly read by reader
+            input.writeByte((byte) 0x80);
+            input.writeByte((byte) 0x00);
+            input.writeByte((byte) 0x00);
+            input.writeByte((byte) 0x7f);
             assertThrows(Http2Exception.class, new Executable() {
                 @Override
                 public void execute() throws Throwable {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2FrameReaderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2FrameReaderTest.java
@@ -386,6 +386,40 @@ public class DefaultHttp2FrameReaderTest {
         }
     }
 
+    @Test
+    public void verifyValidRequestAfterMalformedPacketCausesStreamException() throws Http2Exception {
+        final ByteBuf input = Unpooled.buffer();
+        int priorityStreamId = 3, headerStreamId = 5;
+        try {
+            // Write a malformed priority header causing a stream exception in reader
+            writeFrameHeader(input, 4, PRIORITY, new Http2Flags(), priorityStreamId);
+            assertThrows(Http2Exception.class, new Executable() {
+                @Override
+                public void execute() throws Throwable {
+                    try {
+                        frameReader.readFrame(ctx, input, listener);
+                    } catch (Exception e) {
+                        if (e instanceof Http2Exception && Http2Exception.isStreamError((Http2Exception) e)) {
+                            throw e;
+                        }
+                    }
+                }
+            });
+            // Verify that after stream exception we accept new stream requests
+            Http2Headers headers = new DefaultHttp2Headers()
+                    .authority("foo")
+                    .method("get")
+                    .path("/")
+                    .scheme("https");
+            Http2Flags flags = new Http2Flags().endOfHeaders(true).endOfStream(true);
+            writeHeaderFrame(input, headerStreamId, headers, flags);
+            frameReader.readFrame(ctx, input, listener);
+            verify(listener).onHeadersRead(ctx, 5, headers, 0, true);
+        } finally {
+            input.release();
+        }
+    }
+
     private void writeHeaderFrame(
             ByteBuf output, int streamId, Http2Headers headers,
             Http2Flags flags) throws Http2Exception {


### PR DESCRIPTION
Motivation:
When a malformed request comes in where a stream error is thrown, data is still left on the reader and not properly cleaned. When a valid request comes in, it is not properly parsed because of the leftover data being included.

Modifications:
Updated DefaultHttp2Reader to clean up leftover data if these types of stream exceptions come in the wire.

Result:
After this change, data should be properly parsed after a malformed request
Fixes #13788 

If there is no issue then describe the changes introduced by this PR.
