### PR TITLE
HashedWheelTimer.stop() must cancel tasks.

### DIFF
--- a/common/src/main/java/io/netty/util/HashedWheelTimer.java
+++ b/common/src/main/java/io/netty/util/HashedWheelTimer.java
@@ -418,7 +418,14 @@ public class HashedWheelTimer implements Timer {
                 assert closed;
             }
         }
-        return worker.unprocessedTimeouts();
+        Set<Timeout> unprocessed = worker.unprocessedTimeouts();
+        Set<Timeout> cancelled = new HashSet<Timeout>(unprocessed.size());
+        for (Timeout timeout : unprocessed) {
+            if (timeout.cancel()) {
+                cancelled.add(timeout);
+            }
+        }
+        return cancelled;
     }
 
     @Override

--- a/common/src/test/java/io/netty/util/HashedWheelTimerTest.java
+++ b/common/src/test/java/io/netty/util/HashedWheelTimerTest.java
@@ -280,6 +280,24 @@ public class HashedWheelTimerTest {
         timer.stop();
     }
 
+    @Test
+    @org.junit.jupiter.api.Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
+    public void testStopTimerCancelsPendingTasks() throws InterruptedException {
+        final Timer timerUnprocessed = new HashedWheelTimer();
+        for (int i = 0; i < 5; i ++) {
+            timerUnprocessed.newTimeout(new TimerTask() {
+                @Override
+                public void run(Timeout timeout) throws Exception {
+                }
+            }, 5, TimeUnit.SECONDS);
+        }
+        Thread.sleep(1000L); // sleep for a second
+
+        for (Timeout timeout : timerUnprocessed.stop()) {
+            assertTrue(timeout.isCancelled(), "All unprocessed tasks should be canceled");
+        }
+    }
+
     private static TimerTask createNoOpTimerTask() {
         return new TimerTask() {
             @Override


### PR DESCRIPTION
Motivation:

HashedWheelTimer must mark all tasks that were not processed as cancelled before returning them.

Modifications:

- Cancel tasks
- Add unit test

Result:

Fixes https://github.com/netty/netty/issues/14081