### PR TITLE
Add `frameType` method to `Http2Frame`.

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2DataFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2DataFrame.java
@@ -88,6 +88,11 @@ public final class DefaultHttp2DataFrame extends AbstractHttp2StreamFrame implem
     }
 
     @Override
+    public byte frameType() {
+        return Http2FrameTypes.DATA;
+    }
+
+    @Override
     public String name() {
         return "DATA";
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2GoAwayFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2GoAwayFrame.java
@@ -84,6 +84,11 @@ public final class DefaultHttp2GoAwayFrame extends DefaultByteBufHolder implemen
     }
 
     @Override
+    public byte frameType() {
+        return Http2FrameTypes.GO_AWAY;
+    }
+
+    @Override
     public String name() {
         return "GOAWAY";
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersFrame.java
@@ -70,6 +70,11 @@ public final class DefaultHttp2HeadersFrame extends AbstractHttp2StreamFrame imp
     }
 
     @Override
+    public byte frameType() {
+        return Http2FrameTypes.HEADERS;
+    }
+
+    @Override
     public String name() {
         return "HEADERS";
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2PingFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2PingFrame.java
@@ -43,6 +43,11 @@ public class DefaultHttp2PingFrame implements Http2PingFrame {
     }
 
     @Override
+    public byte frameType() {
+        return Http2FrameTypes.PING;
+    }
+
+    @Override
     public String name() {
         return "PING";
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2PriorityFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2PriorityFrame.java
@@ -55,6 +55,11 @@ public final class DefaultHttp2PriorityFrame extends AbstractHttp2StreamFrame im
     }
 
     @Override
+    public byte frameType() {
+        return Http2FrameTypes.PRIORITY;
+    }
+
+    @Override
     public String name() {
         return "PRIORITY_FRAME";
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2PushPromiseFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2PushPromiseFrame.java
@@ -85,6 +85,11 @@ public final class DefaultHttp2PushPromiseFrame implements Http2PushPromiseFrame
     }
 
     @Override
+    public byte frameType() {
+        return Http2FrameTypes.PUSH_PROMISE;
+    }
+
+    @Override
     public String name() {
         return "PUSH_PROMISE_FRAME";
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ResetFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ResetFrame.java
@@ -53,6 +53,11 @@ public final class DefaultHttp2ResetFrame extends AbstractHttp2StreamFrame imple
     }
 
     @Override
+    public byte frameType() {
+        return Http2FrameTypes.RST_STREAM;
+    }
+
+    @Override
     public String name() {
         return "RST_STREAM";
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2SettingsAckFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2SettingsAckFrame.java
@@ -21,6 +21,12 @@ import io.netty.util.internal.StringUtil;
  * The default {@link Http2SettingsAckFrame} implementation.
  */
 final class DefaultHttp2SettingsAckFrame implements Http2SettingsAckFrame {
+
+    @Override
+    public byte frameType() {
+        return Http2FrameTypes.SETTINGS;
+    }
+
     @Override
     public String name() {
         return "SETTINGS(ACK)";

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2SettingsFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2SettingsFrame.java
@@ -38,6 +38,11 @@ public class DefaultHttp2SettingsFrame implements Http2SettingsFrame {
     }
 
     @Override
+    public byte frameType() {
+        return Http2FrameTypes.SETTINGS;
+    }
+
+    @Override
     public String name() {
         return "SETTINGS";
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2WindowUpdateFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2WindowUpdateFrame.java
@@ -37,6 +37,11 @@ public class DefaultHttp2WindowUpdateFrame extends AbstractHttp2StreamFrame impl
     }
 
     @Override
+    public byte frameType() {
+        return Http2FrameTypes.WINDOW_UPDATE;
+    }
+
+    @Override
     public String name() {
         return "WINDOW_UPDATE";
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2UnknownFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2UnknownFrame.java
@@ -28,6 +28,7 @@ public interface Http2UnknownFrame extends Http2StreamFrame, ByteBufHolder {
     @Override
     Http2UnknownFrame stream(Http2FrameStream stream);
 
+    @Override
     byte frameType();
 
     Http2Flags flags();

--- a/common/src/main/java/io/netty/util/NotImplementedYetException.java
+++ b/common/src/main/java/io/netty/util/NotImplementedYetException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 The Netty Project
+ * Copyright 2020 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,24 +13,15 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package io.netty.handler.codec.http2;
 
-import io.netty.util.NotImplementedYetException;
-import io.netty.util.internal.UnstableApi;
+package io.netty.util;
 
-/** An HTTP/2 frame. */
-@UnstableApi
-public interface Http2Frame {
-
-    /**
-     * Returns the type of the HTTP/2 frame e.g. DATA, GOAWAY, etc.
-     */
-    default byte frameType() {
-        throw new NotImplementedYetException();
+public final class NotImplementedYetException extends RuntimeException {
+    public NotImplementedYetException(String message) {
+        super(message);
     }
 
-    /**
-     * Returns the name of the HTTP/2 frame e.g. DATA, GOAWAY, etc.
-     */
-    String name();
+    public NotImplementedYetException() {
+        super("Not implemented yet.");
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1323,6 +1323,12 @@
                   <new>method io.netty.handler.codec.http2.Http2ConnectionHandlerBuilder io.netty.handler.codec.http2.Http2ConnectionHandlerBuilder::decoderEnforceMaxRstFramesPerWindow(int, int)</new>
                   <justification>Acceptable incompatibility for required change, because the method was not previously exposed; protected visiblity in super-class, not made public in final sub-class until now</justification>
                 </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.addedToInterface</code>
+                  <new>method byte io.netty.handler.codec.http2.Http2Frame::frameType()</new>
+                  <justification>Acceptable incompatibility for required change</justification>
+                </item>
               </differences>
             </revapi.differences>
           </analysisConfiguration>


### PR DESCRIPTION
Motivation:

Add `frameType` to `Http2Frame`, so I can use it more easily with switch expression than the current instance of.

Modification:

Add `frameType` to `Http2Frame`.

Result:

Easier to work with in Java < 17
