### PR TITLE
Limit the number of Continuation frames per HTTP2 Headers

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2ConnectionHandlerBuilder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2ConnectionHandlerBuilder.java
@@ -112,6 +112,8 @@ public abstract class AbstractHttp2ConnectionHandlerBuilder<T extends Http2Conne
     private int maxQueuedControlFrames = Http2CodecUtil.DEFAULT_MAX_QUEUED_CONTROL_FRAMES;
     private int maxConsecutiveEmptyFrames = 2;
     private Integer maxRstFramesPerWindow;
+    private int maxConsecutiveContinuationsFrames = 16;
+
     private int secondsPerWindow = 30;
 
     /**
@@ -453,6 +455,29 @@ public abstract class AbstractHttp2ConnectionHandlerBuilder<T extends Http2Conne
     }
 
     /**
+     * Returns the maximum number of consecutive CONTINUATION frames that are allowed before
+     * the connection is closed. This allows to protect against the remote peer flooding us with such frames.
+     *
+     * {@code 0} means no protection is in place.
+     */
+    protected int decoderEnforceMaxConsecutiveContinuationsFrames() {
+        return maxConsecutiveEmptyFrames;
+    }
+
+    /**
+     * Sets the maximum number of consecutive CONTINUATION frames that are allowed before
+     * the connection is closed. This allows to protect against the remote peer flooding us with such frames.
+     *
+     * {@code 0} means no protection should be applied.
+     */
+    protected B decoderEnforceMaxConsecutiveContinuationsFrames(int maxConsecutiveContinuationsFrames) {
+        enforceNonCodecConstraints("maxConsecutiveContinuationsFrames");
+        this.maxConsecutiveContinuationsFrames = checkPositiveOrZero(
+                maxConsecutiveContinuationsFrames, "maxConsecutiveContinuationsFrames");
+        return self();
+    }
+
+    /**
      * Determine if settings frame should automatically be acknowledged and applied.
      * @return this.
      */
@@ -557,7 +582,7 @@ public abstract class AbstractHttp2ConnectionHandlerBuilder<T extends Http2Conne
         Long maxHeaderListSize = initialSettings.maxHeaderListSize();
         Http2FrameReader reader = new DefaultHttp2FrameReader(new DefaultHttp2HeadersDecoder(isValidateHeaders(),
                 maxHeaderListSize == null ? DEFAULT_HEADER_LIST_SIZE : maxHeaderListSize,
-                /* initialHuffmanDecodeCapacity= */ -1));
+                /* initialHuffmanDecodeCapacity= */ -1), maxConsecutiveContinuationsFrames);
         Http2FrameWriter writer = encoderIgnoreMaxHeaderListSize == null ?
                 new DefaultHttp2FrameWriter(headerSensitivityDetector()) :
                 new DefaultHttp2FrameWriter(headerSensitivityDetector(), encoderIgnoreMaxHeaderListSize);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodecBuilder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodecBuilder.java
@@ -200,6 +200,17 @@ public class Http2FrameCodecBuilder extends
         return super.decoderEnforceMaxRstFramesPerWindow(maxRstFramesPerWindow, secondsPerWindow);
     }
 
+    @Override
+    public int decoderEnforceMaxConsecutiveContinuationsFrames() {
+        return super.decoderEnforceMaxConsecutiveContinuationsFrames();
+    }
+
+    @Override
+    public Http2FrameCodecBuilder decoderEnforceMaxConsecutiveContinuationsFrames(
+            int maxConsecutiveContinuationsFrames) {
+        return super.decoderEnforceMaxConsecutiveContinuationsFrames(maxConsecutiveContinuationsFrames);
+    }
+
     /**
      * Build a {@link Http2FrameCodec} object.
      */
@@ -213,7 +224,8 @@ public class Http2FrameCodecBuilder extends
             Long maxHeaderListSize = initialSettings().maxHeaderListSize();
             Http2FrameReader frameReader = new DefaultHttp2FrameReader(maxHeaderListSize == null ?
                     new DefaultHttp2HeadersDecoder(isValidateHeaders()) :
-                    new DefaultHttp2HeadersDecoder(isValidateHeaders(), maxHeaderListSize));
+                    new DefaultHttp2HeadersDecoder(isValidateHeaders(), maxHeaderListSize),
+                    decoderEnforceMaxConsecutiveContinuationsFrames());
 
             if (frameLogger() != null) {
                 frameWriter = new Http2OutboundFrameLogger(frameWriter, frameLogger());

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodecBuilder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodecBuilder.java
@@ -218,6 +218,17 @@ public class Http2MultiplexCodecBuilder
     }
 
     @Override
+    public int decoderEnforceMaxConsecutiveContinuationsFrames() {
+        return super.decoderEnforceMaxConsecutiveContinuationsFrames();
+    }
+
+    @Override
+    public Http2MultiplexCodecBuilder decoderEnforceMaxConsecutiveContinuationsFrames(
+            int maxConsecutiveContinuationsFrames) {
+        return super.decoderEnforceMaxConsecutiveContinuationsFrames(maxConsecutiveContinuationsFrames);
+    }
+
+    @Override
     public Http2MultiplexCodec build() {
         Http2FrameWriter frameWriter = this.frameWriter;
         if (frameWriter != null) {
@@ -227,7 +238,8 @@ public class Http2MultiplexCodecBuilder
             Long maxHeaderListSize = initialSettings().maxHeaderListSize();
             Http2FrameReader frameReader = new DefaultHttp2FrameReader(maxHeaderListSize == null ?
                     new DefaultHttp2HeadersDecoder(isValidateHeaders()) :
-                    new DefaultHttp2HeadersDecoder(isValidateHeaders(), maxHeaderListSize));
+                    new DefaultHttp2HeadersDecoder(isValidateHeaders(), maxHeaderListSize),
+                    decoderEnforceMaxConsecutiveContinuationsFrames());
 
             if (frameLogger() != null) {
                 frameWriter = new Http2OutboundFrameLogger(frameWriter, frameLogger());


### PR DESCRIPTION
Motivation:

We should limit the number of continuation frames that the remote peer is allowed to sent per headers.

Modifications:

- Limit the number of continuation frames by default to 16 and allow the user to change this.
- Add unit test

Result:

Do some more validations to guard against resource usage
