### PR TITLE
Small typo in InternetProtocolFamily enum javadoc

### DIFF
--- a/transport/src/main/java/io/netty/channel/socket/InternetProtocolFamily.java
+++ b/transport/src/main/java/io/netty/channel/socket/InternetProtocolFamily.java
@@ -22,7 +22,7 @@ import java.net.Inet6Address;
 import java.net.InetAddress;
 
 /**
- * Internet Protocol (IP) families used byte the {@link DatagramChannel}
+ * Internet Protocol (IP) families used by the {@link DatagramChannel}
  */
 public enum InternetProtocolFamily {
     IPv4(Inet4Address.class, 1),


### PR DESCRIPTION
Motivation:

Noticed a typo while working on a project using the Netty library

Modification:

javadoc change in the `InternetProtocolFamily` class

Result:

No typo in the javadoc for the `InternetProtocolFamily` class
