### PR TITLE
HTTP: HttpObjectDecoder must not use HTTPMessage once it is passed to…

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -169,6 +169,9 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
     private HttpMessage message;
     private long chunkSize;
     private long contentLength = Long.MIN_VALUE;
+    private boolean chunked;
+    private boolean isSwitchingToNonHttp1Protocol;
+
     private final AtomicBoolean resetRequested = new AtomicBoolean();
 
     // These will be updated by splitHeader(...)
@@ -352,7 +355,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
             currentState = State.READ_HEADER;
             // fall-through
         } catch (Exception e) {
-            out.add(invalidMessage(buffer, e));
+            out.add(invalidMessage(message, buffer, e));
             return;
         }
         case READ_HEADER: try {
@@ -383,7 +386,6 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
                  * length is 0. However, for a response the body length is the number of octets received prior to the
                  * server closing the connection. So we treat this as variable length chunked encoding.
                  */
-                long contentLength = contentLength();
                 if (contentLength == 0 || contentLength == -1 && isDecodingRequest()) {
                     out.add(message);
                     out.add(LastHttpContent.EMPTY_LAST_CONTENT);
@@ -405,7 +407,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
                 return;
             }
         } catch (Exception e) {
-            out.add(invalidMessage(buffer, e));
+            out.add(invalidMessage(message, buffer, e));
             return;
         }
         case READ_VARIABLE_LENGTH_CONTENT: {
@@ -543,41 +545,52 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
             // LastHttpContent while there was already one.
             resetNow();
         }
-        // Handle the last unfinished message.
-        if (message != null) {
-            boolean chunked = HttpUtil.isTransferEncodingChunked(message);
-            if (currentState == State.READ_VARIABLE_LENGTH_CONTENT && !in.isReadable() && !chunked) {
-                // End of connection.
-                out.add(LastHttpContent.EMPTY_LAST_CONTENT);
-                resetNow();
-                return;
-            }
 
-            if (currentState == State.READ_HEADER) {
+        // Handle the last unfinished message.
+        switch (currentState) {
+            case READ_VARIABLE_LENGTH_CONTENT:
+                if (!chunked && !in.isReadable()) {
+                    // End of connection.
+                    out.add(LastHttpContent.EMPTY_LAST_CONTENT);
+                    resetNow();
+                }
+                return;
+            case READ_HEADER:
                 // If we are still in the state of reading headers we need to create a new invalid message that
                 // signals that the connection was closed before we received the headers.
-                out.add(invalidMessage(Unpooled.EMPTY_BUFFER,
+                out.add(invalidMessage(message, Unpooled.EMPTY_BUFFER,
                         new PrematureChannelClosureException("Connection closed before received headers")));
                 resetNow();
                 return;
-            }
-
-            // Check if the closure of the connection signifies the end of the content.
-            boolean prematureClosure;
-            if (isDecodingRequest() || chunked) {
-                // The last request did not wait for a response.
-                prematureClosure = true;
-            } else {
-                // Compare the length of the received content and the 'Content-Length' header.
-                // If the 'Content-Length' header is absent, the length of the content is determined by the end of the
-                // connection, so it is perfectly fine.
-                prematureClosure = contentLength() > 0;
-            }
-
-            if (!prematureClosure) {
-                out.add(LastHttpContent.EMPTY_LAST_CONTENT);
-            }
-            resetNow();
+            case READ_CHUNK_DELIMITER: // fall-trough
+            case READ_CHUNK_FOOTER: // fall-trough
+            case READ_CHUNKED_CONTENT: // fall-trough
+            case READ_CHUNK_SIZE: // fall-trough
+            case READ_FIXED_LENGTH_CONTENT:
+                // Check if the closure of the connection signifies the end of the content.
+                boolean prematureClosure;
+                if (isDecodingRequest() || chunked) {
+                    // The last request did not wait for a response.
+                    prematureClosure = true;
+                } else {
+                    // Compare the length of the received content and the 'Content-Length' header.
+                    // If the 'Content-Length' header is absent, the length of the content is determined by the end of
+                    // the connection, so it is perfectly fine.
+                    prematureClosure = contentLength > 0;
+                }
+                if (!prematureClosure) {
+                    out.add(LastHttpContent.EMPTY_LAST_CONTENT);
+                }
+                resetNow();
+                return;
+            case SKIP_CONTROL_CHARS: // fall-trough
+            case READ_INITIAL:// fall-trough
+            case BAD_MESSAGE: // fall-trough
+            case UPGRADED: // fall-trough
+                // Do nothing
+                break;
+            default:
+                throw new IllegalStateException("Unhandled state " + currentState);
         }
     }
 
@@ -648,45 +661,45 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
     }
 
     private void resetNow() {
-        HttpMessage message = this.message;
-        this.message = null;
+        message = null;
         name = null;
         value = null;
         contentLength = Long.MIN_VALUE;
+        chunked = false;
         lineParser.reset();
         headerParser.reset();
         trailer = null;
-        if (!isDecodingRequest()) {
-            HttpResponse res = (HttpResponse) message;
-            if (res != null && isSwitchingToNonHttp1Protocol(res)) {
-                currentState = State.UPGRADED;
-                return;
-            }
+        if (isSwitchingToNonHttp1Protocol) {
+            isSwitchingToNonHttp1Protocol = false;
+            currentState = State.UPGRADED;
+            return;
         }
 
         resetRequested.lazySet(false);
         currentState = State.SKIP_CONTROL_CHARS;
     }
 
-    private HttpMessage invalidMessage(ByteBuf in, Exception cause) {
+    private HttpMessage invalidMessage(HttpMessage current, ByteBuf in, Exception cause) {
         currentState = State.BAD_MESSAGE;
+        message = null;
+        trailer = null;
 
         // Advance the readerIndex so that ByteToMessageDecoder does not complain
         // when we produced an invalid message without consuming anything.
         in.skipBytes(in.readableBytes());
 
-        if (message == null) {
-            message = createInvalidMessage();
+        if (current == null) {
+            current = createInvalidMessage();
         }
-        message.setDecoderResult(DecoderResult.failure(cause));
+        current.setDecoderResult(DecoderResult.failure(cause));
 
-        HttpMessage ret = message;
-        message = null;
-        return ret;
+        return current;
     }
 
     private HttpContent invalidChunk(ByteBuf in, Exception cause) {
         currentState = State.BAD_MESSAGE;
+        message = null;
+        trailer = null;
 
         // Advance the readerIndex so that ByteToMessageDecoder does not complain
         // when we produced an invalid message without consuming anything.
@@ -694,8 +707,6 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
 
         HttpContent chunk = new DefaultLastHttpContent(Unpooled.EMPTY_BUFFER);
         chunk.setDecoderResult(DecoderResult.failure(cause));
-        message = null;
-        trailer = null;
         return chunk;
     }
 
@@ -763,21 +774,30 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
                     headers.set(HttpHeaderNames.CONTENT_LENGTH, contentLength);
                 }
             }
+        } else {
+            // We know the content length if it's a Web Socket message even if
+            // Content-Length header is missing.
+            contentLength = HttpUtil.getWebSocketContentLength(message);
         }
-
+        if (!isDecodingRequest() && message instanceof HttpResponse) {
+            HttpResponse res = (HttpResponse) message;
+            this.isSwitchingToNonHttp1Protocol = isSwitchingToNonHttp1Protocol(res);
+        }
         if (isContentAlwaysEmpty(message)) {
             HttpUtil.setTransferEncodingChunked(message, false);
             return State.SKIP_CONTROL_CHARS;
-        } else if (HttpUtil.isTransferEncodingChunked(message)) {
+        }
+        if (HttpUtil.isTransferEncodingChunked(message)) {
+            this.chunked = true;
             if (!contentLengthFields.isEmpty() && message.protocolVersion() == HttpVersion.HTTP_1_1) {
                 handleTransferEncodingChunkedWithContentLength(message);
             }
             return State.READ_CHUNK_SIZE;
-        } else if (contentLength() >= 0) {
-            return State.READ_FIXED_LENGTH_CONTENT;
-        } else {
-            return State.READ_VARIABLE_LENGTH_CONTENT;
         }
+        if (contentLength >= 0) {
+            return State.READ_FIXED_LENGTH_CONTENT;
+        }
+        return State.READ_VARIABLE_LENGTH_CONTENT;
     }
 
     /**
@@ -804,13 +824,6 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
     protected void handleTransferEncodingChunkedWithContentLength(HttpMessage message) {
         message.headers().remove(HttpHeaderNames.CONTENT_LENGTH);
         contentLength = Long.MIN_VALUE;
-    }
-
-    private long contentLength() {
-        if (contentLength == Long.MIN_VALUE) {
-            contentLength = HttpUtil.getContentLength(message, -1L);
-        }
-        return contentLength;
     }
 
     private LastHttpContent readTrailingHeaders(ByteBuf buffer) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
@@ -220,7 +220,7 @@ public final class HttpUtil {
      * Returns the content length of the specified web socket message. If the
      * specified message is not a web socket message, {@code -1} is returned.
      */
