### PR TITLE
Move factory methods to IOUringHandler

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/IOUring.java
+++ b/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/IOUring.java
@@ -15,7 +15,6 @@
  */
 package io.netty5.channel.uring;
 
-import io.netty5.channel.IoHandlerFactory;
 import io.netty5.util.internal.PlatformDependent;
 import io.netty5.util.internal.SystemPropertyUtil;
 import org.slf4j.Logger;
@@ -80,30 +79,6 @@ public final class IOUring {
 
     public static Throwable unavailabilityCause() {
         return UNAVAILABILITY_CAUSE;
-    }
-
-    public static IoHandlerFactory newFactory() {
-        ensureAvailability();
-        return () -> {
-            RingBuffer ringBuffer = Native.createRingBuffer();
-            return new IOUringHandler(ringBuffer);
-        };
-    }
-
-    public static IoHandlerFactory newFactory(int ringSize) {
-        ensureAvailability();
-        return () -> {
-            RingBuffer ringBuffer = Native.createRingBuffer(ringSize);
-            return new IOUringHandler(ringBuffer);
-        };
-    }
-
-    public static IoHandlerFactory newFactory(int ringSize, int kernelWorkerOffloadThreshold) {
-        ensureAvailability();
-        return () -> {
-            RingBuffer ringBuffer = Native.createRingBuffer(ringSize, kernelWorkerOffloadThreshold);
-            return new IOUringHandler(ringBuffer);
-        };
     }
 
     private IOUring() {

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringDetectPeerCloseWithReadTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringDetectPeerCloseWithReadTest.java
@@ -33,7 +33,7 @@ public class IOUringDetectPeerCloseWithReadTest extends DetectPeerCloseWithoutRe
 
     @Override
     protected EventLoopGroup newGroup() {
-        return new MultithreadEventLoopGroup(2, IOUring.newFactory());
+        return new MultithreadEventLoopGroup(2, IOUringHandler.newFactory());
     }
 
     @Override

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringEventLoopTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringEventLoopTest.java
@@ -21,7 +21,6 @@ import io.netty5.channel.IoHandlerFactory;
 import io.netty5.channel.MultithreadEventLoopGroup;
 import io.netty5.channel.ServerChannel;
 import io.netty5.testsuite.transport.AbstractSingleThreadEventLoopTest;
-import io.netty5.util.concurrent.Future;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
@@ -44,7 +43,7 @@ public class IOUringEventLoopTest extends AbstractSingleThreadEventLoopTest {
 
     @Override
     protected IoHandlerFactory newIoHandlerFactory() {
-        return IOUring.newFactory();
+        return IOUringHandler.newFactory();
     }
 
     @Override
@@ -85,7 +84,7 @@ public class IOUringEventLoopTest extends AbstractSingleThreadEventLoopTest {
 
     @Test
     public void testSchedule() throws Exception {
-        EventLoopGroup group = new MultithreadEventLoopGroup(1, IOUring.newFactory());
+        EventLoopGroup group = new MultithreadEventLoopGroup(1, IOUringHandler.newFactory());
         try {
             EventLoop loop = group.next();
             loop.schedule(EMPTY_RUNNABLE, 1, TimeUnit.SECONDS).asStage().sync();

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringRemoteIpTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringRemoteIpTest.java
@@ -67,7 +67,7 @@ public class IOUringRemoteIpTest {
 
     private static void testRemoteAddress(InetAddress server, InetAddress client) throws Exception {
         final Promise<SocketAddress> promise = ImmediateEventExecutor.INSTANCE.newPromise();
-        EventLoopGroup bossGroup = new MultithreadEventLoopGroup(1, IOUring.newFactory());
+        EventLoopGroup bossGroup = new MultithreadEventLoopGroup(1, IOUringHandler.newFactory());
         Socket socket = new Socket();
         try {
             ServerBootstrap b = new ServerBootstrap();

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketTestPermutation.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/IOUringSocketTestPermutation.java
@@ -50,9 +50,9 @@ public class IOUringSocketTestPermutation extends SocketTestPermutation {
     static final IOUringSocketTestPermutation INSTANCE = new IOUringSocketTestPermutation();
 
     static final EventLoopGroup IO_URING_BOSS_GROUP = new MultithreadEventLoopGroup(
-            BOSSES, new DefaultThreadFactory("testsuite-io_uring-boss", true), IOUring.newFactory());
+            BOSSES, new DefaultThreadFactory("testsuite-io_uring-boss", true), IOUringHandler.newFactory());
     static final EventLoopGroup IO_URING_WORKER_GROUP = new MultithreadEventLoopGroup(
-            WORKERS, new DefaultThreadFactory("testsuite-io_uring-worker", true), IOUring.newFactory());
+            WORKERS, new DefaultThreadFactory("testsuite-io_uring-worker", true), IOUringHandler.newFactory());
 
     private static final Logger logger = LoggerFactory.getLogger(IOUringSocketTestPermutation.class);
 

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/PollRemoveTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/PollRemoveTest.java
@@ -39,7 +39,7 @@ public class PollRemoveTest {
 
     private static void ioUringTest() throws Exception {
         Class<? extends ServerSocketChannel> clazz = IOUringServerSocketChannel.class;
-        final EventLoopGroup bossGroup = new MultithreadEventLoopGroup(1, IOUring.newFactory());
+        final EventLoopGroup bossGroup = new MultithreadEventLoopGroup(1, IOUringHandler.newFactory());
 
         try {
             ServerBootstrap b = new ServerBootstrap();

--- a/transport-native-io_uring/src/test/java/io/netty5/channel/uring/example/EchoIOUringServer.java
+++ b/transport-native-io_uring/src/test/java/io/netty5/channel/uring/example/EchoIOUringServer.java
@@ -22,6 +22,7 @@ import io.netty5.channel.EventLoopGroup;
 import io.netty5.channel.MultithreadEventLoopGroup;
 import io.netty5.channel.socket.SocketChannel;
 import io.netty5.channel.uring.IOUring;
+import io.netty5.channel.uring.IOUringHandler;
 import io.netty5.channel.uring.IOUringServerSocketChannel;
 import io.netty5.handler.logging.LogLevel;
 import io.netty5.handler.logging.LoggingHandler;
@@ -31,8 +32,8 @@ public class EchoIOUringServer {
     private static final int PORT = Integer.parseInt(System.getProperty("port", "8080"));
 
     public static void main(String []args) throws Exception {
-        EventLoopGroup bossGroup = new MultithreadEventLoopGroup(1, IOUring.newFactory());
-        EventLoopGroup workerGroup = new MultithreadEventLoopGroup(1, IOUring.newFactory());
+        EventLoopGroup bossGroup = new MultithreadEventLoopGroup(1, IOUringHandler.newFactory());
+        EventLoopGroup workerGroup = new MultithreadEventLoopGroup(1, IOUringHandler.newFactory());
         final EchoIOUringServerHandler serverHandler = new EchoIOUringServerHandler();
         try {
             ServerBootstrap b = new ServerBootstrap();


### PR DESCRIPTION
Motivation:

In all our other transport implementations we have the factory methods in the IoHandler implementation itself. Let's be consistent

Modifications:

Move methods from IOUring to IOUringHandler.

Result:

More consistent API