### PR TITLE
Fix the byte condition in AsciiStringUtil.unrolledToLowerCase

### DIFF
--- a/common/src/main/java/io/netty/util/AsciiStringUtil.java
+++ b/common/src/main/java/io/netty/util/AsciiStringUtil.java
@@ -131,6 +131,7 @@ final class AsciiStringUtil {
             offset += Short.BYTES;
         }
 
+        // this is equivalent to byteCount >= Byte.BYTES
         if ((byteCount & Byte.BYTES) != 0) {
             PlatformDependent.putByte(dst, dstOffset + offset,
                                       toLowerCase(PlatformDependent.getByte(src, srcPos + offset)));

--- a/common/src/main/java/io/netty/util/AsciiStringUtil.java
+++ b/common/src/main/java/io/netty/util/AsciiStringUtil.java
@@ -131,7 +131,7 @@ final class AsciiStringUtil {
             offset += Short.BYTES;
         }
 
-        if ((byteCount & 1) != Byte.BYTES) {
+        if ((byteCount & Byte.BYTES) != 0) {
             PlatformDependent.putByte(dst, dstOffset + offset,
                                       toLowerCase(PlatformDependent.getByte(src, srcPos + offset)));
         }

--- a/common/src/main/java/io/netty/util/AsciiStringUtil.java
+++ b/common/src/main/java/io/netty/util/AsciiStringUtil.java
@@ -131,7 +131,7 @@ final class AsciiStringUtil {
             offset += Short.BYTES;
         }
 
-        // this is equivalent to byteCount >= Byte.BYTES
+        // this is equivalent to byteCount >= Byte.BYTES (i.e. whether byteCount is odd)
         if ((byteCount & Byte.BYTES) != 0) {
             PlatformDependent.putByte(dst, dstOffset + offset,
                                       toLowerCase(PlatformDependent.getByte(src, srcPos + offset)));

--- a/common/src/test/java/io/netty/util/AsciiStringCharacterTest.java
+++ b/common/src/test/java/io/netty/util/AsciiStringCharacterTest.java
@@ -441,6 +441,12 @@ public class AsciiStringCharacterTest {
     }
 
     @Test
+    public void testToLowerCaseForOddLengths() {
+        AsciiString foo = AsciiString.of("This is a test!");
+        assertEquals("this is a test!", foo.toLowerCase().toString());
+    }
+
+    @Test
     public void testToUpperCase() {
         AsciiString foo = AsciiString.of("This is a tesT");
         assertEquals("THIS IS A TEST", foo.toUpperCase().toString());


### PR DESCRIPTION
Motivation:
#13913 breaks the `toLowerCase` conversion when the string's length is odd.

Modifications:
- Fix the byte condition in `AsciiStringUtil.unrolledToLowerCase`
- Add JUnit test

Result:
`toLowerCase` conversion works.