### PR TITLE
Fix x-www-form-urlencoded parsing for no-value key (re-submission)

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
@@ -552,7 +552,8 @@ public class HttpPostStandardRequestDecoder implements InterfaceHttpPostRequestD
                                 charset);
                         currentAttribute = factory.createAttribute(request, key);
                         firstpos = currentpos;
-                    } else if (read == '&' || read == HttpConstants.CR || read == HttpConstants.LF) { // special empty FIELD
+                    } else if (read == '&' || read == HttpConstants.CR ||
+                               read == HttpConstants.LF) { // special empty FIELD
                         currentStatus = MultiPartStatus.DISPOSITION;
                         ampersandpos = currentpos - 1;
                         String key = decodeAttribute(

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
@@ -426,9 +426,9 @@ public class HttpPostStandardRequestDecoder implements InterfaceHttpPostRequestD
                                 charset);
                         currentAttribute = factory.createAttribute(request, key);
                         firstpos = currentpos;
-                    } else if (read == '&') { // special empty FIELD
+                    } else if (read == '&'  || !undecodedChunk.isReadable()) { // special empty FIELD
                         currentStatus = MultiPartStatus.DISPOSITION;
-                        ampersandpos = currentpos - 1;
+                        ampersandpos = read == '&' ? currentpos - 1 : currentpos;
                         String key = decodeAttribute(
                                 undecodedChunk.toString(firstpos, ampersandpos - firstpos, charset), charset);
                         // Some weird request bodies start with an '&' character, eg: &name=J&age=17.
@@ -552,7 +552,7 @@ public class HttpPostStandardRequestDecoder implements InterfaceHttpPostRequestD
                                 charset);
                         currentAttribute = factory.createAttribute(request, key);
                         firstpos = currentpos;
