### PR TITLE
Fix NioSocketChannel usage in graalvm native-image

### DIFF
--- a/transport/src/main/resources/META-INF/native-image/io.netty/netty-transport/reflect-config.json
+++ b/transport/src/main/resources/META-INF/native-image/io.netty/netty-transport/reflect-config.json
@@ -6,6 +6,12 @@
       ]
     },
     {
+      "name": "io.netty.channel.socket.nio.NioSocketChannel",
+      "methods": [
+        { "name": "<init>", "parameterTypes": [] }
+      ]
+    },
+    {
       "name": "sun.nio.ch.SelectorImpl",
       "fields": [
         { "name": "selectedKeys",  "allowUnsafeAccess" : true},


### PR DESCRIPTION
Motivation:

Using NioSocketChannel is currently broken in graalvm native-image builds. Trying to use it throws:
java.lang.NoSuchMethodException: io.netty.channel.socket.nio.NioSocketChannel.<init>()

Modification:
Add it to the graalvm metadata json

Result:
Graalvm will include this method as reachable via reflection.
