### PR TITLE
 Avoid unnecessary reflective probes on netty initialization

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -153,37 +153,39 @@ final class PlatformDependent0 {
                         try {
                             // Other methods like storeFence() and invokeCleaner() are tested for elsewhere.
                             Class<? extends Unsafe> cls = finalUnsafe.getClass();
-                            cls.getDeclaredMethod("objectFieldOffset", Field.class);
-                            cls.getDeclaredMethod("staticFieldOffset", Field.class);
-                            cls.getDeclaredMethod("staticFieldBase", Field.class);
-                            cls.getDeclaredMethod("arrayBaseOffset", Class.class);
-                            cls.getDeclaredMethod("arrayIndexScale", Class.class);
-                            cls.getDeclaredMethod("allocateMemory", long.class);
-                            cls.getDeclaredMethod("reallocateMemory", long.class, long.class);
-                            cls.getDeclaredMethod("freeMemory", long.class);
-                            cls.getDeclaredMethod("setMemory", long.class, long.class, byte.class);
-                            cls.getDeclaredMethod("setMemory", Object.class, long.class, long.class, byte.class);
                             cls.getDeclaredMethod(
                                     "copyMemory", Object.class, long.class, Object.class, long.class, long.class);
-                            cls.getDeclaredMethod("getBoolean", Object.class, long.class);
-                            cls.getDeclaredMethod("getByte", long.class);
-                            cls.getDeclaredMethod("getByte", Object.class, long.class);
-                            cls.getDeclaredMethod("getInt", long.class);
-                            cls.getDeclaredMethod("getInt", Object.class, long.class);
-                            cls.getDeclaredMethod("getLong", long.class);
-                            cls.getDeclaredMethod("getLong", Object.class, long.class);
-                            cls.getDeclaredMethod("putByte", long.class, byte.class);
-                            cls.getDeclaredMethod("putByte", Object.class, long.class, byte.class);
-                            cls.getDeclaredMethod("putInt", long.class, int.class);
-                            cls.getDeclaredMethod("putInt", Object.class, long.class, int.class);
-                            cls.getDeclaredMethod("putLong", long.class, long.class);
-                            cls.getDeclaredMethod("putLong", Object.class, long.class, long.class);
-                            cls.getDeclaredMethod("addressSize");
-                            // The following tests the methods are usable.
-                            // Will throw UnsupportedOperationException if unsafe memory access is denied:
-                            long address = finalUnsafe.allocateMemory(8);
-                            finalUnsafe.putLong(address, 42);
-                            finalUnsafe.freeMemory(address);
+                            if (javaVersion() > 23) {
+                                cls.getDeclaredMethod("objectFieldOffset", Field.class);
+                                cls.getDeclaredMethod("staticFieldOffset", Field.class);
+                                cls.getDeclaredMethod("staticFieldBase", Field.class);
+                                cls.getDeclaredMethod("arrayBaseOffset", Class.class);
+                                cls.getDeclaredMethod("arrayIndexScale", Class.class);
+                                cls.getDeclaredMethod("allocateMemory", long.class);
+                                cls.getDeclaredMethod("reallocateMemory", long.class, long.class);
+                                cls.getDeclaredMethod("freeMemory", long.class);
+                                cls.getDeclaredMethod("setMemory", long.class, long.class, byte.class);
+                                cls.getDeclaredMethod("setMemory", Object.class, long.class, long.class, byte.class);
+                                cls.getDeclaredMethod("getBoolean", Object.class, long.class);
+                                cls.getDeclaredMethod("getByte", long.class);
+                                cls.getDeclaredMethod("getByte", Object.class, long.class);
+                                cls.getDeclaredMethod("getInt", long.class);
+                                cls.getDeclaredMethod("getInt", Object.class, long.class);
+                                cls.getDeclaredMethod("getLong", long.class);
+                                cls.getDeclaredMethod("getLong", Object.class, long.class);
+                                cls.getDeclaredMethod("putByte", long.class, byte.class);
+                                cls.getDeclaredMethod("putByte", Object.class, long.class, byte.class);
+                                cls.getDeclaredMethod("putInt", long.class, int.class);
+                                cls.getDeclaredMethod("putInt", Object.class, long.class, int.class);
+                                cls.getDeclaredMethod("putLong", long.class, long.class);
+                                cls.getDeclaredMethod("putLong", Object.class, long.class, long.class);
+                                cls.getDeclaredMethod("addressSize");
+                                // The following tests the methods are usable.
+                                // Will throw UnsupportedOperationException if unsafe memory access is denied:
+                                long address = finalUnsafe.allocateMemory(8);
+                                finalUnsafe.putLong(address, 42);
+                                finalUnsafe.freeMemory(address);
+                            }
                             return null;
                         } catch (UnsupportedOperationException e) {
                             return e;

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -181,7 +181,7 @@ final class PlatformDependent0 {
                             cls.getDeclaredMethod("addressSize");
                             // The following tests the methods are usable.
                             // Will throw UnsupportedOperationException if unsafe memory access is denied:
-                            long address = finalUnsafe.allocateMemory(Long.BYTES);
+                            long address = finalUnsafe.allocateMemory(8);
                             finalUnsafe.putLong(address, 42);
                             finalUnsafe.freeMemory(address);
                             return null;

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -180,6 +180,8 @@ final class PlatformDependent0 {
                                 cls.getDeclaredMethod("putLong", long.class, long.class);
                                 cls.getDeclaredMethod("putLong", Object.class, long.class, long.class);
                                 cls.getDeclaredMethod("addressSize");
+                            }
+                            if (javaVersion() >= 23) {
                                 // The following tests the methods are usable.
                                 // Will throw UnsupportedOperationException if unsafe memory access is denied:
                                 long address = finalUnsafe.allocateMemory(8);


### PR DESCRIPTION
Motivation:

https://github.com/netty/netty/pull/14090 added multiple reflective accesses on netty initialization to probe availability of Unsafe methods which may be removed after java 23 (jep 471).

This may have negative performance impact on application startup (particularly with lower end machines) since reflection is expensive before jvm is warmed up. However, these reflective method probes may be potentially useful only after java 23 - when/if method removals actually materialize.

Modification:

Make reflective accesses on netty initialization to probe availability of Unsafe methods only if java version > 23.

Result:

Unnecessary reflective accesses on netty initialization are avoided for java version <= 23.