### PR TITLE
Save array bound-checks on AsciiString::contentEqualsIgnoreCase

### DIFF
--- a/common/src/main/java/io/netty/util/AsciiString.java
+++ b/common/src/main/java/io/netty/util/AsciiString.java
@@ -537,8 +537,8 @@ public final class AsciiString implements CharSequence, Comparable<CharSequence>
         if (string instanceof AsciiString) {
             AsciiString rhs = (AsciiString) string;
             byte[] rhsValue = rhs.value;
-            if ((arrayOffset() | rhs.arrayOffset()) == 0) {
-                for (int i = 0; i < length; ++i) {
+            if ((offset | rhs.offset) == 0 && length == value.length) {
+                for (int i = 0; i < value.length; ++i) {
                     if (!equalsIgnoreCase(value[i], rhsValue[i])) {
                         return false;
                     }

--- a/common/src/main/java/io/netty/util/AsciiString.java
+++ b/common/src/main/java/io/netty/util/AsciiString.java
@@ -533,10 +533,12 @@ public final class AsciiString implements CharSequence, Comparable<CharSequence>
             return false;
         }
 
+        byte[] value = this.value;
         if (string instanceof AsciiString) {
             AsciiString rhs = (AsciiString) string;
+            byte[] rhsValue = rhs.value;
             for (int i = arrayOffset(), j = rhs.arrayOffset(), end = i + length(); i < end; ++i, ++j) {
-                if (!equalsIgnoreCase(value[i], rhs.value[j])) {
+                if (!equalsIgnoreCase(value[i], rhsValue[j])) {
                     return false;
                 }
             }

--- a/common/src/main/java/io/netty/util/AsciiString.java
+++ b/common/src/main/java/io/netty/util/AsciiString.java
@@ -537,16 +537,28 @@ public final class AsciiString implements CharSequence, Comparable<CharSequence>
         if (string instanceof AsciiString) {
             AsciiString rhs = (AsciiString) string;
             byte[] rhsValue = rhs.value;
-            for (int i = arrayOffset(), j = rhs.arrayOffset(), end = i + length(); i < end; ++i, ++j) {
-                if (!equalsIgnoreCase(value[i], rhsValue[j])) {
-                    return false;
+            if ((arrayOffset() | rhs.arrayOffset()) == 0) {
+                for (int i = 0; i < length; ++i) {
+                    if (!equalsIgnoreCase(value[i], rhsValue[i])) {
+                        return false;
+                    }
                 }
+                return true;
             }
-            return true;
+            return misalignedEqualsIgnoreCase(rhs, value, rhsValue);
         }
 
         for (int i = arrayOffset(), j = 0, end = length(); j < end; ++i, ++j) {
             if (!equalsIgnoreCase(b2c(value[i]), string.charAt(j))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean misalignedEqualsIgnoreCase(AsciiString rhs, byte[] value, byte[] rhsValue) {
+        for (int i = arrayOffset(), j = rhs.arrayOffset(), end = i + length(); i < end; ++i, ++j) {
+            if (!equalsIgnoreCase(value[i], rhsValue[j])) {
                 return false;
             }
         }

--- a/common/src/main/java/io/netty/util/AsciiString.java
+++ b/common/src/main/java/io/netty/util/AsciiString.java
@@ -533,22 +533,23 @@ public final class AsciiString implements CharSequence, Comparable<CharSequence>
             return false;
         }
 
-        byte[] value = this.value;
         if (string instanceof AsciiString) {
-            AsciiString rhs = (AsciiString) string;
-            byte[] rhsValue = rhs.value;
-            if ((offset | rhs.offset) == 0 && length == value.length) {
+            AsciiString other = (AsciiString) string;
+            byte[] value = this.value;
+            if (offset == 0 && other.offset == 0 && length == value.length) {
+                byte[] otherValue = other.value;
                 for (int i = 0; i < value.length; ++i) {
-                    if (!equalsIgnoreCase(value[i], rhsValue[i])) {
+                    if (!equalsIgnoreCase(value[i], otherValue[i])) {
                         return false;
                     }
                 }
                 return true;
             }
-            return misalignedEqualsIgnoreCase(rhs, value, rhsValue);
+            return misalignedEqualsIgnoreCase(other);
         }
 
-        for (int i = arrayOffset(), j = 0, end = length(); j < end; ++i, ++j) {
+        byte[] value = this.value;
+        for (int i = offset, j = 0; j < string.length(); ++i, ++j) {
             if (!equalsIgnoreCase(b2c(value[i]), string.charAt(j))) {
                 return false;
             }
@@ -556,9 +557,11 @@ public final class AsciiString implements CharSequence, Comparable<CharSequence>
         return true;
     }
 
-    private boolean misalignedEqualsIgnoreCase(AsciiString rhs, byte[] value, byte[] rhsValue) {
-        for (int i = arrayOffset(), j = rhs.arrayOffset(), end = i + length(); i < end; ++i, ++j) {
-            if (!equalsIgnoreCase(value[i], rhsValue[j])) {
+    private boolean misalignedEqualsIgnoreCase(AsciiString other) {
+        byte[] value = this.value;
+        byte[] otherValue = other.value;
+        for (int i = offset, j = other.offset, end = offset + length; i < end; ++i, ++j) {
+            if (!equalsIgnoreCase(value[i], otherValue[j])) {
                 return false;
             }
         }

--- a/microbench/src/main/java/io/netty/microbenchmark/common/AsciiStringBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbenchmark/common/AsciiStringBenchmark.java
@@ -29,9 +29,12 @@ import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.Random;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
 @Threads(1)
-@Measurement(iterations = 5)
-@Warmup(iterations = 5)
+@Measurement(iterations = 5, time = 200, timeUnit = MILLISECONDS)
+@Warmup(iterations = 5, time = 200, timeUnit = MILLISECONDS)
+
 public class AsciiStringBenchmark extends AbstractMicrobenchmark {
 
     @Param({ "3", "5", "7", "8", "10", "20", "50", "100", "1000" })
@@ -40,6 +43,8 @@ public class AsciiStringBenchmark extends AbstractMicrobenchmark {
     private AsciiString asciiString;
     private String string;
     private static final Random random = new Random();
+    private AsciiString connection;
+    private AsciiString Connection;
 
     @Setup(Level.Trial)
     public void setup() {
@@ -47,6 +52,13 @@ public class AsciiStringBenchmark extends AbstractMicrobenchmark {
         random.nextBytes(bytes);
         asciiString = new AsciiString(bytes, false);
         string = new String(bytes, CharsetUtil.US_ASCII);
+        connection = AsciiString.cached("connection");
+        Connection = AsciiString.cached("Connection");
+    }
+
+    @Benchmark
+    public boolean equalsIgnoreCaseBench() {
+        return Connection.contentEqualsIgnoreCase(connection);
     }
 
     @Benchmark


### PR DESCRIPTION
Motivation:

Http headers decoding cache known header names (eg Connection) with first letter upper-case, while users would lookup the same, while using the HttpHeaderNames's form, which is fully lower-case, causing frequent AsciiString::contentEqualsIgnoreCase calls

Modification:

Speedup containEqualsIgnoreCase by caching the compared AsciiString underlying's byte[] as local variable, to save bound-checks during the comparison

Result:

Faster HTTP 1.1 header names lookups on the decoded HTTP requests