### PR TITLE
Update *SocketTestPermutation to use new way of constructing EventLoo…

### DIFF
--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTestPermutation.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTestPermutation.java
@@ -21,6 +21,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFactory;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
@@ -44,10 +45,10 @@ class EpollSocketTestPermutation extends SocketTestPermutation {
 
     static final EpollSocketTestPermutation INSTANCE = new EpollSocketTestPermutation();
 
-    static final EventLoopGroup EPOLL_BOSS_GROUP =
-            new EpollEventLoopGroup(BOSSES, new DefaultThreadFactory("testsuite-epoll-boss", true));
-    static final EventLoopGroup EPOLL_WORKER_GROUP =
-            new EpollEventLoopGroup(WORKERS, new DefaultThreadFactory("testsuite-epoll-worker", true));
+    static final EventLoopGroup EPOLL_BOSS_GROUP = new MultiThreadIoEventLoopGroup(
+            BOSSES, new DefaultThreadFactory("testsuite-epoll-boss", true), EpollIoHandler.newFactory());
+    static final EventLoopGroup EPOLL_WORKER_GROUP = new MultiThreadIoEventLoopGroup(
+            WORKERS, new DefaultThreadFactory("testsuite-epoll-worker", true), EpollIoHandler.newFactory());
 
     @Override
     public List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> socket() {

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketTestPermutation.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketTestPermutation.java
@@ -21,6 +21,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFactory;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
@@ -41,10 +42,10 @@ class KQueueSocketTestPermutation extends SocketTestPermutation {
 
     static final KQueueSocketTestPermutation INSTANCE = new KQueueSocketTestPermutation();
 
-    static final EventLoopGroup KQUEUE_BOSS_GROUP =
-            new KQueueEventLoopGroup(BOSSES, new DefaultThreadFactory("testsuite-KQueue-boss", true));
-    static final EventLoopGroup KQUEUE_WORKER_GROUP =
-            new KQueueEventLoopGroup(WORKERS, new DefaultThreadFactory("testsuite-KQueue-worker", true));
+    static final EventLoopGroup KQUEUE_BOSS_GROUP = new MultiThreadIoEventLoopGroup(
+            BOSSES, new DefaultThreadFactory("testsuite-KQueue-boss", true), KQueueIoHandler.newFactory());
+    static final EventLoopGroup KQUEUE_WORKER_GROUP = new MultiThreadIoEventLoopGroup(
+            WORKERS, new DefaultThreadFactory("testsuite-KQueue-worker", true), KQueueIoHandler.newFactory());
 
     @Override
     public List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> socket() {


### PR DESCRIPTION
…pGroups

Motivation:

https://github.com/netty/netty/pull/14020 did miss to change EpollSocketTestPermution and KqueueSocketTestPermution

Modifications:

Update missed files

Result:

Cleanup