### PR TITLE
DnsNameResolver query server address stream feature

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
@@ -67,6 +67,7 @@ public final class DnsNameResolverBuilder {
     private HostsFileEntriesResolver hostsFileEntriesResolver = HostsFileEntriesResolver.DEFAULT;
     private DnsServerAddressStreamProvider dnsServerAddressStreamProvider =
             DnsServerAddressStreamProviders.platformDefault();
+    private DnsServerAddressStream queryDnsServerAddressStream;
     private DnsQueryLifecycleObserverFactory dnsQueryLifecycleObserverFactory =
             NoopDnsQueryLifecycleObserverFactory.INSTANCE;
     private String[] searchDomains;
@@ -458,6 +459,20 @@ public final class DnsNameResolverBuilder {
         return this;
     }
 
+    protected DnsServerAddressStream queryServerAddressStream() {
+        return this.queryDnsServerAddressStream;
+    }
+
+    /**
+     * Set the {@link DnsServerAddressStream} which provides the server address for DNS queries.
+     * @return {@code this}.
+     */
+    public DnsNameResolverBuilder queryServerAddressStream(DnsServerAddressStream queryServerAddressStream) {
+        this.queryDnsServerAddressStream =
+                checkNotNull(queryServerAddressStream, "queryServerAddressStream");
+        return this;
+    }
+
     /**
      * Set the list of search domains of the resolver.
      *
@@ -508,6 +523,11 @@ public final class DnsNameResolverBuilder {
                 // Let us use the sane ordering as DnsNameResolver will be used when returning
                 // nameservers from the cache.
                 new NameServerComparator(DnsNameResolver.preferredAddressType(resolvedAddressTypes).addressType()));
+    }
+
+    private DnsServerAddressStream newQueryServerAddressStream(
+            DnsServerAddressStreamProvider dnsServerAddressStreamProvider) {
+        return new ThreadLocalNameServerAddressStream(dnsServerAddressStreamProvider);
     }
 
     private DnsCnameCache newCnameCache() {
@@ -567,6 +587,10 @@ public final class DnsNameResolverBuilder {
         DnsCnameCache cnameCache = this.cnameCache != null ? this.cnameCache : newCnameCache();
         AuthoritativeDnsServerCache authoritativeDnsServerCache = this.authoritativeDnsServerCache != null ?
                 this.authoritativeDnsServerCache : newAuthoritativeDnsServerCache();
+
+        DnsServerAddressStream queryDnsServerAddressStream = this.queryDnsServerAddressStream != null ?
+                this.queryDnsServerAddressStream : newQueryServerAddressStream(dnsServerAddressStreamProvider);
+
         return new DnsNameResolver(
                 eventLoop,
                 channelFactory,
@@ -586,6 +610,7 @@ public final class DnsNameResolverBuilder {
                 optResourceEnabled,
                 hostsFileEntriesResolver,
                 dnsServerAddressStreamProvider,
+                queryDnsServerAddressStream,
                 searchDomains,
                 ndots,
                 decodeIdn,
@@ -645,6 +670,10 @@ public final class DnsNameResolverBuilder {
 
         if (dnsServerAddressStreamProvider != null) {
             copiedBuilder.nameServerProvider(dnsServerAddressStreamProvider);
+        }
+
+        if (queryDnsServerAddressStream != null) {
+            copiedBuilder.queryServerAddressStream(queryDnsServerAddressStream);
         }
 
         if (searchDomains != null) {

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/ThreadLocalNameServerAddressStream.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/ThreadLocalNameServerAddressStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 The Netty Project
+ * Copyright 2024 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -22,7 +22,7 @@ import java.net.InetSocketAddress;
 /**
  * A thread local based address stream for a specific hostname.
  */
-class ThreadLocalNameServerAddressStream implements DnsServerAddressStream {
+final class ThreadLocalNameServerAddressStream implements DnsServerAddressStream {
 
     private final String hostname;
     private final DnsServerAddressStreamProvider dnsServerAddressStreamProvider;

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/ThreadLocalNameServerAddressStream.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/ThreadLocalNameServerAddressStream.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import io.netty.util.concurrent.FastThreadLocal;
+
+import java.net.InetSocketAddress;
+
+/**
+ * A thread local based address stream for a specific hostname.
+ */
+class ThreadLocalNameServerAddressStream implements DnsServerAddressStream {
+
+    private final String hostname;
+    private final DnsServerAddressStreamProvider dnsServerAddressStreamProvider;
+    private final FastThreadLocal<DnsServerAddressStream> threadLocal = new FastThreadLocal<DnsServerAddressStream>() {
+        @Override
+        protected DnsServerAddressStream initialValue() {
+            return dnsServerAddressStreamProvider.nameServerAddressStream(hostname);
+        }
+    };
+
+    ThreadLocalNameServerAddressStream(DnsServerAddressStreamProvider dnsServerAddressStreamProvider) {
+        this(dnsServerAddressStreamProvider, "");
+    }
+
+    ThreadLocalNameServerAddressStream(DnsServerAddressStreamProvider dnsServerAddressStreamProvider, String hostname) {
+        this.dnsServerAddressStreamProvider = dnsServerAddressStreamProvider;
+        this.hostname = hostname;
+    }
+
+    @Override
+    public InetSocketAddress next() {
+        return threadLocal.get().next();
+    }
+
+    @Override
+    public DnsServerAddressStream duplicate() {
+        return new ThreadLocalNameServerAddressStream(dnsServerAddressStreamProvider, hostname);
+    }
+
+    @Override
+    public int size() {
+        return threadLocal.get().size();
+    }
+}

--- a/resolver-dns/src/main/resources/META-INF/native-image/io.netty/netty-resolver-dns/generated/handlers/reflect-config.json
+++ b/resolver-dns/src/main/resources/META-INF/native-image/io.netty/netty-resolver-dns/generated/handlers/reflect-config.json
@@ -14,9 +14,9 @@
     "queryAllPublicMethods": true
   },
   {
-    "name": "io.netty.resolver.dns.DnsNameResolver$4",
+    "name": "io.netty.resolver.dns.DnsNameResolver$3",
     "condition": {
-      "typeReachable": "io.netty.resolver.dns.DnsNameResolver$4"
+      "typeReachable": "io.netty.resolver.dns.DnsNameResolver$3"
     },
     "queryAllPublicMethods": true
   },

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverBuilderTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverBuilderTest.java
@@ -65,8 +65,7 @@ class DnsNameResolverBuilderTest {
 
         checkDefaultAuthoritativeDnsServerCache(
                 (DefaultAuthoritativeDnsServerCache) resolver.authoritativeDnsServerCache(), MAX_SUPPORTED_TTL_SECS, 0);
-
-        assertThat(resolver.queryDnsServerAddressStream()).isInstanceOf(ThreadLocalNameServerAddressStream.class);
+assertThat(resolver.queryDnsServerAddressStream()).isInstanceOf(ThreadLocalNameServerAddressStream.class);
     }
 
     @Test
@@ -258,7 +257,7 @@ class DnsNameResolverBuilderTest {
         assertThat(resolver.queryDnsServerAddressStream()).isSameAs(queryAddressStream);
     }
 
-    private static class TestQueryServerAddressStream implements DnsServerAddressStream {
+    private static final class TestQueryServerAddressStream implements DnsServerAddressStream {
 
         @Override
         public InetSocketAddress next() {

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverBuilderTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverBuilderTest.java
@@ -65,6 +65,8 @@ class DnsNameResolverBuilderTest {
 
         checkDefaultAuthoritativeDnsServerCache(
                 (DefaultAuthoritativeDnsServerCache) resolver.authoritativeDnsServerCache(), MAX_SUPPORTED_TTL_SECS, 0);
+
+        assertThat(resolver.queryDnsServerAddressStream()).isInstanceOf(ThreadLocalNameServerAddressStream.class);
     }
 
     @Test
@@ -242,6 +244,35 @@ class DnsNameResolverBuilderTest {
         @Override
         public boolean clear(String hostname) {
             return false;
+        }
+    }
+
+    @Test
+    void testCustomQueryDnsServerAddressStream() {
+        DnsServerAddressStream queryAddressStream = new TestQueryServerAddressStream();
+        resolver = builder.queryServerAddressStream(queryAddressStream).build();
+
+        assertThat(resolver.queryDnsServerAddressStream()).isSameAs(queryAddressStream);
+
+        resolver = builder.copy().build();
+        assertThat(resolver.queryDnsServerAddressStream()).isSameAs(queryAddressStream);
+    }
+
+    private static class TestQueryServerAddressStream implements DnsServerAddressStream {
+
+        @Override
+        public InetSocketAddress next() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int size() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public DnsServerAddressStream duplicate() {
+            throw new UnsupportedOperationException();
         }
     }
 }


### PR DESCRIPTION
Motivation: The DnsNameResolver does instantiate an instance FastThreadLocal for each instance of the resolver that is created. This can have an impact on the InternalThreadLocalMap static index an the size of allocated arrays for FastThreadLocal. In addition this FastThreadLocal is only used by the DnsNameResolver query methods and not the resolve methods. Common usage of the DnsNameResolver by Netty (i.e. by a Bootstrap) only uses resolves and queries are not performed.

Modification: This encapsulate the usage of the FastThreadLocal/dnsServerAddressStreamProvider in a specific implementation of DnsServerAddressStream that is instantiated by the DnsNameResolverBuilder by default to keep the current behavior. The builder now does provide a QueryServerAddressStream  property that can be set prior calling build in order to provide a specific implementation of the stream for use case that do not whish to sustain the cost of instantiating a non static FastThreadLocal.

Result: DnsNameResolver that do not use FastThreadLocal can now be created.

This provides a possible solution for #9884
