### PR TITLE
Add option to disable loading extensions for a particular bootstrap

### DIFF
--- a/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
+++ b/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
@@ -488,6 +488,25 @@ public class BootstrapTest {
         expectedChannel.close().sync();
     }
 
+    @Test
+    void mustNotCallInitializerExtensionsIfDisabled() throws Exception {
+        final Bootstrap cb = new Bootstrap();
+        cb.disableExtensions(true);
+
+        cb.group(groupA);
+        cb.handler(dummyHandler);
+        cb.channel(LocalChannel.class);
+
+        StubChannelInitializerExtension.clearThreadLocals();
+
+        ChannelFuture future = cb.register();
+        future.sync();
+        final Channel expectedChannel = future.channel();
+
+        assertNull(StubChannelInitializerExtension.lastSeenClientChannel.get());
+        expectedChannel.close().sync();
+    }
+
     private static final class DelayedEventLoopGroup extends DefaultEventLoop {
         @Override
         public ChannelFuture register(final Channel channel, final ChannelPromise promise) {


### PR DESCRIPTION
Motivation:

It allows certain library vendors using Netty to vend clients or servers to explicitly turn off adding any extensions to their BootStrap.

Modification:

Added a new flag to explicitly disable extensions in Bootstrap.
Result:

We now can control if we want extensions each instance of a Netty client or server.

