### PR TITLE
Rewrite ZstdDecoder to remove the need of allocate a huge byte[] inte…

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/ZstdDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/ZstdDecoder.java
@@ -146,7 +146,7 @@ public final class ZstdDecoder extends ByteToMessageDecoder {
                 assert inNioBuffer.hasRemaining();
                 current = inNioBuffer;
 
-                // allocate the outBuffer based on what we expect from the decompressingStrean.
+                // allocate the outBuffer based on what we expect from the decompressingStream.
                 if (direct) {
                     outBuffer = alloc.directBuffer(outCapacity);
                 } else {

--- a/codec/src/main/java/io/netty/handler/codec/compression/ZstdDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/ZstdDecoder.java
@@ -16,7 +16,6 @@
 package io.netty.handler.codec.compression;
 
 import com.github.luben.zstd.BaseZstdBufferDecompressingStreamNoFinalizer;
-import com.github.luben.zstd.ZstdBufferDecompressingStream;
 import com.github.luben.zstd.ZstdBufferDecompressingStreamNoFinalizer;
 import com.github.luben.zstd.ZstdDirectBufferDecompressingStreamNoFinalizer;
 import io.netty.buffer.ByteBuf;
@@ -37,7 +36,7 @@ public final class ZstdDecoder extends ByteToMessageDecoder {
     {
         try {
             Zstd.ensureAvailability();
-            outCapacity = ZstdBufferDecompressingStream.recommendedTargetBufferSize();
+            outCapacity = ZstdBufferDecompressingStreamNoFinalizer.recommendedTargetBufferSize();
         } catch (Throwable throwable) {
             throw new ExceptionInInitializerError(throwable);
         }
@@ -191,11 +190,8 @@ public final class ZstdDecoder extends ByteToMessageDecoder {
             return null;
         }
 
-        private ByteBuffer refill(ByteBuffer toRefill) {
-            if (toRefill != current) {
-                return current;
-            }
-            return toRefill;
+        private ByteBuffer refill(@SuppressWarnings("unused") ByteBuffer toRefill) {
+            return current;
         }
 
         void close() {


### PR DESCRIPTION
…rnally

Motivation:

We can just use our own buffering that is provided by ByteToMessageDecoder to reduce the GC pressure and memory overhead.

Modifications:

Rewrite our ZstdDecoder to reduce extra buffering.

Result:

Obsolate https://github.com/netty/netty/pull/13911
