### PR TITLE
NioSelectableChannelIoHandle does not need to get interestedOps as co…

### DIFF
--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
@@ -123,7 +123,7 @@ public final class NioEventLoop extends SingleThreadIoEventLoop {
     private void register0(final SelectableChannel ch, int interestOps, final NioTask<SelectableChannel> task) {
         try {
             register(
-                    new NioSelectableChannelIoHandle<SelectableChannel>(ch, interestOps) {
+                    new NioSelectableChannelIoHandle<SelectableChannel>(ch) {
                         @Override
                         protected void handle(SelectableChannel channel, SelectionKey key) {
                             try {

--- a/transport/src/main/java/io/netty/channel/nio/NioSelectableChannelIoHandle.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioSelectableChannelIoHandle.java
@@ -31,15 +31,9 @@ import java.nio.channels.SelectionKey;
  */
 public abstract class NioSelectableChannelIoHandle<S extends SelectableChannel> implements IoHandle, NioIoHandle {
     private final S channel;
-    final int interestOps;
 
-    public NioSelectableChannelIoHandle(S channel, int interestOps) {
-        if ((interestOps & ~channel.validOps()) != 0) {
-            throw new IllegalArgumentException(
-                    "invalid interestOps: " + interestOps + "(validOps: " + channel.validOps() + ')');
-        }
+    public NioSelectableChannelIoHandle(S channel) {
         this.channel = ObjectUtil.checkNotNull(channel, "channel");
-        this.interestOps = interestOps;
     }
 
     @Override


### PR DESCRIPTION
…nstructor param

Motivation:

As we now pass the ops when we register an IoHandle we dont need to pass these when constructing NioSelectableChannelIoHandle

Modifications:

Fix constructor

Result:

Cleanup code
