### PR TITLE
AdaptivePoolingAllocator EventLoop Magazine's affinity

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/adapt/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/adapt/AdaptivePoolingAllocator.java
@@ -145,7 +145,9 @@ public class AdaptivePoolingAllocator implements BufferAllocator {
                 @Override
                 protected void onRemoval(final Object value) {
                     if (value != NO_MAGAZINE) {
-                        liveMagazines.remove(value);
+                        if (liveMagazines.remove(value)) {
+                            ((Magazine) value).close();
+                        }
                     }
                 }
             };


### PR DESCRIPTION
Motivation:

AdaptivePoolingAllocator uses some shared Magazines hoping thread's id distribution to improve contended behaviour, but event loops threads can just uses their own Magazine(s) and save 2 atomic operations (write lock/unlock) in the hot path, further improving performance.

Modification:

Implements dedicated event loop Magazines

Result:

Better allocation performance for event loop threads