### PR TITLE
SSL: Only try to use TLSv1.3 if a compatible ciphersuite is configured

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
@@ -141,8 +141,8 @@ public final class OpenSsl {
         }
 
         UNAVAILABILITY_CAUSE = cause;
-        CLIENT_DEFAULT_PROTOCOLS = protocols("jdk.tls.client.protocols");
-        SERVER_DEFAULT_PROTOCOLS = protocols("jdk.tls.server.protocols");
+        CLIENT_DEFAULT_PROTOCOLS = defaultProtocols("jdk.tls.client.protocols");
+        SERVER_DEFAULT_PROTOCOLS = defaultProtocols("jdk.tls.server.protocols");
 
         if (cause == null) {
             logger.debug("netty-tcnative using native library: {}", SSL.versionString());
@@ -714,24 +714,24 @@ public final class OpenSsl {
         return false;
     }
 
-    private static Set<String> protocols(String property) {
+    private static Set<String> defaultProtocols(String property) {
         String protocolsString = SystemPropertyUtil.get(property, null);
+        Set<String> protocols = new HashSet<String>();
         if (protocolsString != null) {
-            Set<String> protocols = new HashSet<String>();
             for (String proto : protocolsString.split(",")) {
                 String p = proto.trim();
                 protocols.add(p);
             }
-            return protocols;
+        } else {
+            protocols.add(SslProtocols.TLS_v1_2);
+            protocols.add(SslProtocols.TLS_v1_3);
         }
-        return null;
+        return protocols;
     }
 
     static String[] defaultProtocols(boolean isClient) {
         final Collection<String> defaultProtocols = isClient ? CLIENT_DEFAULT_PROTOCOLS : SERVER_DEFAULT_PROTOCOLS;
-        if (defaultProtocols == null) {
-            return null;
-        }
+        assert defaultProtocols != null;
         List<String> protocols = new ArrayList<String>(defaultProtocols.size());
         for (String proto : defaultProtocols) {
             if (SUPPORTED_PROTOCOLS_SET.contains(proto)) {

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -153,6 +153,8 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
     final Certificate[] keyCertChain;
     final ClientAuth clientAuth;
     final String[] protocols;
+    final boolean hasTLSv13Cipher;
+
     final boolean enableOcsp;
     final OpenSslEngineMap engineMap = new DefaultOpenSslEngineMap();
     final ReadWriteLock ctxLock = new ReentrantReadWriteLock();
@@ -350,14 +352,14 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
                         | SSL.SSL_OP_NO_TLSv1_1 | SSL.SSL_OP_NO_TLSv1_2;
             }
 
-            if (!tlsv13Supported || !anyTlsv13Ciphers) {
+            if (!tlsv13Supported) {
                 // Explicit disable TLSv1.3
                 // See:
                 //  - https://github.com/netty/netty/issues/12968
-                //  - https://github.com/netty/netty/issues/13810
                 options |= SSL.SSL_OP_NO_TLSv1_3;
             }
 
+            hasTLSv13Cipher = anyTlsv13Ciphers;
             SSLContext.setOptions(ctx, options);
 
             // We need to enable SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER as the memory address may change between

--- a/handler/src/test/java/io/netty/handler/ssl/ConscryptJdkSslEngineInteropTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ConscryptJdkSslEngineInteropTest.java
@@ -18,6 +18,7 @@ package io.netty.handler.ssl;
 import java.security.Provider;
 
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -86,5 +87,12 @@ public class ConscryptJdkSslEngineInteropTest extends SSLEngineTest {
     @Override
     public void testInvalidSNIIsIgnoredAndNotThrow(SSLEngineTestParam param) throws Exception {
         super.testInvalidSNIIsIgnoredAndNotThrow(param);
+    }
+
+    @Test
+    @Disabled("Disabled due a conscrypt bug")
+    @Override
+    public void testTLSv13DisabledIfNoValidCipherSuiteConfigured() throws Exception {
+        super.testTLSv13DisabledIfNoValidCipherSuiteConfigured();
     }
 }

--- a/handler/src/test/java/io/netty/handler/ssl/ConscryptOpenSslEngineInteropTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ConscryptOpenSslEngineInteropTest.java
@@ -17,6 +17,7 @@ package io.netty.handler.ssl;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -197,6 +198,13 @@ public class ConscryptOpenSslEngineInteropTest extends ConscryptSslEngineTest {
     @Override
     public void testInvalidSNIIsIgnoredAndNotThrow(SSLEngineTestParam param) throws Exception {
         super.testInvalidSNIIsIgnoredAndNotThrow(param);
+    }
+
+    @Test
+    @Disabled("Disabled due a conscrypt bug")
+    @Override
+    public void testTLSv13DisabledIfNoValidCipherSuiteConfigured() throws Exception {
+        super.testTLSv13DisabledIfNoValidCipherSuiteConfigured();
     }
 
     @Override

--- a/handler/src/test/java/io/netty/handler/ssl/ConscryptSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ConscryptSslEngineTest.java
@@ -17,6 +17,7 @@ package io.netty.handler.ssl;
 
 
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -95,5 +96,12 @@ public class ConscryptSslEngineTest extends SSLEngineTest {
     @Override
     public void testInvalidSNIIsIgnoredAndNotThrow(SSLEngineTestParam param) throws Exception {
         super.testInvalidSNIIsIgnoredAndNotThrow(param);
+    }
+
+    @Test
+    @Disabled("Disabled due a conscrypt bug")
+    @Override
+    public void testTLSv13DisabledIfNoValidCipherSuiteConfigured() throws Exception {
+        super.testTLSv13DisabledIfNoValidCipherSuiteConfigured();
     }
 }

--- a/handler/src/test/java/io/netty/handler/ssl/JdkConscryptSslEngineInteropTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/JdkConscryptSslEngineInteropTest.java
@@ -18,6 +18,7 @@ package io.netty.handler.ssl;
 import java.security.Provider;
 
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -101,5 +102,12 @@ public class JdkConscryptSslEngineInteropTest extends SSLEngineTest {
     @Override
     public void testRSASSAPSS(SSLEngineTestParam param) {
         // skip
+    }
+
+    @Test
+    @Disabled("Disabled due a conscrypt bug")
+    @Override
+    public void testTLSv13DisabledIfNoValidCipherSuiteConfigured() throws Exception {
+        super.testTLSv13DisabledIfNoValidCipherSuiteConfigured();
     }
 }

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslConscryptSslEngineInteropTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslConscryptSslEngineInteropTest.java
@@ -17,6 +17,7 @@ package io.netty.handler.ssl;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -169,6 +170,13 @@ public class OpenSslConscryptSslEngineInteropTest extends ConscryptSslEngineTest
     @Override
     protected void invalidateSessionsAndAssert(SSLSessionContext context) {
         // Not supported by conscrypt
+    }
+
+    @Test
+    @Disabled("Disabled due a conscrypt bug")
+    @Override
+    public void testTLSv13DisabledIfNoValidCipherSuiteConfigured() throws Exception {
+        super.testTLSv13DisabledIfNoValidCipherSuiteConfigured();
     }
 
     @Override


### PR DESCRIPTION
Motivation:

We should not try to use TLSv1.3 if only TLSv1.2 ciphers are configured

Modifications:

- Don't use TLSv1.3 if the ciphers that are configured are not for TLSv1.3
- Add unit tests

Result:

Fixes https://github.com/netty/netty/issues/13810
