### PR TITLE
Correctly override equals and hashCode for our OpenSslSession sub-types

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ExtendedOpenSslSession.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ExtendedOpenSslSession.java
@@ -28,7 +28,6 @@ import java.security.Principal;
 import java.security.cert.Certificate;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Delegates all operations to a wrapped {@link OpenSslSession} except the methods defined by {@link ExtendedSSLSession}
@@ -236,6 +235,16 @@ abstract class ExtendedOpenSslSession extends ExtendedSSLSession implements Open
     public void handshakeFinished(byte[] id, String cipher, String protocol, byte[] peerCertificate,
                                   byte[][] peerCertificateChain, long creationTime, long timeout) throws SSLException {
         wrapped.handshakeFinished(id, cipher, protocol, peerCertificate, peerCertificateChain, creationTime, timeout);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return wrapped.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return wrapped.hashCode();
     }
 
     @Override

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -2721,6 +2721,23 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                     ", id=" + id +
                     '}';
         }
+
+        @Override
+        public int hashCode() {
+            return sessionId().hashCode();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == this) {
+                return true;
+            }
+            // We trust all sub-types as we use different types but the interface is package-private
+            if (!(o instanceof OpenSslSession)) {
+                return false;
+            }
+            return sessionId().equals(((OpenSslSession) o).sessionId());
+        }
     }
 
     private interface NativeSslException {


### PR DESCRIPTION
Motivation:

We did not correct override equals and hashcode methods for some of the OpenSslSession implementations

Modifications:

Override methods

Result:

Be able to correctly understand if a session is equal or not
