### PR TITLE
Increase maxFields for `HttpPostRequestDecoderTest.testChunkCorrect()`

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
@@ -322,7 +322,8 @@ public class HttpPostRequestDecoderTest {
         DefaultHttpRequest defaultHttpRequest =
                 new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/");
 
-        HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(defaultHttpRequest);
+        HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(defaultHttpRequest,
+                140, HttpPostRequestDecoder.DEFAULT_MAX_BUFFERED_BYTES);
 
         int firstChunk = 10;
         int middleChunk = 1024;


### PR DESCRIPTION
Motivation:

0d0c6ed introduced `maxFields` feature for
`HttpPostMultipartRequestDecoder` with default value set to 128. This is not enough for `HttpPostRequestDecoderTest.testChunkCorrect()` which uses 138 fields.

Modifications:

- Configure `HttpPostRequestDecoder` with `maxFields=140` for `HttpPostRequestDecoderTest.testChunkCorrect()`;

Result:

Test passes as expected.

---
Example: https://github.com/netty/netty/pull/13919/checks?check_run_id=22957650659
