### PR TITLE
Update BouncyCastle to the latest version

### DIFF
--- a/codec-http2/pom.xml
+++ b/codec-http2/pom.xml
@@ -76,7 +76,7 @@
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
+      <artifactId>bcpkix-jdk18on</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -221,11 +221,11 @@
     <!-- Needed for OCSP -->
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
+      <artifactId>bcpkix-jdk18on</artifactId>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15on</artifactId>
+      <artifactId>bcprov-jdk18on</artifactId>
     </dependency>
 
     <!-- Needed on Java11 and later -->

--- a/handler-proxy/pom.xml
+++ b/handler-proxy/pom.xml
@@ -79,7 +79,7 @@
     <!-- For SelfSignedCertificate usage on JDK20+ -->
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
+      <artifactId>bcpkix-jdk18on</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/handler-ssl-ocsp/pom.xml
+++ b/handler-ssl-ocsp/pom.xml
@@ -35,7 +35,7 @@
   <dependencies>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
+      <artifactId>bcpkix-jdk18on</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/handler/pom.xml
+++ b/handler/pom.xml
@@ -78,12 +78,12 @@
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
+      <artifactId>bcpkix-jdk18on</artifactId>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bctls-jdk15on</artifactId>
+      <artifactId>bctls-jdk18on</artifactId>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/handler/src/main/java/io/netty/handler/ssl/BouncyCastlePemReader.java
+++ b/handler/src/main/java/io/netty/handler/ssl/BouncyCastlePemReader.java
@@ -75,10 +75,10 @@ final class BouncyCastlePemReader {
             public Void run() {
                 try {
                     ClassLoader classLoader = getClass().getClassLoader();
-                    // Check for bcprov-jdk15on:
+                    // Check for bcprov-jdk18on:
                     Class<Provider> bcProviderClass =
                             (Class<Provider>) Class.forName(BC_PROVIDER, true, classLoader);
-                    // Check for bcpkix-jdk15on:
+                    // Check for bcpkix-jdk18on:
                     Class.forName(BC_PEMPARSER, true, classLoader);
                     bcProvider = bcProviderClass.getConstructor().newInstance();
                     logger.debug("Bouncy Castle provider available");

--- a/pom.xml
+++ b/pom.xml
@@ -620,6 +620,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <netty.build.version>31</netty.build.version>
     <jboss.marshalling.version>1.4.11.Final</jboss.marshalling.version>
+    <bouncycastle.version>1.78.1</bouncycastle.version>
     <jetty.alpnAgent.version>2.0.10</jetty.alpnAgent.version>
     <jetty.alpnAgent.path>"${settings.localRepository}"/org/mortbay/jetty/alpn/jetty-alpn-agent/${jetty.alpnAgent.version}/jetty-alpn-agent-${jetty.alpnAgent.version}.jar</jetty.alpnAgent.path>
     <argLine.common>
@@ -810,8 +811,8 @@
       -->
       <dependency>
         <groupId>org.bouncycastle</groupId>
-        <artifactId>bcpkix-jdk15on</artifactId>
-        <version>1.69</version>
+        <artifactId>bcpkix-jdk18on</artifactId>
+        <version>${bouncycastle.version}</version>
         <scope>compile</scope>
         <optional>true</optional>
       </dependency>
@@ -822,8 +823,8 @@
       -->
       <dependency>
         <groupId>org.bouncycastle</groupId>
-        <artifactId>bcprov-jdk15on</artifactId>
-        <version>1.69</version>
+        <artifactId>bcprov-jdk18on</artifactId>
+        <version>${bouncycastle.version}</version>
         <scope>compile</scope>
         <optional>true</optional>
       </dependency>
@@ -833,8 +834,8 @@
       -->
       <dependency>
         <groupId>org.bouncycastle</groupId>
-        <artifactId>bctls-jdk15on</artifactId>
-        <version>1.69</version>
+        <artifactId>bctls-jdk18on</artifactId>
+        <version>${bouncycastle.version}</version>
         <scope>compile</scope>
         <optional>true</optional>
       </dependency>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -118,7 +118,7 @@
     <!-- For SelfSignedCertificate usage on JDK20+ -->
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
+      <artifactId>bcpkix-jdk18on</artifactId>
       <optional>true</optional>
     </dependency>
   </dependencies>

--- a/transport-blockhound-tests/pom.xml
+++ b/transport-blockhound-tests/pom.xml
@@ -151,7 +151,7 @@
 
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
+      <artifactId>bcpkix-jdk18on</artifactId>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -586,7 +586,7 @@
     <!-- For SelfSignedCertificate usage on JDK20+ -->
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
+      <artifactId>bcpkix-jdk18on</artifactId>
       <optional>true</optional>
     </dependency>
   </dependencies>

--- a/transport-native-kqueue/pom.xml
+++ b/transport-native-kqueue/pom.xml
@@ -655,7 +655,7 @@
     <!-- For SelfSignedCertificate usage on JDK20+ -->
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
+      <artifactId>bcpkix-jdk18on</artifactId>
       <optional>true</optional>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Motivation:
The update was held back by a compatibility.
Since in 4.2 we've moved the JDK baseline from Java 6 to Java 8 anyway, we have the opportunity to bump the BC version as well.

Modification:
Switch all BouncyCastle dependencies from "-jdk15on" to "-jdk18on", and update them to the latest version.

Result:
Fixes #13561
