### PR TITLE
DnsNameResolver: Explicit pass channel and channelReadyFuture

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolveContext.java
@@ -26,6 +26,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.EventLoop;
 import io.netty.handler.codec.dns.DnsRecord;
 import io.netty.handler.codec.dns.DnsRecordType;
+import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 
 final class DnsAddressResolveContext extends DnsResolveContext<InetAddress> {
@@ -34,12 +35,12 @@ final class DnsAddressResolveContext extends DnsResolveContext<InetAddress> {
     private final AuthoritativeDnsServerCache authoritativeDnsServerCache;
     private final boolean completeEarlyIfPossible;
 
-    DnsAddressResolveContext(DnsNameResolver parent, Channel channel, Promise<?> originalPromise,
-                             String hostname, DnsRecord[] additionals,
+    DnsAddressResolveContext(DnsNameResolver parent, Channel channel, Future<? extends Channel> channelReadyFuture,
+                             Promise<?> originalPromise, String hostname, DnsRecord[] additionals,
                              DnsServerAddressStream nameServerAddrs, int allowedQueries, DnsCache resolveCache,
                              AuthoritativeDnsServerCache authoritativeDnsServerCache,
                              boolean completeEarlyIfPossible) {
-        super(parent, channel, originalPromise, hostname, DnsRecord.CLASS_IN,
+        super(parent, channel, channelReadyFuture, originalPromise, hostname, DnsRecord.CLASS_IN,
               parent.resolveRecordTypes(), additionals, nameServerAddrs, allowedQueries);
         this.resolveCache = resolveCache;
         this.authoritativeDnsServerCache = authoritativeDnsServerCache;
@@ -48,13 +49,14 @@ final class DnsAddressResolveContext extends DnsResolveContext<InetAddress> {
 
     @Override
     DnsResolveContext<InetAddress> newResolverContext(DnsNameResolver parent, Channel channel,
+                                                      Future<? extends Channel> channelReadyFuture,
                                                       Promise<?> originalPromise,
                                                       String hostname,
                                                       int dnsClass, DnsRecordType[] expectedTypes,
                                                       DnsRecord[] additionals,
                                                       DnsServerAddressStream nameServerAddrs, int allowedQueries) {
-        return new DnsAddressResolveContext(parent, channel, originalPromise, hostname, additionals, nameServerAddrs,
-                allowedQueries, resolveCache, authoritativeDnsServerCache, completeEarlyIfPossible);
+        return new DnsAddressResolveContext(parent, channel, channelReadyFuture, originalPromise, hostname, additionals,
+                nameServerAddrs, allowedQueries, resolveCache, authoritativeDnsServerCache, completeEarlyIfPossible);
     }
 
     @Override

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsRecordResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsRecordResolveContext.java
@@ -24,34 +24,39 @@ import io.netty.handler.codec.dns.DnsQuestion;
 import io.netty.handler.codec.dns.DnsRecord;
 import io.netty.handler.codec.dns.DnsRecordType;
 import io.netty.util.ReferenceCountUtil;
+import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 
 final class DnsRecordResolveContext extends DnsResolveContext<DnsRecord> {
 
-    DnsRecordResolveContext(DnsNameResolver parent, Channel channel, Promise<?> originalPromise, DnsQuestion question,
-                            DnsRecord[] additionals, DnsServerAddressStream nameServerAddrs, int allowedQueries) {
-        this(parent, channel, originalPromise, question.name(), question.dnsClass(),
+    DnsRecordResolveContext(DnsNameResolver parent, Channel channel, Future<? extends Channel> channelReadyFuture,
+                            Promise<?> originalPromise, DnsQuestion question, DnsRecord[] additionals,
+                            DnsServerAddressStream nameServerAddrs, int allowedQueries) {
+        this(parent, channel, channelReadyFuture, originalPromise, question.name(), question.dnsClass(),
              new DnsRecordType[] { question.type() },
              additionals, nameServerAddrs, allowedQueries);
     }
 
-    private DnsRecordResolveContext(DnsNameResolver parent, Channel channel, Promise<?> originalPromise,
+    private DnsRecordResolveContext(DnsNameResolver parent, Channel channel,
+                                    Future<? extends Channel> channelReadyFuture, Promise<?> originalPromise,
                                     String hostname, int dnsClass, DnsRecordType[] expectedTypes,
                                     DnsRecord[] additionals,
                                     DnsServerAddressStream nameServerAddrs,
                                     int allowedQueries) {
-        super(parent, channel, originalPromise, hostname, dnsClass, expectedTypes,
+        super(parent, channel, channelReadyFuture, originalPromise, hostname, dnsClass, expectedTypes,
                 additionals, nameServerAddrs, allowedQueries);
     }
 
     @Override
-    DnsResolveContext<DnsRecord> newResolverContext(DnsNameResolver parent, Channel channel, Promise<?> originalPromise,
+    DnsResolveContext<DnsRecord> newResolverContext(DnsNameResolver parent, Channel channel,
+                                                    Future<? extends Channel> channelReadyFuture,
+                                                    Promise<?> originalPromise,
                                                     String hostname,
                                                     int dnsClass, DnsRecordType[] expectedTypes,
                                                     DnsRecord[] additionals,
                                                     DnsServerAddressStream nameServerAddrs,
                                                     int allowedQueries) {
-        return new DnsRecordResolveContext(parent, channel, originalPromise, hostname, dnsClass,
+        return new DnsRecordResolveContext(parent, channel, channelReadyFuture, originalPromise, hostname, dnsClass,
                                            expectedTypes, additionals, nameServerAddrs, allowedQueries);
     }
 

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
@@ -92,6 +92,7 @@ abstract class DnsResolveContext<T> {
 
     final DnsNameResolver parent;
     private final Channel channel;
+    private final Future<? extends Channel> channelReadyFuture;
     private final Promise<?> originalPromise;
     private final DnsServerAddressStream nameServerAddrs;
     private final String hostname;
@@ -108,13 +109,14 @@ abstract class DnsResolveContext<T> {
     private boolean triedCNAME;
     private boolean completeEarly;
 
-    DnsResolveContext(DnsNameResolver parent, Channel channel, Promise<?> originalPromise,
-                      String hostname, int dnsClass, DnsRecordType[] expectedTypes,
+    DnsResolveContext(DnsNameResolver parent, Channel channel, Future<? extends Channel> channelReadyFuture,
+                      Promise<?> originalPromise, String hostname, int dnsClass, DnsRecordType[] expectedTypes,
                       DnsRecord[] additionals, DnsServerAddressStream nameServerAddrs, int allowedQueries) {
         assert expectedTypes.length > 0;
 
         this.parent = parent;
         this.channel = channel;
+        this.channelReadyFuture = channelReadyFuture;
         this.originalPromise = originalPromise;
         this.hostname = hostname;
         this.dnsClass = dnsClass;
@@ -190,6 +192,7 @@ abstract class DnsResolveContext<T> {
      * Creates a new context with the given parameters.
      */
     abstract DnsResolveContext<T> newResolverContext(DnsNameResolver parent, Channel channel,
+                                                     Future<? extends Channel> channelReadyFuture,
                                                      Promise<?> originalPromise,
                                                      String hostname,
                                                      int dnsClass, DnsRecordType[] expectedTypes,
@@ -300,8 +303,9 @@ abstract class DnsResolveContext<T> {
     }
 
     void doSearchDomainQuery(String hostname, Promise<List<T>> nextPromise) {
-        DnsResolveContext<T> nextContext = newResolverContext(parent, channel, originalPromise, hostname, dnsClass,
-                                                              expectedTypes, additionals, nameServerAddrs,
+        DnsResolveContext<T> nextContext = newResolverContext(parent, channel, channelReadyFuture,
+                originalPromise, hostname, dnsClass,
+                expectedTypes, additionals, nameServerAddrs,
                 parent.maxQueriesPerResolve());
         nextContext.internalResolve(hostname, nextPromise);
     }
@@ -379,8 +383,8 @@ abstract class DnsResolveContext<T> {
             }
             query(name, expectedTypes[end], nameServerAddressStream, false, promise);
         } finally {
-            // Now flush everything we submitted before.
-            parent.flushQueries();
+            // Now flush everything we submitted before for the Channel.
+            channel.flush();
         }
     }
 
@@ -464,7 +468,8 @@ abstract class DnsResolveContext<T> {
         }
 
         final Future<AddressedEnvelope<DnsResponse, InetSocketAddress>> f =
-                parent.query0(nameServerAddr, question, queryLifecycleObserver, additionals, flush, queryPromise);
+                parent.doQuery(channel, channelReadyFuture, nameServerAddr, question,
+                        queryLifecycleObserver, additionals, flush, queryPromise);
 
         queriesInProgress.add(f);
 
@@ -559,13 +564,13 @@ abstract class DnsResolveContext<T> {
         if (!DnsNameResolver.doResolveAllCached(nameServerName, additionals, resolverPromise, resolveCache,
                 parent.resolvedInternetProtocolFamiliesUnsafe())) {
 
-            new DnsAddressResolveContext(parent, channel, originalPromise, nameServerName, additionals,
-                                         parent.newNameServerAddressStream(nameServerName),
-                                         // Resolving the unresolved nameserver must be limited by allowedQueries
-                                         // so we eventually fail
-                                         allowedQueries,
-                                         resolveCache,
-                                         redirectAuthoritativeDnsServerCache(authoritativeDnsServerCache()), false)
+            new DnsAddressResolveContext(parent, channel, channelReadyFuture,
+                    originalPromise, nameServerName, additionals, parent.newNameServerAddressStream(nameServerName),
+                    // Resolving the unresolved nameserver must be limited by allowedQueries
+                    // so we eventually fail
+                    allowedQueries,
+                    resolveCache,
+                    redirectAuthoritativeDnsServerCache(authoritativeDnsServerCache()), false)
                     .resolve(resolverPromise);
         }
     }


### PR DESCRIPTION
Motivation:

At the moment how we sometimes pass the Channel and Future and sometimes not. This is very confusing.

Modification:

- Explicit pass the paramaets around

Result:

Cleanup