### PR TITLE
Try to make cross-arch verification builds faster

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -158,7 +158,7 @@ jobs:
           #
           # Use tcnative.classifier that is empty as we don't support using the shared lib version on ubuntu.
           run: |
-            JAVA_HOME=/usr/lib/jvm/java-11-openjdk-${{ matrix.java_arch || matrix.arch }} ./mvnw -V -B -ntp -pl testsuite-native -am verify -Pfast -T1C -DskipNativeTestsuite=false -Dtcnative.classifier=
+            JAVA_HOME=/usr/lib/jvm/java-11-openjdk-${{ matrix.java_arch || matrix.arch }} ./mvnw -V -B -ntp -pl testsuite-native -am package -Pfast -DskipNativeTestsuite=false -Dtcnative.classifier=
 
   build-pr:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -158,7 +158,7 @@ jobs:
           #
           # Use tcnative.classifier that is empty as we don't support using the shared lib version on ubuntu.
           run: |
-            JAVA_HOME=/usr/lib/jvm/java-11-openjdk-${{ matrix.java_arch || matrix.arch }} ./mvnw -V -B -ntp -pl testsuite-native -am clean package -DskipTests=true -Dcheckstyle.skip=true -DskipNativeTestsuite=false -Dtcnative.classifier=
+            JAVA_HOME=/usr/lib/jvm/java-11-openjdk-${{ matrix.java_arch || matrix.arch }} ./mvnw -V -B -ntp -pl testsuite-native -am verify -Pfast -T1C -DskipNativeTestsuite=false -Dtcnative.classifier=
 
   build-pr:
     runs-on: ubuntu-latest

--- a/pom.xml
+++ b/pom.xml
@@ -561,6 +561,7 @@
         <japicmp.skip>true</japicmp.skip>
         <revapi.skip>true</revapi.skip>
         <xml.skip>true</xml.skip>
+        <animal.sniffer.skip>true</animal.sniffer.skip>
         <skipShadingTestsuite>true</skipShadingTestsuite>
         <skipDeploy>true</skipDeploy>
         <skipTests>true</skipTests>


### PR DESCRIPTION
Motivation:
The riscv64 build is the slowest part of our PR build.

Modification:
Tweak the build parameters to still run the native verification, but as little else as possible.

Result:
Faster PR build, hopefully.