### PR TITLE
Upgrade zstd-jni version and use zstd constants

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/ZstdConstants.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/ZstdConstants.java
@@ -15,17 +15,24 @@
  */
 package io.netty.handler.codec.compression;
 
+import com.github.luben.zstd.Zstd;
+
 final class ZstdConstants {
 
     /**
      * Default compression level
      */
-    static final int DEFAULT_COMPRESSION_LEVEL = 3;
+    static final int DEFAULT_COMPRESSION_LEVEL = Zstd.defaultCompressionLevel();
+
+    /**
+     * Min compression level
+     */
+    static final int MIN_COMPRESSION_LEVEL = Zstd.minCompressionLevel();
 
     /**
      * Max compression level
      */
-    static final int MAX_COMPRESSION_LEVEL = 22;
+    static final int MAX_COMPRESSION_LEVEL = Zstd.maxCompressionLevel();
 
     /**
      * Max block size

--- a/codec/src/main/java/io/netty/handler/codec/compression/ZstdEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/ZstdEncoder.java
@@ -25,9 +25,10 @@ import io.netty.util.internal.ObjectUtil;
 import java.nio.ByteBuffer;
 
 import static io.netty.handler.codec.compression.ZstdConstants.DEFAULT_COMPRESSION_LEVEL;
+import static io.netty.handler.codec.compression.ZstdConstants.MIN_COMPRESSION_LEVEL;
+import static io.netty.handler.codec.compression.ZstdConstants.MAX_COMPRESSION_LEVEL;
 import static io.netty.handler.codec.compression.ZstdConstants.DEFAULT_BLOCK_SIZE;
 import static io.netty.handler.codec.compression.ZstdConstants.MAX_BLOCK_SIZE;
-import static io.netty.handler.codec.compression.ZstdConstants.MAX_COMPRESSION_LEVEL;
 
 /**
  *  Compresses a {@link ByteBuf} using the Zstandard algorithm.
@@ -81,7 +82,8 @@ public final class ZstdEncoder extends MessageToByteEncoder<ByteBuf> {
      */
     public ZstdEncoder(int compressionLevel, int blockSize, int maxEncodeSize) {
         super(true);
-        this.compressionLevel = ObjectUtil.checkInRange(compressionLevel, 0, MAX_COMPRESSION_LEVEL, "compressionLevel");
+        this.compressionLevel = ObjectUtil.checkInRange(compressionLevel,
+                MIN_COMPRESSION_LEVEL, MAX_COMPRESSION_LEVEL, "compressionLevel");
         this.blockSize = ObjectUtil.checkPositive(blockSize, "blockSize");
         this.maxEncodeSize = ObjectUtil.checkPositive(maxEncodeSize, "maxEncodeSize");
     }

--- a/codec/src/main/java/io/netty/handler/codec/compression/ZstdOptions.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/ZstdOptions.java
@@ -18,6 +18,7 @@ package io.netty.handler.codec.compression;
 import io.netty.util.internal.ObjectUtil;
 
 import static io.netty.handler.codec.compression.ZstdConstants.DEFAULT_COMPRESSION_LEVEL;
+import static io.netty.handler.codec.compression.ZstdConstants.MIN_COMPRESSION_LEVEL;
 import static io.netty.handler.codec.compression.ZstdConstants.MAX_COMPRESSION_LEVEL;
 import static io.netty.handler.codec.compression.ZstdConstants.DEFAULT_BLOCK_SIZE;
 import static io.netty.handler.codec.compression.ZstdConstants.MAX_BLOCK_SIZE;
@@ -54,7 +55,8 @@ public class ZstdOptions implements CompressionOptions {
             throw new IllegalStateException("zstd-jni is not available", Zstd.cause());
         }
 
-        this.compressionLevel = ObjectUtil.checkInRange(compressionLevel, 0, MAX_COMPRESSION_LEVEL, "compressionLevel");
+        this.compressionLevel = ObjectUtil.checkInRange(compressionLevel,
+                MIN_COMPRESSION_LEVEL, MAX_COMPRESSION_LEVEL, "compressionLevel");
         this.blockSize = ObjectUtil.checkPositive(blockSize, "blockSize");
         this.maxEncodeSize = ObjectUtil.checkPositive(maxEncodeSize, "maxEncodeSize");
     }

--- a/pom.xml
+++ b/pom.xml
@@ -880,7 +880,7 @@
       <dependency>
         <groupId>com.github.luben</groupId>
         <artifactId>zstd-jni</artifactId>
-        <version>1.5.0-2</version>
+        <version>1.5.5-11</version>
         <optional>true</optional>
       </dependency>
       <dependency>


### PR DESCRIPTION
Motivation: 
Upgrade zstd-jni version and use `Zstd` constants

Modification:
Upgrade zstd-jni version to 1.5.5-11 and use `Zstd` constants for `ZstdEncoder`

Result:
More efficient code