### PR TITLE
Add io_uring to netty-bom

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -297,6 +297,34 @@
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
+        <artifactId>netty-transport-classes-io_uring</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport-native-io_uring</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport-native-io_uring</artifactId>
+        <version>${project.version}</version>
+        <classifier>linux-aarch_64</classifier>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport-native-io_uring</artifactId>
+        <version>${project.version}</version>
+        <classifier>linux-riscv64</classifier>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport-native-io_uring</artifactId>
+        <version>${project.version}</version>
+        <classifier>linux-x86_64</classifier>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
         <artifactId>netty-transport-classes-kqueue</artifactId>
         <version>${project.version}</version>
       </dependency>


### PR DESCRIPTION
Motivation:

io_uring artifacts are missing from the Netty 4.2.0.Alpha1 BOM

Modification:

add io_uring artifacts to Netty bom/pom.xml

Result:

Netty BOM includes io_uring classes and native artifacts.
