### PR TITLE
Prepare for unsafe memory access deprecated for removal

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -25,6 +25,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
+import java.nio.file.NoSuchFileException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.concurrent.atomic.AtomicLong;
@@ -140,18 +141,52 @@ final class PlatformDependent0 {
                 logger.debug("sun.misc.Unsafe.theUnsafe: available");
             }
 
-            // ensure the unsafe supports all necessary methods to work around the mistake in the latest OpenJDK
+            // ensure the unsafe supports all necessary methods to work around the mistake in the latest OpenJDK,
+            // or that they haven't been removed by JEP 471.
             // https://github.com/netty/netty/issues/1061
             // https://www.mail-archive.com/jdk6-dev@openjdk.java.net/msg00698.html
+            // https://openjdk.org/jeps/471
             if (unsafe != null) {
                 final Unsafe finalUnsafe = unsafe;
                 final Object maybeException = AccessController.doPrivileged(new PrivilegedAction<Object>() {
                     @Override
                     public Object run() {
                         try {
-                            finalUnsafe.getClass().getDeclaredMethod(
+                            // Other methods like storeFence() and invokeCleaner() are tested for elsewhere.
+                            Class<? extends Unsafe> cls = finalUnsafe.getClass();
+                            cls.getDeclaredMethod("objectFieldOffset", Field.class);
+                            cls.getDeclaredMethod("staticFieldOffset", Field.class);
+                            cls.getDeclaredMethod("staticFieldBase", Field.class);
+                            cls.getDeclaredMethod("arrayBaseOffset", Class.class);
+                            cls.getDeclaredMethod("arrayIndexScale", Class.class);
+                            cls.getDeclaredMethod("allocateMemory", long.class);
+                            cls.getDeclaredMethod("reallocateMemory", long.class, long.class);
+                            cls.getDeclaredMethod("freeMemory", long.class);
+                            cls.getDeclaredMethod("setMemory", long.class, long.class, byte.class);
+                            cls.getDeclaredMethod("setMemory", Object.class, long.class, long.class, byte.class);
+                            cls.getDeclaredMethod(
                                     "copyMemory", Object.class, long.class, Object.class, long.class, long.class);
+                            cls.getDeclaredMethod("getBoolean", Object.class, long.class);
+                            cls.getDeclaredMethod("getByte", long.class);
+                            cls.getDeclaredMethod("getByte", Object.class, long.class);
+                            cls.getDeclaredMethod("getInt", long.class);
+                            cls.getDeclaredMethod("getInt", Object.class, long.class);
+                            cls.getDeclaredMethod("getLong", long.class);
+                            cls.getDeclaredMethod("getLong", Object.class, long.class);
+                            cls.getDeclaredMethod("putByte", long.class, byte.class);
+                            cls.getDeclaredMethod("putByte", Object.class, long.class, byte.class);
+                            cls.getDeclaredMethod("putInt", long.class, int.class);
+                            cls.getDeclaredMethod("putInt", Object.class, long.class, int.class);
+                            cls.getDeclaredMethod("putLong", long.class, long.class);
+                            cls.getDeclaredMethod("putLong", Object.class, long.class, long.class);
+                            cls.getDeclaredMethod("addressSize");
+                            // The following may throw UnsupportedOperationException:
+                            long address = finalUnsafe.allocateMemory(Long.BYTES);
+                            finalUnsafe.putLong(address, 42);
+                            finalUnsafe.freeMemory(address);
                             return null;
+                        } catch (UnsupportedOperationException e) {
+                            return e;
                         } catch (NoSuchMethodException e) {
                             return e;
                         } catch (SecurityException e) {
@@ -161,15 +196,15 @@ final class PlatformDependent0 {
                 });
 
                 if (maybeException == null) {
-                    logger.debug("sun.misc.Unsafe.copyMemory: available");
+                    logger.debug("sun.misc.Unsafe base methods: all available");
                 } else {
                     // Unsafe.copyMemory(Object, long, Object, long, long) unavailable.
                     unsafe = null;
                     unsafeUnavailabilityCause = (Throwable) maybeException;
                     if (logger.isTraceEnabled()) {
-                        logger.debug("sun.misc.Unsafe.copyMemory: unavailable", (Throwable) maybeException);
+                        logger.debug("sun.misc.Unsafe method unavailable:", unsafeUnavailabilityCause);
                     } else {
-                        logger.debug("sun.misc.Unsafe.copyMemory: unavailable: {}",
+                        logger.debug("sun.misc.Unsafe method unavailable: {}",
                                 ((Throwable) maybeException).getMessage());
                     }
                 }
@@ -511,8 +546,15 @@ final class PlatformDependent0 {
     }
 
     private static Throwable explicitNoUnsafeCause0() {
-        final boolean noUnsafe = SystemPropertyUtil.getBoolean("io.netty.noUnsafe", false);
+        boolean noUnsafe = SystemPropertyUtil.getBoolean("io.netty.noUnsafe", false);
         logger.debug("-Dio.netty.noUnsafe: {}", noUnsafe);
+
+        // See JDK 23 JEP 471 https://openjdk.org/jeps/471 and sun.misc.Unsafe.beforeMemoryAccess() on JDK 23+.
+        String unsafeMemoryAccess = SystemPropertyUtil.get("sun.misc.unsafe.memory.access", "<unspecified>");
+        if (!("allow".equals(unsafeMemoryAccess) || "<unspecified>".equals(unsafeMemoryAccess))) {
+            logger.debug("--sun-misc-unsafe-memory-access={}", unsafeMemoryAccess);
+            noUnsafe = true;
+        }
 
         if (noUnsafe) {
             logger.debug("sun.misc.Unsafe: unavailable (io.netty.noUnsafe)");


### PR DESCRIPTION
Motivation:
Java 23 will introduce JEP 471 (https://openjdk.org/jeps/471) which deprecates all unsafe memory access methods for removal.

The JEP also starts the removal phase, by introducing a new `--sun-misc-unsafe-memory-access={allow|warn|debug|deny}` command line option. Initially, unsafe memory access will be allowed, but will in future Java versions produce warnings, and then eventually denying access by default. When access is denied, then calling the unsafe memory access methods will produce an `UnsupportedOperationException`.

Modification:
Include the value of `--sun-misc-unsafe-memory-access` in the consideration of explicit-no-unsafe computation. The command line value is available as the `sun.misc.unsafe.memory.access` system property. If the value is not either "allow" or unspecified, then unsafe is explicitly turned off.

Add many more tests to the unsafe availability, probing for all the unsafe memory access methods we use, and also testing some of them with direct calls.

Result:
We should hopefully not see any warnings, or "NoSuchMethodErrors", in the future.

Motivation:

Explain here the context, and why you're making that change.
What is the problem you're trying to solve.

Modification:

Describe the modifications you've done.

Result:

Fixes #<GitHub issue number>. 

If there is no issue then describe the changes introduced by this PR.
