### PR TITLE
SSL: Add missing fail() so the test only pass if the handshake throws

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -4442,6 +4442,7 @@ public abstract class SSLEngineTest {
             serverEngine = wrapEngine(serverSslCtx.newEngine(UnpooledByteBufAllocator.DEFAULT));
 
             handshake(param.type(), param.delegate(), clientEngine, serverEngine);
+            fail();
         } catch (SSLHandshakeException expected) {
             // Expected
         } finally {


### PR DESCRIPTION
Motivation:

We should add a fail() to ensure the handshake really throws an exception as at the moment the test would also pass if it doesnt.

Modifications:

Add missing fail()

Result:

Fix test