### PR TITLE
DnsNameResolver: Allways call bind() during bootstrap

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -506,13 +506,11 @@ public class DnsNameResolver extends InetNameResolver {
             }
         });
 
-        final ChannelFuture future;
         if (localAddress == null) {
-            b.option(ChannelOption.DATAGRAM_CHANNEL_ACTIVE_ON_REGISTRATION, true);
-            future = b.register();
-        } else {
-            future = b.bind(localAddress);
+            localAddress = new InetSocketAddress(0);
         }
+
+        ChannelFuture future = b.bind(localAddress);
         if (future.isDone()) {
             Throwable cause = future.cause();
             if (cause != null) {


### PR DESCRIPTION
Motivation:

We should always call `bind(...)` during bootstrap to allow easier debugging as if not explicit binding the OS will do it anyway. Before calling explicit bind we would not have limited visiblity when logging:

```
10:18:45.466 [main] DEBUG i.netty.resolver.dns.DnsQueryContext - [id: 0x798ced86] WRITE: UDP, [10844: /127.0.0.1:49443], DefaultDnsQuestion(somehost.netty.io. IN TXT)
```

After explicit bind the local address / port is included as well:

```
10:21:30.366 [nioEventLoopGroup-2-1] DEBUG i.netty.resolver.dns.DnsQueryContext - [id: 0xa118f365, L:/[0:0:0:0:0:0:0:0]:54165] WRITE: UDP, [15418: /127.0.0.1:56439], DefaultDnsQuestion(lastname.com. IN AAAA)
```

Modifications:

- Always explicitly call bind(...)

Result:

Better debuggability