### PR TITLE
Allow to cancel connect() operations when using non-blocking IO

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketConnectionAttemptTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketConnectionAttemptTest.java
@@ -16,11 +16,13 @@
 package io.netty.testsuite.transport.socket;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelOption;
+import io.netty.channel.socket.oio.OioSocketChannel;
 import io.netty.util.internal.SocketUtils;
 import io.netty.util.NetUtil;
 import io.netty.util.concurrent.GlobalEventExecutor;
@@ -39,6 +41,7 @@ import static io.netty.testsuite.transport.socket.SocketTestPermutation.BAD_HOST
 import static io.netty.testsuite.transport.socket.SocketTestPermutation.BAD_PORT;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -161,11 +164,18 @@ public class SocketConnectionAttemptTest extends AbstractClientSocketTest {
                 assertThat(future.channel().closeFuture().await(500), is(true));
                 assertThat(future.isCancelled(), is(true));
             } else {
-                // Cancellation not supported by the transport.
+                // Check if cancellation is supported or not.
+                assertFalse(isConnectCancellationSupported(future.channel()), future.channel().getClass() +
+                        " should support connect cancellation");
             }
         } finally {
             future.channel().close();
         }
+    }
+
+    @SuppressWarnings("deprecation")
+    protected boolean isConnectCancellationSupported(Channel channel) {
+        return !(channel instanceof OioSocketChannel);
     }
 
     private static class TestHandler extends ChannelInboundHandlerAdapter {

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
@@ -545,7 +545,9 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
         @Override
         public void connect(
                 final SocketAddress remoteAddress, final SocketAddress localAddress, final ChannelPromise promise) {
-            if (!promise.setUncancellable() || !ensureOpen(promise)) {
+            // Don't mark the connect promise as uncancellable as in fact we can cancel it as it is using
+            // non-blocking io.
+            if (promise.isDone() || !ensureOpen(promise)) {
                 return;
             }
 
@@ -580,7 +582,9 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
 
                     promise.addListener(new ChannelFutureListener() {
                         @Override
-                        public void operationComplete(ChannelFuture future) throws Exception {
+                        public void operationComplete(ChannelFuture future) {
+                            // If the connect future is cancelled we also cancel the timeout and close the
+                            // underlying socket.
                             if (future.isCancelled()) {
                                 if (connectTimeoutFuture != null) {
                                     connectTimeoutFuture.cancel(false);

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
@@ -234,7 +234,9 @@ public abstract class AbstractNioChannel extends AbstractChannel {
         @Override
         public final void connect(
                 final SocketAddress remoteAddress, final SocketAddress localAddress, final ChannelPromise promise) {
-            if (!promise.setUncancellable() || !ensureOpen(promise)) {
+            // Don't mark the connect promise as uncancellable as in fact we can cancel it as it is using
+            // non-blocking io.
+            if (promise.isDone() || !ensureOpen(promise)) {
                 return;
             }
 
@@ -270,7 +272,9 @@ public abstract class AbstractNioChannel extends AbstractChannel {
 
                     promise.addListener(new ChannelFutureListener() {
                         @Override
-                        public void operationComplete(ChannelFuture future) throws Exception {
+                        public void operationComplete(ChannelFuture future) {
+                            // If the connect future is cancelled we also cancel the timeout and close the
+                            // underlying socket.
                             if (future.isCancelled()) {
                                 if (connectTimeoutFuture != null) {
                                     connectTimeoutFuture.cancel(false);


### PR DESCRIPTION
Motivation:

Whe using non-blocking IO we can in fact cancel a connect() operation by just closing the underyling fd.

Modifications:

- Don't mark the promise as uncancellable before issue the non-blocking connect() call
- Add comment to explain code
- Adjust testConnectCancellation(...) to test the possiblity for connection cancellation for various transport implementations

Result:

Fixes https://github.com/netty/netty/issues/13843
