### PR TITLE
Update Brotli4j to v1.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -666,7 +666,7 @@
     <skipAutobahnTestsuite>false</skipAutobahnTestsuite>
     <skipHttp2Testsuite>false</skipHttp2Testsuite>
     <graalvm.version>19.3.6</graalvm.version>
-    <brotli4j.version>1.14.0</brotli4j.version>
+    <brotli4j.version>1.16.0</brotli4j.version>
     <!-- By default skip native testsuite as it requires a custom environment with graalvm installed -->
     <skipNativeImageTestsuite>true</skipNativeImageTestsuite>
     <skipShadingTestsuite>false</skipShadingTestsuite>


### PR DESCRIPTION
Motivation:
There were some mishaps in `linux-x86_64` module of Brotli4j which caused package clash. v1.16.0 release addresses all of them.

Modification:
Updated Brotli4j to v1.16.0

Result:
Latest Brotli4j release