### PR TITLE
Fix `DefaultChannelId#asLongText` NPE

### DIFF
--- a/transport/src/test/java/io/netty/channel/DefaultChannelIdTest.java
+++ b/transport/src/test/java/io/netty/channel/DefaultChannelIdTest.java
@@ -20,10 +20,13 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.ByteBufOutputStream;
 import io.netty.buffer.Unpooled;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.util.Arrays;
+import java.util.Comparator;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -33,6 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("DynamicRegexReplaceableByCompiledPattern")
 public class DefaultChannelIdTest {
+
     @Test
     public void testShortText() {
         String text = DefaultChannelId.newInstance().asShortText();
@@ -83,5 +87,34 @@ public class DefaultChannelIdTest {
         assertThat(a, is(b));
         assertThat(a, is(not(sameInstance(b))));
         assertThat(a.asLongText(), is(b.asLongText()));
+    }
+
+    @Test
+    public void testDeserialization() throws Exception {
+        // DefaultChannelId with 8 byte machineId
+        final DefaultChannelId c8 = new DefaultChannelId(
+                new byte[] {
+                        (byte) 0x01, (byte) 0x23, (byte) 0x45, (byte) 0x67,
+                        (byte) 0x89, (byte) 0xab, (byte) 0xcd, (byte) 0xef
+                },
+                0x000052af,
+                0x00000000,
+                0x06504f638eb4c386L,
+                0xd964df5e);
+
+        // DefaultChannelId with 6 byte machineId
+        final DefaultChannelId c6 =
+                new DefaultChannelId(
+                        new byte[] {
+                                (byte) 0x01, (byte) 0x23, (byte) 0x45, (byte) 0x67,
+                                (byte) 0x89, (byte) 0xab,
+                        },
+                        0xce005283,
+                        0x00000001,
+                        0x069e6dce9eb4516fL,
+                        0x721757b7);
+
+        assertThat(c8.asLongText(), is("0123456789abcdef-000052af-00000000-06504f638eb4c386-d964df5e"));
+        assertThat(c6.asLongText(), is("0123456789ab-ce005283-00000001-069e6dce9eb4516f-721757b7"));
     }
 }


### PR DESCRIPTION
Motivation:
The DefaultChannelId class is serializable, but it does not account for variations in the length of machineId.

Modifications:
Adjusted code to accommodate varying lengths of MachineId.

Result:
Fixed NPE.
Respects varying length of machineId.