### PR TITLE
Add `IpSubnetFilterExample`

### DIFF
--- a/example/src/main/java/io/netty/example/ipfilter/IpSubnetFilterExample.java
+++ b/example/src/main/java/io/netty/example/ipfilter/IpSubnetFilterExample.java
@@ -47,7 +47,7 @@ public final class IpSubnetFilterExample {
         EventLoopGroup workerGroup = new NioEventLoopGroup(1);
 
         try {
-            List<IpSubnetFilterRule> rules = new ArrayList<>();
+            List<IpSubnetFilterRule> rules = new ArrayList<IpSubnetFilterRule>();
 
             // Reject 10.10.10.0/24 and 192.168.0.0/16 ranges but accept the rest
             rules.add(new IpSubnetFilterRule("10.10.10.0", 24, IpFilterRuleType.REJECT));

--- a/example/src/main/java/io/netty/example/ipfilter/IpSubnetFilterExample.java
+++ b/example/src/main/java/io/netty/example/ipfilter/IpSubnetFilterExample.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.example.ipfilter;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.ipfilter.IpFilterRuleType;
+import io.netty.handler.ipfilter.IpSubnetFilter;
+import io.netty.handler.ipfilter.IpSubnetFilterRule;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Discards any incoming data from a blacklisteded IP address subnet and accepts the rest.
+ */
+public final class IpSubnetFilterExample {
+
+    static final int PORT = Integer.parseInt(System.getProperty("port", "8009"));
+
+    public static void main(String[] args) throws Exception {
+        EventLoopGroup bossGroup = new NioEventLoopGroup(1);
+        EventLoopGroup workerGroup = new NioEventLoopGroup(1);
+
+        try {
+            List<IpSubnetFilterRule> rules = new ArrayList<>();
+
+            // Reject 10.10.10.0/24 and 192.168.0.0/16 ranges but accept the rest
+            rules.add(new IpSubnetFilterRule("10.10.10.0", 24, IpFilterRuleType.REJECT));
+            rules.add(new IpSubnetFilterRule("192.168.0.0", 16, IpFilterRuleType.REJECT));
+
+            // Share this same Handler instance with multiple ChannelPipeline(s).
+            final IpSubnetFilter ipFilter = new IpSubnetFilter(rules);
+
+            ServerBootstrap b = new ServerBootstrap();
+            b.group(bossGroup, workerGroup)
+                    .channel(NioServerSocketChannel.class)
+                    .handler(new LoggingHandler(LogLevel.INFO))
+                    .childHandler(new ChannelInitializer<SocketChannel>() {
+                        @Override
+                        public void initChannel(SocketChannel ch) {
+                            ChannelPipeline p = ch.pipeline();
+                            p.addFirst(ipFilter);
+
+                            p.addLast(new SimpleChannelInboundHandler<ByteBuf>() {
+                                @Override
+                                protected void channelRead0(ChannelHandlerContext ctx, ByteBuf msg) throws Exception {
+                                    System.out.println("Received data from: " + ctx.channel().remoteAddress());
+                                }
+                            });
+                        }
+                    });
+
+            // Bind and start to accept incoming connections.
+            ChannelFuture f = b.bind(PORT).sync();
+
+            // Wait until the server socket is closed.
+            // In this example, this does not happen, but you can do that to gracefully
+            // shut down your server.
+            f.channel().closeFuture().sync();
+        } finally {
+            workerGroup.shutdownGracefully();
+            bossGroup.shutdownGracefully();
+        }
+    }
+}

--- a/example/src/main/java/io/netty/example/ipfilter/IpSubnetFilterExample.java
+++ b/example/src/main/java/io/netty/example/ipfilter/IpSubnetFilterExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2024 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance


### PR DESCRIPTION
Motivation:
We should have an example for using `IpSubnetFilterRule` to filter traffic using Netty.

Modification:
Added `IpSubnetFilterExample`

Result:
Example for usages of `IpSubnetFilterRule`
