### PR TITLE
Fix a buffer leak in LoggingHandlerTest

### DIFF
--- a/handler/src/test/java/io/netty5/handler/logging/LoggingHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/logging/LoggingHandlerTest.java
@@ -568,9 +568,10 @@ public class LoggingHandlerTest {
             channel.writeInbound(msg.copy());
             appender.verify(new RegexLogMatcher(".+READ: 0B", false));
 
-            Buffer handledMsg = channel.readInbound();
-            assertEquals(msg, handledMsg);
-            assertThat(channel.readInbound(), is(nullValue()));
+            try (Buffer handledMsg = channel.readInbound()) {
+                assertEquals(msg, handledMsg);
+                assertThat(channel.readInbound(), is(nullValue()));
+            }
         }
     }
 


### PR DESCRIPTION
Motivation:
We should always avoid leaks.

Modification:
Close the buffer copy we get back from channel.readInbound().

Result:
No more leak being reported for the handler module tests.