### PR TITLE
Reduce the likelihood of io_uring OP_CONNECT completions going to the wrong channel

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/IOUringHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/IOUringHandler.java
@@ -106,7 +106,7 @@ final class IOUringHandler implements IoHandler, CompletionCallback {
             return;
         }
         if (op == Native.IORING_OP_ASYNC_CANCEL) {
-            // We don't care about the result of async cancels; they are best effort.
+            // We don't care about the result of async cancels; they are best-effort.
             return;
         }
         AbstractIOUringChannel<?> ch = channels.get(fd);


### PR DESCRIPTION
Motivation:
File descriptor reuse can cause completions to be directed to the wrong channel. This was a problem for connect() operations in our tests. The problem manifests as spurious AlreadyConnectedExceptions being thrown from AbstractChannel.finishConnect().

Modification:
Submit a cancellation for any pending connect operation, when a channel is preparing to close. Also attach a counter to the extra data for connect operations, and ignore OP_CONNECT completions where the counter stamp is not what we expected.

Result:
Although the counter is a 16-bit short, it still greatly reduces the likelihood of OP_CONNECT completions going to the wrong channel, since now both the counter and the file descriptor need to be reused in synchrony.
