### PR TITLE
SSL: Add some jitter when execute SSL tasks to ensure correct handlin…

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/DelayingExecutor.java
+++ b/handler/src/test/java/io/netty/handler/ssl/DelayingExecutor.java
@@ -24,14 +24,15 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
 final class DelayingExecutor implements Executor {
+    private static final int CORE_POOL_SIZE = 10;
     private final ScheduledExecutorService service;
 
     DelayingExecutor() {
-        this.service = Executors.newScheduledThreadPool(10);
+        this.service = Executors.newScheduledThreadPool(CORE_POOL_SIZE);
     }
 
     DelayingExecutor(ThreadFactory threadFactory) {
-        this.service = Executors.newScheduledThreadPool(10, threadFactory);
+        this.service = Executors.newScheduledThreadPool(CORE_POOL_SIZE, threadFactory);
     }
 
     @Override

--- a/handler/src/test/java/io/netty/handler/ssl/DelayingExecutor.java
+++ b/handler/src/test/java/io/netty/handler/ssl/DelayingExecutor.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import io.netty.util.internal.PlatformDependent;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+final class DelayingExecutor implements Executor {
+    private final ScheduledExecutorService service;
+
+    DelayingExecutor() {
+        this.service = Executors.newScheduledThreadPool(10);
+    }
+
+    DelayingExecutor(ThreadFactory threadFactory) {
+        this.service = Executors.newScheduledThreadPool(10, threadFactory);
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        // Let's add some jitter in terms of when the task is actual run
+        service.schedule(command,
+                PlatformDependent.threadLocalRandom().nextInt(100), TimeUnit.MILLISECONDS);
+    }
+
+    void shutdown() {
+        service.shutdown();
+    }
+}

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslPrivateKeyMethodTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslPrivateKeyMethodTest.java
@@ -76,7 +76,7 @@ public class OpenSslPrivateKeyMethodTest {
     private static final String RFC_CIPHER_NAME = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256";
     private static EventLoopGroup GROUP;
     private static SelfSignedCertificate CERT;
-    private static ExecutorService EXECUTOR;
+    private static DelayingExecutor EXECUTOR;
 
     static Collection<Object[]> parameters() {
         List<Object[]> dst = new ArrayList<Object[]>();
@@ -102,7 +102,7 @@ public class OpenSslPrivateKeyMethodTest {
 
         GROUP = new DefaultEventLoopGroup();
         CERT = new SelfSignedCertificate();
-        EXECUTOR = Executors.newCachedThreadPool(new ThreadFactory() {
+        EXECUTOR = new DelayingExecutor(new ThreadFactory() {
             @Override
             public Thread newThread(Runnable r) {
                 return new DelegateThread(r);

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -94,8 +94,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import javax.crypto.SecretKey;
@@ -285,7 +283,7 @@ public abstract class SSLEngineTest {
         return params;
     }
 
-    private ExecutorService delegatingExecutor;
+    private DelayingExecutor delegatingExecutor;
 
     protected ByteBuffer allocateBuffer(BufferType type, int len) {
         switch (type) {
@@ -470,7 +468,7 @@ public abstract class SSLEngineTest {
         MockitoAnnotations.initMocks(this);
         serverLatch = new CountDownLatch(1);
         clientLatch = new CountDownLatch(1);
-        delegatingExecutor = Executors.newCachedThreadPool();
+        delegatingExecutor = new DelayingExecutor();
     }
 
     @AfterEach

--- a/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
@@ -80,8 +80,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -1003,7 +1001,7 @@ public class SslHandlerTest {
 
     @Test
     public void testHandshakeWithExecutorJDK() throws Throwable {
-        ExecutorService executorService = Executors.newCachedThreadPool();
+        DelayingExecutor executorService = new DelayingExecutor();
         try {
             testHandshakeWithExecutor(executorService, SslProvider.JDK, false);
         } finally {
@@ -1032,7 +1030,7 @@ public class SslHandlerTest {
     @Test
     public void testHandshakeWithExecutorOpenSsl() throws Throwable {
         OpenSsl.ensureAvailability();
-        ExecutorService executorService = Executors.newCachedThreadPool();
+        DelayingExecutor executorService = new DelayingExecutor();
         try {
             testHandshakeWithExecutor(executorService, SslProvider.OPENSSL, false);
         } finally {
@@ -1057,7 +1055,7 @@ public class SslHandlerTest {
 
     @Test
     public void testHandshakeMTLSWithExecutorJDK() throws Throwable {
-        ExecutorService executorService = Executors.newCachedThreadPool();
+        DelayingExecutor executorService = new DelayingExecutor();
         try {
             testHandshakeWithExecutor(executorService, SslProvider.JDK, true);
         } finally {
@@ -1086,7 +1084,7 @@ public class SslHandlerTest {
     @Test
     public void testHandshakeMTLSWithExecutorOpenSsl() throws Throwable {
         OpenSsl.ensureAvailability();
-        ExecutorService executorService = Executors.newCachedThreadPool();
+        DelayingExecutor executorService = new DelayingExecutor();
         try {
             testHandshakeWithExecutor(executorService, SslProvider.OPENSSL, true);
         } finally {


### PR DESCRIPTION
…g and implementation

Motivation:

To ensure our SslHandler does correctly handle offloading and resuming of SSL tasks we should add some delay while executing tasks during tests.

Modifications:

Adjust tests to add some jitter.

Result:

Better testing
