### PR TITLE
HTTP2: Update local window should not fail queued frames

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
@@ -900,7 +900,7 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
         }
 
         private void updateLocalWindowIfNeeded() {
-            if (flowControlledBytes != 0) {
+            if (flowControlledBytes != 0 && !parentContext().isRemoved()) {
                 int bytes = flowControlledBytes;
                 flowControlledBytes = 0;
                 ChannelFuture future = write0(parentContext(), new DefaultHttp2WindowUpdateFrame(bytes).stream(stream));


### PR DESCRIPTION
Motivation:

When new stream frames arrive, they can be queued in `AbstractHttp2StreamChannel.inboundBuffer` if the stream channel doesn't have demand. When `stream.read()` is invoked, we first execute `updateLocalWindowIfNeeded()`. For details, see #9400. However, it may happen that the parent channel is already closed by that time. As a result, the write fails and an exception will be propagated through the stream pipeline without allowing users to read frames that were already received.

Modifications:

Taking into account the need to run `updateLocalWindowIfNeeded()` before `doBeginRead()` (described in #9400), add a check for `updateLocalWindowIfNeeded()` to write only if the parent context is not removed.

Result:

Users don't lose queued frames that were received before the parent channel was closed.