### PR TITLE
Optimize wrap buffer cumulation in SslHandler and don't mutate input buffers 

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -1106,9 +1106,8 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
                 // which is better then walking the composed ByteBuf in most cases.
                 if (!(in instanceof CompositeByteBuf) && in.nioBufferCount() == 1) {
                     in0 = singleBuffer;
-                    // We know its only backed by 1 ByteBuffer so use internalNioBuffer to keep object allocation
-                    // to a minimum.
-                    in0[0] = in.internalNioBuffer(readerIndex, readableBytes);
+                    // use nioBuffer method since calling internalNioBuffer isn't thread safe
+                    in0[0] = in.nioBuffer(readerIndex, readableBytes);
                 } else {
                     in0 = in.nioBuffers();
                 }

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -1106,8 +1106,9 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
                 // which is better then walking the composed ByteBuf in most cases.
                 if (!(in instanceof CompositeByteBuf) && in.nioBufferCount() == 1) {
                     in0 = singleBuffer;
-                    // use nioBuffer method since calling internalNioBuffer isn't thread safe
-                    in0[0] = in.nioBuffer(readerIndex, readableBytes);
+                    // We know its only backed by 1 ByteBuffer so use internalNioBuffer to keep object allocation
+                    // to a minimum.
+                    in0[0] = in.internalNioBuffer(readerIndex, readableBytes);
                 } else {
                     in0 = in.nioBuffers();
                 }

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandlerCoalescingBufferQueue.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandlerCoalescingBufferQueue.java
@@ -48,7 +48,7 @@ abstract class SslHandlerCoalescingBufferQueue extends AbstractCoalescingBufferQ
 
     @Override
     protected ByteBuf composeFirst(ByteBufAllocator allocator, ByteBuf first, int bufferSize) {
-        ByteBuf newFirst;
+        final ByteBuf newFirst;
         if (wantsDirectBuffer) {
             newFirst = allocator.directBuffer(bufferSize);
         } else {

--- a/handler/src/test/java/io/netty/handler/ssl/SslHandlerCoalescingBufferQueueTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslHandlerCoalescingBufferQueueTest.java
@@ -21,19 +21,82 @@ import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.nio.ByteBuffer;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SslHandlerCoalescingBufferQueueTest {
+    static final Supplier<ByteBuf> BYTEBUF_SUPPLIER = new Supplier<ByteBuf>() {
+        @Override
+        public ByteBuf get() {
+            ByteBuf buf = Unpooled.directBuffer(128);
+            buf.writeLong(1);
+            buf.writeLong(2);
+            return buf;
+        }
+    };
+    static final Function<ByteBuf, ByteBuf> NO_WRAPPER = new Function<ByteBuf, ByteBuf>() {
+        @Override
+        public ByteBuf apply(ByteBuf byteBuf) {
+            return byteBuf;
+        }
+    };
+    static final Function<ByteBuf, ByteBuf> DUPLICATE_WRAPPER = new Function<ByteBuf, ByteBuf>() {
+        @Override
+        public ByteBuf apply(ByteBuf byteBuf) {
+            return byteBuf.duplicate();
+        }
+    };
+    static final Function<ByteBuf, ByteBuf> SLICE_WRAPPER = new Function<ByteBuf, ByteBuf>() {
+        @Override
+        public ByteBuf apply(ByteBuf byteBuf) {
+            return byteBuf.slice();
+        }
+    };
+    static ByteBuffer createNioBuffer() {
+        ByteBuffer nioBuffer = ByteBuffer.allocateDirect(128);
+        nioBuffer.putLong(1);
+        nioBuffer.putLong(2);
+        nioBuffer.position(nioBuffer.limit());
+        nioBuffer.flip();
+        return nioBuffer;
+    }
+
+    enum CumulationTestScenario {
+        BASIC_NIO_BUFFER(new Supplier() {
+            @Override
+            public ByteBuf get() {
+                return Unpooled.wrappedBuffer(createNioBuffer());
+            }
+        }, NO_WRAPPER),
+        READ_ONLY_AND_DUPLICATE_NIO_BUFFER(new Supplier() {
+            @Override
+            public ByteBuf get() {
+                return Unpooled.wrappedBuffer(createNioBuffer().asReadOnlyBuffer());
+            }
+        }, DUPLICATE_WRAPPER),
+        BASIC_DIRECT_BUFFER(BYTEBUF_SUPPLIER, NO_WRAPPER),
+        DUPLICATE_DIRECT_BUFFER(BYTEBUF_SUPPLIER, DUPLICATE_WRAPPER),
+        SLICED_DIRECT_BUFFER(BYTEBUF_SUPPLIER, SLICE_WRAPPER);
+
+        final Supplier<ByteBuf> bufferSupplier;
+        final Function<ByteBuf, ByteBuf> bufferWrapper;
+
+        CumulationTestScenario(Supplier<ByteBuf> bufferSupplier, Function<ByteBuf, ByteBuf> bufferWrapper) {
+            this.bufferSupplier = bufferSupplier;
+            this.bufferWrapper = bufferWrapper;
+        }
+    }
 
     @ParameterizedTest
-    @ValueSource(booleans = { true, false })
-    public void testCumulation(boolean readOnlyAndDuplicate) {
+    @EnumSource(CumulationTestScenario.class)
+    public void testCumulation(CumulationTestScenario testScenario) {
         EmbeddedChannel channel = new EmbeddedChannel();
         SslHandlerCoalescingBufferQueue queue = new SslHandlerCoalescingBufferQueue(channel, 16, false) {
             @Override
@@ -42,20 +105,9 @@ public class SslHandlerCoalescingBufferQueueTest {
             }
         };
 
-        ByteBuffer nioBuffer = ByteBuffer.allocateDirect(128);
-        nioBuffer.putLong(1);
-        nioBuffer.putLong(2);
-        // use the whole buffer so that the wrapper will have the capacity of 128
-        nioBuffer.position(nioBuffer.limit());
-        nioBuffer.flip();
-        ByteBuf first;
-        if (readOnlyAndDuplicate) {
-            first = Unpooled.wrappedBuffer(nioBuffer.asReadOnlyBuffer()).duplicate();
-            first.writerIndex(8);
-        } else {
-            first = Unpooled.wrappedBuffer(nioBuffer);
-            first.writerIndex(8);
-        }
+        ByteBuf original = testScenario.bufferSupplier.get();
+        original.writerIndex(8);
+        ByteBuf first = testScenario.bufferWrapper.apply(original);
         first.retain();
         queue.add(first);
         ByteBuf second = Unpooled.copyLong(3);
@@ -72,8 +124,9 @@ public class SslHandlerCoalescingBufferQueueTest {
             buffer.release();
         }
         assertTrue(queue.isEmpty());
-        assertEquals(8, first.writerIndex());
-        assertEquals(2, first.getLong(first.writerIndex()));
+        assertEquals(8, original.writerIndex());
+        original.writerIndex(original.capacity());
+        assertEquals(2, original.getLong(8));
         first.release();
         assertEquals(0, first.refCnt());
         assertEquals(0, second.refCnt());

--- a/transport/src/main/java/io/netty/channel/AbstractCoalescingBufferQueue.java
+++ b/transport/src/main/java/io/netty/channel/AbstractCoalescingBufferQueue.java
@@ -334,6 +334,7 @@ public abstract class AbstractCoalescingBufferQueue {
      * Calculate the first {@link ByteBuf} which will be used in subsequent calls to
      * {@link #compose(ByteBufAllocator, ByteBuf, ByteBuf)}.
      * @param bufferSize the optimal size of the buffer needed for cumulation
+     * @return the first buffer
      */
     protected ByteBuf composeFirst(ByteBufAllocator allocator, ByteBuf first, int bufferSize) {
         return composeFirst(allocator, first);
@@ -344,6 +345,7 @@ public abstract class AbstractCoalescingBufferQueue {
      * {@link #compose(ByteBufAllocator, ByteBuf, ByteBuf)}.
      * This method is deprecated and will be removed in the future. Implementing classes should
      * override {@link #composeFirst(ByteBufAllocator, ByteBuf, int)} instead.
+     * @deprecated Use {AbstractCoalescingBufferQueue#composeFirst(ByteBufAllocator, ByteBuf, int)}
      */
     @Deprecated
     protected ByteBuf composeFirst(ByteBufAllocator allocator, ByteBuf first) {

--- a/transport/src/main/java/io/netty/channel/AbstractCoalescingBufferQueue.java
+++ b/transport/src/main/java/io/netty/channel/AbstractCoalescingBufferQueue.java
@@ -181,10 +181,10 @@ public abstract class AbstractCoalescingBufferQueue {
 
                     bytes -= bufferBytes;
                     if (toReturn == null) {
-                        // if there are no more bytes in the queue after this, there's no reason to compose
-                        toReturn = bufferBytes == readableBytes
+                        // if there are no more bytes to read, there's no reason to compose
+                        toReturn = bytes == 0
                                 ? entryBuffer
-                                : composeFirst(alloc, entryBuffer);
+                                : composeFirst(alloc, entryBuffer, bufferBytes + bytes);
                     } else {
                         toReturn = compose(alloc, toReturn, entryBuffer);
                     }
@@ -333,7 +333,19 @@ public abstract class AbstractCoalescingBufferQueue {
     /**
      * Calculate the first {@link ByteBuf} which will be used in subsequent calls to
      * {@link #compose(ByteBufAllocator, ByteBuf, ByteBuf)}.
+     * @param bufferSize the optimal size of the buffer needed for cumulation
      */
+    protected ByteBuf composeFirst(ByteBufAllocator allocator, ByteBuf first, int bufferSize) {
+        return composeFirst(allocator, first);
+    }
+
+    /**
+     * Calculate the first {@link ByteBuf} which will be used in subsequent calls to
+     * {@link #compose(ByteBufAllocator, ByteBuf, ByteBuf)}.
+     * This method is deprecated and will be removed in the future. Implementing classes should
+     * override {@link #composeFirst(ByteBufAllocator, ByteBuf, int)} instead.
+     */
+    @Deprecated
     protected ByteBuf composeFirst(ByteBufAllocator allocator, ByteBuf first) {
         return first;
     }


### PR DESCRIPTION
Motivation:

SslHandler doesn't support sharing the input buffers since the input buffers get mutated. This issue has been reported as #14069. Fixes have already been made to support the use case using read-only buffers as input. However, this is not useful for existing Netty applications.

I checked the Netty code once again and noticed that it's possible to optimize the current implementation in SslHandler and avoid the buffer mutation.

The default behavior in SslHandler causes very hard to debug problems. In Pulsar, there have been issues open for multiple years that have been caused by the SslHandler's default behavior of mutating the input buffers (apache/pulsar#22601 is one starting point to the issues). 

The current implementation of SslHandler will mutate the input buffers by using the input buffer as a cumulation buffer when there's available capacity. This is not optimal at all. This PR contains an improvement where the cumulation buffer is allocated to the final size immediately so that cumulation is more optimal. That's why I think that this will be more optimal in the end and won't cause performance regressions.

After these changes, it should be possible to pass a slice or duplicate of a buffer and the input buffer doesn't get mutated. The input buffer's readIndex will be modified so multiple threads cannot share the same input buffer without a slice or duplicate.

I created a failing test case that shows that a duplicate buffer doesn't prevent input buffer mutation.
![image](https://github.com/netty/netty/assets/66864/0abec333-6079-40bd-8bc1-ccfd3df6fae1)
It's a very surprising behavior of SslHandler that passing a `.retainedDuplicate()` buffer could result in mutations to the original buffer. That's another reason why I think that SslHandler shouldn't ever mutate the inputs.

Modification:

- add `protected ByteBuf composeFirst(ByteBufAllocator allocator, ByteBuf first, int bufferSize)` to AbstractCoalescingBufferQueue to support allocating an optimal cumulation buffer instead of using the input buffer as a cumulation buffer
- remove dead code from `compose` where there was handling for CompositeByteBuf
  - `composeFirst` will be called before `compose` so this case isn't needed.

Result:

Fixes #14069 without the need to set the input buffer as read-only