### PR TITLE
Improve `ByteBufUtil#firstIndexOf`

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -594,9 +594,9 @@ public final class ByteBufUtil {
         for (int i = 0; i < longCount; i++) {
             // use the faster available getLong
             final long word = useLE? buffer._getLongLE(offset) : buffer._getLong(offset);
-            int index = SWARUtil.firstAnyPattern(word, pattern, isNative);
-            if (index < Long.BYTES) {
-                return offset + index;
+            final long result = SWARUtil.applyPattern(word, pattern);
+            if (result != 0) {
+                return offset + SWARUtil.getIndex(result, isNative);
             }
             offset += Long.BYTES;
         }

--- a/common/src/main/java/io/netty/util/internal/SWARUtil.java
+++ b/common/src/main/java/io/netty/util/internal/SWARUtil.java
@@ -29,14 +29,31 @@ public final class SWARUtil {
 
     /**
      * Applies a compiled pattern to given word.
-     * Returns the index of the first occurrence of byte that specified in the pattern.
+     * Returns a word where each byte that matches the pattern has the highest bit set.
+     *
+     * @param word    the word to apply the pattern to
+     * @param pattern the pattern to apply
+     * @return a word where each byte that matches the pattern has the highest bit set
      */
-    public static int firstAnyPattern(long word, long pattern, boolean leading) {
+    public static long applyPattern(final long word, final long pattern) {
         long input = word ^ pattern;
         long tmp = (input & 0x7F7F7F7F7F7F7F7FL) + 0x7F7F7F7F7F7F7F7FL;
-        tmp = ~(tmp | input | 0x7F7F7F7F7F7F7F7FL);
-        final int binaryPosition = leading? Long.numberOfLeadingZeros(tmp) : Long.numberOfTrailingZeros(tmp);
-        return binaryPosition >>> 3;
+        return ~(tmp | input | 0x7F7F7F7F7F7F7F7FL);
+    }
+
+    /**
+     * Returns the index of the first occurrence of byte that specificied in the pattern.
+     * If no pattern is found, returns 8.
+     *
+     * @param word     the return value of {@link #applyPattern(long, long)}
+     * @param isBigEndian if true, if given word is big endian
+     *                 if false, if given word is little endian
+     * @return the index of the first occurrence of the specified pattern in the specified word.
+     * If no pattern is found, returns 8.
+     */
+    public static int getIndex(final long word, final boolean isBigEndian) {
+        final int zeros = isBigEndian? Long.numberOfLeadingZeros(word) : Long.numberOfTrailingZeros(word);
+        return zeros >>> 3;
     }
 
     /**


### PR DESCRIPTION
Motivation:
Enhance performance by optimizing the sequence of operations. This can be achieved by checking the existence of the set bit before attempting to find its index.

Modifications:
Prioritize the detection of the set bit's presence before retrieving its specific index.

Result:
Improved performance.