### PR TITLE
Simplify KQueueIoOps as we don't need to pass the ident

### DIFF
--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
@@ -95,10 +95,10 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
             remote = fd.remoteAddress();
         }
 
-        readEnabledOps = KQueueIoOps.newOps(fd().intValue(), Native.EVFILT_READ, Native.EV_ADD_CLEAR_ENABLE, 0);
-        writeEnabledOps = KQueueIoOps.newOps(fd().intValue(), Native.EVFILT_WRITE, Native.EV_ADD_CLEAR_ENABLE, 0);
-        readDisabledOps = KQueueIoOps.newOps(fd().intValue(), Native.EVFILT_READ, Native.EV_DELETE_DISABLE, 0);
-        writeDisabledOps = KQueueIoOps.newOps(fd().intValue(), Native.EVFILT_WRITE, Native.EV_DELETE_DISABLE, 0);
+        readEnabledOps = KQueueIoOps.newOps(Native.EVFILT_READ, Native.EV_ADD_CLEAR_ENABLE, 0);
+        writeEnabledOps = KQueueIoOps.newOps(Native.EVFILT_WRITE, Native.EV_ADD_CLEAR_ENABLE, 0);
+        readDisabledOps = KQueueIoOps.newOps(Native.EVFILT_READ, Native.EV_DELETE_DISABLE, 0);
+        writeDisabledOps = KQueueIoOps.newOps(Native.EVFILT_WRITE, Native.EV_DELETE_DISABLE, 0);
     }
 
     AbstractKQueueChannel(Channel parent, BsdSocket fd, SocketAddress remote) {
@@ -110,10 +110,10 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
         this.remote = remote;
         local = fd.localAddress();
 
-        readEnabledOps = KQueueIoOps.newOps(fd().intValue(), Native.EVFILT_READ, Native.EV_ADD_CLEAR_ENABLE, 0);
-        writeEnabledOps = KQueueIoOps.newOps(fd().intValue(), Native.EVFILT_WRITE, Native.EV_ADD_CLEAR_ENABLE, 0);
-        readDisabledOps = KQueueIoOps.newOps(fd().intValue(), Native.EVFILT_READ, Native.EV_DELETE_DISABLE, 0);
-        writeDisabledOps = KQueueIoOps.newOps(fd().intValue(), Native.EVFILT_WRITE, Native.EV_DELETE_DISABLE, 0);
+        readEnabledOps = KQueueIoOps.newOps(Native.EVFILT_READ, Native.EV_ADD_CLEAR_ENABLE, 0);
+        writeEnabledOps = KQueueIoOps.newOps(Native.EVFILT_WRITE, Native.EV_ADD_CLEAR_ENABLE, 0);
+        readDisabledOps = KQueueIoOps.newOps(Native.EVFILT_READ, Native.EV_DELETE_DISABLE, 0);
+        writeDisabledOps = KQueueIoOps.newOps(Native.EVFILT_WRITE, Native.EV_DELETE_DISABLE, 0);
     }
 
     @Override
@@ -189,8 +189,7 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
     }
 
     private void clearRdHup0() {
-        submit(KQueueIoOps.newOps(fd().intValue(),
-                Native.EVFILT_SOCK, Native.EV_DELETE_DISABLE, Native.NOTE_RDHUP));
+        submit(KQueueIoOps.newOps(Native.EVFILT_SOCK, Native.EV_DELETE_DISABLE, Native.NOTE_RDHUP));
     }
 
     private void submit(KQueueIoOps ops) {
@@ -229,9 +228,7 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
                 // the Runnable on the new EventLoop.
                 readReadyRunnablePending = false;
 
-                int ident = fd().intValue();
-                submit(KQueueIoOps.newOps(
-                        ident, Native.EVFILT_SOCK, Native.EV_ADD, Native.NOTE_RDHUP));
+                submit(KQueueIoOps.newOps(Native.EVFILT_SOCK, Native.EV_ADD, Native.NOTE_RDHUP));
 
                 // Add the write event first so we get notified of connection refused on the client side!
                 if (writeFilterEnabled) {

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoHandler.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoHandler.java
@@ -379,9 +379,6 @@ public final class KQueueIoHandler implements IoHandler {
         @Override
         public long submit(IoOps ops) {
             KQueueIoOps kQueueIoOps = cast(ops);
-            if (kQueueIoOps.ident() != handle.ident()) {
-                throw new IllegalArgumentException("ident does not match KQueueIoHandle.ident()");
-            }
             if (!isValid()) {
                 return -1;
             }

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoOps.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoOps.java
@@ -22,7 +22,6 @@ import io.netty.channel.IoOps;
  * that is used by {@link KQueueIoHandler} and so for kqueue based transports.
  */
 public final class KQueueIoOps implements IoOps {
-    private int ident;
     private short filter;
     private short flags;
     private int fflags;
@@ -31,18 +30,16 @@ public final class KQueueIoOps implements IoOps {
     /**
      * Creates a new {@link KQueueIoOps}.
      *
-     * @param ident     the identifier for this event.
      * @param filter    the filter for this event.
      * @param flags     the general flags.
      * @param fflags    filter-specific flags.
      * @return          {@link KQueueIoOps}.
      */
-    public static KQueueIoOps newOps(int ident, short filter, short flags, int fflags) {
-        return new KQueueIoOps(ident, filter, flags, fflags, 0);
+    public static KQueueIoOps newOps(short filter, short flags, int fflags) {
+        return new KQueueIoOps(filter, flags, fflags, 0);
     }
 
-    private KQueueIoOps(int ident, short filter, short flags, int fflags, long data) {
-        this.ident = ident;
+    private KQueueIoOps(short filter, short flags, int fflags, long data) {
         this.filter = filter;
         this.flags = flags;
         this.fflags = fflags;
@@ -50,17 +47,9 @@ public final class KQueueIoOps implements IoOps {
     }
 
     KQueueIoOps() {
-        this(0, (short) 0, (short) 0, 0, 0);
+        this((short) 0, (short) 0, 0, 0);
     }
 
-    /**
-     * Returns the identifier for this event.
-     *
-     * @return  ident.
-     */
-    public int ident() {
-        return ident;
-    }
 
     /**
      * Returns the filter for this event.
@@ -101,8 +90,7 @@ public final class KQueueIoOps implements IoOps {
     @Override
     public String toString() {
         return "KQueueIoOps{" +
-                "ident=" + ident +
-                ", filter=" + filter +
+                "filter=" + filter +
                 ", flags=" + flags +
                 ", fflags=" + fflags +
                 ", data=" + data +

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoOps.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoOps.java
@@ -22,10 +22,10 @@ import io.netty.channel.IoOps;
  * that is used by {@link KQueueIoHandler} and so for kqueue based transports.
  */
 public final class KQueueIoOps implements IoOps {
-    private short filter;
-    private short flags;
-    private int fflags;
-    private long data;
+    private final short filter;
+    private final short flags;
+    private final int fflags;
+    private final long data;
 
     /**
      * Creates a new {@link KQueueIoOps}.
@@ -45,11 +45,6 @@ public final class KQueueIoOps implements IoOps {
         this.fflags = fflags;
         this.data = data;
     }
-
-    KQueueIoOps() {
-        this((short) 0, (short) 0, 0, 0);
-    }
-
 
     /**
      * Returns the filter for this event.


### PR DESCRIPTION
Motivation:

We can simplify KqueueIops as we don't need to pass the ident with it. The ident is already known by the KQueueIoRegistration as part of the KqueueIoHandle.

Modifications:

Remove ident from KQueueIoOps

Result:

Simplify API
