### PR TITLE
SSL: Execute SSL_do_handshake(...) after task is run to ensure SSLEng…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -1531,6 +1531,14 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                     return;
                 }
                 task.run();
+                if (handshakeState != HandshakeState.FINISHED && !isDestroyed()) {
+                    // Call SSL.doHandshake(...) If the handshake was not finished yet. This might be needed
+                    // to fill the application buffer and so have getHandshakeStatus() return the right value
+                    // in this case.
+                    if (SSL.doHandshake(ssl) <= 0) {
+                        SSL.clearError();
+                    }
+                }
             } finally {
                 // The task was run, reset needTask to false so getHandshakeStatus() returns the correct value.
                 needTask = false;

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -1536,7 +1536,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                     // to fill the application buffer and so have getHandshakeStatus() return the right value
                     // in this case.
                     if (SSL.doHandshake(ssl) <= 0) {
-                        SSL.clearError();x
+                        SSL.clearError();
                     }
                 }
             } finally {

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -1536,7 +1536,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                     // to fill the application buffer and so have getHandshakeStatus() return the right value
                     // in this case.
                     if (SSL.doHandshake(ssl) <= 0) {
-                        SSL.clearError();
+                        SSL.clearError();x
                     }
                 }
             } finally {

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -4610,7 +4610,8 @@ public abstract class SSLEngineTest {
 
                         runDelegatedTasks(param.delegate(), clientResult, clientEngine);
                         assertEquals(sTOc.position() - sTOcPos, clientResult.bytesConsumed());
-                        assertEquals(clientAppReadBuffer.position() - clientAppReadBufferPos, clientResult.bytesProduced());
+                        assertEquals(clientAppReadBuffer.position() - clientAppReadBufferPos,
+                                clientResult.bytesProduced());
                         assertEquals(0, clientAppReadBuffer.position());
 
                         if (assertHandshakeStatus(clientEngine, clientResult)) {
@@ -4633,7 +4634,8 @@ public abstract class SSLEngineTest {
                         serverResult = serverEngine.unwrap(cTOs, serverAppReadBuffer);
                         runDelegatedTasks(param.delegate(), serverResult, serverEngine);
                         assertEquals(cTOs.position() - cTOsPos, serverResult.bytesConsumed());
-                        assertEquals(serverAppReadBuffer.position() - serverAppReadBufferPos, serverResult.bytesProduced());
+                        assertEquals(serverAppReadBuffer.position() - serverAppReadBufferPos,
+                                serverResult.bytesProduced());
                         assertEquals(0, serverAppReadBuffer.position());
 
                         serverHandshakeFinished = assertHandshakeStatus(serverEngine, serverResult);

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -1686,7 +1686,9 @@ public abstract class SSLEngineTest {
                 // After the handshake completes it is possible we have more data that was send by the server as
                 // the server will send session updates after the handshake. In this case continue to unwrap.
                 SslProtocols.TLS_v1_3.equals(clientEngine.getSession().getProtocol())) {
-                if (sTOc.hasRemaining()) {
+                if (sTOc.hasRemaining() ||
+                        // We need to special case conscrypt due a bug.
+                        Conscrypt.isEngineSupported(clientEngine)) {
                     int clientAppReadBufferPos = clientAppReadBuffer.position();
                     clientResult = clientEngine.unwrap(sTOc, clientAppReadBuffer);
 
@@ -1707,7 +1709,9 @@ public abstract class SSLEngineTest {
             }
 
             if (!serverHandshakeFinished) {
-                if (cTOs.hasRemaining()) {
+                if (cTOs.hasRemaining() ||
+                        // We need to special case conscrypt due a bug.
+                        Conscrypt.isEngineSupported(serverEngine)) {
                     int serverAppReadBufferPos = serverAppReadBuffer.position();
                     serverResult = serverEngine.unwrap(cTOs, serverAppReadBuffer);
                     runDelegatedTasks(delegate, serverResult, serverEngine);
@@ -4603,7 +4607,9 @@ public abstract class SSLEngineTest {
                 sTOcPos = sTOc.position();
 
                 if (!clientHandshakeFinished) {
-                    if (sTOc.hasRemaining()) {
+                    if (sTOc.hasRemaining() ||
+                            // We need to special case conscrypt due a bug.
+                            Conscrypt.isEngineSupported(clientEngine)) {
                         int clientAppReadBufferPos = clientAppReadBuffer.position();
                         clientResult = clientEngine.unwrap(sTOc, clientAppReadBuffer);
 
@@ -4628,7 +4634,9 @@ public abstract class SSLEngineTest {
                 }
 
                 if (!serverHandshakeFinished) {
-                    if (cTOs.hasRemaining()) {
+                    if (cTOs.hasRemaining() ||
+                            // We need to special case conscrypt due a bug.
+                            Conscrypt.isEngineSupported(serverEngine)) {
                         int serverAppReadBufferPos = serverAppReadBuffer.position();
                         serverResult = serverEngine.unwrap(cTOs, serverAppReadBuffer);
                         runDelegatedTasks(param.delegate(), serverResult, serverEngine);

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -1697,7 +1697,9 @@ public abstract class SSLEngineTest {
                     assertEquals(clientAppReadBuffer.position() - clientAppReadBufferPos, clientResult.bytesProduced());
                     assertEquals(0, clientAppReadBuffer.position());
 
-                    clientHandshakeFinished = assertHandshakeStatus(clientEngine, clientResult);
+                    if (assertHandshakeStatus(clientEngine, clientResult)) {
+                        clientHandshakeFinished = true;
+                    }
 
                     if (clientResult.getStatus() == Status.BUFFER_OVERFLOW) {
                         clientAppReadBuffer = increaseDstBuffer(

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -1715,7 +1715,6 @@ public abstract class SSLEngineTest {
                     assertEquals(serverAppReadBuffer.position() - serverAppReadBufferPos, serverResult.bytesProduced());
                     assertEquals(0, serverAppReadBuffer.position());
 
-
                     serverHandshakeFinished = assertHandshakeStatus(serverEngine, serverResult);
 
                     if (serverResult.getStatus() == Status.BUFFER_OVERFLOW) {


### PR DESCRIPTION
…ine.getHandshakeStatus() returns the correct value all the time

Motivation:

We should call SSL_do_handshake(...) after we did run the delegating task so SSLEngine.getHandshakeStatus() will be able to see data that we produce as part of finish the handshake and return NEEDS_WRAP.

Modifications:

- Add SSL_do_handshake(...) call

Result:

Correctly reflect HandshakeStatus after running delegating tasks
