### PR TITLE
Rename IoOpts to IoOps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1478,7 +1478,7 @@
                 <item>
                   <ignore>true</ignore>
                   <code>java.method.finalMethodAddedToNonFinalClass</code>
-                  <new>method io.netty.util.concurrent.Future&lt;io.netty.channel.IoRegistration&gt; io.netty.channel.SingleThreadIoEventLoop::register(io.netty.channel.IoHandle, io.netty.channel.IoOpt) @ io.netty.channel.epoll.EpollEventLoop</new>
+                  <new>method io.netty.util.concurrent.Future&lt;io.netty.channel.IoRegistration&gt; io.netty.channel.SingleThreadIoEventLoop::register(io.netty.channel.IoHandle, io.netty.channel.IoOps) @ io.netty.channel.epoll.EpollEventLoop</new>
                 </item>
 
                 <item>

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollServerChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollServerChannel.java
@@ -38,7 +38,7 @@ public abstract class AbstractEpollServerChannel extends AbstractEpollChannel im
     }
 
     protected AbstractEpollServerChannel(LinuxSocket fd, boolean active) {
-        super(null, fd, active, EpollIoOpt.valueOf(0));
+        super(null, fd, active, EpollIoOps.valueOf(0));
     }
 
     @Override

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
@@ -92,17 +92,17 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
 
     AbstractEpollStreamChannel(Channel parent, LinuxSocket fd) {
         // Add EPOLLRDHUP so we are notified once the remote peer close the connection.
-        super(parent, fd, true, EpollIoOpt.EPOLLRDHUP);
+        super(parent, fd, true, EpollIoOps.EPOLLRDHUP);
     }
 
     protected AbstractEpollStreamChannel(Channel parent, LinuxSocket fd, SocketAddress remote) {
         // Add EPOLLRDHUP so we are notified once the remote peer close the connection.
-        super(parent, fd, remote, EpollIoOpt.EPOLLRDHUP);
+        super(parent, fd, remote, EpollIoOps.EPOLLRDHUP);
     }
 
     protected AbstractEpollStreamChannel(LinuxSocket fd, boolean active) {
         // Add EPOLLRDHUP so we are notified once the remote peer close the connection.
-        super(null, fd, active, EpollIoOpt.EPOLLRDHUP);
+        super(null, fd, active, EpollIoOps.EPOLLRDHUP);
     }
 
     @Override

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollChannelConfig.java
@@ -198,14 +198,14 @@ public class EpollChannelConfig extends DefaultChannelConfig {
         ObjectUtil.checkNotNull(mode, "mode");
 
         AbstractEpollChannel epollChannel = (AbstractEpollChannel) channel;
-        EpollIoOpt initial = epollChannel.initialOpts;
+        EpollIoOps initial = epollChannel.initialOps;
         checkChannelNotRegistered();
         switch (mode) {
             case EDGE_TRIGGERED:
-                epollChannel.initialOpts = initial.with(EpollIoOpt.EPOLLET);
+                epollChannel.initialOps = initial.with(EpollIoOps.EPOLLET);
                 break;
             case LEVEL_TRIGGERED:
-                epollChannel.initialOpts = initial.without(EpollIoOpt.EPOLLET);
+                epollChannel.initialOps = initial.without(EpollIoOps.EPOLLET);
                 break;
             default:
                 throw new Error();

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -101,7 +101,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
     }
 
     private EpollDatagramChannel(LinuxSocket fd, boolean active) {
-        super(null, fd, active, EpollIoOpt.valueOf(0));
+        super(null, fd, active, EpollIoOps.valueOf(0));
         config = new EpollDatagramChannelConfig(this);
     }
 

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainDatagramChannel.java
@@ -69,7 +69,7 @@ public final class EpollDomainDatagramChannel extends AbstractEpollChannel imple
     }
 
     private EpollDomainDatagramChannel(LinuxSocket socket, boolean active) {
-        super(null, socket, active, EpollIoOpt.valueOf(0));
+        super(null, socket, active, EpollIoOps.valueOf(0));
         config = new EpollDomainDatagramChannelConfig(this);
     }
 

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoHandler.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoHandler.java
@@ -23,7 +23,7 @@ import io.netty.channel.IoExecutionContext;
 import io.netty.channel.IoHandle;
 import io.netty.channel.IoHandler;
 import io.netty.channel.IoHandlerFactory;
-import io.netty.channel.IoOpt;
+import io.netty.channel.IoOps;
 import io.netty.channel.SelectStrategy;
 import io.netty.channel.SelectStrategyFactory;
 import io.netty.channel.unix.FileDescriptor;
@@ -140,9 +140,9 @@ public class EpollIoHandler implements IoHandler {
         throw new IllegalArgumentException("IoHandle of type " + StringUtil.simpleClassName(handle) + " not supported");
     }
 
