### PR TITLE
Fix potential github action smells

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -32,9 +32,9 @@ jobs:
   verify-pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
       - name: Set up JDK 8
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4
         with:
           distribution: 'zulu'
           java-version: '8'
@@ -64,10 +64,10 @@ jobs:
     name: windows-x86_64-java11-boringssl
     needs: verify-pr
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4
         with:
           distribution: 'zulu'
           java-version: '11'
@@ -91,12 +91,12 @@ jobs:
 
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4
         with:
           name: test-results-windows-x86_64-java11-boringssl
           path: '**/target/surefire-reports/TEST-*.xml'
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4
         if: ${{ failure() }}
         with:
           name: build-pr-windows-target
@@ -121,11 +121,11 @@ jobs:
       packages: write  # for uraimo/run-on-arch-action to cache docker images
     needs: verify-pr
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
 
       # Cache .m2/repository
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
         continue-on-error: true
         with:
           path: ~/.m2/repository
@@ -134,7 +134,7 @@ jobs:
             ${{ runner.os }}-maven-build-pr-${{ matrix.arch }}-
             ${{ runner.os }}-maven-
 
-      - uses: uraimo/run-on-arch-action@v2
+      - uses: uraimo/run-on-arch-action@b395267f2e280c600d098a503bde851df600e826 # v2
         name: Run commands
         id: runcmd
         with:
@@ -195,11 +195,11 @@ jobs:
     name: ${{ matrix.setup }} build
     needs: verify-pr
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
 
       # Cache .m2/repository
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
         continue-on-error: true
         with:
           path: ~/.m2/repository
@@ -226,12 +226,12 @@ jobs:
 
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4
         with:
           name: test-results-${{ matrix.setup }}
           path: '**/target/surefire-reports/TEST-*.xml'
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4
         if: ${{ failure() }}
         with:
           name: build-${{ matrix.setup }}-target


### PR DESCRIPTION
Hey! 🙂
I've made the following changes to try and improve the github action workflows:

- Use commit hash instead of tags for action versions
  - When using a tag as version, the code related to the tag can be changed after the tag is created, whereas when using the commit hash this cannot. Therefore, for consistency and security a commit hash should be used.
- Use cache parameter instead of cache option
  - Using the cache option from the `setup/java` is easier to configure and thus less prone to mistakes. Furthermore, it makes the workflow smaller and easier to read and understand. 

(These changes are part of a research Study at TU Delft looking at GitHub Action Smells. [Find out more](https://ceddy4395.github.io/research/gha-smells.html))
