### PR TITLE
HTTP2: lastStreamCreated() does return the wrong value when all strea…

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
@@ -865,7 +865,11 @@ public class DefaultHttp2Connection implements Http2Connection {
 
         @Override
         public int lastStreamCreated() {
-            return nextStreamIdToCreate > 1 ? nextStreamIdToCreate - 2 : 0;
+            // Stream ids are always incremented by 2 so just subtract it. This is even ok in the case
+            // of nextStreamIdToCreate overflown as it will just return the correct positive number.
+            // Use max(...) to ensure we return the correct value for the case when its a client and no stream
+            // was created yet.
+            return Math.max(0, nextStreamIdToCreate - 2);
         }
 
         @Override
@@ -917,7 +921,7 @@ public class DefaultHttp2Connection implements Http2Connection {
                         streamId, nextStreamIdToCreate);
             }
             if (nextStreamIdToCreate <= 0) {
-                // We exhausted the stream id space that we  can use. Let's signal this back but also signal that
+                // We exhausted the stream id space that we can use. Let's signal this back but also signal that
                 // we still may want to process active streams.
                 throw new Http2Exception(REFUSED_STREAM, "Stream IDs are exhausted for this endpoint.",
                         Http2Exception.ShutdownHint.GRACEFUL_SHUTDOWN);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
@@ -652,6 +652,32 @@ public class DefaultHttp2ConnectionTest {
         }
     }
 
+    @Test
+    public void clientLastStreamCreatedWithoutStreamCreated() {
+        assertEquals(0, client.local().lastStreamCreated());
+    }
+
+    @Test
+    public void serverLastStreamCreatedWithoutStreamCreated() {
+        assertEquals(0, server.local().lastStreamCreated());
+    }
+
+    @Test
+    public void clientCreateMaxStreamId() throws Exception {
+        int id = MAX_VALUE;
+        client.local().createStream(id, false);
+        assertTrue(client.streamMayHaveExisted(id));
+        assertEquals(id, client.local().lastStreamCreated());
+    }
+
+    @Test
+    public void serverCreateMaxStreamId() throws Exception {
+        int id = MAX_VALUE - 1;
+        server.local().createStream(id, false);
+        assertTrue(server.streamMayHaveExisted(id));
+        assertEquals(id, server.local().lastStreamCreated());
+    }
+
     private void testRemoveAllStreams() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
         final Promise<Void> promise = group.next().newPromise();

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/StreamBufferingEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/StreamBufferingEncoderTest.java
@@ -24,6 +24,7 @@ import static io.netty.handler.codec.http2.Http2Stream.State.HALF_CLOSED_LOCAL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
@@ -509,6 +510,18 @@ public class StreamBufferingEncoderTest {
 
         ChannelFuture f = encoderWriteHeaders(3, newPromise());
         assertNotNull(f.cause());
+    }
+
+    @Test
+    public void testExhaustedStreamId() throws Http2Exception {
+        testStreamId(Integer.MAX_VALUE - 2);
+        testStreamId(connection.local().incrementAndGetNextStreamId());
+    }
+
+    private void testStreamId(int nextStreamId) throws Http2Exception {
+        connection.local().createStream(nextStreamId, false);
+        ChannelFuture channelFuture = encoder.writeData(ctx, nextStreamId, EMPTY_BUFFER, 0, false, newPromise());
+        assertNull(channelFuture.cause());
     }
 
     private void setMaxConcurrentStreams(int newValue) {


### PR DESCRIPTION
…m ids were used

Motivation:

We did not correctly calculate the value returned by DefaultHttp2Connection.DefaultEndpoint.lastStreamCreated() and so returned 0 when all stream ids were used. This did lead to also return an result when checking if a stream might have been existed. As some encoders / decoders also use these methods to determine if a stream existed or not it also resulted in http2 errors.

Modifications:

- Correctly implement lastStreamCreated()
- Add test cases.

Result:

Fixes https://github.com/netty/netty/issues/13805