### PR TITLE
Fix API compat issue for users that upgrade from 4.1.x to 4.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6156,6 +6156,13 @@
                   <serialVersionUID>1</serialVersionUID>
                   <justification>Necessary for com.google.protobuf:protobuf-java upgrade.</justification>
                 </item>
+
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.removed</code>
+                  <old>method io.netty.resolver.ResolvedAddressTypes io.netty.resolver.dns.DnsNameResolverBuilder::computeResolvedAddressTypes(io.netty.channel.socket.SocketProtocolFamily[])</old>
+                  <justification>Ignore changes in Alpha releases</justification>
+                </item>
               </differences>
             </revapi.differences>
           </analysisConfiguration>

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
@@ -326,7 +326,7 @@ public final class DnsNameResolverBuilder {
      *
      * @param internetProtocolFamilies a valid sequence of {@link InternetProtocolFamily}s
      * @return a {@link ResolvedAddressTypes}
-     * @deprecated use {@link #computeResolvedAddressTypes(SocketProtocolFamily...)}
+     * @deprecated use {@link #toResolvedAddressTypes(SocketProtocolFamily...)}
      */
     @Deprecated
     public static ResolvedAddressTypes computeResolvedAddressTypes(InternetProtocolFamily... internetProtocolFamilies) {
@@ -336,7 +336,7 @@ public final class DnsNameResolverBuilder {
         if (internetProtocolFamilies.length > 2) {
             throw new IllegalArgumentException("No more than 2 InternetProtocolFamilies");
         }
-        return computeResolvedAddressTypes(toSocketProtocolFamilies(internetProtocolFamilies));
+        return toResolvedAddressTypes(toSocketProtocolFamilies(internetProtocolFamilies));
     }
 
     private static SocketProtocolFamily[] toSocketProtocolFamilies(InternetProtocolFamily... internetProtocolFamilies) {
@@ -357,7 +357,7 @@ public final class DnsNameResolverBuilder {
      * @param socketProtocolFamilies a valid sequence of {@link SocketProtocolFamily}s
      * @return a {@link ResolvedAddressTypes}
      */
-    public static ResolvedAddressTypes computeResolvedAddressTypes(SocketProtocolFamily... socketProtocolFamilies) {
+    public static ResolvedAddressTypes toResolvedAddressTypes(SocketProtocolFamily... socketProtocolFamilies) {
         if (socketProtocolFamilies == null || socketProtocolFamilies.length == 0) {
             return DnsNameResolver.DEFAULT_RESOLVE_ADDRESS_TYPES;
         }


### PR DESCRIPTION
Motivation:

One API compat issue was detected by servicetalk. We need to fix it:

```
/home/runner/work/servicetalk/servicetalk/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsResolverAddressTypes.java:66: error: reference to computeResolvedAddressTypes is ambiguous

        return fromNettyType(DnsNameResolverBuilder.computeResolvedAddressTypes());
                                                   ^
  both method computeResolvedAddressTypes(io.netty.channel.socket.InternetProtocolFamily...) in io.netty.resolver.dns.DnsNameResolverBuilder and method computeResolvedAddressTypes(io.netty.channel.socket.SocketProtocolFamily...) in io.netty.resolver.dns.DnsNameResolverBuilder match
Note: Some input files use or override a deprecated API.
> Task :servicetalk-dns-discovery-netty:compileJava FAILED
```

Modifications:

Rename method to fix compat

Result:

Be able to use 4.2.0 where 4.1.x was used