### PR TITLE
Stop cancelling build matrix when one build fails

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -108,6 +108,7 @@ jobs:
     # The host should always be Linux
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         include:
           - arch: aarch64
@@ -163,6 +164,7 @@ jobs:
   build-pr:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
           - setup: linux-x86_64-java8


### PR DESCRIPTION
Motivation:
We unfortunately have a number of flaky tests haunting our builds. The GHA build matrix will by default cancel all matrix jobs when one job experiences a failure. This is unproductive with flaky tests, because the more failed builds that need to rerun, the higher the chances of more failures. Also, seeing builds pass on other JVM versions helps build confidence, even if other versions failed on a flaky test.

Modification:
Disable fail-fast on matrix-strategy builds.

Result:
Jobs in a matrix build no longer get cancelled if a sibling-job fails.