-    private static int getWebSocketContentLength(HttpMessage message) {
+    static int getWebSocketContentLength(HttpMessage message) {
         // WebSocket messages have constant content-lengths.
         HttpHeaders h = message.headers();
         if (message instanceof HttpRequest) {

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpObjectAggregatorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpObjectAggregatorTest.java
@@ -22,6 +22,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.DecoderResultProvider;
+import io.netty.handler.codec.PrematureChannelClosureException;
 import io.netty.util.AsciiString;
 import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
@@ -743,5 +744,20 @@ public class HttpObjectAggregatorTest {
         } finally {
           channel.close();
         }
+    }
+
+    @Test
+    public void testPrematureClosureWithChunkedEncodingAndAggregator() {
+        final EmbeddedChannel ch = new EmbeddedChannel(new HttpResponseDecoder(), new HttpObjectAggregator(1024));
+
+        // Write the partial response.
+        assertFalse(ch.writeInbound(Unpooled.copiedBuffer(
+                "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n8\r\n12345678", CharsetUtil.US_ASCII)));
+        assertThrows(PrematureChannelClosureException.class, new Executable() {
+            @Override
+            public void execute() {
+                ch.finish();
+            }
+        });
     }
 }


### PR DESCRIPTION
… the next handler in the ChannelPipeline.

Motivation:

We continued to use the previous generated HttpMessage even after we passed it to the next handler. This is problematic as the HttpMessage might be modified by other handlers.

Modifications:

- Don't use the HttpMessage after it was passed to the next handler.
- Add unit test

Result:

Fixes https://github.com/netty/netty/issues/13816