### PR TITLE
Fix a buffer leak in StreamBufferingEncoderTest

### DIFF
--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/StreamBufferingEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/StreamBufferingEncoderTest.java
@@ -530,8 +530,10 @@ public class StreamBufferingEncoderTest {
 
     private void testStreamId(int nextStreamId) throws Http2Exception {
         connection.local().createStream(nextStreamId, false);
-        Future<Void> channelFuture = encoder.writeData(ctx, nextStreamId, empty(), 0, false);
-        assertFalse(channelFuture.isFailed());
+        try (Buffer empty = empty()) {
+            Future<Void> channelFuture = encoder.writeData(ctx, nextStreamId, empty, 0, false);
+            assertFalse(channelFuture.isFailed());
+        }
     }
 
     private void setMaxConcurrentStreams(int newValue) {


### PR DESCRIPTION
Motivation:
We should always avoid leaks.

Modification:
Close the allocated buffer after we're done with it.

Result:
No more leak being reported for the codec-http2 module tests.