### PR TITLE
Add support for specifying SecureRandom in SSLContext initialization

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/JdkSslClientContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkSslClientContext.java
@@ -27,6 +27,7 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import java.io.File;
 import java.security.PrivateKey;
+import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
 
 /**
@@ -175,7 +176,7 @@ public final class JdkSslClientContext extends JdkSslContext {
                         long sessionCacheSize, long sessionTimeout) throws SSLException {
         super(newSSLContext(provider, toX509CertificatesInternal(trustCertCollectionFile),
                 trustManagerFactory, null, null,
-                null, null, sessionCacheSize, sessionTimeout, KeyStore.getDefaultType()), true,
+                null, null, sessionCacheSize, sessionTimeout, null, KeyStore.getDefaultType()), true,
                 ciphers, cipherFilter, apn, ClientAuth.NONE, null, false);
     }
 
@@ -258,7 +259,8 @@ public final class JdkSslClientContext extends JdkSslContext {
         super(newSSLContext(null, toX509CertificatesInternal(
                 trustCertCollectionFile), trustManagerFactory,
                 toX509CertificatesInternal(keyCertChainFile), toPrivateKeyInternal(keyFile, keyPassword),
-                keyPassword, keyManagerFactory, sessionCacheSize, sessionTimeout, KeyStore.getDefaultType()), true,
+                keyPassword, keyManagerFactory, sessionCacheSize, sessionTimeout,
+                        null, KeyStore.getDefaultType()), true,
                 ciphers, cipherFilter, apn, ClientAuth.NONE, null, false);
     }
 
@@ -267,11 +269,11 @@ public final class JdkSslClientContext extends JdkSslContext {
                         X509Certificate[] keyCertChain, PrivateKey key, String keyPassword,
                         KeyManagerFactory keyManagerFactory, Iterable<String> ciphers, CipherSuiteFilter cipherFilter,
                         ApplicationProtocolConfig apn, String[] protocols, long sessionCacheSize, long sessionTimeout,
-                        String keyStoreType)
+                        SecureRandom secureRandom, String keyStoreType)
             throws SSLException {
         super(newSSLContext(sslContextProvider, trustCertCollection, trustManagerFactory,
                             keyCertChain, key, keyPassword, keyManagerFactory, sessionCacheSize,
-                            sessionTimeout, keyStoreType),
+                            sessionTimeout, secureRandom, keyStoreType),
                 true, ciphers, cipherFilter, toNegotiator(apn, false), ClientAuth.NONE, protocols, false);
     }
 
@@ -280,7 +282,7 @@ public final class JdkSslClientContext extends JdkSslContext {
                                             TrustManagerFactory trustManagerFactory, X509Certificate[] keyCertChain,
                                             PrivateKey key, String keyPassword, KeyManagerFactory keyManagerFactory,
                                             long sessionCacheSize, long sessionTimeout,
-                                            String keyStore) throws SSLException {
+                                            SecureRandom secureRandom, String keyStore) throws SSLException {
         try {
             if (trustCertCollection != null) {
                 trustManagerFactory = buildTrustManagerFactory(trustCertCollection, trustManagerFactory, keyStore);
@@ -293,7 +295,7 @@ public final class JdkSslClientContext extends JdkSslContext {
                 : SSLContext.getInstance(PROTOCOL, sslContextProvider);
             ctx.init(keyManagerFactory == null ? null : keyManagerFactory.getKeyManagers(),
                      trustManagerFactory == null ? null : trustManagerFactory.getTrustManagers(),
-                     null);
+                     secureRandom);
 
             SSLSessionContext sessCtx = ctx.getClientSessionContext();
             if (sessionCacheSize > 0) {

--- a/handler/src/main/java/io/netty/handler/ssl/JdkSslServerContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkSslServerContext.java
@@ -40,6 +40,7 @@ import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509ExtendedTrustManager;
 import java.io.File;
 import java.security.PrivateKey;
+import java.security.SecureRandom;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
@@ -207,7 +208,7 @@ public final class JdkSslServerContext extends JdkSslContext {
                         long sessionCacheSize, long sessionTimeout, String keyStore) throws SSLException {
         super(newSSLContext(provider, null, null,
                 toX509CertificatesInternal(certChainFile), toPrivateKeyInternal(keyFile, keyPassword),
-                keyPassword, null, sessionCacheSize, sessionTimeout, keyStore), false,
+                keyPassword, null, sessionCacheSize, sessionTimeout, null, keyStore), false,
                 ciphers, cipherFilter, apn, ClientAuth.NONE, null, false);
     }
 
@@ -247,7 +248,7 @@ public final class JdkSslServerContext extends JdkSslContext {
                                long sessionCacheSize, long sessionTimeout) throws SSLException {
         super(newSSLContext(null, toX509CertificatesInternal(trustCertCollectionFile), trustManagerFactory,
                 toX509CertificatesInternal(keyCertChainFile), toPrivateKeyInternal(keyFile, keyPassword),
-                keyPassword, keyManagerFactory, sessionCacheSize, sessionTimeout, null), false,
+                keyPassword, keyManagerFactory, sessionCacheSize, sessionTimeout, null, null), false,
                 ciphers, cipherFilter, apn, ClientAuth.NONE, null, false);
     }
 
@@ -288,7 +289,8 @@ public final class JdkSslServerContext extends JdkSslContext {
                                long sessionCacheSize, long sessionTimeout) throws SSLException {
         super(newSSLContext(null, toX509CertificatesInternal(trustCertCollectionFile), trustManagerFactory,
                 toX509CertificatesInternal(keyCertChainFile), toPrivateKeyInternal(keyFile, keyPassword),
-                keyPassword, keyManagerFactory, sessionCacheSize, sessionTimeout, KeyStore.getDefaultType()), false,
+                keyPassword, keyManagerFactory, sessionCacheSize, sessionTimeout,
+                        null, KeyStore.getDefaultType()), false,
                 ciphers, cipherFilter, apn, ClientAuth.NONE, null, false);
     }
 
@@ -298,16 +300,17 @@ public final class JdkSslServerContext extends JdkSslContext {
                         KeyManagerFactory keyManagerFactory, Iterable<String> ciphers, CipherSuiteFilter cipherFilter,
                         ApplicationProtocolConfig apn, long sessionCacheSize, long sessionTimeout,
                         ClientAuth clientAuth, String[] protocols, boolean startTls,
-                        String keyStore) throws SSLException {
+                        SecureRandom secureRandom, String keyStore) throws SSLException {
         super(newSSLContext(provider, trustCertCollection, trustManagerFactory, keyCertChain, key,
-                keyPassword, keyManagerFactory, sessionCacheSize, sessionTimeout, keyStore), false,
+                keyPassword, keyManagerFactory, sessionCacheSize, sessionTimeout, secureRandom, keyStore), false,
                 ciphers, cipherFilter, toNegotiator(apn, true), clientAuth, protocols, startTls);
     }
 
     private static SSLContext newSSLContext(Provider sslContextProvider, X509Certificate[] trustCertCollection,
-                                     TrustManagerFactory trustManagerFactory, X509Certificate[] keyCertChain,
-                                     PrivateKey key, String keyPassword, KeyManagerFactory keyManagerFactory,
-                                     long sessionCacheSize, long sessionTimeout, String keyStore)
+                                            TrustManagerFactory trustManagerFactory, X509Certificate[] keyCertChain,
+                                            PrivateKey key, String keyPassword, KeyManagerFactory keyManagerFactory,
+                                            long sessionCacheSize, long sessionTimeout,
+                                            SecureRandom secureRandom, String keyStore)
             throws SSLException {
         if (key == null && keyManagerFactory == null) {
             throw new NullPointerException("key, keyManagerFactory");
@@ -333,7 +336,7 @@ public final class JdkSslServerContext extends JdkSslContext {
                 : SSLContext.getInstance(PROTOCOL, sslContextProvider);
             ctx.init(keyManagerFactory.getKeyManagers(),
                     wrapTrustManagerIfNeeded(trustManagerFactory.getTrustManagers()),
-                     null);
+                     secureRandom);
 
             SSLSessionContext sessCtx = ctx.getServerSessionContext();
             if (sessionCacheSize > 0) {

--- a/handler/src/main/java/io/netty/handler/ssl/SslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContext.java
@@ -803,7 +803,7 @@ public abstract class SslContext {
                                             toX509Certificates(keyCertChainFile), toPrivateKey(keyFile, keyPassword),
                                             keyPassword, keyManagerFactory, ciphers, cipherFilter,
                                             apn, null, sessionCacheSize, sessionTimeout, false,
-                                            KeyStore.getDefaultType());
+                                            null, KeyStore.getDefaultType());
         } catch (Exception e) {
             if (e instanceof SSLException) {
                 throw (SSLException) e;
@@ -818,7 +818,8 @@ public abstract class SslContext {
             X509Certificate[] trustCert, TrustManagerFactory trustManagerFactory,
             X509Certificate[] keyCertChain, PrivateKey key, String keyPassword, KeyManagerFactory keyManagerFactory,
             Iterable<String> ciphers, CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn, String[] protocols,
-            long sessionCacheSize, long sessionTimeout, boolean enableOcsp, String keyStoreType,
+            long sessionCacheSize, long sessionTimeout, boolean enableOcsp,
+            SecureRandom secureRandom, String keyStoreType,
             Map.Entry<SslContextOption<?>, Object>... options) throws SSLException {
         if (provider == null) {
             provider = defaultClientProvider();
@@ -831,7 +832,7 @@ public abstract class SslContext {
                 return new JdkSslClientContext(sslContextProvider,
                         trustCert, trustManagerFactory, keyCertChain, key, keyPassword,
                         keyManagerFactory, ciphers, cipherFilter, apn, protocols, sessionCacheSize,
-                        sessionTimeout, keyStoreType);
+                        sessionTimeout, secureRandom, keyStoreType);
             case OPENSSL:
                 verifyNullSslContextProvider(provider, sslContextProvider);
                 OpenSsl.ensureAvailability();

--- a/handler/src/main/java/io/netty/handler/ssl/SslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContext.java
@@ -58,6 +58,7 @@ import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
+import java.security.SecureRandom;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
@@ -441,7 +442,7 @@ public abstract class SslContext {
                                             toPrivateKey(keyFile, keyPassword),
                                             keyPassword, keyManagerFactory, ciphers, cipherFilter, apn,
                                             sessionCacheSize, sessionTimeout, ClientAuth.NONE, null,
-                                            false, false, keyStore);
+                                            false, false, null, keyStore);
         } catch (Exception e) {
             if (e instanceof SSLException) {
                 throw (SSLException) e;
@@ -457,7 +458,8 @@ public abstract class SslContext {
             X509Certificate[] keyCertChain, PrivateKey key, String keyPassword, KeyManagerFactory keyManagerFactory,
             Iterable<String> ciphers, CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn,
             long sessionCacheSize, long sessionTimeout, ClientAuth clientAuth, String[] protocols, boolean startTls,
-            boolean enableOcsp, String keyStoreType, Map.Entry<SslContextOption<?>, Object>... ctxOptions)
+            boolean enableOcsp, SecureRandom secureRandom, String keyStoreType,
+            Map.Entry<SslContextOption<?>, Object>... ctxOptions)
             throws SSLException {
 
         if (provider == null) {
@@ -472,7 +474,7 @@ public abstract class SslContext {
             return new JdkSslServerContext(sslContextProvider,
                     trustCertCollection, trustManagerFactory, keyCertChain, key, keyPassword,
                     keyManagerFactory, ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout,
-                    clientAuth, protocols, startTls, keyStoreType);
+                    clientAuth, protocols, startTls, secureRandom, keyStoreType);
         case OPENSSL:
             verifyNullSslContextProvider(provider, sslContextProvider);
             return new OpenSslServerContext(

--- a/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
@@ -601,6 +601,7 @@ public final class SslContextBuilder {
         this.enableOcsp = enableOcsp;
         return this;
     }
+
     /**
      * Specify a non-default source of randomness for the {@link JdkSslContext}
      * <p>

--- a/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
@@ -601,9 +601,15 @@ public final class SslContextBuilder {
         this.enableOcsp = enableOcsp;
         return this;
     }
-
     /**
-     * @param secureRandom the source of randomness for SslContext
+     * Specify a non-default source of randomness for the {@link javax.net.ssl.SSLContext}.
+     * <p>
+     * In general, the best practice is to leave this unspecified, or to assign a new random source using the
+     * default {@code new SecureRandom()} constructor.
+     * Only assign this something when you have a good reason to.
+     *
+     * @param secureRandom the source of randomness for {@link javax.net.ssl.SSLContext}
+     *
      */
     public SslContextBuilder secureRandom(SecureRandom secureRandom) {
         this.secureRandom = secureRandom;

--- a/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
@@ -602,13 +602,13 @@ public final class SslContextBuilder {
         return this;
     }
     /**
-     * Specify a non-default source of randomness for the {@link javax.net.ssl.SSLContext}.
+     * Specify a non-default source of randomness for the {@link JdkSslContext}
      * <p>
      * In general, the best practice is to leave this unspecified, or to assign a new random source using the
      * default {@code new SecureRandom()} constructor.
      * Only assign this something when you have a good reason to.
      *
-     * @param secureRandom the source of randomness for {@link javax.net.ssl.SSLContext}
+     * @param secureRandom the source of randomness for {@link JdkSslContext}
      *
      */
     public SslContextBuilder secureRandom(SecureRandom secureRandom) {
@@ -630,7 +630,8 @@ public final class SslContextBuilder {
         } else {
             return SslContext.newClientContextInternal(provider, sslContextProvider, trustCertCollection,
                 trustManagerFactory, keyCertChain, key, keyPassword, keyManagerFactory,
-                ciphers, cipherFilter, apn, protocols, sessionCacheSize, sessionTimeout, enableOcsp, keyStoreType,
+                ciphers, cipherFilter, apn, protocols, sessionCacheSize,
+                    sessionTimeout, enableOcsp, secureRandom, keyStoreType,
                     toArray(options.entrySet(), EMPTY_ENTRIES));
         }
     }

--- a/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
@@ -31,6 +31,7 @@ import java.io.InputStream;
 import java.security.KeyStore;
 import java.security.PrivateKey;
 import java.security.Provider;
+import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -206,6 +207,7 @@ public final class SslContextBuilder {
     private String[] protocols;
     private boolean startTls;
     private boolean enableOcsp;
+    private SecureRandom secureRandom;
     private String keyStoreType = KeyStore.getDefaultType();
     private final Map<SslContextOption<?>, Object> options = new HashMap<SslContextOption<?>, Object>();
 
@@ -601,6 +603,14 @@ public final class SslContextBuilder {
     }
 
     /**
+     * @param secureRandom the source of randomness for SslContext
+     */
+    public SslContextBuilder secureRandom(SecureRandom secureRandom) {
+        this.secureRandom = secureRandom;
+        return this;
+    }
+
+    /**
      * Create new {@code SslContext} instance with configured settings.
      * <p>If {@link #sslProvider(SslProvider)} is set to {@link SslProvider#OPENSSL_REFCNT} then the caller is
      * responsible for releasing this object, or else native memory may leak.
@@ -610,7 +620,7 @@ public final class SslContextBuilder {
             return SslContext.newServerContextInternal(provider, sslContextProvider, trustCertCollection,
                 trustManagerFactory, keyCertChain, key, keyPassword, keyManagerFactory,
                 ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout, clientAuth, protocols, startTls,
-                enableOcsp, keyStoreType, toArray(options.entrySet(), EMPTY_ENTRIES));
+                enableOcsp, secureRandom, keyStoreType, toArray(options.entrySet(), EMPTY_ENTRIES));
         } else {
             return SslContext.newClientContextInternal(provider, sslContextProvider, trustCertCollection,
                 trustManagerFactory, keyCertChain, key, keyPassword, keyManagerFactory,

--- a/handler/src/test/java/io/netty/handler/ssl/SslContextBuilderTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslContextBuilderTest.java
@@ -450,7 +450,7 @@ public class SslContextBuilderTest {
         server_engine.closeOutbound();
     }
 
-    static class SpySecureRandom extends SecureRandom {
+    private static final class SpySecureRandom extends SecureRandom {
         private int count;
 
         @Override
@@ -490,7 +490,7 @@ public class SslContextBuilderTest {
         }
 
         @Override
-        public synchronized double nextGaussian() {
+        public double nextGaussian() {
             count++;
             return super.nextGaussian();
         }

--- a/handler/src/test/java/io/netty/handler/ssl/SslContextBuilderTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslContextBuilderTest.java
@@ -20,7 +20,6 @@ import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
-import org.mockito.Mockito;
 
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLEngine;


### PR DESCRIPTION
Motivation:

Enhance security by supporting specific secure randomness source in SSLContext initialization

Modification:

Support building SecureRandom in `SslContextBuilder`.
Allow passing SecureRandom as a parameter when creating an instance of `JdkSslServerContext` through its constructor.

Result:

Enhance security

Fixes #14026 
