### PR TITLE
Add a way to check if a IoEventLoopGroup / IoEventLoop is using a spe…

### DIFF
--- a/transport/src/main/java/io/netty/channel/IoEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/IoEventLoop.java
@@ -52,6 +52,11 @@ public interface IoEventLoop extends EventLoop, IoEventLoopGroup {
      */
     Future<IoRegistration> register(IoHandle handle, IoOps initialOps);
 
+    // Force sub-classes to implement.
     @Override
     boolean isCompatible(Class<? extends IoHandle> handleType);
+
+    // Force sub-classes to implement.
+    @Override
+    boolean isIoType(Class<? extends IoHandler> handlerType);
 }

--- a/transport/src/main/java/io/netty/channel/IoEventLoopGroup.java
+++ b/transport/src/main/java/io/netty/channel/IoEventLoopGroup.java
@@ -24,13 +24,24 @@ public interface IoEventLoopGroup extends EventLoopGroup {
     IoEventLoop next();
 
     /**
-     * Returns {@code true} if the given type is compatible with this {@link EventLoopGroup} and so can be registered
-     * to the contained {@link EventLoop}s, {@code false} otherwise.
+     * Returns {@code true} if the given type is compatible with this {@link IoEventLoopGroup} and so can be registered
+     * to the contained {@link IoEventLoop}s, {@code false} otherwise.
      *
      * @param handleType    the type of the {@link IoHandle}.
      * @return              if compatible of not.
      */
     default boolean isCompatible(Class<? extends IoHandle> handleType) {
         return next().isCompatible(handleType);
+    }
+
+    /**
+     * Returns {@code true} if the given {@link IoHandler} type is used by this {@link IoEventLoopGroup},
+     * {@code false} otherwise.
+     *
+     * @param handlerType the type of the {@link IoHandler}.
+     * @return            if used or not.
+     */
+    default boolean isIoType(Class<? extends IoHandler> handlerType) {
+        return next().isIoType(handlerType);
     }
 }

--- a/transport/src/main/java/io/netty/channel/SingleThreadIoEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/SingleThreadIoEventLoop.java
@@ -215,4 +215,9 @@ public class SingleThreadIoEventLoop extends SingleThreadEventLoop implements Io
     public boolean isCompatible(Class<? extends IoHandle> handleType) {
         return ioHandler.isCompatible(handleType);
     }
+
+    @Override
+    public boolean isIoType(Class<? extends IoHandler> handlerType) {
+        return ioHandler.getClass().equals(handlerType);
+    }
 }

--- a/transport/src/test/java/io/netty/channel/SingleThreadIoEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/SingleThreadIoEventLoopTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.Executors;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SingleThreadIoEventLoopTest {
+
+    @Test
+    void testIsUsed() {
+        IoHandler handler = new TestIoHandler();
+        IoHandler handler2 = new TestIoHandler() { };
+
+        IoEventLoopGroup group = new SingleThreadIoEventLoop(null, Executors.defaultThreadFactory(), handler);
+        assertTrue(group.isIoType(handler.getClass()));
+        assertFalse(group.isIoType(handler2.getClass()));
+        group.shutdownGracefully();
+    }
+
+    @Test
+    void testIsCompatible() {
+        IoHandler handler = new TestIoHandler() {
+            @Override
+            public boolean isCompatible(Class<? extends IoHandle> handleType) {
+                return handleType.equals(TestIoHandle.class);
+            }
+        };
+
+        IoHandle handle = new TestIoHandle() { };
+        IoEventLoopGroup group = new SingleThreadIoEventLoop(null, Executors.defaultThreadFactory(), handler);
+        assertTrue(group.isCompatible(TestIoHandle.class));
+        assertFalse(group.isCompatible(handle.getClass()));
+        group.shutdownGracefully();
+    }
+
+    private static class TestIoHandler implements IoHandler {
+        @Override
+        public int run(IoExecutionContext context) {
+            return 0;
+        }
+
+        @Override
+        public void prepareToDestroy() {
+            // NOOP
+        }
+
+        @Override
+        public void destroy() {
+            // NOOP
+        }
+
+        @Override
+        public IoRegistration register(IoEventLoop eventLoop, IoHandle handle, IoOpt opt) {
+            return null;
+        }
+
+        @Override
+        public void wakeup(IoEventLoop eventLoop) {
+            // NOOP
+        }
+
+        @Override
+        public boolean isCompatible(Class<? extends IoHandle> handleType) {
+            return false;
+        }
+    }
+
+    private class TestIoHandle implements IoHandle {
+        @Override
+        public void handle(IoRegistration registration, IoOpt readyOpt) {
+            // NOOP
+        }
+
+        @Override
+        public void close() {
+            // NOOP
+        }
+    }
+}

--- a/transport/src/test/java/io/netty/channel/SingleThreadIoEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/SingleThreadIoEventLoopTest.java
@@ -68,7 +68,7 @@ public class SingleThreadIoEventLoopTest {
         }
 
         @Override
-        public IoRegistration register(IoEventLoop eventLoop, IoHandle handle, IoOpt opt) {
+        public IoRegistration register(IoEventLoop eventLoop, IoHandle handle, IoOps ops) {
             return null;
         }
 
@@ -85,7 +85,7 @@ public class SingleThreadIoEventLoopTest {
 
     private class TestIoHandle implements IoHandle {
         @Override
-        public void handle(IoRegistration registration, IoOpt readyOpt) {
+        public void handle(IoRegistration registration, IoOps readyOps) {
             // NOOP
         }
 

--- a/transport/src/test/java/io/netty/channel/SingleThreadIoEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/SingleThreadIoEventLoopTest.java
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class SingleThreadIoEventLoopTest {
 
     @Test
-    void testIsUsed() {
+    void testIsIoType() {
         IoHandler handler = new TestIoHandler();
         IoHandler handler2 = new TestIoHandler() { };
 


### PR DESCRIPTION
…cific IoHandler

Motivation:

We need to provide a way for the user to check if an `IoEventLoopGroup` is supporting NIO / Epoll / KQueue etc. Before people often used `group instanceof NioEventLoopGroup` etc.

Modifications:

Add new method that people can use to check what kind of IO is used.

Result:

People can use `group.isIoType(NioHandler.class)` etc.
