### PR TITLE
Save Snappy's encode tmp table allocation #13826

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/Snappy.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Snappy.java
@@ -191,9 +191,8 @@ public final class Snappy {
     private short[] getHashTable(int hashTableSize) {
         if (reuseHashtable) {
             return getHashTableFastThreadLocalArrayFill(hashTableSize);
-        } else {
-            return new short[hashTableSize];
         }
+        return new short[hashTableSize];
     }
 
     /**

--- a/codec/src/main/java/io/netty/handler/codec/compression/Snappy.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Snappy.java
@@ -84,11 +84,6 @@ public final class Snappy {
     private byte tag;
     private int written;
 
-    public enum HashType {
-        NEW_ARRAY,
-        FAST_THREAD_LOCAL_ARRAY_FILL
-    }
-
     private enum State {
         READING_PREAMBLE,
         READING_TAG,

--- a/codec/src/main/java/io/netty/handler/codec/compression/Snappy.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Snappy.java
@@ -51,21 +51,7 @@ public final class Snappy {
     // Hash table used to compress, shared between subsequent call to .encode()
     private static final FastThreadLocal<short[]> HASH_TABLE = new FastThreadLocal<short[]>();
 
-    private static final boolean DEFAULT_REUSE_HASHTABLE;
-
-    static {
-        String hashTableTypeKey = "io.netty.handler.codec.compression.snappy.reuseHashTable";
-        String hashTableTypeProperty = SystemPropertyUtil.get(hashTableTypeKey, Boolean.FALSE.toString());
-
-        hashTableTypeProperty = hashTableTypeProperty.toLowerCase(Locale.US).trim();
-        boolean reuseHashtable = Boolean.parseBoolean(hashTableTypeProperty);
-
-        if (reuseHashtable) {
-            logger.debug("-D{}=\"{}\"", hashTableTypeKey, hashTableTypeProperty);
-        }
-
-        DEFAULT_REUSE_HASHTABLE = reuseHashtable;
-    }
+    private static final boolean DEFAULT_REUSE_HASHTABLE = SystemPropertyUtil.getBoolean("io.netty.handler.codec.compression.snappy.reuseHashTable", false);
 
     public Snappy() {
         this(DEFAULT_REUSE_HASHTABLE);

--- a/codec/src/main/java/io/netty/handler/codec/compression/Snappy.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Snappy.java
@@ -51,7 +51,8 @@ public final class Snappy {
     // Hash table used to compress, shared between subsequent call to .encode()
     private static final FastThreadLocal<short[]> HASH_TABLE = new FastThreadLocal<short[]>();
 
-    private static final boolean DEFAULT_REUSE_HASHTABLE = SystemPropertyUtil.getBoolean("io.netty.handler.codec.compression.snappy.reuseHashTable", false);
+    private static final boolean DEFAULT_REUSE_HASHTABLE =
+            SystemPropertyUtil.getBoolean("io.netty.handler.codec.compression.snappy.reuseHashTable", false);
 
     public Snappy() {
         this(DEFAULT_REUSE_HASHTABLE);

--- a/microbench/src/main/java/io/netty/microbench/snappy/SnappyDirectBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/snappy/SnappyDirectBenchmark.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.microbench.snappy;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.Unpooled;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.handler.codec.compression.Snappy;
+import io.netty.microbench.util.AbstractMicrobenchmark;
+import org.openjdk.jmh.annotations.AuxCounters;
+import org.openjdk.jmh.annotations.AuxCounters.Type;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
+
+@State(Scope.Benchmark)
+@Fork(1)
+@Threads(1)
+@Warmup(iterations = 5)
+@Measurement(iterations = 3)
+public class SnappyDirectBenchmark extends AbstractMicrobenchmark {
+
+    @Param()
+    public Snappy.HashType hashType;
+    private ByteBuf buffer;
+    private Snappy snappy;
+    private ByteBuf in;
+    private ByteBuf out;
+
+    @Param({ "4096", "2048", "1024", "512", "256", "128" })
+    private int bufferSizeInBytes;
+
+    @AuxCounters(value = Type.OPERATIONS)
+    @State(Scope.Thread)
+    public static class AllocationMetrics {
+        private long inputSize;
+
+        private long outputSize;
+
+        public long compressedRatio() {
+            return inputSize / outputSize;
+        }
+    }
+
+    @Setup
+    public void setup() throws UnsupportedEncodingException {
+        ByteBufAllocator allocator = UnpooledByteBufAllocator.DEFAULT;
+        buffer = allocator.buffer(bufferSizeInBytes);
+
+        switch (hashType) {
+        case NEW_ARRAY:
+            snappy = new Snappy();
+            break;
+        case FAST_THREAD_LOCAL_ARRAY_FILL:
+            snappy = Snappy.withHashTableReuse();
+            break;
+        }
+
+        byte[] compressibleByteArray = new byte[buffer.writableBytes()];
+        Arrays.fill(compressibleByteArray, (byte) 1);
+        buffer.writeBytes(compressibleByteArray);
+
+        in = Unpooled.wrappedBuffer(compressibleByteArray);
+        out = Unpooled.directBuffer();
+    }
+
+    @Benchmark
+    public ByteBuf encode(AllocationMetrics allocationMetrics) {
+
+        int length = in.readableBytes();
+        snappy.encode(in, out, length);
+        in.resetReaderIndex();
+        allocationMetrics.inputSize += length;
+        allocationMetrics.outputSize += out.readableBytes();
+        out.setIndex(0, 0);
+
+        return out;
+    }
+
+    @TearDown(Level.Trial)
+    public void teardown() {
+        buffer.release();
+        buffer = null;
+        out.release();
+        out = null;
+    }
+}

--- a/microbench/src/main/java/io/netty/microbench/snappy/SnappyDirectBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/snappy/SnappyDirectBenchmark.java
@@ -45,8 +45,8 @@ import java.util.Arrays;
 @Measurement(iterations = 3)
 public class SnappyDirectBenchmark extends AbstractMicrobenchmark {
 
-    @Param()
-    public Snappy.HashType hashType;
+    @Param({ "true", "false" })
+    public boolean reuseHashTable;
     private ByteBuf buffer;
     private Snappy snappy;
     private ByteBuf in;
@@ -72,13 +72,10 @@ public class SnappyDirectBenchmark extends AbstractMicrobenchmark {
         ByteBufAllocator allocator = UnpooledByteBufAllocator.DEFAULT;
         buffer = allocator.buffer(bufferSizeInBytes);
 
-        switch (hashType) {
-        case NEW_ARRAY:
-            snappy = new Snappy();
-            break;
-        case FAST_THREAD_LOCAL_ARRAY_FILL:
+        if (reuseHashTable) {
             snappy = Snappy.withHashTableReuse();
-            break;
+        } else {
+            snappy = new Snappy();
         }
 
         byte[] compressibleByteArray = new byte[buffer.writableBytes()];

--- a/microbench/src/main/java/io/netty/microbench/snappy/SnappyDirectBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/snappy/SnappyDirectBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 The Netty Project
+ * Copyright 2024 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -91,7 +91,6 @@ public class SnappyDirectBenchmark extends AbstractMicrobenchmark {
 
     @Benchmark
     public ByteBuf encode(AllocationMetrics allocationMetrics) {
-
         int length = in.readableBytes();
         snappy.encode(in, out, length);
         in.resetReaderIndex();

--- a/microbench/src/main/java/io/netty/microbench/snappy/package-info.java
+++ b/microbench/src/main/java/io/netty/microbench/snappy/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * Benchmarks for Snappy ({@link io.netty.handler.codec.compression.Snappy}).
+ */
+package io.netty.microbench.snappy;

--- a/microbench/src/main/java/io/netty/microbench/snappy/package-info.java
+++ b/microbench/src/main/java/io/netty/microbench/snappy/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Netty Project
+ * Copyright 2024 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance


### PR DESCRIPTION
Motivation:

Allocating a new byte[] on the hot path is expensive

Modifications:

- Use FastThreadLocal to recycle the byte[] when it's the same size
- Fill the array with 0 to ensure correctness of compression
- Created a Benchmark in the microbench module
- New system property `io.netty.handler.codec.compression.snappy.hashTableType` with possible value `newarray` (default) or `reuse` to use a single buffer

Result:

Fixes #13826
Benchmarks results on #13826
