### PR TITLE
Transport: AdaptiveRecvByteBufAllocator does not correctly calculate …

### DIFF
--- a/transport/src/main/java/io/netty/channel/AdaptiveRecvByteBufAllocator.java
+++ b/transport/src/main/java/io/netty/channel/AdaptiveRecvByteBufAllocator.java
@@ -98,11 +98,11 @@ public class AdaptiveRecvByteBufAllocator extends DefaultMaxMessagesRecvByteBufA
         private int nextReceiveBufferSize;
         private boolean decreaseNow;
 
-        HandleImpl(int minIndex, int maxIndex, int initial) {
+        HandleImpl(int minIndex, int maxIndex, int initialIndex) {
             this.minIndex = minIndex;
             this.maxIndex = maxIndex;
 
-            index = getSizeTableIndex(initial);
+            index = initialIndex;
             nextReceiveBufferSize = SIZE_TABLE[index];
         }
 
@@ -147,7 +147,7 @@ public class AdaptiveRecvByteBufAllocator extends DefaultMaxMessagesRecvByteBufA
 
     private final int minIndex;
     private final int maxIndex;
-    private final int initial;
+    private final int initialIndex;
 
     /**
      * Creates a new predictor with the default parameters.  With the default
@@ -188,13 +188,18 @@ public class AdaptiveRecvByteBufAllocator extends DefaultMaxMessagesRecvByteBufA
             this.maxIndex = maxIndex;
         }
 
-        this.initial = initial;
+        int initialIndex = getSizeTableIndex(initial);
+        if (SIZE_TABLE[initialIndex] > initial) {
+            this.initialIndex = initialIndex - 1;
+        } else {
+            this.initialIndex = initialIndex;
+        }
     }
 
     @SuppressWarnings("deprecation")
     @Override
     public Handle newHandle() {
-        return new HandleImpl(minIndex, maxIndex, initial);
+        return new HandleImpl(minIndex, maxIndex, initialIndex);
     }
 
     @Override

--- a/transport/src/test/java/io/netty/channel/AdaptiveRecvByteBufAllocatorTest.java
+++ b/transport/src/test/java/io/netty/channel/AdaptiveRecvByteBufAllocatorTest.java
@@ -20,9 +20,11 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 import org.mockito.Mock;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -96,6 +98,45 @@ public class AdaptiveRecvByteBufAllocatorTest {
 
         handle.reset(config);
         allocReadExpected(handle, alloc, 131072);
+    }
+
+    @Test
+    public void doesNotExceedMaximum() {
+        AdaptiveRecvByteBufAllocator recvByteBufAllocator = new AdaptiveRecvByteBufAllocator(64, 9000, 9000);
+        RecvByteBufAllocator.ExtendedHandle handle =
+                (RecvByteBufAllocator.ExtendedHandle) recvByteBufAllocator.newHandle();
+        handle.reset(config);
+        allocReadExpected(handle, alloc, 8192);
+    }
+
+    @Test
+    public void throwsIfInitialIsBiggerThenMaximum() {
+        assertThrows(IllegalArgumentException.class, new Executable() {
+            @Override
+            public void execute() {
+                new AdaptiveRecvByteBufAllocator(64, 4096 , 1024);
+            }
+        });
+    }
+
+    @Test
+    public void throwsIfInitialIsSmallerThenMinimum() {
+        assertThrows(IllegalArgumentException.class, new Executable() {
+            @Override
+            public void execute() {
+                new AdaptiveRecvByteBufAllocator(512, 64 , 1024);
+            }
+        });
+    }
+
+    @Test
+    public void throwsIfMinimumIsBiggerThenMaximum() {
+        assertThrows(IllegalArgumentException.class, new Executable() {
+            @Override
+            public void execute() {
+                new AdaptiveRecvByteBufAllocator(2048, 64 , 1024);
+            }
+        });
     }
 
     private static void allocReadExpected(RecvByteBufAllocator.ExtendedHandle handle,

--- a/transport/src/test/java/io/netty/channel/AdaptiveRecvByteBufAllocatorTest.java
+++ b/transport/src/test/java/io/netty/channel/AdaptiveRecvByteBufAllocatorTest.java
@@ -110,6 +110,15 @@ public class AdaptiveRecvByteBufAllocatorTest {
     }
 
     @Test
+    public void doesSetCorrectMinBounds() {
+        AdaptiveRecvByteBufAllocator recvByteBufAllocator = new AdaptiveRecvByteBufAllocator(81, 95, 95);
+        RecvByteBufAllocator.ExtendedHandle handle =
+                (RecvByteBufAllocator.ExtendedHandle) recvByteBufAllocator.newHandle();
+        handle.reset(config);
+        allocReadExpected(handle, alloc, 81);
+    }
+
+    @Test
     public void throwsIfInitialIsBiggerThenMaximum() {
         assertThrows(IllegalArgumentException.class, new Executable() {
             @Override


### PR DESCRIPTION
…initial buffer capacity in some cases

Motivation:

We did not correctly calculate the initial index sometimes which could lead to the initial buffer capacity to exceed the configured maximum size.

Modifications:

- Correctly calculate initialIndex
- Add unit tests

Result:

Fixes https://github.com/netty/netty/issues/13722
