### PR TITLE
Socks5 Compatible with multiple authentication methods

### DIFF
--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/DefaultSocks5PasswordAuthRequest.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/DefaultSocks5PasswordAuthRequest.java
@@ -24,12 +24,19 @@ import io.netty.util.internal.StringUtil;
  */
 public class DefaultSocks5PasswordAuthRequest extends AbstractSocks5Message implements Socks5PasswordAuthRequest {
 
+    private final Socks5AuthMethod authMethod;
     private final String username;
     private final String password;
 
+    @Deprecated
     public DefaultSocks5PasswordAuthRequest(String username, String password) {
+        this(Socks5AuthMethod.PASSWORD, username, password);
+    }
+
+    public DefaultSocks5PasswordAuthRequest(Socks5AuthMethod authMethod, String username, String password) {
         ObjectUtil.checkNotNull(username, "username");
         ObjectUtil.checkNotNull(password, "password");
+        ObjectUtil.checkNotNull(authMethod, "authMethod");
 
         if (username.length() > 255) {
             throw new IllegalArgumentException("username: **** (expected: less than 256 chars)");
@@ -40,8 +47,8 @@ public class DefaultSocks5PasswordAuthRequest extends AbstractSocks5Message impl
 
         this.username = username;
         this.password = password;
+        this.authMethod = authMethod;
     }
-
     @Override
     public String username() {
         return username;
@@ -53,6 +60,11 @@ public class DefaultSocks5PasswordAuthRequest extends AbstractSocks5Message impl
     }
 
     @Override
+    public Socks5AuthMethod authMethod() {
+        return authMethod;
+    }
+
+    @Override
     public String toString() {
         StringBuilder buf = new StringBuilder(StringUtil.simpleClassName(this));
 
@@ -60,13 +72,14 @@ public class DefaultSocks5PasswordAuthRequest extends AbstractSocks5Message impl
         if (!decoderResult.isSuccess()) {
             buf.append("(decoderResult: ");
             buf.append(decoderResult);
-            buf.append(", username: ");
+            buf.append(", authMethod: ");
         } else {
-            buf.append("(username: ");
+            buf.append("(authMethod: ");
         }
-        buf.append(username());
+        buf.append(authMethod());
+        buf.append(", username: ");
+        buf.append(username);
         buf.append(", password: ****)");
-
         return buf.toString();
     }
 }

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/DefaultSocks5PasswordAuthResponse.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/DefaultSocks5PasswordAuthResponse.java
@@ -24,10 +24,21 @@ import io.netty.util.internal.StringUtil;
  */
 public class DefaultSocks5PasswordAuthResponse extends AbstractSocks5Message implements Socks5PasswordAuthResponse {
 
+    private final Socks5AuthMethod authMethod;
     private final Socks5PasswordAuthStatus status;
 
     public DefaultSocks5PasswordAuthResponse(Socks5PasswordAuthStatus status) {
+        this(Socks5AuthMethod.PASSWORD, status);
+    }
+
+    public DefaultSocks5PasswordAuthResponse(Socks5AuthMethod authMethod, Socks5PasswordAuthStatus status) {
+        this.authMethod = ObjectUtil.checkNotNull(authMethod, "authMethod");
         this.status = ObjectUtil.checkNotNull(status, "status");
+    }
+
+    @Override
+    public Socks5AuthMethod authMethod() {
+        return authMethod;
     }
 
     @Override

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5PasswordAuthRequest.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5PasswordAuthRequest.java
@@ -22,6 +22,13 @@ package io.netty.handler.codec.socksx.v5;
 public interface Socks5PasswordAuthRequest extends Socks5Message {
 
     /**
+     * Returns the {@code METHOD} field of this request.
+     */
+    default Socks5AuthMethod authMethod() {
+        return Socks5AuthMethod.PASSWORD;
+    }
+
+    /**
      * Returns the username of this request.
      */
     String username();
@@ -30,4 +37,5 @@ public interface Socks5PasswordAuthRequest extends Socks5Message {
      * Returns the password of this request.
      */
     String password();
+
 }

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5PasswordAuthRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5PasswordAuthRequestDecoder.java
@@ -53,16 +53,14 @@ public class Socks5PasswordAuthRequestDecoder extends ReplayingDecoder<State> {
             case INIT: {
                 final int startOffset = in.readerIndex();
                 final byte version = in.getByte(startOffset);
-                if (version != 1) {
-                    throw new DecoderException("unsupported subnegotiation version: " + version + " (expected: 1)");
-                }
-
+                final Socks5AuthMethod authMethod = Socks5AuthMethod.valueOf(version);
                 final int usernameLength = in.getUnsignedByte(startOffset + 1);
                 final int passwordLength = in.getUnsignedByte(startOffset + 2 + usernameLength);
                 final int totalLength = usernameLength + passwordLength + 3;
 
                 in.skipBytes(totalLength);
                 out.add(new DefaultSocks5PasswordAuthRequest(
+                        authMethod,
                         in.toString(startOffset + 2, usernameLength, CharsetUtil.US_ASCII),
                         in.toString(startOffset + 3 + usernameLength, passwordLength, CharsetUtil.US_ASCII)));
 
@@ -92,7 +90,7 @@ public class Socks5PasswordAuthRequestDecoder extends ReplayingDecoder<State> {
 
         checkpoint(State.FAILURE);
 
-        Socks5Message m = new DefaultSocks5PasswordAuthRequest("", "");
+        Socks5Message m = new DefaultSocks5PasswordAuthRequest(Socks5AuthMethod.PASSWORD, "", "");
         m.setDecoderResult(DecoderResult.failure(cause));
         out.add(m);
     }

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5PasswordAuthResponse.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5PasswordAuthResponse.java
@@ -21,7 +21,15 @@ package io.netty.handler.codec.socksx.v5;
  */
 public interface Socks5PasswordAuthResponse extends Socks5Message {
     /**
+     * Returns the {@code METHOD} field of this response.
+     */
+    default Socks5AuthMethod authMethod() {
+        return Socks5AuthMethod.PASSWORD;
+    }
+
+    /**
      * Returns the status of this response.
      */
     Socks5PasswordAuthStatus status();
+
 }

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5PasswordAuthResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5PasswordAuthResponseDecoder.java
@@ -51,11 +51,11 @@ public class Socks5PasswordAuthResponseDecoder extends ReplayingDecoder<State> {
             switch (state()) {
             case INIT: {
                 final byte version = in.readByte();
-                if (version != 1) {
-                    throw new DecoderException("unsupported subnegotiation version: " + version + " (expected: 1)");
-                }
+                Socks5AuthMethod authMethod = Socks5AuthMethod.valueOf(version);
 
-                out.add(new DefaultSocks5PasswordAuthResponse(Socks5PasswordAuthStatus.valueOf(in.readByte())));
+                out.add(new DefaultSocks5PasswordAuthResponse(
+                        authMethod,
+                        Socks5PasswordAuthStatus.valueOf(in.readByte())));
                 checkpoint(State.SUCCESS);
             }
             case SUCCESS: {

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5ServerEncoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5ServerEncoder.java
@@ -75,7 +75,7 @@ public class Socks5ServerEncoder extends MessageToByteEncoder<Socks5Message> {
     }
 
     private static void encodePasswordAuthResponse(Socks5PasswordAuthResponse msg, ByteBuf out) {
-        out.writeByte(0x01);
+        out.writeByte(msg.authMethod().byteValue());
         out.writeByte(msg.status().byteValue());
     }
 

--- a/handler-proxy/src/main/java/io/netty/handler/proxy/Socks5ProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/handler/proxy/Socks5ProxyHandler.java
@@ -146,6 +146,7 @@ public final class Socks5ProxyHandler extends ProxyHandler {
                 // In case of password authentication, send an authentication request.
                 ctx.pipeline().replace(decoderName, decoderName, new Socks5PasswordAuthResponseDecoder());
                 sendToProxyServer(new DefaultSocks5PasswordAuthRequest(
+                        Socks5AuthMethod.PASSWORD,
                         username != null? username : "", password != null? password : ""));
             } else {
                 // Should never reach here.


### PR DESCRIPTION
SOCKS5 encoder and decoder are both limited to only performing username password authentication. Such a design obviously violates the SRP. Whether authentication methods are supported should be handled by the application layer rather than the encoding layer. Besides, when we implement other authentication methods, we have to rewrite these decoders and encoders.