### PR TITLE
Add devcontainers for Linux

### DIFF
--- a/.devcontainer/alpine/Dockerfile
+++ b/.devcontainer/alpine/Dockerfile
@@ -1,0 +1,6 @@
+FROM mcr.microsoft.com/devcontainers/base:alpine
+RUN apk -U upgrade && apk add \
+    autoconf automake linux-headers libtool make tar libaio-dev openssl-dev apr-dev gcc \
+    mandoc man-pages autoconf-doc automake-doc libtool-doc make-doc tar-doc gcc-doc \
+    perf perf-bash-completion htop htop-doc strace strace-doc ripgrep ripgrep-doc \
+    openjdk21-jdk openjdk21-doc openjdk21-src maven

--- a/.devcontainer/alpine/devcontainer.json
+++ b/.devcontainer/alpine/devcontainer.json
@@ -1,0 +1,10 @@
+{
+  name: "netty-on-alpine",
+  containerEnv: {
+    JAVA_HOME: "/usr/lib/jvm/default-jvm",
+    CPATH: "/usr/lib/jvm/default-jvm/include/:/usr/lib/jvm/default-jvm/include/linux/"
+  },
+  build: {
+    dockerfile: "Dockerfile",
+  }
+}

--- a/.devcontainer/ubuntu/Dockerfile
+++ b/.devcontainer/ubuntu/Dockerfile
@@ -1,0 +1,5 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu
+RUN apt-get update && apt-get install -y \
+    autotools-dev autoconf automake libtool make tar libaio-dev libssl-dev libapr1-dev lksctp-tools gcc \
+    htop strace \
+    openjdk-21-jdk-headless openjdk-21-source

--- a/.devcontainer/ubuntu/devcontainer.json
+++ b/.devcontainer/ubuntu/devcontainer.json
@@ -1,0 +1,9 @@
+{
+  name: "netty-on-ubuntu",
+  containerEnv: {
+    CPATH: "/usr/lib/jvm/java-21-openjdk-arm64/include/:/usr/lib/jvm/java-21-openjdk-arm64/include/linux/"
+  },
+  build: {
+    dockerfile: "Dockerfile"
+  }
+}


### PR DESCRIPTION
Motivation:
Linux is the most important deployment OS, but a significant amount of development takes place on Windows and MacOS. Devcontainers allow developers to quickly spin up a Docker container, to run their IDE inside a native Linux environment. This is helpful for debugging and testing.
Intellij IDEA Ultimate and Visual Studio Code both have support for devcontainers.

Modifications:
Add devcontainer spec files for Alpine (a musl-libc environment) and Ubuntu (a glibc environment).

Result:
It's now possible to run an IDE in a Linux devcontainer environment on Windows and MacOS. Although, I have only actually tested this with Intellij IDEA on MacOS. Actual IDE support may vary across IDEs and platforms. For instance, Intellij IDEA does not support Alpine because the JetBrainsRuntime (a vendored JDK) does not provide musl-libc compatible builds.