### PR TITLE
Prefer `/etc/resolv.conf` on Linux and Mac

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsServerAddressStreamProvider.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsServerAddressStreamProvider.java
@@ -52,7 +52,12 @@ public final class DefaultDnsServerAddressStreamProvider implements DnsServerAdd
         if (!PlatformDependent.isAndroid()) {
             // Only try to use when not on Android as the classes not exists there:
             // See https://github.com/netty/netty/issues/8654
-            DirContextUtils.addNameServers(defaultNameServers, DNS_PORT);
+            if (!PlatformDependent.isWindows()) {
+                // /etc/resolv.conf exists on Linux + macOS, but not on Android
+                defaultNameServers.addAll(ResolvConf.system().getNameservers());
+            } else {
+                DirContextUtils.addNameServers(defaultNameServers, DNS_PORT);
+            }
         }
 
         // Only try when using on Java8 and lower as otherwise it will produce:

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/ResolvConf.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/ResolvConf.java
@@ -26,14 +26,14 @@ import java.util.List;
 /**
  * Looks up the {@code nameserver}s from the {@code /etc/resolv.conf} file, intended for Linux and macOS.
  */
-public final class ResolvConf {
+final class ResolvConf {
     private final List<InetSocketAddress> nameservers;
 
     /**
      * Reads from the given reader and extracts the {@code nameserver}s using the syntax of the
      * {@code /etc/resolv.conf} file, see {@code man resolv.conf}.
      */
-    public static ResolvConf fromReader(BufferedReader reader) throws IOException {
+    static ResolvConf fromReader(BufferedReader reader) throws IOException {
         return new ResolvConf(reader);
     }
 
@@ -41,7 +41,7 @@ public final class ResolvConf {
      * Reads the given file and extracts the {@code nameserver}s using the syntax of the
      * {@code /etc/resolv.conf} file, see {@code man resolv.conf}.
      */
-    public static ResolvConf fromFile(String file) throws IOException {
+    static ResolvConf fromFile(String file) throws IOException {
         FileReader fileReader = new FileReader(file);
         try {
             BufferedReader reader = new BufferedReader(new FileReader(file));
@@ -55,7 +55,7 @@ public final class ResolvConf {
      * Returns the {@code nameserver}s from the {@code /etc/resolv.conf} file. The file is only read once
      * during the lifetime of this class.
      */
-    public static ResolvConf system() {
+    static ResolvConf system() {
         ResolvConf resolvConv = ResolvConfLazy.machineResolvConf;
         if (resolvConv != null) {
             return resolvConv;
@@ -80,7 +80,7 @@ public final class ResolvConf {
         this.nameservers = Collections.unmodifiableList(nameservers);
     }
 
-    public List<InetSocketAddress> getNameservers() {
+    List<InetSocketAddress> getNameservers() {
         return nameservers;
     }
 

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/ResolvConf.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/ResolvConf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The Netty Project
+ * Copyright 2024 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -32,6 +32,9 @@ final class ResolvConf {
     /**
      * Reads from the given reader and extracts the {@code nameserver}s using the syntax of the
      * {@code /etc/resolv.conf} file, see {@code man resolv.conf}.
+     *
+     * @param reader contents of {@code resolv.conf} are read from this {@link BufferedReader},
+     *              up to the caller to close it
      */
     static ResolvConf fromReader(BufferedReader reader) throws IOException {
         return new ResolvConf(reader);
@@ -84,7 +87,7 @@ final class ResolvConf {
         return nameservers;
     }
 
-    static final class ResolvConfLazy {
+    private static final class ResolvConfLazy {
         static final ResolvConf machineResolvConf;
 
         static {

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/ResolvConf.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/ResolvConf.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Looks up the {@code nameserver}s from the {@code /etc/resolv.conf} file, intended for Linux and macOS.
+ */
+public final class ResolvConf {
+    private final List<InetSocketAddress> nameservers;
+
+    /**
+     * Reads from the given reader and extracts the {@code nameserver}s using the syntax of the
+     * {@code /etc/resolv.conf} file, see {@code man resolv.conf}.
+     */
+    public static ResolvConf fromReader(BufferedReader reader) throws IOException {
+        return new ResolvConf(reader);
+    }
+
+    /**
+     * Reads the given file and extracts the {@code nameserver}s using the syntax of the
+     * {@code /etc/resolv.conf} file, see {@code man resolv.conf}.
+     */
+    public static ResolvConf fromFile(String file) throws IOException {
+        FileReader fileReader = new FileReader(file);
+        try {
+            BufferedReader reader = new BufferedReader(new FileReader(file));
+            return fromReader(reader);
+        } finally {
+            fileReader.close();
+        }
+    }
+
+    /**
+     * Returns the {@code nameserver}s from the {@code /etc/resolv.conf} file. The file is only read once
+     * during the lifetime of this class.
+     */
+    public static ResolvConf system() {
+        ResolvConf resolvConv = ResolvConfLazy.machineResolvConf;
+        if (resolvConv != null) {
+            return resolvConv;
+        }
+        throw new IllegalStateException("/etc/resolv.conf could not be read");
+    }
+
+    private ResolvConf(BufferedReader reader) throws IOException {
+        List<InetSocketAddress> nameservers = new ArrayList<InetSocketAddress>();
+        String ln;
+        while ((ln = reader.readLine()) != null) {
+            ln = ln.trim();
+            if (ln.isEmpty()) {
+                continue;
+            }
+
+            if (ln.startsWith("nameserver")) {
+                ln = ln.substring("nameserver".length()).trim();
+                nameservers.add(new InetSocketAddress(ln, 53));
+            }
+        }
+        this.nameservers = Collections.unmodifiableList(nameservers);
+    }
+
+    public List<InetSocketAddress> getNameservers() {
+        return nameservers;
+    }
+
+    static final class ResolvConfLazy {
+        static final ResolvConf machineResolvConf;
+
+        static {
+            ResolvConf resolvConf;
+            try {
+                resolvConf = ResolvConf.fromFile("/etc/resolv.conf");
+            } catch (IOException e) {
+                resolvConf = null;
+            }
+            machineResolvConf = resolvConf;
+        }
+    }
+}

--- a/resolver-dns/src/main/resources/META-INF/native-image/io.netty/netty-resolver-dns/native-image.properties
+++ b/resolver-dns/src/main/resources/META-INF/native-image/io.netty/netty-resolver-dns/native-image.properties
@@ -16,6 +16,5 @@ Args = --initialize-at-run-time=io.netty.resolver.dns.DefaultDnsServerAddressStr
        --initialize-at-run-time=io.netty.resolver.dns.DnsServerAddressStreamProviders$DefaultProviderHolder \
        --initialize-at-run-time=io.netty.resolver.dns.DnsNameResolver \
        --initialize-at-run-time=io.netty.resolver.HostsFileEntriesResolver \
-       --initialize-at-run-time=java.net.Inet4Address \
-       --initialize-at-run-time=java.net.Inet6Address \
-       --initialize-at-run-time=io.netty.resolver.dns.ResolvConf$ResolvConfLazy
+       --initialize-at-run-time=io.netty.resolver.dns.ResolvConf$ResolvConfLazy \
+       --initialize-at-run-time=io.netty.resolver.dns.DefaultDnsServerAddressStreamProvider

--- a/resolver-dns/src/main/resources/META-INF/native-image/io.netty/netty-resolver-dns/native-image.properties
+++ b/resolver-dns/src/main/resources/META-INF/native-image/io.netty/netty-resolver-dns/native-image.properties
@@ -16,4 +16,6 @@ Args = --initialize-at-run-time=io.netty.resolver.dns.DefaultDnsServerAddressStr
        --initialize-at-run-time=io.netty.resolver.dns.DnsServerAddressStreamProviders$DefaultProviderHolder \
        --initialize-at-run-time=io.netty.resolver.dns.DnsNameResolver \
        --initialize-at-run-time=io.netty.resolver.HostsFileEntriesResolver \
+       --initialize-at-run-time=java.net.Inet4Address \
+       --initialize-at-run-time=java.net.Inet6Address \
        --initialize-at-run-time=io.netty.resolver.dns.ResolvConf$ResolvConfLazy

--- a/resolver-dns/src/main/resources/META-INF/native-image/io.netty/netty-resolver-dns/native-image.properties
+++ b/resolver-dns/src/main/resources/META-INF/native-image/io.netty/netty-resolver-dns/native-image.properties
@@ -16,4 +16,4 @@ Args = --initialize-at-run-time=io.netty.resolver.dns.DefaultDnsServerAddressStr
        --initialize-at-run-time=io.netty.resolver.dns.DnsServerAddressStreamProviders$DefaultProviderHolder \
        --initialize-at-run-time=io.netty.resolver.dns.DnsNameResolver \
        --initialize-at-run-time=io.netty.resolver.HostsFileEntriesResolver \
-       --initialize-at-run-time=io.netty.resolver.dns.ResolvConf.ResolvConfLazy
+       --initialize-at-run-time=io.netty.resolver.dns.ResolvConf$ResolvConfLazy

--- a/resolver-dns/src/main/resources/META-INF/native-image/io.netty/netty-resolver-dns/native-image.properties
+++ b/resolver-dns/src/main/resources/META-INF/native-image/io.netty/netty-resolver-dns/native-image.properties
@@ -15,4 +15,5 @@
 Args = --initialize-at-run-time=io.netty.resolver.dns.DefaultDnsServerAddressStreamProvider \
        --initialize-at-run-time=io.netty.resolver.dns.DnsServerAddressStreamProviders$DefaultProviderHolder \
        --initialize-at-run-time=io.netty.resolver.dns.DnsNameResolver \
-       --initialize-at-run-time=io.netty.resolver.HostsFileEntriesResolver
+       --initialize-at-run-time=io.netty.resolver.HostsFileEntriesResolver \
+       --initialize-at-run-time=io.netty.resolver.dns.ResolvConf.ResolvConfLazy

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/ResolvConfTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/ResolvConfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The Netty Project
+ * Copyright 2024 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -29,7 +29,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static java.util.Collections.emptyList;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/ResolvConfTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/ResolvConfTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.BufferedReader;
+import java.io.StringReader;
+import java.net.InetSocketAddress;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.Collections.emptyList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public class ResolvConfTest {
+    @Test
+    @DisabledOnOs({OS.WINDOWS})
+    public void readSystem() {
+        assertThat(ResolvConf.system().getNameservers().size(), is(greaterThan(0)));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    public void scenarios(String resolvConf, List<String> nameservers) throws Exception {
+        assertIterableEquals(
+                ResolvConf.fromReader(new BufferedReader(new StringReader(resolvConf))).getNameservers(),
+                nameservers.stream().map(new Function<String, InetSocketAddress>() {
+                    @Override
+                    public InetSocketAddress apply(String n) {
+                        return new InetSocketAddress(n, 53);
+                    }
+                }).collect(Collectors.toList()));
+    }
+
+    static List<Arguments> scenarios() {
+        return Arrays.asList(
+                arguments("", emptyList()),
+                arguments(
+                        "# some comment\n"
+                                + "# nameserver hello\n"
+                                + "\n"
+                                + "nameserver 1.2.3.4\n"
+                                + "nameserver 127.1.2.3",
+                        Arrays.asList("1.2.3.4", "127.1.2.3")),
+                arguments(
+                        "# some comment\n"
+                                + "# nameserver hello\n"
+                                + "\n"
+                                + "nameserver 1.2.3.4\n"
+                                + "nameserver 127.1.2.3",
+                        Arrays.asList("1.2.3.4", "127.1.2.3")),
+                arguments(
+                        "# some comment\n" + "nameserver 0:0:0:0:0:0:0:1\n" + "nameserver 127.0.0.1",
+                        Arrays.asList("0:0:0:0:0:0:0:1", "127.0.0.1")),
+                arguments(
+                        "# options and search are ignored\n"
+                                + "nameserver 127.0.0.53\n"
+                                + "options edns0 trust-ad"
+                                + "search netty.io projectnessie.org",
+                        Arrays.asList("127.0.0.53")));
+    }
+}


### PR DESCRIPTION
Quarkus disables JNDI by default, which breaks the (default) DNS servers lookup in `DirContextUtils`, so DNS lookups default to the public Google DNS servers. This means, that looking up k8s service names, or any internal names, isn't possible without either enabling JNDI, which is not such a great option, or specifying DNS servers manually, which is awkward, since there is `/etc/resolv.conf`.

This change prefers reading the nameservers from `/etc/resolv.conf` over looking those up on JNDI on Linux + macOS. This is effectively a noop-change when JNDI is enabled, because the nameservers available via JNDI are read from `/etc/resolv.conf`. Behavior for Windows (still requires JNDI) and Android (neither JNDI nor `/etc/resolv.conf`) is not changed.

Fixes #13883