### PR TITLE
Keep used NioIoOps and SelectionKey in sync

### DIFF
--- a/transport/src/main/java/io/netty/channel/nio/NioIoOps.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioIoOps.java
@@ -93,7 +93,7 @@ public final class NioIoOps implements IoOps {
      * @return      {@code true} if a combination of the given.
      */
     public boolean contains(NioIoOps ops) {
-        return (value & ops.value) != 0;
+        return isIncludedIn(ops.value);
     }
 
     /**
@@ -123,7 +123,7 @@ public final class NioIoOps implements IoOps {
     }
 
     /**
-     * Returns the underlying value of the {@link NioIoOps}.
+     * Returns the underlying ops value of the {@link NioIoOps}.
      *
      * @return value.
      */
@@ -156,6 +156,26 @@ public final class NioIoOps implements IoOps {
      */
     public static NioIoOps valueOf(int value) {
         return eventOf(value).ops();
+    }
+
+    /**
+     * Returns {@code true} if this {@link NioIoOps} is <strong>included </strong> in the given {@code ops}.
+     *
+     * @param ops   the ops to check.
+     * @return      {@code true} if <strong>included</strong>, {@code false} otherwise.
+     */
+    public boolean isIncludedIn(int ops) {
+        return (ops & value) != 0;
+    }
+
+    /**
+     * Returns {@code true} if this {@link NioIoOps} is <strong>not included</strong> in the given {@code ops}.
+     *
+     * @param ops   the ops to check.
+     * @return      {@code true} if <strong>not included</strong>, {@code false} otherwise.
+     */
+    public boolean isNotIncludedIn(int ops) {
+        return (ops & value) == 0;
     }
 
     static NioIoEvent eventOf(int value) {


### PR DESCRIPTION
Motivation:

As the user is able to retieve the underlying SelectionKey via the NioRegistration we need to ensure we always keep this and the current used NioIoOps in sync.

Modifications:

Remove the local stored NioOps and just always reconstruct using the underlying SelectionKey. This is not a concern in terms of performance and object creation as we pre-construct them.

Result:

Keep current used NioIoOps and SelectionKey always in sync