### PR TITLE
Add Java 22 build support

### DIFF
--- a/.github/workflows/ci-pr-reports.yml
+++ b/.github/workflows/ci-pr-reports.yml
@@ -42,6 +42,8 @@ jobs:
           - setup: linux-x86_64-java11-boringssl
           - setup: linux-x86_64-java17
           - setup: linux-x86_64-java18
+          - setup: linux-x86_64-java21
+          - setup: linux-x86_64-java22
           - setup: windows-x86_64-java11-boringssl
     continue-on-error: ${{ matrix.ignore-if-missing }}
     steps:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -180,6 +180,9 @@ jobs:
           - setup: linux-x86_64-java21
             docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.21.yaml build"
             docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.21.yaml run build-leak"
+          - setup: linux-x86_64-java22
+            docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.22.yaml build"
+            docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.22.yaml run build-leak"
           - setup: linux-x86_64-java11-boringssl
             docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.111.yaml build"
             docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.111.yaml run build-leak-boringssl-static"

--- a/docker/docker-compose.centos-6.22.yaml
+++ b/docker/docker-compose.centos-6.22.yaml
@@ -1,0 +1,27 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: netty:centos-6-22
+    build:
+      args:
+        java_version : "22.0.2-zulu"
+
+  build:
+    image: netty:centos-6-22
+
+  build-leak:
+    image: netty:centos-6-22
+
+  build-boringssl-static:
+    image: netty:centos-6-22
+
+  build-leak-boringssl-static:
+    image: netty:centos-6-22
+
+  build-boringssl-snapshot:
+    image: netty:centos-6-22
+
+  shell:
+    image: netty:centos-6-22

--- a/docker/docker-compose.centos-6.22.yaml
+++ b/docker/docker-compose.centos-6.22.yaml
@@ -6,7 +6,7 @@ services:
     image: netty:centos-6-22
     build:
       args:
-        java_version : "22.0.2-zulu"
+        java_version : "22-zulu"
 
   build:
     image: netty:centos-6-22

--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,30 @@
       </properties>
     </profile>
     <profile>
+      <id>java22</id>
+      <activation>
+        <jdk>22</jdk>
+      </activation>
+      <properties>
+        <!-- Not use alpn agent as Java11+ supports alpn out of the box -->
+        <argLine.alpnAgent />
+        <argLine.java9.extras />
+        <!-- Export some stuff which is used during our tests -->
+        <argLine.java9>--illegal-access=deny ${argLine.java9.extras}</argLine.java9>
+        <forbiddenapis.skip>true</forbiddenapis.skip>
+        <!-- 1.4.x does not work in Java10+ -->
+        <jboss.marshalling.version>2.0.5.Final</jboss.marshalling.version>
+        <!-- We need to use 1.8 as otherwise default methods are not picked up and so result in compile errors for
+             our EventExecutorGroup implementations
+        -->
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <!-- pax-exam does not work on latest Java12 EA 22 build -->
+        <skipOsgiTestsuite>true</skipOsgiTestsuite>
+        <revapi.skip>true</revapi.skip>
+      </properties>
+    </profile>
+    <profile>
       <id>java21</id>
       <activation>
         <jdk>21</jdk>


### PR DESCRIPTION
Motivation:

Java 22 has been released.

Modification:

Add a JDK 22 profile to the `pom.xml` file, and add JDK 22 to the PR build matrix.

Result:

We now build PRs on JDK 22, in addition to the existing Java versions.