### PR TITLE
Utilize `ByteBuf#indexOf`

### DIFF
--- a/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessage.java
+++ b/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessage.java
@@ -189,7 +189,7 @@ public final class HAProxyMessage extends AbstractReferenceCounted {
                             Math.min(addressInfoLen, header.readableBytes()) + " bytes (expected: 216+ bytes)");
             }
             int startIdx = header.readerIndex();
-            int addressEnd = header.forEachByte(startIdx, 108, ByteProcessor.FIND_NUL);
+            int addressEnd = header.indexOf(startIdx, startIdx + 108, (byte) 0); // FIND_NUL
             if (addressEnd == -1) {
                 addressLen = 108;
             } else {
@@ -199,7 +199,7 @@ public final class HAProxyMessage extends AbstractReferenceCounted {
 
             startIdx += 108;
 
-            addressEnd = header.forEachByte(startIdx, 108, ByteProcessor.FIND_NUL);
+            addressEnd = header.indexOf(startIdx, startIdx + 108, (byte) 0); // FIND_NUL
             if (addressEnd == -1) {
                 addressLen = 108;
             } else {

--- a/codec-redis/src/main/java/io/netty/handler/codec/redis/RedisDecoder.java
+++ b/codec-redis/src/main/java/io/netty/handler/codec/redis/RedisDecoder.java
@@ -277,7 +277,7 @@ public final class RedisDecoder extends ByteToMessageDecoder {
         if (!in.isReadable(RedisConstants.EOL_LENGTH)) {
             return null;
         }
-        final int lfIndex = in.forEachByte(ByteProcessor.FIND_LF);
+        final int lfIndex = in.indexOf(in.readerIndex(), in.writerIndex(), (byte) '\n');
         if (lfIndex < 0) {
             return null;
         }

--- a/codec/src/main/java/io/netty/handler/codec/LineBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/LineBasedFrameDecoder.java
@@ -172,7 +172,8 @@ public class LineBasedFrameDecoder extends ByteToMessageDecoder {
      */
     private int findEndOfLine(final ByteBuf buffer) {
         int totalLength = buffer.readableBytes();
-        int i = buffer.forEachByte(buffer.readerIndex() + offset, totalLength - offset, ByteProcessor.FIND_LF);
+        int i = buffer.indexOf(buffer.readerIndex() + offset,
+                               buffer.readerIndex() + totalLength, (byte) '\n');
         if (i >= 0) {
             offset = 0;
             if (i > 0 && buffer.getByte(i - 1) == '\r') {


### PR DESCRIPTION
Motivation:
`ByteBuf#indexOf` employees advanced algorithm to search a given byte.

Modification:
Utilize `ByteBuf#indexOf` instead `forEachByte`.

Result:
Better performance.