### PR TITLE
Remove references to ByteBuf and update buffer package docs

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/BufferAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/BufferAllocator.java
@@ -131,7 +131,7 @@ public interface BufferAllocator extends SafeCloseable {
     Buffer allocate(int size);
 
     /**
-     * Compose the send of a buffer and present them as a single buffer.
+     * Compose the Send of a buffer and present them as a single buffer.
      * <p>
      * When a composite buffer is closed, all of its constituent component buffers are closed as well.
      * <p>
@@ -148,7 +148,7 @@ public interface BufferAllocator extends SafeCloseable {
     }
 
     /**
-     * Compose the given sequence of sends of buffers and present them as a single buffer.
+     * Compose the given sequence of Sends of buffers and present them as a single buffer.
      * <p>
      * When a composite buffer is closed, all of its constituent component buffers are closed as well.
      * <p>

--- a/buffer/src/main/java/io/netty5/buffer/BufferUtil.java
+++ b/buffer/src/main/java/io/netty5/buffer/BufferUtil.java
@@ -30,7 +30,7 @@ import static io.netty5.util.internal.ObjectUtil.checkPositiveOrZero;
 import static io.netty5.util.internal.StringUtil.NEWLINE;
 
 /**
- * A collection of utility methods that is related with handling {@code ByteBuf},
+ * A collection of utility methods that is related with handling {@code Buffer},
  * such as the generation of hex dump and swapping an integer's byte order.
  */
 public final class BufferUtil {

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/TcpDnsQueryEncoder.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/TcpDnsQueryEncoder.java
@@ -52,7 +52,7 @@ public final class TcpDnsQueryEncoder extends MessageToByteEncoder<DnsQuery> {
         out.skipWritableBytes(2);
         encoder.encode(msg, out);
 
-        // Now fill in the correct length based on the amount of data that we wrote the ByteBuf.
+        // Now fill in the correct length based on the amount of data that we wrote the Buffer.
         out.setShort(initialOffset, (short) (out.writerOffset() - initialOffset - 2));
     }
 

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocket13FrameEncoder.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocket13FrameEncoder.java
@@ -79,7 +79,7 @@ public class WebSocket13FrameEncoder extends MessageToMessageEncoder<WebSocketFr
     private static final byte OPCODE_PONG = 0xA;
     /**
      * The size threshold for gathering writes. Non-Masked messages bigger than this size will be be sent fragmented as
-     * a header and a content ByteBuf whereas messages smaller than the size will be merged into a single buffer and
+     * a header and a content Buffer whereas messages smaller than the size will be merged into a single buffer and
      * sent at once.<br>
      * Masked messages will always be sent at once.
      */

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/StreamBufferingEncoder.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/StreamBufferingEncoder.java
@@ -195,7 +195,7 @@ public class StreamBufferingEncoder extends DecoratingHttp2ConnectionEncoder {
             return super.writeRstStream(ctx, streamId, errorCode);
         }
         // Since the delegate doesn't know about any buffered streams we have to handle cancellation
-        // of the promises and releasing of the ByteBufs here.
+        // of the promises and releasing of the Buffers here.
         PendingStream stream = pendingStreams.remove(streamId);
         if (stream != null) {
             // Sending a RST_STREAM to a buffered stream will succeed the promise of all frames

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/DefaultHttp2FrameWriterTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/DefaultHttp2FrameWriterTest.java
@@ -301,8 +301,8 @@ public class DefaultHttp2FrameWriterTest {
         byte[] payload = {(byte) 0x01, (byte) 0x03, (byte) 0x05, (byte) 0x07, (byte) 0x09};
 
         // will auto release after frameWriter.writeFrame succeed
-        Buffer payloadByteBuf = bb(payload);
-        frameWriter.writeFrame(ctx, (byte) 0xf, 0, new Http2Flags(), payloadByteBuf);
+        Buffer payloadBuffer = bb(payload);
+        frameWriter.writeFrame(ctx, (byte) 0xf, 0, new Http2Flags(), payloadBuffer);
 
         byte[] expectedFrameHeaderBytes = {
                 (byte) 0x00, (byte) 0x00, (byte) 0x05, // payload length

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ControlFrameLimitEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ControlFrameLimitEncoderTest.java
@@ -158,7 +158,7 @@ public class Http2ControlFrameLimitEncoderTest {
         // Close and release any buffered frames.
         encoder.close();
 
-        // Notify all goAway Promise instances now as these will also release the retained ByteBuf for the
+        // Notify all goAway Promise instances now as these will also release the retained Buffer for the
         // debugData.
         for (;;) {
             Promise<Void> promise = goAwayPromises.poll();

--- a/codec/src/main/java/io/netty5/handler/codec/DatagramPacketEncoder.java
+++ b/codec/src/main/java/io/netty5/handler/codec/DatagramPacketEncoder.java
@@ -87,7 +87,7 @@ public class DatagramPacketEncoder<M> extends MessageToMessageEncoder<AddressedE
             out.set(0, new DatagramPacket((Buffer) content, msg.recipient(), msg.sender()));
         } else {
             throw new EncoderException(
-                    StringUtil.simpleClassName(encoder) + " must produce only ByteBuf.");
+                    StringUtil.simpleClassName(encoder) + " must produce only Buffer.");
         }
     }
 

--- a/codec/src/main/java/io/netty5/handler/codec/base64/package-info.java
+++ b/codec/src/main/java/io/netty5/handler/codec/base64/package-info.java
@@ -17,7 +17,7 @@
 /**
  * Encoder and decoder which transform a
  * <a href="https://en.wikipedia.org/wiki/Base64">Base64</a>-encoded
- * {@link java.lang.String} or {@link io.netty5.buffer.ByteBuf}
- * into a decoded {@link io.netty5.buffer.ByteBuf} and vice versa.
+ * {@link java.lang.String} or {@link io.netty5.buffer.Buffer}
+ * into a decoded {@link io.netty5.buffer.Buffer} and vice versa.
  */
 package io.netty5.handler.codec.base64;

--- a/codec/src/main/java/io/netty5/handler/codec/bytes/ByteArrayDecoder.java
+++ b/codec/src/main/java/io/netty5/handler/codec/bytes/ByteArrayDecoder.java
@@ -18,6 +18,7 @@ package io.netty5.handler.codec.bytes;
 import io.netty5.buffer.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
+import io.netty5.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty5.handler.codec.LengthFieldPrepender;
 import io.netty5.handler.codec.MessageToMessageDecoder;
 
@@ -48,7 +49,7 @@ import io.netty5.handler.codec.MessageToMessageDecoder;
 public class ByteArrayDecoder extends MessageToMessageDecoder<Buffer> {
     @Override
     protected void decode(ChannelHandlerContext ctx, Buffer msg) throws Exception {
-         // copy the ByteBuf content to a byte array
+         // copy the Buffer content to a byte array
         byte[] array = new byte[msg.readableBytes()];
         msg.readBytes(array, 0, array.length);
         ctx.fireChannelRead(array);

--- a/codec/src/main/java/io/netty5/handler/codec/bytes/package-info.java
+++ b/codec/src/main/java/io/netty5/handler/codec/bytes/package-info.java
@@ -16,6 +16,6 @@
 
 /**
  * Encoder and decoder which transform an array of bytes into a
- * {@link io.netty5.buffer.ByteBuf} and vice versa.
+ * {@link io.netty5.buffer.Buffer} and vice versa.
  */
 package io.netty5.handler.codec.bytes;

--- a/codec/src/main/java/io/netty5/handler/codec/compression/Bzip2Decompressor.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/Bzip2Decompressor.java
@@ -37,7 +37,7 @@ import static io.netty5.handler.codec.compression.Bzip2Constants.MIN_BLOCK_SIZE;
 
 /**
  * Uncompresses a {@link Buffer} encoded with the Bzip2 format.
- *
+ * <p>
  * See <a href="https://en.wikipedia.org/wiki/Bzip2">Bzip2</a>.
  */
 public final class Bzip2Decompressor implements Decompressor {
@@ -240,7 +240,7 @@ public final class Bzip2Decompressor implements Decompressor {
                             for (currSelector = huffmanStageDecoder.currentSelector;
                                  currSelector < totalSelectors; currSelector++) {
                                 if (!reader.hasReadableBits(HUFFMAN_SELECTOR_LIST_MAX_LENGTH)) {
-                                    // Save state if end of current ByteBuf was reached
+                                    // Save state if end of current Buffer was reached
                                     huffmanStageDecoder.currentSelector = currSelector;
                                     return null;
                                 }
@@ -302,7 +302,7 @@ public final class Bzip2Decompressor implements Decompressor {
                                 modifyLength = false;
                             }
                             if (saveStateAndReturn) {
-                                // Save state if end of current ByteBuf was reached
+                                // Save state if end of current Buffer was reached
                                 huffmanStageDecoder.currentGroup = currGroup;
                                 huffmanStageDecoder.currentLength = currLength;
                                 huffmanStageDecoder.currentAlpha = currAlpha;
@@ -323,7 +323,7 @@ public final class Bzip2Decompressor implements Decompressor {
                             }
                             // It used to avoid "Bzip2Decoder.decode() did not read anything but decoded a message"
                             // exception. Because previous operation may read only a few bits from
-                            // Bzip2BitReader.bitBuffer and don't read incoming ByteBuf.
+                            // Bzip2BitReader.bitBuffer and don't read incoming Buffer.
                             if (in.readerOffset() == oldReaderIndex && in.readableBytes() > 0) {
                                 reader.refill();
                             }
@@ -340,7 +340,7 @@ public final class Bzip2Decompressor implements Decompressor {
                                 int currentBlockCRC = blockDecompressor.checkCRC();
                                 streamCRC = (streamCRC << 1 | streamCRC >>> 31) ^ currentBlockCRC;
 
-                                // Return here so the ByteBuf that was put in the List will be forwarded to the user
+                                // Return here so the Buffer that was put in the List will be forwarded to the user
                                 // and so can be released as soon as possible.
                                 Buffer data = uncompressed;
                                 uncompressed = null;

--- a/codec/src/main/java/io/netty5/handler/codec/compression/Bzip2HuffmanStageDecoder.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/Bzip2HuffmanStageDecoder.java
@@ -85,7 +85,7 @@ final class Bzip2HuffmanStageDecoder {
      */
     final Bzip2MoveToFrontTable tableMTF = new Bzip2MoveToFrontTable();
 
-    // For saving state if end of current ByteBuf was reached
+    // For saving state if end of current Buffer was reached
     int currentSelector;
 
     /**
@@ -93,7 +93,7 @@ final class Bzip2HuffmanStageDecoder {
      */
     final byte[][] tableCodeLengths;
 
-    // For saving state if end of current ByteBuf was reached
+    // For saving state if end of current Buffer was reached
     int currentGroup;
     int currentLength = -1;
     int currentAlpha;

--- a/codec/src/main/java/io/netty5/handler/codec/compression/package-info.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/package-info.java
@@ -15,7 +15,7 @@
  */
 
 /**
- * Encoder and decoder which compresses and decompresses {@link io.netty5.buffer.ByteBuf}s
+ * Encoder and decoder which compresses and decompresses {@link io.netty5.buffer.Buffer}s
  * in a compression format such as <a href="https://en.wikipedia.org/wiki/Zlib">zlib</a>,
  * <a href="https://en.wikipedia.org/wiki/Gzip">gzip</a>, and
  * <a href="https://github.com/google/snappy">Snappy</a>.

--- a/codec/src/main/java/io/netty5/handler/codec/string/package-info.java
+++ b/codec/src/main/java/io/netty5/handler/codec/string/package-info.java
@@ -16,6 +16,6 @@
 
 /**
  * Encoder and decoder which transform a {@link java.lang.String} into a
- * {@link io.netty5.buffer.ByteBuf} and vice versa.
+ * {@link io.netty5.buffer.Buffer} and vice versa.
  */
 package io.netty5.handler.codec.string;

--- a/codec/src/test/java/io/netty5/handler/codec/compression/BufferChecksumTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/compression/BufferChecksumTest.java
@@ -54,12 +54,12 @@ public class BufferChecksumTest {
         try (buf) {
             // all variations of xxHash32: slow and naive, optimised, wrapped optimised;
             // the last two should be literally identical, but it's best to guard against
-            // an accidental regression in ByteBufChecksum#wrapChecksum(Checksum)
+            // an accidental regression in BufferChecksum#wrapChecksum(Checksum)
             testUpdate(xxHash32(DEFAULT_SEED), new BufferChecksum(xxHash32(DEFAULT_SEED)), buf);
             testUpdate(xxHash32(DEFAULT_SEED), new Lz4XXHash32(DEFAULT_SEED), buf);
             testUpdate(xxHash32(DEFAULT_SEED), new BufferChecksum(new Lz4XXHash32(DEFAULT_SEED)), buf);
 
-            // CRC32 and Adler32, special-cased to use ReflectiveByteBufChecksum
+            // CRC32 and Adler32, special-cased optimization
             testUpdate(new CRC32(), new BufferChecksum(new CRC32()), buf);
             testUpdate(new Adler32(), new BufferChecksum(new Adler32()), buf);
         }

--- a/handler/src/main/java/io/netty5/handler/logging/LoggingHandler.java
+++ b/handler/src/main/java/io/netty5/handler/logging/LoggingHandler.java
@@ -31,7 +31,7 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * A {@link ChannelHandler} that logs all events using a logging framework.
- * By default, all events are logged at <tt>DEBUG</tt> level and full hex dumps are recorded for ByteBufs.
+ * By default, all events are logged at <tt>DEBUG</tt> level and full hex dumps are recorded for Buffers.
  */
 @SuppressWarnings("StringBufferReplaceableByString")
 public class LoggingHandler implements ChannelHandler {
@@ -53,7 +53,7 @@ public class LoggingHandler implements ChannelHandler {
      * Creates a new instance whose logger name is the fully qualified class
      * name of the instance.
      *
-     * @param format Format of ByteBuf dumping
+     * @param format Format of Buffer dumping
      */
     public LoggingHandler(BufferFormat format) {
         this(DEFAULT_LEVEL, format);
@@ -74,7 +74,7 @@ public class LoggingHandler implements ChannelHandler {
      * name of the instance.
      *
      * @param level the log level
-     * @param bufferFormat the ByteBuf format
+     * @param bufferFormat the Buffer format
      */
     public LoggingHandler(LogLevel level, BufferFormat bufferFormat) {
         this.level = requireNonNull(level, "level").unwrap();
@@ -107,7 +107,7 @@ public class LoggingHandler implements ChannelHandler {
      *
      * @param clazz the class type to generate the logger for
      * @param level the log level
-     * @param bufferFormat the ByteBuf format
+     * @param bufferFormat the Buffer format
      */
     public LoggingHandler(Class<?> clazz, LogLevel level, BufferFormat bufferFormat) {
         requireNonNull(clazz, "clazz");
@@ -140,7 +140,7 @@ public class LoggingHandler implements ChannelHandler {
      *
      * @param name the name of the class to use for the logger
      * @param level the log level
-     * @param bufferFormat the ByteBuf format
+     * @param bufferFormat the Buffer format
      */
     public LoggingHandler(String name, LogLevel level, BufferFormat bufferFormat) {
         requireNonNull(name, "name");

--- a/handler/src/main/java/io/netty5/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -1237,7 +1237,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine
                             }
                             // We are directly using the ByteBuffer memory for the write, and so we only know what has
                             // been consumed after we let SSL decrypt the data. At this point we should update the
-                            // number of bytes consumed, update the ByteBuffer position, and release temp ByteBuf.
+                            // number of bytes consumed, update the ByteBuffer position, and release temp Buffer.
                             int localBytesConsumed = pendingEncryptedBytes - SSL.bioLengthByteBuffer(networkBIO);
                             bytesConsumed += localBytesConsumed;
                             packetLength -= localBytesConsumed;

--- a/handler/src/main/java/io/netty5/handler/stream/ChunkedWriteHandler.java
+++ b/handler/src/main/java/io/netty5/handler/stream/ChunkedWriteHandler.java
@@ -262,7 +262,7 @@ public class ChunkedWriteHandler implements ChannelHandler {
                 }
 
                 if (message == null) {
-                    // If message is null write an empty ByteBuf.
+                    // If message is null write an empty Buffer.
                     // See https://github.com/netty/netty/issues/1671
                     message = allocator.allocate(0);
                 }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/CompositeBufferGatheringWriteTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/CompositeBufferGatheringWriteTest.java
@@ -153,7 +153,7 @@ public class CompositeBufferGatheringWriteTest extends AbstractSocketTest {
 
     public void testCompositeBufferPartialWriteDoesNotCorruptData(ServerBootstrap sb, Bootstrap cb) throws Throwable {
         // The scenario is the following:
-        // Limit SO_SNDBUF so that a single buffer can be written, and part of a CompositeByteBuf at the same time.
+        // Limit SO_SNDBUF so that a single buffer can be written, and part of a CompositeBuffer at the same time.
         // We then write the single buffer, the CompositeBuffer, and another single buffer and verify the data is not
         // corrupted when we read it on the other side.
         Channel serverChannel = null;

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioDatagramChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioDatagramChannel.java
@@ -65,7 +65,7 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * An NIO {@link io.netty5.channel.socket.DatagramChannel} that sends and receives an
- * {@link AddressedEnvelope AddressedEnvelope<ByteBuf, SocketAddress>}.
+ * {@link AddressedEnvelope AddressedEnvelope<Buffer, SocketAddress>}.
  *
  * <h3>Available options</h3>
  *
@@ -281,11 +281,9 @@ public final class NioDatagramChannel
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public boolean isActive() {
         DatagramChannel ch = javaChannel();
-        return ch.isOpen() && (getOption(ChannelOption.DATAGRAM_CHANNEL_ACTIVE_ON_REGISTRATION) && isRegistered()
-                || bound);
+        return ch.isOpen() && (getOption(DATAGRAM_CHANNEL_ACTIVE_ON_REGISTRATION) && isRegistered() || bound);
     }
 
     @Override
@@ -468,7 +466,7 @@ public final class NioDatagramChannel
 
     private static void checkUnresolved(AddressedEnvelope<?, ?> envelope) {
         if (envelope.recipient() instanceof InetSocketAddress
-                && (((InetSocketAddress) envelope.recipient()).isUnresolved())) {
+                && ((InetSocketAddress) envelope.recipient()).isUnresolved()) {
             throw new UnresolvedAddressException();
         }
     }

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioSocketChannel.java
@@ -303,7 +303,7 @@ public class NioSocketChannel
                 super.doWriteNow(writeSink);
                 return;
             case 1: {
-                // Only one ByteBuf so use non-gathering write
+                // Only one Buffer so use non-gathering write
                 // Zero length buffers are not added to nioBuffers by ChannelOutboundBuffer, so there is no need
                 // to check if the total size of all the buffers is non-zero.
                 ByteBuffer buffer = nioBuffers[0];
@@ -346,7 +346,6 @@ public class NioSocketChannel
         return null;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     protected <T> T getExtendedOption(ChannelOption<T> option) {
         SocketOption<T> socketOption = NioChannelOption.toSocketOption(option);


### PR DESCRIPTION
Motivation:
Netty 5 uses a Buffer interface instead of the ByteBuf from Netty 4. Some of our javadocs are out of date, or have been forward-ported without being updated.

Modification:
- Remove all references to ByteBuf.
- Update the `io.netty5.buffer` package documentation.
- Update the `PoolChunk` javadocs.

Result:
More up to date documentation of our buffers.

Fixes #14062
