### PR TITLE
ReadOnlyByteBuf (and sub-classes) does not create derived buffers tha…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBuf.java
@@ -295,7 +295,7 @@ public class ReadOnlyByteBuf extends AbstractDerivedByteBuf {
 
     @Override
     public ByteBuf slice(int index, int length) {
-        return Unpooled.unmodifiableBuffer(unwrap().slice(index, length));
+        return new ReadOnlyByteBuf(unwrap().slice(index, length));
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBufferBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBufferBuf.java
@@ -564,12 +564,80 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     public ByteBuf duplicate() {
-        return new ReadOnlyByteBufferBuf(allocator, buffer);
+        return new ReadOnlyDuplicatedByteBuf(this);
     }
 
     @Override
     public ByteBuf slice(int index, int length) {
-        return new ReadOnlyByteBufferBuf(allocator,
-                (ByteBuffer) buffer.duplicate().position(index).limit(index + length));
+        return new ReadOnlySlicedByteBuf(this, index, length);
+    }
+
+    @Override
+    public ByteBuf asReadOnly() {
+        return this;
+    }
+
+    @SuppressWarnings("deprecation")
+    private static final class ReadOnlySlicedByteBuf extends SlicedByteBuf {
+        ReadOnlySlicedByteBuf(ByteBuf buffer, int index, int length) {
+            super(buffer, index, length);
+        }
+
+        @Override
+        public ByteBuf asReadOnly() {
+            return this;
+        }
+
+        @Override
+        public ByteBuf slice(int index, int length) {
+            return new ReadOnlySlicedByteBuf(this, index, length);
+        }
+
+        @Override
+        public ByteBuf duplicate() {
+            return new ReadOnlyDuplicatedByteBuf(this);
+        }
+
+        @Override
+        public boolean isWritable() {
+            return false;
+        }
+
+        @Override
+        public boolean isWritable(int numBytes) {
+            return false;
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    private static final class ReadOnlyDuplicatedByteBuf extends DuplicatedByteBuf {
+        ReadOnlyDuplicatedByteBuf(ByteBuf buffer) {
+            super(buffer);
+        }
+
+        @Override
+        public ByteBuf asReadOnly() {
+            return this;
+        }
+
+        @Override
+        public ByteBuf slice(int index, int length) {
+            return new ReadOnlySlicedByteBuf(this, index, length);
+        }
+
+        @Override
+        public ByteBuf duplicate() {
+            return new ReadOnlyDuplicatedByteBuf(this);
+        }
+
+        @Override
+        public boolean isWritable() {
+            return false;
+        }
+
+        @Override
+        public boolean isWritable(int numBytes) {
+            return false;
+        }
     }
 }

--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBufferBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBufferBuf.java
@@ -607,6 +607,11 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
         public boolean isWritable(int numBytes) {
             return false;
         }
+
+        @Override
+        public int ensureWritable(int minWritableBytes, boolean force) {
+            return 1;
+        }
     }
 
     @SuppressWarnings("deprecation")
@@ -638,6 +643,11 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
         @Override
         public boolean isWritable(int numBytes) {
             return false;
+        }
+
+        @Override
+        public int ensureWritable(int minWritableBytes, boolean force) {
+            return 1;
         }
     }
 }

--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyUnsafeDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyUnsafeDirectByteBuf.java
@@ -121,15 +121,4 @@ final class ReadOnlyUnsafeDirectByteBuf extends ReadOnlyByteBufferBuf {
     private long addr(int index) {
         return memoryAddress + index;
     }
-
-    @Override
-    public ByteBuf duplicate() {
-        return new ReadOnlyUnsafeDirectByteBuf(alloc(), buffer);
-    }
-
-    @Override
-    public ByteBuf slice(int index, int length) {
-        return new ReadOnlyUnsafeDirectByteBuf(
-                alloc(), (ByteBuffer) buffer.duplicate().position(index).limit(index + length));
-    }
 }

--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
@@ -2915,6 +2915,23 @@ public abstract class AbstractByteBufTest {
         buffer.release();
     }
 
+    @Test
+    public void ensureWritableWithForceAsReadyOnly() {
+        ensureWritableReadOnly(true);
+    }
+
+    @Test
+    public void ensureWritableWithOutForceAsReadOnly() {
+        ensureWritableReadOnly(false);
+    }
+
+    private void ensureWritableReadOnly(boolean force) {
+        final ByteBuf buffer = newBuffer(8);
+        buffer.writerIndex(buffer.capacity());
+        assertEquals(1, buffer.asReadOnly().ensureWritable(8, force));
+        buffer.release();
+    }
+
     // See:
     // - https://github.com/netty/netty/issues/2587
     // - https://github.com/netty/netty/issues/2580
