### PR TITLE
Add missing NULL checks in native code

### DIFF
--- a/transport-native-epoll/src/main/c/netty_epoll_linuxsocket.c
+++ b/transport-native-epoll/src/main/c/netty_epoll_linuxsocket.c
@@ -698,6 +698,9 @@ static jobject netty_epoll_linuxsocket_getPeerCredentials(JNIEnv *env, jclass cl
          return NULL;
      }
      jintArray gids = (*env)->NewIntArray(env, 1);
+     if (gids == NULL) {
+        return NULL;
+     }
      (*env)->SetIntArrayRegion(env, gids, 0, 1, (jint*) &credentials.gid);
 
      NETTY_JNI_UTIL_NEW_LOCAL_FROM_WEAK(env, peerCredentialsClass, peerCredentialsClassWeak, error);

--- a/transport-native-io_uring/src/main/c/netty_io_uring_linuxsocket.c
+++ b/transport-native-io_uring/src/main/c/netty_io_uring_linuxsocket.c
@@ -635,6 +635,9 @@ static jobject netty_io_uring_linuxsocket_getPeerCredentials(JNIEnv *env, jclass
          return NULL;
      }
      jintArray gids = (*env)->NewIntArray(env, 1);
+     if (gids == NULL) {
+        return NULL;
+     }
      (*env)->SetIntArrayRegion(env, gids, 0, 1, (jint*) &credentials.gid);
 
      NETTY_JNI_UTIL_NEW_LOCAL_FROM_WEAK(env, peerCredentialsClass, peerCredentialsClassWeak, error);

--- a/transport-native-io_uring/src/main/c/netty_io_uring_native.c
+++ b/transport-native-io_uring/src/main/c/netty_io_uring_native.c
@@ -218,6 +218,9 @@ static jboolean netty_io_uring_probe(JNIEnv *env, jclass clazz, jint ring_fd, ji
 
     jsize opsLen = (*env)->GetArrayLength(env, ops);
     jint *opsElements = (*env)->GetIntArrayElements(env, ops, 0);
+    if (opsElements == NULL) {
+        goto done;
+    }
     int i;
     for (i = 0; i < opsLen; i++) {
         int op = opsElements[i];

--- a/transport-native-unix-common/src/main/c/netty_unix_socket.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_socket.c
@@ -1170,7 +1170,7 @@ static void netty_unix_socket_setIntOpt(JNIEnv* env, jclass clazz, jint fd, jint
 static void netty_unix_socket_setRawOptArray(JNIEnv* env, jclass clazz, jint fd, jint level, jint optname, jbyteArray inArray, jint offset, jint len) {
     jbyte* optval = (*env)->GetByteArrayElements(env, inArray, 0);
     if (optval == NULL) {
-        return:
+        return;
     }
     netty_unix_socket_setOption(env, fd, level, optname, optval + offset, len);
     (*env)->ReleaseByteArrayElements(env, inArray, optval, 0);

--- a/transport-native-unix-common/src/main/c/netty_unix_socket.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_socket.c
@@ -384,6 +384,9 @@ static jint _sendToDomainSocket(JNIEnv* env, jint fd, void* buffer, jint pos, ji
     addr.sun_family = AF_UNIX;
 
     jbyte* socket_path = (*env)->GetByteArrayElements(env, socketPath, 0);
+    if (socket_path == NULL) {
+        return -1;
+    }
     socket_path_len = (*env)->GetArrayLength(env, socketPath);
     if (socket_path_len > sizeof(addr.sun_path)) {
         socket_path_len = sizeof(addr.sun_path);
@@ -805,6 +808,9 @@ static jint netty_unix_socket_sendToAddressesDomainSocket(JNIEnv* env, jclass cl
     addr.sun_family = AF_UNIX;
 
     jbyte* socket_path = (*env)->GetByteArrayElements(env, socketPath, 0);
+    if (socket_path == NULL) {
+        return -1;
+    }
     socket_path_len = (*env)->GetArrayLength(env, socketPath);
     if (socket_path_len > sizeof(addr.sun_path)) {
         socket_path_len = sizeof(addr.sun_path);
@@ -857,6 +863,9 @@ static jint netty_unix_socket_bindDomainSocket(JNIEnv* env, jclass clazz, jint f
     addr.sun_family = AF_UNIX;
 
     jbyte* socket_path = (*env)->GetByteArrayElements(env, socketPath, 0);
+    if (socket_path == NULL) {
+        return -1;
+    }
     jint socket_path_len = (*env)->GetArrayLength(env, socketPath);
 
     if (socket_path_len > sizeof(addr.sun_path) || (socket_path_len == sizeof(addr.sun_path) && socket_path[socket_path_len] != '\0')) {
@@ -886,6 +895,9 @@ static jint netty_unix_socket_connectDomainSocket(JNIEnv* env, jclass clazz, jin
     addr.sun_family = AF_UNIX;
 
     jbyte* socket_path = (*env)->GetByteArrayElements(env, socketPath, 0);
+    if (socket_path == NULL) {
+        return -1;
+    }
     socket_path_len = (*env)->GetArrayLength(env, socketPath);
 
     if (socket_path_len > sizeof(addr.sun_path) || (socket_path_len == sizeof(addr.sun_path) && socket_path[socket_path_len] != '\0')) {
@@ -1157,6 +1169,9 @@ static void netty_unix_socket_setIntOpt(JNIEnv* env, jclass clazz, jint fd, jint
 
 static void netty_unix_socket_setRawOptArray(JNIEnv* env, jclass clazz, jint fd, jint level, jint optname, jbyteArray inArray, jint offset, jint len) {
     jbyte* optval = (*env)->GetByteArrayElements(env, inArray, 0);
+    if (optval == NULL) {
+        return:
+    }
     netty_unix_socket_setOption(env, fd, level, optname, optval + offset, len);
     (*env)->ReleaseByteArrayElements(env, inArray, optval, 0);
 }
@@ -1175,6 +1190,9 @@ static jint netty_unix_socket_getIntOpt(JNIEnv* env, jclass clazz, jint fd, jint
 
 static void netty_unix_socket_getRawOptArray(JNIEnv* env, jclass clazz, jint fd, jint level, jint optname, jbyteArray outArray, jint offset, jint len) {
     jbyte* optval = (*env)->GetByteArrayElements(env, outArray, 0);
+    if (optval == NULL) {
+        return;
+    }
     netty_unix_socket_getOption(env, fd, level, optname, optval + offset, len);
     (*env)->ReleaseByteArrayElements(env, outArray, optval, 0);
 }


### PR DESCRIPTION
Motivation:

We didn't have all the necessary NULL checks in place which could cause a segfault when an operation failed in native code due an OOME (for example).

Modifications:

Add missing NULL checks

Result:

Correctly handle error scenarios