### PR TITLE
Fix methods AsciiStringUtil.toLowerCas/toUpperCase to properly offset the src array's starting index

### DIFF
--- a/common/src/main/java/io/netty/util/AsciiStringUtil.java
+++ b/common/src/main/java/io/netty/util/AsciiStringUtil.java
@@ -101,7 +101,7 @@ final class AsciiStringUtil {
         final int longCount = length >>> 3;
         int offset = 0;
         for (int i = 0; i < longCount; ++i) {
-            final long word = PlatformDependent.getLong(src, srcOffset);
+            final long word = PlatformDependent.getLong(src, srcOffset + offset);
             PlatformDependent.putLong(dst, offset, SWARUtil.toLowerCase(word));
             offset += Long.BYTES;
         }
@@ -216,7 +216,7 @@ final class AsciiStringUtil {
         final int longCount = length >>> 3;
         int offset = 0;
         for (int i = 0; i < longCount; ++i) {
-            final long word = PlatformDependent.getLong(src, srcOffset);
+            final long word = PlatformDependent.getLong(src, srcOffset + offset);
             PlatformDependent.putLong(dst, offset, SWARUtil.toUpperCase(word));
             offset += Long.BYTES;
         }

--- a/common/src/test/java/io/netty/util/AsciiStringCharacterTest.java
+++ b/common/src/test/java/io/netty/util/AsciiStringCharacterTest.java
@@ -447,8 +447,20 @@ public class AsciiStringCharacterTest {
     }
 
     @Test
+    public void testToLowerCaseLong() {
+        AsciiString foo = AsciiString.of("This is a test for longer sequences");
+        assertEquals("this is a test for longer sequences", foo.toLowerCase().toString());
+    }
+
+    @Test
     public void testToUpperCase() {
         AsciiString foo = AsciiString.of("This is a tesT");
         assertEquals("THIS IS A TEST", foo.toUpperCase().toString());
+    }
+
+    @Test
+    public void testToUpperCaseLong() {
+        AsciiString foo = AsciiString.of("This is a test for longer sequences");
+        assertEquals("THIS IS A TEST FOR LONGER SEQUENCES", foo.toUpperCase().toString());
     }
 }


### PR DESCRIPTION
Motivation:
#13913 fails to properly convert strings of length longer than 16 characters to lowercase/uppercase. The current algorithm doesn’t offset the src array's starting index leading to duplication and loss of data.

Modifications:
- Fix the logic behind methods `AsciiStringUtil.toLowerCase` and `AsciiStringUtil.toUpperCase` to properly offset the starting index
- Add JUnit tests

Result: Conversions work.