### PR TITLE
codec-http2: fix some frame validation errors

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameReader.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameReader.java
@@ -113,7 +113,7 @@ public class DefaultHttp2FrameReader implements Http2FrameReader, Http2FrameSize
     public void maxFrameSize(int max) throws Http2Exception {
         if (!isMaxFrameSizeValid(max)) {
             // SETTINGS frames affect the entire connection state and thus errors must be connection errors.
-            throw connectionError(FRAME_SIZE_ERROR,"Invalid MAX_FRAME_SIZE specified in sent settings: %d", max);
+            throw connectionError(FRAME_SIZE_ERROR, "Invalid MAX_FRAME_SIZE specified in sent settings: %d", max);
         }
         maxFrameSize = max;
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameReader.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameReader.java
@@ -21,6 +21,7 @@ import io.netty.handler.codec.http2.Http2FrameReader.Configuration;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.UnstableApi;
 
+import static io.netty.handler.codec.http2.Http2CodecUtil.CONNECTION_STREAM_ID;
 import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_MAX_FRAME_SIZE;
 import static io.netty.handler.codec.http2.Http2CodecUtil.FRAME_HEADER_LENGTH;
 import static io.netty.handler.codec.http2.Http2CodecUtil.INT_FIELD_LENGTH;
@@ -111,8 +112,8 @@ public class DefaultHttp2FrameReader implements Http2FrameReader, Http2FrameSize
     @Override
     public void maxFrameSize(int max) throws Http2Exception {
         if (!isMaxFrameSizeValid(max)) {
-            throw streamError(streamId, FRAME_SIZE_ERROR,
-                    "Invalid MAX_FRAME_SIZE specified in sent settings: %d", max);
+            // SETTINGS frames affect the entire connection state and thus errors must be connection errors.
+            throw connectionError(FRAME_SIZE_ERROR,"Invalid MAX_FRAME_SIZE specified in sent settings: %d", max);
         }
         maxFrameSize = max;
     }
@@ -299,8 +300,10 @@ public class DefaultHttp2FrameReader implements Http2FrameReader, Http2FrameSize
 
         int requiredLength = flags.getPaddingPresenceFieldLength() + flags.getNumPriorityBytes();
         if (payloadLength < requiredLength) {
-            throw streamError(streamId, FRAME_SIZE_ERROR,
-                    "Frame length too small." + payloadLength);
+            // HEADER frames carry a field_block and thus failure to process them results
+            // in HPACK corruption and renders the connection unusable.
+            throw connectionError(FRAME_SIZE_ERROR,
+                    "Frame length %d too small for HEADERS frame with stream %d.", payloadLength, streamId);
         }
     }
 
@@ -343,8 +346,10 @@ public class DefaultHttp2FrameReader implements Http2FrameReader, Http2FrameSize
         // rest of the payload (header block fragment + payload).
         int minLength = flags.getPaddingPresenceFieldLength() + INT_FIELD_LENGTH;
         if (payloadLength < minLength) {
-            throw streamError(streamId, FRAME_SIZE_ERROR,
-                    "Frame length %d too small.", payloadLength);
+            // PUSH_PROMISE frames carry a field_block and thus failure to process them results
+            // in HPACK corruption and renders the connection unusable.
+            throw connectionError(FRAME_SIZE_ERROR,
+                    "Frame length %d too small for PUSH_PROMISE frame with stream id %d.", payloadLength, streamId);
         }
     }
 
@@ -391,11 +396,6 @@ public class DefaultHttp2FrameReader implements Http2FrameReader, Http2FrameSize
             throw connectionError(PROTOCOL_ERROR, "Continuation stream ID does not match pending headers. "
                     + "Expected %d, but received %d.", headersContinuation.getStreamId(), streamId);
         }
