### PR TITLE
Remove the lock usage in PoolArena#numPinnedBytes()

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -515,20 +515,15 @@ abstract class PoolArena<T> implements PoolArenaMetric {
     }
 
     /**
-     * Return the number of bytes that are currently pinned to buffer instances, by the arena. The pinned memory is not
-     * accessible for use by any other allocation, until the buffers using have all been released.
+     * Return an estimate of the number of bytes that are currently pinned to buffer instances, by the arena. The
+     * pinned memory is not accessible for use by any other allocation, until the buffers using have all been released.
      */
     public long numPinnedBytes() {
         long val = activeBytesHuge.value(); // Huge chunks are exact-sized for the buffers they were allocated to.
-        lock();
-        try {
-            for (int i = 0; i < chunkListMetrics.size(); i++) {
-                for (PoolChunkMetric m: chunkListMetrics.get(i)) {
-                    val += ((PoolChunk<?>) m).pinnedBytes();
-                }
+        for (int i = 0; i < chunkListMetrics.size(); i++) {
+            for (PoolChunkMetric m: chunkListMetrics.get(i)) {
+                val += ((PoolChunk<?>) m).pinnedBytes();
             }
-        } finally {
-            unlock();
         }
         return max(0, val);
     }


### PR DESCRIPTION
The implementation of `PoolArena#numPinnedBytes()` uses a lock to compute the result of the method. This only purpose of this lock is to provide an accurate computation of metric of the list of chunks: the `chunkListMetrics` is final and an unmodifiable list. Note that the returned value is already an estimate since the computation also sums `activeBytesHuge` outside of the lock. In addition this method is used by the allocator and is already an estimate as it sums the list of arenas which can change during the iteration.

This removes the lock around the `chunkListMetrics` iteration in the `PoolArena#numPinnedBytes()` method.
