### PR TITLE
ReadyOnly*Buf must return false for isWritable(*) when sliced or duplicated

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBufferBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBufferBuf.java
@@ -483,4 +483,14 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
     public long memoryAddress() {
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public ByteBuf duplicate() {
+        return new ReadOnlyByteBufferBuf(allocator, buffer);
+    }
+
+    @Override
+    public ByteBuf slice(int index, int length) {
+        return new ReadOnlyByteBufferBuf(allocator, (ByteBuffer) buffer.duplicate().position(index).limit(length));
+    }
 }

--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBufferBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBufferBuf.java
@@ -491,6 +491,7 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     public ByteBuf slice(int index, int length) {
-        return new ReadOnlyByteBufferBuf(allocator, (ByteBuffer) buffer.duplicate().position(index).limit(length));
+        return new ReadOnlyByteBufferBuf(allocator,
+                (ByteBuffer) buffer.duplicate().position(index).limit(index + length));
     }
 }

--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyUnsafeDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyUnsafeDirectByteBuf.java
@@ -121,4 +121,14 @@ final class ReadOnlyUnsafeDirectByteBuf extends ReadOnlyByteBufferBuf {
     private long addr(int index) {
         return memoryAddress + index;
     }
+
+    @Override
+    public ByteBuf duplicate() {
+        return new ReadOnlyUnsafeDirectByteBuf(alloc(), buffer);
+    }
+
+    @Override
+    public ByteBuf slice(int index, int length) {
+        return new ReadOnlyUnsafeDirectByteBuf(alloc(), (ByteBuffer) buffer.duplicate().position(index).limit(length));
+    }
 }

--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyUnsafeDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyUnsafeDirectByteBuf.java
@@ -129,6 +129,7 @@ final class ReadOnlyUnsafeDirectByteBuf extends ReadOnlyByteBufferBuf {
 
     @Override
     public ByteBuf slice(int index, int length) {
-        return new ReadOnlyUnsafeDirectByteBuf(alloc(), (ByteBuffer) buffer.duplicate().position(index).limit(length));
+        return new ReadOnlyUnsafeDirectByteBuf(
+                alloc(), (ByteBuffer) buffer.duplicate().position(index).limit(index + length));
     }
 }

--- a/buffer/src/test/java/io/netty/buffer/ReadOnlyDirectByteBufferBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ReadOnlyDirectByteBufferBufTest.java
@@ -18,6 +18,8 @@ package io.netty.buffer;
 import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -419,6 +421,57 @@ public class ReadOnlyDirectByteBufferBufTest {
             } catch (UnsupportedOperationException expected) {
                 // expected
             }
