### PR TITLE
HTTP2: Fix hashCode() and equals(...) implementation

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamFrame.java
@@ -52,7 +52,7 @@ public abstract class AbstractHttp2StreamFrame implements Http2StreamFrame {
     public int hashCode() {
         Http2FrameStream stream = this.stream;
         if (stream == null) {
-            return super.hashCode();
+            return 31;
         }
         return stream.hashCode();
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2PingFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2PingFrame.java
@@ -63,7 +63,7 @@ public class DefaultHttp2PingFrame implements Http2PingFrame {
 
     @Override
     public int hashCode() {
-        int hash = super.hashCode();
+        int hash = (int) (content ^ (content >>> 32));
         hash = hash * 31 + (ack ? 1 : 0);
         return hash;
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
@@ -765,5 +765,28 @@ public class Http2FrameCodec extends Http2ConnectionHandler {
         public String toString() {
             return String.valueOf(id());
         }
+
+        @Override
+        public int hashCode() {
+            Http2Stream stream = this.stream;
+            if (stream == null) {
+                return id;
+            }
+            return stream.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            DefaultHttp2FrameStream that = (DefaultHttp2FrameStream) o;
+            Http2Stream stream = this.stream;
+            Http2Stream thatStream = that.stream;
+            return id == that.id && stream != null && stream.equals(thatStream);
+        }
     }
 }


### PR DESCRIPTION
Motivation:

Our implementations of hashCode() and equals(...) were not correct for some frames.

Modifications:

Correctly implement both methods

Result:

Fixes https://github.com/netty/netty/issues/13659
