### PR TITLE
Bump japicmp to 0.21.0

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
@@ -770,7 +770,7 @@ public class SslHandlerTest {
                 .trustManager(new SelfSignedCertificate().cert())
                 .build();
 
-        EventLoopGroup group = new NioEventLoopGroup(1);
+        EventLoopGroup group = new DefaultEventLoopGroup(1);
         Channel sc = null;
         Channel cc = null;
         try {

--- a/pom.xml
+++ b/pom.xml
@@ -1375,7 +1375,7 @@
       <plugin>
         <groupId>com.github.siom79.japicmp</groupId>
         <artifactId>japicmp-maven-plugin</artifactId>
-        <version>0.15.7</version>
+        <version>0.21.0</version>
         <configuration>
           <parameter>
             <ignoreMissingOldVersion>true</ignoreMissingOldVersion>


### PR DESCRIPTION
Motivation:

Bump japicmp to 0.21.0

Modification:

There was an issue in the newer version, but after reported now it's fixed.
https://github.com/siom79/japicmp/issues/393
https://github.com/siom79/japicmp/issues/394

Result:

Bump japicmp to 0.21.0

