### PR TITLE
Introduce IoEvent to prepare support for io_uring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1478,7 +1478,7 @@
                 <item>
                   <ignore>true</ignore>
                   <code>java.method.finalMethodAddedToNonFinalClass</code>
-                  <new>method io.netty.util.concurrent.Future&lt;io.netty.channel.IoRegistration&gt; io.netty.channel.SingleThreadIoEventLoop::register(io.netty.channel.IoHandle, io.netty.channel.IoOps) @ io.netty.channel.epoll.EpollEventLoop</new>
+                  <new>method io.netty.util.concurrent.Future&lt;io.netty.channel.IoRegistration&gt; io.netty.channel.SingleThreadIoEventLoop::register(io.netty.channel.IoHandle) @ io.netty.channel.epoll.EpollEventLoop</new>
                 </item>
 
                 <item>

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
@@ -288,9 +288,10 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
         // make sure the epollInReadyRunnablePending variable is reset so we will be able to execute the Runnable on the
         // new EventLoop.
         epollInReadyRunnablePending = false;
-        ((IoEventLoop) eventLoop()).register((AbstractEpollUnsafe) unsafe(), initialOps).addListener(f -> {
+        ((IoEventLoop) eventLoop()).register((AbstractEpollUnsafe) unsafe()).addListener(f -> {
             if (f.isSuccess()) {
                 registration = (EpollIoRegistration) f.getNow();
+                registration.updateInterestOps(initialOps);
                 promise.setSuccess();
             } else {
                 promise.setFailure(f.cause());

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
@@ -76,6 +76,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
     boolean inputClosedSeenErrorOnRead;
     boolean epollInReadyRunnablePending;
     private EpollIoOps ops;
+    private EpollIoOps inital;
     protected volatile boolean active;
 
     AbstractEpollChannel(Channel parent, LinuxSocket fd, boolean active, EpollIoOps initialOps) {
@@ -238,6 +239,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
     protected void doDeregister() throws Exception {
         EpollIoRegistration registration = this.registration;
         if (registration != null) {
+            ops = inital;
             registration.cancel();
         }
     }
@@ -313,6 +315,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
             if (f.isSuccess()) {
                 registration = (EpollIoRegistration) f.getNow();
                 registration.submit(ops);
+                inital = ops;
                 promise.setSuccess();
             } else {
                 promise.setFailure(f.cause());

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
@@ -75,7 +75,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
     private EpollIoRegistration registration;
     boolean inputClosedSeenErrorOnRead;
     boolean epollInReadyRunnablePending;
-    volatile EpollIoOps initialOps;
+    private EpollIoOps ops;
     protected volatile boolean active;
 
     AbstractEpollChannel(Channel parent, LinuxSocket fd, boolean active, EpollIoOps initialOps) {
@@ -88,7 +88,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
             this.local = fd.localAddress();
             this.remote = fd.remoteAddress();
         }
-        this.initialOps = initialOps;
+        this.ops = initialOps;
     }
 
     AbstractEpollChannel(Channel parent, LinuxSocket fd, SocketAddress remote, EpollIoOps initialOps) {
@@ -99,7 +99,15 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
         // See https://github.com/netty/netty/issues/2359
         this.remote = remote;
         this.local = fd.localAddress();
-        this.initialOps = initialOps;
+        this.ops = initialOps;
+    }
+
+    void add(EpollIoOps add) {
+        ops = ops.with(add);
+    }
+
+    void remove(EpollIoOps remove) {
+        ops = ops.without(remove);
     }
 
     static boolean isSoErrorZero(Socket fd) {
@@ -111,18 +119,31 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
     }
 
     protected void setFlag(int flag) throws IOException {
+        ops = ops.with(EpollIoOps.valueOf(flag));
         if (isRegistered()) {
             EpollIoRegistration registration = registration();
-            registration.updateInterestOps(registration.interestOps().with(EpollIoOps.valueOf(flag)));
+            try {
+                registration.submit(ops);
+            } catch (IOException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new IllegalStateException(e);
+            }
         } else {
-            initialOps = initialOps.with(EpollIoOps.valueOf(flag));
+            ops = ops.with(EpollIoOps.valueOf(flag));
         }
     }
 
     void clearFlag(int flag) throws IOException {
         EpollIoRegistration registration = registration();
-        registration.updateInterestOps(
-                registration.interestOps().without(EpollIoOps.valueOf(flag)));
+        ops = ops.without(EpollIoOps.valueOf(flag));
+        try {
+            registration.submit(ops);
+        } catch (IOException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
     }
 
     protected final EpollIoRegistration registration() {
@@ -131,7 +152,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
     }
 
     boolean isFlagSet(int flag) {
-        return (registration().interestOps().value & flag) != 0;
+        return (ops.value & flag) != 0;
     }
 
     @Override
@@ -278,7 +299,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
         } else  {
             // The EventLoop is not registered atm so just update the flags so the correct value
             // will be used once the channel is registered
-            initialOps = initialOps.without(EpollIoOps.EPOLLIN);
+            ops = ops.without(EpollIoOps.EPOLLIN);
         }
     }
 
@@ -291,7 +312,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
         ((IoEventLoop) eventLoop()).register((AbstractEpollUnsafe) unsafe()).addListener(f -> {
             if (f.isSuccess()) {
                 registration = (EpollIoRegistration) f.getNow();
-                registration.updateInterestOps(initialOps);
+                registration.submit(ops);
                 promise.setSuccess();
             } else {
                 promise.setFailure(f.cause());
@@ -641,9 +662,10 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
             assert eventLoop().inEventLoop();
             try {
                 readPending = false;
+                ops = ops.without(EpollIoOps.EPOLLIN);
                 EpollIoRegistration registration = registration();
-                registration.updateInterestOps(registration.interestOps().without(EpollIoOps.EPOLLIN));
-            } catch (IOException e) {
+                registration.submit(ops);
+            } catch (Exception e) {
                 // When this happens there is something completely wrong with either the filedescriptor or epoll,
                 // so fire the exception through the pipeline and close the Channel.
                 pipeline().fireExceptionCaught(e);

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
@@ -30,8 +30,8 @@ import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.ConnectTimeoutException;
 import io.netty.channel.EventLoop;
+import io.netty.channel.IoEvent;
 import io.netty.channel.IoEventLoop;
-import io.netty.channel.IoOps;
 import io.netty.channel.IoRegistration;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.socket.ChannelInputShutdownEvent;
@@ -451,8 +451,9 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
         }
 
         @Override
-        public void handle(IoRegistration registration, IoOps readyOps) {
-            EpollIoOps epollOps = (EpollIoOps)  readyOps;
+        public void handle(IoRegistration registration, IoEvent event) {
+            EpollIoEvent epollEvent = (EpollIoEvent) event;
+            EpollIoOps epollOps = epollEvent.ops();
 
             // Don't change the ordering of processing EPOLLOUT | EPOLLRDHUP / EPOLLIN if you're not 100%
             // sure about it!

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollChannelConfig.java
@@ -198,14 +198,13 @@ public class EpollChannelConfig extends DefaultChannelConfig {
         ObjectUtil.checkNotNull(mode, "mode");
 
         AbstractEpollChannel epollChannel = (AbstractEpollChannel) channel;
-        EpollIoOps initial = epollChannel.initialOps;
         checkChannelNotRegistered();
         switch (mode) {
             case EDGE_TRIGGERED:
-                epollChannel.initialOps = initial.with(EpollIoOps.EPOLLET);
+                epollChannel.add(EpollIoOps.EPOLLET);
                 break;
             case LEVEL_TRIGGERED:
-                epollChannel.initialOps = initial.without(EpollIoOps.EPOLLET);
+                epollChannel.remove(EpollIoOps.EPOLLET);
                 break;
             default:
                 throw new Error();

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoEvent.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoEvent.java
@@ -13,20 +13,19 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package io.netty.channel;
+package io.netty.channel.epoll;
+
+import io.netty.channel.IoEvent;
 
 /**
- * A handle that can be registered to a {@link IoEventLoop}.
- * All methods must be called from the {@link IoEventLoop} thread.
+ * {@link IoEvent} that must be handled by the {@link EpollIoHandle}.
  */
-public interface IoHandle extends AutoCloseable {
+public interface EpollIoEvent extends IoEvent {
 
     /**
-     * Be called once there is something to handle.
+     * Returns the {@link EpollIoOps} which did trigger the {@link EpollIoEvent}.
      *
-     * @param registration  the {@link IoRegistration} for this {@link IoHandle}.
-     * @param ioEvent       the {@link IoEvent} that must be handled. The {@link IoEvent} is only valid
-     *                      while this method is executed and so must not escape it.
+     * @return  ops.
      */
-    void handle(IoRegistration registration, IoEvent ioEvent);
+    EpollIoOps ops();
 }

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoHandler.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoHandler.java
@@ -342,7 +342,7 @@ public class EpollIoHandler implements IoHandler {
         }
 
         void handle(long ev) {
-            handle.handle(this, EpollIoOps.valueOf((int) ev));
+            handle.handle(this, EpollIoOps.eventOf((int) ev));
         }
     }
 

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoHandler.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoHandler.java
@@ -260,32 +260,24 @@ public class EpollIoHandler implements IoHandler {
         private final IoEventLoop eventLoop;
         final EpollIoHandle handle;
 
-        private volatile EpollIoOps currentOps;
-
-        DefaultEpollIoRegistration(IoEventLoop eventLoop, EpollIoHandle handle, EpollIoOps initialOps) {
+        DefaultEpollIoRegistration(IoEventLoop eventLoop, EpollIoHandle handle) {
             this.eventLoop = eventLoop;
             this.handle = handle;
-            this.currentOps = initialOps;
         }
 
         @Override
-        public void updateInterestOps(EpollIoOps ops) throws IOException {
-            currentOps = ops;
+        public void submit(IoOps ops) throws Exception {
+            EpollIoOps epollIoOps = cast(ops);
             try {
                 if (!isValid()) {
                     return;
                 }
-                Native.epollCtlMod(epollFd.intValue(), handle.fd().intValue(), ops.value);
+                Native.epollCtlMod(epollFd.intValue(), handle.fd().intValue(), epollIoOps.value);
             } catch (IOException e) {
                 throw e;
             } catch (Exception e) {
                 throw new IOException(e);
             }
-        }
-
-        @Override
-        public EpollIoOps interestOps() {
-            return currentOps;
         }
 
         @Override
@@ -350,10 +342,9 @@ public class EpollIoHandler implements IoHandler {
     public EpollIoRegistration register(IoEventLoop eventLoop, IoHandle handle)
             throws Exception {
         final EpollIoHandle epollHandle = cast(handle);
-        DefaultEpollIoRegistration registration = new DefaultEpollIoRegistration(eventLoop, epollHandle,
-                EpollIoOps.EPOLLERR);
+        DefaultEpollIoRegistration registration = new DefaultEpollIoRegistration(eventLoop, epollHandle);
         int fd = epollHandle.fd().intValue();
-        Native.epollCtlAdd(epollFd.intValue(), fd, registration.interestOps().value);
+        Native.epollCtlAdd(epollFd.intValue(), fd, EpollIoOps.EPOLLERR.value);
         DefaultEpollIoRegistration old = registrations.put(fd, registration);
 
         // We either expect to have no registration in the map with the same FD or that the FD of the old registration

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoHandler.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoHandler.java
@@ -347,12 +347,11 @@ public class EpollIoHandler implements IoHandler {
     }
 
     @Override
-    public EpollIoRegistration register(IoEventLoop eventLoop, IoHandle handle,
-                                      IoOps initialOps)
+    public EpollIoRegistration register(IoEventLoop eventLoop, IoHandle handle)
             throws Exception {
         final EpollIoHandle epollHandle = cast(handle);
-        EpollIoOps ops = cast(initialOps);
-        DefaultEpollIoRegistration registration = new DefaultEpollIoRegistration(eventLoop, epollHandle, ops);
+        DefaultEpollIoRegistration registration = new DefaultEpollIoRegistration(eventLoop, epollHandle,
+                EpollIoOps.EPOLLERR);
         int fd = epollHandle.fd().intValue();
         Native.epollCtlAdd(epollFd.intValue(), fd, registration.interestOps().value);
         DefaultEpollIoRegistration old = registrations.put(fd, registration);

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoOps.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoOps.java
@@ -145,6 +145,14 @@ public final class EpollIoOps implements IoOps {
         return eventOf(value).ops();
     }
 
+
+    @Override
+    public String toString() {
+        return "EpollIoOps{" +
+                "value=" + value +
+                '}';
+    }
+
     static EpollIoEvent eventOf(int value) {
         if (value > 0 && value < EVENTS.length) {
             EpollIoEvent event = EVENTS[value];
@@ -182,6 +190,13 @@ public final class EpollIoOps implements IoOps {
         @Override
         public int hashCode() {
             return ops().hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return "DefaultEpollIoEvent{" +
+                    "ops=" + ops +
+                    '}';
         }
     }
 }

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoOps.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoOps.java
@@ -29,7 +29,8 @@ public final class EpollIoOps implements IoOps {
     }
 
     /**
-     * Interested in IO events that should be handled by accepting new connections
+     * Interested in IO events which tell that the underlying channel is writable again or a connection
+     * attempt can be continued.
      */
     public static final EpollIoOps EPOLLOUT = new EpollIoOps(Native.EPOLLOUT);
 
@@ -39,7 +40,7 @@ public final class EpollIoOps implements IoOps {
     public static final EpollIoOps EPOLLIN = new EpollIoOps(Native.EPOLLIN);
 
     /**
-     * Interested in IO events which tell that the underlying channel is writable again.
+     * Error condition happened on the associated file descriptor.
      */
     public static final EpollIoOps EPOLLERR = new EpollIoOps(Native.EPOLLERR);
 

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoOps.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoOps.java
@@ -145,7 +145,6 @@ public final class EpollIoOps implements IoOps {
         return eventOf(value).ops();
     }
 
-
     @Override
     public String toString() {
         return "EpollIoOps{" +

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoRegistration.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoRegistration.java
@@ -17,28 +17,10 @@ package io.netty.channel.epoll;
 
 import io.netty.channel.IoRegistration;
 
-import java.io.IOException;
-
 /**
  * Registration with an {@link EpollIoHandler}.
  */
 public interface EpollIoRegistration extends IoRegistration {
-    /**
-     * Update the {@link EpollIoOps} for this registration.
-     *
-     * @param ops   the {@link EpollIoOps} to use.
-     */
-    void updateInterestOps(EpollIoOps ops) throws IOException;
-
-    /**
-     * The used {@link EpollIoOps} for this registration.
-     *
-     * @return  ops.
-     */
-    EpollIoOps interestOps();
-
-    @Override
-    void cancel() throws IOException;
 
     @Override
     EpollIoHandler ioHandler();

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
@@ -213,7 +213,7 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
 
     @Override
     protected void doRegister(ChannelPromise promise) {
-        ((IoEventLoop) eventLoop()).register((AbstractKQueueUnsafe) unsafe(), KQueueIoOps.NONE).addListener(f -> {
+        ((IoEventLoop) eventLoop()).register((AbstractKQueueUnsafe) unsafe()).addListener(f -> {
             if (f.isSuccess()) {
                 this.registration = (KQueueIoRegistration) f.getNow();
                 // Just in case the previous EventLoop was shutdown abruptly, or an event is still pending on the old

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoEvent.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoEvent.java
@@ -16,6 +16,7 @@
 package io.netty.channel.kqueue;
 
 import io.netty.channel.IoEvent;
+
 /**
  * {@link IoEvent} to use with {@link KQueueIoHandler}.
  */

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoEvent.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoEvent.java
@@ -108,7 +108,7 @@ public final class KQueueIoEvent implements IoEvent {
 
     @Override
     public String toString() {
-        return "KQueueEventIoOps{" +
+        return "KQueueIoEvent{" +
                 "ident=" + ident +
                 ", filter=" + filter +
                 ", flags=" + flags +

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoEvent.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoEvent.java
@@ -15,12 +15,11 @@
  */
 package io.netty.channel.kqueue;
 
-import io.netty.channel.IoOps;
-
+import io.netty.channel.IoEvent;
 /**
- * {@link IoOps} to use with {@link KQueueIoHandler}.
+ * {@link IoEvent} to use with {@link KQueueIoHandler}.
  */
-public final class KQueueEventIoOps implements IoOps {
+public final class KQueueIoEvent implements IoEvent {
     private int ident;
     private short filter;
     private short flags;
@@ -28,19 +27,19 @@ public final class KQueueEventIoOps implements IoOps {
     private long data;
 
     /**
-     * Creates a new {@link KQueueEventIoOps}.
+     * Creates a new {@link KQueueIoEvent}.
      *
      * @param ident     the identifier for this event.
      * @param filter    the filter for this event.
      * @param flags     the general flags.
      * @param fflags    filter-specific flags.
-     * @return          {@link KQueueEventIoOps}.
+     * @return          {@link KQueueIoEvent}.
      */
-    public static KQueueEventIoOps newOps(int ident, short filter, short flags, int fflags) {
-        return new KQueueEventIoOps(ident, filter, flags, fflags, 0);
+    public static KQueueIoEvent newEvent(int ident, short filter, short flags, int fflags) {
+        return new KQueueIoEvent(ident, filter, flags, fflags, 0);
     }
 
-    private KQueueEventIoOps(int ident, short filter, short flags, int fflags, long data) {
+    private KQueueIoEvent(int ident, short filter, short flags, int fflags, long data) {
         this.ident = ident;
         this.filter = filter;
         this.flags = flags;
@@ -48,7 +47,7 @@ public final class KQueueEventIoOps implements IoOps {
         this.data = data;
     }
 
-    KQueueEventIoOps() {
+    KQueueIoEvent() {
         this(0, (short) 0, (short) 0, 0, 0);
     }
 

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoHandler.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoHandler.java
@@ -23,6 +23,7 @@ import io.netty.channel.IoExecutionContext;
 import io.netty.channel.IoHandle;
 import io.netty.channel.IoHandler;
 import io.netty.channel.IoHandlerFactory;
+import io.netty.channel.IoOps;
 import io.netty.channel.SelectStrategy;
 import io.netty.channel.SelectStrategyFactory;
 import io.netty.channel.unix.FileDescriptor;
@@ -351,6 +352,13 @@ public final class KQueueIoHandler implements IoHandler {
         throw new IllegalArgumentException("IoHandle of type " + StringUtil.simpleClassName(handle) + " not supported");
     }
 
+    private static KQueueIoOps cast(IoOps ops) {
+        if (ops instanceof KQueueIoOps) {
+            return (KQueueIoOps) ops;
+        }
+        throw new IllegalArgumentException("IoOps of type " + StringUtil.simpleClassName(ops) + " not supported");
+    }
+
     @Override
     public boolean isCompatible(Class<? extends IoHandle> handleType) {
         return KQueueIoHandle.class.isAssignableFrom(handleType);
@@ -369,8 +377,9 @@ public final class KQueueIoHandler implements IoHandler {
         }
 
         @Override
-        public void evSet(KQueueIoEvent event) {
-            if (event.ident() != handle.ident()) {
+        public void submit(IoOps ops) {
+            KQueueIoOps kQueueIoOps = cast(ops);
+            if (kQueueIoOps.ident() != handle.ident()) {
                 throw new IllegalArgumentException("ident does not match KQueueIoHandle.ident()");
             }
             if (!isValid()) {

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoHandler.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoHandler.java
@@ -23,7 +23,6 @@ import io.netty.channel.IoExecutionContext;
 import io.netty.channel.IoHandle;
 import io.netty.channel.IoHandler;
 import io.netty.channel.IoHandlerFactory;
-import io.netty.channel.IoOps;
 import io.netty.channel.SelectStrategy;
 import io.netty.channel.SelectStrategyFactory;
 import io.netty.channel.unix.FileDescriptor;
@@ -324,14 +323,10 @@ public final class KQueueIoHandler implements IoHandler {
     }
 
     @Override
-    public KQueueIoRegistration register(IoEventLoop eventLoop, IoHandle handle, IoOps initialOps) {
+    public KQueueIoRegistration register(IoEventLoop eventLoop, IoHandle handle) {
         final KQueueIoHandle kqueueHandle = cast(handle);
         if (kqueueHandle.ident() == KQUEUE_WAKE_UP_IDENT) {
             throw new IllegalArgumentException("ident " + KQUEUE_WAKE_UP_IDENT + " is reserved for internal usage");
-        }
-        if (initialOps != KQueueIoOps.NONE) {
-            throw new IllegalArgumentException(
-                    "IoOpt of type " + StringUtil.simpleClassName(initialOps) + " not supported");
         }
 
         DefaultKqueueIoRegistration registration = new DefaultKqueueIoRegistration(

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoHandler.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoHandler.java
@@ -329,7 +329,11 @@ public final class KQueueIoHandler implements IoHandler {
         if (kqueueHandle.ident() == KQUEUE_WAKE_UP_IDENT) {
             throw new IllegalArgumentException("ident " + KQUEUE_WAKE_UP_IDENT + " is reserved for internal usage");
         }
-        KQueueEventIoOps eventIoOps = cast(initialOps);
+        if (initialOps != KQueueIoOps.NONE) {
+            throw new IllegalArgumentException(
+                    "IoOpt of type " + StringUtil.simpleClassName(initialOps) + " not supported");
+        }
+
         DefaultKqueueIoRegistration registration = new DefaultKqueueIoRegistration(
                 eventLoop, kqueueHandle);
         DefaultKqueueIoRegistration old = registrations.put(kqueueHandle.ident(), registration);
@@ -339,7 +343,6 @@ public final class KQueueIoHandler implements IoHandler {
             throw new IllegalStateException("registration for the KQueueIoHandle.ident() already exists");
         }
 
-        registration.addOps(eventIoOps);
         if (kqueueHandle instanceof AbstractKQueueChannel.AbstractKQueueUnsafe) {
             numChannels++;
         }
@@ -353,20 +356,13 @@ public final class KQueueIoHandler implements IoHandler {
         throw new IllegalArgumentException("IoHandle of type " + StringUtil.simpleClassName(handle) + " not supported");
     }
 
-    private static KQueueEventIoOps cast(IoOps ops) {
-        if (ops instanceof KQueueEventIoOps) {
-            return (KQueueEventIoOps) ops;
-        }
-        throw new IllegalArgumentException("IoOps of type " + StringUtil.simpleClassName(ops) + " not supported");
-    }
-
     @Override
     public boolean isCompatible(Class<? extends IoHandle> handleType) {
         return KQueueIoHandle.class.isAssignableFrom(handleType);
     }
 
     private final class DefaultKqueueIoRegistration extends AtomicBoolean implements KQueueIoRegistration {
-        private final KQueueEventIoOps readyEventIoOps = new KQueueEventIoOps();
+        private final KQueueIoEvent event = new KQueueIoEvent();
 
         final KQueueIoHandle handle;
 
@@ -378,17 +374,17 @@ public final class KQueueIoHandler implements IoHandler {
         }
 
         @Override
-        public void addOps(KQueueEventIoOps ops) {
-            if (ops.ident() != handle.ident()) {
+        public void evSet(KQueueIoEvent event) {
+            if (event.ident() != handle.ident()) {
                 throw new IllegalArgumentException("ident does not match KQueueIoHandle.ident()");
             }
             if (!isValid()) {
                 return;
             }
             if (eventLoop.inEventLoop()) {
-                evSet(ops.filter(), ops.flags(), ops.fflags());
+                evSet(event.filter(), event.flags(), event.fflags());
             } else {
-                eventLoop.execute(() -> evSet(ops.filter(), ops.flags(), ops.fflags()));
+                eventLoop.execute(() -> evSet(event.filter(), event.flags(), event.fflags()));
             }
         }
 
@@ -398,8 +394,8 @@ public final class KQueueIoHandler implements IoHandler {
         }
 
         void handle(int ident, short filter, short flags, int fflags, long data) {
-            readyEventIoOps.update(ident, filter, flags, fflags, data);
-            handle.handle(this, readyEventIoOps);
+            event.update(ident, filter, flags, fflags, data);
+            handle.handle(this, event);
         }
 
         private void evSet(short filter, short flags, int fflags) {

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoOps.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoOps.java
@@ -100,7 +100,7 @@ public final class KQueueIoOps implements IoOps {
 
     @Override
     public String toString() {
-        return "KQueueEventIoOps{" +
+        return "KQueueIoOps{" +
                 "ident=" + ident +
                 ", filter=" + filter +
                 ", flags=" + flags +

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoOps.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoOps.java
@@ -13,20 +13,17 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package io.netty.channel;
+package io.netty.channel.kqueue;
+
+import io.netty.channel.IoOps;
 
 /**
- * A handle that can be registered to a {@link IoEventLoop}.
- * All methods must be called from the {@link IoEventLoop} thread.
+ * Implementation of {@link IoOps} for
+ * that is used by {@link KQueueIoHandler} and so for kqueue based transports.
  */
-public interface IoHandle extends AutoCloseable {
+public final class KQueueIoOps implements IoOps {
 
-    /**
-     * Be called once there is something to handle.
-     *
-     * @param registration  the {@link IoRegistration} for this {@link IoHandle}.
-     * @param ioEvent       the {@link IoEvent} that must be handled. The {@link IoEvent} is only valid
-     *                      while this method is executed and so must not escape it.
-     */
-    void handle(IoRegistration registration, IoEvent ioEvent);
+    public static final KQueueIoOps NONE = new KQueueIoOps();
+
+    private KQueueIoOps() { }
 }

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoOps.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoOps.java
@@ -22,8 +22,90 @@ import io.netty.channel.IoOps;
  * that is used by {@link KQueueIoHandler} and so for kqueue based transports.
  */
 public final class KQueueIoOps implements IoOps {
+    private int ident;
+    private short filter;
+    private short flags;
+    private int fflags;
+    private long data;
 
-    public static final KQueueIoOps NONE = new KQueueIoOps();
+    /**
+     * Creates a new {@link KQueueIoOps}.
+     *
+     * @param ident     the identifier for this event.
+     * @param filter    the filter for this event.
+     * @param flags     the general flags.
+     * @param fflags    filter-specific flags.
+     * @return          {@link KQueueIoOps}.
+     */
+    public static KQueueIoOps newOps(int ident, short filter, short flags, int fflags) {
+        return new KQueueIoOps(ident, filter, flags, fflags, 0);
+    }
 
-    private KQueueIoOps() { }
+    private KQueueIoOps(int ident, short filter, short flags, int fflags, long data) {
+        this.ident = ident;
+        this.filter = filter;
+        this.flags = flags;
+        this.fflags = fflags;
+        this.data = data;
+    }
+
+    KQueueIoOps() {
+        this(0, (short) 0, (short) 0, 0, 0);
+    }
+
+    /**
+     * Returns the identifier for this event.
+     *
+     * @return  ident.
+     */
+    public int ident() {
+        return ident;
+    }
+
+    /**
+     * Returns the filter for this event.
+     *
+     * @return filter.
+     */
+    public short filter() {
+        return filter;
+    }
+
+    /**
+     * Returns the general flags.
+     *
+     * @return flags.
+     */
+    public short flags() {
+        return flags;
+    }
+
+    /**
+     * Returns filter-specific flags.
+     *
+     * @return fflags.
+     */
+    public int fflags() {
+        return fflags;
+    }
+
+    /**
+     * Returns filter-specific data.
+     *
+     * @return data.
+     */
+    public long data() {
+        return data;
+    }
+
+    @Override
+    public String toString() {
+        return "KQueueEventIoOps{" +
+                "ident=" + ident +
+                ", filter=" + filter +
+                ", flags=" + flags +
+                ", fflags=" + fflags +
+                ", data=" + data +
+                '}';
+    }
 }

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoRegistration.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoRegistration.java
@@ -22,13 +22,6 @@ import io.netty.channel.IoRegistration;
  */
 public interface KQueueIoRegistration extends IoRegistration {
 
-    /**
-     * Set the {@link KQueueIoEvent}.
-     *
-     * @param event the {@link KQueueIoEvent} to use.
-     */
-    void evSet(KQueueIoEvent event);
-
     @Override
     KQueueIoHandler ioHandler();
 }

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoRegistration.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoRegistration.java
@@ -23,11 +23,11 @@ import io.netty.channel.IoRegistration;
 public interface KQueueIoRegistration extends IoRegistration {
 
     /**
-     * Add the {@link KQueueEventIoOps} to the registration.
+     * Set the {@link KQueueIoEvent}.
      *
-     * @param ops   the {@link KQueueEventIoOps} to use.
+     * @param event the {@link KQueueIoEvent} to use.
      */
-    void addOps(KQueueEventIoOps ops);
+    void evSet(KQueueIoEvent event);
 
     @Override
     KQueueIoHandler ioHandler();

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpChannel.java
@@ -232,7 +232,7 @@ public class NioSctpChannel extends AbstractNioMessageChannel implements io.nett
         try {
             boolean connected = javaChannel().connect(remoteAddress);
             if (!connected) {
-                registration().updateInterestOps(NioIoOps.CONNECT);
+                addAndSubmit(NioIoOps.CONNECT);
             }
             success = true;
             return connected;

--- a/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtByteConnectorChannel.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtByteConnectorChannel.java
@@ -25,7 +25,6 @@ import io.netty.channel.FileRegion;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.nio.AbstractNioByteChannel;
 import io.netty.channel.nio.NioIoOps;
-import io.netty.channel.nio.NioIoRegistration;
 import io.netty.channel.udt.DefaultUdtChannelConfig;
 import io.netty.channel.udt.UdtChannel;
 import io.netty.channel.udt.UdtChannelConfig;
@@ -113,8 +112,7 @@ public class NioUdtByteConnectorChannel extends AbstractNioByteChannel implement
         try {
             final boolean connected = SocketUtils.connect(javaChannel(), remoteAddress);
             if (!connected) {
-                NioIoRegistration registration = registration();
-                registration.updateInterestOps(registration.interestOps().with(NioIoOps.CONNECT));
+                addAndSubmit(NioIoOps.CONNECT);
             }
             success = true;
             return connected;
@@ -133,8 +131,7 @@ public class NioUdtByteConnectorChannel extends AbstractNioByteChannel implement
     @Override
     protected void doFinishConnect() throws Exception {
         if (javaChannel().finishConnect()) {
-            NioIoRegistration registration = registration();
-            registration.updateInterestOps(registration.interestOps().without(NioIoOps.CONNECT));
+            removeAndSubmit(NioIoOps.CONNECT);
         } else {
             throw new Error(
                     "Provider error: failed to finish connect. Provider library should be upgraded.");

--- a/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtMessageConnectorChannel.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtMessageConnectorChannel.java
@@ -116,8 +116,7 @@ public class NioUdtMessageConnectorChannel extends AbstractNioMessageChannel imp
         try {
             final boolean connected = SocketUtils.connect(javaChannel(), remoteAddress);
             if (!connected) {
-                NioIoRegistration registration = registration();
-                registration.updateInterestOps(registration.interestOps().with(NioIoOps.CONNECT));
+                addAndSubmit(NioIoOps.CONNECT);
             }
             success = true;
             return connected;
@@ -137,7 +136,7 @@ public class NioUdtMessageConnectorChannel extends AbstractNioMessageChannel imp
     protected void doFinishConnect() throws Exception {
         if (javaChannel().finishConnect()) {
             NioIoRegistration registration = registration();
-            registration.updateInterestOps(registration.interestOps().without(NioIoOps.CONNECT));
+            removeAndSubmit(NioIoOps.CONNECT);
         } else {
             throw new Error(
                     "Provider error: failed to finish connect. Provider library should be upgraded.");

--- a/transport/src/main/java/io/netty/channel/IoEvent.java
+++ b/transport/src/main/java/io/netty/channel/IoEvent.java
@@ -16,17 +16,9 @@
 package io.netty.channel;
 
 /**
- * A handle that can be registered to a {@link IoEventLoop}.
- * All methods must be called from the {@link IoEventLoop} thread.
+ * An IO event that is dispatched to an {@link IoHandle}.
+ * Concrete {@link IoHandle} implementations support different concrete {@link IoEvent} implementations.
  */
-public interface IoHandle extends AutoCloseable {
-
-    /**
-     * Be called once there is something to handle.
-     *
-     * @param registration  the {@link IoRegistration} for this {@link IoHandle}.
-     * @param ioEvent       the {@link IoEvent} that must be handled. The {@link IoEvent} is only valid
-     *                      while this method is executed and so must not escape it.
-     */
-    void handle(IoRegistration registration, IoEvent ioEvent);
+public interface IoEvent {
+    // Marker interface.
 }

--- a/transport/src/main/java/io/netty/channel/IoEvent.java
+++ b/transport/src/main/java/io/netty/channel/IoEvent.java
@@ -16,7 +16,8 @@
 package io.netty.channel;
 
 /**
- * An IO event that is dispatched to an {@link IoHandle}.
+ * An IO event that is dispatched to an {@link IoHandle} as a result of a previous submitted {@link IoOps}.
+ *
  * Concrete {@link IoHandle} implementations support different concrete {@link IoEvent} implementations.
  */
 public interface IoEvent {

--- a/transport/src/main/java/io/netty/channel/IoEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/IoEventLoop.java
@@ -30,14 +30,14 @@ public interface IoEventLoop extends EventLoop, IoEventLoopGroup {
         return this;
     }
     /**
-     * @deprecated Use {@link #register(IoHandle, IoOps)}
+     * @deprecated Use {@link #register(IoHandle)}
      */
     @Deprecated
     @Override
     ChannelFuture register(Channel channel);
 
     /**
-     * @deprecated Use {@link #register(IoHandle, IoOps)}
+     * @deprecated Use {@link #register(IoHandle)}
      */
     @Deprecated
     @Override
@@ -47,10 +47,9 @@ public interface IoEventLoop extends EventLoop, IoEventLoopGroup {
      * Register the {@link IoHandle} to the {@link EventLoop} for I/O processing.
      *
      * @param handle        the {@link IoHandle} to register.
-     * @param initialOps    the initial {@link IoOps} to use.
      * @return              the {@link Future} that is notified once the operations completes.
      */
-    Future<IoRegistration> register(IoHandle handle, IoOps initialOps);
+    Future<IoRegistration> register(IoHandle handle);
 
     // Force sub-classes to implement.
     @Override

--- a/transport/src/main/java/io/netty/channel/IoHandler.java
+++ b/transport/src/main/java/io/netty/channel/IoHandler.java
@@ -19,6 +19,13 @@ package io.netty.channel;
  * Handles IO dispatching for an {@link IoEventLoop}
  * All operations except {@link #wakeup(IoEventLoop)} and {@link #isCompatible(Class)} <strong>MUST</strong> be executed
  * on the {@link IoEventLoop} thread and should never be called from the user-directly.
+ * <p>
+ * Once a {@link IoHandle} is registered via the {@link #register(IoEventLoop, IoHandle)} method it's possible
+ * to submit {@link IoOps} related to the {@link IoHandle} via {@link IoRegistration#submit(IoOps)}.
+ * These submitted {@link IoOps} are the "source" of {@link IoEvent}s that are dispatched to the registered
+ * {@link IoHandle} via the {@link IoHandle#handle(IoRegistration, IoEvent)} method.
+ * These events must be consumed (and handled) as otherwise they might be reported again until handled.
+ *
  */
 public interface IoHandler {
     /**

--- a/transport/src/main/java/io/netty/channel/IoHandler.java
+++ b/transport/src/main/java/io/netty/channel/IoHandler.java
@@ -48,10 +48,9 @@ public interface IoHandler {
      *
      * @param eventLoop     the {@link IoEventLoop} that did issue the registration.
      * @param handle        the {@link IoHandle} to register.
-     * @param initialOps           the {@link IoOps} which should be used during registration.
      * @throws Exception    thrown if an error happens during registration.
      */
-    IoRegistration register(IoEventLoop eventLoop, IoHandle handle, IoOps initialOps) throws Exception;
+    IoRegistration register(IoEventLoop eventLoop, IoHandle handle) throws Exception;
 
     /**
      * Wakeup the {@link IoHandler}, which means if any operation blocks it should be unblocked and

--- a/transport/src/main/java/io/netty/channel/IoOps.java
+++ b/transport/src/main/java/io/netty/channel/IoOps.java
@@ -16,8 +16,10 @@
 package io.netty.channel;
 
 /**
- * An IO op that is used when register an {@link IoHandle} to an {@link IoEventLoop}.
- * Concrete {@link IoHandle} implementations support different concrete {@link IoOps} implementations.
+ * An IO op that can be submitted to an {@link IoRegistration} via {@link IoRegistration#submit(IoOps)}.
+// * These submitted {@link IoOps} will result in {@link IoEvent}s on the related {@link IoHandle}.
+ * Concrete {@link IoRegistration} implementations support different concrete {@link IoOps} implementations and
+ * will so also "produce" concrete {@link IoEvent}s.
  */
 public interface IoOps {
     // Marker interface.

--- a/transport/src/main/java/io/netty/channel/IoRegistration.java
+++ b/transport/src/main/java/io/netty/channel/IoRegistration.java
@@ -22,6 +22,13 @@ package io.netty.channel;
 public interface IoRegistration {
 
     /**
+     * Submit the {@link IoOps} to the registration.
+     *
+     * @param ops ops.
+     */
+    void submit(IoOps ops) throws Exception;
+
+    /**
      * Returns {@code true} if the registration is still valid. Once {@link #cancel()} is called this
      * will return {@code false}.
      *

--- a/transport/src/main/java/io/netty/channel/SingleThreadIoEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/SingleThreadIoEventLoop.java
@@ -176,23 +176,22 @@ public class SingleThreadIoEventLoop extends SingleThreadEventLoop implements Io
     }
 
     @Override
-    public final Future<IoRegistration> register(final IoHandle handle, IoOps initialOps) {
+    public final Future<IoRegistration> register(final IoHandle handle) {
         Promise<IoRegistration> promise = newPromise();
         if (inEventLoop()) {
-            registerForIo0(handle, initialOps, promise);
+            registerForIo0(handle, promise);
         } else {
-            execute(() -> registerForIo0(handle, initialOps, promise));
+            execute(() -> registerForIo0(handle, promise));
         }
 
         return promise;
     }
 
-    private void registerForIo0(final IoHandle handle, IoOps initialOps,
-                               Promise<IoRegistration> promise) {
+    private void registerForIo0(final IoHandle handle, Promise<IoRegistration> promise) {
         assert inEventLoop();
         final IoRegistration registration;
         try {
-            registration = ioHandler.register(this, handle, initialOps);
+            registration = ioHandler.register(this, handle);
         } catch (Exception e) {
             promise.setFailure(e);
             return;

--- a/transport/src/main/java/io/netty/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalChannel.java
@@ -166,7 +166,7 @@ public class LocalChannel extends AbstractChannel {
         EventLoop loop = eventLoop();
         if (loop instanceof IoEventLoop) {
             assert registration == null;
-            ((IoEventLoop) loop).register((LocalUnsafe) unsafe(), LocalIoOps.DEFAULT).addListener(f -> {
+            ((IoEventLoop) loop).register((LocalUnsafe) unsafe()).addListener(f -> {
                if (f.isSuccess()) {
                    registration = (IoRegistration) f.getNow();
                    promise.setSuccess();

--- a/transport/src/main/java/io/netty/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalChannel.java
@@ -25,8 +25,8 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.EventLoop;
+import io.netty.channel.IoEvent;
 import io.netty.channel.IoEventLoop;
-import io.netty.channel.IoOps;
 import io.netty.channel.IoRegistration;
 import io.netty.channel.PreferHeapByteBufAllocator;
 import io.netty.channel.RecvByteBufAllocator;
@@ -479,7 +479,7 @@ public class LocalChannel extends AbstractChannel {
         }
 
         @Override
-        public void handle(IoRegistration registration, IoOps readyOps) {
+        public void handle(IoRegistration registration, IoEvent event) {
             // NOOP
         }
 

--- a/transport/src/main/java/io/netty/channel/local/LocalIoHandler.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalIoHandler.java
@@ -20,7 +20,6 @@ import io.netty.channel.IoExecutionContext;
 import io.netty.channel.IoHandle;
 import io.netty.channel.IoHandler;
 import io.netty.channel.IoHandlerFactory;
-import io.netty.channel.IoOps;
 import io.netty.channel.IoRegistration;
 import io.netty.util.internal.StringUtil;
 
@@ -90,12 +89,8 @@ public final class LocalIoHandler implements IoHandler {
     }
 
     @Override
-    public IoRegistration register(IoEventLoop eventLoop, IoHandle handle, IoOps initialOps) {
+    public IoRegistration register(IoEventLoop eventLoop, IoHandle handle) {
         LocalIoHandle localHandle = cast(handle);
-        if (initialOps != LocalIoOps.DEFAULT) {
-            throw new IllegalArgumentException(
-                    "IoOps of type " + StringUtil.simpleClassName(initialOps) + " not supported");
-        }
         if (registeredChannels.add(localHandle)) {
             LocalIoRegistration registration = new LocalIoRegistration(eventLoop, localHandle);
             localHandle.registerNow();

--- a/transport/src/main/java/io/netty/channel/local/LocalIoHandler.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalIoHandler.java
@@ -20,6 +20,7 @@ import io.netty.channel.IoExecutionContext;
 import io.netty.channel.IoHandle;
 import io.netty.channel.IoHandler;
 import io.netty.channel.IoHandlerFactory;
+import io.netty.channel.IoOps;
 import io.netty.channel.IoRegistration;
 import io.netty.util.internal.StringUtil;
 
@@ -111,6 +112,11 @@ public final class LocalIoHandler implements IoHandler {
         LocalIoRegistration(IoEventLoop eventLoop, LocalIoHandle handle) {
             this.eventLoop = eventLoop;
             this.handle = handle;
+        }
+
+        @Override
+        public void submit(IoOps ops) {
+            throw new UnsupportedOperationException();
         }
 
         @Override

--- a/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
@@ -102,7 +102,7 @@ public class LocalServerChannel extends AbstractServerChannel {
         EventLoop loop = eventLoop();
         if (loop instanceof IoEventLoop) {
             assert registration == null;
-            ((IoEventLoop) loop).register((LocalServerUnsafe) unsafe(), LocalIoOps.DEFAULT).addListener(f -> {
+            ((IoEventLoop) loop).register((LocalServerUnsafe) unsafe()).addListener(f -> {
                 if (f.isSuccess()) {
                     registration = (IoRegistration) f.getNow();
                     promise.setSuccess();

--- a/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
@@ -21,9 +21,9 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.EventLoop;
+import io.netty.channel.IoEvent;
 import io.netty.channel.IoEventLoop;
 import io.netty.channel.IoEventLoopGroup;
-import io.netty.channel.IoOps;
 import io.netty.channel.IoRegistration;
 import io.netty.channel.PreferHeapByteBufAllocator;
 import io.netty.channel.RecvByteBufAllocator;
@@ -227,7 +227,7 @@ public class LocalServerChannel extends AbstractServerChannel {
         }
 
         @Override
-        public void handle(IoRegistration registration, IoOps readyOps) {
+        public void handle(IoRegistration registration, IoEvent event) {
             // NOOP
         }
 

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioByteChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioByteChannel.java
@@ -330,10 +330,8 @@ public abstract class AbstractNioByteChannel extends AbstractNioChannel {
         if (!registration.isValid()) {
             return;
         }
-        final NioIoOps ops = registration.interestOps();
-        if (!ops.contains(NioIoOps.WRITE)) {
-            registration.updateInterestOps(ops.with(NioIoOps.WRITE));
-        }
+
+        addAndSubmit(NioIoOps.WRITE);
     }
 
     protected final void clearOpWrite() {
@@ -344,6 +342,6 @@ public abstract class AbstractNioByteChannel extends AbstractNioChannel {
         if (!registration.isValid()) {
             return;
         }
-        registration.updateInterestOps(registration.interestOps().without(NioIoOps.WRITE));
+        removeAndSubmit(NioIoOps.WRITE);
     }
 }

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
@@ -123,7 +123,7 @@ public abstract class AbstractNioChannel extends AbstractChannel {
         if (ops.contains(removeOps)) {
             ops = ops.without(removeOps);
             try {
-            registration().submit(ops);
+                registration().submit(ops);
             } catch (Exception e) {
                 throw new ChannelException(e);
             }
@@ -491,7 +491,7 @@ public abstract class AbstractNioChannel extends AbstractChannel {
 
         readPending = true;
 
-        addAndSubmit(ops.with(readOps));
+        addAndSubmit(readOps);
     }
 
     /**

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
@@ -438,7 +438,7 @@ public abstract class AbstractNioChannel extends AbstractChannel {
     @Override
     protected void doRegister(ChannelPromise promise) {
         assert registration == null;
-        ((IoEventLoop) eventLoop()).register((AbstractNioUnsafe) unsafe(), NioIoOps.NONE).addListener(f -> {
+        ((IoEventLoop) eventLoop()).register((AbstractNioUnsafe) unsafe()).addListener(f -> {
             if (f.isSuccess()) {
                 registration = (NioIoRegistration) f.getNow();
                 promise.setSuccess();

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
@@ -27,9 +27,9 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.ConnectTimeoutException;
 import io.netty.channel.EventLoop;
+import io.netty.channel.IoEvent;
 import io.netty.channel.IoEventLoop;
 import io.netty.channel.IoEventLoopGroup;
-import io.netty.channel.IoOps;
 import io.netty.channel.IoRegistration;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.ReferenceCounted;
@@ -396,10 +396,11 @@ public abstract class AbstractNioChannel extends AbstractChannel {
         }
 
         @Override
-        public void handle(IoRegistration registration, IoOps readyOps) {
+        public void handle(IoRegistration registration, IoEvent event) {
             try {
                 NioIoRegistration nioRegistration = (NioIoRegistration) registration;
-                NioIoOps nioReadyOps = (NioIoOps) readyOps;
+                NioIoEvent nioEvent = (NioIoEvent) event;
+                NioIoOps nioReadyOps = nioEvent.ops();
                 // We first need to call finishConnect() before try to trigger a read(...) or write(...) as otherwise
                 // the NIO JDK channel implementation may throw a NotYetConnectedException.
                 if (nioReadyOps.contains(NioIoOps.CONNECT)) {

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
@@ -59,6 +59,7 @@ public abstract class AbstractNioChannel extends AbstractChannel {
     protected final int readInterestOp;
     protected final NioIoOps readOps;
 
+    // We always start with NONE as initial ops.
     private NioIoOps ops = NioIoOps.NONE;
 
     volatile NioIoRegistration registration;
@@ -271,7 +272,7 @@ public abstract class AbstractNioChannel extends AbstractChannel {
             if (!registration.isValid()) {
                 return;
             }
-            addAndSubmit(readOps);
+            removeAndSubmit(readOps);
         }
 
         @Override
@@ -477,6 +478,8 @@ public abstract class AbstractNioChannel extends AbstractChannel {
         NioIoRegistration registration = registration();
         if (registration != null) {
             this.registration = null;
+            // Reset to NONE so we have the correct value when we register again.
+            ops = NioIoOps.NONE;
             registration.cancel();
         }
     }

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioMessageChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioMessageChannel.java
@@ -131,9 +131,6 @@ public abstract class AbstractNioMessageChannel extends AbstractNioChannel {
 
     @Override
     protected void doWrite(ChannelOutboundBuffer in) throws Exception {
-        final NioIoRegistration registration = registration();
-        final NioIoOps ops = registration.interestOps();
-
         int maxMessagesPerWrite = maxMessagesPerWrite();
         while (maxMessagesPerWrite > 0) {
             Object msg = in.current();
@@ -166,10 +163,10 @@ public abstract class AbstractNioMessageChannel extends AbstractNioChannel {
         }
         if (in.isEmpty()) {
             // Wrote all messages.
-            registration.updateInterestOps(ops.without(NioIoOps.WRITE));
+            removeAndSubmit(NioIoOps.WRITE);
         } else {
             // Did not write all messages.
-            registration.updateInterestOps(ops.with(NioIoOps.WRITE));
+            addAndSubmit(NioIoOps.WRITE);
         }
     }
 

--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
@@ -142,7 +142,7 @@ public final class NioEventLoop extends SingleThreadIoEventLoop {
                             }
                         }
                     }).get();
-            registration.updateInterestOps(NioIoOps.valueOf(interestOps));
+            registration.submit(NioIoOps.valueOf(interestOps));
         } catch (Exception e) {
             throw new IllegalStateException(e);
         }

--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
@@ -122,7 +122,7 @@ public final class NioEventLoop extends SingleThreadIoEventLoop {
 
     private void register0(final SelectableChannel ch, int interestOps, final NioTask<SelectableChannel> task) {
         try {
-            register(
+            NioIoRegistration registration = (NioIoRegistration) register(
                     new NioSelectableChannelIoHandle<SelectableChannel>(ch) {
                         @Override
                         protected void handle(SelectableChannel channel, SelectionKey key) {
@@ -141,7 +141,8 @@ public final class NioEventLoop extends SingleThreadIoEventLoop {
                                 logger.warn("Unexpected exception while running NioTask.channelUnregistered(...)", e);
                             }
                         }
-                    }, NioIoOps.valueOf(interestOps)).get();
+                    }).get();
+            registration.updateInterestOps(NioIoOps.valueOf(interestOps));
         } catch (Exception e) {
             throw new IllegalStateException(e);
         }

--- a/transport/src/main/java/io/netty/channel/nio/NioIoEvent.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioIoEvent.java
@@ -13,20 +13,19 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package io.netty.channel;
+package io.netty.channel.nio;
+
+import io.netty.channel.IoEvent;
 
 /**
- * A handle that can be registered to a {@link IoEventLoop}.
- * All methods must be called from the {@link IoEventLoop} thread.
+ * {@link IoEvent} that must be handled by the {@link NioIoHandle}.
  */
-public interface IoHandle extends AutoCloseable {
+public interface NioIoEvent extends IoEvent {
 
     /**
-     * Be called once there is something to handle.
+     * Returns the {@link NioIoOps} which did trigger the {@link NioIoEvent}.
      *
-     * @param registration  the {@link IoRegistration} for this {@link IoHandle}.
-     * @param ioEvent       the {@link IoEvent} that must be handled. The {@link IoEvent} is only valid
-     *                      while this method is executed and so must not escape it.
+     * @return  ops.
      */
-    void handle(IoRegistration registration, IoEvent ioEvent);
+    NioIoOps ops();
 }

--- a/transport/src/main/java/io/netty/channel/nio/NioIoHandler.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioIoHandler.java
@@ -384,10 +384,10 @@ public final class NioIoHandler implements IoHandler {
     }
 
     @Override
-    public NioIoRegistration register(IoEventLoop eventLoop, IoHandle handle, IoOps initialOps)
+    public NioIoRegistration register(IoEventLoop eventLoop, IoHandle handle)
             throws Exception {
         NioIoHandle nioHandle = nioHandle(handle);
-        NioIoOps ops = cast(initialOps);
+        NioIoOps ops = NioIoOps.NONE;
         boolean selected = false;
         for (;;) {
             try {

--- a/transport/src/main/java/io/netty/channel/nio/NioIoHandler.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioIoHandler.java
@@ -374,7 +374,7 @@ public final class NioIoHandler implements IoHandler {
         }
 
         void handle(int ready) {
-            handle.handle(this, NioIoOps.valueOf(ready));
+            handle.handle(this, NioIoOps.eventOf(ready));
         }
 
         @Override

--- a/transport/src/main/java/io/netty/channel/nio/NioIoHandler.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioIoHandler.java
@@ -328,8 +328,7 @@ public final class NioIoHandler implements IoHandler {
         }
 
         void register(Selector selector) throws IOException {
-            NioIoOps ops = interestOps();
-            SelectionKey newKey = handle.selectableChannel().register(selector, ops.value, this);
+            SelectionKey newKey = handle.selectableChannel().register(selector, key.interestOps(), this);
             key.cancel();
             key = newKey;
         }
@@ -345,13 +344,8 @@ public final class NioIoHandler implements IoHandler {
         }
 
         @Override
-        public void updateInterestOps(NioIoOps ops) {
-            key.interestOps(ops.value);
-        }
-
-        @Override
-        public NioIoOps interestOps() {
-            return NioIoOps.valueOf(key.interestOps());
+        public void submit(IoOps ops) {
+            key.interestOps(cast(ops).value);
         }
 
         @Override

--- a/transport/src/main/java/io/netty/channel/nio/NioIoRegistration.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioIoRegistration.java
@@ -30,23 +30,6 @@ public interface NioIoRegistration extends IoRegistration {
      */
     SelectionKey selectionKey();
 
-    /**
-     * Update the {@link NioIoOps} for this registration.
-     *
-     * @param ops   the {@link NioIoOps} to use.
-     */
-    void updateInterestOps(NioIoOps ops);
-
-    /**
-     * The used {@link NioIoOps} for this registration.
-     *
-     * @return  ops.
-     */
-    NioIoOps interestOps();
-
-    @Override
-    void cancel();
-
     @Override
     NioIoHandler ioHandler();
 }

--- a/transport/src/main/java/io/netty/channel/nio/NioSelectableChannelIoHandle.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioSelectableChannelIoHandle.java
@@ -16,8 +16,8 @@
 package io.netty.channel.nio;
 
 
+import io.netty.channel.IoEvent;
 import io.netty.channel.IoHandle;
-import io.netty.channel.IoOps;
 import io.netty.channel.IoRegistration;
 import io.netty.util.internal.ObjectUtil;
 
@@ -37,7 +37,7 @@ public abstract class NioSelectableChannelIoHandle<S extends SelectableChannel> 
     }
 
     @Override
-    public void handle(IoRegistration registration, IoOps ioEvent) {
+    public void handle(IoRegistration registration, IoEvent ioEvent) {
         SelectionKey key = ((NioIoRegistration) registration).selectionKey();
         NioSelectableChannelIoHandle.this.handle(channel, key);
     }

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
@@ -28,7 +28,6 @@ import io.netty.channel.FileRegion;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.nio.AbstractNioByteChannel;
 import io.netty.channel.nio.NioIoOps;
-import io.netty.channel.nio.NioIoRegistration;
 import io.netty.channel.socket.DefaultSocketChannelConfig;
 import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.channel.socket.ServerSocketChannel;
@@ -306,8 +305,7 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
         try {
             boolean connected = SocketUtils.connect(javaChannel(), remoteAddress);
             if (!connected) {
-                NioIoRegistration registration = registration();
-                registration.updateInterestOps(registration.interestOps().with(NioIoOps.CONNECT));
+                addAndSubmit(NioIoOps.CONNECT);
             }
             success = true;
             return connected;

--- a/transport/src/test/java/io/netty/channel/SingleThreadIoEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/SingleThreadIoEventLoopTest.java
@@ -85,7 +85,7 @@ public class SingleThreadIoEventLoopTest {
 
     private class TestIoHandle implements IoHandle {
         @Override
-        public void handle(IoRegistration registration, IoOps readyOps) {
+        public void handle(IoRegistration registration, IoEvent readyOps) {
             // NOOP
         }
 

--- a/transport/src/test/java/io/netty/channel/SingleThreadIoEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/SingleThreadIoEventLoopTest.java
@@ -68,7 +68,7 @@ public class SingleThreadIoEventLoopTest {
         }
 
         @Override
-        public IoRegistration register(IoEventLoop eventLoop, IoHandle handle, IoOps ops) {
+        public IoRegistration register(IoEventLoop eventLoop, IoHandle handle) {
             return null;
         }
 

--- a/transport/src/test/java/io/netty/channel/nio/NioEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/nio/NioEventLoopTest.java
@@ -183,7 +183,7 @@ public class NioEventLoopTest extends AbstractEventLoopTest {
                 }
             }).get();
 
-            registration.updateInterestOps(NioIoOps.valueOf(SelectionKey.OP_CONNECT));
+            registration.submit(NioIoOps.valueOf(SelectionKey.OP_CONNECT));
 
             latch.await();
 

--- a/transport/src/test/java/io/netty/channel/nio/NioEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/nio/NioEventLoopTest.java
@@ -174,12 +174,16 @@ public class NioEventLoopTest extends AbstractEventLoopTest {
 
             final CountDownLatch latch = new CountDownLatch(1);
 
-            loop.register(new NioSelectableChannelIoHandle<SocketChannel>(selectableChannel) {
+            NioIoRegistration registration =
+                    (NioIoRegistration) loop.register(
+                            new NioSelectableChannelIoHandle<SocketChannel>(selectableChannel) {
                 @Override
                 protected void handle(SocketChannel channel, SelectionKey key) {
                     latch.countDown();
                 }
-            }, NioIoOps.valueOf(SelectionKey.OP_CONNECT));
+            }).get();
+
+            registration.updateInterestOps(NioIoOps.valueOf(SelectionKey.OP_CONNECT));
 
             latch.await();
 


### PR DESCRIPTION
Motiviation:

To support things like io_uring we need to support different things like IoOps as a result for notifications. Like for example you would issue a connect via the IoRegistration when using io_uring but receive some specific event on the completion queue once it was done.

Modification:

- Add new IoEvent interface
- Change IoHandle.handle(...) signature to use IoEvent as a param
- Rewrite existing implementations to use new signature.

Result:

More flexible API which can support also things like io_uring