### PR TITLE
Fix possible AssertionError in AbstractNioChannel

### DIFF
--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
@@ -471,7 +471,7 @@ public abstract class AbstractNioChannel extends AbstractChannel {
 
     @Override
     protected void doDeregister() throws Exception {
-        NioIoRegistration registration = registration();
+        NioIoRegistration registration = this.registration;
         if (registration != null) {
             this.registration = null;
             registration.cancel();


### PR DESCRIPTION
Motivation:

We need to use this.registration directly as otherwise we might cause an error like

```
09:51:58.318 [testsuite-nio-worker-7-3] WARN  io.netty.channel.AbstractChannel - Unexpected exception occurred while deregistering a channel.
java.lang.AssertionError: null
	at io.netty.channel.nio.AbstractNioChannel.registration(AbstractNioChannel.java:156)
	at io.netty.channel.nio.AbstractNioChannel.doDeregister(AbstractNioChannel.java:474)
	at io.netty.channel.AbstractChannel$AbstractUnsafe$8.run(AbstractChannel.java:814)
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470)
	at io.netty.channel.SingleThreadIoEventLoop.run(SingleThreadIoEventLoop.java:154)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```

Modifications:

- Use registration field directly

Result:

No more AssertionError
