### PR TITLE
Update JUnit and make use of `@AutoClose`

### DIFF
--- a/buffer/src/test/java/io/netty5/buffer/tests/BufferAndChannelTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/tests/BufferAndChannelTest.java
@@ -20,7 +20,7 @@ import io.netty5.buffer.BufferAllocator;
 import io.netty5.buffer.BufferClosedException;
 import io.netty5.buffer.BufferReadOnlyException;
 import io.netty5.buffer.DefaultBufferAllocators;
-import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -51,6 +51,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Execution(ExecutionMode.SAME_THREAD)
 public class BufferAndChannelTest extends BufferTestSupport {
     private static FileChannel closedChannel;
+    @AutoClose
     private static FileChannel channel;
 
     @BeforeAll
@@ -58,11 +59,6 @@ public class BufferAndChannelTest extends BufferTestSupport {
         closedChannel = tempFileChannel(parentDirectory);
         closedChannel.close();
         channel = tempFileChannel(parentDirectory);
-    }
-
-    @AfterAll
-    static void tearDownChannels() throws IOException {
-        channel.close();
     }
 
     @ParameterizedTest

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/DefaultHttp2FrameReaderTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/DefaultHttp2FrameReaderTest.java
@@ -17,7 +17,7 @@ package io.netty5.handler.codec.http2;
 import io.netty5.buffer.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.http2.headers.Http2Headers;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
@@ -57,6 +57,7 @@ public class DefaultHttp2FrameReaderTest {
     @Mock
     private ChannelHandlerContext ctx;
 
+    @AutoClose
     private DefaultHttp2FrameReader frameReader;
 
     // Used to generate frame
@@ -70,11 +71,6 @@ public class DefaultHttp2FrameReaderTest {
 
         frameReader = new DefaultHttp2FrameReader();
         hpackEncoder = new HpackEncoder();
-    }
-
-    @AfterEach
-    public void tearDown() {
-        frameReader.close();
     }
 
     @Test

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/DefaultHttp2FrameWriterTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/DefaultHttp2FrameWriterTest.java
@@ -21,7 +21,7 @@ import io.netty5.handler.codec.http2.headers.Http2Headers;
 import io.netty5.util.Resource;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.ImmediateEventExecutor;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -45,12 +45,13 @@ import static org.mockito.Mockito.when;
  * Tests for {@link DefaultHttp2FrameWriter}.
  */
 public class DefaultHttp2FrameWriterTest {
+    @AutoClose
     private DefaultHttp2FrameWriter frameWriter;
-
+    @AutoClose
     private Buffer outbound;
-
+    @AutoClose
     private Buffer expectedOutbound;
-
+    @AutoClose
     private Http2HeadersEncoder http2HeadersEncoder;
 
     @Mock
@@ -86,16 +87,6 @@ public class DefaultHttp2FrameWriterTest {
         when(ctx.channel()).thenReturn(channel);
         when(ctx.executor()).thenReturn(ImmediateEventExecutor.INSTANCE);
         when(ctx.newPromise()).thenReturn(ImmediateEventExecutor.INSTANCE.newPromise());
-    }
-
-    @AfterEach
-    public void tearDown() throws Exception {
-        outbound.close();
-        if (expectedOutbound != null) {
-            expectedOutbound.close();
-        }
-        http2HeadersEncoder.close();
-        frameWriter.close();
     }
 
     @Test

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/DefaultHttp2HeadersEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/DefaultHttp2HeadersEncoderTest.java
@@ -18,7 +18,7 @@ import io.netty5.buffer.Buffer;
 import io.netty5.handler.codec.http2.Http2Exception.StreamException;
 import io.netty5.handler.codec.http2.headers.Http2Headers;
 import io.netty5.util.AsciiString;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
@@ -32,17 +32,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Tests for {@link DefaultHttp2HeadersEncoder}.
  */
 public class DefaultHttp2HeadersEncoderTest {
-
+    @AutoClose
     private DefaultHttp2HeadersEncoder encoder;
 
     @BeforeEach
     public void setup() {
         encoder = new DefaultHttp2HeadersEncoder(Http2HeadersEncoder.NEVER_SENSITIVE, newTestEncoder());
-    }
-
-    @AfterEach
-    public void tearDown() {
-        encoder.close();
     }
 
     @Test

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/HpackEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/HpackEncoderTest.java
@@ -17,8 +17,8 @@ package io.netty5.handler.codec.http2;
 
 import io.netty5.buffer.Buffer;
 import io.netty5.handler.codec.http2.headers.Http2Headers;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -36,6 +36,7 @@ public class HpackEncoderTest {
     private HpackDecoder hpackDecoder;
     private HpackEncoder hpackEncoder;
     private Http2Headers mockHeaders;
+    @AutoClose
     private Buffer buf;
 
     @BeforeEach
@@ -44,11 +45,6 @@ public class HpackEncoderTest {
         hpackDecoder = new HpackDecoder(DEFAULT_HEADER_LIST_SIZE);
         mockHeaders = mock(Http2Headers.class);
         buf = onHeapAllocator().allocate(256);
-    }
-
-    @AfterEach
-    public void teardown() {
-        buf.close();
     }
 
     @Test

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameRoundtripTest.java
@@ -24,7 +24,7 @@ import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.GlobalEventExecutor;
 import io.netty5.util.concurrent.ImmediateEventExecutor;
 import io.netty5.util.concurrent.Promise;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
@@ -82,7 +82,7 @@ public class Http2FrameRoundtripTest {
 
     @Mock
     private Channel channel;
-
+    @AutoClose
     private Http2FrameWriter writer;
     private Http2FrameReader reader;
 
@@ -100,11 +100,6 @@ public class Http2FrameRoundtripTest {
 
         writer = new DefaultHttp2FrameWriter(new DefaultHttp2HeadersEncoder(NEVER_SENSITIVE, newTestEncoder()));
         reader = new DefaultHttp2FrameReader(new DefaultHttp2HeadersDecoder(false, false, newTestDecoder()));
-    }
-
-    @AfterEach
-    public void tearDown() {
-        writer.close();
     }
 
     @Test

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2HeaderBlockIOTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2HeaderBlockIOTest.java
@@ -17,7 +17,7 @@ package io.netty5.handler.codec.http2;
 import io.netty5.buffer.Buffer;
 import io.netty5.handler.codec.http2.headers.Http2Headers;
 import io.netty5.util.AsciiString;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +31,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class Http2HeaderBlockIOTest {
 
     private DefaultHttp2HeadersDecoder decoder;
+    @AutoClose
     private DefaultHttp2HeadersEncoder encoder;
+    @AutoClose
     private Buffer buffer;
 
     @BeforeEach
@@ -39,12 +41,6 @@ public class Http2HeaderBlockIOTest {
         encoder = new DefaultHttp2HeadersEncoder();
         decoder = new DefaultHttp2HeadersDecoder(false);
         buffer = onHeapAllocator().allocate(256);
-    }
-
-    @AfterEach
-    public void teardown() {
-        encoder.close();
-        buffer.close();
     }
 
     @Test

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/StreamBufferingEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/StreamBufferingEncoderTest.java
@@ -28,7 +28,7 @@ import io.netty5.util.concurrent.ImmediateEventExecutor;
 import io.netty5.util.concurrent.Promise;
 import io.netty5.util.internal.SilentDispose;
 
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -75,7 +75,7 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings("unchecked")
 public class StreamBufferingEncoderTest {
     private static final Logger logger = LoggerFactory.getLogger(StreamBufferingEncoderTest.class);
-
+    @AutoClose
     private StreamBufferingEncoder encoder;
 
     private Http2Connection connection;
@@ -150,12 +150,6 @@ public class StreamBufferingEncoderTest {
                 new WriteBufferWaterMark(1024, Integer.MAX_VALUE));
         when(channel.getOption(ChannelOption.MESSAGE_SIZE_ESTIMATOR)).thenReturn(DefaultMessageSizeEstimator.DEFAULT);
         handler.handlerAdded(ctx);
-    }
-
-    @AfterEach
-    public void teardown() {
-        // Close and release any buffered frames.
-        encoder.close();
     }
 
     @Test

--- a/codec/src/test/java/io/netty5/handler/codec/frame/LengthFieldPrependerTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/frame/LengthFieldPrependerTest.java
@@ -20,7 +20,7 @@ import io.netty5.buffer.DefaultBufferAllocators;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.handler.codec.EncoderException;
 import io.netty5.handler.codec.LengthFieldPrepender;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -32,17 +32,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LengthFieldPrependerTest {
-
+    @AutoClose
     private Buffer message;
 
     @BeforeEach
     public void setUp() throws Exception {
         message = DefaultBufferAllocators.onHeapAllocator().copyOf(new byte[] {50});
-    }
-
-    @AfterEach
-    public void tearDown() {
-        message.close();
     }
 
     @Test

--- a/common/src/test/java/io/netty5/util/concurrent/FutureCompletionStageTest.java
+++ b/common/src/test/java/io/netty5/util/concurrent/FutureCompletionStageTest.java
@@ -15,7 +15,7 @@
  */
 package io.netty5.util.concurrent;
 
-import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -40,8 +40,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class FutureCompletionStageTest {
-
+    @AutoClose("shutdownGracefully")
     private static EventExecutorGroup group;
+    @AutoClose("shutdownGracefully")
     private static EventExecutorGroup asyncExecutorGroup;
     private static final IllegalStateException EXPECTED_EXCEPTION = new IllegalStateException();
     private static final Integer EXPECTED_INTEGER = 1;
@@ -52,12 +53,6 @@ public class FutureCompletionStageTest {
     public static void setup() {
         group = new MultithreadEventExecutorGroup(1, Executors.defaultThreadFactory());
         asyncExecutorGroup = new MultithreadEventExecutorGroup(1, Executors.defaultThreadFactory());
-    }
-
-    @AfterAll
-    public static void destroy() {
-        group.shutdownGracefully();
-        asyncExecutorGroup.shutdownGracefully();
     }
 
     private static EventExecutor executor() {

--- a/handler/src/test/java/io/netty5/handler/flow/FlowControlHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/flow/FlowControlHandlerTest.java
@@ -34,7 +34,7 @@ import io.netty5.channel.socket.nio.NioServerSocketChannel;
 import io.netty5.channel.socket.nio.NioSocketChannel;
 import io.netty5.handler.timeout.IdleStateEvent;
 import io.netty5.handler.timeout.IdleStateHandler;
-import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -57,16 +57,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class FlowControlHandlerTest {
+    @AutoClose("shutdownGracefully")
     private static EventLoopGroup eventLoopGroup;
 
     @BeforeAll
     public static void init() {
         eventLoopGroup = new MultithreadEventLoopGroup(NioHandler.newFactory());
-    }
-
-    @AfterAll
-    public static void destroy() {
-        eventLoopGroup.shutdownGracefully();
     }
 
     /**

--- a/handler/src/test/java/io/netty5/handler/traffic/FileRegionThrottleTest.java
+++ b/handler/src/test/java/io/netty5/handler/traffic/FileRegionThrottleTest.java
@@ -31,7 +31,7 @@ import io.netty5.channel.socket.nio.NioServerSocketChannel;
 import io.netty5.channel.socket.nio.NioSocketChannel;
 import io.netty5.handler.codec.LineBasedFrameDecoder;
 import io.netty5.util.internal.PlatformDependent;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -55,6 +55,7 @@ public class FileRegionThrottleTest {
     private static final byte[] BYTES = new byte[64 * 1024 * 4];
     private static final long WRITE_LIMIT = 64 * 1024;
     private static File tmp;
+    @AutoClose("shutdownGracefully")
     private EventLoopGroup group;
 
     @BeforeAll
@@ -77,11 +78,6 @@ public class FileRegionThrottleTest {
     @BeforeEach
     public void setUp() {
         group = new MultithreadEventLoopGroup(NioHandler.newFactory());
-    }
-
-    @AfterEach
-    public void tearDown() {
-        group.shutdownGracefully();
     }
 
     @Disabled("This test is flaky, need more investigation")

--- a/pom.xml
+++ b/pom.xml
@@ -603,7 +603,7 @@
     <logging.logLevel>debug</logging.logLevel>
     <log4j2.version>2.17.2</log4j2.version>
     <enforcer.plugin.version>3.0.0</enforcer.plugin.version>
-    <junit.version>5.9.0</junit.version>
+    <junit.version>5.11.0-M1</junit.version>
     <nativebuildtools.version>0.9.13</nativebuildtools.version>
     <skipTests>false</skipTests>
     <testJavaHome>${java.home}</testJavaHome>

--- a/resolver-dns/src/test/java/io/netty5/resolver/dns/DnsNameResolverBuilderTest.java
+++ b/resolver-dns/src/test/java/io/netty5/resolver/dns/DnsNameResolverBuilderTest.java
@@ -21,8 +21,8 @@ import io.netty5.channel.MultithreadEventLoopGroup;
 import io.netty5.channel.nio.NioHandler;
 import io.netty5.channel.socket.nio.NioDatagramChannel;
 import io.netty5.handler.codec.dns.DnsRecord;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -34,6 +34,7 @@ import static io.netty5.resolver.dns.Cache.MAX_SUPPORTED_TTL_SECS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class DnsNameResolverBuilderTest {
+    @AutoClose("shutdownGracefully")
     private static final EventLoopGroup GROUP = new MultithreadEventLoopGroup(1, NioHandler.newFactory());
 
     private DnsNameResolverBuilder builder;
@@ -49,11 +50,6 @@ class DnsNameResolverBuilderTest {
         if (resolver != null) {
             resolver.close();
         }
-    }
-
-    @AfterAll
-    static void shutdownEventLoopGroup() {
-        GROUP.shutdownGracefully();
     }
 
     @Test

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollSocketTcpMd5Test.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollSocketTcpMd5Test.java
@@ -23,8 +23,8 @@ import io.netty5.channel.ConnectTimeoutException;
 import io.netty5.channel.EventLoopGroup;
 import io.netty5.channel.MultithreadEventLoopGroup;
 import io.netty5.util.NetUtil;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,17 +40,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class EpollSocketTcpMd5Test {
     private static final byte[] SERVER_KEY = "abc".getBytes(StandardCharsets.US_ASCII);
     private static final byte[] BAD_KEY = "def".getBytes(StandardCharsets.US_ASCII);
+    @AutoClose("shutdownGracefully")
     private static EventLoopGroup GROUP;
     private EpollServerSocketChannel server;
 
     @BeforeAll
     public static void beforeClass() {
         GROUP = new MultithreadEventLoopGroup(1, EpollHandler.newFactory());
-    }
-
-    @AfterAll
-    public static void afterClass() {
-        GROUP.shutdownGracefully();
     }
 
     @BeforeEach

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/NativeTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/NativeTest.java
@@ -19,7 +19,7 @@ import io.netty5.buffer.Buffer;
 import io.netty5.buffer.BufferAllocator;
 import io.netty5.buffer.DefaultBufferAllocators;
 import io.netty5.channel.unix.FileDescriptor;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,16 +41,12 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class NativeTest {
+    @AutoClose("shutdown")
     private ExecutorService executor;
 
     @BeforeEach
     void createExecutor() {
         executor = Executors.newCachedThreadPool();
-    }
-
-    @AfterEach
-    void shutDownExecutor() {
-        executor.shutdown();
     }
 
     @BeforeAll

--- a/transport-native-unix-common-tests/src/main/java/io/netty5/channel/unix/tests/SocketTest.java
+++ b/transport-native-unix-common-tests/src/main/java/io/netty5/channel/unix/tests/SocketTest.java
@@ -19,7 +19,7 @@ import io.netty5.channel.unix.Buffer;
 import io.netty5.channel.unix.IovArray;
 import io.netty5.channel.unix.Socket;
 import io.netty5.util.internal.PlatformDependent;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -39,6 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public abstract class SocketTest<T extends Socket> {
+    @AutoClose
     protected T socket;
 
     protected abstract T newSocket();
@@ -46,11 +47,6 @@ public abstract class SocketTest<T extends Socket> {
     @BeforeEach
     public void setup() {
         socket = newSocket();
-    }
-
-    @AfterEach
-    public void tearDown() throws IOException {
-        socket.close();
     }
 
     @Test

--- a/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTailTest.java
+++ b/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTailTest.java
@@ -16,7 +16,7 @@
 package io.netty5.channel;
 
 import io.netty5.buffer.Buffer;
-import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -32,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class DefaultChannelPipelineTailTest {
     private static final long TIMEOUT_SEC = 10L;
 
+    @AutoClose("shutdownGracefully")
     private static EventLoopGroup group;
 
     @BeforeAll
@@ -86,11 +87,6 @@ public class DefaultChannelPipelineTailTest {
                 return MyChannel.class.isAssignableFrom(handleType);
             }
         });
-    }
-
-    @AfterAll
-    public static void destroy() {
-        group.shutdownGracefully();
     }
 
     @Test


### PR DESCRIPTION
Motivation:
JUnit put out a milestone release so people could test it. It's potentially interesting, so let's give it a try.

Modification:
Update JUnit to 5.11.0-M1.
Replace a number of obvious `@AfterEach/All` methods with `@AutoClose` field annotations.

Result:
Cleaner test code.
