### PR TITLE
Fix C portability issues

### DIFF
--- a/transport-native-epoll/src/main/c/netty_epoll_linuxsocket.c
+++ b/transport-native-epoll/src/main/c/netty_epoll_linuxsocket.c
@@ -163,10 +163,10 @@ static void netty_epoll_linuxsocket_setTimeToLive(JNIEnv* env, jclass clazz, jin
 
 static void netty_epoll_linuxsocket_setIpMulticastLoop(JNIEnv* env, jclass clazz, jint fd, jboolean ipv6, jint optval) {
     if (ipv6 == JNI_TRUE) {
-        u_int val = (u_int) optval;
+        unsigned int val = (u_int) optval;
         netty_unix_socket_setOption(env, fd, IPPROTO_IPV6, IPV6_MULTICAST_LOOP, &val, sizeof(val));
     } else {
-        u_char val = (u_char) optval;
+        unsigned char val = (unsigned char) optval;
         netty_unix_socket_setOption(env, fd, IPPROTO_IP, IP_MULTICAST_LOOP, &val, sizeof(val));
     }
 }
@@ -538,13 +538,13 @@ static jint netty_epoll_linuxsocket_getTimeToLive(JNIEnv* env, jclass clazz, jin
 
 static jint netty_epoll_linuxsocket_getIpMulticastLoop(JNIEnv* env, jclass clazz, jint fd, jboolean ipv6) {
     if (ipv6 == JNI_TRUE) {
-        u_int optval;
+        unsigned int optval;
         if (netty_unix_socket_getOption(env, fd, IPPROTO_IPV6, IPV6_MULTICAST_LOOP, &optval, sizeof(optval)) == -1) {
             return -1;
         }
         return (jint) optval;
     } else {
-        u_char optval;
+        unsigned char optval;
         if (netty_unix_socket_getOption(env, fd, IPPROTO_IP, IP_MULTICAST_LOOP, &optval, sizeof(optval)) == -1) {
             return -1;
         }

--- a/transport-native-epoll/src/main/c/netty_epoll_linuxsocket.c
+++ b/transport-native-epoll/src/main/c/netty_epoll_linuxsocket.c
@@ -163,7 +163,7 @@ static void netty_epoll_linuxsocket_setTimeToLive(JNIEnv* env, jclass clazz, jin
 
 static void netty_epoll_linuxsocket_setIpMulticastLoop(JNIEnv* env, jclass clazz, jint fd, jboolean ipv6, jint optval) {
     if (ipv6 == JNI_TRUE) {
-        unsigned int val = (u_int) optval;
+        unsigned int val = (unsigned int) optval;
         netty_unix_socket_setOption(env, fd, IPPROTO_IPV6, IPV6_MULTICAST_LOOP, &val, sizeof(val));
     } else {
         unsigned char val = (unsigned char) optval;

--- a/transport-native-epoll/src/main/c/netty_epoll_native.c
+++ b/transport-native-epoll/src/main/c/netty_epoll_native.c
@@ -86,7 +86,7 @@
 extern int epoll_create1(int flags) __attribute__((weak));
 extern int epoll_pwait2(int epfd, struct epoll_event *events, int maxevents, const struct timespec *timeout, const sigset_t *sigmask) __attribute__((weak));
 
-#ifndef __USE_GNU
+#ifndef _GNU_SOURCE
 struct mmsghdr {
     struct msghdr msg_hdr;  /* Message header */
     unsigned int  msg_len;  /* Number of bytes transmitted */


### PR DESCRIPTION
Motivation:
Some GNU-isms had snuck into our Linux-specific C code, which meant we required glibc to compile.

There is really not any reason to limit ourselves to that, though glibc is obviously very popular, so is musl-libc.

Modification:
Use correct feature-test macros for defining `mmsghdr` on BSDs, and use portable `unsigned char` and `unsigned int` instead of non-portable `u_char` and `u_int`.

Result:
We can now compile on Linux distros that don't use glibc, such as Alpine.