### PR TITLE
Avoid copying of MqttPublishMessage.payload byte buffer

### DIFF
--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttEncoder.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttEncoder.java
@@ -424,7 +424,7 @@ public final class MqttEncoder extends MessageToMessageEncoder<MqttMessage> {
         MqttVersion mqttVersion = getMqttVersion(ctx);
         MqttFixedHeader mqttFixedHeader = message.fixedHeader();
         MqttPublishVariableHeader variableHeader = message.variableHeader();
-        ByteBuf payload = message.payload().duplicate();
+        ByteBuf payload = message.payload();
 
         String topicName = variableHeader.topicName();
         int topicNameBytes = utf8Bytes(topicName);

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttMessageBuilders.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttMessageBuilders.java
@@ -73,7 +73,7 @@ public final class MqttMessageBuilders {
             MqttFixedHeader mqttFixedHeader = new MqttFixedHeader(MqttMessageType.PUBLISH, false, qos, retained, 0);
             MqttPublishVariableHeader mqttVariableHeader =
                     new MqttPublishVariableHeader(topic, messageId, mqttProperties);
-            return new MqttPublishMessage(mqttFixedHeader, mqttVariableHeader, Unpooled.buffer().writeBytes(payload));
+            return new MqttPublishMessage(mqttFixedHeader, mqttVariableHeader, payload);
         }
     }
 

--- a/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
+++ b/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
@@ -276,6 +276,8 @@ public class MqttCodecTest {
     @Test
     public void testPublishMessage() throws Exception {
         final MqttPublishMessage message = createPublishMessage();
+        ByteBuf payload = message.payload().copy();
+
         ByteBuf byteBuf = MqttEncoder.doEncode(ctx, message);
 
         mqttDecoder.channelRead(ctx, byteBuf);
@@ -285,7 +287,7 @@ public class MqttCodecTest {
         final MqttPublishMessage decodedMessage = (MqttPublishMessage) out.get(0);
         validateFixedHeaders(message.fixedHeader(), decodedMessage.fixedHeader());
         validatePublishVariableHeader(message.variableHeader(), decodedMessage.variableHeader());
-        validatePublishPayload(message.payload(), decodedMessage.payload());
+        validatePublishPayload(payload, decodedMessage.payload());
     }
 
     @Test
@@ -600,6 +602,8 @@ public class MqttCodecTest {
         assertEquals(3,
                 ((MqttProperties.UserProperties) props.getProperty(USER_PROPERTY.value())).value.size());
         final MqttPublishMessage message = createPublishMessage(props);
+        ByteBuf payload = message.payload().copy();
+
         ByteBuf byteBuf = MqttEncoder.doEncode(ctx, message);
 
         mqttDecoder.channelRead(ctx, byteBuf);
@@ -609,7 +613,7 @@ public class MqttCodecTest {
         final MqttPublishMessage decodedMessage = (MqttPublishMessage) out.get(0);
         validateFixedHeaders(message.fixedHeader(), decodedMessage.fixedHeader());
         validatePublishVariableHeader(message.variableHeader(), decodedMessage.variableHeader());
-        validatePublishPayload(message.payload(), decodedMessage.payload());
+        validatePublishPayload(payload, decodedMessage.payload());
     }
 
     @Test


### PR DESCRIPTION
Motivation:
`MqttMessageBuilders` make unnecessary copies of Publish message payload,which takes up extra CPU and memory.
Most user cases allow avoiding this.

Modification:
Remove payload copying in `MqttMessageBuilders.PublishBuilder` and duplicating in `MqttEncoder`.

Result:
Less CPU and memory usage.

Fixes #13844 