-    private static EpollIoOpt cast(IoOpt opt) {
-        if (opt instanceof EpollIoOpt) {
-            return (EpollIoOpt) opt;
+    private static EpollIoOps cast(IoOps opt) {
+        if (opt instanceof EpollIoOps) {
+            return (EpollIoOps) opt;
         }
         throw new IllegalArgumentException("IoOpt of type " + StringUtil.simpleClassName(opt) + " not supported");
     }
@@ -260,16 +260,16 @@ public class EpollIoHandler implements IoHandler {
         private final IoEventLoop eventLoop;
         final EpollIoHandle handle;
 
-        private volatile EpollIoOpt currentOpt;
+        private volatile EpollIoOps currentOpt;
 
-        DefaultEpollIoRegistration(IoEventLoop eventLoop, EpollIoHandle handle, EpollIoOpt initialOpt) {
+        DefaultEpollIoRegistration(IoEventLoop eventLoop, EpollIoHandle handle, EpollIoOps initialOpt) {
             this.eventLoop = eventLoop;
             this.handle = handle;
             this.currentOpt = initialOpt;
         }
 
         @Override
-        public void updateInterestOpt(EpollIoOpt opt) throws IOException {
+        public void updateInterestOpt(EpollIoOps opt) throws IOException {
             currentOpt = opt;
             try {
                 if (!isValid()) {
@@ -284,7 +284,7 @@ public class EpollIoHandler implements IoHandler {
         }
 
         @Override
-        public EpollIoOpt interestOpt() {
+        public EpollIoOps interestOpt() {
             return currentOpt;
         }
 
@@ -342,16 +342,16 @@ public class EpollIoHandler implements IoHandler {
         }
 
         void handle(long ev) {
-            handle.handle(this, EpollIoOpt.valueOf((int) ev));
+            handle.handle(this, EpollIoOps.valueOf((int) ev));
         }
     }
 
     @Override
     public EpollIoRegistration register(IoEventLoop eventLoop, IoHandle handle,
-                                      IoOpt initialOpt)
+                                      IoOps initialOpt)
             throws Exception {
         final EpollIoHandle epollHandle = cast(handle);
-        EpollIoOpt opt = cast(initialOpt);
+        EpollIoOps opt = cast(initialOpt);
         DefaultEpollIoRegistration registration = new DefaultEpollIoRegistration(eventLoop, epollHandle, opt);
         int fd = epollHandle.fd().intValue();
         Native.epollCtlAdd(epollFd.intValue(), fd, registration.interestOpt().value);

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoOps.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoOps.java
@@ -15,12 +15,12 @@
  */
 package io.netty.channel.epoll;
 
-import io.netty.channel.IoOpt;
+import io.netty.channel.IoOps;
 
 /**
- * Implementation of {@link IoOpt} that is used by {@link EpollIoHandler} and so for epoll based transports.
+ * Implementation of {@link IoOps} that is used by {@link EpollIoHandler} and so for epoll based transports.
  */
-public final class EpollIoOpt implements IoOpt {
+public final class EpollIoOps implements IoOps {
 
     static {
         // Need to ensure we load the native lib before trying to use the values in Native to construct the different
@@ -31,32 +31,32 @@ public final class EpollIoOpt implements IoOpt {
     /**
      * Interested in IO events that should be handled by accepting new connections
      */
-    public static final EpollIoOpt EPOLLOUT = new EpollIoOpt(Native.EPOLLOUT);
+    public static final EpollIoOps EPOLLOUT = new EpollIoOps(Native.EPOLLOUT);
 
     /**
      * Interested in IO events which should be handled by finish pending connect operations
      */
-    public static final EpollIoOpt EPOLLIN = new EpollIoOpt(Native.EPOLLIN);
+    public static final EpollIoOps EPOLLIN = new EpollIoOps(Native.EPOLLIN);
 
     /**
      * Interested in IO events which tell that the underlying channel is writable again.
      */
-    public static final EpollIoOpt EPOLLERR = new EpollIoOpt(Native.EPOLLERR);
+    public static final EpollIoOps EPOLLERR = new EpollIoOps(Native.EPOLLERR);
 
     /**
      * Interested in IO events which should be handled by reading data.
      */
-    public static final EpollIoOpt EPOLLRDHUP = new EpollIoOpt(Native.EPOLLRDHUP);
+    public static final EpollIoOps EPOLLRDHUP = new EpollIoOps(Native.EPOLLRDHUP);
 
-    public static final EpollIoOpt EPOLLET = new EpollIoOpt(Native.EPOLLET);
+    public static final EpollIoOps EPOLLET = new EpollIoOps(Native.EPOLLET);
 
     // Just use an array to store often used values.
-    private static final EpollIoOpt[] OPTS;
+    private static final EpollIoOps[] OPTS;
 
     static {
-        EpollIoOpt all = new EpollIoOpt(
+        EpollIoOps all = new EpollIoOps(
                 EPOLLOUT.value | EPOLLIN.value | EPOLLERR.value | EPOLLRDHUP.value);
-        OPTS = new EpollIoOpt[all.value + 1];
+        OPTS = new EpollIoOps[all.value + 1];
         addToArray(OPTS, EPOLLOUT);
         addToArray(OPTS, EPOLLIN);
         addToArray(OPTS, EPOLLERR);
@@ -64,32 +64,32 @@ public final class EpollIoOpt implements IoOpt {
         addToArray(OPTS, all);
     }
 
-    private static void addToArray(EpollIoOpt[] array, EpollIoOpt opt) {
+    private static void addToArray(EpollIoOps[] array, EpollIoOps opt) {
         array[opt.value] = opt;
     }
 
     final int value;
 
-    private EpollIoOpt(int value) {
+    private EpollIoOps(int value) {
         this.value = value;
     }
 
     /**
-     * Returns {@code true} if this {@link EpollIoOpt} is a combination of the given {@link EpollIoOpt}.
+     * Returns {@code true} if this {@link EpollIoOps} is a combination of the given {@link EpollIoOps}.
      * @param opt   the opt.
      * @return      {@code true} if a combination of the given.
      */
-    public boolean contains(EpollIoOpt opt) {
+    public boolean contains(EpollIoOps opt) {
         return (value & opt.value) != 0;
     }
 
     /**
-     * Return a {@link EpollIoOpt} which is a combination of the current and the given {@link EpollIoOpt}.
+     * Return a {@link EpollIoOps} which is a combination of the current and the given {@link EpollIoOps}.
      *
-     * @param opt   the {@link EpollIoOpt} that should be added to this one.
-     * @return      a {@link EpollIoOpt}.
+     * @param opt   the {@link EpollIoOps} that should be added to this one.
+     * @return      a {@link EpollIoOps}.
      */
-    public EpollIoOpt with(EpollIoOpt opt) {
+    public EpollIoOps with(EpollIoOps opt) {
         if (contains(opt)) {
             return this;
         }
@@ -97,12 +97,12 @@ public final class EpollIoOpt implements IoOpt {
     }
 
     /**
-     * Return a {@link EpollIoOpt} which is not a combination of the current and the given {@link EpollIoOpt}.
+     * Return a {@link EpollIoOps} which is not a combination of the current and the given {@link EpollIoOps}.
      *
-     * @param opt   the {@link EpollIoOpt} that should be remove from this one.
-     * @return      a {@link EpollIoOpt}.
+     * @param opt   the {@link EpollIoOps} that should be remove from this one.
+     * @return      a {@link EpollIoOps}.
      */
-    public EpollIoOpt without(EpollIoOpt opt) {
+    public EpollIoOps without(EpollIoOps opt) {
         if (!contains(opt)) {
             return this;
         }
@@ -110,7 +110,7 @@ public final class EpollIoOpt implements IoOpt {
     }
 
     /**
-     * Returns the underlying value of the {@link EpollIoOpt}.
+     * Returns the underlying value of the {@link EpollIoOps}.
      *
      * @return value.
      */
@@ -126,7 +126,7 @@ public final class EpollIoOpt implements IoOpt {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        EpollIoOpt nioOpt = (EpollIoOpt) o;
+        EpollIoOps nioOpt = (EpollIoOps) o;
         return value == nioOpt.value;
     }
 
@@ -136,13 +136,13 @@ public final class EpollIoOpt implements IoOpt {
     }
 
     /**
-     * Returns a {@link EpollIoOpt} for the given value.
+     * Returns a {@link EpollIoOps} for the given value.
      *
      * @param   value the value
-     * @return  the {@link EpollIoOpt}.
+     * @return  the {@link EpollIoOps}.
      */
-    public static EpollIoOpt valueOf(int value) {
-        final EpollIoOpt opt;
+    public static EpollIoOps valueOf(int value) {
+        final EpollIoOps opt;
         if (value > 0 && value < OPTS.length) {
             opt = OPTS[value];
             if (opt != null) {
@@ -151,6 +151,6 @@ public final class EpollIoOpt implements IoOpt {
         } else if (value == EPOLLET.value) {
             return EPOLLET;
         }
-        return new EpollIoOpt(value);
+        return new EpollIoOps(value);
     }
 }

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoRegistration.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoRegistration.java
@@ -24,18 +24,18 @@ import java.io.IOException;
  */
 public interface EpollIoRegistration extends IoRegistration {
     /**
-     * Update the {@link EpollIoOpt} for this registration.
+     * Update the {@link EpollIoOps} for this registration.
      *
-     * @param opt   the {@link EpollIoOpt} to use.
+     * @param opt   the {@link EpollIoOps} to use.
      */
-    void updateInterestOpt(EpollIoOpt opt) throws IOException;
+    void updateInterestOpt(EpollIoOps opt) throws IOException;
 
     /**
-     * The used {@link EpollIoOpt} for this registration.
+     * The used {@link EpollIoOps} for this registration.
      *
      * @return  opt.
      */
-    EpollIoOpt interestOpt();
+    EpollIoOps interestOpt();
 
     @Override
     void cancel() throws IOException;

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventIoOps.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventIoOps.java
@@ -15,12 +15,12 @@
  */
 package io.netty.channel.kqueue;
 
-import io.netty.channel.IoOpt;
+import io.netty.channel.IoOps;
 
 /**
- * {@link IoOpt} to use with {@link KQueueIoHandler}.
+ * {@link IoOps} to use with {@link KQueueIoHandler}.
  */
-public final class KQueueEventIoOpt implements IoOpt {
+public final class KQueueEventIoOps implements IoOps {
     private int ident;
     private short filter;
     private short flags;
@@ -28,19 +28,19 @@ public final class KQueueEventIoOpt implements IoOpt {
     private long data;
 
     /**
-     * Creates a new {@link KQueueEventIoOpt}.
+     * Creates a new {@link KQueueEventIoOps}.
      *
      * @param ident     the identifier for this event.
      * @param filter    the filter for this event.
      * @param flags     the general flags.
      * @param fflags    filter-specific flags.
-     * @return          {@link KQueueEventIoOpt}.
+     * @return          {@link KQueueEventIoOps}.
      */
-    public static KQueueEventIoOpt newOpt(int ident, short filter, short flags, int fflags) {
-        return new KQueueEventIoOpt(ident, filter, flags, fflags, 0);
+    public static KQueueEventIoOps newOpt(int ident, short filter, short flags, int fflags) {
+        return new KQueueEventIoOps(ident, filter, flags, fflags, 0);
     }
 
-    private KQueueEventIoOpt(int ident, short filter, short flags, int fflags, long data) {
+    private KQueueEventIoOps(int ident, short filter, short flags, int fflags, long data) {
         this.ident = ident;
         this.filter = filter;
         this.flags = flags;
@@ -48,7 +48,7 @@ public final class KQueueEventIoOpt implements IoOpt {
         this.data = data;
     }
 
-    KQueueEventIoOpt() {
+    KQueueEventIoOps() {
         this(0, (short) 0, (short) 0, 0, 0);
     }
 

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoHandler.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoHandler.java
@@ -23,7 +23,7 @@ import io.netty.channel.IoExecutionContext;
 import io.netty.channel.IoHandle;
 import io.netty.channel.IoHandler;
 import io.netty.channel.IoHandlerFactory;
-import io.netty.channel.IoOpt;
+import io.netty.channel.IoOps;
 import io.netty.channel.SelectStrategy;
 import io.netty.channel.SelectStrategyFactory;
 import io.netty.channel.unix.FileDescriptor;
@@ -324,12 +324,12 @@ public final class KQueueIoHandler implements IoHandler {
     }
 
     @Override
-    public KQueueIoRegistration register(IoEventLoop eventLoop, IoHandle handle, IoOpt initialOpts) {
+    public KQueueIoRegistration register(IoEventLoop eventLoop, IoHandle handle, IoOps initialOpts) {
         final KQueueIoHandle kqueueHandle = cast(handle);
         if (kqueueHandle.ident() == KQUEUE_WAKE_UP_IDENT) {
             throw new IllegalArgumentException("ident " + KQUEUE_WAKE_UP_IDENT + " is reserved for internal usage");
         }
-        KQueueEventIoOpt eventIoOpt = cast(initialOpts);
+        KQueueEventIoOps eventIoOpt = cast(initialOpts);
         DefaultKqueueIoRegistration registration = new DefaultKqueueIoRegistration(
                 eventLoop, kqueueHandle);
         DefaultKqueueIoRegistration old = registrations.put(kqueueHandle.ident(), registration);
@@ -353,9 +353,9 @@ public final class KQueueIoHandler implements IoHandler {
         throw new IllegalArgumentException("IoHandle of type " + StringUtil.simpleClassName(handle) + " not supported");
     }
 
-    private static KQueueEventIoOpt cast(IoOpt opt) {
-        if (opt instanceof KQueueEventIoOpt) {
-            return (KQueueEventIoOpt) opt;
+    private static KQueueEventIoOps cast(IoOps opt) {
+        if (opt instanceof KQueueEventIoOps) {
+            return (KQueueEventIoOps) opt;
         }
         throw new IllegalArgumentException("IoOpt of type " + StringUtil.simpleClassName(opt) + " not supported");
     }
@@ -366,7 +366,7 @@ public final class KQueueIoHandler implements IoHandler {
     }
 
     private final class DefaultKqueueIoRegistration extends AtomicBoolean implements KQueueIoRegistration {
-        private final KQueueEventIoOpt readyEventIoOpt = new KQueueEventIoOpt();
+        private final KQueueEventIoOps readyEventIoOpt = new KQueueEventIoOps();
 
         final KQueueIoHandle handle;
 
@@ -378,7 +378,7 @@ public final class KQueueIoHandler implements IoHandler {
         }
 
         @Override
-        public void addOpt(KQueueEventIoOpt opt) {
+        public void addOpt(KQueueEventIoOps opt) {
             if (opt.ident() != handle.ident()) {
                 throw new IllegalArgumentException("ident does not match KQueueIoHandle.ident()");
             }

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoRegistration.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoRegistration.java
@@ -23,11 +23,11 @@ import io.netty.channel.IoRegistration;
 public interface KQueueIoRegistration extends IoRegistration {
 
     /**
-     * Add the {@link KQueueEventIoOpt} to the registration.
+     * Add the {@link KQueueEventIoOps} to the registration.
      *
-     * @param opt   the {@link KQueueEventIoOpt} to use.
+     * @param opt   the {@link KQueueEventIoOps} to use.
      */
-    void addOpt(KQueueEventIoOpt opt);
+    void addOpt(KQueueEventIoOps opt);
 
     @Override
     KQueueIoHandler ioHandler();

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpChannel.java
@@ -29,7 +29,7 @@ import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.nio.AbstractNioMessageChannel;
-import io.netty.channel.nio.NioIoOpt;
+import io.netty.channel.nio.NioIoOps;
 import io.netty.channel.sctp.DefaultSctpChannelConfig;
 import io.netty.channel.sctp.SctpChannelConfig;
 import io.netty.channel.sctp.SctpMessage;
@@ -232,7 +232,7 @@ public class NioSctpChannel extends AbstractNioMessageChannel implements io.nett
         try {
             boolean connected = javaChannel().connect(remoteAddress);
             if (!connected) {
-                registration().updateInterestOpt(NioIoOpt.CONNECT);
+                registration().updateInterestOpt(NioIoOps.CONNECT);
             }
             success = true;
             return connected;

--- a/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtByteConnectorChannel.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtByteConnectorChannel.java
@@ -24,7 +24,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.FileRegion;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.nio.AbstractNioByteChannel;
-import io.netty.channel.nio.NioIoOpt;
+import io.netty.channel.nio.NioIoOps;
 import io.netty.channel.nio.NioIoRegistration;
 import io.netty.channel.udt.DefaultUdtChannelConfig;
 import io.netty.channel.udt.UdtChannel;
@@ -114,7 +114,7 @@ public class NioUdtByteConnectorChannel extends AbstractNioByteChannel implement
             final boolean connected = SocketUtils.connect(javaChannel(), remoteAddress);
             if (!connected) {
                 NioIoRegistration registration = registration();
-                registration.updateInterestOpt(registration.interestOpt().with(NioIoOpt.CONNECT));
+                registration.updateInterestOpt(registration.interestOpt().with(NioIoOps.CONNECT));
             }
             success = true;
             return connected;
@@ -134,7 +134,7 @@ public class NioUdtByteConnectorChannel extends AbstractNioByteChannel implement
     protected void doFinishConnect() throws Exception {
         if (javaChannel().finishConnect()) {
             NioIoRegistration registration = registration();
-            registration.updateInterestOpt(registration.interestOpt().without(NioIoOpt.CONNECT));
+            registration.updateInterestOpt(registration.interestOpt().without(NioIoOps.CONNECT));
         } else {
             throw new Error(
                     "Provider error: failed to finish connect. Provider library should be upgraded.");

--- a/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtMessageConnectorChannel.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtMessageConnectorChannel.java
@@ -22,7 +22,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelMetadata;
 import io.netty.channel.ChannelOutboundBuffer;
-import io.netty.channel.nio.NioIoOpt;
+import io.netty.channel.nio.NioIoOps;
 import io.netty.channel.nio.NioIoRegistration;
 import io.netty.util.internal.SocketUtils;
 import io.netty.channel.nio.AbstractNioMessageChannel;
@@ -63,7 +63,7 @@ public class NioUdtMessageConnectorChannel extends AbstractNioMessageChannel imp
     }
 
     public NioUdtMessageConnectorChannel(final Channel parent, final SocketChannelUDT channelUDT) {
-        super(parent, channelUDT, NioIoOpt.READ);
+        super(parent, channelUDT, NioIoOps.READ);
         try {
             channelUDT.configureBlocking(false);
             switch (channelUDT.socketUDT().status()) {
@@ -117,7 +117,7 @@ public class NioUdtMessageConnectorChannel extends AbstractNioMessageChannel imp
             final boolean connected = SocketUtils.connect(javaChannel(), remoteAddress);
             if (!connected) {
                 NioIoRegistration registration = registration();
-                registration.updateInterestOpt(registration.interestOpt().with(NioIoOpt.CONNECT));
+                registration.updateInterestOpt(registration.interestOpt().with(NioIoOps.CONNECT));
             }
             success = true;
             return connected;
@@ -137,7 +137,7 @@ public class NioUdtMessageConnectorChannel extends AbstractNioMessageChannel imp
     protected void doFinishConnect() throws Exception {
         if (javaChannel().finishConnect()) {
             NioIoRegistration registration = registration();
-            registration.updateInterestOpt(registration.interestOpt().without(NioIoOpt.CONNECT));
+            registration.updateInterestOpt(registration.interestOpt().without(NioIoOps.CONNECT));
         } else {
             throw new Error(
                     "Provider error: failed to finish connect. Provider library should be upgraded.");

--- a/transport/src/main/java/io/netty/channel/IoEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/IoEventLoop.java
@@ -30,14 +30,14 @@ public interface IoEventLoop extends EventLoop, IoEventLoopGroup {
         return this;
     }
     /**
-     * @deprecated Use {@link #register(IoHandle, IoOpt)}
+     * @deprecated Use {@link #register(IoHandle, IoOps)}
      */
     @Deprecated
     @Override
     ChannelFuture register(Channel channel);
 
     /**
-     * @deprecated Use {@link #register(IoHandle, IoOpt)}
+     * @deprecated Use {@link #register(IoHandle, IoOps)}
      */
     @Deprecated
     @Override
@@ -47,10 +47,10 @@ public interface IoEventLoop extends EventLoop, IoEventLoopGroup {
      * Register the {@link IoHandle} to the {@link EventLoop} for I/O processing.
      *
      * @param handle        the {@link IoHandle} to register.
-     * @param initialOpt    the initial {@link IoOpt} to use.
+     * @param initialOpt    the initial {@link IoOps} to use.
      * @return              the {@link Future} that is notified once the operations completes.
      */
-    Future<IoRegistration> register(IoHandle handle, IoOpt initialOpt);
+    Future<IoRegistration> register(IoHandle handle, IoOps initialOpt);
 
     @Override
     boolean isCompatible(Class<? extends IoHandle> handleType);

--- a/transport/src/main/java/io/netty/channel/IoHandle.java
+++ b/transport/src/main/java/io/netty/channel/IoHandle.java
@@ -25,8 +25,8 @@ public interface IoHandle extends AutoCloseable {
      * Be called once there is something to handle.
      *
      * @param registration  the {@link IoRegistration} for this {@link IoHandle}.
-     * @param readyOpt      the {@link IoOpt} that must be handled. The {@link IoOpt} is only valid
+     * @param readyOpt      the {@link IoOps} that must be handled. The {@link IoOps} is only valid
      *                      while this method is executed and so must not escape it.
      */
-    void handle(IoRegistration registration, IoOpt readyOpt);
+    void handle(IoRegistration registration, IoOps readyOpt);
 }

--- a/transport/src/main/java/io/netty/channel/IoHandler.java
+++ b/transport/src/main/java/io/netty/channel/IoHandler.java
@@ -48,10 +48,10 @@ public interface IoHandler {
      *
      * @param eventLoop     the {@link IoEventLoop} that did issue the registration.
      * @param handle        the {@link IoHandle} to register.
-     * @param opt           the {@link IoOpt} which should be used during registration.
+     * @param opt           the {@link IoOps} which should be used during registration.
      * @throws Exception    thrown if an error happens during registration.
      */
-    IoRegistration register(IoEventLoop eventLoop, IoHandle handle, IoOpt opt) throws Exception;
+    IoRegistration register(IoEventLoop eventLoop, IoHandle handle, IoOps opt) throws Exception;
 
     /**
      * Wakeup the {@link IoHandler}, which means if any operation blocks it should be unblocked and

--- a/transport/src/main/java/io/netty/channel/IoOps.java
+++ b/transport/src/main/java/io/netty/channel/IoOps.java
@@ -17,8 +17,8 @@ package io.netty.channel;
 
 /**
  * An IO opt that is used when register an {@link IoHandle} to an {@link IoEventLoop}.
- * Concrete {@link IoHandle} implementations support different concrete {@link IoOpt} implementations.
+ * Concrete {@link IoHandle} implementations support different concrete {@link IoOps} implementations.
  */
-public interface IoOpt {
+public interface IoOps {
     // Marker interface.
 }

--- a/transport/src/main/java/io/netty/channel/SingleThreadIoEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/SingleThreadIoEventLoop.java
@@ -176,7 +176,7 @@ public class SingleThreadIoEventLoop extends SingleThreadEventLoop implements Io
     }
 
     @Override
-    public final Future<IoRegistration> register(final IoHandle handle, IoOpt initialOpt) {
+    public final Future<IoRegistration> register(final IoHandle handle, IoOps initialOpt) {
         Promise<IoRegistration> promise = newPromise();
         if (inEventLoop()) {
             registerForIo0(handle, initialOpt, promise);
@@ -187,7 +187,7 @@ public class SingleThreadIoEventLoop extends SingleThreadEventLoop implements Io
         return promise;
     }
 
-    private void registerForIo0(final IoHandle handle, IoOpt initialOpt,
+    private void registerForIo0(final IoHandle handle, IoOps initialOpt,
                                Promise<IoRegistration> promise) {
         assert inEventLoop();
         final IoRegistration registration;

--- a/transport/src/main/java/io/netty/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalChannel.java
@@ -26,7 +26,7 @@ import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.EventLoop;
 import io.netty.channel.IoEventLoop;
-import io.netty.channel.IoOpt;
+import io.netty.channel.IoOps;
 import io.netty.channel.IoRegistration;
 import io.netty.channel.PreferHeapByteBufAllocator;
 import io.netty.channel.RecvByteBufAllocator;
@@ -166,7 +166,7 @@ public class LocalChannel extends AbstractChannel {
         EventLoop loop = eventLoop();
         if (loop instanceof IoEventLoop) {
             assert registration == null;
-            ((IoEventLoop) loop).register((LocalUnsafe) unsafe(), LocalIoOpt.DEFAULT).addListener(f -> {
+            ((IoEventLoop) loop).register((LocalUnsafe) unsafe(), LocalIoOps.DEFAULT).addListener(f -> {
                if (f.isSuccess()) {
                    registration = (IoRegistration) f.getNow();
                    promise.setSuccess();
@@ -479,7 +479,7 @@ public class LocalChannel extends AbstractChannel {
         }
 
         @Override
-        public void handle(IoRegistration registration, IoOpt readyOpt) {
+        public void handle(IoRegistration registration, IoOps readyOpt) {
             // NOOP
         }
 

--- a/transport/src/main/java/io/netty/channel/local/LocalIoHandler.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalIoHandler.java
@@ -20,7 +20,7 @@ import io.netty.channel.IoExecutionContext;
 import io.netty.channel.IoHandle;
 import io.netty.channel.IoHandler;
 import io.netty.channel.IoHandlerFactory;
-import io.netty.channel.IoOpt;
+import io.netty.channel.IoOps;
 import io.netty.channel.IoRegistration;
 import io.netty.util.internal.StringUtil;
 
@@ -90,9 +90,9 @@ public final class LocalIoHandler implements IoHandler {
     }
 
     @Override
-    public IoRegistration register(IoEventLoop eventLoop, IoHandle handle, IoOpt initialOpt) {
+    public IoRegistration register(IoEventLoop eventLoop, IoHandle handle, IoOps initialOpt) {
         LocalIoHandle localHandle = cast(handle);
-        if (initialOpt != LocalIoOpt.DEFAULT) {
+        if (initialOpt != LocalIoOps.DEFAULT) {
             throw new IllegalArgumentException(
                     "IoOpt of type " + StringUtil.simpleClassName(initialOpt) + " not supported");
         }

--- a/transport/src/main/java/io/netty/channel/local/LocalIoOps.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalIoOps.java
@@ -15,17 +15,17 @@
  */
 package io.netty.channel.local;
 
-import io.netty.channel.IoOpt;
+import io.netty.channel.IoOps;
 
 /**
- * {@link IoOpt} implementation that can be used with {@link LocalIoHandler}.
+ * {@link IoOps} implementation that can be used with {@link LocalIoHandler}.
  */
-public final class LocalIoOpt implements IoOpt {
+public final class LocalIoOps implements IoOps {
 
     /**
      * Default instance to use.
      */
-    public static final LocalIoOpt DEFAULT = new LocalIoOpt();
+    public static final LocalIoOps DEFAULT = new LocalIoOps();
 
-    private LocalIoOpt() { }
+    private LocalIoOps() { }
 }

--- a/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
@@ -23,7 +23,7 @@ import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.EventLoop;
 import io.netty.channel.IoEventLoop;
 import io.netty.channel.IoEventLoopGroup;
-import io.netty.channel.IoOpt;
+import io.netty.channel.IoOps;
 import io.netty.channel.IoRegistration;
 import io.netty.channel.PreferHeapByteBufAllocator;
 import io.netty.channel.RecvByteBufAllocator;
@@ -102,7 +102,7 @@ public class LocalServerChannel extends AbstractServerChannel {
         EventLoop loop = eventLoop();
         if (loop instanceof IoEventLoop) {
             assert registration == null;
-            ((IoEventLoop) loop).register((LocalServerUnsafe) unsafe(), LocalIoOpt.DEFAULT).addListener(f -> {
+            ((IoEventLoop) loop).register((LocalServerUnsafe) unsafe(), LocalIoOps.DEFAULT).addListener(f -> {
                 if (f.isSuccess()) {
                     registration = (IoRegistration) f.getNow();
                     promise.setSuccess();
@@ -227,7 +227,7 @@ public class LocalServerChannel extends AbstractServerChannel {
         }
 
         @Override
-        public void handle(IoRegistration registration, IoOpt readyOpt) {
+        public void handle(IoRegistration registration, IoOps readyOpt) {
             // NOOP
         }
 

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioByteChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioByteChannel.java
@@ -330,9 +330,9 @@ public abstract class AbstractNioByteChannel extends AbstractNioChannel {
         if (!registration.isValid()) {
             return;
         }
-        final NioIoOpt opt = registration.interestOpt();
-        if (!opt.contains(NioIoOpt.WRITE)) {
-            registration.updateInterestOpt(opt.with(NioIoOpt.WRITE));
+        final NioIoOps opt = registration.interestOpt();
+        if (!opt.contains(NioIoOps.WRITE)) {
+            registration.updateInterestOpt(opt.with(NioIoOps.WRITE));
         }
     }
 
@@ -344,6 +344,6 @@ public abstract class AbstractNioByteChannel extends AbstractNioChannel {
         if (!registration.isValid()) {
             return;
         }
-        registration.updateInterestOpt(registration.interestOpt().without(NioIoOpt.WRITE));
+        registration.updateInterestOpt(registration.interestOpt().without(NioIoOps.WRITE));
     }
 }

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioMessageChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioMessageChannel.java
@@ -41,7 +41,7 @@ public abstract class AbstractNioMessageChannel extends AbstractNioChannel {
         super(parent, ch, readInterestOp);
     }
 
-    protected AbstractNioMessageChannel(Channel parent, SelectableChannel ch, NioIoOpt readOpt) {
+    protected AbstractNioMessageChannel(Channel parent, SelectableChannel ch, NioIoOps readOpt) {
         super(parent, ch, readOpt);
     }
 
@@ -132,7 +132,7 @@ public abstract class AbstractNioMessageChannel extends AbstractNioChannel {
     @Override
     protected void doWrite(ChannelOutboundBuffer in) throws Exception {
         final NioIoRegistration registration = registration();
-        final NioIoOpt opt = registration.interestOpt();
+        final NioIoOps opt = registration.interestOpt();
 
         int maxMessagesPerWrite = maxMessagesPerWrite();
         while (maxMessagesPerWrite > 0) {
@@ -166,10 +166,10 @@ public abstract class AbstractNioMessageChannel extends AbstractNioChannel {
         }
         if (in.isEmpty()) {
             // Wrote all messages.
-            registration.updateInterestOpt(opt.without(NioIoOpt.WRITE));
+            registration.updateInterestOpt(opt.without(NioIoOps.WRITE));
         } else {
             // Did not write all messages.
-            registration.updateInterestOpt(opt.with(NioIoOpt.WRITE));
+            registration.updateInterestOpt(opt.with(NioIoOps.WRITE));
         }
     }
 

--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
@@ -141,7 +141,7 @@ public final class NioEventLoop extends SingleThreadIoEventLoop {
                                 logger.warn("Unexpected exception while running NioTask.channelUnregistered(...)", e);
                             }
                         }
-                    }, NioIoOpt.valueOf(interestOps)).get();
+                    }, NioIoOps.valueOf(interestOps)).get();
         } catch (Exception e) {
             throw new IllegalStateException(e);
         }

--- a/transport/src/main/java/io/netty/channel/nio/NioIoHandler.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioIoHandler.java
@@ -22,7 +22,7 @@ import io.netty.channel.IoExecutionContext;
 import io.netty.channel.IoHandle;
 import io.netty.channel.IoHandler;
 import io.netty.channel.IoHandlerFactory;
-import io.netty.channel.IoOpt;
+import io.netty.channel.IoOps;
 import io.netty.channel.SelectStrategy;
 import io.netty.channel.SelectStrategyFactory;
 import io.netty.util.IntSupplier;
@@ -307,9 +307,9 @@ public final class NioIoHandler implements IoHandler {
         throw new IllegalArgumentException("IoHandle of type " + StringUtil.simpleClassName(handle) + " not supported");
     }
 
-    private static NioIoOpt cast(IoOpt opt) {
-        if (opt instanceof NioIoOpt) {
-            return (NioIoOpt) opt;
+    private static NioIoOps cast(IoOps opt) {
+        if (opt instanceof NioIoOps) {
+            return (NioIoOps) opt;
         }
         throw new IllegalArgumentException("IoOpt of type " + StringUtil.simpleClassName(opt) + " not supported");
     }
@@ -318,7 +318,7 @@ public final class NioIoHandler implements IoHandler {
         private final NioIoHandle handle;
         private volatile SelectionKey key;
 
-        DefaultNioRegistration(NioIoHandle handle, NioIoOpt initialOpt, Selector selector) throws IOException {
+        DefaultNioRegistration(NioIoHandle handle, NioIoOps initialOpt, Selector selector) throws IOException {
             this.handle = handle;
             key = handle.selectableChannel().register(selector, initialOpt.value, this);
         }
@@ -328,7 +328,7 @@ public final class NioIoHandler implements IoHandler {
         }
 
         void register(Selector selector) throws IOException {
-            NioIoOpt opts = interestOpt();
+            NioIoOps opts = interestOpt();
             SelectionKey newKey = handle.selectableChannel().register(selector, opts.value, this);
             key.cancel();
             key = newKey;
@@ -345,13 +345,13 @@ public final class NioIoHandler implements IoHandler {
         }
 
         @Override
-        public void updateInterestOpt(NioIoOpt opt) {
+        public void updateInterestOpt(NioIoOps opt) {
             key.interestOps(opt.value);
         }
 
         @Override
-        public NioIoOpt interestOpt() {
-            return NioIoOpt.valueOf(key.interestOps());
+        public NioIoOps interestOpt() {
+            return NioIoOps.valueOf(key.interestOps());
         }
 
         @Override
@@ -374,7 +374,7 @@ public final class NioIoHandler implements IoHandler {
         }
 
         void handle(int ready) {
-            handle.handle(this, NioIoOpt.valueOf(ready));
+            handle.handle(this, NioIoOps.valueOf(ready));
         }
 
         @Override
@@ -384,10 +384,10 @@ public final class NioIoHandler implements IoHandler {
     }
 
     @Override
-    public NioIoRegistration register(IoEventLoop eventLoop, IoHandle handle, IoOpt initialOpt)
+    public NioIoRegistration register(IoEventLoop eventLoop, IoHandle handle, IoOps initialOpt)
             throws Exception {
         NioIoHandle nioHandle = nioHandle(handle);
-        NioIoOpt opt = cast(initialOpt);
+        NioIoOps opt = cast(initialOpt);
         boolean selected = false;
         for (;;) {
             try {

--- a/transport/src/main/java/io/netty/channel/nio/NioIoOps.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioIoOps.java
@@ -15,57 +15,57 @@
  */
 package io.netty.channel.nio;
 
-import io.netty.channel.IoOpt;
+import io.netty.channel.IoOps;
 
 import java.nio.channels.SelectionKey;
 
 /**
- * Implementation of {@link IoOpt} for
+ * Implementation of {@link IoOps} for
  * that is used by {@link NioIoHandler} and so for NIO based transports.
  */
-public final class NioIoOpt implements IoOpt {
+public final class NioIoOps implements IoOps {
     /**
      * Interested in NO IO events.
      */
-    public static final NioIoOpt NONE = new NioIoOpt(0);
+    public static final NioIoOps NONE = new NioIoOps(0);
 
     /**
      * Interested in IO events that should be handled by accepting new connections
      */
-    public static final NioIoOpt ACCEPT = new NioIoOpt(SelectionKey.OP_ACCEPT);
+    public static final NioIoOps ACCEPT = new NioIoOps(SelectionKey.OP_ACCEPT);
 
     /**
      * Interested in IO events which should be handled by finish pending connect operations
      */
-    public static final NioIoOpt CONNECT = new NioIoOpt(SelectionKey.OP_CONNECT);
+    public static final NioIoOps CONNECT = new NioIoOps(SelectionKey.OP_CONNECT);
 
     /**
      * Interested in IO events which tell that the underlying channel is writable again.
      */
-    public static final NioIoOpt WRITE = new NioIoOpt(SelectionKey.OP_WRITE);
+    public static final NioIoOps WRITE = new NioIoOps(SelectionKey.OP_WRITE);
 
     /**
      * Interested in IO events which should be handled by reading data.
      */
-    public static final NioIoOpt READ = new NioIoOpt(SelectionKey.OP_READ);
+    public static final NioIoOps READ = new NioIoOps(SelectionKey.OP_READ);
 
     /**
      * Interested in IO events which should be either handled by reading or accepting.
      */
-    public static final NioIoOpt READ_AND_ACCEPT = new NioIoOpt(SelectionKey.OP_READ | SelectionKey.OP_ACCEPT);
+    public static final NioIoOps READ_AND_ACCEPT = new NioIoOps(SelectionKey.OP_READ | SelectionKey.OP_ACCEPT);
 
     /**
      * Interested in IO events which should be either handled by reading or writing.
      */
-    public static final NioIoOpt READ_AND_WRITE = new NioIoOpt(SelectionKey.OP_READ | SelectionKey.OP_WRITE);
+    public static final NioIoOps READ_AND_WRITE = new NioIoOps(SelectionKey.OP_READ | SelectionKey.OP_WRITE);
 
     // Just use an array to store often used values.
-    private static final NioIoOpt[] OPTS;
+    private static final NioIoOps[] OPTS;
 
     static {
-        NioIoOpt all = new NioIoOpt(
+        NioIoOps all = new NioIoOps(
                 NONE.value | ACCEPT.value | CONNECT.value | WRITE.value | READ.value);
-        OPTS = new NioIoOpt[all.value + 1];
+        OPTS = new NioIoOps[all.value + 1];
         addToArray(OPTS, NONE);
         addToArray(OPTS, ACCEPT);
         addToArray(OPTS, CONNECT);
@@ -76,32 +76,32 @@ public final class NioIoOpt implements IoOpt {
         addToArray(OPTS, all);
     }
 
-    private static void addToArray(NioIoOpt[] array, NioIoOpt opt) {
+    private static void addToArray(NioIoOps[] array, NioIoOps opt) {
         array[opt.value] = opt;
     }
 
     final int value;
 
-    private NioIoOpt(int value) {
+    private NioIoOps(int value) {
         this.value = value;
     }
 
     /**
-     * Returns {@code true} if this {@link NioIoOpt} is a combination of the given {@link NioIoOpt}.
+     * Returns {@code true} if this {@link NioIoOps} is a combination of the given {@link NioIoOps}.
      * @param opt   the opt.
      * @return      {@code true} if a combination of the given.
      */
-    public boolean contains(NioIoOpt opt) {
+    public boolean contains(NioIoOps opt) {
         return (value & opt.value) != 0;
     }
 
     /**
-     * Return a {@link NioIoOpt} which is a combination of the current and the given {@link NioIoOpt}.
+     * Return a {@link NioIoOps} which is a combination of the current and the given {@link NioIoOps}.
      *
-     * @param opt   the {@link NioIoOpt} that should be added to this one.
-     * @return      a {@link NioIoOpt}.
+     * @param opt   the {@link NioIoOps} that should be added to this one.
+     * @return      a {@link NioIoOps}.
      */
-    public NioIoOpt with(NioIoOpt opt) {
+    public NioIoOps with(NioIoOps opt) {
         if (contains(opt)) {
             return this;
         }
@@ -109,12 +109,12 @@ public final class NioIoOpt implements IoOpt {
     }
 
     /**
-     * Return a {@link NioIoOpt} which is not a combination of the current and the given {@link NioIoOpt}.
+     * Return a {@link NioIoOps} which is not a combination of the current and the given {@link NioIoOps}.
      *
-     * @param opt   the {@link NioIoOpt} that should be remove from this one.
-     * @return      a {@link NioIoOpt}.
+     * @param opt   the {@link NioIoOps} that should be remove from this one.
+     * @return      a {@link NioIoOps}.
      */
-    public NioIoOpt without(NioIoOpt opt) {
+    public NioIoOps without(NioIoOps opt) {
         if (!contains(opt)) {
             return this;
         }
@@ -122,7 +122,7 @@ public final class NioIoOpt implements IoOpt {
     }
 
     /**
-     * Returns the underlying value of the {@link NioIoOpt}.
+     * Returns the underlying value of the {@link NioIoOps}.
      *
      * @return value.
      */
@@ -138,7 +138,7 @@ public final class NioIoOpt implements IoOpt {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        NioIoOpt nioOpt = (NioIoOpt) o;
+        NioIoOps nioOpt = (NioIoOps) o;
         return value == nioOpt.value;
     }
 
@@ -148,19 +148,19 @@ public final class NioIoOpt implements IoOpt {
     }
 
     /**
-     * Returns a {@link NioIoOpt} for the given value.
+     * Returns a {@link NioIoOps} for the given value.
      *
      * @param   value the value
-     * @return  the {@link NioIoOpt}.
+     * @return  the {@link NioIoOps}.
      */
-    public static NioIoOpt valueOf(int value) {
-        final NioIoOpt opt;
+    public static NioIoOps valueOf(int value) {
+        final NioIoOps opt;
         if (value < OPTS.length) {
             opt = OPTS[value];
             if (opt != null) {
                 return opt;
             }
         }
-        return new NioIoOpt(value);
+        return new NioIoOps(value);
     }
 }

--- a/transport/src/main/java/io/netty/channel/nio/NioIoRegistration.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioIoRegistration.java
@@ -31,18 +31,18 @@ public interface NioIoRegistration extends IoRegistration {
     SelectionKey selectionKey();
 
     /**
-     * Update the {@link NioIoOpt} for this registration.
+     * Update the {@link NioIoOps} for this registration.
      *
-     * @param opt   the {@link NioIoOpt} to use.
+     * @param opt   the {@link NioIoOps} to use.
      */
-    void updateInterestOpt(NioIoOpt opt);
+    void updateInterestOpt(NioIoOps opt);
 
     /**
-     * The used {@link NioIoOpt} for this registration.
+     * The used {@link NioIoOps} for this registration.
      *
      * @return  opt.
      */
-    NioIoOpt interestOpt();
+    NioIoOps interestOpt();
 
     @Override
     void cancel();

--- a/transport/src/main/java/io/netty/channel/nio/NioSelectableChannelIoHandle.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioSelectableChannelIoHandle.java
@@ -17,7 +17,7 @@ package io.netty.channel.nio;
 
 
 import io.netty.channel.IoHandle;
-import io.netty.channel.IoOpt;
+import io.netty.channel.IoOps;
 import io.netty.channel.IoRegistration;
 import io.netty.util.internal.ObjectUtil;
 
@@ -37,7 +37,7 @@ public abstract class NioSelectableChannelIoHandle<S extends SelectableChannel> 
     }
 
     @Override
-    public void handle(IoRegistration registration, IoOpt ioEvent) {
+    public void handle(IoRegistration registration, IoOps ioEvent) {
         SelectionKey key = ((NioIoRegistration) registration).selectionKey();
         NioSelectableChannelIoHandle.this.handle(channel, key);
     }

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
@@ -27,7 +27,7 @@ import io.netty.channel.EventLoop;
 import io.netty.channel.FileRegion;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.nio.AbstractNioByteChannel;
-import io.netty.channel.nio.NioIoOpt;
+import io.netty.channel.nio.NioIoOps;
 import io.netty.channel.nio.NioIoRegistration;
 import io.netty.channel.socket.DefaultSocketChannelConfig;
 import io.netty.channel.socket.InternetProtocolFamily;
@@ -307,7 +307,7 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
             boolean connected = SocketUtils.connect(javaChannel(), remoteAddress);
             if (!connected) {
                 NioIoRegistration registration = registration();
-                registration.updateInterestOpt(registration.interestOpt().with(NioIoOpt.CONNECT));
+                registration.updateInterestOpt(registration.interestOpt().with(NioIoOps.CONNECT));
             }
             success = true;
             return connected;


### PR DESCRIPTION
Motivation:

https://github.com/netty/netty/pull/14020 introduced a new way how registrations are done. Unfortunally there was a type and so interfaces / classes were named incorrectly.

Modifications:

- Rename *IoOpts to *IoOps

Result:

Correct spelling