### PR TITLE
feat: add setter for topicFilter field, allowing MQTT broker to implement topic rewrite feature

### DIFF
--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttTopicSubscription.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttTopicSubscription.java
@@ -52,11 +52,11 @@ public final class MqttTopicSubscription {
     /**
      * Rewrite topic filter.
      * <p>
-     * 
+     *
      * Many IoT devices do not support reconfiguration or upgrade, so it is hard to
      * change their subscribed topics. To resolve this issue, MQTT server may offer
      * topic rewrite capability.
-     * 
+     *
      * @param topicFilter Topic to rewrite to
      */
     public void setTopicFilter(String topicFilter) {

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttTopicSubscription.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttTopicSubscription.java
@@ -24,7 +24,7 @@ import io.netty.util.internal.StringUtil;
  */
 public final class MqttTopicSubscription {
 
-    private final String topicFilter;
+    private String topicFilter;
     private final MqttSubscriptionOption option;
 
     public MqttTopicSubscription(String topicFilter, MqttQoS qualityOfService) {
@@ -49,6 +49,20 @@ public final class MqttTopicSubscription {
         return topicFilter;
     }
 
+    /**
+     * Rewrite topic filter.
+     * <p>
+     * 
+     * Many IoT devices do not support reconfiguration or upgrade, so it is hard to
+     * change their subscribed topics. To resolve this issue, MQTT server may offer
+     * topic rewrite capability.
+     * 
+     * @param topicFilter Topic to rewrite to
+     */
+    public void setTopicFilter(String topicFilter) {
+        this.topicFilter = topicFilter;
+    }
+
     public MqttQoS qualityOfService() {
         return option.qos();
     }
@@ -60,10 +74,10 @@ public final class MqttTopicSubscription {
     @Override
     public String toString() {
         return new StringBuilder(StringUtil.simpleClassName(this))
-            .append('[')
-            .append("topicFilter=").append(topicFilter)
-            .append(", option=").append(this.option)
-            .append(']')
-            .toString();
+                .append('[')
+                .append("topicFilter=").append(topicFilter)
+                .append(", option=").append(this.option)
+                .append(']')
+                .toString();
     }
 }


### PR DESCRIPTION
Motivation:

As discussed in the issue #13899 , many IoT devices do not support reconfiguration or upgrade, so it is hard to change their subscribed topics. To resolve this issue, MQTT server has to offer topic rewrite capability.

Modification:
Add a setter method to MqttTopicSubscription.topicFilter

Result:

Fixes #13899 . 