### PR TITLE
Fix Zstd throws Exception on read-only volumes (#13978)

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/Zstd.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Zstd.java
@@ -35,11 +35,17 @@ public final class Zstd {
             t = e;
             logger.debug(
                 "zstd-jni not in the classpath; Zstd support will be unavailable.");
-        } catch (Throwable e) {
-            t = e;
-            logger.debug("Failed to load zstd-jni; Zstd support will be unavailable.", t);
         }
 
+        // If in the classpath, try to load the native library and initialize zstd.
+        if (t == null) {
+            try {
+                com.github.luben.zstd.util.Native.load();
+            } catch (Throwable e) {
+                t = e;
+                logger.debug("Failed to load zstd-jni; Zstd support will be unavailable.", t);
+            }
+        }
         cause = t;
     }
 


### PR DESCRIPTION
Motivation:

When deploying Netty on a read-only volume (e.g, within a Docker container) with "zstd-jni" included in the classpath, initialization of zstd will fail because it requires unpacking files into a temporary directory. Therefore, it is crucial to verify whether zstd can be initialized, rather than merely checking for the presence of the library in the classpath.

Modification:

During the verification process for the presence of "zstd-jni" in the classpath, the system will also attempt to initialize the library. This initialization follows a pattern similar to that used for the Brotli library check.

Result:

Fixes #13978.
