### PR TITLE
ReadOnlyByteBufferBuf | ReadOnlyUnsafeDirectByteBuf get*, copy*, dupl…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBufferBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBufferBuf.java
@@ -176,13 +176,25 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     public ByteBuf getBytes(int index, ByteBuf dst, int dstIndex, int length) {
+        return getBytes(index, dst, dstIndex, length, false);
+    }
+
+    @Override
+    public ByteBuf readBytes(ByteBuf dst, int dstIndex, int length) {
+        checkReadableBytes(length);
+        getBytes(readerIndex, dst, dstIndex, length, true);
+        readerIndex += length;
+        return this;
+    }
+
+    protected ByteBuf getBytes(int index, ByteBuf dst, int dstIndex, int length, boolean internal) {
         checkDstIndex(index, length, dstIndex, dst.capacity());
         if (dst.hasArray()) {
             getBytes(index, dst.array(), dst.arrayOffset() + dstIndex, length);
         } else if (dst.nioBufferCount() > 0) {
             for (ByteBuffer bb: dst.nioBuffers(dstIndex, length)) {
                 int bbLen = bb.remaining();
-                getBytes(index, bb);
+                getBytes(index, bb, internal);
                 index += bbLen;
             }
         } else {
@@ -193,9 +205,21 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     public ByteBuf getBytes(int index, byte[] dst, int dstIndex, int length) {
+        return getBytes(index, dst, dstIndex, length, false);
+    }
+
+    @Override
+    public ByteBuf readBytes(byte[] dst, int dstIndex, int length) {
+        checkReadableBytes(length);
+        getBytes(readerIndex, dst, dstIndex, length, true);
+        readerIndex += length;
+        return this;
+    }
+
+    protected ByteBuf getBytes(int index, byte[] dst, int dstIndex, int length, boolean internal) {
         checkDstIndex(index, length, dstIndex, dst.length);
 
-        ByteBuffer tmpBuf = internalNioBuffer();
+        final ByteBuffer tmpBuf = nioBuffer(internal);
         tmpBuf.clear().position(index).limit(index + length);
         tmpBuf.get(dst, dstIndex, length);
         return this;
@@ -203,9 +227,22 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     public ByteBuf getBytes(int index, ByteBuffer dst) {
+        return getBytes(index, dst, false);
+    }
+
+    @Override
+    public ByteBuf readBytes(ByteBuffer dst) {
+        int length = dst.remaining();
+        checkReadableBytes(length);
+        getBytes(readerIndex, dst, true);
+        readerIndex += length;
+        return this;
+    }
+
+    private ByteBuf getBytes(int index, ByteBuffer dst, boolean internal) {
         checkIndex(index, dst.remaining());
 
-        ByteBuffer tmpBuf = internalNioBuffer();
+        final ByteBuffer tmpBuf = nioBuffer(internal);
         tmpBuf.clear().position(index).limit(index + dst.remaining());
         dst.put(tmpBuf);
         return this;
@@ -338,6 +375,18 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     public ByteBuf getBytes(int index, OutputStream out, int length) throws IOException {
+        return getBytes(index, out, length, false);
+    }
+
+    @Override
+    public ByteBuf readBytes(OutputStream out, int length) throws IOException {
+        checkReadableBytes(length);
+        getBytes(readerIndex, out, length, true);
+        readerIndex += length;
+        return this;
+    }
+
+    private ByteBuf getBytes(int index, OutputStream out, int length, boolean internal) throws IOException {
         ensureAccessible();
         if (length == 0) {
             return this;
@@ -347,7 +396,7 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
             out.write(buffer.array(), index + buffer.arrayOffset(), length);
         } else {
             byte[] tmp = ByteBufUtil.threadLocalTempArray(length);
-            ByteBuffer tmpBuf = internalNioBuffer();
+            ByteBuffer tmpBuf = nioBuffer(internal);
             tmpBuf.clear().position(index);
             tmpBuf.get(tmp, 0, length);
             out.write(tmp, 0, length);
@@ -357,24 +406,48 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     public int getBytes(int index, GatheringByteChannel out, int length) throws IOException {
+        return getBytes(index, out, length, false);
+    }
+
+    @Override
+    public int readBytes(GatheringByteChannel out, int length) throws IOException {
+        checkReadableBytes(length);
+        int readBytes = getBytes(readerIndex, out, length, true);
+        readerIndex += readBytes;
+        return readBytes;
+    }
+
+    private int getBytes(int index, GatheringByteChannel out, int length, boolean internal) throws IOException {
         ensureAccessible();
         if (length == 0) {
             return 0;
         }
 
-        ByteBuffer tmpBuf = internalNioBuffer();
+        ByteBuffer tmpBuf = nioBuffer(internal);
         tmpBuf.clear().position(index).limit(index + length);
         return out.write(tmpBuf);
     }
 
     @Override
     public int getBytes(int index, FileChannel out, long position, int length) throws IOException {
+        return getBytes(index, out, position, length, false);
+    }
+
+    @Override
+    public int readBytes(FileChannel out, long position, int length) throws IOException {
+        checkReadableBytes(length);
+        int readBytes = getBytes(readerIndex, out, position, length, true);
+        readerIndex += readBytes;
+        return readBytes;
+    }
+
+    private int getBytes(int index, FileChannel out, long position, int length, boolean internal) throws IOException {
         ensureAccessible();
         if (length == 0) {
             return 0;
         }
 
-        ByteBuffer tmpBuf = internalNioBuffer();
+        ByteBuffer tmpBuf = nioBuffer(internal);
         tmpBuf.clear().position(index).limit(index + length);
         return out.write(tmpBuf, position);
     }
@@ -422,7 +495,8 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
         ensureAccessible();
         ByteBuffer src;
         try {
-            src = (ByteBuffer) internalNioBuffer().clear().position(index).limit(index + length);
+            // Always duplicate the buffer so it's safe to call copy from multiple threads.
+            src = (ByteBuffer) buffer.duplicate().clear().position(index).limit(index + length);
         } catch (IllegalArgumentException ignored) {
             throw new IndexOutOfBoundsException("Too many bytes to read - Need " + (index + length));
         }
@@ -482,5 +556,9 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
     @Override
     public long memoryAddress() {
         throw new UnsupportedOperationException();
+    }
+
+    private ByteBuffer nioBuffer(boolean internal) {
+        return internal ? internalNioBuffer() : buffer.duplicate();
     }
 }

--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyUnsafeDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyUnsafeDirectByteBuf.java
@@ -61,7 +61,7 @@ final class ReadOnlyUnsafeDirectByteBuf extends ReadOnlyByteBufferBuf {
     }
 
     @Override
-    public ByteBuf getBytes(int index, ByteBuf dst, int dstIndex, int length) {
+    protected ByteBuf getBytes(int index, ByteBuf dst, int dstIndex, int length, boolean internal) {
         checkIndex(index, length);
         ObjectUtil.checkNotNull(dst, "dst");
         if (dstIndex < 0 || dstIndex > dst.capacity() - length) {
@@ -79,7 +79,7 @@ final class ReadOnlyUnsafeDirectByteBuf extends ReadOnlyByteBufferBuf {
     }
 
     @Override
-    public ByteBuf getBytes(int index, byte[] dst, int dstIndex, int length) {
+    protected ByteBuf getBytes(int index, byte[] dst, int dstIndex, int length, boolean internal) {
         checkIndex(index, length);
         ObjectUtil.checkNotNull(dst, "dst");
         if (dstIndex < 0 || dstIndex > dst.length - length) {

--- a/buffer/src/test/java/io/netty/buffer/ReadOnlyDirectByteBufferBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ReadOnlyDirectByteBufferBufTest.java
@@ -15,8 +15,10 @@
  */
 package io.netty.buffer;
 
+import io.netty.util.CharsetUtil;
 import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.function.Executable;
 
 import java.io.ByteArrayInputStream;
@@ -26,7 +28,13 @@ import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.ReadOnlyBufferException;
 import java.nio.channels.FileChannel;
+import java.util.concurrent.TimeUnit;
 
+import static io.netty.buffer.AbstractByteBufTest.testBytesInArrayMultipleThreads;
+import static io.netty.buffer.AbstractByteBufTest.testCopyMultipleThreads0;
+import static io.netty.buffer.AbstractByteBufTest.testReadGatheringByteChannelMultipleThreads;
+import static io.netty.buffer.AbstractByteBufTest.testReadOutputStreamMultipleThreads;
+import static io.netty.buffer.AbstractByteBufTest.testToStringMultipleThreads0;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -421,6 +429,128 @@ public class ReadOnlyDirectByteBufferBufTest {
             }
         } finally {
             buf.release();
+        }
+    }
+
+    @Test
+    public void testDuplicateReadGatheringByteChannelMultipleThreads() throws Exception {
+        final byte[] bytes = new byte[8];
+        PlatformDependent.threadLocalRandom().nextBytes(bytes);
+        ByteBuffer nioBuffer = allocate(bytes.length);
+        nioBuffer.put(bytes);
+        nioBuffer.flip();
+        final ByteBuf buffer = buffer(nioBuffer.asReadOnlyBuffer());
+        try {
+            testReadGatheringByteChannelMultipleThreads(buffer, bytes, false);
+        } finally {
+            buffer.release();
+        }
+    }
+
+    @Test
+    public void testSliceReadGatheringByteChannelMultipleThreads() throws Exception {
+        final byte[] bytes = new byte[8];
+        PlatformDependent.threadLocalRandom().nextBytes(bytes);
+        ByteBuffer nioBuffer = allocate(bytes.length);
+        nioBuffer.put(bytes);
+        nioBuffer.flip();
+        final ByteBuf buffer = buffer(nioBuffer.asReadOnlyBuffer());
+        try {
+            testReadGatheringByteChannelMultipleThreads(buffer, bytes, true);
+        } finally {
+            buffer.release();
+        }
+    }
+
+    @Test
+    public void testDuplicateReadOutputStreamMultipleThreads() throws Exception {
+        final byte[] bytes = new byte[8];
+        PlatformDependent.threadLocalRandom().nextBytes(bytes);
+        ByteBuffer nioBuffer = allocate(bytes.length);
+        nioBuffer.put(bytes);
+        nioBuffer.flip();
+        final ByteBuf buffer = buffer(nioBuffer.asReadOnlyBuffer());
+        try {
+            testReadOutputStreamMultipleThreads(buffer, bytes, false);
+        } finally {
+            buffer.release();
+        }
+    }
+
+    @Test
+    public void testSliceReadOutputStreamMultipleThreads() throws Exception {
+        final byte[] bytes = new byte[8];
+        PlatformDependent.threadLocalRandom().nextBytes(bytes);
+        ByteBuffer nioBuffer = allocate(bytes.length);
+        nioBuffer.put(bytes);
+        nioBuffer.flip();
+        final ByteBuf buffer = buffer(nioBuffer.asReadOnlyBuffer());
+        try {
+            testReadOutputStreamMultipleThreads(buffer, bytes, true);
+        } finally {
+            buffer.release();
+        }
+    }
+
+    @Test
+    public void testDuplicateBytesInArrayMultipleThreads() throws Exception {
+        final byte[] bytes = new byte[8];
+        PlatformDependent.threadLocalRandom().nextBytes(bytes);
+        ByteBuffer nioBuffer = allocate(bytes.length);
+        nioBuffer.put(bytes);
+        nioBuffer.flip();
+        final ByteBuf buffer = buffer(nioBuffer.asReadOnlyBuffer());
+        try {
+            testBytesInArrayMultipleThreads(buffer, bytes, false);
+        } finally {
+            buffer.release();
+        }
+    }
+
+    @Test
+    public void testSliceBytesInArrayMultipleThreads() throws Exception {
+        final byte[] bytes = new byte[8];
+        PlatformDependent.threadLocalRandom().nextBytes(bytes);
+        ByteBuffer nioBuffer = allocate(bytes.length);
+        nioBuffer.put(bytes);
+        nioBuffer.flip();
+        final ByteBuf buffer = buffer(nioBuffer.asReadOnlyBuffer());
+        try {
+            testBytesInArrayMultipleThreads(buffer, bytes, true);
+        } finally {
+            buffer.release();
+        }
+    }
+
+    @Test
+    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+    public void testToStringMultipleThreads1() throws Throwable {
+        String expected = "Hello, World!";
+        byte[] bytes = expected.getBytes(CharsetUtil.ISO_8859_1);
+        ByteBuffer nioBuffer = allocate(bytes.length);
+        nioBuffer.put(bytes);
+        nioBuffer.flip();
+        final ByteBuf buffer = buffer(nioBuffer.asReadOnlyBuffer());
+        try {
+            testToStringMultipleThreads0(buffer);
+        } finally {
+            buffer.release();
+        }
+    }
+
+    @Test
+    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+    public void testCopyMultipleThreads() throws Throwable {
+        final byte[] bytes = new byte[8];
+        PlatformDependent.threadLocalRandom().nextBytes(bytes);
+        ByteBuffer nioBuffer = allocate(bytes.length);
+        nioBuffer.put(bytes);
+        nioBuffer.flip();
+        final ByteBuf buffer = buffer(nioBuffer.asReadOnlyBuffer());
+        try {
+            testCopyMultipleThreads0(buffer);
+        } finally {
+            buffer.release();
         }
     }
 }


### PR DESCRIPTION
…icate*, slice*  methods should be safe to be called from multiple threads.

Motivation:

Get* operations should always be safe to be used from different Threads.

Modifications:

- Only use internalNioBuffer when one of the read* or write* mthods are used. This is neccessary to prevent races as those can happen when a slice or duplicate is shared between different Channels
- Add unit tests

Result:

Fixes https://github.com/netty/netty/issues/14070. Related to https://github.com/netty/netty/issues/1865
