### PR TITLE
KQueueIoHandler should pass IoOps to evSet

### DIFF
--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoHandler.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoHandler.java
@@ -385,10 +385,13 @@ public final class KQueueIoHandler implements IoHandler {
             if (!isValid()) {
                 return -1;
             }
+            short filter = kQueueIoOps.filter();
+            short flags = kQueueIoOps.flags();
+            int fflags = kQueueIoOps.fflags();
             if (eventLoop.inEventLoop()) {
-                evSet(event.filter(), event.flags(), event.fflags());
+                evSet(filter, flags, fflags);
             } else {
-                eventLoop.execute(() -> evSet(event.filter(), event.flags(), event.fflags()));
+                eventLoop.execute(() -> evSet(filter, flags, fflags));
             }
             return 0;
         }


### PR DESCRIPTION
Motivation:

7ed972d070f9c1f8d89cc226568e61e3b5f2a6f5 introduced a change but did break our native kqueue implementation

Modifications:

Correctly use values of KQueueIoOps when calling evSet

Result:

KQueue tests pass again
