### PR TITLE
Use `PlatformDependent.threadLocalRandom()` to reduce memory footprint

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryIdSpace.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryIdSpace.java
@@ -17,7 +17,6 @@ package io.netty.resolver.dns;
 
 import io.netty.util.internal.MathUtil;
 import io.netty.util.internal.PlatformDependent;
-import io.netty.util.internal.ThreadLocalRandom;
 
 import java.util.Random;
 
@@ -62,7 +61,7 @@ final class DnsQueryIdSpace {
                 }
             } else if (freeIdx == -1 ||
                     // Let's make it somehow random which free slot is used.
-                    ThreadLocalRandom.current().nextBoolean()) {
+                    PlatformDependent.threadLocalRandom().nextBoolean()) {
                     // We have a slot that we can use to create a new bucket if we need to.
                     freeIdx = bucketIdx;
             }


### PR DESCRIPTION
Motivation:
Direct use of `io.netty.util.internal.ThreadLocalRandom` and `j.u.c.ThreadLocalRandom` could cause a lot of memory waste.

Modifications:
Use `PlatformDependent.threadLocalRandom()`.

Result:
Reduced Memory footprint.