### PR TITLE
Support bc-fips in BouncyCastleSelfSignedCertGenerator

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/util/SelfSignedCertificate.java
+++ b/handler/src/main/java/io/netty/handler/ssl/util/SelfSignedCertificate.java
@@ -409,6 +409,7 @@ public final class SelfSignedCertificate {
 
     private static boolean isBouncyCastleAvailable() {
         try {
+            // this class is in bcpkix, both fips and non-fips
             Class.forName("org.bouncycastle.cert.X509v3CertificateBuilder");
             return true;
         } catch (ClassNotFoundException e) {

--- a/handler/src/main/resources/META-INF/native-image/io.netty/netty-handler/generated/handlers/reflect-config.json
+++ b/handler/src/main/resources/META-INF/native-image/io.netty/netty-handler/generated/handlers/reflect-config.json
@@ -635,19 +635,5 @@
       "typeReachable": "io.netty.handler.traffic.GlobalTrafficShapingHandler"
     },
     "queryAllPublicMethods": true
-  },
-  {
-    "name": "org.bouncycastle.jcajce.provider.BouncyCastleProvider",
-    "condition": {
-      "typeReachable": "org.bouncycastle.jcajce.provider.BouncyCastleProvider"
-    },
-    "allPublicConstructors": true
-  },
-  {
-    "name": "org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider",
-    "condition": {
-      "typeReachable": "org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider"
-    },
-    "allPublicConstructors": true
   }
 ]

--- a/handler/src/main/resources/META-INF/native-image/io.netty/netty-handler/generated/handlers/reflect-config.json
+++ b/handler/src/main/resources/META-INF/native-image/io.netty/netty-handler/generated/handlers/reflect-config.json
@@ -635,5 +635,19 @@
       "typeReachable": "io.netty.handler.traffic.GlobalTrafficShapingHandler"
     },
     "queryAllPublicMethods": true
+  },
+  {
+    "name": "org.bouncycastle.jcajce.provider.BouncyCastleProvider",
+    "condition": {
+      "typeReachable": "org.bouncycastle.jcajce.provider.BouncyCastleProvider"
+    },
+    "allPublicConstructors": true
+  },
+  {
+    "name": "org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider",
+    "condition": {
+      "typeReachable": "org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider"
+    },
+    "allPublicConstructors": true
   }
 ]

--- a/handler/src/main/resources/META-INF/native-image/io.netty/netty-handler/reflect-config.json
+++ b/handler/src/main/resources/META-INF/native-image/io.netty/netty-handler/reflect-config.json
@@ -1,0 +1,28 @@
+[
+  {
+    "name": "org.bouncycastle.jce.provider.BouncyCastleProvider",
+    "condition": {
+      "typeReachable": "org.bouncycastle.jcajce.provider.BouncyCastleProvider"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider",
+    "condition": {
+      "typeReachable": "org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Motivation:

When using the bouncycastle FIPS dependencies (bcpkix-fips instead of bcpkix, and bc-fips instead of bcprov), BouncyCastleProvider is replaced by BouncyCastleFipsProvider. This made BouncyCastleSelfSignedCertGenerator fail even though all the necessary algorithms are present.

While bc-fips is only necessary for fips-compliant production deployments, and self-signed certs are only necessary in test deployments that don't have to be fips-compliant, this change is still useful because the fips and non-fips artifacts cannot exist alongside each other. So if you have a prod fips dependency, tests that also have a non-fips dependency for self-signed certs cannot live alongside each other. It's easiest to just use the fips dependency everywhere.

Modification:

Use reflection in BouncyCastleSelfSignedCertGenerator to instantiate whichever provider is available. This has the advantage of not needing a new dependency, though it may have some impact on native image deployments. For this reason I've also added the providers to the reflect-config.json.

No test is possible because it would require a different classpath. I tested manually that it works by changing to the fips dependencies and then running SelfSignedCertificateTest, and checking with a debugger that the correct provider was used.

Result:

SelfSignedCertificate will work with bc-fips dependencies.