+        } finally {
+            buf.release();
+        }
+    }
+
+    @Test
+    public void testDuplicate() {
+        ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
+        try {
+            assertEquals(buf.getClass(), buf.duplicate().getClass());
+        } finally {
+            buf.release();
+        }
+    }
+
+    @Test
+    public void testSlice() {
+        ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
+        try {
+            assertEquals(buf.getClass(), buf.slice().getClass());
+        } finally {
+            buf.release();
+        }
+    }
+
+    enum WritableParam {
+        None,
+        Duplicate,
+        Slice
+    }
+
+    @ParameterizedTest
+    @EnumSource(WritableParam.class)
+    void testIsWritable(WritableParam param) {
+        ByteBuffer buffer = allocate(24);
+        ByteBuf buf = buffer(buffer.asReadOnlyBuffer());
+        buf.writerIndex(8);
+
+        switch (param) {
+            case None:
+                break;
+            case Duplicate:
+                buf = buf.duplicate();
+                break;
+            case Slice:
+                buf = buf.slice(0, buf.capacity()).writerIndex(8);
+                break;
+        }
+        try {
+            assertFalse(buf.isWritable());
+            assertFalse(buf.isWritable(1));
         } finally {
             buf.release();
         }

--- a/buffer/src/test/java/io/netty/buffer/ReadOnlyDirectByteBufferBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ReadOnlyDirectByteBufferBufTest.java
@@ -430,7 +430,7 @@ public class ReadOnlyDirectByteBufferBufTest {
     public void testDuplicate() {
         ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
         try {
-            assertEquals(buf.getClass(), buf.duplicate().getClass());
+            assertTrue(buf.duplicate().isReadOnly());
         } finally {
             buf.release();
         }
@@ -440,7 +440,7 @@ public class ReadOnlyDirectByteBufferBufTest {
     public void testSlice() {
         ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
         try {
-            assertEquals(buf.getClass(), buf.slice().getClass());
+            assertTrue(buf.slice().isReadOnly());
         } finally {
             buf.release();
         }

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -2435,6 +2435,15 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
 
     private static boolean attemptCopyToCumulation(ByteBuf cumulation, ByteBuf next, int wrapDataSize) {
         final int inReadableBytes = next.readableBytes();
+        // Nothing to copy so just release the buffer.
+        if (inReadableBytes == 0) {
+            next.release();
+            return true;
+        }
+        // don't attempt to write to a readonly buffer. isWritable might return true for a readonly buffer.
+        if (cumulation.isReadOnly()) {
+            return false;
+        }
         final int cumulationCapacity = cumulation.capacity();
         if (wrapDataSize - cumulation.readableBytes() >= inReadableBytes &&
                 // Avoid using the same buffer if next's data would make cumulation exceed the wrapDataSize.

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -20,7 +20,6 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.channel.AbstractCoalescingBufferQueue;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelException;
@@ -72,7 +71,6 @@ import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLSession;
 
-import static io.netty.buffer.ByteBufUtil.ensureWritableSuccess;
 import static io.netty.handler.ssl.SslUtils.NOT_ENOUGH_DATA;
 import static io.netty.handler.ssl.SslUtils.getEncryptedPacketLength;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
@@ -2078,7 +2076,12 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
     public void handlerAdded(final ChannelHandlerContext ctx) throws Exception {
         this.ctx = ctx;
         Channel channel = ctx.channel();
-        pendingUnencryptedWrites = new SslHandlerCoalescingBufferQueue(channel, 16);
+        pendingUnencryptedWrites = new SslHandlerCoalescingBufferQueue(channel, 16, engineType.wantsDirectBuffer) {
+            @Override
+            protected int wrapDataSize() {
+                return SslHandler.this.wrapDataSize;
+            }
+        };
 
         setOpensslEngineSocketFd(channel);
         boolean fastOpen = Boolean.TRUE.equals(channel.config().getOption(ChannelOption.TCP_FASTOPEN_CONNECT));
@@ -2378,85 +2381,6 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
 
     private void clearState(int bit) {
         state &= ~bit;
-    }
-
-    /**
-     * Each call to SSL_write will introduce about ~100 bytes of overhead. This coalescing queue attempts to increase
-     * goodput by aggregating the plaintext in chunks of {@link #wrapDataSize}. If many small chunks are written
-     * this can increase goodput, decrease the amount of calls to SSL_write, and decrease overall encryption operations.
-     */
-    private final class SslHandlerCoalescingBufferQueue extends AbstractCoalescingBufferQueue {
-
-        SslHandlerCoalescingBufferQueue(Channel channel, int initSize) {
-            super(channel, initSize);
-        }
-
-        @Override
-        protected ByteBuf compose(ByteBufAllocator alloc, ByteBuf cumulation, ByteBuf next) {
-            final int wrapDataSize = SslHandler.this.wrapDataSize;
-            if (cumulation instanceof CompositeByteBuf) {
-                CompositeByteBuf composite = (CompositeByteBuf) cumulation;
-                int numComponents = composite.numComponents();
-                if (numComponents == 0 ||
-                        !attemptCopyToCumulation(composite.internalComponent(numComponents - 1), next, wrapDataSize)) {
-                    composite.addComponent(true, next);
-                }
-                return composite;
-            }
-            return attemptCopyToCumulation(cumulation, next, wrapDataSize) ? cumulation :
-                    copyAndCompose(alloc, cumulation, next);
-        }
-
-        @Override
-        protected ByteBuf composeFirst(ByteBufAllocator allocator, ByteBuf first) {
-            if (first instanceof CompositeByteBuf) {
-                CompositeByteBuf composite = (CompositeByteBuf) first;
-                if (engineType.wantsDirectBuffer) {
-                    first = allocator.directBuffer(composite.readableBytes());
-                } else {
-                    first = allocator.heapBuffer(composite.readableBytes());
-                }
-                try {
-                    first.writeBytes(composite);
-                } catch (Throwable cause) {
-                    first.release();
-                    PlatformDependent.throwException(cause);
-                }
-                composite.release();
-            }
-            return first;
-        }
-
-        @Override
-        protected ByteBuf removeEmptyValue() {
-            return null;
-        }
-    }
-
-    private static boolean attemptCopyToCumulation(ByteBuf cumulation, ByteBuf next, int wrapDataSize) {
-        final int inReadableBytes = next.readableBytes();
-        // Nothing to copy so just release the buffer.
-        if (inReadableBytes == 0) {
-            next.release();
-            return true;
-        }
-        // don't attempt to write to a readonly buffer. isWritable might return true for a readonly buffer.
-        if (cumulation.isReadOnly()) {
-            return false;
-        }
-        final int cumulationCapacity = cumulation.capacity();
-        if (wrapDataSize - cumulation.readableBytes() >= inReadableBytes &&
-                // Avoid using the same buffer if next's data would make cumulation exceed the wrapDataSize.
-                // Only copy if there is enough space available and the capacity is large enough, and attempt to
-                // resize if the capacity is small.
-                (cumulation.isWritable(inReadableBytes) && cumulationCapacity >= wrapDataSize ||
-                        cumulationCapacity < wrapDataSize &&
-                                ensureWritableSuccess(cumulation.ensureWritable(inReadableBytes, false)))) {
-            cumulation.writeBytes(next);
-            next.release();
-            return true;
-        }
-        return false;
     }
 
     private final class LazyChannelPromise extends DefaultPromise<Channel> {

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandlerCoalescingBufferQueue.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandlerCoalescingBufferQueue.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.CompositeByteBuf;
+import io.netty.channel.AbstractCoalescingBufferQueue;
+import io.netty.channel.Channel;
+import io.netty.util.internal.PlatformDependent;
+
+import static io.netty.buffer.ByteBufUtil.ensureWritableSuccess;
+
+/**
+ * Each call to SSL_write will introduce about ~100 bytes of overhead. This coalescing queue attempts to increase
+ * goodput by aggregating the plaintext in chunks of {@link #wrapDataSize}. If many small chunks are written
+ * this can increase goodput, decrease the amount of calls to SSL_write, and decrease overall encryption operations.
+ */
+abstract class SslHandlerCoalescingBufferQueue extends AbstractCoalescingBufferQueue {
+
+    private final boolean wantsDirectBuffer;
+
+    SslHandlerCoalescingBufferQueue(Channel channel, int initSize, boolean wantsDirectBuffer) {
+        super(channel, initSize);
+        this.wantsDirectBuffer = wantsDirectBuffer;
+    }
+
+    protected abstract int wrapDataSize();
+
+    @Override
+    protected ByteBuf compose(ByteBufAllocator alloc, ByteBuf cumulation, ByteBuf next) {
+        final int wrapDataSize = wrapDataSize();
+        if (cumulation instanceof CompositeByteBuf) {
+            CompositeByteBuf composite = (CompositeByteBuf) cumulation;
+            int numComponents = composite.numComponents();
+            if (numComponents == 0 ||
+                    !attemptCopyToCumulation(composite.internalComponent(numComponents - 1), next, wrapDataSize)) {
+                composite.addComponent(true, next);
+            }
+            return composite;
+        }
+        return attemptCopyToCumulation(cumulation, next, wrapDataSize) ? cumulation :
+                copyAndCompose(alloc, cumulation, next);
+    }
+
+    @Override
+    protected ByteBuf composeFirst(ByteBufAllocator allocator, ByteBuf first) {
+        if (first instanceof CompositeByteBuf) {
+            CompositeByteBuf composite = (CompositeByteBuf) first;
+            if (wantsDirectBuffer) {
+                first = allocator.directBuffer(composite.readableBytes());
+            } else {
+                first = allocator.heapBuffer(composite.readableBytes());
+            }
+            try {
+                first.writeBytes(composite);
+            } catch (Throwable cause) {
+                first.release();
+                PlatformDependent.throwException(cause);
+            }
+            composite.release();
+        }
+        return first;
+    }
+
+    @Override
+    protected ByteBuf removeEmptyValue() {
+        return null;
+    }
+
+    private static boolean attemptCopyToCumulation(ByteBuf cumulation, ByteBuf next, int wrapDataSize) {
+        final int inReadableBytes = next.readableBytes();
+        // Nothing to copy so just release the buffer.
+        if (inReadableBytes == 0) {
+            next.release();
+            return true;
+        }
+        final int cumulationCapacity = cumulation.capacity();
+        if (wrapDataSize - cumulation.readableBytes() >= inReadableBytes &&
+                // Avoid using the same buffer if next's data would make cumulation exceed the wrapDataSize.
+                // Only copy if there is enough space available and the capacity is large enough, and attempt to
+                // resize if the capacity is small.
+                (cumulation.isWritable(inReadableBytes) && cumulationCapacity >= wrapDataSize ||
+                        cumulationCapacity < wrapDataSize &&
+                                ensureWritableSuccess(cumulation.ensureWritable(inReadableBytes, false)))) {
+            cumulation.writeBytes(next);
+            next.release();
+            return true;
+        }
+        return false;
+    }
+}

--- a/handler/src/test/java/io/netty/handler/ssl/SslHandlerCoalescingBufferQueueTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslHandlerCoalescingBufferQueueTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.nio.ByteBuffer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SslHandlerCoalescingBufferQueueTest {
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    public void testCumulation(boolean readOnlyAndDuplicate) {
+        EmbeddedChannel channel = new EmbeddedChannel();
+        SslHandlerCoalescingBufferQueue queue = new SslHandlerCoalescingBufferQueue(channel, 16, false) {
+            @Override
+            protected int wrapDataSize() {
+                return 128;
+            }
+        };
+
+        ByteBuffer nioBuffer = ByteBuffer.allocateDirect(128);
+        nioBuffer.putLong(0);
+        nioBuffer.putLong(0);
+        nioBuffer.putLong(0);
+        nioBuffer.flip();
+        ByteBuf first;
+        if (readOnlyAndDuplicate) {
+            first = Unpooled.wrappedBuffer(nioBuffer.asReadOnlyBuffer()).duplicate();
+            first.writerIndex(8);
+        } else {
+            first = Unpooled.wrappedBuffer(nioBuffer);
+            first.writerIndex(8);
+        }
+        queue.add(first);
+        ByteBuf second = Unpooled.copyLong(1);
+        queue.add(second);
+
+        ChannelPromise promise = channel.newPromise();
+        assertFalse(queue.isEmpty());
+        ByteBuf buffer = queue.remove(UnpooledByteBufAllocator.DEFAULT, 128, promise);
+        try {
+            assertEquals(16, buffer.readableBytes());
+            assertEquals(0, buffer.readLong());
+            assertEquals(1, buffer.readLong());
+        } finally {
+            buffer.release();
+        }
+        assertTrue(queue.isEmpty());
+        assertEquals(0, first.refCnt());
+        assertEquals(0, second.refCnt());
+    }
+}


### PR DESCRIPTION
Motivation:

We need to ensure we return the correct type when duplicate() or slice(*) is called as otherwise we might return true when isWritable(...) is called

Modifications:

- Return correct type
- Add test-cases

Result:

Related to https://github.com/netty/netty/issues/14069