### PR TITLE
Add support for the Partitioned attribute in cookies

### DIFF
--- a/codec-http/src/main/java/io/netty5/handler/codec/http/headers/HttpSetCookie.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/headers/HttpSetCookie.java
@@ -138,4 +138,11 @@ public interface HttpSetCookie extends HttpCookiePair {
     enum SameSite {
         Lax, Strict, None
     }
+
+    /**
+     * Checks to see if this {@link HttpSetCookie} is partitioned
+     *
+     * @return True if this {@link HttpSetCookie} is partitioned, otherwise false
+     */
+    boolean isPartitioned();
 }

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpResponseDecoderTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpResponseDecoderTest.java
@@ -794,7 +794,7 @@ public class HttpResponseDecoderTest {
         setUpNoValidation();
         String cookieString = "Set-Cookie: myCookie=myValue;expires="
                               + DateFormatter.format(new Date(System.currentTimeMillis() + 50000))
-                              + ";path=/apathsomewhere;domain=.adomainsomewhere;secure;SameSite=None";
+                              + ";path=/apathsomewhere;domain=.adomainsomewhere;secure;SameSite=None;Partitioned";
         HttpSetCookie cookie = parseRequestWithCookies(cookieString).headers().getSetCookie("myCookie");
         assertNotNull(cookie);
         assertEquals("myValue", cookie.value());
@@ -804,13 +804,14 @@ public class HttpResponseDecoderTest {
         assertTrue(cookie.isSecure());
 
         assertEquals(SameSite.None, cookie.sameSite());
+        assertTrue(cookie.isPartitioned());
     }
 
     @Test
     public void setCookieHeaderDecodingSingleCookieV0Validating() {
         String cookieString = "Set-Cookie: myCookie=myValue; expires="
                               + DateFormatter.format(new Date(System.currentTimeMillis() + 50000))
-                              + "; path=/apathsomewhere; domain=.adomainsomewhere; secure; SameSite=None";
+                              + "; path=/apathsomewhere; domain=.adomainsomewhere; secure; SameSite=None; Partitioned";
         HttpSetCookie cookie = parseRequestWithCookies(cookieString).headers().getSetCookie("myCookie");
         assertNotNull(cookie);
         assertEquals("myValue", cookie.value());
@@ -819,6 +820,7 @@ public class HttpResponseDecoderTest {
         assertEquals("/apathsomewhere", cookie.path());
         assertTrue(cookie.isSecure());
         assertEquals(SameSite.None, cookie.sameSite());
+        assertTrue(cookie.isPartitioned());
     }
 
     @Test

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/headers/DefaultHttpSetCookiesTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/headers/DefaultHttpSetCookiesTest.java
@@ -790,7 +790,8 @@ class DefaultHttpSetCookiesTest {
                 cookie1.sameSite() == cookie2.sameSite() &&
                 cookie1.isHttpOnly() == cookie2.isHttpOnly() &&
                 cookie1.isSecure() == cookie2.isSecure() &&
-                cookie1.isWrapped() == cookie2.isWrapped();
+                cookie1.isWrapped() == cookie2.isWrapped() &&
+                cookie1.isPartitioned() == cookie2.isPartitioned();
     }
 
     private static boolean areCookiesEqual(final HttpCookiePair cookie1, final HttpCookiePair cookie2) {
@@ -885,6 +886,11 @@ class DefaultHttpSetCookiesTest {
         @Override
         public boolean isHttpOnly() {
             return isHttpOnly;
+        }
+
+        @Override
+        public boolean isPartitioned() {
+            return false;
         }
 
         @Override


### PR DESCRIPTION
Motivation:

This is a forward port from the fix in 4.1.
Netty currently does not support the `Partitioned` attribute for response cookies. 
https://developers.google.com/privacy-sandbox/3pcd/chips

Modifications:

- Added new method to the `HttpSetCookie` interface and updated the default implementation.
- Added encoding functionality
- Added junit tests

Result:

Response cookies with the `Partitioned` attribute set can be written by Netty. 
Fixes #13740