@@ -6136,5 +6153,4 @@ public abstract class AbstractByteBufTest {
         buffer.setDoubleLE(0, Double.longBitsToDouble(0x0102030405060708L));
         assertEquals(0x0102030405060708L, Double.doubleToRawLongBits(buffer.getDoubleLE(0)));
     }
-
 }

--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
@@ -64,6 +64,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -5552,6 +5553,14 @@ public abstract class AbstractByteBufTest {
         assertEquals(0, buf.refCnt());
     }
 
+    @Test
+    public void testReadOnlyRelease() {
+        ByteBuf buf = newBuffer(8);
+        assertEquals(1, buf.refCnt());
+        assertTrue(buf.asReadOnly().release());
+        assertEquals(0, buf.refCnt());
+    }
+
     // Test-case trying to reproduce:
     // https://github.com/netty/netty/issues/2843
     @Test
@@ -6127,4 +6136,5 @@ public abstract class AbstractByteBufTest {
         buffer.setDoubleLE(0, Double.longBitsToDouble(0x0102030405060708L));
         assertEquals(0x0102030405060708L, Double.doubleToRawLongBits(buffer.getDoubleLE(0)));
     }
+
 }

--- a/buffer/src/test/java/io/netty/buffer/ReadOnlyDirectByteBufferBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ReadOnlyDirectByteBufferBufTest.java
@@ -606,4 +606,59 @@ public class ReadOnlyDirectByteBufferBufTest {
             buffer.release();
         }
     }
+
+    @Test
+    public void testReadOnlyRelease() {
+        ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
+        buf.writerIndex(4);
+        testRelease(buf, buf.asReadOnly());
+    }
+
+    @Test
+    public void testDuplicateRelease() {
+        ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
+        buf.writerIndex(4);
+        testRelease(buf, buf.duplicate());
+    }
+
+    @Test
+    public void testSliceRelease() {
+        ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
+        buf.writerIndex(4);
+        testRelease(buf, buf.slice());
+    }
+
+    @Test
+    public void testDuplicateDuplicateRelease() {
+        ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
+        buf.writerIndex(4);
+        testRelease(buf, buf.duplicate().duplicate());
+    }
+
+    @Test
+    public void testDuplicateSliceRelease() {
+        ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
+        buf.writerIndex(4);
+        testRelease(buf, buf.duplicate().duplicate());
+    }
+
+    @Test
+    public void testSliceDuplicateRelease() {
+        ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
+        buf.writerIndex(4);
+        testRelease(buf, buf.slice().duplicate());
+    }
+
+    @Test
+    public void testSliceSliceRelease() {
+        ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
+        buf.writerIndex(4);
+        testRelease(buf, buf.slice().slice());
+    }
+
+    private static void testRelease(ByteBuf parent, ByteBuf derived) {
+        assertEquals(1, parent.refCnt());
+        assertTrue(derived.release());
+        assertEquals(0, parent.refCnt());
+    }
 }

--- a/buffer/src/test/java/io/netty/buffer/ReadOnlyDirectByteBufferBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ReadOnlyDirectByteBufferBufTest.java
@@ -661,4 +661,20 @@ public class ReadOnlyDirectByteBufferBufTest {
         assertTrue(derived.release());
         assertEquals(0, parent.refCnt());
     }
+
+    @Test
+    public void ensureWritableWithForceAsReadyOnly() {
+        ensureWritableReadOnly(true);
+    }
+
+    @Test
+    public void ensureWritableWithOutForceAsReadOnly() {
+        ensureWritableReadOnly(false);
+    }
+
+    private void ensureWritableReadOnly(boolean force) {
+        ByteBuf buffer = buffer(allocate(8).asReadOnlyBuffer());
+        assertEquals(1, buffer.ensureWritable(8, force));
+        buffer.release();
+    }
 }


### PR DESCRIPTION
…t share reference count

Motivation:

The derived buffers that are created via ReadOnlyByteBuf (and sub-classes) do not share the reference count with the parent. This results in buffer leaks

Modifications:

- Correctly share reference count
- Add unit tests

Result:

Fix https://github.com/netty/netty/issues/14075
