### PR TITLE
Refactor file descriptor handling in openFileDescriptors()

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
@@ -137,31 +137,21 @@ public class EpollEventLoop extends SingleThreadEventLoop {
             success = true;
         } finally {
             if (!success) {
-                if (epollFd != null) {
-                    try {
-                        epollFd.close();
-                    } catch (Exception e) {
-                        // ignore
-                    }
-                }
-                if (eventFd != null) {
-                    try {
-                        eventFd.close();
-                    } catch (Exception e) {
-                        // ignore
-                    }
-                }
-                if (timerFd != null) {
-                    try {
-                        timerFd.close();
-                    } catch (Exception e) {
-                        // ignore
-                    }
-                }
+                closeFileDescriptor(epollFd);
+                closeFileDescriptor(eventFd);
+                closeFileDescriptor(timerFd);
             }
         }
     }
-
+    private static void closeFileDescriptor(FileDescriptor fd) {
+        if (fd != null) {
+            try {
+                fd.close();
+            } catch (Exception e) {
+                // ignore
+            }
+        }
+    }
     private static Queue<Runnable> newTaskQueue(
             EventLoopTaskQueueFactory queueFactory) {
         if (queueFactory == null) {

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
@@ -153,6 +153,7 @@ public class EpollEventLoop extends SingleThreadEventLoop {
             }
         }
     }
+
     private static Queue<Runnable> newTaskQueue(
             EventLoopTaskQueueFactory queueFactory) {
         if (queueFactory == null) {

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
@@ -143,6 +143,7 @@ public class EpollEventLoop extends SingleThreadEventLoop {
             }
         }
     }
+
     private static void closeFileDescriptor(FileDescriptor fd) {
         if (fd != null) {
             try {


### PR DESCRIPTION
Motivation:

The motivation behind this change is to enhance the readability and maintainability of the codebase by refactoring the file descriptor handling in the openFileDescriptors method. By extracting the logic for closing file descriptors into a separate method, closeFileDescriptor, 

Modification:

In this commit, I have refactored the openFileDescriptors method by extracting the code responsible for closing file descriptors into a separate method, closeFileDescriptor. 

Result:

This PR introduces improved code organization and readability by separating the concerns of opening and closing file descriptors in the openFileDescriptors method. It does not introduce any functional changes.
