### PR TITLE
Fix 13926: Added SslHandshakeTimeoutException create instance for test

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslHandshakeTimeoutException.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandshakeTimeoutException.java
@@ -22,6 +22,8 @@ import javax.net.ssl.SSLHandshakeException;
  */
 public final class SslHandshakeTimeoutException extends SSLHandshakeException {
 
+    public static final SslHandshakeTimeoutException TEST_EXCEPTION =
+            new SslHandshakeTimeoutException("Simulated handshake timed out");
     SslHandshakeTimeoutException(String reason) {
         super(reason);
     }

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandshakeTimeoutException.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandshakeTimeoutException.java
@@ -22,9 +22,7 @@ import javax.net.ssl.SSLHandshakeException;
  */
 public final class SslHandshakeTimeoutException extends SSLHandshakeException {
 
-    public static final SslHandshakeTimeoutException TEST_EXCEPTION =
-            new SslHandshakeTimeoutException("Simulated handshake timed out");
-    SslHandshakeTimeoutException(String reason) {
+    public SslHandshakeTimeoutException(String reason) {
         super(reason);
     }
 }


### PR DESCRIPTION
Motivation:
During our testing phase, I encountered a challenge with the SslHandshakeTimeoutException as its constructor was protected, making it inaccessible for direct instantiation within our test suite. This limitation prevented thorough testing of scenarios involving SSL handshake timeouts. To address this, I've introduced TEST_EXCEPTION as a workaround, allowing us to simulate SslHandshakeTimeoutException instances within our tests effectively.

Modification:
Recognizing the need for comprehensive test coverage, I've introduced TEST_EXCEPTION as a placeholder for creating instances of SslHandshakeTimeoutException within our test module. This modification enables us to properly simulate and test scenarios related to SSL handshake timeouts, thereby enhancing the robustness and effectiveness of our test suite.

Result:
Fixes #13926. 

This pull request resolves the challenge of inaccessible constructors for SslHandshakeTimeoutException within our test suite by introducing TEST_EXCEPTION for testing purposes. With this enhancement, we can now thoroughly test and validate scenarios involving SSL handshake timeouts, ensuring the reliability and effectiveness of our tests.


