### PR TITLE
Epoll: Fix possible Classloader deadlock caused by loading class via JNI

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -320,7 +320,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
             if (socketAddress.getAddress().isAnyLocalAddress() &&
                     socketAddress.getAddress() instanceof Inet4Address) {
                 if (socket.family() == InternetProtocolFamily.IPv6) {
-                    localAddress = new InetSocketAddress(LinuxSocket.INET6_ANY, socketAddress.getPort());
+                    localAddress = new InetSocketAddress(Native.INET6_ANY, socketAddress.getPort());
                 }
             }
         }

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/LinuxSocket.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/LinuxSocket.java
@@ -41,8 +41,6 @@ import static io.netty.channel.unix.Errors.newIOException;
  */
 @UnstableApi
 public final class LinuxSocket extends Socket {
-    static final InetAddress INET6_ANY = unsafeInetAddrByName("::");
-    private static final InetAddress INET_ANY = unsafeInetAddrByName("0.0.0.0");
     private static final long MAX_UINT32_T = 0xFFFFFFFFL;
 
     LinuxSocket(int fd) {
@@ -78,7 +76,7 @@ public final class LinuxSocket extends Socket {
 
     void setNetworkInterface(NetworkInterface netInterface) throws IOException {
         InetAddress address = deriveInetAddress(netInterface, family() == InternetProtocolFamily.IPv6);
-        if (address.equals(family() == InternetProtocolFamily.IPv4 ? INET_ANY : INET6_ANY)) {
+        if (address.equals(family() == InternetProtocolFamily.IPv4 ? Native.INET_ANY : Native.INET6_ANY)) {
             throw new IOException("NetworkInterface does not support " + family());
         }
         final NativeInetAddress nativeAddress = NativeInetAddress.newInstance(address);
@@ -355,7 +353,7 @@ public final class LinuxSocket extends Socket {
     }
 
     private static InetAddress deriveInetAddress(NetworkInterface netInterface, boolean ipv6) {
-        final InetAddress ipAny = ipv6 ? INET6_ANY : INET_ANY;
+        final InetAddress ipAny = ipv6 ? Native.INET6_ANY : Native.INET_ANY;
         if (netInterface != null) {
             final Enumeration<InetAddress> ias = netInterface.getInetAddresses();
             while (ias.hasMoreElements()) {
@@ -415,14 +413,6 @@ public final class LinuxSocket extends Socket {
 
     public static LinuxSocket newSocketDomainDgram() {
         return new LinuxSocket(newSocketDomainDgram0());
-    }
-
-    private static InetAddress unsafeInetAddrByName(String inetName) {
-        try {
-            return InetAddress.getByName(inetName);
-        } catch (UnknownHostException uhe) {
-            throw new ChannelException(uhe);
-        }
     }
 
     private static native int newVSockStreamFd();

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/Native.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/Native.java
@@ -28,6 +28,8 @@ import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.nio.channels.FileChannel;
 import java.nio.channels.Selector;
 
@@ -51,6 +53,8 @@ import static io.netty.channel.unix.Errors.newIOException;
  */
 public final class Native {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(Native.class);
+    static final InetAddress INET6_ANY;
+    static final InetAddress INET_ANY;
 
     static {
         Selector selector = null;
@@ -62,6 +66,13 @@ public final class Native {
             selector = Selector.open();
         } catch (IOException ignore) {
             // Just ignore
+        }
+
+        try {
+            INET_ANY = InetAddress.getByName("0.0.0.0");
+            INET6_ANY = InetAddress.getByName("::");
+        } catch (UnknownHostException e) {
+            throw new ExceptionInInitializerError(e);
         }
 
         // Preload all classes that will be used in the OnLoad(...) function of JNI to eliminate the possiblity of a


### PR DESCRIPTION
Motivation:

LinuxSocket is loaded by by JNI when "binding" methods to native code. The problem is that LinuxSocket also try to use `InetAddress.getName(...)` when init static fields, which might deadlock as we are still in native code while doing so

Modifications:

Move static fields to Native class and init these before we try to load JNI code.

Result:

Fixes https://github.com/netty/netty/issues/13871