### PR TITLE
Add ReferenceCountUtil.touch(...) calls before we store messages into…

### DIFF
--- a/transport/src/main/java/io/netty/channel/AbstractCoalescingBufferQueue.java
+++ b/transport/src/main/java/io/netty/channel/AbstractCoalescingBufferQueue.java
@@ -17,6 +17,7 @@ package io.netty.channel;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.CompositeByteBuf;
+import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -58,6 +59,9 @@ public abstract class AbstractCoalescingBufferQueue {
     }
 
     private void addFirst(ByteBuf buf, ChannelFutureListener listener) {
+        // Touch the message to make it easier to debug buffer leaks.
+        ReferenceCountUtil.touch(buf);
+
         if (listener != null) {
             bufAndListenerPairs.addFirst(listener);
         }
@@ -91,6 +95,9 @@ public abstract class AbstractCoalescingBufferQueue {
      * @param listener to notify when all the bytes have been consumed and written, can be {@code null}.
      */
     public final void add(ByteBuf buf, ChannelFutureListener listener) {
+        // Touch the message to make it easier to debug buffer leaks.
+        ReferenceCountUtil.touch(buf);
+
         // buffers are added before promises so that we naturally 'consume' the entire buffer during removal
         // before we complete it's promise.
         bufAndListenerPairs.add(buf);

--- a/transport/src/main/java/io/netty/channel/AbstractCoalescingBufferQueue.java
+++ b/transport/src/main/java/io/netty/channel/AbstractCoalescingBufferQueue.java
@@ -17,7 +17,6 @@ package io.netty.channel;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.CompositeByteBuf;
-import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -60,7 +59,7 @@ public abstract class AbstractCoalescingBufferQueue {
 
     private void addFirst(ByteBuf buf, ChannelFutureListener listener) {
         // Touch the message to make it easier to debug buffer leaks.
-        ReferenceCountUtil.touch(buf);
+        buf.touch();
 
         if (listener != null) {
             bufAndListenerPairs.addFirst(listener);
@@ -96,7 +95,7 @@ public abstract class AbstractCoalescingBufferQueue {
      */
     public final void add(ByteBuf buf, ChannelFutureListener listener) {
         // Touch the message to make it easier to debug buffer leaks.
-        ReferenceCountUtil.touch(buf);
+        buf.touch();
 
         // buffers are added before promises so that we naturally 'consume' the entire buffer during removal
         // before we complete it's promise.

--- a/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
@@ -125,6 +125,9 @@ public final class ChannelOutboundBuffer {
             unflushedEntry = entry;
         }
 
+        // Touch the message to make it easier to debug buffer leaks.
+        ReferenceCountUtil.touch(msg);
+
         // increment pending bytes after adding message to the unflushed arrays.
         // See https://github.com/netty/netty/issues/1619
         incrementPendingOutboundBytes(entry.pendingSize, false);

--- a/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
@@ -126,7 +126,15 @@ public final class ChannelOutboundBuffer {
         }
 
         // Touch the message to make it easier to debug buffer leaks.
-        ReferenceCountUtil.touch(msg);
+
+        // this save both checking against the ReferenceCounted interface
+        // and makes better use of virtual calls vs interface ones
+        if (msg instanceof AbstractReferenceCountedByteBuf) {
+            // release now as it is flushed.
+            ((AbstractReferenceCountedByteBuf) msg).touch();
+        } else {
+            ReferenceCountUtil.touch(msg);
+        }
 
         // increment pending bytes after adding message to the unflushed arrays.
         // See https://github.com/netty/netty/issues/1619

--- a/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
@@ -130,7 +130,6 @@ public final class ChannelOutboundBuffer {
         // this save both checking against the ReferenceCounted interface
         // and makes better use of virtual calls vs interface ones
         if (msg instanceof AbstractReferenceCountedByteBuf) {
-            // release now as it is flushed.
             ((AbstractReferenceCountedByteBuf) msg).touch();
         } else {
             ReferenceCountUtil.touch(msg);

--- a/transport/src/main/java/io/netty/channel/PendingWriteQueue.java
+++ b/transport/src/main/java/io/netty/channel/PendingWriteQueue.java
@@ -125,7 +125,6 @@ public final class PendingWriteQueue {
         // this save both checking against the ReferenceCounted interface
         // and makes better use of virtual calls vs interface ones
         if (msg instanceof AbstractReferenceCountedByteBuf) {
-            // release now as it is flushed.
             ((AbstractReferenceCountedByteBuf) msg).touch();
         } else {
             ReferenceCountUtil.touch(msg);

--- a/transport/src/main/java/io/netty/channel/PendingWriteQueue.java
+++ b/transport/src/main/java/io/netty/channel/PendingWriteQueue.java
@@ -119,6 +119,8 @@ public final class PendingWriteQueue {
         size ++;
         bytes += messageSize;
         tracker.incrementPendingOutboundBytes(write.size);
+        // Touch the message to make it easier to debug buffer leaks.
+        ReferenceCountUtil.touch(msg);
     }
 
     /**


### PR DESCRIPTION
… a queue to make debugging leaks easier

Motivation:

We should touch our messages when we take over ownership, this allows easier debugging of buffer leaks.

Modifications:

Let's add touch call before enqueue into internal datastructure

Result:

Easier to debug buffer leaks
