### PR TITLE
Add active flag to EpollServerDomainSocketChannel fd constructor

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerDomainSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerDomainSocketChannel.java
@@ -43,6 +43,10 @@ public final class EpollServerDomainSocketChannel extends AbstractEpollServerCha
         super(fd);
     }
 
+    public EpollServerDomainSocketChannel(int fd, boolean active) {
+        super(new LinuxSocket(fd), active);
+    }
+
     EpollServerDomainSocketChannel(LinuxSocket fd) {
         super(fd);
     }


### PR DESCRIPTION
Motivation:

When constructing an EpollServerDomainSocketChannel from a file descriptor, the channel is not initially active. It is only made active on bind. However, if the file descriptor is inherited from systemd socket activation, it is already bound, so we only want to register it. The channel then never becomes active, netty never calls read(), and no sockets are accepted on the channel.

To reproduce, build the following program:

```java
import io.netty.bootstrap.ServerBootstrap;
import io.netty.channel.Channel;
import io.netty.channel.ChannelInitializer;
import io.netty.channel.epoll.EpollEventLoopGroup;
import io.netty.channel.epoll.EpollServerDomainSocketChannel;
import org.jetbrains.annotations.NotNull;

import java.lang.reflect.Field;

public class Main {
    public static void main(String[] args) {
        new ServerBootstrap()
                .childHandler(new ChannelInitializer<>() {
                    @Override
                    protected void initChannel(@NotNull Channel ch) {
                        System.err.println("Socket accepted");
                        ch.close();
                    }
                })
                .group(new EpollEventLoopGroup(1))
                .channelFactory(() -> {
                    EpollServerDomainSocketChannel c = new EpollServerDomainSocketChannel(3);
                    try {
                        Field active = Class.forName("io.netty.channel.epoll.AbstractEpollChannel").getDeclaredField("active");
                        active.setAccessible(true);
                        active.set(c, true);
                    } catch (ReflectiveOperationException e) {
                        throw new RuntimeException(e);
                    }
                    return c;
                })
                .register().syncUninterruptibly().channel();
    }
}
```

Launch it with `systemd-socket-activate -l /tmp/test.sock java -jar build/libs/systemd-activation-0.1-all.jar`, and connect to the exposed port, e.g. `curl --unix-socket /tmp/test.sock -v http://127.0.0.1:8888`. You should see `Socket accepted` logged and the connection closed. If you remove the code that sets the `active` flag, the connection instead just hangs and the socket is never accepted.

For some reason, this bug is *not* present for `EpollServerSocketChannel`. The `EpollServerSocketChannel(int)` constructor actually goes through `AbstractEpollServerChannel(LinuxSocket)`, which actively checks isSoErrorZero to determine whether the socket should be immediately active or not. I'm not sure what this does or if epoll could do the same thing.

Modification:

Add a `EpollServerDomainSocketChannel(int, boolean)` constructor so the user can specify whether the socket is active or not directly. This is the safe option, vs moving to a similar approach as `EpollServerSocketChannel`.

Result:

Users can manually specify the active status depending on whether they want to bind or just register the socket. This allows progress even when the server socket is already bound.
