### PR TITLE
The problem of low efficiency and multiple cycles may occur in the TimeWheel Algorithm #13166

### DIFF
--- a/common/src/main/java/io/netty/util/HashedWheelTimer.java
+++ b/common/src/main/java/io/netty/util/HashedWheelTimer.java
@@ -23,6 +23,7 @@ import io.netty.util.concurrent.ImmediateExecutor;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
+import org.jctools.util.Pow2;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -333,23 +334,13 @@ public class HashedWheelTimer implements Timer {
     }
 
     private static HashedWheelBucket[] createWheel(int ticksPerWheel) {
-        //ticksPerWheel may not be greater than 2^30
-        checkInRange(ticksPerWheel, 1, 1073741824, "ticksPerWheel");
+        ticksPerWheel = Pow2.roundToPowerOfTwo(ticksPerWheel);
 
-        ticksPerWheel = normalizeTicksPerWheel(ticksPerWheel);
         HashedWheelBucket[] wheel = new HashedWheelBucket[ticksPerWheel];
         for (int i = 0; i < wheel.length; i ++) {
             wheel[i] = new HashedWheelBucket();
         }
         return wheel;
-    }
-
-    private static int normalizeTicksPerWheel(int ticksPerWheel) {
-        int normalizedTicksPerWheel = 1;
-        while (normalizedTicksPerWheel < ticksPerWheel) {
-            normalizedTicksPerWheel <<= 1;
-        }
-        return normalizedTicksPerWheel;
     }
 
     /**


### PR DESCRIPTION
See https://github.com/netty/netty/issues/13166

Use JCTools' roundToPowerOfTwo (includes range check) instead of handcrafted power of to method.

Motivation:

Handcrafted solution might be inefficient

Modification:

Uses JCTools' version that includes the range check and it's more efficient as it supports `@IntrinsicCandidate`

Result:

Fixes #13166

If there is no issue then describe the changes introduced by this PR.