-
-        if (payloadLength < flags.getPaddingPresenceFieldLength()) {
-            throw streamError(streamId, FRAME_SIZE_ERROR,
-                    "Frame length %d too small for padding.", payloadLength);
-        }
     }
 
     private void verifyUnknownFrame() throws Http2Exception {
@@ -429,7 +429,11 @@ public class DefaultHttp2FrameReader implements Http2FrameReader, Http2FrameSize
             final boolean exclusive = (word1 & 0x80000000L) != 0;
             final int streamDependency = (int) (word1 & 0x7FFFFFFFL);
             if (streamDependency == streamId) {
-                throw streamError(streamId, PROTOCOL_ERROR, "A stream cannot depend on itself.");
+                // RFC 7540 section 5.3.1 says this must be treated as a stream error of type PROTOCOL_ERROR
+                // but because we will not process the payload, a simple stream error could result in HPACK
+                // corruption. Therefor, we are elevating this to a connection error.
+                throw connectionError(
+                        PROTOCOL_ERROR, "HEADERS frame for stream %d cannot depend on itself.", streamId);
             }
             final short weight = (short) (payload.readUnsignedByte() + 1);
             final int lenToRead = lengthWithoutTrailingPadding(payloadEndIndex - payload.readerIndex(), padding);
@@ -585,8 +589,13 @@ public class DefaultHttp2FrameReader implements Http2FrameReader, Http2FrameSize
             Http2FrameListener listener) throws Http2Exception {
         int windowSizeIncrement = readUnsignedInt(payload);
         if (windowSizeIncrement == 0) {
-            throw streamError(streamId, PROTOCOL_ERROR,
-                    "Received WINDOW_UPDATE with delta 0 for stream: %d", streamId);
+            if (streamId == CONNECTION_STREAM_ID) {
+                throw connectionError(PROTOCOL_ERROR,
+                        "Received WINDOW_UPDATE with delta 0 for connection stream");
+            } else {
+                throw streamError(streamId, PROTOCOL_ERROR,
+                        "Received WINDOW_UPDATE with delta 0 for stream: %d", streamId);
+            }
         }
         listener.onWindowUpdateRead(ctx, streamId, windowSizeIncrement);
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2FrameReaderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2FrameReaderTest.java
@@ -27,6 +27,9 @@ import org.mockito.MockitoAnnotations;
 
 import static io.netty.handler.codec.http2.Http2CodecUtil.*;
 import static io.netty.handler.codec.http2.Http2FrameTypes.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
@@ -140,12 +143,13 @@ public class DefaultHttp2FrameReaderTest {
             writeHeaderFrame(input, streamId, headers, flags);
             writeFrameHeader(input, 0, (byte) 0xff, new Http2Flags(), streamId);
 
-            assertThrows(Http2Exception.class, new Executable() {
+            Http2Exception ex = assertThrows(Http2Exception.class, new Executable() {
                 @Override
                 public void execute() throws Throwable {
                     frameReader.readFrame(ctx, input, listener);
                 }
             });
+            assertFalse(ex instanceof Http2Exception.StreamException);
         } finally {
             input.release();
         }
@@ -165,12 +169,13 @@ public class DefaultHttp2FrameReaderTest {
             writeContinuationFrame(input, 3, new DefaultHttp2Headers().add("foo", "bar"),
                     new Http2Flags().endOfHeaders(true));
 
-            assertThrows(Http2Exception.class, new Executable() {
+            Http2Exception ex = assertThrows(Http2Exception.class, new Executable() {
                 @Override
                 public void execute() throws Throwable {
                     frameReader.readFrame(ctx, input, listener);
                 }
             });
+            assertFalse(ex instanceof Http2Exception.StreamException);
         } finally {
             input.release();
         }
@@ -182,12 +187,13 @@ public class DefaultHttp2FrameReaderTest {
         try {
             writeContinuationFrame(input, 1, new DefaultHttp2Headers().add("foo", "bar"),
                                    new Http2Flags().endOfHeaders(true));
-            assertThrows(Http2Exception.class, new Executable() {
+            Http2Exception ex = assertThrows(Http2Exception.class, new Executable() {
                 @Override
                 public void execute() throws Throwable {
                     frameReader.readFrame(ctx, input, listener);
                 }
             });
+            assertFalse(ex instanceof Http2Exception.StreamException);
         } finally {
             input.release();
         }
@@ -206,12 +212,32 @@ public class DefaultHttp2FrameReaderTest {
                     input, 1, headers,
                     new Http2Flags().endOfHeaders(true).endOfStream(true).priorityPresent(true),
                     1, 10);
-            assertThrows(Http2Exception.class, new Executable() {
+            Http2Exception ex = assertThrows(Http2Exception.class, new Executable() {
                 @Override
                 public void execute() throws Throwable {
                     frameReader.readFrame(ctx, input, listener);
                 }
             });
+            assertFalse(ex instanceof Http2Exception.StreamException);
+        } finally {
+            input.release();
+        }
+    }
+
+    @Test
+    public void failedHeadersValidationThrowsConnectionError() throws Http2Exception {
+        final ByteBuf input = Unpooled.buffer();
+        try {
+            // Because we have padding we need at least 1 byte in the payload to specify the padding length.
+            writeFrameHeader(input, 0, HEADERS, new Http2Flags().paddingPresent(true), 1);
+            Http2Exception ex = assertThrows(Http2Exception.class, new Executable() {
+                @Override
+                public void execute() throws Throwable {
+                    frameReader.readFrame(ctx, input, listener);
+                }
+            });
+            assertFalse(ex instanceof Http2Exception.StreamException);
+            assertEquals(Http2Error.FRAME_SIZE_ERROR, ex.error());
         } finally {
             input.release();
         }
@@ -289,17 +315,36 @@ public class DefaultHttp2FrameReaderTest {
     }
 
     @Test
-    public void failedWhenWindowUpdateFrameWithZeroDelta() throws Http2Exception {
+    public void failedWhenConnectionWindowUpdateFrameWithZeroDelta() throws Http2Exception {
         final ByteBuf input = Unpooled.buffer();
         try {
             writeFrameHeader(input, 4, WINDOW_UPDATE, new Http2Flags(), 0);
             input.writeInt(0);
-            assertThrows(Http2Exception.class, new Executable() {
+            Http2Exception ex = assertThrows(Http2Exception.class, new Executable() {
                 @Override
                 public void execute() throws Throwable {
                     frameReader.readFrame(ctx, input, listener);
                 }
             });
+            assertFalse(ex instanceof Http2Exception.StreamException);
+        } finally {
+            input.release();
+        }
+    }
+
+    @Test
+    public void failedWhenStreamWindowUpdateFrameWithZeroDelta() throws Http2Exception {
+        final ByteBuf input = Unpooled.buffer();
+        try {
+            writeFrameHeader(input, 4, WINDOW_UPDATE, new Http2Flags(), 1);
+            input.writeInt(0);
+            Http2Exception ex = assertThrows(Http2Exception.class, new Executable() {
+                @Override
+                public void execute() throws Throwable {
+                    frameReader.readFrame(ctx, input, listener);
+                }
+            });
+            assertInstanceOf(Http2Exception.StreamException.class, ex);
         } finally {
             input.release();
         }
@@ -340,12 +385,13 @@ public class DefaultHttp2FrameReaderTest {
             writeFrameHeader(input, 6, SETTINGS, new Http2Flags(), 1);
             input.writeShort(SETTINGS_MAX_HEADER_LIST_SIZE);
             input.writeInt(1024);
-            assertThrows(Http2Exception.class, new Executable() {
+            Http2Exception ex = assertThrows(Http2Exception.class, new Executable() {
                 @Override
                 public void execute() throws Throwable {
                     frameReader.readFrame(ctx, input, listener);
                 }
             });
+            assertFalse(ex instanceof Http2Exception.StreamException);
         } finally {
             input.release();
         }
@@ -357,12 +403,13 @@ public class DefaultHttp2FrameReaderTest {
         try {
             writeFrameHeader(input, 1, SETTINGS, new Http2Flags().ack(true), 0);
             input.writeByte(1);
-            assertThrows(Http2Exception.class, new Executable() {
+            Http2Exception ex = assertThrows(Http2Exception.class, new Executable() {
                 @Override
                 public void execute() throws Throwable {
                     frameReader.readFrame(ctx, input, listener);
                 }
             });
+            assertFalse(ex instanceof Http2Exception.StreamException);
         } finally {
             input.release();
         }
@@ -375,12 +422,13 @@ public class DefaultHttp2FrameReaderTest {
             writeFrameHeader(input, 8, SETTINGS, new Http2Flags(), 0);
             input.writeInt(SETTINGS_MAX_HEADER_LIST_SIZE);
             input.writeInt(1024);
-            assertThrows(Http2Exception.class, new Executable() {
+            Http2Exception ex = assertThrows(Http2Exception.class, new Executable() {
                 @Override
                 public void execute() throws Throwable {
                     frameReader.readFrame(ctx, input, listener);
                 }
             });
+            assertFalse(ex instanceof Http2Exception.StreamException);
         } finally {
             input.release();
         }


### PR DESCRIPTION
Motivation:

Some of our HTTP/2 frame validations throw a stream error when they should be throwing a connection error. This is particularly true for frames carrying a headers block because failure to process the block will result in HPACK corruption.

Modifications:

- elevate candidate stream errors to connection errors
- add some tests

Result:

A more correct HTTP/2 codec.

Relates to https://github.com/netty/netty/pull/13789.