### PR TITLE
Allow getting TCP info till tcpi_segs_in

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollTcpInfo.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollTcpInfo.java
@@ -56,12 +56,19 @@ package io.netty.channel.epoll;
  *      __u32   tcpi_rcv_space;
  *
  *      __u32   tcpi_total_retrans;
+ *
+ *      __u64   tcpi_pacing_rate;
+ *      __u64   tcpi_max_pacing_rate;
+ *      __u64   tcpi_bytes_acked;
+ *      __u64   tcpi_bytes_received;
+ *      __u32   tcpi_segs_out;
+ *      __u32   tcpi_segs_in;
  * };
  * </p>
  */
 public final class EpollTcpInfo {
 
-    final long[] info = new long[32];
+    final long[] info = new long[38];
 
     public int state() {
         return (int) info[0];
@@ -189,5 +196,41 @@ public final class EpollTcpInfo {
 
     public long totalRetrans() {
         return info[31];
+    }
+
+    /**
+     * Returns an unsigned long
+     */
+    public long pacingRate() {
+        return info[32];
+    }
+
+    /**
+     * Returns an unsigned long
+     */
+    public long maxPacingRate() {
+        return info[33];
+    }
+
+    /**
+     * Returns an unsigned long
+     */
+    public long bytesAcked() {
+        return info[34];
+    }
+
+    /**
+     * Returns an unsigned long
+     */
+    public long bytesReceived() {
+        return info[35];
+    }
+
+    public long segsOut() {
+        return info[36];
+    }
+
+    public long segsIn() {
+        return info[37];
     }
 }

--- a/transport-native-epoll/src/main/c/netty_epoll_linuxsocket.c
+++ b/transport-native-epoll/src/main/c/netty_epoll_linuxsocket.c
@@ -613,7 +613,7 @@ static void netty_epoll_linuxsocket_getTcpInfo(JNIEnv* env, jclass clazz, jint f
      if (netty_unix_socket_getOption(env, fd, IPPROTO_TCP, TCP_INFO, &tcp_info, sizeof(tcp_info)) == -1) {
          return;
      }
-     jlong cArray[32];
+     jlong cArray[38];
      // Expand to 64 bits, then cast away unsigned-ness.
      cArray[0] = (jlong) (uint64_t) tcp_info.tcpi_state;
      cArray[1] = (jlong) (uint64_t) tcp_info.tcpi_ca_state;
@@ -647,8 +647,14 @@ static void netty_epoll_linuxsocket_getTcpInfo(JNIEnv* env, jclass clazz, jint f
      cArray[29] = (jlong) (uint64_t) tcp_info.tcpi_rcv_rtt;
      cArray[30] = (jlong) (uint64_t) tcp_info.tcpi_rcv_space;
      cArray[31] = (jlong) (uint64_t) tcp_info.tcpi_total_retrans;
+     cArray[32] = (jlong) (uint64_t) tcp_info.tcpi_pacing_rate;
+     cArray[33] = (jlong) (uint64_t) tcp_info.tcpi_max_pacing_rate;
+     cArray[34] = (jlong) (uint64_t) tcp_info.tcpi_bytes_acked;
+     cArray[35] = (jlong) (uint64_t) tcp_info.tcpi_bytes_received;
+     cArray[36] = (jlong) (uint64_t) tcp_info.tcpi_segs_out;
+     cArray[37] = (jlong) (uint64_t) tcp_info.tcpi_segs_in;
 
-     (*env)->SetLongArrayRegion(env, array, 0, 32, cArray);
+     (*env)->SetLongArrayRegion(env, array, 0, 38, cArray);
 }
 
 static jint netty_epoll_linuxsocket_isTcpCork(JNIEnv* env, jclass clazz, jint fd) {

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketChannelTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketChannelTest.java
@@ -101,6 +101,12 @@ public class EpollSocketChannelTest {
         assertTrue(info.rcvRtt() >= 0);
         assertTrue(info.rcvSpace() >= 0);
         assertTrue(info.totalRetrans() >= 0);
+        assertTrue(info.pacingRate() >= 0);
+        assertTrue(info.maxPacingRate() >= 0);
+        assertTrue(info.bytesAcked() >= 0);
+        assertTrue(info.bytesReceived() >= 0);
+        assertTrue(info.segsOut() >= 0);
+        assertTrue(info.segsIn() >= 0);
     }
 
     // See https://github.com/netty/netty/issues/7159


### PR DESCRIPTION
Motivation:

In order to be able to calculate the loss percentage, tcpi_segs_out has to be exposed.

Modification:

Exposed every field until tcpi_segs_in

Minimum Linux requirement: v4.2 released on 30 August 2015
https://github.com/torvalds/linux/commit/2efd055c53c06b7e89c167c98069bab9afce7e59

Result:

Implements #14022
