### PR TITLE
Add no-value key handling only for form body

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
@@ -470,7 +470,8 @@ public class HttpPostStandardRequestDecoder implements InterfaceHttpPostRequestD
                                 charset);
                         currentAttribute = factory.createAttribute(request, key);
                         firstpos = currentpos;
-                    } else if (read == '&' || (isLastChunk && !undecodedChunk.isReadable() && hasFormBody())) { // special empty FIELD
+                    } else if (read == '&' ||
+                            (isLastChunk && !undecodedChunk.isReadable() && hasFormBody())) { // special empty FIELD
                         currentStatus = MultiPartStatus.DISPOSITION;
                         ampersandpos = read == '&' ? currentpos - 1 : currentpos;
                         String key = decodeAttribute(
@@ -596,7 +597,8 @@ public class HttpPostStandardRequestDecoder implements InterfaceHttpPostRequestD
                                 charset);
                         currentAttribute = factory.createAttribute(request, key);
                         firstpos = currentpos;
-                    } else if (read == '&' || (isLastChunk && !undecodedChunk.isReadable() && hasFormBody())) { // special empty FIELD
+                    } else if (read == '&' ||
+                            (isLastChunk && !undecodedChunk.isReadable() && hasFormBody())) { // special empty FIELD
                         currentStatus = MultiPartStatus.DISPOSITION;
                         ampersandpos = read == '&' ? currentpos - 1 : currentpos;
                         String key = decodeAttribute(
@@ -787,7 +789,9 @@ public class HttpPostStandardRequestDecoder implements InterfaceHttpPostRequestD
      */
     private boolean hasFormBody() {
         String contentHeader = request.headers().get("Content-Type");
-        if(contentHeader == null) return false;
+        if (contentHeader == null) {
+            return false;
+        }
         return contentHeader.equals("application/x-www-form-urlencoded") || contentHeader.equals("multipart/form-data");
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
@@ -22,6 +22,8 @@ import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.codec.http.QueryStringDecoder;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.multipart.HttpPostBodyUtil.SeekAheadOptimize;
 import io.netty.handler.codec.http.multipart.HttpPostRequestDecoder.EndOfDataDecoderException;
 import io.netty.handler.codec.http.multipart.HttpPostRequestDecoder.ErrorDataDecoderException;
@@ -788,11 +790,12 @@ public class HttpPostStandardRequestDecoder implements InterfaceHttpPostRequestD
      * Check if request has headers indicating that it contains form body
      */
     private boolean hasFormBody() {
-        String contentHeader = request.headers().get("Content-Type");
-        if (contentHeader == null) {
+        String contentHeaderValue = request.headers().get(HttpHeaderNames.CONTENT_TYPE);
+        if (contentHeaderValue == null) {
             return false;
         }
-        return contentHeader.equals("application/x-www-form-urlencoded") || contentHeader.equals("multipart/form-data");
+        return HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.contentEquals(contentHeaderValue)
+                || HttpHeaderValues.MULTIPART_FORM_DATA.contentEquals(contentHeaderValue);
     }
 
     private static final class UrlEncodedDetector implements ByteProcessor {

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoderTest.java
@@ -17,7 +17,13 @@ package io.netty.handler.codec.http.multipart;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.handler.codec.http.*;
+import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.DefaultLastHttpContent;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
Motivation:

This is a fix for issue #13981 that reports a changed behaviour of HttpPostStandardRequestDecoder after this PR - https://github.com/netty/netty/pull/13908 

Because HttpPostStandardRequestDecoder changed the contract, some code implementations relying on certain parsing are failing


Modification:

This PR makes sure, that the edge case handling for form body happenes only when the content is in fact form body

Result:

Fixes #13981 

