### PR TITLE
Throw error on invalid cookie value

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
@@ -544,6 +544,9 @@ public final class HttpConversionUtil {
                             do {
                                 out.add(COOKIE, value.subSequence(start, index, false));
                                 // skip 2 characters "; " (see https://tools.ietf.org/html/rfc6265#section-4.2.1)
+                                if (index + 1 >= value.length() || value.charAt(index + 1) != ' ') {
+                                    throw new IllegalArgumentException("cookie value has a semicolon not followed by a space, counter to spec: " + value);
+                                }
                                 start = index + 2;
                             } while (start < value.length() &&
                                     (index = value.forEachByte(start, value.length() - start, FIND_SEMI_COLON)) != -1);
@@ -554,6 +557,8 @@ public final class HttpConversionUtil {
                         } else {
                             out.add(COOKIE, value);
                         }
+                    } catch (IllegalArgumentException e) {
+                        throw e;
                     } catch (Exception e) {
                         // This is not expect to happen because FIND_SEMI_COLON never throws but must be caught
                         // because of the ByteProcessor interface.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
@@ -569,7 +569,8 @@ public final class HttpConversionUtil {
                                     // skip 2 characters "; " (see https://tools.ietf.org/html/rfc6265#section-4.2.1)
                                     start = index + 2;
                                 } while (start < value.length() &&
-                                        (index = value.forEachByte(start, value.length() - start, FIND_SEMI_COLON)) != -1);
+                                        (index = value.forEachByte(start, value.length() - start, FIND_SEMI_COLON))
+                                                != -1);
                                 assert start < value.length();
                                 out.add(COOKIE, value.subSequence(start, value.length(), false));
                             } else {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
@@ -545,7 +545,9 @@ public final class HttpConversionUtil {
                                 out.add(COOKIE, value.subSequence(start, index, false));
                                 // skip 2 characters "; " (see https://tools.ietf.org/html/rfc6265#section-4.2.1)
                                 if (index + 1 >= value.length() || value.charAt(index + 1) != ' ') {
-                                    throw new IllegalArgumentException("cookie value has a semicolon not followed by a space, counter to spec: " + value);
+                                    throw new IllegalArgumentException(
+                                            "cookie value has a semicolon not followed by a space, counter to spec: "
+                                                    + value);
                                 }
                                 start = index + 2;
                             } while (start < value.length() &&

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
@@ -535,59 +535,61 @@ public final class HttpConversionUtil {
                     toHttp2HeadersFilterTE(entry, out);
                 } else if (aName.contentEqualsIgnoreCase(COOKIE)) {
                     CharSequence valueCs = entry.getValue();
-                    try {
-                        // validate
-                        boolean invalid = false;
-                        for (int i = 0; i < valueCs.length(); i++) {
-                            char c = valueCs.charAt(i);
-                            if (c == ';') {
-                                if (i + 1 >= valueCs.length() || valueCs.charAt(i + 1) != ' ') {
-                                    invalid = true;
-                                    break;
-                                }
-                                i++; // skip space
-                            } else if (c > 255) {
-                                // not ascii, don't split
+                    // validate
+                    boolean invalid = false;
+                    for (int i = 0; i < valueCs.length(); i++) {
+                        char c = valueCs.charAt(i);
+                        if (c == ';') {
+                            if (i + 1 >= valueCs.length() || valueCs.charAt(i + 1) != ' ') {
+                                // semicolon not followed by space. invalid, don't split
                                 invalid = true;
                                 break;
                             }
+                            i++; // skip space
+                        } else if (c > 255) {
+                            // not ascii, don't split
+                            invalid = true;
+                            break;
                         }
+                    }
 
-                        if (invalid) {
-                            out.add(COOKIE, valueCs);
-                        } else {
-                            AsciiString value = AsciiString.of(valueCs);
-                            // split up cookies to allow for better compression
-                            // https://tools.ietf.org/html/rfc7540#section-8.1.2.5
-                            int index = value.forEachByte(FIND_SEMI_COLON);
-                            if (index != -1) {
-                                int start = 0;
-                                do {
-                                    out.add(COOKIE, value.subSequence(start, index, false));
-                                    assert index + 1 < value.length();
-                                    assert value.charAt(index + 1) == ' ';
-                                    // skip 2 characters "; " (see https://tools.ietf.org/html/rfc6265#section-4.2.1)
-                                    start = index + 2;
-                                } while (start < value.length() &&
-                                        (index = value.forEachByte(start, value.length() - start, FIND_SEMI_COLON))
-                                                != -1);
-                                assert start < value.length();
-                                out.add(COOKIE, value.subSequence(start, value.length(), false));
-                            } else {
-                                out.add(COOKIE, value);
-                            }
-                        }
-                    } catch (IllegalArgumentException e) {
-                        throw e;
-                    } catch (Exception e) {
-                        // This is not expect to happen because FIND_SEMI_COLON never throws but must be caught
-                        // because of the ByteProcessor interface.
-                        throw new IllegalStateException(e);
+                    if (invalid) {
+                        out.add(COOKIE, valueCs);
+                    } else {
+                        splitValidCookieHeader(out, valueCs);
                     }
                 } else {
                     out.add(aName, entry.getValue());
                 }
             }
+        }
+    }
+
+    private static void splitValidCookieHeader(Http2Headers out, CharSequence valueCs) {
+        try {
+            AsciiString value = AsciiString.of(valueCs);
+            // split up cookies to allow for better compression
+            // https://tools.ietf.org/html/rfc7540#section-8.1.2.5
+            int index = value.forEachByte(FIND_SEMI_COLON);
+            if (index != -1) {
+                int start = 0;
+                do {
+                    out.add(COOKIE, value.subSequence(start, index, false));
+                    assert index + 1 < value.length();
+                    assert value.charAt(index + 1) == ' ';
+                    // skip 2 characters "; " (see https://tools.ietf.org/html/rfc6265#section-4.2.1)
+                    start = index + 2;
+                } while (start < value.length() &&
+                        (index = value.forEachByte(start, value.length() - start, FIND_SEMI_COLON)) != -1);
+                assert start < value.length();
+                out.add(COOKIE, value.subSequence(start, value.length(), false));
+            } else {
+                out.add(COOKIE, value);
+            }
+        } catch (Exception e) {
+            // This is not expect to happen because FIND_SEMI_COLON never throws but must be caught
+            // because of the ByteProcessor interface.
+            throw new IllegalStateException(e);
         }
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilTest.java
@@ -188,16 +188,30 @@ public class HttpConversionUtilTest {
     }
 
     @Test
-    public void noSpace() {
+    public void cookieNoSpace() {
         final HttpHeaders inHeaders = new DefaultHttpHeaders();
         inHeaders.add(COOKIE, "one=foo;two=bar");
         final Http2Headers out = new DefaultHttp2Headers();
-        assertThrows(IllegalArgumentException.class, new Executable() {
-            @Override
-            public void execute() {
-                HttpConversionUtil.toHttp2Headers(inHeaders, out);
-            }
-        });
+        HttpConversionUtil.toHttp2Headers(inHeaders, out);
+        assertEquals("one=foo;two=bar", out.get(COOKIE)); // not split
+    }
+
+    @Test
+    public void cookieTailSemicolon() {
+        final HttpHeaders inHeaders = new DefaultHttpHeaders();
+        inHeaders.add(COOKIE, "one=foo;");
+        final Http2Headers out = new DefaultHttp2Headers();
+        HttpConversionUtil.toHttp2Headers(inHeaders, out);
+        assertEquals("one=foo;", out.get(COOKIE)); // not split
+    }
+
+    @Test
+    public void cookieNonAscii() {
+        final HttpHeaders inHeaders = new DefaultHttpHeaders();
+        inHeaders.add(COOKIE, "one=\uD83D\uDE43; two=ü");
+        final Http2Headers out = new DefaultHttp2Headers();
+        HttpConversionUtil.toHttp2Headers(inHeaders, out);
+        assertSame("one=\uD83D\uDE43; two=ü", out.get(COOKIE)); // not split
     }
 
     @Test

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilTest.java
@@ -250,20 +250,6 @@ public class HttpConversionUtilTest {
     }
 
     @Test
-    public void httpToHttp2Cookie() throws Http2Exception {
-        Http2Headers inHeaders = new DefaultHttp2Headers();
-        inHeaders.add("yes", "no");
-        inHeaders.add(COOKIE, "foo=bar");
-        inHeaders.add(COOKIE, "bax=baz");
-
-        HttpHeaders outHeaders = new DefaultHttpHeaders();
-
-        HttpConversionUtil.addHttp2ToHttpHeaders(5, inHeaders, outHeaders, HttpVersion.HTTP_1_1, false, false);
-        assertEquals("no", outHeaders.get("yes"));
-        assertEquals("foo=bar; bax=baz", outHeaders.get(COOKIE.toString()));
-    }
-
-    @Test
     public void connectionSpecificHeadersShouldBeRemoved() {
         HttpHeaders inHeaders = new DefaultHttpHeaders();
         inHeaders.add(CONNECTION, "keep-alive");

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilTest.java
@@ -25,8 +25,6 @@ import io.netty.util.AsciiString;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
-import java.util.Arrays;
-
 import static io.netty.handler.codec.http.HttpHeaderNames.CONNECTION;
 import static io.netty.handler.codec.http.HttpHeaderNames.COOKIE;
 import static io.netty.handler.codec.http.HttpHeaderNames.HOST;


### PR DESCRIPTION
Motivation:

Many browsers support cookie values separated by ';' instead of '; ', even if they violate the HTTP spec. HttpConversionUtil.toHttp2Headers would, however, silently drop a character of a second cookie in this case ('one=foo;two=bar' -> 'one=foo' and 'wo=bar').

Modification:

Check that the skipped character is actually a space.

Result:

An exception is thrown on invalid input, saving time for the next person that has to debug this :)