### PR TITLE
Add build workflow to run with netty-tcnative-boringssl-static snapshot

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -40,6 +40,9 @@ jobs:
           - setup: linux-x86_64-java11
             docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.111.yaml build"
             docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.111.yaml run build"
+          - setup: linux-x86_64-java11-boringssl-snapshot
+            docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.111.yaml build"
+            docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.111.yaml run build-boringssl-snapshot"
 
     name: ${{ matrix.setup }}
     steps:

--- a/docker/docker-compose.centos-6.111.yaml
+++ b/docker/docker-compose.centos-6.111.yaml
@@ -20,6 +20,9 @@ services:
   build-leak-boringssl-static:
     image: netty:centos-6-1.11
 
+  build-boringssl-snapshot:
+    image: netty:centos-6-1.11
+
   shell:
     image: netty:centos-6-1.11
 

--- a/docker/docker-compose.centos-6.18.yaml
+++ b/docker/docker-compose.centos-6.18.yaml
@@ -20,6 +20,9 @@ services:
   build-leak-boringssl-static:
     image: netty:centos-6-1.8
 
+  build-boringssl-snapshot:
+    image: netty:centos-6-1.8
+
   stage-snapshot:
     image: netty:centos-6-1.8
 

--- a/docker/docker-compose.centos-6.20.yaml
+++ b/docker/docker-compose.centos-6.20.yaml
@@ -20,5 +20,8 @@ services:
   build-leak-boringssl-static:
     image: netty:centos-6-20
 
+  build-boringssl-snapshot:
+    image: netty:centos-6-20
+
   shell:
     image: netty:centos-6-20

--- a/docker/docker-compose.centos-6.21.yaml
+++ b/docker/docker-compose.centos-6.21.yaml
@@ -20,5 +20,8 @@ services:
   build-leak-boringssl-static:
     image: netty:centos-6-21
 
+  build-boringssl-snapshot:
+    image: netty:centos-6-21
+
   shell:
     image: netty:centos-6-21

--- a/docker/docker-compose.centos-6.graalvm111.yaml
+++ b/docker/docker-compose.centos-6.graalvm111.yaml
@@ -20,5 +20,8 @@ services:
   build-leak-boringssl-static:
     image: netty:centos-6-1.11
 
+  build-boringssl-snapshot:
+    image: netty:centos-6-1.11
+
   shell:
     image: netty:centos-6-1.11

--- a/docker/docker-compose.centos-7.117.yaml
+++ b/docker/docker-compose.centos-7.117.yaml
@@ -20,5 +20,8 @@ services:
   build-leak-boringssl-static:
     image: netty:centos-7-1.17
 
+  build-boringssl-snapshot:
+    image: netty:centos-6-1.17
+
   shell:
     image: netty:centos-7-1.17

--- a/docker/docker-compose.centos-7.119.yaml
+++ b/docker/docker-compose.centos-7.119.yaml
@@ -20,5 +20,8 @@ services:
   build-leak-boringssl-static:
     image: netty:centos-7-1.19
 
+  build-boringssl-snapshot:
+    image: netty:centos-6-1.19
+
   shell:
     image: netty:centos-7-1.19

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -66,6 +66,10 @@ services:
     <<: *common
     command: /bin/bash -cl "./mvnw -B -ntp -Pboringssl,leak clean install -Dio.netty.testsuite.badHost=netty.io -Dxml.skip=true"
 
+  build-boringssl-snapshot:
+    <<: *common
+    command: /bin/bash -cl "./mvnw -B -ntp -pl handler -Pboringssl-snapshot clean package -Dxml.skip=true"
+
   shell:
     <<: *common
     entrypoint: /bin/bash


### PR DESCRIPTION
Motivation:

Let's also build once a day with netty-tcnative-boringssl-static SNAPSHOT

Modifications:

Add docker-compose config and workflow

Result:

Build once a day with SNAPSHOT