-                    } else if (read == '&') { // special empty FIELD
+                    } else if (read == '&' || read == HttpConstants.CR || read == HttpConstants.LF) { // special empty FIELD
                         currentStatus = MultiPartStatus.DISPOSITION;
                         ampersandpos = currentpos - 1;
                         String key = decodeAttribute(

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
@@ -426,7 +426,7 @@ public class HttpPostStandardRequestDecoder implements InterfaceHttpPostRequestD
                                 charset);
                         currentAttribute = factory.createAttribute(request, key);
                         firstpos = currentpos;
-                    } else if (read == '&' || !undecodedChunk.isReadable()) { // special empty FIELD
+                    } else if (read == '&' || (isLastChunk && !undecodedChunk.isReadable())) { // special empty FIELD
                         currentStatus = MultiPartStatus.DISPOSITION;
                         ampersandpos = read == '&' ? currentpos - 1 : currentpos;
                         String key = decodeAttribute(
@@ -552,7 +552,7 @@ public class HttpPostStandardRequestDecoder implements InterfaceHttpPostRequestD
                                 charset);
                         currentAttribute = factory.createAttribute(request, key);
                         firstpos = currentpos;
-                    } else if (read == '&' || !undecodedChunk.isReadable()) { // special empty FIELD
+                    } else if (read == '&' || (isLastChunk && !undecodedChunk.isReadable())) { // special empty FIELD
                         currentStatus = MultiPartStatus.DISPOSITION;
                         ampersandpos = read == '&' ? currentpos - 1 : currentpos;
                         String key = decodeAttribute(

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
@@ -426,7 +426,7 @@ public class HttpPostStandardRequestDecoder implements InterfaceHttpPostRequestD
                                 charset);
                         currentAttribute = factory.createAttribute(request, key);
                         firstpos = currentpos;
-                    } else if (read == '&'  || !undecodedChunk.isReadable()) { // special empty FIELD
+                    } else if (read == '&' || !undecodedChunk.isReadable()) { // special empty FIELD
                         currentStatus = MultiPartStatus.DISPOSITION;
                         ampersandpos = read == '&' ? currentpos - 1 : currentpos;
                         String key = decodeAttribute(
@@ -552,10 +552,9 @@ public class HttpPostStandardRequestDecoder implements InterfaceHttpPostRequestD
                                 charset);
                         currentAttribute = factory.createAttribute(request, key);
                         firstpos = currentpos;
-                    } else if (read == '&' || read == HttpConstants.CR ||
-                               read == HttpConstants.LF) { // special empty FIELD
+                    } else if (read == '&' || !undecodedChunk.isReadable()) { // special empty FIELD
                         currentStatus = MultiPartStatus.DISPOSITION;
-                        ampersandpos = currentpos - 1;
+                        ampersandpos = read == '&' ? currentpos - 1 : currentpos;
                         String key = decodeAttribute(
                                 undecodedChunk.toString(firstpos, ampersandpos - firstpos, charset), charset);
                         // Some weird request bodies start with an '&' char, eg: &name=J&age=17.

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoderTest.java
@@ -23,6 +23,7 @@ import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
 
@@ -57,6 +58,24 @@ class HttpPostStandardRequestDecoderTest {
         ByteBuf buf = Unpooled.wrappedBuffer(requestBody.getBytes(CharsetUtil.UTF_8));
         DefaultHttpContent httpContent = new DefaultLastHttpContent(buf);
         decoder.offer(httpContent);
+
+        assertEquals(1, decoder.getBodyHttpDatas().size());
+        assertMemoryAttribute(decoder.getBodyHttpData("key1"), "");
+        decoder.destroy();
+    }
+
+    @Test
+    void testDecodeSingleAttributeWithNoValueEmptyLast() {
+        String requestBody = "key1";
+
+        HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/upload");
+
+        HttpPostStandardRequestDecoder decoder = new HttpPostStandardRequestDecoder(httpDiskDataFactory(), request);
+        ByteBuf buf = Unpooled.wrappedBuffer(requestBody.getBytes(CharsetUtil.UTF_8));
+        DefaultHttpContent httpContent = new DefaultHttpContent(buf);
+        decoder.offer(httpContent);
+
+        decoder.offer(LastHttpContent.EMPTY_LAST_CONTENT);
 
         assertEquals(1, decoder.getBodyHttpDatas().size());
         assertMemoryAttribute(decoder.getBodyHttpData("key1"), "");

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoderTest.java
@@ -48,6 +48,92 @@ class HttpPostStandardRequestDecoderTest {
     }
 
     @Test
+    void testDecodeSingleAttributeWithNoValue() {
+        String requestBody = "key1";
+
+        HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/upload");
+
+        HttpPostStandardRequestDecoder decoder = new HttpPostStandardRequestDecoder(httpDiskDataFactory(), request);
+        ByteBuf buf = Unpooled.wrappedBuffer(requestBody.getBytes(CharsetUtil.UTF_8));
+        DefaultHttpContent httpContent = new DefaultLastHttpContent(buf);
+        decoder.offer(httpContent);
+
+        assertEquals(1, decoder.getBodyHttpDatas().size());
+        assertMemoryAttribute(decoder.getBodyHttpData("key1"), "");
+        decoder.destroy();
+    }
+
+    @Test
+    void testDecodeEndAttributeWithNoValue() {
+        String requestBody = "key1=value1&key2";
+
+        HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/upload");
+
+        HttpPostStandardRequestDecoder decoder = new HttpPostStandardRequestDecoder(httpDiskDataFactory(), request);
+        ByteBuf buf = Unpooled.wrappedBuffer(requestBody.getBytes(CharsetUtil.UTF_8));
+        DefaultHttpContent httpContent = new DefaultLastHttpContent(buf);
+        decoder.offer(httpContent);
+
+        assertEquals(2, decoder.getBodyHttpDatas().size());
+        assertMemoryAttribute(decoder.getBodyHttpData("key1"), "value1");
+        assertMemoryAttribute(decoder.getBodyHttpData("key2"), "");
+        decoder.destroy();
+    }
+
+    @Test
+    void testDecodeStartAttributeWithNoValue() {
+        String requestBody = "key1&key2=value2";
+
+        HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/upload");
+
+        HttpPostStandardRequestDecoder decoder = new HttpPostStandardRequestDecoder(httpDiskDataFactory(), request);
+        ByteBuf buf = Unpooled.wrappedBuffer(requestBody.getBytes(CharsetUtil.UTF_8));
+        DefaultHttpContent httpContent = new DefaultLastHttpContent(buf);
+        decoder.offer(httpContent);
+
+        assertEquals(2, decoder.getBodyHttpDatas().size());
+        assertMemoryAttribute(decoder.getBodyHttpData("key1"), "");
+        assertMemoryAttribute(decoder.getBodyHttpData("key2"), "value2");
+        decoder.destroy();
+    }
+
+    @Test
+    void testDecodeMultipleAttributesWithNoValue() {
+        String requestBody = "key1&key2&key3";
+
+        HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/upload");
+
+        HttpPostStandardRequestDecoder decoder = new HttpPostStandardRequestDecoder(httpDiskDataFactory(), request);
+        ByteBuf buf = Unpooled.wrappedBuffer(requestBody.getBytes(CharsetUtil.UTF_8));
+        DefaultHttpContent httpContent = new DefaultLastHttpContent(buf);
+        decoder.offer(httpContent);
+
+        assertEquals(3, decoder.getBodyHttpDatas().size());
+        assertMemoryAttribute(decoder.getBodyHttpData("key1"), "");
+        assertMemoryAttribute(decoder.getBodyHttpData("key2"), "");
+        assertMemoryAttribute(decoder.getBodyHttpData("key3"), "");
+        decoder.destroy();
+    }
+
+    @Test
+    void testDecodeNestedAttributeWithNoValue() {
+        String requestBody = "key1=value1&key2&key3=value3";
+
+        HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/upload");
+
+        HttpPostStandardRequestDecoder decoder = new HttpPostStandardRequestDecoder(httpDiskDataFactory(), request);
+        ByteBuf buf = Unpooled.wrappedBuffer(requestBody.getBytes(CharsetUtil.UTF_8));
+        DefaultHttpContent httpContent = new DefaultLastHttpContent(buf);
+        decoder.offer(httpContent);
+
+        assertEquals(3, decoder.getBodyHttpDatas().size());
+        assertMemoryAttribute(decoder.getBodyHttpData("key1"), "value1");
+        assertMemoryAttribute(decoder.getBodyHttpData("key2"), "");
+        assertMemoryAttribute(decoder.getBodyHttpData("key3"), "value3");
+        decoder.destroy();
+    }
+
+    @Test
     void testDecodeAttributesWithAmpersandPrefixSkipsNullAttribute() {
         String requestBody = "&key1=value1";
 


### PR DESCRIPTION
Motivation:

According to the specification for parsing of
application/x-www-form-urlencoded content at
https://url.spec.whatwg.org/#application/x-www-form-urlencoded, a key
without an = should be able to be parsed and given an empty value. The
current implementation of HttpPostStandardRequestDecoder fails to parse
these no-value keys when they are the last value in the sequence.

Modifications:

HttpPostStandardRequestDecoder is modified to include a key with no
value that is at the end of the undecoded chunk in the existing "special
empty FIELD" code path that currently only handles such fields when they
are followed by a '&' character.

Additional tests are provided to throroughly exercise variations of
content bodies with such empty fields.

A test has also been added to verify that the change works with an empty
last chunk, as suggested in the original PR #13904 

Result:

Keys with no value that appear at the end of a x-www-form-urlencoded
sequence will be parsed according to the spec.
