### PR TITLE
Remove unwanted mandatory dependency in OSGi

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1654,7 +1654,7 @@
               <instructions>
                 <Export-Package>${project.groupId}.*</Export-Package>
                 <!-- enforce JVM vendor package as optional -->
-                <Import-Package>sun.net.dns.*;resolution:=optional,sun.misc.*;resolution:=optional,sun.nio.ch;resolution:=optional,sun.security.*;resolution:=optional,org.eclipse.jetty.npn;version="[1,2)";resolution:=optional,org.eclipse.jetty.alpn;version="[1,2)";resolution:=optional,*</Import-Package>
+                <Import-Package>sun.net.dns.*;resolution:=optional,sun.misc.*;resolution:=optional,sun.nio.ch;resolution:=optional,sun.security.*;resolution:=optional,org.eclipse.jetty.npn;version="[1,2)";resolution:=optional,org.eclipse.jetty.alpn;version="[1,2)";resolution:=optional,org.bouncycastle.jcajce.provider;version="[1.0,2)";resolution:=optional,*</Import-Package>
                 <!-- override "internal" private package convention -->
                 <Private-Package>!*</Private-Package>
               </instructions>


### PR DESCRIPTION
Motivation:

The BouncyCastle bc-fips dependency was inadvertently added as a mandatory dependency by:
https://github.com/netty/netty/commit/d868c7b5926c0c00a2367543ba91901072cce636
The intention of the commit was to make it possible to replace bcpkix and bcprov with bcpkix-fips and bc-fips.
Because bc-prov is not added as a depenency in the pom file the mave-bundle-plugin defaults to make it mandatory.

Modification:

Add maven-bundle-plugin configuration to make bc-fips optional in OSGi deployments like all other BouncyCastle bundles are.

Result:

The netty-handler bundle has a optional dependency instead of a mandatory dependency on bc-fips in OSGi deployments.

Fixes #14080.