### PR TITLE
Fix property names

### DIFF
--- a/microbench/src/main/java/io/netty5/microbench/snappy/package-info.java
+++ b/microbench/src/main/java/io/netty5/microbench/snappy/package-info.java
@@ -14,6 +14,6 @@
  * under the License.
  */
 /**
- * Benchmarks for Snappy ({@link io.netty.handler.codec.compression.Snappy}).
+ * Benchmarks for Snappy ({@link io.netty5.handler.codec.compression.Snappy}).
  */
 package io.netty5.microbench.snappy;

--- a/microbench/src/main/java/io/netty5/util/AsciiStringCaseConversionBenchmark.java
+++ b/microbench/src/main/java/io/netty5/util/AsciiStringCaseConversionBenchmark.java
@@ -61,7 +61,7 @@ public class AsciiStringCaseConversionBenchmark {
 
     @Setup(Level.Trial)
     public void init() {
-        System.setProperty("io.netty.noUnsafe", Boolean.valueOf(noUnsafe).toString());
+        System.setProperty("io.netty5.noUnsafe", Boolean.valueOf(noUnsafe).toString());
         final SplittableRandom random = new SplittableRandom(seed);
         permutations = 1 << logPermutations;
         ret = new byte[size];

--- a/resolver-dns/src/main/java/io/netty5/resolver/dns/DnsQueryContext.java
+++ b/resolver-dns/src/main/java/io/netty5/resolver/dns/DnsQueryContext.java
@@ -54,8 +54,8 @@ abstract class DnsQueryContext {
 
     static {
         ID_REUSE_ON_TIMEOUT_DELAY_MILLIS =
-                SystemPropertyUtil.getLong("io.netty.resolver.dns.idReuseOnTimeoutDelayMillis", 10000);
-        logger.debug("-Dio.netty.resolver.dns.idReuseOnTimeoutDelayMillis: {}", ID_REUSE_ON_TIMEOUT_DELAY_MILLIS);
+                SystemPropertyUtil.getLong("io.netty5.resolver.dns.idReuseOnTimeoutDelayMillis", 10000);
+        logger.debug("-Dio.netty5.resolver.dns.idReuseOnTimeoutDelayMillis: {}", ID_REUSE_ON_TIMEOUT_DELAY_MILLIS);
     }
 
     private static final TcpDnsQueryEncoder TCP_ENCODER = new TcpDnsQueryEncoder();

--- a/transport/src/main/java/io/netty5/bootstrap/ChannelInitializerExtensions.java
+++ b/transport/src/main/java/io/netty5/bootstrap/ChannelInitializerExtensions.java
@@ -39,7 +39,7 @@ abstract class ChannelInitializerExtensions {
 
     /**
      * Get the configuration extensions, which is a no-op implementation by default,
-     * or a service-loading implementation if the {@code io.netty.bootstrap.extensions} system property is
+     * or a service-loading implementation if the {@code io.netty5.bootstrap.extensions} system property is
      * {@code serviceload}.
      */
     static ChannelInitializerExtensions getExtensions() {


### PR DESCRIPTION
Motivation:
Old property name(`io.netty.*`)is used

Modifications:
Replaced `io.netty.*` -> `io.netty5.*`

Result:
Clean up