### PR TITLE
Add transport-native-io_uring to docker compose files

### DIFF
--- a/docker/docker-compose.centos-7.yaml
+++ b/docker/docker-compose.centos-7.yaml
@@ -28,7 +28,7 @@ services:
 
   cross-compile-aarch64-deploy:
     <<: *cross-compile-aarch64-common
-    command: /bin/bash -cl "./mvnw -B -ntp -Plinux-aarch64 -pl transport-native-unix-common,transport-native-epoll -am clean deploy -DskipTests=true"
+    command: /bin/bash -cl "./mvnw -B -ntp -Plinux-aarch64 -pl transport-native-unix-common,transport-native-epoll,transport-native-io_uring -am clean deploy -DskipTests=true"
 
   cross-compile-aarch64-stage-snapshot:
     <<: *cross-compile-aarch64-common
@@ -38,7 +38,7 @@ services:
       - ~/.m2:/root/.m2
       - ~/local-staging:/root/local-staging
       - ..:/code
-    command: /bin/bash -cl "./mvnw -B -ntp -Plinux-aarch64 -pl transport-native-unix-common,transport-native-epoll -am clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"
+    command: /bin/bash -cl "./mvnw -B -ntp -Plinux-aarch64 -pl transport-native-unix-common,transport-native-epoll,transport-native-io_uring -am clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"
 
   cross-compile-aarch64-stage-release:
     <<: *cross-compile-aarch64-common
@@ -47,7 +47,7 @@ services:
       - ~/.m2:/root/.m2
       - ~/local-staging:/root/local-staging
       - ..:/code
-    command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && ./mvnw -B -ntp -Plinux-aarch64 -pl transport-native-unix-common,transport-native-epoll -am clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME}"
+    command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && ./mvnw -B -ntp -Plinux-aarch64 -pl transport-native-unix-common,transport-native-epoll,transport-native-io_uring -am clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME}"
 
   cross-compile-aarch64-shell:
     <<: *cross-compile-aarch64-common
@@ -55,4 +55,4 @@ services:
 
   cross-compile-aarch64-build:
     <<: *cross-compile-aarch64-common
-    command: /bin/bash -cl "./mvnw -B -ntp -Plinux-aarch64 -pl transport-native-unix-common,transport-native-epoll -am clean package -DskipTests=true"
+    command: /bin/bash -cl "./mvnw -B -ntp -Plinux-aarch64 -pl transport-native-unix-common,transport-native-epoll,transport-native-io_uring -am clean package -DskipTests=true"

--- a/docker/docker-compose.ubuntu-20.04.yaml
+++ b/docker/docker-compose.ubuntu-20.04.yaml
@@ -25,7 +25,7 @@ services:
 
   cross-compile-riscv64-deploy:
     <<: *cross-compile-riscv64-common
-    command: /bin/bash -cl "./mvnw -B -ntp -Plinux-riscv64 -pl transport-native-unix-common,transport-native-epoll -am clean deploy -DskipTests=true"
+    command: /bin/bash -cl "./mvnw -B -ntp -Plinux-riscv64 -pl transport-native-unix-common,transport-native-epoll,transport-native-io_uring -am clean deploy -DskipTests=true"
 
   cross-compile-riscv64-stage-snapshot:
     <<: *cross-compile-riscv64-common
@@ -35,7 +35,7 @@ services:
       - ~/.m2:/root/.m2
       - ~/local-staging:/root/local-staging
       - ..:/code
-    command: /bin/bash -cl "./mvnw -B -ntp -Plinux-riscv64 -pl transport-native-unix-common,transport-native-epoll -am clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"
+    command: /bin/bash -cl "./mvnw -B -ntp -Plinux-riscv64 -pl transport-native-unix-common,transport-native-epoll,transport-native-io_uring -am clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"
 
   cross-compile-riscv64-stage-release:
     <<: *cross-compile-riscv64-common
@@ -44,7 +44,7 @@ services:
       - ~/.m2:/root/.m2
       - ~/local-staging:/root/local-staging
       - ..:/code
-    command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && ./mvnw -B -ntp -Plinux-riscv64 -pl transport-native-unix-common,transport-native-epoll -am clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME}"
+    command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && ./mvnw -B -ntp -Plinux-riscv64 -pl transport-native-unix-common,transport-native-epoll,transport-native-io_uring -am clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME}"
 
   cross-compile-riscv64-shell:
     <<: *cross-compile-riscv64-common
@@ -52,4 +52,4 @@ services:
 
   cross-compile-riscv64-build:
     <<: *cross-compile-riscv64-common
-    command: /bin/bash -cl "./mvnw -B -ntp -Plinux-riscv64 -pl transport-native-unix-common,transport-native-epoll -am clean package -DskipTests=true"
+    command: /bin/bash -cl "./mvnw -B -ntp -Plinux-riscv64 -pl transport-native-unix-common,transport-native-epoll,transport-native-io_uring -am clean package -DskipTests=true"


### PR DESCRIPTION
Motivation:

in the 4.2.0-Alpha2-SNAPSHOT, I am seeing only 1 Linux classifier (linux-x86_64) for io_uring 

https://oss.sonatype.org/content/repositories/snapshots/io/netty/netty-transport-native-io_uring/4.2.0.Alpha2-SNAPSHOT/maven-metadata.xml

I do not see 'linux-aarch_64' or 'linux-riscv64' artifacts in the Maven metadata


Modification:

add 'transport-native-io_uring' to Docker Compose files

Result:

- creates an artifact for transport-native-io_uring with classifier linux-aarch_64
- creates an artifact for transport-native-io_uring with classifier linux-riscv64
