### PR TITLE
Duplicate of slice should have the same capacity as the original slice so that it's not writable

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractUnpooledSlicedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractUnpooledSlicedByteBuf.java
@@ -215,7 +215,12 @@ abstract class AbstractUnpooledSlicedByteBuf extends AbstractDerivedByteBuf {
 
     @Override
     public ByteBuf duplicate() {
-        return unwrap().duplicate().setIndex(idx(readerIndex()), idx(writerIndex()));
+        return slice(0, capacity()).setIndex(readerIndex(), writerIndex());
+    }
+
+    @Override
+    public ByteBuf retainedDuplicate() {
+        return retainedSlice(0, capacity()).setIndex(readerIndex(), writerIndex());
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/PooledSlicedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledSlicedByteBuf.java
@@ -115,12 +115,12 @@ final class PooledSlicedByteBuf extends AbstractPooledDerivedByteBuf {
 
     @Override
     public ByteBuf duplicate() {
-        return duplicate0().setIndex(idx(readerIndex()), idx(writerIndex()));
+        return slice(0, capacity()).setIndex(readerIndex(), writerIndex());
     }
 
     @Override
     public ByteBuf retainedDuplicate() {
-        return PooledDuplicatedByteBuf.newInstance(unwrap(), this, idx(readerIndex()), idx(writerIndex()));
+        return retainedSlice(0, capacity()).setIndex(readerIndex(), writerIndex());
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBufferBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBufferBuf.java
@@ -595,7 +595,7 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
 
         @Override
         public ByteBuf duplicate() {
-            return new ReadOnlyDuplicatedByteBuf(this);
+            return slice(0, capacity()).setIndex(readerIndex(), writerIndex());
         }
 
         @Override

--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
@@ -2138,6 +2138,52 @@ public abstract class AbstractByteBufTest {
     }
 
     @Test
+    public void testDuplicateOfSliceHasTheSameCapacityAsTheSlice() {
+        ByteBuf slice = buffer.slice();
+        ByteBuf duplicate = slice.duplicate();
+        assertEquals(slice.capacity(), duplicate.capacity());
+
+        slice = buffer.slice(0, buffer.capacity() - 2);
+        duplicate = slice.duplicate();
+        assertEquals(slice.capacity(), duplicate.capacity());
+
+        slice = buffer.slice();
+        duplicate = slice.retainedDuplicate();
+        assertEquals(slice.capacity(), duplicate.capacity());
+        duplicate.release();
+
+        slice = buffer.slice(0, buffer.capacity() - 2);
+        duplicate = slice.retainedDuplicate();
+        assertEquals(slice.capacity(), duplicate.capacity());
+        duplicate.release();
+    }
+
+    @Test
+    public void testDuplicateOfRetainedSliceHasTheSameCapacityAsTheSlice() {
+        ByteBuf slice = buffer.retainedSlice();
+        ByteBuf duplicate = slice.duplicate();
+        assertEquals(slice.capacity(), duplicate.capacity());
+        slice.release();
+
+        slice = buffer.retainedSlice(0, buffer.capacity() - 2);
+        duplicate = slice.duplicate();
+        assertEquals(slice.capacity(), duplicate.capacity());
+        slice.release();
+
+        slice = buffer.retainedSlice();
+        duplicate = slice.retainedDuplicate();
+        assertEquals(slice.capacity(), duplicate.capacity());
+        slice.release();
+        duplicate.release();
+
+        slice = buffer.retainedSlice(0, buffer.capacity() - 2);
+        duplicate = slice.retainedDuplicate();
+        assertEquals(slice.capacity(), duplicate.capacity());
+        slice.release();
+        duplicate.release();
+    }
+
+    @Test
     @SuppressWarnings("ObjectEqualsNull")
     public void testEquals() {
         assertFalse(buffer.equals(null));

--- a/buffer/src/test/java/io/netty/buffer/ReadOnlyByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ReadOnlyByteBufTest.java
@@ -297,4 +297,59 @@ public class ReadOnlyByteBufTest {
         assertSame(readOnly, readOnly.asReadOnly());
         readOnly.release();
     }
+
+    @Test
+    public void testDuplicateOfSliceHasTheSameCapacityAsTheSlice() {
+        ByteBuf buffer = buffer(16);
+
+        ByteBuf slice = buffer.slice();
+        ByteBuf duplicate = slice.duplicate();
+        assertEquals(slice.capacity(), duplicate.capacity());
+
+        slice = buffer.slice(0, buffer.capacity() - 2);
+        duplicate = slice.duplicate();
+        assertEquals(slice.capacity(), duplicate.capacity());
+
+        slice = buffer.slice();
+        duplicate = slice.retainedDuplicate();
+        assertEquals(slice.capacity(), duplicate.capacity());
+        duplicate.release();
+
+        slice = buffer.slice(0, buffer.capacity() - 2);
+        duplicate = slice.retainedDuplicate();
+        assertEquals(slice.capacity(), duplicate.capacity());
+        duplicate.release();
+
+        buffer.release();
+    }
+
+    @Test
+    public void testDuplicateOfRetainedSliceHasTheSameCapacityAsTheSlice() {
+        ByteBuf buffer = buffer(16);
+
+        ByteBuf slice = buffer.retainedSlice();
+        ByteBuf duplicate = slice.duplicate();
+        assertEquals(slice.capacity(), duplicate.capacity());
+        slice.release();
+
+        slice = buffer.retainedSlice(0, buffer.capacity() - 2);
+        duplicate = slice.duplicate();
+        assertEquals(slice.capacity(), duplicate.capacity());
+        slice.release();
+
+        slice = buffer.retainedSlice();
+        duplicate = slice.retainedDuplicate();
+        assertEquals(slice.capacity(), duplicate.capacity());
+        slice.release();
+        duplicate.release();
+
+        slice = buffer.retainedSlice(0, buffer.capacity() - 2);
+        duplicate = slice.retainedDuplicate();
+        assertEquals(slice.capacity(), duplicate.capacity());
+        slice.release();
+        duplicate.release();
+
+        buffer.release();
+    }
+
 }


### PR DESCRIPTION
Motivation:

The issue https://github.com/netty/netty/issues/12919 is titled "ByteBuf slice duplicates are not slices". This behavior is very surprising. It explains why the SslHandler has been causing issues in Apache Pulsar. The incoming messages come from the network and use the LengthFieldBasedFrameDecoder, which slices the buffer into frame buffers. Pulsar later calls retainedDuplicate. This removes the effect of slicing (as described in issue https://github.com/netty/netty/issues/12919) and makes the buffer writable. The impact of this is that the original buffer used by the LengthFieldBasedFrameDecoder gets mutated by the SslHandler later when the sliced frame buffer (which is made writable with .retainedDuplicate) is passed to the Apache Bookkeeper client, which also uses Netty and contains an SslHandler. The SslHandler's cumulation in the attemptCopyToCumulation method thinks that it's fine to mutate the input buffer since it's writable and that's what causes data corruption.

Issue https://github.com/netty/netty/issues/12919 references the vert.x issue https://github.com/eclipse-vertx/vert.x/issues/4509. It seems vert.x applied a workaround in https://github.com/eclipse-vertx/vert.x/issues/4517.

I also found a workaround for a data corruption issue within Netty's http codecs, https://github.com/netty/netty/pull/11802. That was to address https://github.com/netty/netty/issues/11792.

Such workarounds won't be needed when we eliminate the surprising behaviour. The PR will address it for Sslhandler and also optimise the cumulation. I think https://github.com/netty/netty/issues/12919 should also be addressed so that a duplicating a slice doesn't provide write access to the parent buffer outside of the slice.

Modification:

For sliced buffers, make the `duplicate()` method duplicate the slice and not the underlying buffer.
When I was working on the changes, I noticed that `io.netty.buffer.AdaptivePoolingAllocator.PooledNonRetainedSlicedByteBuf` had already implemented `duplicate` so that it duplicates the slice and not the underlying buffer:
https://github.com/netty/netty/blob/ecebe1c102cf9a9e2faaccbfc12f594963af7326/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java#L1238-L1242

Result:

Fixes  #12919.

If there is no issue then describe the changes introduced by this PR.
