### PR TITLE
We should use the correct EventLoopGroup type when using our local tr…

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
@@ -770,7 +770,7 @@ public class SslHandlerTest {
                 .trustManager(new SelfSignedCertificate().cert())
                 .build();
 
-        EventLoopGroup group = new NioEventLoopGroup(1);
+        EventLoopGroup group = new DefaultEventLoopGroup(1);
         Channel sc = null;
         Channel cc = null;
         try {


### PR DESCRIPTION
…ansport

Motivation:

We used the NioEventLoopGroup in the test which is not really correct and just works because of some implementation details. Better use the correct EventLoopGroup

Modifications:

Change to use DefaultEventLoopGroup

Result:

Fix incorrect code in test