### PR TITLE
[DOCUMENTATION] Make it clearer that MessageSizeEstimator is critical to get accurate backpressure

### DIFF
--- a/transport/src/main/java/io/netty/channel/Channel.java
+++ b/transport/src/main/java/io/netty/channel/Channel.java
@@ -157,18 +157,25 @@ public interface Channel extends AttributeMap, ChannelOutboundInvoker, Comparabl
      * requested write operation immediately.  Any write requests made when
      * this method returns {@code false} are queued until the I/O thread is
      * ready to process the queued write requests.
+     *
+     * {@link WriteBufferWaterMark} can be used to configure on which coundition 
+     * the write buffer would cause this channel to change writability.
      */
     boolean isWritable();
 
     /**
      * Get how many bytes can be written until {@link #isWritable()} returns {@code false}.
      * This quantity will always be non-negative. If {@link #isWritable()} is {@code false} then 0.
+     *
+     * {@link WriteBufferWaterMark} can be used to define writability settings.
      */
     long bytesBeforeUnwritable();
 
     /**
      * Get how many bytes must be drained from underlying buffers until {@link #isWritable()} returns {@code true}.
      * This quantity will always be non-negative. If {@link #isWritable()} is {@code true} then 0.
+     *
+     * {@link WriteBufferWaterMark} can be used to define writability settings.
      */
     long bytesBeforeWritable();
 

--- a/transport/src/main/java/io/netty/channel/Channel.java
+++ b/transport/src/main/java/io/netty/channel/Channel.java
@@ -158,7 +158,7 @@ public interface Channel extends AttributeMap, ChannelOutboundInvoker, Comparabl
      * this method returns {@code false} are queued until the I/O thread is
      * ready to process the queued write requests.
      *
-     * {@link WriteBufferWaterMark} can be used to configure on which coundition 
+     * {@link WriteBufferWaterMark} can be used to configure on which coundition
      * the write buffer would cause this channel to change writability.
      */
     boolean isWritable();

--- a/transport/src/main/java/io/netty/channel/Channel.java
+++ b/transport/src/main/java/io/netty/channel/Channel.java
@@ -158,7 +158,7 @@ public interface Channel extends AttributeMap, ChannelOutboundInvoker, Comparabl
      * this method returns {@code false} are queued until the I/O thread is
      * ready to process the queued write requests.
      *
-     * {@link WriteBufferWaterMark} can be used to configure on which coundition
+     * {@link WriteBufferWaterMark} can be used to configure on which condition
      * the write buffer would cause this channel to change writability.
      */
     boolean isWritable();

--- a/transport/src/main/java/io/netty/channel/WriteBufferWaterMark.java
+++ b/transport/src/main/java/io/netty/channel/WriteBufferWaterMark.java
@@ -29,6 +29,9 @@ import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
  * dropped down below the {@linkplain #low low water mark},
  * {@link Channel#isWritable()} will start to return
  * {@code true} again.
+ * <p>
+ * Note that messages needs to be handled by the {@link MessageSizeEstimator} 
+ * used by the channel for {@link Channel#isWritable()} to provide accurate back-pressure.
  */
 public final class WriteBufferWaterMark {
 

--- a/transport/src/main/java/io/netty/channel/WriteBufferWaterMark.java
+++ b/transport/src/main/java/io/netty/channel/WriteBufferWaterMark.java
@@ -30,7 +30,7 @@ import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
  * {@link Channel#isWritable()} will start to return
  * {@code true} again.
  * <p>
- * Note that messages needs to be handled by the {@link MessageSizeEstimator} 
+ * Note that messages needs to be handled by the {@link MessageSizeEstimator}
  * used by the channel for {@link Channel#isWritable()} to provide accurate back-pressure.
  */
 public final class WriteBufferWaterMark {


### PR DESCRIPTION
Motivation:

Without such warning it might be tricky to get backpressure right.

Modification:

Simple documentation

Result:

Simple documentation
