### PR TITLE
SSLSession.getLastAccessedTime() and getCreationTime() should not be …

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ExtendedOpenSslSession.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ExtendedOpenSslSession.java
@@ -28,6 +28,7 @@ import java.security.Principal;
 import java.security.cert.Certificate;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Delegates all operations to a wrapped {@link OpenSslSession} except the methods defined by {@link ExtendedSSLSession}
@@ -69,8 +70,8 @@ abstract class ExtendedOpenSslSession extends ExtendedSSLSession implements Open
     }
 
     @Override
-    public void setSessionId(OpenSslSessionId id) {
-        wrapped.setSessionId(id);
+    public void setSessionDetails(long creationTime, long lastAccessedTime, OpenSslSessionId id) {
+        wrapped.setSessionDetails(creationTime, lastAccessedTime, id);
     }
 
     @Override
@@ -111,6 +112,11 @@ abstract class ExtendedOpenSslSession extends ExtendedSSLSession implements Open
     @Override
     public final long getLastAccessedTime() {
         return wrapped.getLastAccessedTime();
+    }
+
+    @Override
+    public void setLastAccessedTime(long time) {
+        wrapped.setLastAccessedTime(time);
     }
 
     @Override

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslClientSessionCache.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslClientSessionCache.java
@@ -55,33 +55,40 @@ final class OpenSslClientSessionCache extends OpenSslSessionCache {
     }
 
     @Override
-    void setSession(long ssl, String host, int port) {
+    void setSession(long ssl, OpenSslSession session, String host, int port) {
         HostPort hostPort = keyFor(host, port);
         if (hostPort == null) {
             return;
         }
-        final NativeSslSession session;
+        final NativeSslSession nativeSslSession;
         final boolean reused;
+        boolean singleUsed = false;
         synchronized (this) {
-            session = sessions.get(hostPort);
-            if (session == null) {
+            nativeSslSession = sessions.get(hostPort);
+            if (nativeSslSession == null) {
                 return;
             }
-            if (!session.isValid()) {
-                removeSessionWithId(session.sessionId());
+            if (!nativeSslSession.isValid()) {
+                removeSessionWithId(nativeSslSession.sessionId());
                 return;
             }
             // Try to set the session, if true is returned OpenSSL incremented the reference count
             // of the underlying SSL_SESSION*.
-            reused = SSL.setSession(ssl, session.session());
+            reused = SSL.setSession(ssl, nativeSslSession.session());
+            if (reused) {
+                singleUsed = nativeSslSession.shouldBeSingleUse();
+            }
         }
 
         if (reused) {
-            if (session.shouldBeSingleUse()) {
+            if (singleUsed) {
                 // Should only be used once
+                nativeSslSession.invalidate();
                 session.invalidate();
             }
-            session.updateLastAccessedTime();
+            nativeSslSession.setLastAccessedTime(System.currentTimeMillis());
+            session.setSessionDetails(nativeSslSession.getCreationTime(), nativeSslSession.getLastAccessedTime(),
+                    nativeSslSession.sessionId());
         }
     }
 

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslSession.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslSession.java
@@ -15,15 +15,12 @@
  */
 package io.netty.handler.ssl;
 
-import io.netty.util.ReferenceCounted;
-
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLSession;
 import java.security.cert.Certificate;
 
 /**
- * {@link SSLSession} that is specific to our native implementation and {@link ReferenceCounted} to track native
- * resources.
+ * {@link SSLSession} that is specific to our native implementation.
  */
 interface OpenSslSession extends SSLSession {
 
@@ -41,7 +38,14 @@ interface OpenSslSession extends SSLSession {
     /**
      * Set the {@link OpenSslSessionId} for the {@link OpenSslSession}.
      */
-    void setSessionId(OpenSslSessionId id);
+    void setSessionDetails(long creationTime, long lastAccessedTime, OpenSslSessionId id);
+
+    /**
+     * Set the last access time which will be returned by {@link #getLastAccessedTime()}.
+     *
+     * @param time the time
+     */
+    void setLastAccessedTime(long time);
 
     @Override
     OpenSslSessionContext getSessionContext();

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslSessionContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslSessionContext.java
@@ -216,8 +216,8 @@ public abstract class OpenSslSessionContext implements SSLSessionContext {
         return sessionCache.containsSessionWithId(id);
     }
 
-    void setSessionFromCache(String host, int port, long ssl) {
-        sessionCache.setSession(ssl, host, port);
+    void setSessionFromCache(long ssl, OpenSslSession session, String host, int port) {
+        sessionCache.setSession(ssl, session, host, port);
     }
 
     final void destroy() {

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
@@ -1567,11 +1567,12 @@ public class OpenSslEngineTest extends SSLEngineTest {
     protected void assertSessionReusedForEngine(SSLEngine clientEngine, SSLEngine serverEngine, boolean reuse) {
         assertEquals(reuse, unwrapEngine(clientEngine).isSessionReused());
         assertEquals(reuse, unwrapEngine(serverEngine).isSessionReused());
+        super.assertSessionReusedForEngine(clientEngine, serverEngine, reuse);
     }
 
     @Override
-    protected boolean isSessionMaybeReused(SSLEngine engine) {
-        return unwrapEngine(engine).isSessionReused();
+    protected SessionReusedState isSessionReused(SSLEngine engine) {
+        return unwrapEngine(engine).isSessionReused() ? SessionReusedState.REUSED : SessionReusedState.NOT_REUSED;
     }
 
     @MethodSource("newTestParams")


### PR DESCRIPTION
…equals when session is reused

Motivation:

SSLSession.getLastAccessedTime() and getCreationTime() should not be equal when the session is reused. Also the last accessed time need to be updated whenever we re-use the session

Modifications:

- Correctly update session * times.
- Adjust unit tests

Result:

Correctly represent times in SSLSession implementation when using native impl
