### PR TITLE
Fix copy-paste mistake in LazyX509Certificate.getIssuerAlternativeNames()

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/util/LazyX509Certificate.java
+++ b/handler/src/main/java/io/netty/handler/ssl/util/LazyX509Certificate.java
@@ -93,7 +93,7 @@ public final class LazyX509Certificate extends X509Certificate {
 
     @Override
     public Collection<List<?>> getIssuerAlternativeNames() throws CertificateParsingException {
-        return unwrap().getSubjectAlternativeNames();
+        return unwrap().getIssuerAlternativeNames();
     }
 
     // No @Override annotation as it was only introduced in Java8.

--- a/handler/src/test/java/io/netty/handler/ssl/util/LazyJavaxX509CertificateTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/util/LazyJavaxX509CertificateTest.java
@@ -16,6 +16,8 @@
 package io.netty.handler.ssl.util;
 
 import io.netty.util.CharsetUtil;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 import javax.security.cert.CertificateException;
@@ -59,10 +61,12 @@ public class LazyJavaxX509CertificateTest {
         try {
             x509Certificate = X509Certificate.getInstance(CERTIFICATE.getBytes(CharsetUtil.UTF_8));
         } catch (CertificateException e) {
+            Assumptions.abort("JDK does not support creating " + X509Certificate.class);
             // JDK does not support this anymore
             return;
         }
-        LazyJavaxX509Certificate lazyX509Certificate = new LazyJavaxX509Certificate(CERTIFICATE.getBytes(CharsetUtil.UTF_8));
+        LazyJavaxX509Certificate lazyX509Certificate =
+                new LazyJavaxX509Certificate(CERTIFICATE.getBytes(CharsetUtil.UTF_8));
         assertEquals(x509Certificate.getVersion(), lazyX509Certificate.getVersion());
         assertEquals(x509Certificate.getSerialNumber(), lazyX509Certificate.getSerialNumber());
         assertEquals(x509Certificate.getIssuerDN(), lazyX509Certificate.getIssuerDN());

--- a/handler/src/test/java/io/netty/handler/ssl/util/LazyJavaxX509CertificateTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/util/LazyJavaxX509CertificateTest.java
@@ -16,14 +16,12 @@
 package io.netty.handler.ssl.util;
 
 import io.netty.util.CharsetUtil;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 import javax.security.cert.CertificateException;
 import javax.security.cert.X509Certificate;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class LazyJavaxX509CertificateTest {
@@ -76,6 +74,5 @@ public class LazyJavaxX509CertificateTest {
         assertEquals(x509Certificate.getSigAlgName(), lazyX509Certificate.getSigAlgName());
         assertEquals(x509Certificate.getSigAlgOID(), lazyX509Certificate.getSigAlgOID());
         assertEquals(x509Certificate.getSigAlgParams(), lazyX509Certificate.getSigAlgParams());
-        assertArrayEquals(x509Certificate.getEncoded(), lazyX509Certificate.getEncoded());
     }
 }

--- a/handler/src/test/java/io/netty/handler/ssl/util/LazyJavaxX509CertificateTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/util/LazyJavaxX509CertificateTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl.util;
+
+import io.netty.util.CharsetUtil;
+import org.junit.jupiter.api.Test;
+
+import javax.security.cert.CertificateException;
+import javax.security.cert.X509Certificate;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class LazyJavaxX509CertificateTest {
+
+    private static final String CERTIFICATE =
+            "-----BEGIN CERTIFICATE-----\n" +
+                    "MIIEITCCAwmgAwIBAgIUaLL8vLOhWLCLXVHEJqXJhfmsTB8wDQYJKoZIhvcNAQEL\n" +
+                    "BQAwgawxCzAJBgNVBAYTAlVTMRYwFAYDVQQIDA1NYXNzYWNodXNldHRzMRIwEAYD\n" +
+                    "VQQHDAlDYW1icmlkZ2UxGDAWBgNVBAoMD25ldHR5IHRlc3QgY2FzZTEYMBYGA1UE\n" +
+                    "CwwPbmV0dHkgdGVzdCBjYXNlMRgwFgYDVQQDDA9uZXR0eSB0ZXN0IGNhc2UxIzAh\n" +
+                    "BgkqhkiG9w0BCQEWFGNjb25uZWxsQGh1YnNwb3QuY29tMB4XDTI0MDEyMTE5MzMy\n" +
+                    "MFoXDTI1MDEyMDE5MzMyMFowgawxCzAJBgNVBAYTAlVTMRYwFAYDVQQIDA1NYXNz\n" +
+                    "YWNodXNldHRzMRIwEAYDVQQHDAlDYW1icmlkZ2UxGDAWBgNVBAoMD25ldHR5IHRl\n" +
+                    "c3QgY2FzZTEYMBYGA1UECwwPbmV0dHkgdGVzdCBjYXNlMRgwFgYDVQQDDA9uZXR0\n" +
+                    "eSB0ZXN0IGNhc2UxIzAhBgkqhkiG9w0BCQEWFGNjb25uZWxsQGh1YnNwb3QuY29t\n" +
+                    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAy+qzEZpQMjVdLj0siUcG\n" +
+                    "y8LIHOW4S+tgHIKFkF865qWq6FVGbROe2Z0f5W6yIamZkdxzptT0iv+8S5okNNeW\n" +
+                    "2NbsN/HNJIRtWfxku1Jh1gBqSkAYIjXyq7+20hIaJTzzxqike9M/Lc14EGb33Ja/\n" +
+                    "kDPRV3UtiM3Ntf3eALXKbrWptkbgQngCaTgtfg8IkMAEpP270wZ9fW0lDHv3NPPt\n" +
+                    "Zt0QSJzWSqWfu+l4ayvcUQYyNJesx9YmTHSJu69lvT4QApoX8FEiHfNCJ28R50CS\n" +
+                    "aIgOpCWUvkH7rqx0p9q393uJRS/S6RlLbU30xUN1fNrVmP/XAapfy+R0PSgiUi8o\n" +
+                    "EQIDAQABozkwNzAWBgNVHRIEDzANggt3d3cuZm9vLmNvbTAdBgNVHQ4EFgQUl4FD\n" +
+                    "Y8jJ/JHJR68YqPsGUjUJuwgwDQYJKoZIhvcNAQELBQADggEBADVzivYz2M0qsWUc\n" +
+                    "jXjCHymwTIr+7ud10um53FbYEAfKWsIY8Pp35fKpFzUwc5wVdCnLU86K/YMKRzNB\n" +
+                    "zL2Auow3PJFRvXecOv7dWxNlNneLDcwbVrdNRu6nQXmZUgyz0oUKuJbF+JGtI+7W\n" +
+                    "kRw7yhBfki+UCSQWeDqvaWzgmA4Us0N8NFq3euAs4xFbMMPMQWrT9Z7DGchCeRiB\n" +
+                    "dkQBvh88vbR3v2Saq14W4Wt5rj2++vXWGQSeAQL6nGbOwc3ohW6isNNV0eGQQTmS\n" +
+                    "khS2d/JDZq2XL5RGexf3CA6YYzWiTr9YZHNjuobvLH7mVnA2c8n6Zty/UhfnuK1x\n" +
+                    "JbkleFk=\n" +
+                    "-----END CERTIFICATE-----";
+
+    @Test
+    public void testLazyX509Certificate() throws Exception {
+        X509Certificate x509Certificate;
+        try {
+            x509Certificate = X509Certificate.getInstance(CERTIFICATE.getBytes(CharsetUtil.UTF_8));
+        } catch (CertificateException e) {
+            // JDK does not support this anymore
+            return;
+        }
+        LazyX509Certificate lazyX509Certificate = new LazyX509Certificate(CERTIFICATE.getBytes(CharsetUtil.UTF_8));
+        assertEquals(x509Certificate.getVersion(), lazyX509Certificate.getVersion());
+        assertEquals(x509Certificate.getSerialNumber(), lazyX509Certificate.getSerialNumber());
+        assertEquals(x509Certificate.getIssuerDN(), lazyX509Certificate.getIssuerDN());
+        assertEquals(x509Certificate.getSubjectDN(), lazyX509Certificate.getSubjectDN());
+        assertEquals(x509Certificate.getNotBefore(), lazyX509Certificate.getNotBefore());
+        assertEquals(x509Certificate.getNotAfter(), lazyX509Certificate.getNotAfter());
+        assertEquals(x509Certificate.getSigAlgName(), lazyX509Certificate.getSigAlgName());
+        assertEquals(x509Certificate.getSigAlgOID(), lazyX509Certificate.getSigAlgOID());
+        assertEquals(x509Certificate.getSigAlgParams(), lazyX509Certificate.getSigAlgParams());
+        assertArrayEquals(x509Certificate.getEncoded(), lazyX509Certificate.getEncoded());
+    }
+}

--- a/handler/src/test/java/io/netty/handler/ssl/util/LazyJavaxX509CertificateTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/util/LazyJavaxX509CertificateTest.java
@@ -62,7 +62,7 @@ public class LazyJavaxX509CertificateTest {
             // JDK does not support this anymore
             return;
         }
-        LazyX509Certificate lazyX509Certificate = new LazyX509Certificate(CERTIFICATE.getBytes(CharsetUtil.UTF_8));
+        LazyJavaxX509Certificate lazyX509Certificate = new LazyJavaxX509Certificate(CERTIFICATE.getBytes(CharsetUtil.UTF_8));
         assertEquals(x509Certificate.getVersion(), lazyX509Certificate.getVersion());
         assertEquals(x509Certificate.getSerialNumber(), lazyX509Certificate.getSerialNumber());
         assertEquals(x509Certificate.getIssuerDN(), lazyX509Certificate.getIssuerDN());

--- a/handler/src/test/java/io/netty/handler/ssl/util/LazyX509CertificateTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/util/LazyX509CertificateTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl.util;
+
+import io.netty.util.CharsetUtil;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class LazyX509CertificateTest {
+
+    private static final String CERTIFICATE =
+            "-----BEGIN CERTIFICATE-----\n" +
+                    "MIIEITCCAwmgAwIBAgIUaLL8vLOhWLCLXVHEJqXJhfmsTB8wDQYJKoZIhvcNAQEL\n" +
+                    "BQAwgawxCzAJBgNVBAYTAlVTMRYwFAYDVQQIDA1NYXNzYWNodXNldHRzMRIwEAYD\n" +
+                    "VQQHDAlDYW1icmlkZ2UxGDAWBgNVBAoMD25ldHR5IHRlc3QgY2FzZTEYMBYGA1UE\n" +
+                    "CwwPbmV0dHkgdGVzdCBjYXNlMRgwFgYDVQQDDA9uZXR0eSB0ZXN0IGNhc2UxIzAh\n" +
+                    "BgkqhkiG9w0BCQEWFGNjb25uZWxsQGh1YnNwb3QuY29tMB4XDTI0MDEyMTE5MzMy\n" +
+                    "MFoXDTI1MDEyMDE5MzMyMFowgawxCzAJBgNVBAYTAlVTMRYwFAYDVQQIDA1NYXNz\n" +
+                    "YWNodXNldHRzMRIwEAYDVQQHDAlDYW1icmlkZ2UxGDAWBgNVBAoMD25ldHR5IHRl\n" +
+                    "c3QgY2FzZTEYMBYGA1UECwwPbmV0dHkgdGVzdCBjYXNlMRgwFgYDVQQDDA9uZXR0\n" +
+                    "eSB0ZXN0IGNhc2UxIzAhBgkqhkiG9w0BCQEWFGNjb25uZWxsQGh1YnNwb3QuY29t\n" +
+                    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAy+qzEZpQMjVdLj0siUcG\n" +
+                    "y8LIHOW4S+tgHIKFkF865qWq6FVGbROe2Z0f5W6yIamZkdxzptT0iv+8S5okNNeW\n" +
+                    "2NbsN/HNJIRtWfxku1Jh1gBqSkAYIjXyq7+20hIaJTzzxqike9M/Lc14EGb33Ja/\n" +
+                    "kDPRV3UtiM3Ntf3eALXKbrWptkbgQngCaTgtfg8IkMAEpP270wZ9fW0lDHv3NPPt\n" +
+                    "Zt0QSJzWSqWfu+l4ayvcUQYyNJesx9YmTHSJu69lvT4QApoX8FEiHfNCJ28R50CS\n" +
+                    "aIgOpCWUvkH7rqx0p9q393uJRS/S6RlLbU30xUN1fNrVmP/XAapfy+R0PSgiUi8o\n" +
+                    "EQIDAQABozkwNzAWBgNVHRIEDzANggt3d3cuZm9vLmNvbTAdBgNVHQ4EFgQUl4FD\n" +
+                    "Y8jJ/JHJR68YqPsGUjUJuwgwDQYJKoZIhvcNAQELBQADggEBADVzivYz2M0qsWUc\n" +
+                    "jXjCHymwTIr+7ud10um53FbYEAfKWsIY8Pp35fKpFzUwc5wVdCnLU86K/YMKRzNB\n" +
+                    "zL2Auow3PJFRvXecOv7dWxNlNneLDcwbVrdNRu6nQXmZUgyz0oUKuJbF+JGtI+7W\n" +
+                    "kRw7yhBfki+UCSQWeDqvaWzgmA4Us0N8NFq3euAs4xFbMMPMQWrT9Z7DGchCeRiB\n" +
+                    "dkQBvh88vbR3v2Saq14W4Wt5rj2++vXWGQSeAQL6nGbOwc3ohW6isNNV0eGQQTmS\n" +
+                    "khS2d/JDZq2XL5RGexf3CA6YYzWiTr9YZHNjuobvLH7mVnA2c8n6Zty/UhfnuK1x\n" +
+                    "JbkleFk=\n" +
+                    "-----END CERTIFICATE-----";
+
+    @Test
+    public void testLazyX509Certificate() throws Exception {
+        CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
+        X509Certificate x509Certificate =
+                (X509Certificate) certificateFactory.generateCertificate(
+                        new ByteArrayInputStream(CERTIFICATE.getBytes(CharsetUtil.UTF_8))
+                );
+        LazyX509Certificate lazyX509Certificate = new LazyX509Certificate(CERTIFICATE.getBytes(CharsetUtil.UTF_8));
+        assertEquals(x509Certificate.getVersion(), lazyX509Certificate.getVersion());
+        assertEquals(x509Certificate.getSerialNumber(), lazyX509Certificate.getSerialNumber());
+        assertEquals(x509Certificate.getIssuerDN(), lazyX509Certificate.getIssuerDN());
+        assertEquals(x509Certificate.getIssuerX500Principal(), lazyX509Certificate.getIssuerX500Principal());
+        assertEquals(x509Certificate.getSubjectDN(), lazyX509Certificate.getSubjectDN());
+        assertEquals(x509Certificate.getNotBefore(), lazyX509Certificate.getNotBefore());
+        assertEquals(x509Certificate.getNotAfter(), lazyX509Certificate.getNotAfter());
+        assertArrayEquals(x509Certificate.getTBSCertificate(), lazyX509Certificate.getTBSCertificate());
+        assertArrayEquals(x509Certificate.getSignature(), lazyX509Certificate.getSignature());
+        assertEquals(x509Certificate.getSigAlgName(), lazyX509Certificate.getSigAlgName());
+        assertEquals(x509Certificate.getSigAlgOID(), lazyX509Certificate.getSigAlgOID());
+        assertEquals(x509Certificate.getSigAlgParams(), lazyX509Certificate.getSigAlgParams());
+        assertArrayEquals(x509Certificate.getIssuerUniqueID(), lazyX509Certificate.getIssuerUniqueID());
+        assertArrayEquals(x509Certificate.getSubjectUniqueID(), lazyX509Certificate.getSubjectUniqueID());
+        assertArrayEquals(x509Certificate.getKeyUsage(), lazyX509Certificate.getKeyUsage());
+        assertEquals(x509Certificate.getExtendedKeyUsage(), lazyX509Certificate.getExtendedKeyUsage());
+        assertEquals(x509Certificate.getBasicConstraints(), lazyX509Certificate.getBasicConstraints());
+        assertEquals(x509Certificate.getSubjectAlternativeNames(), lazyX509Certificate.getSubjectAlternativeNames());
+        assertEquals(x509Certificate.getIssuerAlternativeNames(), lazyX509Certificate.getIssuerAlternativeNames());
+    }
+}


### PR DESCRIPTION
Motivation:

At present, `LazyX509Certificate.getIssuerAlternativeNames()` returns completely incorrect values. I discovered this while working on a project for my employer, HubSpot. We are planning to use this field to convey some company-specific authentication information in our internal systems. This bug is somewhat blocking our ability to read these values inside HBase servers, which use Netty for TLS support.

Modification:

Change the one-line implementation of this method from `return unwrap().getSubjectAlternativeNames();` to `return unwrap().getIssuerAlternativeNames();`

Result:

Get the correct values from the certificate.

Fixes #13796. 

This is my first contribution to netty, and I wasn't sure what branch to target, so I picked 4.1 since it's the github default.
