### PR TITLE
Always send ChannelInputShutdownReadComplete in epoll

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
@@ -567,7 +567,9 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
                         // We attempted to shutdown and failed, which means the input has already effectively been
                         // shutdown.
                     }
-                    clearEpollIn0();
+                    if (shouldStopReading(config())) {
+                        clearEpollIn0();
+                    }
                     pipeline().fireUserEventTriggered(ChannelInputShutdownEvent.INSTANCE);
                 } else {
                     close(voidPromise());


### PR DESCRIPTION
Motivation:
We were observing EpollSocketHalfClosedTest was occasionally failing.
This appears to be because we were clearing EPOLLIN when we shouldn't, and prevent ourselves from getting the RDHUP where we send the ChannelInputShutdownReadComplete event.

Modification:
Predicate the `clearEpollIn0()` call on `shouldStopReading(config())`, so we continue to try reading when reads are queued.
This allows us to get another RDHUP which we will turn into the read-complete event.

Result:
We no longer miss out on read-complete events from input shut down.