### PR TITLE
Add more JDK versions to the devcontainers

### DIFF
--- a/.devcontainer/alpine/Dockerfile
+++ b/.devcontainer/alpine/Dockerfile
@@ -3,6 +3,6 @@ RUN apk -U upgrade && apk add \
     autoconf automake linux-headers libtool make tar libaio-dev openssl-dev apr-dev gcc \
     mandoc man-pages autoconf-doc automake-doc libtool-doc make-doc tar-doc gcc-doc \
     perf perf-bash-completion htop htop-doc strace strace-doc ripgrep ripgrep-doc \
-    openjdk8-jdk openjdk8-doc openjdk8-src openjdk11-jdk openjdk11-doc openjdk1-src \
+    openjdk8-jdk openjdk8-doc openjdk8-src openjdk11-jdk openjdk11-doc openjdk11-src \
     openjdk17-jdk openjdk17-doc openjdk1-src openjdk21-jdk openjdk21-doc openjdk21-src \
     maven

--- a/.devcontainer/alpine/Dockerfile
+++ b/.devcontainer/alpine/Dockerfile
@@ -3,4 +3,6 @@ RUN apk -U upgrade && apk add \
     autoconf automake linux-headers libtool make tar libaio-dev openssl-dev apr-dev gcc \
     mandoc man-pages autoconf-doc automake-doc libtool-doc make-doc tar-doc gcc-doc \
     perf perf-bash-completion htop htop-doc strace strace-doc ripgrep ripgrep-doc \
-    openjdk21-jdk openjdk21-doc openjdk21-src maven
+    openjdk8-jdk openjdk8-doc openjdk8-src openjdk11-jdk openjdk11-doc openjdk1-src \
+    openjdk17-jdk openjdk17-doc openjdk1-src openjdk21-jdk openjdk21-doc openjdk21-src \
+    maven

--- a/.devcontainer/ubuntu/Dockerfile
+++ b/.devcontainer/ubuntu/Dockerfile
@@ -1,5 +1,5 @@
 FROM mcr.microsoft.com/devcontainers/base:ubuntu
 RUN apt-get update && apt-get install -y \
     autotools-dev autoconf automake libtool make tar libaio-dev libssl-dev libapr1-dev lksctp-tools gcc \
-    htop strace \
-    openjdk-21-jdk-headless openjdk-21-source
+    htop strace  openjdk-8-jdk-headless openjdk-8-source openjdk-11-jdk-headless openjdk-11-source \
+    openjdk-17-jdk-headless openjdk-17-source openjdk-21-jdk-headless openjdk-21-source


### PR DESCRIPTION
Motivation:

We should add also other JDKs to the docker images that are used by devcontainers so its easier to debug with different JDKs

Modifications:

Add Java 8,11,17

Result:

Easier to debug with devcontainers