### PR TITLE
DnsNameResolver: Add DnsQueryIdSpace class to reduce overhead while g…

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryIdSpace.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryIdSpace.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import io.netty.util.internal.MathUtil;
+import io.netty.util.internal.PlatformDependent;
+
+import java.util.Random;
+
+/**
+ * Special data-structure that will allow to retrieve the next query id to use, while still guarantee some sort
+ * of randomness.
+ * The query id will be between 0 (inclusive) and 65535 (inclusive) as defined by the RFC.
+ */
+final class DnsQueryIdSpace {
+    private static final int MAX_ID = 65535;
+
+    // Holds all possible ids which are stored as unsigned shorts
+    private final short[] ids = new short[MAX_ID + 1];
+    private final int mask = ids.length - 1;
+    private int head;
+    private int tail;
+    private int count;
+
+    DnsQueryIdSpace() {
+        assert ids.length == MathUtil.findNextPositivePowerOfTwo(MAX_ID);
+        for (int v = 0; v <= MAX_ID; v++) {
+            pushId(v);
+        }
+    }
+
+    /**
+     * Returns the next ID to use for a query or {@code -1} if there is none left to use.
+     *
+     * @return  next id to use.
+     */
+    int nextId() {
+        assert count >= 0;
+        if (count == 0) {
+            return -1;
+        }
+        short id = ids[head];
+        head = (head + 1) & mask;
+        count--;
+
+        return id & 0xFFFF;
+    }
+
+    /**
+     * Push back the id, so it can be used again for the next query.
+     *
+     * @param id    the id.
+     */
+    void pushId(int id) {
+        if (count == ids.length) {
+            throw new IllegalStateException("overflow");
+        }
+
+        assert id <= MAX_ID && id >= 0;
+        if (tail == head) {
+            ids[tail] = (short) id;
+        } else {
+            // Let's ensure our ids will be returned in a random fashion by not always add the id to the tail.
+            final int idx;
+            Random random = PlatformDependent.threadLocalRandom();
+            if (tail < head) {
+                if (tail != 0 && random.nextBoolean()) {
+                    idx = random.nextInt(tail);
+                } else {
+                    idx = random.nextInt(ids.length - head) + head;
+                }
+            } else {
+                idx = random.nextInt(tail - head) + head;
+            }
+            short otherId = ids[idx];
+            ids[idx] = (short) id;
+            ids[tail] = otherId;
+            assert otherId != (short) id;
+        }
+        tail = (tail + 1) & mask;
+        count++;
+    }
+
+    /**
+     * Return how much more usable ids are left.
+     *
+     * @return  the number of ids that are left for usage.
+     */
+    int usableIds() {
+        return count;
+    }
+
+    /**
+     * Return the maximum number of ids that are supported.
+     *
+     * @return  the maximum number of ids.
+     */
+    int maxUsableIds() {
+        return ids.length;
+    }
+}

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsQueryIdSpaceTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsQueryIdSpaceTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DnsQueryIdSpaceTest {
+
+    @Test
+    public void testOverflow() {
+        final DnsQueryIdSpace ids = new DnsQueryIdSpace();
+        assertThrows(IllegalStateException.class, new Executable() {
+            @Override
+            public void execute() {
+                ids.pushId(1);
+            }
+        });
+    }
+
+    @Test
+    public void testConsumeAndProduceAll() {
+        final DnsQueryIdSpace ids = new DnsQueryIdSpace();
+        assertEquals(ids.maxUsableIds(), ids.usableIds());
+        Set<Integer> producedIdRound1 = new LinkedHashSet<Integer>();
+        Set<Integer> producedIdRound2 = new LinkedHashSet<Integer>();
+
+        for (int i = ids.maxUsableIds(); i > 0; i--) {
+            int id = ids.nextId();
+            assertTrue(id >= 0);
+            assertTrue(producedIdRound1.add(id));
+        }
+        assertEquals(0, ids.usableIds());
+        assertEquals(-1, ids.nextId());
+
+        for (Integer v :  producedIdRound1) {
+            ids.pushId(v);
+        }
+
+        for (int i = ids.maxUsableIds(); i > 0; i--) {
+            int id = ids.nextId();
+            assertTrue(id >= 0);
+            assertTrue(producedIdRound2.add(id));
+        }
+
+        assertEquals(producedIdRound1.size(), producedIdRound2.size());
+
+        Iterator<Integer> producedIdRoundIt = producedIdRound1.iterator();
+        Iterator<Integer> producedIdRound2It = producedIdRound2.iterator();
+
+        boolean notSame = false;
+        while (producedIdRoundIt.hasNext()) {
+            if (producedIdRoundIt.next().intValue() != producedIdRound2It.next().intValue()) {
+                notSame = true;
+                break;
+            }
+        }
+        assertTrue(notSame);
+    }
+}


### PR DESCRIPTION
…enerating IDs

Motivation:

How we currently implement the selection of the next id to use for a query is very inefficient, especially once we already have a lot of inflight queries. This is problematic as we basically "block" the eventloop while doing the for loop.

Modifications:

Add new datastructure for storing and selecting ids that is basically O(1)

Result:

Less overhead while selecting ids
