### PR TITLE
ByteBuf Output Stream Reference Count Ownership

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/ByteBufStreamTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufStreamTest.java
@@ -15,6 +15,7 @@
  */
 package io.netty.buffer;
 
+import io.netty.util.ReferenceCountUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
@@ -22,7 +23,7 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.nio.charset.Charset;
 
-import static io.netty.util.internal.EmptyArrays.*;
+import static io.netty.util.internal.EmptyArrays.EMPTY_BYTES;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -306,5 +307,51 @@ public class ByteBufStreamTest {
             buf.release();
             in.close();
         }
+    }
+
+    @Test
+    public void testReleaseOnCloseInByteBufOutputStream() throws Exception {
+        ByteBuf buf = PooledByteBufAllocator.DEFAULT.buffer(16);
+        buf.writeBytes(new byte[] { 1, 2, 3, 4, 5, 6 });
+        final ByteBufOutputStream out = new ByteBufOutputStream(buf, true);
+        try {
+            out.writeBoolean(true);
+            out.writeBoolean(false);
+            out.writeByte(42);
+            out.writeByte(224);
+            out.writeBytes("Hello, World!");
+            out.write(new byte[]{1, 3, 3, 4}, 0, 0);
+        } finally {
+            out.close();
+        }
+        // When releaseOnClose is set to true, ByteBuf will be automatically released after calling the close method of
+        // ByteBufOutputStream.
+        int i = ReferenceCountUtil.refCnt(out.buffer());
+        assertEquals(0, i);
+    }
+
+    @Test
+    public void testGeneralByteBufOutputStream() throws Exception {
+        // case1
+        ByteBuf buf = PooledByteBufAllocator.DEFAULT.buffer(16);
+        buf.writeBytes(new byte[] { 1, 2, 3, 4, 5, 6 });
+        final ByteBufOutputStream out = new ByteBufOutputStream(buf, false);
+        try {
+            out.writeBoolean(true);
+            out.writeBoolean(false);
+            out.writeByte(42);
+            out.writeByte(224);
+            out.writeBytes("Hello, World!");
+            out.write(new byte[]{1, 3, 3, 4}, 0, 0);
+        } finally {
+            out.close();
+        }
+        int i = ReferenceCountUtil.refCnt(out.buffer());
+        assertEquals(1, i);
+
+        // When releaseOnClose is not set or releaseOnClose is false, ByteBuf must be released manually.
+        out.buffer().release();
+        i = ReferenceCountUtil.refCnt(out.buffer());
+        assertEquals(0, i);
     }
 }

--- a/buffer/src/test/java/io/netty/buffer/ByteBufStreamTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufStreamTest.java
@@ -345,12 +345,10 @@ public class ByteBufStreamTest {
         } finally {
             out.close();
         }
-        int i = ReferenceCountUtil.refCnt(out.buffer());
-        assertEquals(1, i);
+        assertEquals(1, out.buffer().refCnt());
 
         // When releaseOnClose is not set or releaseOnClose is false, ByteBuf must be released manually.
         out.buffer().release();
-        i = ReferenceCountUtil.refCnt(out.buffer());
-        assertEquals(0, i);
+        assertEquals(0, out.buffer().refCnt());
     }
 }

--- a/buffer/src/test/java/io/netty/buffer/ByteBufStreamTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufStreamTest.java
@@ -326,8 +326,7 @@ public class ByteBufStreamTest {
         }
         // When releaseOnClose is set to true, ByteBuf will be automatically released after calling the close method of
         // ByteBufOutputStream.
-        int i = ReferenceCountUtil.refCnt(out.buffer());
-        assertEquals(0, i);
+        assertEquals(0, out.buffer().refCnt());
     }
 
     @Test


### PR DESCRIPTION
Motivation:
Netty provides a adaptor from ByteBuf to Java's OutputStream interface. The JDK Stream interfaces have an explicit lifetime because they implement the Closable interface. This lifetime may be differnt than the ByteBuf which is wrapped, and controlled by the interface which accepts the JDK Stream. However Netty's ByteBufOutputStream currently does not take reference count ownership of the underlying ByteBuf. There may be no way for existing classes which only accept the OutputStream interface to communicate when they are done with the stream, other than calling close(). This means that when the stream is closed it may be appropriate to release the underlying ByteBuf, as the ownership of the underlying ByteBuf resource may be transferred to the Java Stream.

Modification:
Add the parameter releaseOnClose to ByteBufOutputStream.

Result:
ByteBufOutputStream can assume reference count ownership so the underlying ByteBuf can be cleaned up when the stream is closed.

Related issue: #13985 
