### PR TITLE
Upgrade to jctools from 3.1.0 to 4.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -962,7 +962,7 @@
       <dependency>
         <groupId>org.jctools</groupId>
         <artifactId>jctools-core</artifactId>
-        <version>3.1.0</version>
+        <version>4.0.5</version>
       </dependency>
 
       <!-- Annotations for IDE integration and analysis -->


### PR DESCRIPTION
Motivation:

* jctools 3.1.0 is almost 4 years old.
* jctools 4 is still compatible with Java 6, hence with Netty 4.1.