### PR TITLE
Add profile for running build with netty-tcnative-boringssl-static sn…

### DIFF
--- a/.github/scripts/check_bom_dependencies.sh
+++ b/.github/scripts/check_bom_dependencies.sh
@@ -16,7 +16,7 @@
 # ----------------------------------------------------------------------------
 set -e
 
-PARENT_TCNATIVE_VERSION=$(grep "<tcnative.version>" pom.xml | sed -n  's/.*<tcnative.version>\(.*\)<\/tcnative.version>/\1/p')
+PARENT_TCNATIVE_VERSION=$(grep "<tcnative.version>" pom.xml | tail -n1 | sed -n  's/.*<tcnative.version>\(.*\)<\/tcnative.version>/\1/p')
 BOM_TCNATIVE_VERSION=$(grep "<tcnative.version>" bom/pom.xml | sed -n  's/.*<tcnative.version>\(.*\)<\/tcnative.version>/\1/p')
 
 if [ "$PARENT_TCNATIVE_VERSION" != "$BOM_TCNATIVE_VERSION" ]; then

--- a/pom.xml
+++ b/pom.xml
@@ -527,6 +527,14 @@
       </properties>
     </profile>
     <profile>
+      <id>boringssl-snapshot</id>
+      <properties>
+        <tcnative.artifactId>netty-tcnative-boringssl-static</tcnative.artifactId>
+        <tcnative.version>2.0.63.Final-SNAPSHOT</tcnative.version>
+        <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
+      </properties>
+    </profile>
+    <profile>
       <id>leak</id>
       <properties>
         <argLine.leak>-Dio.netty.leakDetectionLevel=paranoid -Dio.netty.leakDetection.targetRecords=32</argLine.leak>


### PR DESCRIPTION
…apshot

Motivation:

We should run a build from time to time aginst the SNAPSHOT build of netty-tcnative

Modifications:

Add profile to use netty-tcnative-boringssl-static

Result:

Be able to build with SNAPSHOT

