### PR TITLE
DNS: DnsNameResolverTest sometimes failed when it was not able to bin…

### DIFF
--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -3212,13 +3212,6 @@ public class DnsNameResolverTest {
 
     private static void testTruncated0(boolean tcpFallback, final boolean truncatedBecauseOfMtu) throws IOException {
         ServerSocket serverSocket = null;
-        if (tcpFallback) {
-            // If we are configured to use TCP as a fallback also bind a TCP socket
-            serverSocket = new ServerSocket();
-            serverSocket.setReuseAddress(true);
-            serverSocket.bind(new InetSocketAddress(NetUtil.LOCALHOST4, 0));
-        }
-
         final String host = "somehost.netty.io";
         final String txt = "this is a txt record";
         final AtomicReference<DnsMessage> messageRef = new AtomicReference<DnsMessage>();
@@ -3262,8 +3255,8 @@ public class DnsNameResolverTest {
             };
             builder.channelFactory(channelFactory);
             if (tcpFallback) {
-                dnsServer2.start(null, (InetSocketAddress) serverSocket.getLocalSocketAddress());
-
+                // If we are configured to use TCP as a fallback also bind a TCP socket
+                serverSocket = startDnsServerAndCreateServerSocket(dnsServer2);
                 // If we are configured to use TCP as a fallback also bind a TCP socket
                 builder.socketChannelType(NioSocketChannel.class);
             } else {
@@ -3366,11 +3359,28 @@ public class DnsNameResolverTest {
         testTcpFallbackWhenTimeout(false);
     }
 
-    private void testTcpFallbackWhenTimeout(boolean tcpSuccess) throws IOException {
-        ServerSocket serverSocket = new ServerSocket();
-        serverSocket.setReuseAddress(true);
-        serverSocket.bind(new InetSocketAddress(NetUtil.LOCALHOST4, 0));
+    private static ServerSocket startDnsServerAndCreateServerSocket(TestDnsServer dns) throws IOException {
+        for (int i = 0;; i++) {
+            ServerSocket serverSocket = new ServerSocket();
+            serverSocket.setReuseAddress(true);
+            serverSocket.bind(new InetSocketAddress(NetUtil.LOCALHOST4, 0));
+            try {
+                dns.start(null, (InetSocketAddress) serverSocket.getLocalSocketAddress());
+                return serverSocket;
+            } catch (IOException e) {
+                serverSocket.close();
+                if (i == 10) {
+                    // We tried 10 times without success
+                    throw new IllegalStateException(
+                            "Unable to bind TestDnsServer and ServerSocket to the same address", e);
+                }
+                // We could not start the DnsServer which is most likely because the localAddress was already used,
+                // let's retry
+            }
+        }
+    }
 
+    private void testTcpFallbackWhenTimeout(boolean tcpSuccess) throws IOException {
         final String host = "somehost.netty.io";
         final String txt = "this is a txt record";
         final AtomicReference<DnsMessage> messageRef = new AtomicReference<DnsMessage>();
@@ -3396,6 +3406,7 @@ public class DnsNameResolverTest {
             }
         };
         DnsNameResolver resolver = null;
+        ServerSocket serverSocket = null;
         try {
             DnsNameResolverBuilder builder = newResolver();
             final DatagramChannel datagramChannel = new NioDatagramChannel();
@@ -3406,7 +3417,7 @@ public class DnsNameResolverTest {
                 }
             };
             builder.channelFactory(channelFactory);
-            dnsServer2.start(null, (InetSocketAddress) serverSocket.getLocalSocketAddress());
+            serverSocket = startDnsServerAndCreateServerSocket(dnsServer2);
             // If we are configured to use TCP as a fallback also bind a TCP socket
             builder.socketChannelType(NioSocketChannel.class, true);
 


### PR DESCRIPTION
…d to the same address via TCP and UDP.

Motivation:

For some of our tests we need to bind to the same address with TCP and UDP at the same time. This can fail when the port is already in use, in this case we should retry. This was observed while building another PR:

```
java.net.BindException: Address already in use: bind
	at java.base/sun.nio.ch.Net.bind0(Native Method)
	at java.base/sun.nio.ch.Net.bind(Net.java:459)
	at java.base/sun.nio.ch.DatagramChannelImpl.bindInternal(DatagramChannelImpl.java:817)
	at java.base/sun.nio.ch.DatagramChannelImpl.bind(DatagramChannelImpl.java:788)
	at java.base/sun.nio.ch.DatagramSocketAdaptor.bind(DatagramSocketAdaptor.java:103)
	at org.apache.mina.transport.socket.nio.NioDatagramAcceptor.open(NioDatagramAcceptor.java:108)
	at org.apache.mina.transport.socket.nio.NioDatagramAcceptor.open(NioDatagramAcceptor.java:46)
	at org.apache.mina.core.polling.AbstractPollingConnectionlessIoAcceptor.registerHandles(AbstractPollingConnectionlessIoAcceptor.java:529)
	at org.apache.mina.core.polling.AbstractPollingConnectionlessIoAcceptor.access$500(AbstractPollingConnectionlessIoAcceptor.java:56)
	at org.apache.mina.core.polling.AbstractPollingConnectionlessIoAcceptor$Acceptor.run(AbstractPollingConnectionlessIoAcceptor.java:357)
	at org.apache.mina.util.NamePreservingRunnable.run(NamePreservingRunnable.java:64)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

Modifications:

Add helper method that retries binding to the same address multiple times before giving up.

Result:

More robust testsuite.
