### PR TITLE
build: update slf4j from 1.x to 2.0.13, logback to 1.3.14

### DIFF
--- a/codec/src/test/resources/io/netty/handler/codec/xml/sample-04.xml
+++ b/codec/src/test/resources/io/netty/handler/codec/xml/sample-04.xml
@@ -145,7 +145,7 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.21</version>
+        <version>2.0.13</version>
       </dependency>
       <dependency>
         <groupId>commons-logging</groupId>
@@ -231,7 +231,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.1.7</version>
+      <version>1.3.14</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -973,7 +973,7 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.30</version>
+        <version>2.0.13</version>
       </dependency>
       <dependency>
         <groupId>commons-logging</groupId>
@@ -1069,7 +1069,7 @@
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
-        <version>1.2.13</version>
+        <version>1.3.14</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
Update slf4j to 2.x, logback to 1.3.14. This is a backward-compatible change. 


## slf4j
SLF4J API version 2.0.0 requires Java 8 and introduces a backward-compatible fluent logging API. By backward-compatible, we mean that existing logging frameworks do not have to be changed in order for the user to benefit from the fluent logging API.

## logback
Version 1.3.x supports Java EE, while version 1.4.x supports Jakarta EE. The two versions are feature identical.

Both 1.3.x and 1.4.x series require SLF4J 2.0.x or later.

The 1.3.x series requires Java 8 at runtime.

Result:

Fixes #14011 
