### PR TITLE
Not passing args since FormattingTuple is already formatted

### DIFF
--- a/common/src/main/java/io/netty/util/internal/logging/LocationAwareSlf4JLogger.java
+++ b/common/src/main/java/io/netty/util/internal/logging/LocationAwareSlf4JLogger.java
@@ -47,7 +47,7 @@ final class LocationAwareSlf4JLogger extends AbstractInternalLogger {
     }
 
     private void log(final int level, final org.slf4j.helpers.FormattingTuple tuple) {
-        logger.log(null, FQCN, level, tuple.getMessage(), tuple.getArgArray(), tuple.getThrowable());
+        logger.log(null, FQCN, level, tuple.getMessage(), null, tuple.getThrowable());
     }
 
     @Override

--- a/common/src/test/java/io/netty/util/internal/logging/Slf4JLoggerFactoryTest.java
+++ b/common/src/test/java/io/netty/util/internal/logging/Slf4JLoggerFactoryTest.java
@@ -89,19 +89,19 @@ public class Slf4JLoggerFactoryTest {
         internalLogger.warn("{} {} {}", "warn1", "warn2", "warn3");
 
         verify(logger, times(3)).log(ArgumentMatchers.<Marker>isNull(), eq(LocationAwareSlf4JLogger.FQCN),
-                eq(LocationAwareLogger.DEBUG_INT), captor.capture(), any(Object[].class),
+                eq(LocationAwareLogger.DEBUG_INT), captor.capture(), ArgumentMatchers.<Object[]>isNull(),
                 ArgumentMatchers.<Throwable>isNull());
         verify(logger, times(3)).log(ArgumentMatchers.<Marker>isNull(), eq(LocationAwareSlf4JLogger.FQCN),
-                eq(LocationAwareLogger.ERROR_INT), captor.capture(), any(Object[].class),
+                eq(LocationAwareLogger.ERROR_INT), captor.capture(), ArgumentMatchers.<Object[]>isNull(),
                 ArgumentMatchers.<Throwable>isNull());
         verify(logger, times(3)).log(ArgumentMatchers.<Marker>isNull(), eq(LocationAwareSlf4JLogger.FQCN),
-                eq(LocationAwareLogger.INFO_INT), captor.capture(), any(Object[].class),
+                eq(LocationAwareLogger.INFO_INT), captor.capture(), ArgumentMatchers.<Object[]>isNull(),
                 ArgumentMatchers.<Throwable>isNull());
         verify(logger, times(3)).log(ArgumentMatchers.<Marker>isNull(), eq(LocationAwareSlf4JLogger.FQCN),
-                eq(LocationAwareLogger.TRACE_INT), captor.capture(), any(Object[].class),
+                eq(LocationAwareLogger.TRACE_INT), captor.capture(), ArgumentMatchers.<Object[]>isNull(),
                 ArgumentMatchers.<Throwable>isNull());
         verify(logger, times(3)).log(ArgumentMatchers.<Marker>isNull(), eq(LocationAwareSlf4JLogger.FQCN),
-                eq(LocationAwareLogger.WARN_INT), captor.capture(), any(Object[].class),
+                eq(LocationAwareLogger.WARN_INT), captor.capture(), ArgumentMatchers.<Object[]>isNull(),
                 ArgumentMatchers.<Throwable>isNull());
 
         Iterator<String> logMessages = captor.getAllValues().iterator();


### PR DESCRIPTION
Motivation:

Not passing args since FormattingTuple is already formatted. This causes another round of formatting to happen in the Logger implementation which is useless and no-op.

Modification:

Don't pass the args.

Result:

Slightly better perf since no double formatting.

If there is no issue then describe the changes introduced by this PR.
