### PR TITLE
bump japicmp plugin to 0.15.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1375,7 +1375,7 @@
       <plugin>
         <groupId>com.github.siom79.japicmp</groupId>
         <artifactId>japicmp-maven-plugin</artifactId>
-        <version>0.15.4</version>
+        <version>0.15.7</version>
         <configuration>
           <parameter>
             <ignoreMissingOldVersion>true</ignoreMissingOldVersion>


### PR DESCRIPTION
Motivation:

Bump the japicmp to 0.15.7

I checked 0.20.0 too, but a false alarm will be raised.

Modification:

Bump the japicmp to 0.15.7

Result:

Use japicmp to 0.15.7 now

