### PR TITLE
DNS resolver final CNAME lookup disabled

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
@@ -70,7 +70,7 @@ abstract class DnsResolveContext<T> {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(DnsResolveContext.class);
     private static final String PROP_TRY_FINAL_CNAME_ON_ADDRESS_LOOKUPS =
             "io.netty.resolver.dns.trycnameonaddresslookups";
-    private static final boolean TRY_FINAL_CNAME_ON_ADDRESS_LOOKUPS;
+    static boolean TRY_FINAL_CNAME_ON_ADDRESS_LOOKUPS;
 
     static {
         TRY_FINAL_CNAME_ON_ADDRESS_LOOKUPS =

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
@@ -1067,7 +1067,7 @@ abstract class DnsResolveContext<T> {
             // .. and we could not find any expected records.
 
             // The following is of questionable benefit, but has been around for a while that
-            // it may be risky to remove.
+            // it may be risky to remove. Reference https://datatracker.ietf.org/doc/html/rfc8020
             // - If we receive NXDOMAIN we know the domain doesn't exist, any other lookup type is meaningless.
             // - If we receive SERVFAIL, and we attempt a CNAME that returns NOERROR with 0 answers, it may lead the
             //   call-site to invalidate previously advertised addresses.

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
@@ -69,7 +69,7 @@ import static java.lang.Math.min;
 abstract class DnsResolveContext<T> {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(DnsResolveContext.class);
     private static final String PROP_TRY_FINAL_CNAME_ON_ADDRESS_LOOKUPS =
-            "io.netty.resolver.dns.trycnameonaddresslookups";
+            "io.netty.resolver.dns.tryCnameOnAddressLookups";
     static boolean TRY_FINAL_CNAME_ON_ADDRESS_LOOKUPS;
 
     static {

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
@@ -40,6 +40,7 @@ import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.SuppressJava6Requirement;
+import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.ThrowableUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -67,6 +68,18 @@ import static java.lang.Math.min;
 
 abstract class DnsResolveContext<T> {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(DnsResolveContext.class);
+    private static final String PROP_TRY_FINAL_CNAME_ON_ADDRESS_LOOKUPS =
+            "io.netty.resolver.dns.trycnameonaddresslookups";
+    private static final boolean TRY_FINAL_CNAME_ON_ADDRESS_LOOKUPS;
+
+    static {
+        TRY_FINAL_CNAME_ON_ADDRESS_LOOKUPS =
+                SystemPropertyUtil.getBoolean(PROP_TRY_FINAL_CNAME_ON_ADDRESS_LOOKUPS, false);
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("-D{}: {}", PROP_TRY_FINAL_CNAME_ON_ADDRESS_LOOKUPS, TRY_FINAL_CNAME_ON_ADDRESS_LOOKUPS);
+        }
+    }
 
     private static final RuntimeException NXDOMAIN_QUERY_FAILED_EXCEPTION =
             DnsResolveContextException.newStatic("No answer found and NXDOMAIN response code returned",
@@ -673,9 +686,9 @@ abstract class DnsResolveContext<T> {
                 //                ....
                 if (!res.isAuthoritativeAnswer()) {
                     query(nameServerAddrStream, nameServerAddrStreamIndex + 1, question,
-                            newDnsQueryLifecycleObserver(question), true, promise, null);
+                            newDnsQueryLifecycleObserver(question), true, promise, cause(code));
                 } else {
-                    // Failed with NX cause - distinction between an authoritative NXDOMAIN vs a timeout
+                    // Failed with NX cause - distinction between NXDOMAIN vs a timeout
                     tryToFinishResolve(nameServerAddrStream, nameServerAddrStreamIndex, question,
                             queryLifecycleObserver, promise, NXDOMAIN_CAUSE_QUERY_FAILED_EXCEPTION);
                 }
@@ -1053,16 +1066,29 @@ abstract class DnsResolveContext<T> {
 
             // .. and we could not find any expected records.
 
-            // If cause != null we know this was caused by a timeout / cancel / transport exception. In this case we
-            // won't try to resolve the CNAME as we only should do this if we could not get the expected records
-            // because they do not exist and the DNS server did probably signal it.
-            if (cause == null && !triedCNAME &&
-                    (question.type() == DnsRecordType.A || question.type() == DnsRecordType.AAAA)) {
-                // As the last resort, try to query CNAME, just in case the name server has it.
-                triedCNAME = true;
+            // The following is of questionable benefit, but has been around for a while that
+            // it may be risky to remove.
+            // - If we receive NXDOMAIN we know the domain doesn't exist, any other lookup type is meaningless.
+            // - If we receive SERVFAIL, and we attempt a CNAME that returns NOERROR with 0 answers, it may lead the
+            //   call-site to invalidate previously advertised addresses.
+            // Having said that, there is the case of DNS services that don't respect the protocol either
+            // - An A lookup could result in NXDOMAIN but a CNAME may succeed with answers.
+            // It's an imperfect world. Accept it.
+            // Guarding it with a system property, as an opt-in functionality.
+            if (TRY_FINAL_CNAME_ON_ADDRESS_LOOKUPS) {
+                // If cause != null we know this was caused by a timeout / cancel / transport exception. In this case we
+                // won't try to resolve the CNAME as we only should do this if we could not get the expected records
+                // because they do not exist and the DNS server did probably signal it.
+                final boolean isValidResponse =
+                        cause == NXDOMAIN_CAUSE_QUERY_FAILED_EXCEPTION || cause == SERVFAIL_QUERY_FAILED_EXCEPTION;
+                if ((cause == null || isValidResponse) && !triedCNAME &&
+                        (question.type() == DnsRecordType.A || question.type() == DnsRecordType.AAAA)) {
+                    // As the last resort, try to query CNAME, just in case the name server has it.
+                    triedCNAME = true;
 
-                query(hostname, DnsRecordType.CNAME, getNameServers(hostname), true, promise);
-                return;
+                    query(hostname, DnsRecordType.CNAME, getNameServers(hostname), true, promise);
+                    return;
+                }
             }
         } else {
             queryLifecycleObserver.queryCancelled(allowedQueries);

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -118,6 +118,7 @@ import static io.netty.handler.codec.dns.DnsRecordType.CNAME;
 import static io.netty.handler.codec.dns.DnsRecordType.NAPTR;
 import static io.netty.handler.codec.dns.DnsRecordType.SRV;
 import static io.netty.resolver.dns.DnsNameResolver.DEFAULT_RESOLVE_ADDRESS_TYPES;
+import static io.netty.resolver.dns.DnsResolveContext.TRY_FINAL_CNAME_ON_ADDRESS_LOOKUPS;
 import static io.netty.resolver.dns.DnsServerAddresses.sequential;
 import static io.netty.resolver.dns.TestDnsServer.newARecord;
 import static java.util.Arrays.asList;
@@ -146,10 +147,6 @@ public class DnsNameResolverTest {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(DnsNameResolver.class);
     private static final long DEFAULT_TEST_TIMEOUT_MS = 30000;
-
-    static {
-        System.setProperty("io.netty.resolver.dns.trycnameonaddresslookups", "true");
-    }
 
     // Using the top-100 web sites ranked in Alexa.com (Oct 2014)
     // Please use the following series of shell commands to get this up-to-date:
@@ -3739,7 +3736,7 @@ public class DnsNameResolverTest {
 
     @Test
     public void testCNAMEOnlyTriedOnAddressLookups() throws Exception {
-
+        TRY_FINAL_CNAME_ON_ADDRESS_LOOKUPS = true;
         final AtomicInteger cnameQueries = new AtomicInteger();
 
         TestDnsServer dnsServer2 = new TestDnsServer(new RecordStore() {
@@ -3753,9 +3750,9 @@ public class DnsNameResolverTest {
             }
         });
 
-        dnsServer2.start();
         DnsNameResolver resolver = null;
         try {
+            dnsServer2.start();
             resolver = newNonCachedResolver(ResolvedAddressTypes.IPV4_PREFERRED)
                     .maxQueriesPerResolve(4)
                     .searchDomains(Collections.<String>emptyList())
@@ -3792,6 +3789,7 @@ public class DnsNameResolverTest {
             if (resolver != null) {
                 resolver.close();
             }
+            TRY_FINAL_CNAME_ON_ADDRESS_LOOKUPS = false;
         }
     }
 

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -50,7 +50,6 @@ import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SocketUtils;
 import io.netty.util.internal.StringUtil;
-import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.ThreadLocalRandom;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -50,6 +50,7 @@ import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SocketUtils;
 import io.netty.util.internal.StringUtil;
+import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.ThreadLocalRandom;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -145,6 +146,10 @@ public class DnsNameResolverTest {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(DnsNameResolver.class);
     private static final long DEFAULT_TEST_TIMEOUT_MS = 30000;
+
+    static {
+        System.setProperty("io.netty.resolver.dns.trycnameonaddresslookups", "true");
+    }
 
     // Using the top-100 web sites ranked in Alexa.com (Oct 2014)
     // Please use the following series of shell commands to get this up-to-date:
@@ -3749,7 +3754,6 @@ public class DnsNameResolverTest {
         });
 
         dnsServer2.start();
-
         DnsNameResolver resolver = null;
         try {
             resolver = newNonCachedResolver(ResolvedAddressTypes.IPV4_PREFERRED)


### PR DESCRIPTION
Follow up of https://github.com/netty/netty/pull/13721

Motivation:

The previous effort introduced a root-cause for NXDOMAIN and SERVFAIL. That was only for the authoritative part. The non-authoritative was slightly different because it allowed a CNAME lookup regardless, for legacy reasons. In this effort, I take another stab at it, by making the additional CNAME lookup an opt-in feature. Justification included in the patch.

Modification:

Last resort CNAME lookup while doing address resolutions, is now an opt-in feature by default. The non-authoritative flow also includes the root cause as part of the UnknownHostException.

