### PR TITLE
Re-enable testChannelRegistered test

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
@@ -50,7 +50,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public abstract class AbstractSingleThreadEventLoopTest {
-
+    @Test
     @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
     public void testChannelsRegistered() throws Exception {
         EventLoopGroup group = newEventLoopGroup();


### PR DESCRIPTION
I suspect it was accidentally disabled in bc7434aedb6f25b2c3f6679340e4d540c5ca8815.
