### PR TITLE
Remove @UnstableApi usage

### DIFF
--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/AbstractDnsMessage.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/AbstractDnsMessage.java
@@ -22,7 +22,6 @@ import io.netty.util.ResourceLeakDetector;
 import io.netty.util.ResourceLeakDetectorFactory;
 import io.netty.util.ResourceLeakTracker;
 import io.netty.util.internal.StringUtil;
-import io.netty.util.internal.UnstableApi;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,7 +31,6 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
 /**
  * A skeletal implementation of {@link DnsMessage}.
  */
-@UnstableApi
 public abstract class AbstractDnsMessage extends AbstractReferenceCounted implements DnsMessage {
 
     private static final ResourceLeakDetector<DnsMessage> leakDetector =

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/AbstractDnsOptPseudoRrRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/AbstractDnsOptPseudoRrRecord.java
@@ -16,7 +16,6 @@
 package io.netty.handler.codec.dns;
 
 import io.netty.util.internal.StringUtil;
-import io.netty.util.internal.UnstableApi;
 
 /**
  * An <a href="https://tools.ietf.org/html/rfc6891#section-6.1">OPT RR</a> record.
@@ -24,7 +23,6 @@ import io.netty.util.internal.UnstableApi;
  * This is used for <a href="https://tools.ietf.org/html/rfc6891#section-6.1.3">
  *     Extension Mechanisms for DNS (EDNS(0))</a>.
  */
-@UnstableApi
 public abstract class AbstractDnsOptPseudoRrRecord extends AbstractDnsRecord implements DnsOptPseudoRecord {
 
     protected AbstractDnsOptPseudoRrRecord(int maxPayloadSize, int extendedRcode, int version) {

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/AbstractDnsRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/AbstractDnsRecord.java
@@ -17,7 +17,6 @@ package io.netty.handler.codec.dns;
 
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
-import io.netty.util.internal.UnstableApi;
 
 import java.net.IDN;
 
@@ -27,7 +26,6 @@ import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 /**
  * A skeletal implementation of {@link DnsRecord}.
  */
-@UnstableApi
 public abstract class AbstractDnsRecord implements DnsRecord {
 
     private final String name;

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsQuery.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsQuery.java
@@ -16,7 +16,6 @@
 package io.netty.handler.codec.dns;
 
 import io.netty.channel.AddressedEnvelope;
-import io.netty.util.internal.UnstableApi;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -24,7 +23,6 @@ import java.net.SocketAddress;
 /**
  * A {@link DnsQuery} implementation for UDP/IP.
  */
-@UnstableApi
 public class DatagramDnsQuery extends DefaultDnsQuery
         implements AddressedEnvelope<DatagramDnsQuery, InetSocketAddress> {
 

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsQueryDecoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsQueryDecoder.java
@@ -19,7 +19,6 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.handler.codec.MessageToMessageDecoder;
-import io.netty.util.internal.UnstableApi;
 
 import java.util.List;
 
@@ -28,7 +27,6 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
 /**
  * Decodes a {@link DatagramPacket} into a {@link DatagramDnsQuery}.
  */
-@UnstableApi
 @ChannelHandler.Sharable
 public class DatagramDnsQueryDecoder extends MessageToMessageDecoder<DatagramPacket> {
 

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsQueryEncoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsQueryEncoder.java
@@ -21,7 +21,6 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.handler.codec.MessageToMessageEncoder;
-import io.netty.util.internal.UnstableApi;
 
 import java.net.InetSocketAddress;
 import java.util.List;
@@ -30,7 +29,6 @@ import java.util.List;
  * Encodes a {@link DatagramDnsQuery} (or an {@link AddressedEnvelope} of {@link DnsQuery}} into a
  * {@link DatagramPacket}.
  */
-@UnstableApi
 @ChannelHandler.Sharable
 public class DatagramDnsQueryEncoder extends MessageToMessageEncoder<AddressedEnvelope<DnsQuery, InetSocketAddress>> {
 

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsResponse.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsResponse.java
@@ -16,7 +16,6 @@
 package io.netty.handler.codec.dns;
 
 import io.netty.channel.AddressedEnvelope;
-import io.netty.util.internal.UnstableApi;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -24,7 +23,6 @@ import java.net.SocketAddress;
 /**
  * A {@link DnsResponse} implementation for UDP/IP.
  */
-@UnstableApi
 public class DatagramDnsResponse extends DefaultDnsResponse
         implements AddressedEnvelope<DatagramDnsResponse, InetSocketAddress> {
 

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsResponseDecoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsResponseDecoder.java
@@ -20,7 +20,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.handler.codec.CorruptedFrameException;
 import io.netty.handler.codec.MessageToMessageDecoder;
-import io.netty.util.internal.UnstableApi;
 
 import java.net.InetSocketAddress;
 import java.util.List;
@@ -28,7 +27,6 @@ import java.util.List;
 /**
  * Decodes a {@link DatagramPacket} into a {@link DatagramDnsResponse}.
  */
-@UnstableApi
 @ChannelHandler.Sharable
 public class DatagramDnsResponseDecoder extends MessageToMessageDecoder<DatagramPacket> {
 

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsResponseEncoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsResponseEncoder.java
@@ -21,7 +21,6 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.handler.codec.MessageToMessageEncoder;
-import io.netty.util.internal.UnstableApi;
 
 import java.net.InetSocketAddress;
 import java.util.List;
@@ -32,7 +31,6 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
  * Encodes a {@link DatagramDnsResponse} (or an {@link AddressedEnvelope} of {@link DnsResponse}} into a
  * {@link DatagramPacket}.
  */
-@UnstableApi
 @ChannelHandler.Sharable
 public class DatagramDnsResponseEncoder
     extends MessageToMessageEncoder<AddressedEnvelope<DnsResponse, InetSocketAddress>> {

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsOptEcsRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsOptEcsRecord.java
@@ -18,7 +18,6 @@ package io.netty.handler.codec.dns;
 import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.channel.socket.SocketProtocolFamily;
 import io.netty.util.NetUtil;
-import io.netty.util.internal.UnstableApi;
 
 import java.net.InetAddress;
 import java.util.Arrays;
@@ -26,7 +25,6 @@ import java.util.Arrays;
 /**
  * Default {@link DnsOptEcsRecord} implementation.
  */
-@UnstableApi
 public final class DefaultDnsOptEcsRecord extends AbstractDnsOptPseudoRrRecord implements DnsOptEcsRecord {
     private final int srcPrefixLength;
     private final byte[] address;

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsPtrRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsPtrRecord.java
@@ -18,9 +18,7 @@ package io.netty.handler.codec.dns;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 import io.netty.util.internal.StringUtil;
-import io.netty.util.internal.UnstableApi;
 
-@UnstableApi
 public class DefaultDnsPtrRecord extends AbstractDnsRecord implements DnsPtrRecord {
 
     private final String hostname;

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsQuery.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsQuery.java
@@ -15,12 +15,9 @@
  */
 package io.netty.handler.codec.dns;
 
-import io.netty.util.internal.UnstableApi;
-
 /**
  * The default {@link DnsQuery} implementation.
  */
-@UnstableApi
 public class DefaultDnsQuery extends AbstractDnsMessage implements DnsQuery {
 
     /**

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsQuestion.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsQuestion.java
@@ -16,12 +16,10 @@
 package io.netty.handler.codec.dns;
 
 import io.netty.util.internal.StringUtil;
-import io.netty.util.internal.UnstableApi;
 
 /**
  * The default {@link DnsQuestion} implementation.
  */
-@UnstableApi
 public class DefaultDnsQuestion extends AbstractDnsRecord implements DnsQuestion {
 
     /**

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsRawRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsRawRecord.java
@@ -17,14 +17,12 @@ package io.netty.handler.codec.dns;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.util.internal.StringUtil;
-import io.netty.util.internal.UnstableApi;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
  * The default {@code DnsRawRecord} implementation.
  */
-@UnstableApi
 public class DefaultDnsRawRecord extends AbstractDnsRecord implements DnsRawRecord {
 
     private final ByteBuf content;

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsRecordDecoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsRecordDecoder.java
@@ -16,14 +16,12 @@
 package io.netty.handler.codec.dns;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.util.internal.UnstableApi;
 
 /**
  * The default {@link DnsRecordDecoder} implementation.
  *
  * @see DefaultDnsRecordEncoder
  */
-@UnstableApi
 public class DefaultDnsRecordDecoder implements DnsRecordDecoder {
 
     static final String ROOT = ".";

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsRecordEncoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsRecordEncoder.java
@@ -17,14 +17,12 @@ package io.netty.handler.codec.dns;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.UnsupportedMessageTypeException;
-import io.netty.util.internal.UnstableApi;
 
 /**
  * The default {@link DnsRecordEncoder} implementation.
  *
  * @see DefaultDnsRecordDecoder
  */
-@UnstableApi
 public class DefaultDnsRecordEncoder implements DnsRecordEncoder {
     private static final int PREFIX_MASK = Byte.SIZE - 1;
 

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsResponse.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsResponse.java
@@ -15,14 +15,11 @@
  */
 package io.netty.handler.codec.dns;
 
-import io.netty.util.internal.UnstableApi;
-
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
  * The default {@link DnsResponse} implementation.
  */
-@UnstableApi
 public class DefaultDnsResponse extends AbstractDnsMessage implements DnsResponse {
 
     private boolean authoritativeAnswer;

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsMessage.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsMessage.java
@@ -16,12 +16,10 @@
 package io.netty.handler.codec.dns;
 
 import io.netty.util.ReferenceCounted;
-import io.netty.util.internal.UnstableApi;
 
 /**
  * The superclass which contains core information concerning a {@link DnsQuery} and a {@link DnsResponse}.
  */
-@UnstableApi
 public interface DnsMessage extends ReferenceCounted {
 
     /**

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsOpCode.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsOpCode.java
@@ -15,14 +15,11 @@
  */
 package io.netty.handler.codec.dns;
 
-import io.netty.util.internal.UnstableApi;
-
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
  * The DNS {@code OpCode} as defined in <a href="https://tools.ietf.org/html/rfc2929">RFC2929</a>.
  */
-@UnstableApi
 public class DnsOpCode implements Comparable<DnsOpCode> {
 
     /**

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsOptEcsRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsOptEcsRecord.java
@@ -15,14 +15,11 @@
  */
 package io.netty.handler.codec.dns;
 
-import io.netty.util.internal.UnstableApi;
-
 import java.net.InetAddress;
 
 /**
  * An ECS record as defined in <a href="https://tools.ietf.org/html/rfc7871#section-6">Client Subnet in DNS Queries</a>.
  */
-@UnstableApi
 public interface DnsOptEcsRecord extends DnsOptPseudoRecord {
 
     /**

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsOptPseudoRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsOptPseudoRecord.java
@@ -15,15 +15,12 @@
  */
 package io.netty.handler.codec.dns;
 
-import io.netty.util.internal.UnstableApi;
-
 /**
  * An <a href="https://tools.ietf.org/html/rfc6891#section-6.1">OPT RR</a> record.
  * <p>
  * This is used for <a href="https://tools.ietf.org/html/rfc6891#section-6.1.3">Extension
  * Mechanisms for DNS (EDNS(0))</a>.
  */
-@UnstableApi
 public interface DnsOptPseudoRecord extends DnsRecord {
 
     /**

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsPtrRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsPtrRecord.java
@@ -15,9 +15,6 @@
  */
 package io.netty.handler.codec.dns;
 
-import io.netty.util.internal.UnstableApi;
-
-@UnstableApi
 public interface DnsPtrRecord extends DnsRecord {
 
     /**

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsQuery.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsQuery.java
@@ -15,12 +15,9 @@
  */
 package io.netty.handler.codec.dns;
 
-import io.netty.util.internal.UnstableApi;
-
 /**
  * A DNS query message.
  */
-@UnstableApi
 public interface DnsQuery extends DnsMessage {
     @Override
     DnsQuery setId(int id);

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsQuestion.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsQuestion.java
@@ -15,12 +15,9 @@
  */
 package io.netty.handler.codec.dns;
 
-import io.netty.util.internal.UnstableApi;
-
 /**
  * A DNS question.
  */
-@UnstableApi
 public interface DnsQuestion extends DnsRecord {
     /**
      * An unused property. This method will always return {@code 0}.

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsRawRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsRawRecord.java
@@ -17,12 +17,10 @@ package io.netty.handler.codec.dns;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
-import io.netty.util.internal.UnstableApi;
 
 /**
  * A generic {@link DnsRecord} that contains an undecoded {@code RDATA}.
  */
-@UnstableApi
 public interface DnsRawRecord extends DnsRecord, ByteBufHolder {
     @Override
     DnsRawRecord copy();

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsRecord.java
@@ -15,12 +15,9 @@
  */
 package io.netty.handler.codec.dns;
 
-import io.netty.util.internal.UnstableApi;
-
 /**
  * A DNS resource record.
  */
-@UnstableApi
 public interface DnsRecord {
 
     /**

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsRecordDecoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsRecordDecoder.java
@@ -16,14 +16,12 @@
 package io.netty.handler.codec.dns;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.util.internal.UnstableApi;
 
 /**
  * Decodes a DNS record into its object representation.
  *
  * @see DatagramDnsResponseDecoder
  */
-@UnstableApi
 public interface DnsRecordDecoder {
 
     DnsRecordDecoder DEFAULT = new DefaultDnsRecordDecoder();

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsRecordEncoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsRecordEncoder.java
@@ -16,14 +16,12 @@
 package io.netty.handler.codec.dns;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.util.internal.UnstableApi;
 
 /**
  * Encodes a {@link DnsRecord} into binary representation.
  *
  * @see DatagramDnsQueryEncoder
  */
-@UnstableApi
 public interface DnsRecordEncoder {
 
     DnsRecordEncoder DEFAULT = new DefaultDnsRecordEncoder();

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsRecordType.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsRecordType.java
@@ -16,7 +16,6 @@
 package io.netty.handler.codec.dns;
 
 import io.netty.util.collection.IntObjectHashMap;
-import io.netty.util.internal.UnstableApi;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -24,7 +23,6 @@ import java.util.Map;
 /**
  * Represents a DNS record type.
  */
-@UnstableApi
 public class DnsRecordType implements Comparable<DnsRecordType> {
 
     /**

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsResponse.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsResponse.java
@@ -15,12 +15,9 @@
  */
 package io.netty.handler.codec.dns;
 
-import io.netty.util.internal.UnstableApi;
-
 /**
  * A DNS response message.
  */
-@UnstableApi
 public interface DnsResponse extends DnsMessage {
 
     /**

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsResponseCode.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsResponseCode.java
@@ -15,14 +15,11 @@
  */
 package io.netty.handler.codec.dns;
 
-import io.netty.util.internal.UnstableApi;
-
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
  * The DNS {@code RCODE}, as defined in <a href="https://tools.ietf.org/html/rfc2929">RFC2929</a>.
  */
-@UnstableApi
 public class DnsResponseCode implements Comparable<DnsResponseCode> {
 
     /**

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsSection.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsSection.java
@@ -15,12 +15,9 @@
  */
 package io.netty.handler.codec.dns;
 
-import io.netty.util.internal.UnstableApi;
-
 /**
  * Represents a section of a {@link DnsMessage}.
  */
-@UnstableApi
 public enum DnsSection {
     /**
      * The section that contains {@link DnsQuestion}s.

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/TcpDnsQueryDecoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/TcpDnsQueryDecoder.java
@@ -19,9 +19,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty.util.internal.ObjectUtil;
-import io.netty.util.internal.UnstableApi;
 
-@UnstableApi
 public final class TcpDnsQueryDecoder extends LengthFieldBasedFrameDecoder {
     private final DnsRecordDecoder decoder;
 

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/TcpDnsQueryEncoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/TcpDnsQueryEncoder.java
@@ -19,10 +19,8 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToByteEncoder;
-import io.netty.util.internal.UnstableApi;
 
 @ChannelHandler.Sharable
-@UnstableApi
 public final class TcpDnsQueryEncoder extends MessageToByteEncoder<DnsQuery> {
 
     private final DnsQueryEncoder encoder;

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/TcpDnsResponseDecoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/TcpDnsResponseDecoder.java
@@ -18,11 +18,9 @@ package io.netty.handler.codec.dns;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
-import io.netty.util.internal.UnstableApi;
 
 import java.net.SocketAddress;
 
-@UnstableApi
 public final class TcpDnsResponseDecoder extends LengthFieldBasedFrameDecoder {
 
     private final DnsResponseDecoder<SocketAddress> responseDecoder;

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/TcpDnsResponseEncoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/TcpDnsResponseEncoder.java
@@ -20,11 +20,9 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToMessageEncoder;
 import io.netty.util.internal.ObjectUtil;
-import io.netty.util.internal.UnstableApi;
 
 import java.util.List;
 
-@UnstableApi
 @ChannelHandler.Sharable
 public final class TcpDnsResponseEncoder extends MessageToMessageEncoder<DnsResponse> {
     private final DnsRecordEncoder encoder;

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/package-info.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/package-info.java
@@ -17,7 +17,4 @@
 /**
  * DNS codec.
  */
-@UnstableApi
 package io.netty.handler.codec.dns;
-
-import io.netty.util.internal.UnstableApi;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderValidationUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderValidationUtil.java
@@ -16,14 +16,12 @@
 package io.netty.handler.codec.http;
 
 import io.netty.util.AsciiString;
-import io.netty.util.internal.UnstableApi;
 
 import static io.netty.util.AsciiString.contentEqualsIgnoreCase;
 
 /**
  * Functions used to perform various validations of HTTP header names and values.
  */
-@UnstableApi
 public final class HttpHeaderValidationUtil {
     private HttpHeaderValidationUtil() {
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
@@ -28,7 +28,6 @@ import io.netty.util.AsciiString;
 import io.netty.util.CharsetUtil;
 import io.netty.util.NetUtil;
 import io.netty.util.internal.ObjectUtil;
-import io.netty.util.internal.UnstableApi;
 
 import static io.netty.util.internal.StringUtil.COMMA;
 import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
@@ -564,7 +563,6 @@ public final class HttpUtil {
      * @return the normalized content length from the headers or {@code -1} if the fields were empty.
      * @throws IllegalArgumentException if the content-length fields are not valid
      */
-    @UnstableApi
     public static long normalizeAndGetContentLength(
             List<? extends CharSequence> contentLengthFields, boolean isHttp10OrEarlier,
             boolean allowDuplicateContentLengths) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtensionHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtensionHandler.java
@@ -32,7 +32,6 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.LastHttpContent;
-import io.netty.util.internal.UnstableApi;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -119,7 +118,6 @@ public class WebSocketServerExtensionHandler extends ChannelDuplexHandler {
      * <strong>IMPORTANT:</strong>
      * It already call {@code super.channelRead(ctx, request)} before returning.
      */
-    @UnstableApi
     protected void onHttpRequestChannelRead(ChannelHandlerContext ctx, HttpRequest request) throws Exception {
         List<WebSocketServerExtension> validExtensionsList = null;
 
@@ -201,7 +199,6 @@ public class WebSocketServerExtensionHandler extends ChannelDuplexHandler {
      * <strong>IMPORTANT:</strong>
      * It already call {@code super.write(ctx, response, promise)} before returning.
      */
-    @UnstableApi
     protected void onHttpResponseWrite(ChannelHandlerContext ctx, HttpResponse response, ChannelPromise promise)
             throws Exception {
         List<WebSocketServerExtension> validExtensionsList = validExtensions.poll();

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2ConnectionHandlerBuilder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2ConnectionHandlerBuilder.java
@@ -18,7 +18,6 @@ package io.netty.handler.codec.http2;
 
 import io.netty.channel.Channel;
 import io.netty.handler.codec.http2.Http2HeadersEncoder.SensitivityDetector;
-import io.netty.util.internal.UnstableApi;
 
 import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_HEADER_LIST_SIZE;
 import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_MAX_RESERVED_STREAMS;
@@ -71,7 +70,6 @@ import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
  * @param <T> The type of handler created by this builder.
  * @param <B> The concrete type of this builder.
  */
-@UnstableApi
 public abstract class AbstractHttp2ConnectionHandlerBuilder<T extends Http2ConnectionHandler,
                                                             B extends AbstractHttp2ConnectionHandlerBuilder<T, B>> {
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamFrame.java
@@ -15,12 +15,9 @@
  */
 package io.netty.handler.codec.http2;
 
-import io.netty.util.internal.UnstableApi;
-
 /**
  * Abstract implementation of {@link Http2StreamFrame}.
  */
-@UnstableApi
 public abstract class AbstractHttp2StreamFrame implements Http2StreamFrame {
 
     private Http2FrameStream stream;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractInboundHttp2ToHttpAdapterBuilder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractInboundHttp2ToHttpAdapterBuilder.java
@@ -15,14 +15,12 @@
 package io.netty.handler.codec.http2;
 
 import io.netty.handler.codec.TooLongFrameException;
-import io.netty.util.internal.UnstableApi;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
  * A skeletal builder implementation of {@link InboundHttp2ToHttpAdapter} and its subtypes.
  */
-@UnstableApi
 public abstract class AbstractInboundHttp2ToHttpAdapterBuilder<
         T extends InboundHttp2ToHttpAdapter, B extends AbstractInboundHttp2ToHttpAdapterBuilder<T, B>> {
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/CharSequenceMap.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/CharSequenceMap.java
@@ -18,7 +18,6 @@ package io.netty.handler.codec.http2;
 import io.netty.handler.codec.DefaultHeaders;
 import io.netty.handler.codec.UnsupportedValueConverter;
 import io.netty.handler.codec.ValueConverter;
-import io.netty.util.internal.UnstableApi;
 
 import static io.netty.util.AsciiString.CASE_INSENSITIVE_HASHER;
 import static io.netty.util.AsciiString.CASE_SENSITIVE_HASHER;
@@ -26,7 +25,6 @@ import static io.netty.util.AsciiString.CASE_SENSITIVE_HASHER;
 /**
  * Internal use only!
  */
-@UnstableApi
 public final class CharSequenceMap<V> extends DefaultHeaders<CharSequence, V, CharSequenceMap<V>> {
     public CharSequenceMap() {
         this(true);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/CleartextHttp2ServerUpgradeHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/CleartextHttp2ServerUpgradeHandler.java
@@ -22,7 +22,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.codec.http.HttpServerUpgradeHandler;
-import io.netty.util.internal.UnstableApi;
 
 import java.util.List;
 
@@ -37,7 +36,6 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
  * And will update pipeline once it detect the connection is starting HTTP/2 by
  * prior knowledge or not.
  */
-@UnstableApi
 public final class CleartextHttp2ServerUpgradeHandler extends ByteToMessageDecoder {
     private static final ByteBuf CONNECTION_PREFACE = unreleasableBuffer(connectionPrefaceBuf()).asReadOnly();
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/CompressorHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/CompressorHttp2ConnectionEncoder.java
@@ -37,7 +37,6 @@ import io.netty.handler.codec.compression.SnappyFrameEncoder;
 import io.netty.handler.codec.compression.SnappyOptions;
 import io.netty.util.concurrent.PromiseCombiner;
 import io.netty.util.internal.ObjectUtil;
-import io.netty.util.internal.UnstableApi;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -57,7 +56,6 @@ import static io.netty.handler.codec.http.HttpHeaderValues.SNAPPY;
  * A decorating HTTP2 encoder that will compress data frames according to the {@code content-encoding} header for each
  * stream. The compression provided by this class will be applied to the data for the entire stream.
  */
-@UnstableApi
 public class CompressorHttp2ConnectionEncoder extends DecoratingHttp2ConnectionEncoder {
     // We cannot remove this because it'll be breaking change
     public static final int DEFAULT_COMPRESSION_LEVEL = 6;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DecoratingHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DecoratingHttp2ConnectionDecoder.java
@@ -18,14 +18,12 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.util.internal.UnstableApi;
 
 import java.util.List;
 
 /**
  * Decorator around another {@link Http2ConnectionDecoder} instance.
  */
-@UnstableApi
 public class DecoratingHttp2ConnectionDecoder implements Http2ConnectionDecoder {
     private final Http2ConnectionDecoder delegate;
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DecoratingHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DecoratingHttp2ConnectionEncoder.java
@@ -14,14 +14,11 @@
  */
 package io.netty.handler.codec.http2;
 
-import io.netty.util.internal.UnstableApi;
-
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
  * A decorator around another {@link Http2ConnectionEncoder} instance.
  */
-@UnstableApi
 public class DecoratingHttp2ConnectionEncoder extends DecoratingHttp2FrameWriter implements Http2ConnectionEncoder,
         Http2SettingsReceivedConsumer {
     private final Http2ConnectionEncoder delegate;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DecoratingHttp2FrameWriter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DecoratingHttp2FrameWriter.java
@@ -18,14 +18,12 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
-import io.netty.util.internal.UnstableApi;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
  * Decorator around another {@link Http2FrameWriter} instance.
  */
-@UnstableApi
 public class DecoratingHttp2FrameWriter implements Http2FrameWriter {
     private final Http2FrameWriter delegate;
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
@@ -26,7 +26,6 @@ import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.concurrent.PromiseNotifier;
 import io.netty.util.internal.EmptyArrays;
-import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -61,7 +60,6 @@ import static java.lang.Integer.MAX_VALUE;
 /**
  * Simple implementation of {@link Http2Connection}.
  */
-@UnstableApi
 public class DefaultHttp2Connection implements Http2Connection {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(DefaultHttp2Connection.class);
     // Fields accessed by inner classes

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -20,7 +20,6 @@ import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpStatusClass;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http2.Http2Connection.Endpoint;
-import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -51,7 +50,6 @@ import static java.lang.Math.min;
  * This interface enforces inbound flow control functionality through
  * {@link Http2LocalFlowController}
  */
-@UnstableApi
 public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(DefaultHttp2ConnectionDecoder.class);
     private Http2FrameListener internalFrameListener = new PrefaceFrameListener();

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
@@ -22,7 +22,6 @@ import io.netty.channel.ChannelPromise;
 import io.netty.channel.CoalescingBufferQueue;
 import io.netty.handler.codec.http.HttpStatusClass;
 import io.netty.handler.codec.http2.Http2CodecUtil.SimpleChannelPromiseAggregator;
-import io.netty.util.internal.UnstableApi;
 
 import java.util.ArrayDeque;
 import java.util.Queue;
@@ -39,7 +38,6 @@ import static java.lang.Math.min;
 /**
  * Default implementation of {@link Http2ConnectionEncoder}.
  */
-@UnstableApi
 public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder, Http2SettingsReceivedConsumer {
     private final Http2FrameWriter frameWriter;
     private final Http2Connection connection;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2DataFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2DataFrame.java
@@ -19,7 +19,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.util.internal.StringUtil;
-import io.netty.util.internal.UnstableApi;
 
 import static io.netty.handler.codec.http2.Http2CodecUtil.verifyPadding;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
@@ -27,7 +26,6 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
 /**
  * The default {@link Http2DataFrame} implementation.
  */
-@UnstableApi
 public final class DefaultHttp2DataFrame extends AbstractHttp2StreamFrame implements Http2DataFrame {
     private final ByteBuf content;
     private final boolean endStream;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameReader.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameReader.java
@@ -19,7 +19,6 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http2.Http2FrameReader.Configuration;
 import io.netty.util.internal.PlatformDependent;
-import io.netty.util.internal.UnstableApi;
 
 import static io.netty.handler.codec.http2.Http2CodecUtil.CONNECTION_STREAM_ID;
 import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_MAX_FRAME_SIZE;
@@ -51,7 +50,6 @@ import static io.netty.handler.codec.http2.Http2FrameTypes.WINDOW_UPDATE;
 /**
  * A {@link Http2FrameReader} that supports all frame types defined by the HTTP/2 specification.
  */
-@UnstableApi
 public class DefaultHttp2FrameReader implements Http2FrameReader, Http2FrameSizePolicy, Configuration {
     private final Http2HeadersDecoder headersDecoder;
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriter.java
@@ -25,7 +25,6 @@ import io.netty.handler.codec.http2.Http2CodecUtil.SimpleChannelPromiseAggregato
 import io.netty.handler.codec.http2.Http2FrameWriter.Configuration;
 import io.netty.handler.codec.http2.Http2HeadersEncoder.SensitivityDetector;
 import io.netty.util.internal.PlatformDependent;
-import io.netty.util.internal.UnstableApi;
 
 import static io.netty.buffer.Unpooled.directBuffer;
 import static io.netty.buffer.Unpooled.unreleasableBuffer;
@@ -71,7 +70,6 @@ import static java.lang.Math.min;
 /**
  * A {@link Http2FrameWriter} that supports all frame types defined by the HTTP/2 specification.
  */
-@UnstableApi
 public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSizePolicy, Configuration {
     private static final String STREAM_ID = "Stream ID";
     private static final String STREAM_DEPENDENCY = "Stream Dependency";

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2GoAwayFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2GoAwayFrame.java
@@ -21,12 +21,10 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.DefaultByteBufHolder;
 import io.netty.buffer.Unpooled;
 import io.netty.util.internal.StringUtil;
-import io.netty.util.internal.UnstableApi;
 
 /**
  * The default {@link Http2GoAwayFrame} implementation.
  */
-@UnstableApi
 public final class DefaultHttp2GoAwayFrame extends DefaultByteBufHolder implements Http2GoAwayFrame {
 
     private final long errorCode;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
@@ -20,7 +20,6 @@ import io.netty.handler.codec.http.HttpHeaderValidationUtil;
 import io.netty.util.AsciiString;
 import io.netty.util.ByteProcessor;
 import io.netty.util.internal.PlatformDependent;
-import io.netty.util.internal.UnstableApi;
 
 import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
 import static io.netty.handler.codec.http2.Http2Exception.connectionError;
@@ -30,7 +29,6 @@ import static io.netty.util.AsciiString.CASE_INSENSITIVE_HASHER;
 import static io.netty.util.AsciiString.CASE_SENSITIVE_HASHER;
 import static io.netty.util.AsciiString.isUpperCase;
 
-@UnstableApi
 public class DefaultHttp2Headers
         extends DefaultHeaders<CharSequence, CharSequence, Http2Headers> implements Http2Headers {
     private static final ByteProcessor HTTP2_NAME_VALIDATOR_PROCESSOR = new ByteProcessor() {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoder.java
@@ -17,14 +17,12 @@ package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.util.internal.ObjectUtil;
-import io.netty.util.internal.UnstableApi;
 
 import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_HEADER_LIST_SIZE;
 import static io.netty.handler.codec.http2.Http2Error.COMPRESSION_ERROR;
 import static io.netty.handler.codec.http2.Http2Error.INTERNAL_ERROR;
 import static io.netty.handler.codec.http2.Http2Exception.connectionError;
 
-@UnstableApi
 public class DefaultHttp2HeadersDecoder implements Http2HeadersDecoder, Http2HeadersDecoder.Configuration {
     private static final float HEADERS_COUNT_WEIGHT_NEW = 1 / 5f;
     private static final float HEADERS_COUNT_WEIGHT_HISTORICAL = 1 - HEADERS_COUNT_WEIGHT_NEW;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersEncoder.java
@@ -19,13 +19,11 @@ import java.io.Closeable;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.util.internal.UnstableApi;
 
 import static io.netty.handler.codec.http2.Http2Error.COMPRESSION_ERROR;
 import static io.netty.handler.codec.http2.Http2Exception.connectionError;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
-@UnstableApi
 public class DefaultHttp2HeadersEncoder implements
     Http2HeadersEncoder, Http2HeadersEncoder.Configuration, Closeable {
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersFrame.java
@@ -16,7 +16,6 @@
 package io.netty.handler.codec.http2;
 
 import io.netty.util.internal.StringUtil;
-import io.netty.util.internal.UnstableApi;
 
 import static io.netty.handler.codec.http2.Http2CodecUtil.verifyPadding;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
@@ -24,7 +23,6 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
 /**
  * The default {@link Http2HeadersFrame} implementation.
  */
-@UnstableApi
 public final class DefaultHttp2HeadersFrame extends AbstractHttp2StreamFrame implements Http2HeadersFrame {
     private final Http2Headers headers;
     private final boolean endStream;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowController.java
@@ -32,7 +32,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http2.Http2Exception.CompositeStreamException;
 import io.netty.handler.codec.http2.Http2Exception.StreamException;
 import io.netty.util.internal.PlatformDependent;
-import io.netty.util.internal.UnstableApi;
 
 /**
  * Basic implementation of {@link Http2LocalFlowController}.
@@ -40,7 +39,6 @@ import io.netty.util.internal.UnstableApi;
  * This class is <strong>NOT</strong> thread safe. The assumption is all methods must be invoked from a single thread.
  * Typically this thread is the event loop thread for the {@link ChannelHandlerContext} managed by this class.
  */
-@UnstableApi
 public class DefaultHttp2LocalFlowController implements Http2LocalFlowController {
     /**
      * The default ratio of window size to initial window size below which a {@code WINDOW_UPDATE}

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2PingFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2PingFrame.java
@@ -17,12 +17,10 @@
 package io.netty.handler.codec.http2;
 
 import io.netty.util.internal.StringUtil;
-import io.netty.util.internal.UnstableApi;
 
 /**
  * The default {@link Http2PingFrame} implementation.
  */
-@UnstableApi
 public class DefaultHttp2PingFrame implements Http2PingFrame {
 
     private final long content;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2PriorityFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2PriorityFrame.java
@@ -15,12 +15,9 @@
  */
 package io.netty.handler.codec.http2;
 
-import io.netty.util.internal.UnstableApi;
-
 /**
  * Default implementation of {@linkplain Http2PriorityFrame}
  */
-@UnstableApi
 public final class DefaultHttp2PriorityFrame extends AbstractHttp2StreamFrame implements Http2PriorityFrame {
 
     private final int streamDependency;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2PushPromiseFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2PushPromiseFrame.java
@@ -15,12 +15,9 @@
  */
 package io.netty.handler.codec.http2;
 
-import io.netty.util.internal.UnstableApi;
-
 /**
  * Default implementation of {@link Http2PushPromiseFrame}
  */
-@UnstableApi
 public final class DefaultHttp2PushPromiseFrame implements Http2PushPromiseFrame {
 
     private Http2FrameStream pushStreamFrame;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
@@ -15,7 +15,6 @@
 package io.netty.handler.codec.http2;
 
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -41,7 +40,6 @@ import static java.lang.Math.min;
  * This class is <strong>NOT</strong> thread safe. The assumption is all methods must be invoked from a single thread.
  * Typically this thread is the event loop thread for the {@link ChannelHandlerContext} managed by this class.
  */
-@UnstableApi
 public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowController {
     private static final InternalLogger logger =
             InternalLoggerFactory.getInstance(DefaultHttp2RemoteFlowController.class);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ResetFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ResetFrame.java
@@ -16,14 +16,12 @@
 package io.netty.handler.codec.http2;
 
 import io.netty.util.internal.StringUtil;
-import io.netty.util.internal.UnstableApi;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
  * The default {@link Http2ResetFrame} implementation.
  */
-@UnstableApi
 public final class DefaultHttp2ResetFrame extends AbstractHttp2StreamFrame implements Http2ResetFrame {
 
     private final long errorCode;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2SettingsFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2SettingsFrame.java
@@ -18,12 +18,10 @@ package io.netty.handler.codec.http2;
 
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
-import io.netty.util.internal.UnstableApi;
 
 /**
  * The default {@link Http2SettingsFrame} implementation.
  */
-@UnstableApi
 public class DefaultHttp2SettingsFrame implements Http2SettingsFrame {
 
     private final Http2Settings settings;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2UnknownFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2UnknownFrame.java
@@ -19,9 +19,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.DefaultByteBufHolder;
 import io.netty.buffer.Unpooled;
 import io.netty.util.internal.StringUtil;
-import io.netty.util.internal.UnstableApi;
 
-@UnstableApi
 public final class DefaultHttp2UnknownFrame extends DefaultByteBufHolder implements Http2UnknownFrame {
     private final byte frameType;
     private final Http2Flags flags;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2WindowUpdateFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2WindowUpdateFrame.java
@@ -16,12 +16,10 @@
 package io.netty.handler.codec.http2;
 
 import io.netty.util.internal.StringUtil;
-import io.netty.util.internal.UnstableApi;
 
 /**
  * The default {@link Http2WindowUpdateFrame} implementation.
  */
-@UnstableApi
 public class DefaultHttp2WindowUpdateFrame extends AbstractHttp2StreamFrame implements Http2WindowUpdateFrame {
 
     private final int windowUpdateIncrement;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingDecompressorFrameListener.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingDecompressorFrameListener.java
@@ -19,7 +19,6 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.ByteToMessageDecoder;
-import io.netty.util.internal.UnstableApi;
 import io.netty.handler.codec.compression.Brotli;
 import io.netty.handler.codec.compression.BrotliDecoder;
 import io.netty.handler.codec.compression.Zstd;
@@ -47,7 +46,6 @@ import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
  * An HTTP2 frame listener that will decompress data frames according to the {@code content-encoding} header for each
  * stream. The decompression provided by this class will be applied to the data for the entire stream.
  */
-@UnstableApi
 public class DelegatingDecompressorFrameListener extends Http2FrameListenerDecorator {
 
     private final Http2Connection connection;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/EmptyHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/EmptyHttp2Headers.java
@@ -16,9 +16,7 @@
 package io.netty.handler.codec.http2;
 
 import io.netty.handler.codec.EmptyHeaders;
-import io.netty.util.internal.UnstableApi;
 
-@UnstableApi
 public final class EmptyHttp2Headers
         extends EmptyHeaders<CharSequence, CharSequence, Http2Headers> implements Http2Headers {
     public static final EmptyHttp2Headers INSTANCE = new EmptyHttp2Headers();

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ChannelDuplexHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ChannelDuplexHandler.java
@@ -20,7 +20,6 @@ import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
 import io.netty.util.internal.StringUtil;
-import io.netty.util.internal.UnstableApi;
 
 /**
  * A {@link ChannelDuplexHandler} providing additional functionality for HTTP/2. Specifically it allows to:
@@ -32,7 +31,6 @@ import io.netty.util.internal.UnstableApi;
  * <p>The {@link Http2FrameCodec} is required to be part of the {@link ChannelPipeline} before this handler is added,
  * or else an {@link IllegalStateException} will be thrown.
  */
-@UnstableApi
 public abstract class Http2ChannelDuplexHandler extends ChannelDuplexHandler {
 
     private volatile Http2FrameCodec frameCodec;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ClientUpgradeCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ClientUpgradeCodec.java
@@ -22,7 +22,6 @@ import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpClientUpgradeHandler;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.util.collection.CharObjectMap;
-import io.netty.util.internal.UnstableApi;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -39,7 +38,6 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
 /**
  * Client-side cleartext upgrade codec from HTTP to HTTP/2.
  */
-@UnstableApi
 public class Http2ClientUpgradeCodec implements HttpClientUpgradeHandler.UpgradeCodec {
 
     private static final List<CharSequence> UPGRADE_HEADERS = Collections.singletonList(HTTP_UPGRADE_SETTINGS_HEADER);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
@@ -25,7 +25,6 @@ import io.netty.channel.DefaultChannelPromise;
 import io.netty.handler.ssl.ApplicationProtocolNames;
 import io.netty.util.AsciiString;
 import io.netty.util.concurrent.EventExecutor;
-import io.netty.util.internal.UnstableApi;
 
 import static io.netty.buffer.Unpooled.directBuffer;
 import static io.netty.buffer.Unpooled.unreleasableBuffer;
@@ -41,7 +40,6 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 /**
  * Constants and utility method used for encoding/decoding HTTP2 frames.
  */
-@UnstableApi
 public final class Http2CodecUtil {
     public static final int CONNECTION_STREAM_ID = 0;
     public static final int HTTP_UPGRADE_STREAM_ID = 1;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
@@ -18,12 +18,10 @@ package io.netty.handler.codec.http2;
 import io.netty.buffer.ByteBuf;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
-import io.netty.util.internal.UnstableApi;
 
 /**
  * Manager for the state of an HTTP/2 connection with the remote end-point.
  */
-@UnstableApi
 public interface Http2Connection {
     /**
      * Listener for life-cycle events for streams in this connection.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionAdapter.java
@@ -15,12 +15,10 @@
 package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.util.internal.UnstableApi;
 
 /**
  * Provides empty implementations of all {@link Http2Connection.Listener} methods.
  */
-@UnstableApi
 public class Http2ConnectionAdapter implements Http2Connection.Listener {
     @Override
     public void onStreamAdded(Http2Stream stream) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionDecoder.java
@@ -16,7 +16,6 @@ package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.util.internal.UnstableApi;
 
 import java.io.Closeable;
 import java.util.List;
@@ -27,7 +26,6 @@ import java.util.List;
  * application-specific processing. Note that frames of an unknown type (i.e. HTTP/2 extensions)
  * will skip all protocol checks and be given directly to the listener for processing.
  */
-@UnstableApi
 public interface Http2ConnectionDecoder extends Closeable {
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionEncoder.java
@@ -18,13 +18,11 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
-import io.netty.util.internal.UnstableApi;
 
 
 /**
  * Handler for outbound HTTP/2 traffic.
  */
-@UnstableApi
 public interface Http2ConnectionEncoder extends Http2FrameWriter {
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -28,7 +28,6 @@ import io.netty.handler.codec.http2.Http2Exception.CompositeStreamException;
 import io.netty.handler.codec.http2.Http2Exception.StreamException;
 import io.netty.util.CharsetUtil;
 import io.netty.util.concurrent.Future;
-import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -62,7 +61,6 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
  * This interface enforces inbound flow control functionality through
  * {@link Http2LocalFlowController}
  */
-@UnstableApi
 public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http2LifecycleManager,
                                                                             ChannelOutboundHandler {
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandlerBuilder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandlerBuilder.java
@@ -17,12 +17,10 @@
 package io.netty.handler.codec.http2;
 
 import io.netty.handler.codec.http2.Http2HeadersEncoder.SensitivityDetector;
-import io.netty.util.internal.UnstableApi;
 
 /**
  * Builder which builds {@link Http2ConnectionHandler} objects.
  */
-@UnstableApi
 public final class Http2ConnectionHandlerBuilder
         extends AbstractHttp2ConnectionHandlerBuilder<Http2ConnectionHandler, Http2ConnectionHandlerBuilder> {
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionPrefaceAndSettingsFrameWrittenEvent.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionPrefaceAndSettingsFrameWrittenEvent.java
@@ -14,14 +14,11 @@
  */
 package io.netty.handler.codec.http2;
 
-import io.netty.util.internal.UnstableApi;
-
 /**
  * Signifies that the <a href="https://tools.ietf.org/html/rfc7540#section-3.5">connection preface</a> and
  * the initial SETTINGS frame have been sent. The client sends the preface, and the server receives the preface.
  * The client shouldn't write any data until this event has been processed.
  */
-@UnstableApi
 public final class Http2ConnectionPrefaceAndSettingsFrameWrittenEvent {
     static final Http2ConnectionPrefaceAndSettingsFrameWrittenEvent INSTANCE =
             new Http2ConnectionPrefaceAndSettingsFrameWrittenEvent();

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2DataFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2DataFrame.java
@@ -17,12 +17,10 @@ package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
-import io.netty.util.internal.UnstableApi;
 
 /**
  * HTTP/2 DATA frame.
  */
-@UnstableApi
 public interface Http2DataFrame extends Http2StreamFrame, ByteBufHolder {
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2DataWriter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2DataWriter.java
@@ -18,12 +18,10 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
-import io.netty.util.internal.UnstableApi;
 
 /**
  * Interface that defines an object capable of producing HTTP/2 data frames.
  */
-@UnstableApi
 public interface Http2DataWriter {
     /**
      * Writes a {@code DATA} frame to the remote endpoint. This will result in one or more

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Error.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Error.java
@@ -15,12 +15,9 @@
 
 package io.netty.handler.codec.http2;
 
-import io.netty.util.internal.UnstableApi;
-
 /**
  * All error codes identified by the HTTP/2 spec.
  */
-@UnstableApi
 public enum Http2Error {
     NO_ERROR(0x0),
     PROTOCOL_ERROR(0x1),

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2EventAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2EventAdapter.java
@@ -16,13 +16,11 @@ package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.util.internal.UnstableApi;
 
 /**
  * This class brings {@link Http2Connection.Listener} and {@link Http2FrameListener} together to provide
  * NOOP implementation so inheriting classes can selectively choose which methods to override.
  */
-@UnstableApi
 public class Http2EventAdapter implements Http2Connection.Listener, Http2FrameListener {
     @Override
     public int onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding, boolean endOfStream)

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Exception.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Exception.java
@@ -16,7 +16,6 @@
 package io.netty.handler.codec.http2;
 
 import io.netty.util.internal.ThrowableUtil;
-import io.netty.util.internal.UnstableApi;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -29,7 +28,6 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
 /**
  * Exception thrown when an HTTP/2 error was encountered.
  */
-@UnstableApi
 public class Http2Exception extends Exception {
     private static final long serialVersionUID = -6941186345430164209L;
     private final Http2Error error;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Flags.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Flags.java
@@ -15,12 +15,9 @@
 
 package io.netty.handler.codec.http2;
 
-import io.netty.util.internal.UnstableApi;
-
 /**
  * Provides utility methods for accessing specific flags as defined by the HTTP/2 spec.
  */
-@UnstableApi
 public final class Http2Flags {
     public static final short END_STREAM = 0x1;
     public static final short END_HEADERS = 0x4;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FlowController.java
@@ -15,12 +15,10 @@
 package io.netty.handler.codec.http2;
 
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.util.internal.UnstableApi;
 
 /**
  * Base interface for all HTTP/2 flow controllers.
  */
-@UnstableApi
 public interface Http2FlowController {
     /**
      * Set the {@link ChannelHandlerContext} for which to apply flow control on.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Frame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Frame.java
@@ -15,10 +15,7 @@
  */
 package io.netty.handler.codec.http2;
 
-import io.netty.util.internal.UnstableApi;
-
 /** An HTTP/2 frame. */
-@UnstableApi
 public interface Http2Frame {
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameAdapter.java
@@ -16,12 +16,10 @@ package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.util.internal.UnstableApi;
 
 /**
  * Convenience class that provides no-op implementations for all methods of {@link Http2FrameListener}.
  */
-@UnstableApi
 public class Http2FrameAdapter implements Http2FrameListener {
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
@@ -32,7 +32,6 @@ import io.netty.util.ReferenceCountUtil;
 import io.netty.util.ReferenceCounted;
 import io.netty.util.collection.IntObjectHashMap;
 import io.netty.util.collection.IntObjectMap;
-import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -144,7 +143,6 @@ import static io.netty.util.internal.logging.InternalLogLevel.DEBUG;
  * Server-side HTTP to HTTP/2 upgrade is supported in conjunction with {@link Http2ServerUpgradeCodec}; the necessary
  * HTTP-to-HTTP/2 conversion is performed automatically.
  */
-@UnstableApi
 public class Http2FrameCodec extends Http2ConnectionHandler {
 
     private static final InternalLogger LOG = InternalLoggerFactory.getInstance(Http2FrameCodec.class);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodecBuilder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodecBuilder.java
@@ -16,14 +16,11 @@
 
 package io.netty.handler.codec.http2;
 
-import io.netty.util.internal.UnstableApi;
-
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
  * Builder for the {@link Http2FrameCodec}.
  */
-@UnstableApi
 public class Http2FrameCodecBuilder extends
         AbstractHttp2ConnectionHandlerBuilder<Http2FrameCodec, Http2FrameCodecBuilder> {
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameListener.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameListener.java
@@ -17,12 +17,10 @@ package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.util.internal.UnstableApi;
 
 /**
  * An listener of HTTP/2 frames.
  */
-@UnstableApi
 public interface Http2FrameListener {
     /**
      * Handles an inbound {@code DATA} frame.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameListenerDecorator.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameListenerDecorator.java
@@ -17,12 +17,10 @@ package io.netty.handler.codec.http2;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.util.internal.UnstableApi;
 
 /**
  * Provides a decorator around a {@link Http2FrameListener} and delegates all method calls
  */
-@UnstableApi
 public class Http2FrameListenerDecorator implements Http2FrameListener {
     protected final Http2FrameListener listener;
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameLogger.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameLogger.java
@@ -20,7 +20,6 @@ import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelHandlerAdapter;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.logging.LogLevel;
-import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogLevel;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -30,7 +29,6 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
 /**
  * Logs HTTP2 frames for debugging purposes.
  */
-@UnstableApi
 public class Http2FrameLogger extends ChannelHandlerAdapter {
 
     public enum Direction {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameReader.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameReader.java
@@ -17,7 +17,6 @@ package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.util.internal.UnstableApi;
 
 import java.io.Closeable;
 
@@ -25,7 +24,6 @@ import java.io.Closeable;
  * Reads HTTP/2 frames from an input {@link ByteBuf} and notifies the specified
  * {@link Http2FrameListener} when frames are complete.
  */
-@UnstableApi
 public interface Http2FrameReader extends Closeable {
     /**
      * Configuration specific to {@link Http2FrameReader}

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameSizePolicy.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameSizePolicy.java
@@ -14,9 +14,6 @@
  */
 package io.netty.handler.codec.http2;
 
-import io.netty.util.internal.UnstableApi;
-
-@UnstableApi
 public interface Http2FrameSizePolicy {
     /**
      * Sets the maximum allowed frame size. Attempts to write frames longer than this maximum will fail.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameStream.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameStream.java
@@ -17,12 +17,10 @@
 package io.netty.handler.codec.http2;
 
 import io.netty.handler.codec.http2.Http2Stream.State;
-import io.netty.util.internal.UnstableApi;
 
 /**
  * A single stream within an HTTP/2 connection. To be used with the {@link Http2FrameCodec}.
  */
-@UnstableApi
 public interface Http2FrameStream {
     /**
      * Returns the stream identifier.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameStreamEvent.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameStreamEvent.java
@@ -15,15 +15,11 @@
  */
 package io.netty.handler.codec.http2;
 
-import io.netty.util.internal.UnstableApi;
-
-@UnstableApi
 public final class Http2FrameStreamEvent {
 
     private final Http2FrameStream stream;
     private final Type type;
 
-    @UnstableApi
     public enum Type {
         State,
         Writability

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameStreamException.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameStreamException.java
@@ -16,14 +16,11 @@
 
 package io.netty.handler.codec.http2;
 
-import io.netty.util.internal.UnstableApi;
-
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
  * An HTTP/2 exception for a specific {@link Http2FrameStream}.
  */
-@UnstableApi
 public final class Http2FrameStreamException extends Exception {
 
     private static final long serialVersionUID = -4407186173493887044L;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameStreamVisitor.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameStreamVisitor.java
@@ -16,12 +16,9 @@
 
 package io.netty.handler.codec.http2;
 
-import io.netty.util.internal.UnstableApi;
-
 /**
  * A visitor that allows to iterate over a collection of {@link Http2FrameStream}s.
  */
-@UnstableApi
 public interface Http2FrameStreamVisitor {
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameTypes.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameTypes.java
@@ -15,12 +15,9 @@
 
 package io.netty.handler.codec.http2;
 
-import io.netty.util.internal.UnstableApi;
-
 /**
  * Registry of all standard frame types defined by the HTTP/2 specification.
  */
-@UnstableApi
 public final class Http2FrameTypes {
     public static final byte DATA = 0x0;
     public static final byte HEADERS = 0x1;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameWriter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameWriter.java
@@ -19,7 +19,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
-import io.netty.util.internal.UnstableApi;
 
 import java.io.Closeable;
 
@@ -28,7 +27,6 @@ import java.io.Closeable;
  * this interface write to the context, but DO NOT FLUSH. To perform a flush, you must separately
  * call {@link ChannelHandlerContext#flush()}.
  */
-@UnstableApi
 public interface Http2FrameWriter extends Http2DataWriter, Closeable {
     /**
      * Configuration specific to {@link Http2FrameWriter}

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2GoAwayFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2GoAwayFrame.java
@@ -17,7 +17,6 @@ package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
-import io.netty.util.internal.UnstableApi;
 
 /**
  * HTTP/2 GOAWAY frame.
@@ -29,7 +28,6 @@ import io.netty.util.internal.UnstableApi;
  * <p>Graceful shutdown as described in the HTTP/2 spec can be accomplished by calling
  * {@code #setExtraStreamIds(Integer.MAX_VALUE)}.
  */
-@UnstableApi
 public interface Http2GoAwayFrame extends Http2Frame, ByteBufHolder {
     /**
      * The reason for beginning closure of the connection. Represented as an HTTP/2 error code.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Headers.java
@@ -17,7 +17,6 @@ package io.netty.handler.codec.http2;
 
 import io.netty.handler.codec.Headers;
 import io.netty.util.AsciiString;
-import io.netty.util.internal.UnstableApi;
 
 import java.util.Iterator;
 import java.util.Map.Entry;
@@ -25,7 +24,6 @@ import java.util.Map.Entry;
 /**
  * A collection of headers sent or received via HTTP/2.
  */
-@UnstableApi
 public interface Http2Headers extends Headers<CharSequence, CharSequence, Http2Headers> {
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2HeadersDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2HeadersDecoder.java
@@ -16,12 +16,10 @@
 package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.util.internal.UnstableApi;
 
 /**
  * Decodes HPACK-encoded headers blocks into {@link Http2Headers}.
  */
-@UnstableApi
 public interface Http2HeadersDecoder {
     /**
      * Configuration related elements for the {@link Http2HeadersDecoder} interface

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2HeadersEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2HeadersEncoder.java
@@ -16,12 +16,10 @@
 package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.util.internal.UnstableApi;
 
 /**
  * Encodes {@link Http2Headers} into HPACK-encoded headers blocks.
  */
-@UnstableApi
 public interface Http2HeadersEncoder {
     /**
      * Configuration related elements for the {@link Http2HeadersEncoder} interface

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2HeadersFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2HeadersFrame.java
@@ -15,12 +15,9 @@
  */
 package io.netty.handler.codec.http2;
 
-import io.netty.util.internal.UnstableApi;
-
 /**
  * HTTP/2 HEADERS frame.
  */
-@UnstableApi
 public interface Http2HeadersFrame extends Http2StreamFrame {
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2InboundFrameLogger.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2InboundFrameLogger.java
@@ -19,13 +19,11 @@ import static io.netty.handler.codec.http2.Http2FrameLogger.Direction.INBOUND;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.util.internal.UnstableApi;
 
 /**
  * Decorator around a {@link Http2FrameReader} that logs all inbound frames before calling
  * back the listener.
  */
-@UnstableApi
 public class Http2InboundFrameLogger implements Http2FrameReader {
     private final Http2FrameReader reader;
     private final Http2FrameLogger logger;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2LifecycleManager.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2LifecycleManager.java
@@ -18,13 +18,11 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
-import io.netty.util.internal.UnstableApi;
 
 /**
  * Manager for the life cycle of the HTTP/2 connection. Handles graceful shutdown of the channel,
  * closing only after all of the streams have closed.
  */
-@UnstableApi
 public interface Http2LifecycleManager {
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2LocalFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2LocalFlowController.java
@@ -15,12 +15,10 @@
 package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.util.internal.UnstableApi;
 
 /**
  * A {@link Http2FlowController} for controlling the inbound flow of {@code DATA} frames from the remote endpoint.
  */
-@UnstableApi
 public interface Http2LocalFlowController extends Http2FlowController {
     /**
      * Sets the writer to be use for sending {@code WINDOW_UPDATE} frames. This must be called before any flow

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
@@ -27,7 +27,6 @@ import io.netty.channel.socket.ChannelInputShutdownReadComplete;
 import io.netty.channel.socket.ChannelOutputShutdownEvent;
 import io.netty.handler.ssl.SslCloseCompletionEvent;
 import io.netty.util.ReferenceCounted;
-import io.netty.util.internal.UnstableApi;
 
 import java.util.ArrayDeque;
 import java.util.Queue;
@@ -87,7 +86,6 @@ import static io.netty.handler.codec.http2.Http2Exception.connectionError;
  * @deprecated use {@link Http2FrameCodecBuilder} together with {@link Http2MultiplexHandler}.
  */
 @Deprecated
-@UnstableApi
 public class Http2MultiplexCodec extends Http2FrameCodec {
 
     private final ChannelHandler inboundStreamHandler;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodecBuilder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodecBuilder.java
@@ -17,7 +17,6 @@ package io.netty.handler.codec.http2;
 
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerAdapter;
-import io.netty.util.internal.UnstableApi;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
@@ -27,7 +26,6 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
  * @deprecated use {@link Http2FrameCodecBuilder} together with {@link Http2MultiplexHandler}.
  */
 @Deprecated
-@UnstableApi
 public class Http2MultiplexCodecBuilder
         extends AbstractHttp2ConnectionHandlerBuilder<Http2MultiplexCodec, Http2MultiplexCodecBuilder> {
     private Http2FrameWriter frameWriter;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexHandler.java
@@ -31,7 +31,6 @@ import io.netty.handler.codec.http2.Http2FrameCodec.DefaultHttp2FrameStream;
 import io.netty.handler.ssl.SslCloseCompletionEvent;
 import io.netty.util.ReferenceCounted;
 import io.netty.util.internal.ObjectUtil;
-import io.netty.util.internal.UnstableApi;
 
 import java.util.ArrayDeque;
 import java.util.Queue;
@@ -98,7 +97,6 @@ import static io.netty.handler.codec.http2.Http2Exception.connectionError;
  * and send a {@link Http2ResetFrame} with the unwrapped {@link Http2Error} set. Another possibility is to just
  * directly write a {@link Http2ResetFrame} to the {@link Http2StreamChannel}l.
  */
-@UnstableApi
 public final class Http2MultiplexHandler extends Http2ChannelDuplexHandler {
 
     static final ChannelFutureListener CHILD_CHANNEL_REGISTRATION_LISTENER = new ChannelFutureListener() {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2NoMoreStreamIdsException.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2NoMoreStreamIdsException.java
@@ -14,14 +14,11 @@
  */
 package io.netty.handler.codec.http2;
 
-import io.netty.util.internal.UnstableApi;
-
 import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
 
 /**
  * This exception is thrown when there are no more stream IDs available for the current connection
  */
-@UnstableApi
 public class Http2NoMoreStreamIdsException extends Http2Exception {
     private static final long serialVersionUID = -7756236161274851110L;
     private static final String ERROR_MESSAGE = "No more streams can be created on this connection";

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2OutboundFrameLogger.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2OutboundFrameLogger.java
@@ -21,13 +21,11 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
-import io.netty.util.internal.UnstableApi;
 
 /**
  * Decorator around a {@link Http2FrameWriter} that logs all outbound frames before calling the
  * writer.
  */
-@UnstableApi
 public class Http2OutboundFrameLogger implements Http2FrameWriter {
     private final Http2FrameWriter writer;
     private final Http2FrameLogger logger;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2PingFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2PingFrame.java
@@ -16,12 +16,9 @@
 
 package io.netty.handler.codec.http2;
 
-import io.netty.util.internal.UnstableApi;
-
 /**
  * HTTP/2 PING Frame.
  */
-@UnstableApi
 public interface Http2PingFrame extends Http2Frame {
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2PriorityFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2PriorityFrame.java
@@ -15,12 +15,9 @@
  */
 package io.netty.handler.codec.http2;
 
-import io.netty.util.internal.UnstableApi;
-
 /**
  * HTTP/2 Priority Frame
  */
-@UnstableApi
 public interface Http2PriorityFrame extends Http2StreamFrame {
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2PromisedRequestVerifier.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2PromisedRequestVerifier.java
@@ -15,13 +15,11 @@
 package io.netty.handler.codec.http2;
 
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.util.internal.UnstableApi;
 
 /**
  * Provides an extensibility point for users to define the validity of push requests.
  * @see <a href="https://tools.ietf.org/html/rfc7540#section-8.2">[RFC 7540], Section 8.2</a>.
  */
-@UnstableApi
 public interface Http2PromisedRequestVerifier {
     /**
      * Determine if a {@link Http2Headers} are authoritative for a particular {@link ChannelHandlerContext}.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2PushPromiseFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2PushPromiseFrame.java
@@ -15,12 +15,9 @@
  */
 package io.netty.handler.codec.http2;
 
-import io.netty.util.internal.UnstableApi;
-
 /**
  * HTTP/2 Push Promise Frame
  */
-@UnstableApi
 public interface Http2PushPromiseFrame extends Http2StreamFrame {
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2RemoteFlowController.java
@@ -15,13 +15,11 @@
 package io.netty.handler.codec.http2;
 
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.util.internal.UnstableApi;
 
 /**
  * A {@link Http2FlowController} for controlling the flow of outbound {@code DATA} frames to the remote
  * endpoint.
  */
-@UnstableApi
 public interface Http2RemoteFlowController extends Http2FlowController {
     /**
      * Get the {@link ChannelHandlerContext} for which to apply flow control on.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ResetFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ResetFrame.java
@@ -15,10 +15,7 @@
  */
 package io.netty.handler.codec.http2;
 
-import io.netty.util.internal.UnstableApi;
-
 /** HTTP/2 RST_STREAM frame. */
-@UnstableApi
 public interface Http2ResetFrame extends Http2StreamFrame {
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2SecurityUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2SecurityUtil.java
@@ -15,8 +15,6 @@
  */
 package io.netty.handler.codec.http2;
 
-import io.netty.util.internal.UnstableApi;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -25,7 +23,6 @@ import java.util.List;
 /**
  * Provides utilities related to security requirements specific to HTTP/2.
  */
-@UnstableApi
 public final class Http2SecurityUtil {
     /**
      * The following list is derived from <a

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ServerUpgradeCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ServerUpgradeCodec.java
@@ -23,7 +23,6 @@ import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpServerUpgradeHandler;
 import io.netty.util.CharsetUtil;
-import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -41,7 +40,6 @@ import static io.netty.handler.codec.http2.Http2FrameTypes.SETTINGS;
 /**
  * Server-side codec for performing a cleartext upgrade from HTTP/1.x to HTTP/2.
  */
-@UnstableApi
 public class Http2ServerUpgradeCodec implements HttpServerUpgradeHandler.UpgradeCodec {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(Http2ServerUpgradeCodec.class);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Settings.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Settings.java
@@ -16,7 +16,6 @@
 package io.netty.handler.codec.http2;
 
 import io.netty.util.collection.CharObjectHashMap;
-import io.netty.util.internal.UnstableApi;
 
 import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_HEADER_LIST_SIZE;
 import static io.netty.handler.codec.http2.Http2CodecUtil.MAX_CONCURRENT_STREAMS;
@@ -46,7 +45,6 @@ import static java.lang.Integer.toHexString;
  * the spec for the SETTINGS frame. Permits storage of arbitrary key/value pairs but provides helper
  * methods for standard settings.
  */
-@UnstableApi
 public final class Http2Settings extends CharObjectHashMap<Long> {
     /**
      * Default capacity based on the number of standard settings from the HTTP/2 spec, adjusted so that adding all of

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Stream.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Stream.java
@@ -15,12 +15,9 @@
 
 package io.netty.handler.codec.http2;
 
-import io.netty.util.internal.UnstableApi;
-
 /**
  * A single stream within an HTTP2 connection. Streams are compared to each other by priority.
  */
-@UnstableApi
 public interface Http2Stream {
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamChannel.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamChannel.java
@@ -17,13 +17,11 @@
 package io.netty.handler.codec.http2;
 
 import io.netty.channel.Channel;
-import io.netty.util.internal.UnstableApi;
 
 // TODO: Should we have an extra method to "open" the stream and so Channel and take care of sending the
 //       Http2HeadersFrame under the hood ?
 // TODO: Should we extend SocketChannel and map input and output state to the stream state ?
 //
-@UnstableApi
 public interface Http2StreamChannel extends Channel {
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamChannelBootstrap.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamChannelBootstrap.java
@@ -28,7 +28,6 @@ import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
-import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -37,7 +36,6 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-@UnstableApi
 public final class Http2StreamChannelBootstrap {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(Http2StreamChannelBootstrap.class);
     @SuppressWarnings("unchecked")

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamFrame.java
@@ -15,14 +15,11 @@
  */
 package io.netty.handler.codec.http2;
 
-import io.netty.util.internal.UnstableApi;
-
 /**
  * A frame whose meaning <em>may</em> apply to a particular stream, instead of the entire connection. It is still
  * possible for this frame type to apply to the entire connection. In such cases, the {@link #stream()} must return
  * {@code null}. If the frame applies to a stream, the {@link Http2FrameStream#id()} must be greater than zero.
  */
-@UnstableApi
 public interface Http2StreamFrame extends Http2Frame {
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamFrameToHttpObjectCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamFrameToHttpObjectCodec.java
@@ -44,7 +44,6 @@ import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
-import io.netty.util.internal.UnstableApi;
 
 import java.util.List;
 
@@ -57,7 +56,6 @@ import java.util.List;
  * For simplicity, it converts to chunked encoding unless the entire stream
  * is a single header.
  */
-@UnstableApi
 @Sharable
 public class Http2StreamFrameToHttpObjectCodec extends MessageToMessageCodec<Http2StreamFrame, HttpObject> {
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamVisitor.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamVisitor.java
@@ -14,12 +14,9 @@
  */
 package io.netty.handler.codec.http2;
 
-import io.netty.util.internal.UnstableApi;
-
 /**
  * A visitor that allows iteration over a collection of streams.
  */
-@UnstableApi
 public interface Http2StreamVisitor {
     /**
      * @return <ul>

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2UnknownFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2UnknownFrame.java
@@ -17,9 +17,7 @@ package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
-import io.netty.util.internal.UnstableApi;
 
-@UnstableApi
 public interface Http2UnknownFrame extends Http2StreamFrame, ByteBufHolder {
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2WindowUpdateFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2WindowUpdateFrame.java
@@ -15,12 +15,9 @@
  */
 package io.netty.handler.codec.http2;
 
-import io.netty.util.internal.UnstableApi;
-
 /**
  * HTTP/2 WINDOW_UPDATE frame.
  */
-@UnstableApi
 public interface Http2WindowUpdateFrame extends Http2StreamFrame {
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
@@ -35,7 +35,6 @@ import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.util.AsciiString;
 import io.netty.util.internal.InternalThreadLocalMap;
-import io.netty.util.internal.UnstableApi;
 
 import java.net.URI;
 import java.util.Iterator;
@@ -68,7 +67,6 @@ import static io.netty.util.internal.StringUtil.unescapeCsvFields;
 /**
  * Provides utility methods and constants for the HTTP/2 to HTTP conversion
  */
-@UnstableApi
 public final class HttpConversionUtil {
     /**
      * The set of headers that should not be directly copied when converting headers from HTTP to HTTP/2.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandler.java
@@ -27,14 +27,12 @@ import io.netty.handler.codec.http.HttpScheme;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.codec.http2.Http2CodecUtil.SimpleChannelPromiseAggregator;
 import io.netty.util.ReferenceCountUtil;
-import io.netty.util.internal.UnstableApi;
 
 /**
  * Translates HTTP/1.x object writes into HTTP/2 frames.
  * <p>
  * See {@link InboundHttp2ToHttpAdapter} to get translation from HTTP/2 frames to HTTP/1.x objects.
  */
-@UnstableApi
 public class HttpToHttp2ConnectionHandler extends Http2ConnectionHandler {
 
     private final boolean validateHeaders;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandlerBuilder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandlerBuilder.java
@@ -18,12 +18,10 @@ package io.netty.handler.codec.http2;
 
 import io.netty.handler.codec.http.HttpScheme;
 import io.netty.handler.codec.http2.Http2HeadersEncoder.SensitivityDetector;
-import io.netty.util.internal.UnstableApi;
 
 /**
  * Builder which builds {@link HttpToHttp2ConnectionHandler} objects.
  */
-@UnstableApi
 public final class HttpToHttp2ConnectionHandlerBuilder extends
         AbstractHttp2ConnectionHandlerBuilder<HttpToHttp2ConnectionHandler, HttpToHttp2ConnectionHandlerBuilder> {
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapter.java
@@ -23,7 +23,6 @@ import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpStatusClass;
 import io.netty.handler.codec.http.HttpUtil;
-import io.netty.util.internal.UnstableApi;
 
 import static io.netty.handler.codec.http2.Http2Error.INTERNAL_ERROR;
 import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
@@ -38,7 +37,6 @@ import static io.netty.util.internal.ObjectUtil.checkPositive;
  * <p>
  * See {@link HttpToHttp2ConnectionHandler} to get translation from HTTP/1.x objects to HTTP/2 frames for writes.
  */
-@UnstableApi
 public class InboundHttp2ToHttpAdapter extends Http2EventAdapter {
     private static final ImmediateSendDetector DEFAULT_SEND_DETECTOR = new ImmediateSendDetector() {
         @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterBuilder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterBuilder.java
@@ -14,12 +14,9 @@
  */
 package io.netty.handler.codec.http2;
 
-import io.netty.util.internal.UnstableApi;
-
 /**
  * Builds an {@link InboundHttp2ToHttpAdapter}.
  */
-@UnstableApi
 public final class InboundHttp2ToHttpAdapterBuilder
         extends AbstractInboundHttp2ToHttpAdapterBuilder<InboundHttp2ToHttpAdapter, InboundHttp2ToHttpAdapterBuilder> {
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttpToHttp2Adapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttpToHttp2Adapter.java
@@ -20,12 +20,10 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.FullHttpMessage;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpScheme;
-import io.netty.util.internal.UnstableApi;
 
 /**
  * Translates HTTP/1.x object reads into HTTP/2 frames.
  */
-@UnstableApi
 public class InboundHttpToHttp2Adapter extends ChannelInboundHandlerAdapter {
     private final Http2Connection connection;
     private final Http2FrameListener listener;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/StreamBufferingEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/StreamBufferingEncoder.java
@@ -21,7 +21,6 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.util.ReferenceCountUtil;
-import io.netty.util.internal.UnstableApi;
 
 import java.util.ArrayDeque;
 import java.util.Iterator;
@@ -55,7 +54,6 @@ import static io.netty.handler.codec.http2.Http2Exception.connectionError;
  * drop-in decorator of {@link DefaultHttp2ConnectionEncoder}.
  * </p>
  */
-@UnstableApi
 public class StreamBufferingEncoder extends DecoratingHttp2ConnectionEncoder {
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/StreamByteDistributor.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/StreamByteDistributor.java
@@ -15,13 +15,10 @@
 
 package io.netty.handler.codec.http2;
 
-import io.netty.util.internal.UnstableApi;
-
 /**
  * An object (used by remote flow control) that is responsible for distributing the bytes to be
  * written across the streams in the connection.
  */
-@UnstableApi
 public interface StreamByteDistributor {
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/UniformStreamByteDistributor.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/UniformStreamByteDistributor.java
@@ -14,8 +14,6 @@
  */
 package io.netty.handler.codec.http2;
 
-import io.netty.util.internal.UnstableApi;
-
 import java.util.ArrayDeque;
 import java.util.Deque;
 
@@ -34,7 +32,6 @@ import static java.lang.Math.min;
  * fewer streams may be written to in each call to {@link #distribute(int, Writer)}, doing this
  * should improve the goodput on each written stream.
  */
-@UnstableApi
 public final class UniformStreamByteDistributor implements StreamByteDistributor {
     private final Http2Connection.PropertyKey stateKey;
     private final Deque<State> queue = new ArrayDeque<State>(4);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/WeightedFairQueueByteDistributor.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/WeightedFairQueueByteDistributor.java
@@ -23,7 +23,6 @@ import io.netty.util.internal.MathUtil;
 import io.netty.util.internal.PriorityQueue;
 import io.netty.util.internal.PriorityQueueNode;
 import io.netty.util.internal.SystemPropertyUtil;
-import io.netty.util.internal.UnstableApi;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -56,7 +55,6 @@ import static java.lang.Math.min;
  * Each write operation will use the {@link #allocationQuantum(int)} to know how many more bytes should be allocated
  * relative to the next stream which wants to write. This is to balance fairness while also considering goodput.
  */
-@UnstableApi
 public final class WeightedFairQueueByteDistributor implements StreamByteDistributor {
     /**
      * The initial size of the children map is chosen to be conservative on initial memory allocations under

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/package-info.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/package-info.java
@@ -16,7 +16,4 @@
 /**
  * Handlers for sending and receiving HTTP/2 frames.
  */
-@UnstableApi
 package io.netty.handler.codec.http2;
-
-import io.netty.util.internal.UnstableApi;

--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeDecoder.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeDecoder.java
@@ -26,7 +26,6 @@ import io.netty.handler.codec.stomp.StompSubframeDecoder.State;
 import io.netty.util.ByteProcessor;
 import io.netty.util.internal.AppendableCharSequence;
 import io.netty.util.internal.StringUtil;
-import io.netty.util.internal.UnstableApi;
 
 import java.util.List;
 
@@ -56,7 +55,10 @@ public class StompSubframeDecoder extends ReplayingDecoder<State> {
     private static final int DEFAULT_CHUNK_SIZE = 8132;
     private static final int DEFAULT_MAX_LINE_LENGTH = 1024;
 
-    @UnstableApi
+    /**
+     * @deprecated this should never be used by an user!
+     */
+    @Deprecated
     public enum State {
         SKIP_CONTROL_CHARACTERS,
         READ_HEADERS,

--- a/common/src/main/java/io/netty/util/concurrent/DefaultEventExecutorChooserFactory.java
+++ b/common/src/main/java/io/netty/util/concurrent/DefaultEventExecutorChooserFactory.java
@@ -15,15 +15,12 @@
  */
 package io.netty.util.concurrent;
 
-import io.netty.util.internal.UnstableApi;
-
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Default implementation which uses simple round-robin to choose next {@link EventExecutor}.
  */
-@UnstableApi
 public final class DefaultEventExecutorChooserFactory implements EventExecutorChooserFactory {
 
     public static final DefaultEventExecutorChooserFactory INSTANCE = new DefaultEventExecutorChooserFactory();

--- a/common/src/main/java/io/netty/util/concurrent/EventExecutorChooserFactory.java
+++ b/common/src/main/java/io/netty/util/concurrent/EventExecutorChooserFactory.java
@@ -15,12 +15,9 @@
  */
 package io.netty.util.concurrent;
 
-import io.netty.util.internal.UnstableApi;
-
 /**
  * Factory that creates new {@link EventExecutorChooser}s.
  */
-@UnstableApi
 public interface EventExecutorChooserFactory {
 
     /**
@@ -31,7 +28,6 @@ public interface EventExecutorChooserFactory {
     /**
      * Chooses the next {@link EventExecutor} to use.
      */
-    @UnstableApi
     interface EventExecutorChooser {
 
         /**

--- a/common/src/main/java/io/netty/util/concurrent/FastThreadLocalThread.java
+++ b/common/src/main/java/io/netty/util/concurrent/FastThreadLocalThread.java
@@ -16,7 +16,6 @@
 package io.netty.util.concurrent;
 
 import io.netty.util.internal.InternalThreadLocalMap;
-import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -98,7 +97,6 @@ public class FastThreadLocalThread extends Thread {
     /**
      * Returns {@code true} if {@link FastThreadLocal#removeAll()} will be called once {@link #run()} completes.
      */
-    @UnstableApi
     public boolean willCleanupFastThreadLocals() {
         return cleanupFastThreadLocals;
     }
@@ -106,7 +104,6 @@ public class FastThreadLocalThread extends Thread {
     /**
      * Returns {@code true} if {@link FastThreadLocal#removeAll()} will be called once {@link Thread#run()} completes.
      */
-    @UnstableApi
     public static boolean willCleanupFastThreadLocals(Thread thread) {
         return thread instanceof FastThreadLocalThread &&
                 ((FastThreadLocalThread) thread).willCleanupFastThreadLocals();

--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -19,7 +19,6 @@ import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.ThreadExecutorMap;
-import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import org.jetbrains.annotations.Async.Schedule;
@@ -495,7 +494,6 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
     /**
      * Invoked before returning from {@link #runAllTasks()} and {@link #runAllTasks(long)}.
      */
-    @UnstableApi
     protected void afterRunningAllTasks() { }
 
     /**
@@ -516,7 +514,6 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
      * Returns the absolute point in time (relative to {@link #getCurrentTimeNanos()}) at which the next
      * closest scheduled task should run.
      */
-    @UnstableApi
     protected long deadlineNanos() {
         ScheduledFutureTask<?> scheduledTask = peekScheduledTask();
         if (scheduledTask == null) {

--- a/handler/src/main/java/io/netty/handler/ssl/SniCompletionEvent.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SniCompletionEvent.java
@@ -15,13 +15,10 @@
  */
 package io.netty.handler.ssl;
 
-import io.netty.util.internal.UnstableApi;
-
 /**
  * Event that is fired once we did a selection of a {@link SslContext} based on the {@code SNI hostname},
  * which may be because it was successful or there was an error.
  */
-@UnstableApi
 public final class SniCompletionEvent extends SslCompletionEvent {
     private final String hostname;
 

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
@@ -37,7 +37,6 @@ import io.netty.channel.unix.SocketWritableByteChannel;
 import io.netty.channel.unix.UnixChannelUtil;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
-import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -529,7 +528,6 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
                 "unsupported message type: " + StringUtil.simpleClassName(msg) + EXPECTED_TYPES);
     }
 
-    @UnstableApi
     @Override
     protected final void doShutdownOutput() throws Exception {
         socket.shutdown(false, true);

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainDatagramChannel.java
@@ -33,7 +33,6 @@ import io.netty.channel.unix.UnixChannelUtil;
 import io.netty.util.CharsetUtil;
 import io.netty.util.UncheckedBooleanSupplier;
 import io.netty.util.internal.StringUtil;
-import io.netty.util.internal.UnstableApi;
 
 import java.io.IOException;
 import java.net.SocketAddress;
@@ -41,7 +40,6 @@ import java.nio.ByteBuffer;
 
 import static io.netty.channel.epoll.LinuxSocket.newSocketDomainDgram;
 
-@UnstableApi
 public final class EpollDomainDatagramChannel extends AbstractEpollChannel implements DomainDatagramChannel {
 
     private static final ChannelMetadata METADATA = new ChannelMetadata(true, 16);

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainDatagramChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainDatagramChannelConfig.java
@@ -23,7 +23,6 @@ import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.unix.DomainDatagramChannelConfig;
-import io.netty.util.internal.UnstableApi;
 
 import java.io.IOException;
 import java.util.Map;
@@ -31,7 +30,6 @@ import java.util.Map;
 import static io.netty.channel.ChannelOption.DATAGRAM_CHANNEL_ACTIVE_ON_REGISTRATION;
 import static io.netty.channel.ChannelOption.SO_SNDBUF;
 
-@UnstableApi
 public final class EpollDomainDatagramChannelConfig extends EpollChannelConfig implements DomainDatagramChannelConfig {
 
     private boolean activeOnOpen;

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannel.java
@@ -23,7 +23,6 @@ import io.netty.channel.unix.DomainSocketAddress;
 import io.netty.channel.unix.DomainSocketChannel;
 import io.netty.channel.unix.FileDescriptor;
 import io.netty.channel.unix.PeerCredentials;
-import io.netty.util.internal.UnstableApi;
 
 import java.io.IOException;
 import java.net.SocketAddress;
@@ -127,7 +126,6 @@ public final class EpollDomainSocketChannel extends AbstractEpollStreamChannel i
      * Returns the unix credentials (uid, gid, pid) of the peer
      * <a href=https://man7.org/linux/man-pages/man7/socket.7.html>SO_PEERCRED</a>
      */
-    @UnstableApi
     public PeerCredentials peerCredentials() throws IOException {
         return socket.getPeerCredentials();
     }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -27,7 +27,6 @@ import io.netty.channel.EventLoop;
 import io.netty.channel.socket.DuplexChannel;
 import io.netty.channel.unix.IovArray;
 import io.netty.channel.unix.Limits;
-import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -88,7 +87,6 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
         return promise;
     }
 
-    @UnstableApi
     @Override
     protected final void doShutdownOutput() throws Exception {
         socket.shutdown(false, true);

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueServerChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueServerChannel.java
@@ -21,12 +21,10 @@ import io.netty.channel.ChannelMetadata;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ServerChannel;
-import io.netty.util.internal.UnstableApi;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 
-@UnstableApi
 public abstract class AbstractKQueueServerChannel extends AbstractKQueueChannel implements ServerChannel {
     private static final ChannelMetadata METADATA = new ChannelMetadata(false, 16);
 

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueStreamChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueStreamChannel.java
@@ -47,7 +47,6 @@ import java.util.concurrent.Executor;
 import static io.netty.channel.internal.ChannelUtils.MAX_BYTES_PER_GATHERING_WRITE_ATTEMPTED_LOW_THRESHOLD;
 import static io.netty.channel.internal.ChannelUtils.WRITE_STATUS_SNDBUF_FULL;
 
-@UnstableApi
 public abstract class AbstractKQueueStreamChannel extends AbstractKQueueChannel implements DuplexChannel {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(AbstractKQueueStreamChannel.class);
     private static final ChannelMetadata METADATA = new ChannelMetadata(false, 16);

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueue.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueue.java
@@ -18,12 +18,10 @@ package io.netty.channel.kqueue;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.unix.FileDescriptor;
 import io.netty.util.internal.SystemPropertyUtil;
-import io.netty.util.internal.UnstableApi;
 
 /**
  * If KQueue is available the JNI resources will be loaded when this class loads.
  */
-@UnstableApi
 public final class KQueue {
     private static final Throwable UNAVAILABILITY_CAUSE;
 

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueChannelConfig.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueChannelConfig.java
@@ -24,7 +24,6 @@ import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.unix.IntegerUnixChannelOption;
 import io.netty.channel.unix.RawUnixChannelOption;
-import io.netty.util.internal.UnstableApi;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -34,7 +33,6 @@ import static io.netty.channel.kqueue.KQueueChannelOption.RCV_ALLOC_TRANSPORT_PR
 import static io.netty.channel.unix.Limits.SSIZE_MAX;
 import static java.lang.Math.min;
 
-@UnstableApi
 public class KQueueChannelConfig extends DefaultChannelConfig {
     private volatile boolean transportProvidesGuess;
     private volatile long maxBytesPerGatheringWrite = SSIZE_MAX;

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueChannelOption.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueChannelOption.java
@@ -18,9 +18,7 @@ package io.netty.channel.kqueue;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.unix.UnixChannelOption;
-import io.netty.util.internal.UnstableApi;
 
-@UnstableApi
 public final class KQueueChannelOption<T> extends UnixChannelOption<T> {
     public static final ChannelOption<Integer> SO_SNDLOWAT = valueOf(KQueueChannelOption.class, "SO_SNDLOWAT");
     public static final ChannelOption<Boolean> TCP_NOPUSH = valueOf(KQueueChannelOption.class, "TCP_NOPUSH");

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannel.java
@@ -34,7 +34,6 @@ import io.netty.channel.unix.UnixChannelUtil;
 import io.netty.util.UncheckedBooleanSupplier;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
-import io.netty.util.internal.UnstableApi;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -47,7 +46,6 @@ import java.nio.channels.UnresolvedAddressException;
 
 import static io.netty.channel.kqueue.BsdSocket.newSocketDgram;
 
-@UnstableApi
 public final class KQueueDatagramChannel extends AbstractKQueueDatagramChannel implements DatagramChannel {
     private static final String EXPECTED_TYPES =
             " (expected: " + StringUtil.simpleClassName(DatagramPacket.class) + ", " +

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannelConfig.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannelConfig.java
@@ -23,7 +23,6 @@ import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.socket.DatagramChannelConfig;
-import io.netty.util.internal.UnstableApi;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -42,7 +41,6 @@ import static io.netty.channel.ChannelOption.SO_REUSEADDR;
 import static io.netty.channel.ChannelOption.SO_SNDBUF;
 import static io.netty.channel.unix.UnixChannelOption.SO_REUSEPORT;
 
-@UnstableApi
 public final class KQueueDatagramChannelConfig extends KQueueChannelConfig implements DatagramChannelConfig {
     private boolean activeOnOpen;
 

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainDatagramChannel.java
@@ -31,7 +31,6 @@ import io.netty.channel.unix.UnixChannelUtil;
 import io.netty.util.CharsetUtil;
 import io.netty.util.UncheckedBooleanSupplier;
 import io.netty.util.internal.StringUtil;
-import io.netty.util.internal.UnstableApi;
 
 import java.io.IOException;
 import java.net.SocketAddress;
@@ -39,7 +38,6 @@ import java.nio.ByteBuffer;
 
 import static io.netty.channel.kqueue.BsdSocket.newSocketDomainDgram;
 
-@UnstableApi
 public final class KQueueDomainDatagramChannel extends AbstractKQueueDatagramChannel implements DomainDatagramChannel {
 
     private static final String EXPECTED_TYPES =

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainDatagramChannelConfig.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainDatagramChannelConfig.java
@@ -23,7 +23,6 @@ import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.unix.DomainDatagramChannelConfig;
-import io.netty.util.internal.UnstableApi;
 
 import java.io.IOException;
 import java.util.Map;
@@ -31,7 +30,6 @@ import java.util.Map;
 import static io.netty.channel.ChannelOption.DATAGRAM_CHANNEL_ACTIVE_ON_REGISTRATION;
 import static io.netty.channel.ChannelOption.SO_SNDBUF;
 
-@UnstableApi
 public final class KQueueDomainDatagramChannelConfig
         extends KQueueChannelConfig implements DomainDatagramChannelConfig {
 

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainSocketChannel.java
@@ -30,7 +30,6 @@ import java.net.SocketAddress;
 
 import static io.netty.channel.kqueue.BsdSocket.newSocketDomain;
 
-@UnstableApi
 public final class KQueueDomainSocketChannel extends AbstractKQueueStreamChannel implements DomainSocketChannel {
     private final KQueueDomainSocketChannelConfig config = new KQueueDomainSocketChannelConfig(this);
 

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainSocketChannelConfig.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainSocketChannelConfig.java
@@ -24,7 +24,6 @@ import io.netty.channel.socket.DuplexChannelConfig;
 import io.netty.channel.unix.DomainSocketChannelConfig;
 import io.netty.channel.unix.DomainSocketReadMode;
 import io.netty.util.internal.ObjectUtil;
-import io.netty.util.internal.UnstableApi;
 
 import java.io.IOException;
 import java.util.Map;
@@ -34,7 +33,6 @@ import static io.netty.channel.ChannelOption.SO_RCVBUF;
 import static io.netty.channel.ChannelOption.SO_SNDBUF;
 import static io.netty.channel.unix.UnixChannelOption.DOMAIN_SOCKET_READ_MODE;
 
-@UnstableApi
 public final class KQueueDomainSocketChannelConfig extends KQueueChannelConfig
         implements DomainSocketChannelConfig, DuplexChannelConfig {
     private volatile DomainSocketReadMode mode = DomainSocketReadMode.BYTES;

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoopGroup.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoopGroup.java
@@ -29,7 +29,6 @@ import io.netty.util.concurrent.EventExecutorChooserFactory;
 import io.netty.util.concurrent.RejectedExecutionHandler;
 import io.netty.util.concurrent.RejectedExecutionHandlers;
 import io.netty.util.internal.PlatformDependent;
-import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -43,7 +42,6 @@ import java.util.concurrent.ThreadFactory;
  * @deprecated Use {@link MultiThreadIoEventLoopGroup} with {@link KQueueIoHandler}.
  */
 @Deprecated
-@UnstableApi
 public final class KQueueEventLoopGroup extends MultiThreadIoEventLoopGroup {
 
     // This does not use static by design to ensure the class can be loaded and only do the check when its actually

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueServerChannelConfig.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueServerChannelConfig.java
@@ -24,7 +24,6 @@ import io.netty.channel.ServerChannelRecvByteBufAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.socket.ServerSocketChannelConfig;
 import io.netty.util.NetUtil;
-import io.netty.util.internal.UnstableApi;
 
 import java.io.IOException;
 import java.util.Map;
@@ -35,7 +34,6 @@ import static io.netty.channel.ChannelOption.SO_REUSEADDR;
 import static io.netty.channel.ChannelOption.TCP_FASTOPEN;
 import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 
-@UnstableApi
 public class KQueueServerChannelConfig extends KQueueChannelConfig implements ServerSocketChannelConfig {
     private volatile int backlog = NetUtil.SOMAXCONN;
     private volatile boolean enableTcpFastOpen;

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueServerDomainSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueServerDomainSocketChannel.java
@@ -18,7 +18,6 @@ package io.netty.channel.kqueue;
 import io.netty.channel.Channel;
 import io.netty.channel.unix.DomainSocketAddress;
 import io.netty.channel.unix.ServerDomainSocketChannel;
-import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -27,7 +26,6 @@ import java.net.SocketAddress;
 
 import static io.netty.channel.kqueue.BsdSocket.newSocketDomain;
 
-@UnstableApi
 public final class KQueueServerDomainSocketChannel extends AbstractKQueueServerChannel
                                                   implements ServerDomainSocketChannel {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueServerSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueServerSocketChannel.java
@@ -17,7 +17,6 @@ package io.netty.channel.kqueue;
 
 import io.netty.channel.Channel;
 import io.netty.channel.socket.ServerSocketChannel;
-import io.netty.util.internal.UnstableApi;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -25,7 +24,6 @@ import java.net.SocketAddress;
 import static io.netty.channel.kqueue.BsdSocket.newSocketStream;
 import static io.netty.channel.unix.NativeInetAddress.address;
 
-@UnstableApi
 public final class KQueueServerSocketChannel extends AbstractKQueueServerChannel implements ServerSocketChannel {
     private final KQueueServerSocketChannelConfig config;
 

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueServerSocketChannelConfig.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueServerSocketChannelConfig.java
@@ -21,8 +21,6 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.WriteBufferWaterMark;
-import io.netty.channel.socket.ServerSocketChannelConfig;
-import io.netty.util.internal.UnstableApi;
 
 import java.io.IOException;
 import java.util.Map;
@@ -30,7 +28,6 @@ import java.util.Map;
 import static io.netty.channel.kqueue.KQueueChannelOption.SO_ACCEPTFILTER;
 import static io.netty.channel.unix.UnixChannelOption.SO_REUSEPORT;
 
-@UnstableApi
 public class KQueueServerSocketChannelConfig extends KQueueServerChannelConfig {
     KQueueServerSocketChannelConfig(KQueueServerSocketChannel channel) {
         super(channel);

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueSocketChannel.java
@@ -24,13 +24,11 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.SocketProtocolFamily;
 import io.netty.channel.unix.IovArray;
 import io.netty.util.concurrent.GlobalEventExecutor;
-import io.netty.util.internal.UnstableApi;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.concurrent.Executor;
 
-@UnstableApi
 public final class KQueueSocketChannel extends AbstractKQueueStreamChannel implements SocketChannel {
     private final KQueueSocketChannelConfig config;
 
@@ -40,7 +38,7 @@ public final class KQueueSocketChannel extends AbstractKQueueStreamChannel imple
     }
 
     /**
-     * @deprecated use {@link SocketProtocolFamily#KQueueDatagramChannel(SocketProtocolFamily)}
+     * @deprecated use {@link KQueueDatagramChannel(SocketProtocolFamily)}
      */
     @Deprecated
     public KQueueSocketChannel(InternetProtocolFamily protocol) {

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueSocketChannelConfig.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueSocketChannelConfig.java
@@ -23,7 +23,6 @@ import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.socket.SocketChannelConfig;
 import io.netty.util.internal.PlatformDependent;
-import io.netty.util.internal.UnstableApi;
 
 import java.io.IOException;
 import java.util.Map;
@@ -39,7 +38,6 @@ import static io.netty.channel.ChannelOption.TCP_NODELAY;
 import static io.netty.channel.kqueue.KQueueChannelOption.SO_SNDLOWAT;
 import static io.netty.channel.kqueue.KQueueChannelOption.TCP_NOPUSH;
 
-@UnstableApi
 public final class KQueueSocketChannelConfig extends KQueueChannelConfig implements SocketChannelConfig {
     private volatile boolean allowHalfClosure;
     private volatile boolean tcpFastopen;

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/package-info.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/package-info.java
@@ -17,7 +17,4 @@
 /**
  * BSD specific transport.
  */
-@UnstableApi
 package io.netty.channel.kqueue;
-
-import io.netty.util.internal.UnstableApi;

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -21,7 +21,6 @@ import io.netty.util.DefaultAttributeMap;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
-import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -490,7 +489,6 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
          * Shutdown the output portion of the corresponding {@link Channel}.
          * For example this will clean up the {@link ChannelOutboundBuffer} and not allow any more writes.
          */
-        @UnstableApi
         public final void shutdownOutput(final ChannelPromise promise) {
             assertEventLoop();
             shutdownOutput(promise, null);
@@ -982,7 +980,6 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
      * Called when conditions justify shutting down the output portion of the channel. This may happen if a write
      * operation throws an exception.
      */
-    @UnstableApi
     protected void doShutdownOutput() throws Exception {
         doClose();
     }

--- a/transport/src/main/java/io/netty/channel/ChannelException.java
+++ b/transport/src/main/java/io/netty/channel/ChannelException.java
@@ -52,7 +52,6 @@ public class ChannelException extends RuntimeException {
         super(cause);
     }
 
-    @UnstableApi
     protected ChannelException(String message, Throwable cause, boolean shared) {
         super(message, cause, false, true);
         assert shared;

--- a/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
@@ -23,7 +23,6 @@ import io.netty.util.concurrent.EventExecutorGroup;
 import io.netty.util.concurrent.FastThreadLocal;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
-import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -1225,7 +1224,6 @@ public class DefaultChannelPipeline implements ChannelPipeline {
     protected void onUnhandledChannelWritabilityChanged() {
     }
 
-    @UnstableApi
     protected void incrementPendingOutboundBytes(long size) {
         ChannelOutboundBuffer buffer = channel.unsafe().outboundBuffer();
         if (buffer != null) {
@@ -1233,7 +1231,6 @@ public class DefaultChannelPipeline implements ChannelPipeline {
         }
     }
 
-    @UnstableApi
     protected void decrementPendingOutboundBytes(long size) {
         ChannelOutboundBuffer buffer = channel.unsafe().outboundBuffer();
         if (buffer != null) {

--- a/transport/src/main/java/io/netty/channel/RecvByteBufAllocator.java
+++ b/transport/src/main/java/io/netty/channel/RecvByteBufAllocator.java
@@ -108,7 +108,6 @@ public interface RecvByteBufAllocator {
     }
 
     @SuppressWarnings("deprecation")
-    @UnstableApi
     interface ExtendedHandle extends Handle {
         /**
          * Same as {@link Handle#continueReading()} except "more data" is determined by the supplier parameter.

--- a/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
@@ -103,7 +103,6 @@ public abstract class SingleThreadEventLoop extends SingleThreadEventExecutor im
      *
      * @param task to be added.
      */
-    @UnstableApi
     public final void executeAfterEventLoopIteration(Runnable task) {
         ObjectUtil.checkNotNull(task, "task");
         if (isShutdown()) {
@@ -126,7 +125,6 @@ public abstract class SingleThreadEventLoop extends SingleThreadEventExecutor im
      *
      * @return {@code true} if the task was removed as a result of this call.
      */
-    @UnstableApi
     final boolean removeAfterEventLoopIterationTask(Runnable task) {
         return tailTasks.remove(ObjectUtil.checkNotNull(task, "task"));
     }

--- a/transport/src/main/java/io/netty/channel/socket/ChannelOutputShutdownEvent.java
+++ b/transport/src/main/java/io/netty/channel/socket/ChannelOutputShutdownEvent.java
@@ -17,14 +17,12 @@ package io.netty.channel.socket;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandler;
-import io.netty.util.internal.UnstableApi;
 
 /**
  * Special event which will be fired and passed to the
  * {@link ChannelInboundHandler#userEventTriggered(ChannelHandlerContext, Object)} methods once the output of
  * a {@link SocketChannel} was shutdown.
  */
-@UnstableApi
 public final class ChannelOutputShutdownEvent {
     public static final ChannelOutputShutdownEvent INSTANCE = new ChannelOutputShutdownEvent();
 

--- a/transport/src/main/java/io/netty/channel/socket/ChannelOutputShutdownException.java
+++ b/transport/src/main/java/io/netty/channel/socket/ChannelOutputShutdownException.java
@@ -1,5 +1,3 @@
-
-
 /*
  * Copyright 2017 The Netty Project
  *
@@ -17,14 +15,12 @@
  */
 package io.netty.channel.socket;
 
-import io.netty.util.internal.UnstableApi;
 
 import java.io.IOException;
 
 /**
  * Used to fail pending writes when a channel's output has been shutdown.
  */
-@UnstableApi
 public final class ChannelOutputShutdownException extends IOException {
     private static final long serialVersionUID = 6712549938359321378L;
 

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioDomainSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioDomainSocketChannel.java
@@ -38,7 +38,6 @@ import io.netty.channel.socket.ServerSocketChannel;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SocketUtils;
 import io.netty.util.internal.SuppressJava6Requirement;
-import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -161,8 +160,6 @@ public final class NioDomainSocketChannel extends AbstractNioByteChannel
         return isInputShutdown() && isOutputShutdown() || !isActive();
     }
 
-    @SuppressJava6Requirement(reason = "Usage guarded by java version check")
-    @UnstableApi
     @Override
     protected void doShutdownOutput() throws Exception {
         javaChannel().shutdownOutput();

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
@@ -35,7 +35,6 @@ import io.netty.channel.socket.SocketChannelConfig;
 import io.netty.channel.socket.SocketProtocolFamily;
 import io.netty.util.concurrent.GlobalEventExecutor;
 import io.netty.util.internal.SocketUtils;
-import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -169,7 +168,6 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
         return (InetSocketAddress) super.remoteAddress();
     }
 
-    @UnstableApi
     @Override
     protected final void doShutdownOutput() throws Exception {
         javaChannel().shutdownOutput();

--- a/transport/src/main/java/io/netty/channel/socket/oio/OioSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/OioSocketChannel.java
@@ -27,7 +27,6 @@ import io.netty.channel.oio.OioByteStreamChannel;
 import io.netty.channel.socket.ServerSocketChannel;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.util.internal.SocketUtils;
-import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -133,7 +132,6 @@ public class OioSocketChannel extends OioByteStreamChannel implements SocketChan
         return socket.isInputShutdown() && socket.isOutputShutdown() || !isActive();
     }
 
-    @UnstableApi
     @Override
     protected final void doShutdownOutput() throws Exception {
         shutdownOutput0();


### PR DESCRIPTION
Motivation:

We should just remove @UnstableApi from things that we will not break before 5.0. This removes confusion and also ensures we will be able to detect breakage via our maven plugins.

Modifications:

Remove annotation usage where it makes sense

Result:

Fixes https://github.com/netty/netty/issues/14012
