### PR TITLE
More renames of IoOpts to IoOps

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoHandler.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoHandler.java
@@ -140,11 +140,11 @@ public class EpollIoHandler implements IoHandler {
         throw new IllegalArgumentException("IoHandle of type " + StringUtil.simpleClassName(handle) + " not supported");
     }
 
-    private static EpollIoOps cast(IoOps opt) {
-        if (opt instanceof EpollIoOps) {
-            return (EpollIoOps) opt;
+    private static EpollIoOps cast(IoOps ops) {
+        if (ops instanceof EpollIoOps) {
+            return (EpollIoOps) ops;
         }
-        throw new IllegalArgumentException("IoOpt of type " + StringUtil.simpleClassName(opt) + " not supported");
+        throw new IllegalArgumentException("IoOps of type " + StringUtil.simpleClassName(ops) + " not supported");
     }
 
     /**
@@ -260,22 +260,22 @@ public class EpollIoHandler implements IoHandler {
         private final IoEventLoop eventLoop;
         final EpollIoHandle handle;
 
-        private volatile EpollIoOps currentOpt;
+        private volatile EpollIoOps currentOps;
 
-        DefaultEpollIoRegistration(IoEventLoop eventLoop, EpollIoHandle handle, EpollIoOps initialOpt) {
+        DefaultEpollIoRegistration(IoEventLoop eventLoop, EpollIoHandle handle, EpollIoOps initialOps) {
             this.eventLoop = eventLoop;
             this.handle = handle;
-            this.currentOpt = initialOpt;
+            this.currentOps = initialOps;
         }
 
         @Override
-        public void updateInterestOpt(EpollIoOps opt) throws IOException {
-            currentOpt = opt;
+        public void updateInterestOps(EpollIoOps ops) throws IOException {
+            currentOps = ops;
             try {
                 if (!isValid()) {
                     return;
                 }
-                Native.epollCtlMod(epollFd.intValue(), handle.fd().intValue(), opt.value);
+                Native.epollCtlMod(epollFd.intValue(), handle.fd().intValue(), ops.value);
             } catch (IOException e) {
                 throw e;
             } catch (Exception e) {
@@ -284,8 +284,8 @@ public class EpollIoHandler implements IoHandler {
         }
 
         @Override
-        public EpollIoOps interestOpt() {
-            return currentOpt;
+        public EpollIoOps interestOps() {
+            return currentOps;
         }
 
         @Override
@@ -348,13 +348,13 @@ public class EpollIoHandler implements IoHandler {
 
     @Override
     public EpollIoRegistration register(IoEventLoop eventLoop, IoHandle handle,
-                                      IoOps initialOpt)
+                                      IoOps initialOps)
             throws Exception {
         final EpollIoHandle epollHandle = cast(handle);
-        EpollIoOps opt = cast(initialOpt);
-        DefaultEpollIoRegistration registration = new DefaultEpollIoRegistration(eventLoop, epollHandle, opt);
+        EpollIoOps ops = cast(initialOps);
+        DefaultEpollIoRegistration registration = new DefaultEpollIoRegistration(eventLoop, epollHandle, ops);
         int fd = epollHandle.fd().intValue();
-        Native.epollCtlAdd(epollFd.intValue(), fd, registration.interestOpt().value);
+        Native.epollCtlAdd(epollFd.intValue(), fd, registration.interestOps().value);
         DefaultEpollIoRegistration old = registrations.put(fd, registration);
 
         // We either expect to have no registration in the map with the same FD or that the FD of the old registration

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoOps.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoOps.java
@@ -51,21 +51,21 @@ public final class EpollIoOps implements IoOps {
     public static final EpollIoOps EPOLLET = new EpollIoOps(Native.EPOLLET);
 
     // Just use an array to store often used values.
-    private static final EpollIoOps[] OPTS;
+    private static final EpollIoOps[] OPS;
 
     static {
         EpollIoOps all = new EpollIoOps(
                 EPOLLOUT.value | EPOLLIN.value | EPOLLERR.value | EPOLLRDHUP.value);
-        OPTS = new EpollIoOps[all.value + 1];
-        addToArray(OPTS, EPOLLOUT);
-        addToArray(OPTS, EPOLLIN);
-        addToArray(OPTS, EPOLLERR);
-        addToArray(OPTS, EPOLLRDHUP);
-        addToArray(OPTS, all);
+        OPS = new EpollIoOps[all.value + 1];
+        addToArray(OPS, EPOLLOUT);
+        addToArray(OPS, EPOLLIN);
+        addToArray(OPS, EPOLLERR);
+        addToArray(OPS, EPOLLRDHUP);
+        addToArray(OPS, all);
     }
 
-    private static void addToArray(EpollIoOps[] array, EpollIoOps opt) {
-        array[opt.value] = opt;
+    private static void addToArray(EpollIoOps[] array, EpollIoOps ops) {
+        array[ops.value] = ops;
     }
 
     final int value;
@@ -76,37 +76,37 @@ public final class EpollIoOps implements IoOps {
 
     /**
      * Returns {@code true} if this {@link EpollIoOps} is a combination of the given {@link EpollIoOps}.
-     * @param opt   the opt.
+     * @param ops   the ops.
      * @return      {@code true} if a combination of the given.
      */
-    public boolean contains(EpollIoOps opt) {
-        return (value & opt.value) != 0;
+    public boolean contains(EpollIoOps ops) {
+        return (value & ops.value) != 0;
     }
 
     /**
      * Return a {@link EpollIoOps} which is a combination of the current and the given {@link EpollIoOps}.
      *
-     * @param opt   the {@link EpollIoOps} that should be added to this one.
+     * @param ops   the {@link EpollIoOps} that should be added to this one.
      * @return      a {@link EpollIoOps}.
      */
-    public EpollIoOps with(EpollIoOps opt) {
-        if (contains(opt)) {
+    public EpollIoOps with(EpollIoOps ops) {
+        if (contains(ops)) {
             return this;
         }
-        return valueOf(value | opt.value());
+        return valueOf(value | ops.value());
     }
 
     /**
      * Return a {@link EpollIoOps} which is not a combination of the current and the given {@link EpollIoOps}.
      *
-     * @param opt   the {@link EpollIoOps} that should be remove from this one.
+     * @param ops   the {@link EpollIoOps} that should be remove from this one.
      * @return      a {@link EpollIoOps}.
      */
-    public EpollIoOps without(EpollIoOps opt) {
-        if (!contains(opt)) {
+    public EpollIoOps without(EpollIoOps ops) {
+        if (!contains(ops)) {
             return this;
         }
-        return valueOf(value & ~opt.value());
+        return valueOf(value & ~ops.value());
     }
 
     /**
@@ -126,8 +126,8 @@ public final class EpollIoOps implements IoOps {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        EpollIoOps nioOpt = (EpollIoOps) o;
-        return value == nioOpt.value;
+        EpollIoOps nioOps = (EpollIoOps) o;
+        return value == nioOps.value;
     }
 
     @Override
@@ -142,11 +142,11 @@ public final class EpollIoOps implements IoOps {
      * @return  the {@link EpollIoOps}.
      */
     public static EpollIoOps valueOf(int value) {
-        final EpollIoOps opt;
-        if (value > 0 && value < OPTS.length) {
-            opt = OPTS[value];
-            if (opt != null) {
-                return opt;
+        final EpollIoOps ops;
+        if (value > 0 && value < OPS.length) {
+            ops = OPS[value];
+            if (ops != null) {
+                return ops;
             }
         } else if (value == EPOLLET.value) {
             return EPOLLET;

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoRegistration.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoRegistration.java
@@ -26,16 +26,16 @@ public interface EpollIoRegistration extends IoRegistration {
     /**
      * Update the {@link EpollIoOps} for this registration.
      *
-     * @param opt   the {@link EpollIoOps} to use.
+     * @param ops   the {@link EpollIoOps} to use.
      */
-    void updateInterestOpt(EpollIoOps opt) throws IOException;
+    void updateInterestOps(EpollIoOps ops) throws IOException;
 
     /**
      * The used {@link EpollIoOps} for this registration.
      *
-     * @return  opt.
+     * @return  ops.
      */
-    EpollIoOps interestOpt();
+    EpollIoOps interestOps();
 
     @Override
     void cancel() throws IOException;

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventIoOps.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventIoOps.java
@@ -36,7 +36,7 @@ public final class KQueueEventIoOps implements IoOps {
      * @param fflags    filter-specific flags.
      * @return          {@link KQueueEventIoOps}.
      */
-    public static KQueueEventIoOps newOpt(int ident, short filter, short flags, int fflags) {
+    public static KQueueEventIoOps newOps(int ident, short filter, short flags, int fflags) {
         return new KQueueEventIoOps(ident, filter, flags, fflags, 0);
     }
 
@@ -108,7 +108,7 @@ public final class KQueueEventIoOps implements IoOps {
 
     @Override
     public String toString() {
-        return "KQueueEventIoOpt{" +
+        return "KQueueEventIoOps{" +
                 "ident=" + ident +
                 ", filter=" + filter +
                 ", flags=" + flags +

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoRegistration.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoRegistration.java
@@ -25,9 +25,9 @@ public interface KQueueIoRegistration extends IoRegistration {
     /**
      * Add the {@link KQueueEventIoOps} to the registration.
      *
-     * @param opt   the {@link KQueueEventIoOps} to use.
+     * @param ops   the {@link KQueueEventIoOps} to use.
      */
-    void addOpt(KQueueEventIoOps opt);
+    void addOps(KQueueEventIoOps ops);
 
     @Override
     KQueueIoHandler ioHandler();

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpChannel.java
@@ -232,7 +232,7 @@ public class NioSctpChannel extends AbstractNioMessageChannel implements io.nett
         try {
             boolean connected = javaChannel().connect(remoteAddress);
             if (!connected) {
-                registration().updateInterestOpt(NioIoOps.CONNECT);
+                registration().updateInterestOps(NioIoOps.CONNECT);
             }
             success = true;
             return connected;

--- a/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtByteConnectorChannel.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtByteConnectorChannel.java
@@ -114,7 +114,7 @@ public class NioUdtByteConnectorChannel extends AbstractNioByteChannel implement
             final boolean connected = SocketUtils.connect(javaChannel(), remoteAddress);
             if (!connected) {
                 NioIoRegistration registration = registration();
-                registration.updateInterestOpt(registration.interestOpt().with(NioIoOps.CONNECT));
+                registration.updateInterestOps(registration.interestOps().with(NioIoOps.CONNECT));
             }
             success = true;
             return connected;
@@ -134,7 +134,7 @@ public class NioUdtByteConnectorChannel extends AbstractNioByteChannel implement
     protected void doFinishConnect() throws Exception {
         if (javaChannel().finishConnect()) {
             NioIoRegistration registration = registration();
-            registration.updateInterestOpt(registration.interestOpt().without(NioIoOps.CONNECT));
+            registration.updateInterestOps(registration.interestOps().without(NioIoOps.CONNECT));
         } else {
             throw new Error(
                     "Provider error: failed to finish connect. Provider library should be upgraded.");

--- a/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtMessageConnectorChannel.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtMessageConnectorChannel.java
@@ -117,7 +117,7 @@ public class NioUdtMessageConnectorChannel extends AbstractNioMessageChannel imp
             final boolean connected = SocketUtils.connect(javaChannel(), remoteAddress);
             if (!connected) {
                 NioIoRegistration registration = registration();
-                registration.updateInterestOpt(registration.interestOpt().with(NioIoOps.CONNECT));
+                registration.updateInterestOps(registration.interestOps().with(NioIoOps.CONNECT));
             }
             success = true;
             return connected;
@@ -137,7 +137,7 @@ public class NioUdtMessageConnectorChannel extends AbstractNioMessageChannel imp
     protected void doFinishConnect() throws Exception {
         if (javaChannel().finishConnect()) {
             NioIoRegistration registration = registration();
-            registration.updateInterestOpt(registration.interestOpt().without(NioIoOps.CONNECT));
+            registration.updateInterestOps(registration.interestOps().without(NioIoOps.CONNECT));
         } else {
             throw new Error(
                     "Provider error: failed to finish connect. Provider library should be upgraded.");

--- a/transport/src/main/java/io/netty/channel/IoEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/IoEventLoop.java
@@ -47,10 +47,10 @@ public interface IoEventLoop extends EventLoop, IoEventLoopGroup {
      * Register the {@link IoHandle} to the {@link EventLoop} for I/O processing.
      *
      * @param handle        the {@link IoHandle} to register.
-     * @param initialOpt    the initial {@link IoOps} to use.
+     * @param initialOps    the initial {@link IoOps} to use.
      * @return              the {@link Future} that is notified once the operations completes.
      */
-    Future<IoRegistration> register(IoHandle handle, IoOps initialOpt);
+    Future<IoRegistration> register(IoHandle handle, IoOps initialOps);
 
     @Override
     boolean isCompatible(Class<? extends IoHandle> handleType);

--- a/transport/src/main/java/io/netty/channel/IoHandle.java
+++ b/transport/src/main/java/io/netty/channel/IoHandle.java
@@ -25,8 +25,8 @@ public interface IoHandle extends AutoCloseable {
      * Be called once there is something to handle.
      *
      * @param registration  the {@link IoRegistration} for this {@link IoHandle}.
-     * @param readyOpt      the {@link IoOps} that must be handled. The {@link IoOps} is only valid
+     * @param readyOps      the {@link IoOps} that must be handled. The {@link IoOps} is only valid
      *                      while this method is executed and so must not escape it.
      */
-    void handle(IoRegistration registration, IoOps readyOpt);
+    void handle(IoRegistration registration, IoOps readyOps);
 }

--- a/transport/src/main/java/io/netty/channel/IoHandler.java
+++ b/transport/src/main/java/io/netty/channel/IoHandler.java
@@ -48,10 +48,10 @@ public interface IoHandler {
      *
      * @param eventLoop     the {@link IoEventLoop} that did issue the registration.
      * @param handle        the {@link IoHandle} to register.
-     * @param opt           the {@link IoOps} which should be used during registration.
+     * @param initialOps           the {@link IoOps} which should be used during registration.
      * @throws Exception    thrown if an error happens during registration.
      */
-    IoRegistration register(IoEventLoop eventLoop, IoHandle handle, IoOps opt) throws Exception;
+    IoRegistration register(IoEventLoop eventLoop, IoHandle handle, IoOps initialOps) throws Exception;
 
     /**
      * Wakeup the {@link IoHandler}, which means if any operation blocks it should be unblocked and

--- a/transport/src/main/java/io/netty/channel/IoOps.java
+++ b/transport/src/main/java/io/netty/channel/IoOps.java
@@ -16,7 +16,7 @@
 package io.netty.channel;
 
 /**
- * An IO opt that is used when register an {@link IoHandle} to an {@link IoEventLoop}.
+ * An IO op that is used when register an {@link IoHandle} to an {@link IoEventLoop}.
  * Concrete {@link IoHandle} implementations support different concrete {@link IoOps} implementations.
  */
 public interface IoOps {

--- a/transport/src/main/java/io/netty/channel/SingleThreadIoEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/SingleThreadIoEventLoop.java
@@ -176,23 +176,23 @@ public class SingleThreadIoEventLoop extends SingleThreadEventLoop implements Io
     }
 
     @Override
-    public final Future<IoRegistration> register(final IoHandle handle, IoOps initialOpt) {
+    public final Future<IoRegistration> register(final IoHandle handle, IoOps initialOps) {
         Promise<IoRegistration> promise = newPromise();
         if (inEventLoop()) {
-            registerForIo0(handle, initialOpt, promise);
+            registerForIo0(handle, initialOps, promise);
         } else {
-            execute(() -> registerForIo0(handle, initialOpt, promise));
+            execute(() -> registerForIo0(handle, initialOps, promise));
         }
 
         return promise;
     }
 
-    private void registerForIo0(final IoHandle handle, IoOps initialOpt,
+    private void registerForIo0(final IoHandle handle, IoOps initialOps,
                                Promise<IoRegistration> promise) {
         assert inEventLoop();
         final IoRegistration registration;
         try {
-            registration = ioHandler.register(this, handle, initialOpt);
+            registration = ioHandler.register(this, handle, initialOps);
         } catch (Exception e) {
             promise.setFailure(e);
             return;

--- a/transport/src/main/java/io/netty/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalChannel.java
@@ -479,7 +479,7 @@ public class LocalChannel extends AbstractChannel {
         }
 
         @Override
-        public void handle(IoRegistration registration, IoOps readyOpt) {
+        public void handle(IoRegistration registration, IoOps readyOps) {
             // NOOP
         }
 

--- a/transport/src/main/java/io/netty/channel/local/LocalIoHandler.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalIoHandler.java
@@ -90,11 +90,11 @@ public final class LocalIoHandler implements IoHandler {
     }
 
     @Override
-    public IoRegistration register(IoEventLoop eventLoop, IoHandle handle, IoOps initialOpt) {
+    public IoRegistration register(IoEventLoop eventLoop, IoHandle handle, IoOps initialOps) {
         LocalIoHandle localHandle = cast(handle);
-        if (initialOpt != LocalIoOps.DEFAULT) {
+        if (initialOps != LocalIoOps.DEFAULT) {
             throw new IllegalArgumentException(
-                    "IoOpt of type " + StringUtil.simpleClassName(initialOpt) + " not supported");
+                    "IoOps of type " + StringUtil.simpleClassName(initialOps) + " not supported");
         }
         if (registeredChannels.add(localHandle)) {
             LocalIoRegistration registration = new LocalIoRegistration(eventLoop, localHandle);

--- a/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
@@ -227,7 +227,7 @@ public class LocalServerChannel extends AbstractServerChannel {
         }
 
         @Override
-        public void handle(IoRegistration registration, IoOps readyOpt) {
+        public void handle(IoRegistration registration, IoOps readyOps) {
             // NOOP
         }
 

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioByteChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioByteChannel.java
@@ -330,9 +330,9 @@ public abstract class AbstractNioByteChannel extends AbstractNioChannel {
         if (!registration.isValid()) {
             return;
         }
-        final NioIoOps opt = registration.interestOpt();
-        if (!opt.contains(NioIoOps.WRITE)) {
-            registration.updateInterestOpt(opt.with(NioIoOps.WRITE));
+        final NioIoOps ops = registration.interestOps();
+        if (!ops.contains(NioIoOps.WRITE)) {
+            registration.updateInterestOps(ops.with(NioIoOps.WRITE));
         }
     }
 
@@ -344,6 +344,6 @@ public abstract class AbstractNioByteChannel extends AbstractNioChannel {
         if (!registration.isValid()) {
             return;
         }
-        registration.updateInterestOpt(registration.interestOpt().without(NioIoOps.WRITE));
+        registration.updateInterestOps(registration.interestOps().without(NioIoOps.WRITE));
     }
 }

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioMessageChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioMessageChannel.java
@@ -41,8 +41,8 @@ public abstract class AbstractNioMessageChannel extends AbstractNioChannel {
         super(parent, ch, readInterestOp);
     }
 
-    protected AbstractNioMessageChannel(Channel parent, SelectableChannel ch, NioIoOps readOpt) {
-        super(parent, ch, readOpt);
+    protected AbstractNioMessageChannel(Channel parent, SelectableChannel ch, NioIoOps readOps) {
+        super(parent, ch, readOps);
     }
 
     @Override
@@ -132,7 +132,7 @@ public abstract class AbstractNioMessageChannel extends AbstractNioChannel {
     @Override
     protected void doWrite(ChannelOutboundBuffer in) throws Exception {
         final NioIoRegistration registration = registration();
-        final NioIoOps opt = registration.interestOpt();
+        final NioIoOps ops = registration.interestOps();
 
         int maxMessagesPerWrite = maxMessagesPerWrite();
         while (maxMessagesPerWrite > 0) {
@@ -166,10 +166,10 @@ public abstract class AbstractNioMessageChannel extends AbstractNioChannel {
         }
         if (in.isEmpty()) {
             // Wrote all messages.
-            registration.updateInterestOpt(opt.without(NioIoOps.WRITE));
+            registration.updateInterestOps(ops.without(NioIoOps.WRITE));
         } else {
             // Did not write all messages.
-            registration.updateInterestOpt(opt.with(NioIoOps.WRITE));
+            registration.updateInterestOps(ops.with(NioIoOps.WRITE));
         }
     }
 

--- a/transport/src/main/java/io/netty/channel/nio/NioIoHandler.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioIoHandler.java
@@ -307,20 +307,20 @@ public final class NioIoHandler implements IoHandler {
         throw new IllegalArgumentException("IoHandle of type " + StringUtil.simpleClassName(handle) + " not supported");
     }
 
-    private static NioIoOps cast(IoOps opt) {
-        if (opt instanceof NioIoOps) {
-            return (NioIoOps) opt;
+    private static NioIoOps cast(IoOps ops) {
+        if (ops instanceof NioIoOps) {
+            return (NioIoOps) ops;
         }
-        throw new IllegalArgumentException("IoOpt of type " + StringUtil.simpleClassName(opt) + " not supported");
+        throw new IllegalArgumentException("IoOps of type " + StringUtil.simpleClassName(ops) + " not supported");
     }
 
     final class DefaultNioRegistration implements NioIoRegistration {
         private final NioIoHandle handle;
         private volatile SelectionKey key;
 
-        DefaultNioRegistration(NioIoHandle handle, NioIoOps initialOpt, Selector selector) throws IOException {
+        DefaultNioRegistration(NioIoHandle handle, NioIoOps initialOps, Selector selector) throws IOException {
             this.handle = handle;
-            key = handle.selectableChannel().register(selector, initialOpt.value, this);
+            key = handle.selectableChannel().register(selector, initialOps.value, this);
         }
 
         NioIoHandle handle() {
@@ -328,8 +328,8 @@ public final class NioIoHandler implements IoHandler {
         }
 
         void register(Selector selector) throws IOException {
-            NioIoOps opts = interestOpt();
-            SelectionKey newKey = handle.selectableChannel().register(selector, opts.value, this);
+            NioIoOps ops = interestOps();
+            SelectionKey newKey = handle.selectableChannel().register(selector, ops.value, this);
             key.cancel();
             key = newKey;
         }
@@ -345,12 +345,12 @@ public final class NioIoHandler implements IoHandler {
         }
 
         @Override
-        public void updateInterestOpt(NioIoOps opt) {
-            key.interestOps(opt.value);
+        public void updateInterestOps(NioIoOps ops) {
+            key.interestOps(ops.value);
         }
 
         @Override
-        public NioIoOps interestOpt() {
+        public NioIoOps interestOps() {
             return NioIoOps.valueOf(key.interestOps());
         }
 
@@ -384,14 +384,14 @@ public final class NioIoHandler implements IoHandler {
     }
 
     @Override
-    public NioIoRegistration register(IoEventLoop eventLoop, IoHandle handle, IoOps initialOpt)
+    public NioIoRegistration register(IoEventLoop eventLoop, IoHandle handle, IoOps initialOps)
             throws Exception {
         NioIoHandle nioHandle = nioHandle(handle);
-        NioIoOps opt = cast(initialOpt);
+        NioIoOps ops = cast(initialOps);
         boolean selected = false;
         for (;;) {
             try {
-                return new DefaultNioRegistration(nioHandle, opt, unwrappedSelector());
+                return new DefaultNioRegistration(nioHandle, ops, unwrappedSelector());
             } catch (CancelledKeyException e) {
                 if (!selected) {
                     // Force the Selector to select now as the "canceled" SelectionKey may still be

--- a/transport/src/main/java/io/netty/channel/nio/NioIoOps.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioIoOps.java
@@ -60,24 +60,24 @@ public final class NioIoOps implements IoOps {
     public static final NioIoOps READ_AND_WRITE = new NioIoOps(SelectionKey.OP_READ | SelectionKey.OP_WRITE);
 
     // Just use an array to store often used values.
-    private static final NioIoOps[] OPTS;
+    private static final NioIoOps[] OPS;
 
     static {
         NioIoOps all = new NioIoOps(
                 NONE.value | ACCEPT.value | CONNECT.value | WRITE.value | READ.value);
-        OPTS = new NioIoOps[all.value + 1];
-        addToArray(OPTS, NONE);
-        addToArray(OPTS, ACCEPT);
-        addToArray(OPTS, CONNECT);
-        addToArray(OPTS, WRITE);
-        addToArray(OPTS, READ);
-        addToArray(OPTS, READ_AND_ACCEPT);
-        addToArray(OPTS, READ_AND_WRITE);
-        addToArray(OPTS, all);
+        OPS = new NioIoOps[all.value + 1];
+        addToArray(OPS, NONE);
+        addToArray(OPS, ACCEPT);
+        addToArray(OPS, CONNECT);
+        addToArray(OPS, WRITE);
+        addToArray(OPS, READ);
+        addToArray(OPS, READ_AND_ACCEPT);
+        addToArray(OPS, READ_AND_WRITE);
+        addToArray(OPS, all);
     }
 
-    private static void addToArray(NioIoOps[] array, NioIoOps opt) {
-        array[opt.value] = opt;
+    private static void addToArray(NioIoOps[] array, NioIoOps op) {
+        array[op.value] = op;
     }
 
     final int value;
@@ -88,37 +88,37 @@ public final class NioIoOps implements IoOps {
 
     /**
      * Returns {@code true} if this {@link NioIoOps} is a combination of the given {@link NioIoOps}.
-     * @param opt   the opt.
+     * @param ops   the ops.
      * @return      {@code true} if a combination of the given.
      */
-    public boolean contains(NioIoOps opt) {
-        return (value & opt.value) != 0;
+    public boolean contains(NioIoOps ops) {
+        return (value & ops.value) != 0;
     }
 
     /**
      * Return a {@link NioIoOps} which is a combination of the current and the given {@link NioIoOps}.
      *
-     * @param opt   the {@link NioIoOps} that should be added to this one.
+     * @param ops   the {@link NioIoOps} that should be added to this one.
      * @return      a {@link NioIoOps}.
      */
-    public NioIoOps with(NioIoOps opt) {
-        if (contains(opt)) {
+    public NioIoOps with(NioIoOps ops) {
+        if (contains(ops)) {
             return this;
         }
-        return valueOf(value | opt.value());
+        return valueOf(value | ops.value());
     }
 
     /**
      * Return a {@link NioIoOps} which is not a combination of the current and the given {@link NioIoOps}.
      *
-     * @param opt   the {@link NioIoOps} that should be remove from this one.
+     * @param ops   the {@link NioIoOps} that should be remove from this one.
      * @return      a {@link NioIoOps}.
      */
-    public NioIoOps without(NioIoOps opt) {
-        if (!contains(opt)) {
+    public NioIoOps without(NioIoOps ops) {
+        if (!contains(ops)) {
             return this;
         }
-        return valueOf(value & ~opt.value());
+        return valueOf(value & ~ops.value());
     }
 
     /**
@@ -138,8 +138,8 @@ public final class NioIoOps implements IoOps {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        NioIoOps nioOpt = (NioIoOps) o;
-        return value == nioOpt.value;
+        NioIoOps nioOps = (NioIoOps) o;
+        return value == nioOps.value;
     }
 
     @Override
@@ -154,11 +154,11 @@ public final class NioIoOps implements IoOps {
      * @return  the {@link NioIoOps}.
      */
     public static NioIoOps valueOf(int value) {
-        final NioIoOps opt;
-        if (value < OPTS.length) {
-            opt = OPTS[value];
-            if (opt != null) {
-                return opt;
+        final NioIoOps ops;
+        if (value < OPS.length) {
+            ops = OPS[value];
+            if (ops != null) {
+                return ops;
             }
         }
         return new NioIoOps(value);

--- a/transport/src/main/java/io/netty/channel/nio/NioIoRegistration.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioIoRegistration.java
@@ -33,16 +33,16 @@ public interface NioIoRegistration extends IoRegistration {
     /**
      * Update the {@link NioIoOps} for this registration.
      *
-     * @param opt   the {@link NioIoOps} to use.
+     * @param ops   the {@link NioIoOps} to use.
      */
-    void updateInterestOpt(NioIoOps opt);
+    void updateInterestOps(NioIoOps ops);
 
     /**
      * The used {@link NioIoOps} for this registration.
      *
-     * @return  opt.
+     * @return  ops.
      */
-    NioIoOps interestOpt();
+    NioIoOps interestOps();
 
     @Override
     void cancel();

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
@@ -307,7 +307,7 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
             boolean connected = SocketUtils.connect(javaChannel(), remoteAddress);
             if (!connected) {
                 NioIoRegistration registration = registration();
-                registration.updateInterestOpt(registration.interestOpt().with(NioIoOps.CONNECT));
+                registration.updateInterestOps(registration.interestOps().with(NioIoOps.CONNECT));
             }
             success = true;
             return connected;


### PR DESCRIPTION
Motivation:
The interface was renamed in #14021, but many variables, fields, parameters and method names still referenced "opt".

Modifications:
Extend the rename to the remaining parts of the code.

Result:
Spelling corrected everywhere.