### PR TITLE
Allow control frames between fragments

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/Utf8FrameValidator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/Utf8FrameValidator.java
@@ -38,6 +38,13 @@ public class Utf8FrameValidator extends ChannelInboundHandlerAdapter {
         this.closeOnProtocolViolation = closeOnProtocolViolation;
     }
 
+    // See https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.
+    private static boolean isControlFrame(WebSocketFrame frame) {
+        return frame instanceof CloseWebSocketFrame ||
+                frame instanceof PingWebSocketFrame ||
+                frame instanceof PongWebSocketFrame;
+    }
+
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
         if (msg instanceof WebSocketFrame) {
@@ -46,14 +53,16 @@ public class Utf8FrameValidator extends ChannelInboundHandlerAdapter {
             try {
                 // Processing for possible fragmented messages for text and binary
                 // frames
-                if (((WebSocketFrame) msg).isFinalFragment()) {
-                    // Final frame of the sequence. Apparently ping frames are
-                    // allowed in the middle of a fragmented message
-                    if (!(frame instanceof PingWebSocketFrame)) {
+                if (frame.isFinalFragment()) {
+                    // Control frames are allowed between fragments
+                    // See https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.
+                    if (!isControlFrame(frame)) {
+
+                        // Final frame of the sequence.
                         fragmentedFramesCount = 0;
 
                         // Check text for UTF8 correctness
-                        if ((frame instanceof TextWebSocketFrame) ||
+                        if (frame instanceof TextWebSocketFrame ||
                                 (utf8Validator != null && utf8Validator.isChecking())) {
                             // Check UTF-8 correctness for this payload
                             checkUTF8String(frame.content());

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketUtf8FrameValidatorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketUtf8FrameValidatorTest.java
@@ -76,4 +76,26 @@ public class WebSocketUtf8FrameValidatorTest {
         assertFalse(channel.finish());
     }
 
+    @Test
+    void testCloseWithStatusInTheMiddleOfFragmentAllowed() {
+        testControlFrameInTheMiddleOfFragmentAllowed(new CloseWebSocketFrame(WebSocketCloseStatus.NORMAL_CLOSURE));
+    }
+
+    @Test
+    void testPingInTheMiddleOfFragmentAllowed() {
+        testControlFrameInTheMiddleOfFragmentAllowed(new PingWebSocketFrame(Unpooled.EMPTY_BUFFER));
+    }
+
+    @Test
+    void testPongInTheMiddleOfFragmentAllowed() {
+        testControlFrameInTheMiddleOfFragmentAllowed(new PongWebSocketFrame(Unpooled.EMPTY_BUFFER));
+    }
+
+    private static void testControlFrameInTheMiddleOfFragmentAllowed(WebSocketFrame controlFrame) {
+        final EmbeddedChannel channel = new EmbeddedChannel(new Utf8FrameValidator(false));
+        final TextWebSocketFrame frame = new TextWebSocketFrame(false, 0, "text");
+        assertTrue(channel.writeInbound(frame));
+        assertTrue(channel.writeInbound(controlFrame));
+        assertTrue(channel.finishAndReleaseAll());
+    }
 }


### PR DESCRIPTION
Motivation:

In WebSockets control frames are allowed to be send between fragments.

Modifications:

Allow all control frames to be send in between (only PING was handled)

Result:

Fixes https://github.com/netty/netty/issues/14118
