### PR TITLE
ByteToMessageDecoder.channelReadComplete(...) does call read() too of…

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
@@ -355,6 +355,7 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
             ctx.read();
         }
         firedChannelRead = false;
+        selfFiredChannelRead = false;
         ctx.fireChannelReadComplete();
     }
 


### PR DESCRIPTION
…ten.

Motivation:

ByteToMessageDecoder.channelReadComplete(...) should only call read() once if channelRead(...) did not produce any message.

Modifications:

- Correctly reset variable
- Add unit test

Result:

Not break flow-control
