### PR TITLE
Add constructors for UTF8 validation configuration to WebSocketClientProtocolHandler

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolConfig.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolConfig.java
@@ -35,6 +35,7 @@ public final class WebSocketClientProtocolConfig {
     static final boolean DEFAULT_HANDLE_CLOSE_FRAMES = true;
     static final boolean DEFAULT_DROP_PONG_FRAMES = true;
     static final boolean DEFAULT_GENERATE_ORIGIN_HEADER = true;
+    static final boolean DEFAULT_WITH_UTF8_VALIDATOR = true;
 
     private final URI webSocketUri;
     private final String subprotocol;
@@ -195,7 +196,7 @@ public final class WebSocketClientProtocolConfig {
                 -1,
                 false,
                 DEFAULT_GENERATE_ORIGIN_HEADER,
-                true);
+                DEFAULT_WITH_UTF8_VALIDATOR);
     }
 
     public static final class Builder {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandler.java
@@ -27,6 +27,7 @@ import static io.netty.handler.codec.http.websocketx.WebSocketClientProtocolConf
 import static io.netty.handler.codec.http.websocketx.WebSocketClientProtocolConfig.DEFAULT_DROP_PONG_FRAMES;
 import static io.netty.handler.codec.http.websocketx.WebSocketClientProtocolConfig.DEFAULT_HANDLE_CLOSE_FRAMES;
 import static io.netty.handler.codec.http.websocketx.WebSocketClientProtocolConfig.DEFAULT_PERFORM_MASKING;
+import static io.netty.handler.codec.http.websocketx.WebSocketClientProtocolConfig.DEFAULT_WITH_UTF8_VALIDATOR;
 import static io.netty.handler.codec.http.websocketx.WebSocketServerProtocolConfig.DEFAULT_HANDSHAKE_TIMEOUT_MILLIS;
 import static io.netty.util.internal.ObjectUtil.*;
 
@@ -97,6 +98,23 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
             clientConfig.absoluteUpgradeUrl(),
             clientConfig.generateOriginHeader()
         );
+        this.clientConfig = clientConfig;
+    }
+
+    /**
+     * Base constructor
+     *
+     * @param handshaker
+     *            The {@link WebSocketClientHandshaker} which will be used to issue the handshake once the connection
+     *            was established to the remote peer.
+     * @param clientConfig
+     *            Client protocol configuration.
+     */
+    public WebSocketClientProtocolHandler(WebSocketClientHandshaker handshaker,
+                                          WebSocketClientProtocolConfig clientConfig) {
+        super(checkNotNull(clientConfig, "clientConfig").dropPongFrames(),
+              clientConfig.sendCloseFrame(), clientConfig.forceCloseTimeoutMillis());
+        this.handshaker = handshaker;
         this.clientConfig = clientConfig;
     }
 
@@ -329,11 +347,34 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
      */
     public WebSocketClientProtocolHandler(WebSocketClientHandshaker handshaker, boolean handleCloseFrames,
                                           boolean dropPongFrames, long handshakeTimeoutMillis) {
+        this(handshaker, handleCloseFrames, dropPongFrames, handshakeTimeoutMillis, DEFAULT_WITH_UTF8_VALIDATOR);
+    }
+
+    /**
+     * Base constructor
+     *
+     * @param handshaker
+     *            The {@link WebSocketClientHandshaker} which will be used to issue the handshake once the connection
+     *            was established to the remote peer.
+     * @param handleCloseFrames
+     *            {@code true} if close frames should not be forwarded and just close the channel
+     * @param dropPongFrames
+     *            {@code true} if pong frames should not be forwarded
+     * @param handshakeTimeoutMillis
+     *            Handshake timeout in mills, when handshake timeout, will trigger user
+     *            event {@link ClientHandshakeStateEvent#HANDSHAKE_TIMEOUT}
+     * @param withUTF8Validator
+     *            {@code true} if UTF8 validation of text frames should be enabled
+     */
+    public WebSocketClientProtocolHandler(WebSocketClientHandshaker handshaker, boolean handleCloseFrames,
+                                          boolean dropPongFrames, long handshakeTimeoutMillis,
+                                          boolean withUTF8Validator) {
         super(dropPongFrames);
         this.handshaker = handshaker;
         this.clientConfig = WebSocketClientProtocolConfig.newBuilder()
             .handleCloseFrames(handleCloseFrames)
             .handshakeTimeoutMillis(handshakeTimeoutMillis)
+            .withUTF8Validator(withUTF8Validator)
             .build();
     }
 


### PR DESCRIPTION
Motivation:

Ability to disable UTF8 validation was added in https://github.com/netty/netty/commit/ebfc79c85deb8ba6fda54b8cb7fa925573076b21 but constructors in the WebSocketClientProtocolHandler were not updated appropriately, preventing disabling of UTF8 validation when passing in an externally-instantiated handshaker.

Modification:

This PR adds two additional constructors:
- A constructor that takes a WebSocketClientHandshaker and accepts a withUTF8FrameValidation boolean as an addition to previously supported config params.
- A constructor that takes a WebSocketClientHandshaker and a WebSocketClientProtocolConfig as params, allowing for more convenient instantiation and robustness to future WebSocketClientProtocolConfig changes.

Result:

Allows instantiation of a WebSocketClientProtocolHandler which takes an externally-provided handshaker and disables UTF8 validation.