### PR TITLE
Default hostname validation, configured via SslContextBuilder

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/JdkSslClientContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkSslClientContext.java
@@ -269,12 +269,13 @@ public final class JdkSslClientContext extends JdkSslContext {
                         X509Certificate[] keyCertChain, PrivateKey key, String keyPassword,
                         KeyManagerFactory keyManagerFactory, Iterable<String> ciphers, CipherSuiteFilter cipherFilter,
                         ApplicationProtocolConfig apn, String[] protocols, long sessionCacheSize, long sessionTimeout,
-                        SecureRandom secureRandom, String keyStoreType)
+                        SecureRandom secureRandom, String keyStoreType, String endpointIdentificationAlgorithm)
             throws SSLException {
         super(newSSLContext(sslContextProvider, trustCertCollection, trustManagerFactory,
                             keyCertChain, key, keyPassword, keyManagerFactory, sessionCacheSize,
                             sessionTimeout, secureRandom, keyStoreType),
-                true, ciphers, cipherFilter, toNegotiator(apn, false), ClientAuth.NONE, protocols, false);
+                true, ciphers, cipherFilter, toNegotiator(apn, false), ClientAuth.NONE, protocols, false,
+                endpointIdentificationAlgorithm);
     }
 
     private static SSLContext newSSLContext(Provider sslContextProvider,

--- a/handler/src/main/java/io/netty/handler/ssl/JdkSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkSslContext.java
@@ -190,6 +190,7 @@ public class JdkSslContext extends SslContext {
     private final ClientAuth clientAuth;
     private final SSLContext sslContext;
     private final boolean isClient;
+    private final String endpointIdentificationAlgorithm;
 
     /**
      * Creates a new {@link JdkSslContext} from a pre-configured {@link SSLContext}.
@@ -259,10 +260,18 @@ public class JdkSslContext extends SslContext {
     @SuppressWarnings("deprecation")
     JdkSslContext(SSLContext sslContext, boolean isClient, Iterable<String> ciphers, CipherSuiteFilter cipherFilter,
                   JdkApplicationProtocolNegotiator apn, ClientAuth clientAuth, String[] protocols, boolean startTls) {
+        this(sslContext, isClient, ciphers, cipherFilter, apn, clientAuth, protocols, startTls, null);
+    }
+
+    @SuppressWarnings("deprecation")
+    JdkSslContext(SSLContext sslContext, boolean isClient, Iterable<String> ciphers, CipherSuiteFilter cipherFilter,
+                  JdkApplicationProtocolNegotiator apn, ClientAuth clientAuth, String[] protocols, boolean startTls,
+                  String endpointIdentificationAlgorithm) {
         super(startTls);
         this.apn = checkNotNull(apn, "apn");
         this.clientAuth = checkNotNull(clientAuth, "clientAuth");
         this.sslContext = checkNotNull(sslContext, "sslContext");
+        this.endpointIdentificationAlgorithm = endpointIdentificationAlgorithm;
 
         final List<String> defaultCiphers;
         final Set<String> supportedCiphers;
@@ -370,6 +379,9 @@ public class JdkSslContext extends SslContext {
         if (factory instanceof JdkApplicationProtocolNegotiator.AllocatorAwareSslEngineWrapperFactory) {
             return ((JdkApplicationProtocolNegotiator.AllocatorAwareSslEngineWrapperFactory) factory)
                     .wrapSslEngine(engine, alloc, apn, isServer());
+        }
+        if (endpointIdentificationAlgorithm != null) {
+            engine.getSSLParameters().setEndpointIdentificationAlgorithm(endpointIdentificationAlgorithm);
         }
         return factory.wrapSslEngine(engine, apn, isServer());
     }

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslClientContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslClientContext.java
@@ -178,18 +178,18 @@ public final class OpenSslClientContext extends OpenSslContext {
         this(toX509CertificatesInternal(trustCertCollectionFile), trustManagerFactory,
                 toX509CertificatesInternal(keyCertChainFile), toPrivateKeyInternal(keyFile, keyPassword),
                 keyPassword, keyManagerFactory, ciphers, cipherFilter, apn, null, sessionCacheSize,
-                sessionTimeout, false, KeyStore.getDefaultType());
+                sessionTimeout, false, KeyStore.getDefaultType(), null);
     }
 
     OpenSslClientContext(X509Certificate[] trustCertCollection, TrustManagerFactory trustManagerFactory,
                          X509Certificate[] keyCertChain, PrivateKey key, String keyPassword,
-                                KeyManagerFactory keyManagerFactory, Iterable<String> ciphers,
-                                CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn, String[] protocols,
-                                long sessionCacheSize, long sessionTimeout, boolean enableOcsp, String keyStore,
-                         Map.Entry<SslContextOption<?>, Object>... options)
+                         KeyManagerFactory keyManagerFactory, Iterable<String> ciphers,
+                         CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn, String[] protocols,
+                         long sessionCacheSize, long sessionTimeout, boolean enableOcsp, String keyStore,
+                         String endpointIdentificationAlgorithm, Map.Entry<SslContextOption<?>, Object>... options)
             throws SSLException {
         super(ciphers, cipherFilter, apn, SSL.SSL_MODE_CLIENT, keyCertChain,
-                ClientAuth.NONE, protocols, false, enableOcsp, options);
+                ClientAuth.NONE, protocols, false, endpointIdentificationAlgorithm, enableOcsp, options);
         boolean success = false;
         try {
             OpenSslKeyMaterialProvider.validateKeyMaterialSupported(keyCertChain, key, keyPassword);

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslContext.java
@@ -30,11 +30,11 @@ import javax.net.ssl.SSLException;
 public abstract class OpenSslContext extends ReferenceCountedOpenSslContext {
     OpenSslContext(Iterable<String> ciphers, CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apnCfg,
                    int mode, Certificate[] keyCertChain,
-                   ClientAuth clientAuth, String[] protocols, boolean startTls, boolean enableOcsp,
-                   Map.Entry<SslContextOption<?>, Object>... options)
+                   ClientAuth clientAuth, String[] protocols, boolean startTls, String endpointIdentificationAlgorithm,
+                   boolean enableOcsp, Map.Entry<SslContextOption<?>, Object>... options)
             throws SSLException {
         super(ciphers, cipherFilter, toNegotiator(apnCfg), mode, keyCertChain,
-                clientAuth, protocols, startTls, enableOcsp, false, options);
+                clientAuth, protocols, startTls, endpointIdentificationAlgorithm, enableOcsp, false, options);
     }
 
     OpenSslContext(Iterable<String> ciphers, CipherSuiteFilter cipherFilter, OpenSslApplicationProtocolNegotiator apn,
@@ -43,12 +43,13 @@ public abstract class OpenSslContext extends ReferenceCountedOpenSslContext {
                    Map.Entry<SslContextOption<?>, Object>... options)
             throws SSLException {
         super(ciphers, cipherFilter, apn, mode, keyCertChain,
-                clientAuth, protocols, startTls, enableOcsp, false, options);
+                clientAuth, protocols, startTls, null, enableOcsp, false, options);
     }
 
     @Override
     final SSLEngine newEngine0(ByteBufAllocator alloc, String peerHost, int peerPort, boolean jdkCompatibilityMode) {
-        return new OpenSslEngine(this, alloc, peerHost, peerPort, jdkCompatibilityMode);
+        return new OpenSslEngine(this, alloc, peerHost, peerPort, jdkCompatibilityMode,
+                endpointIdentificationAlgorithm);
     }
 
     @Override

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslEngine.java
@@ -28,8 +28,8 @@ import javax.net.ssl.SSLEngine;
  */
 public final class OpenSslEngine extends ReferenceCountedOpenSslEngine {
     OpenSslEngine(OpenSslContext context, ByteBufAllocator alloc, String peerHost, int peerPort,
-                  boolean jdkCompatibilityMode) {
-        super(context, alloc, peerHost, peerPort, jdkCompatibilityMode, false);
+                  boolean jdkCompatibilityMode, String endpointIdentificationAlgorithm) {
+        super(context, alloc, peerHost, peerPort, jdkCompatibilityMode, false, endpointIdentificationAlgorithm);
     }
 
     @Override

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslClientContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslClientContext.java
@@ -60,10 +60,10 @@ public final class ReferenceCountedOpenSslClientContext extends ReferenceCounted
                                          KeyManagerFactory keyManagerFactory, Iterable<String> ciphers,
                                          CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn,
                                          String[] protocols, long sessionCacheSize, long sessionTimeout,
-                                         boolean enableOcsp, String keyStore,
+                                         boolean enableOcsp, String keyStore, String endpointIdentificationAlgorithm,
                                          Map.Entry<SslContextOption<?>, Object>... options) throws SSLException {
         super(ciphers, cipherFilter, toNegotiator(apn), SSL.SSL_MODE_CLIENT, keyCertChain,
-              ClientAuth.NONE, protocols, false, enableOcsp, true, options);
+              ClientAuth.NONE, protocols, false, endpointIdentificationAlgorithm, enableOcsp, true, options);
         boolean success = false;
         try {
             sessionContext = newSessionContext(this, ctx, engineMap, trustCertCollection, trustManagerFactory,

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -151,6 +151,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
     final Certificate[] keyCertChain;
     final ClientAuth clientAuth;
     final String[] protocols;
+    final String endpointIdentificationAlgorithm;
     final boolean hasTLSv13Cipher;
 
     final boolean enableOcsp;
@@ -206,7 +207,8 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
 
     ReferenceCountedOpenSslContext(Iterable<String> ciphers, CipherSuiteFilter cipherFilter,
                                    OpenSslApplicationProtocolNegotiator apn, int mode, Certificate[] keyCertChain,
-                                   ClientAuth clientAuth, String[] protocols, boolean startTls, boolean enableOcsp,
+                                   ClientAuth clientAuth, String[] protocols, boolean startTls,
+                                   String endpointIdentificationAlgorithm, boolean enableOcsp,
                                    boolean leakDetection, Map.Entry<SslContextOption<?>, Object>... ctxOptions)
             throws SSLException {
         super(startTls);
@@ -262,6 +264,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
         this.mode = mode;
         this.clientAuth = isServer() ? checkNotNull(clientAuth, "clientAuth") : ClientAuth.NONE;
         this.protocols = protocols == null ? OpenSsl.defaultProtocols(mode == SSL.SSL_MODE_CLIENT) : protocols;
+        this.endpointIdentificationAlgorithm = endpointIdentificationAlgorithm;
         this.enableOcsp = enableOcsp;
 
         this.keyCertChain = keyCertChain == null ? null : keyCertChain.clone();
@@ -489,7 +492,8 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
     }
 
     SSLEngine newEngine0(ByteBufAllocator alloc, String peerHost, int peerPort, boolean jdkCompatibilityMode) {
-        return new ReferenceCountedOpenSslEngine(this, alloc, peerHost, peerPort, jdkCompatibilityMode, true);
+        return new ReferenceCountedOpenSslEngine(this, alloc, peerHost, peerPort, jdkCompatibilityMode, true,
+                endpointIdentificationAlgorithm);
     }
 
     /**

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslServerContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslServerContext.java
@@ -70,7 +70,9 @@ public final class ReferenceCountedOpenSslServerContext extends ReferenceCounted
             boolean enableOcsp, String keyStore, Map.Entry<SslContextOption<?>, Object>... options)
             throws SSLException {
         super(ciphers, cipherFilter, apn, SSL.SSL_MODE_SERVER, keyCertChain,
-              clientAuth, protocols, startTls, enableOcsp, true, options);
+                clientAuth, protocols, startTls,
+                null, // No endpoint validation for servers.
+                enableOcsp, true, options);
         // Create a new SSL_CTX and configure it.
         boolean success = false;
         try {

--- a/handler/src/main/java/io/netty/handler/ssl/SslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContext.java
@@ -801,7 +801,7 @@ public abstract class SslContext {
                                             toX509Certificates(keyCertChainFile), toPrivateKey(keyFile, keyPassword),
                                             keyPassword, keyManagerFactory, ciphers, cipherFilter,
                                             apn, null, sessionCacheSize, sessionTimeout, false,
-                                            null, KeyStore.getDefaultType());
+                                            null, KeyStore.getDefaultType(), "HTTPS");
         } catch (Exception e) {
             if (e instanceof SSLException) {
                 throw (SSLException) e;
@@ -817,7 +817,7 @@ public abstract class SslContext {
             X509Certificate[] keyCertChain, PrivateKey key, String keyPassword, KeyManagerFactory keyManagerFactory,
             Iterable<String> ciphers, CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn, String[] protocols,
             long sessionCacheSize, long sessionTimeout, boolean enableOcsp,
-            SecureRandom secureRandom, String keyStoreType,
+            SecureRandom secureRandom, String keyStoreType, String endpointIdentificationAlgorithm,
             Map.Entry<SslContextOption<?>, Object>... options) throws SSLException {
         if (provider == null) {
             provider = defaultClientProvider();
@@ -830,21 +830,21 @@ public abstract class SslContext {
                 return new JdkSslClientContext(sslContextProvider,
                         trustCert, trustManagerFactory, keyCertChain, key, keyPassword,
                         keyManagerFactory, ciphers, cipherFilter, apn, protocols, sessionCacheSize,
-                        sessionTimeout, secureRandom, keyStoreType);
+                        sessionTimeout, secureRandom, keyStoreType, endpointIdentificationAlgorithm);
             case OPENSSL:
                 verifyNullSslContextProvider(provider, sslContextProvider);
                 OpenSsl.ensureAvailability();
                 return new OpenSslClientContext(
                         trustCert, trustManagerFactory, keyCertChain, key, keyPassword,
                         keyManagerFactory, ciphers, cipherFilter, apn, protocols, sessionCacheSize, sessionTimeout,
-                        enableOcsp, keyStoreType, options);
+                        enableOcsp, keyStoreType, endpointIdentificationAlgorithm, options);
             case OPENSSL_REFCNT:
                 verifyNullSslContextProvider(provider, sslContextProvider);
                 OpenSsl.ensureAvailability();
                 return new ReferenceCountedOpenSslClientContext(
                         trustCert, trustManagerFactory, keyCertChain, key, keyPassword,
                         keyManagerFactory, ciphers, cipherFilter, apn, protocols, sessionCacheSize, sessionTimeout,
-                        enableOcsp, keyStoreType, options);
+                        enableOcsp, keyStoreType, endpointIdentificationAlgorithm, options);
             default:
                 throw new Error(provider.toString());
         }

--- a/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
@@ -209,10 +209,14 @@ public final class SslContextBuilder {
     private boolean enableOcsp;
     private SecureRandom secureRandom;
     private String keyStoreType = KeyStore.getDefaultType();
+    private String endpointIdentificationAlgorithm;
     private final Map<SslContextOption<?>, Object> options = new HashMap<SslContextOption<?>, Object>();
 
     private SslContextBuilder(boolean forServer) {
         this.forServer = forServer;
+        if (!forServer) {
+            endpointIdentificationAlgorithm = "HTTPS";
+        }
     }
 
     /**
@@ -618,6 +622,21 @@ public final class SslContextBuilder {
     }
 
     /**
+     * Specify the endpoint identification algorithm (aka. hostname verification algorithm) that clients will use as
+     * part of authenticating servers.
+     * <p>
+     * See <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#jssenames">
+     *     Java Security Standard Names</a> for a list of supported algorithms.
+     *
+     * @param algorithm either {@code "HTTPS"}, {@code "LDAPS"}, or {@code null} (disables hostname verification).
+     * @see javax.net.ssl.SSLParameters#setEndpointIdentificationAlgorithm(String)
+     */
+    public SslContextBuilder endpointIdentificationAlgorithm(String algorithm) {
+        endpointIdentificationAlgorithm = algorithm;
+        return this;
+    }
+
+    /**
      * Create new {@code SslContext} instance with configured settings.
      * <p>If {@link #sslProvider(SslProvider)} is set to {@link SslProvider#OPENSSL_REFCNT} then the caller is
      * responsible for releasing this object, or else native memory may leak.
@@ -632,7 +651,7 @@ public final class SslContextBuilder {
             return SslContext.newClientContextInternal(provider, sslContextProvider, trustCertCollection,
                 trustManagerFactory, keyCertChain, key, keyPassword, keyManagerFactory,
                 ciphers, cipherFilter, apn, protocols, sessionCacheSize,
-                    sessionTimeout, enableOcsp, secureRandom, keyStoreType,
+                    sessionTimeout, enableOcsp, secureRandom, keyStoreType, endpointIdentificationAlgorithm,
                     toArray(options.entrySet(), EMPTY_ENTRIES));
         }
     }

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
@@ -1190,6 +1190,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
                 .trustManager(cert.certificate())
                 .protocols(param.protocols())
                 .ciphers(param.ciphers())
+                .endpointIdentificationAlgorithm(null)
                 .sslProvider(OPENSSL).build());
         final SSLEngine clientEngine =
                 wrapEngine(clientSslCtx.newEngine(UnpooledByteBufAllocator.DEFAULT));

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
@@ -685,6 +685,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
                 .sslProvider(sslClientProvider())
                 .protocols(param.protocols())
                 .ciphers(param.ciphers())
+                .endpointIdentificationAlgorithm(null)
                 .build());
         SSLEngine client = wrapEngine(clientSslCtx.newHandler(UnpooledByteBufAllocator.DEFAULT).engine());
 
@@ -767,6 +768,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
                 .sslProvider(sslClientProvider())
                 .protocols(param.protocols())
                 .ciphers(param.ciphers())
+                .endpointIdentificationAlgorithm(null)
                 .build());
         SSLEngine client = wrapEngine(clientSslCtx.newHandler(UnpooledByteBufAllocator.DEFAULT).engine());
 
@@ -858,6 +860,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
                 .sslProvider(sslClientProvider())
                 .protocols(param.protocols())
                 .ciphers(param.ciphers())
+                .endpointIdentificationAlgorithm(null)
                 .build());
         SSLEngine client = wrapEngine(clientSslCtx.newHandler(UnpooledByteBufAllocator.DEFAULT).engine());
 
@@ -939,6 +942,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
                 .sslProvider(sslClientProvider())
                 .protocols(param.protocols())
                 .ciphers(param.ciphers())
+                .endpointIdentificationAlgorithm(null)
                 .build());
         SSLEngine client = wrapEngine(clientSslCtx.newHandler(UnpooledByteBufAllocator.DEFAULT).engine());
 

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -143,6 +143,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.verify;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -800,29 +801,28 @@ public abstract class SSLEngineTest {
                                      ClientAuth clientAuth, final boolean failureExpected,
                                      final boolean serverInitEngine)
             throws SSLException, InterruptedException {
-        serverSslCtx =
-                wrapContext(param, SslContextBuilder.forServer(serverKMF)
-                                 .protocols(param.protocols())
-                                 .ciphers(param.ciphers())
-                                 .sslProvider(sslServerProvider())
-                                 .sslContextProvider(serverSslContextProvider())
-                                 .trustManager(serverTrustManager)
-                                 .clientAuth(clientAuth)
-                                 .ciphers(null, IdentityCipherSuiteFilter.INSTANCE)
-                                 .sessionCacheSize(0)
-                                 .sessionTimeout(0).build());
+        serverSslCtx = wrapContext(param, SslContextBuilder.forServer(serverKMF)
+                .protocols(param.protocols())
+                .ciphers(param.ciphers())
+                .sslProvider(sslServerProvider())
+                .sslContextProvider(serverSslContextProvider())
+                .trustManager(serverTrustManager)
+                .clientAuth(clientAuth)
+                .ciphers(null, IdentityCipherSuiteFilter.INSTANCE)
+                .sessionCacheSize(0)
+                .sessionTimeout(0).build());
 
-        clientSslCtx =
-                wrapContext(param, SslContextBuilder.forClient()
-                                 .protocols(param.protocols())
-                                 .ciphers(param.ciphers())
-                                 .sslProvider(sslClientProvider())
-                                 .sslContextProvider(clientSslContextProvider())
-                                 .trustManager(clientTrustManager)
-                                 .keyManager(clientKMF)
-                                 .ciphers(null, IdentityCipherSuiteFilter.INSTANCE)
-                                 .sessionCacheSize(0)
-                                 .sessionTimeout(0).build());
+        clientSslCtx = wrapContext(param, SslContextBuilder.forClient()
+                .protocols(param.protocols())
+                .ciphers(param.ciphers())
+                .sslProvider(sslClientProvider())
+                .sslContextProvider(clientSslContextProvider())
+                .trustManager(clientTrustManager)
+                .keyManager(clientKMF)
+                .ciphers(null, IdentityCipherSuiteFilter.INSTANCE)
+                .sessionCacheSize(0)
+                .endpointIdentificationAlgorithm(null)
+                .sessionTimeout(0).build());
 
         serverConnectedChannel = null;
         sb = new ServerBootstrap();
@@ -1159,27 +1159,26 @@ public abstract class SSLEngineTest {
             File servertTrustCrtFile, File serverKeyFile, final File serverCrtFile, String serverKeyPassword,
             File clientTrustCrtFile, File clientKeyFile, final File clientCrtFile, String clientKeyPassword)
             throws InterruptedException, SSLException {
-        serverSslCtx =
-                wrapContext(param, SslContextBuilder.forServer(serverCrtFile, serverKeyFile, serverKeyPassword)
-                                 .sslProvider(sslServerProvider())
-                                 .sslContextProvider(serverSslContextProvider())
-                                 .protocols(param.protocols())
-                                 .ciphers(param.ciphers())
-                                 .trustManager(servertTrustCrtFile)
-                                 .ciphers(null, IdentityCipherSuiteFilter.INSTANCE)
-                                 .sessionCacheSize(0)
-                                 .sessionTimeout(0).build());
-        clientSslCtx =
-                wrapContext(param, SslContextBuilder.forClient()
-                                 .sslProvider(sslClientProvider())
-                                 .sslContextProvider(clientSslContextProvider())
-                                 .protocols(param.protocols())
-                                 .ciphers(param.ciphers())
-                                 .trustManager(clientTrustCrtFile)
-                                 .keyManager(clientCrtFile, clientKeyFile, clientKeyPassword)
-                                 .ciphers(null, IdentityCipherSuiteFilter.INSTANCE)
-                                 .sessionCacheSize(0)
-                                 .sessionTimeout(0).build());
+        serverSslCtx = wrapContext(param, SslContextBuilder.forServer(serverCrtFile, serverKeyFile, serverKeyPassword)
+                .sslProvider(sslServerProvider())
+                .sslContextProvider(serverSslContextProvider())
+                .protocols(param.protocols())
+                .ciphers(param.ciphers())
+                .trustManager(servertTrustCrtFile)
+                .ciphers(null, IdentityCipherSuiteFilter.INSTANCE)
+                .sessionCacheSize(0)
+                .sessionTimeout(0).build());
+        clientSslCtx = wrapContext(param, SslContextBuilder.forClient()
+                .sslProvider(sslClientProvider())
+                .sslContextProvider(clientSslContextProvider())
+                .protocols(param.protocols())
+                .ciphers(param.ciphers())
+                .trustManager(clientTrustCrtFile)
+                .keyManager(clientCrtFile, clientKeyFile, clientKeyPassword)
+                .ciphers(null, IdentityCipherSuiteFilter.INSTANCE)
+                .sessionCacheSize(0)
+                .endpointIdentificationAlgorithm(null)
+                .sessionTimeout(0).build());
 
         serverConnectedChannel = null;
         sb = new ServerBootstrap();
@@ -2043,14 +2042,16 @@ public abstract class SSLEngineTest {
         chainStream.write(Files.readAllBytes(clientCert.certificate().toPath()));
         chainStream.write(Files.readAllBytes(serverCert.certificate().toPath()));
 
-        clientSslCtx =
-                wrapContext(param, SslContextBuilder.forClient().keyManager(
+        clientSslCtx = wrapContext(param, SslContextBuilder.forClient().keyManager(
                         new ByteArrayInputStream(chainStream.toByteArray()),
                         new FileInputStream(clientCert.privateKey()))
                 .trustManager(new FileInputStream(serverCert.certificate()))
                 .sslProvider(sslClientProvider())
                 .sslContextProvider(clientSslContextProvider())
-                .protocols(param.protocols()).ciphers(param.ciphers()).build());
+                .endpointIdentificationAlgorithm(null)
+                .protocols(param.protocols())
+                .ciphers(param.ciphers())
+                .build());
         cb = new Bootstrap();
         cb.group(new MultiThreadIoEventLoopGroup(NioIoHandler.newFactory()));
         cb.channel(NioSocketChannel.class);
@@ -2080,6 +2081,7 @@ public abstract class SSLEngineTest {
                 .sslProvider(sslClientProvider())
                 .protocols(param.protocols())
                 .ciphers(param.ciphers())
+                .endpointIdentificationAlgorithm(null)
                 .build());
         SSLEngine client = wrapEngine(clientSslCtx.newEngine(UnpooledByteBufAllocator.DEFAULT));
 
@@ -2178,6 +2180,7 @@ public abstract class SSLEngineTest {
                 .trustManager(cert.cert())
                 .sslProvider(sslClientProvider())
                 .protocols(clientProtocols)
+                .endpointIdentificationAlgorithm(null)
                 .build());
         SSLEngine client = wrapEngine(clientSslCtx.newEngine(UnpooledByteBufAllocator.DEFAULT));
 
@@ -2298,6 +2301,7 @@ public abstract class SSLEngineTest {
                 .sslProvider(sslClientProvider())
                 .protocols(param.protocols())
                 .ciphers(param.ciphers())
+                .endpointIdentificationAlgorithm(null)
                 .build());
         SSLEngine client = wrapEngine(clientSslCtx.newEngine(UnpooledByteBufAllocator.DEFAULT));
 
@@ -2512,6 +2516,7 @@ public abstract class SSLEngineTest {
                 .trustManager(cert.cert())
                 .sslContextProvider(clientSslContextProvider())
                 .sslProvider(sslClientProvider())
+                .endpointIdentificationAlgorithm(null)
                 // This test only works for non TLSv1.3 for now
                 .protocols(SslProtocols.TLS_v1_2)
                 .build());
@@ -2672,6 +2677,7 @@ public abstract class SSLEngineTest {
                 .sslContextProvider(clientSslContextProvider())
                 .protocols(param.protocols())
                 .ciphers(param.ciphers())
+                .endpointIdentificationAlgorithm(null)
                 .build());
         SSLEngine client = wrapEngine(clientSslCtx.newEngine(UnpooledByteBufAllocator.DEFAULT));
 
@@ -2718,6 +2724,7 @@ public abstract class SSLEngineTest {
                 .sslProvider(sslClientProvider())
                 .protocols(param.protocols())
                 .ciphers(param.ciphers())
+                .endpointIdentificationAlgorithm(null)
                 .build());
         SSLEngine client = wrapEngine(clientSslCtx.newEngine(UnpooledByteBufAllocator.DEFAULT));
 
@@ -2800,6 +2807,7 @@ public abstract class SSLEngineTest {
                 .sslProvider(sslClientProvider())
                 .protocols(param.protocols())
                 .ciphers(param.ciphers())
+                .endpointIdentificationAlgorithm(null)
                 .build());
         SSLEngine client = wrapEngine(clientSslCtx.newEngine(UnpooledByteBufAllocator.DEFAULT));
 
@@ -2871,6 +2879,7 @@ public abstract class SSLEngineTest {
                 .sslProvider(sslClientProvider())
                 .protocols(param.protocols())
                 .ciphers(param.ciphers())
+                .endpointIdentificationAlgorithm(null)
                 .build());
         SSLEngine client = wrapEngine(clientSslCtx.newEngine(UnpooledByteBufAllocator.DEFAULT));
 
@@ -2949,6 +2958,7 @@ public abstract class SSLEngineTest {
                 .sslProvider(sslClientProvider())
                 .protocols(param.protocols())
                 .ciphers(param.ciphers())
+                .endpointIdentificationAlgorithm(null)
                 .build());
         SSLEngine client = wrapEngine(clientSslCtx.newEngine(UnpooledByteBufAllocator.DEFAULT));
 

--- a/handler/src/test/java/io/netty/handler/ssl/SniHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SniHandlerTest.java
@@ -82,6 +82,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 
 public class SniHandlerTest {
@@ -133,7 +134,10 @@ public class SniHandlerTest {
 
         File crtFile = ResourcesUtil.getFile(SniHandlerTest.class, "test.crt");
 
-        SslContextBuilder sslCtxBuilder = SslContextBuilder.forClient().trustManager(crtFile).sslProvider(provider);
+        SslContextBuilder sslCtxBuilder = SslContextBuilder.forClient()
+                .trustManager(crtFile)
+                .endpointIdentificationAlgorithm(null)
+                .sslProvider(provider);
         if (apn) {
             sslCtxBuilder.applicationProtocolConfig(newApnConfig());
         }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
@@ -134,6 +134,7 @@ public class SocketSslEchoTest extends AbstractSocketTest {
                                             .trustManager(CERT_FILE)
                                             // As we test renegotiation we should use a protocol that support it.
                                             .protocols("TLSv1.2")
+                                            .endpointIdentificationAlgorithm(null)
                                             .build());
 
         boolean hasOpenSsl = OpenSsl.isAvailable();
@@ -148,6 +149,7 @@ public class SocketSslEchoTest extends AbstractSocketTest {
                                                 .trustManager(CERT_FILE)
                                                 // As we test renegotiation we should use a protocol that support it.
                                                 .protocols("TLSv1.2")
+                                                .endpointIdentificationAlgorithm(null)
                                                 .build());
         } else {
             logger.warn("OpenSSL is unavailable and thus will not be tested.", OpenSsl.unavailabilityCause());

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslGreetingTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslGreetingTest.java
@@ -91,6 +91,7 @@ public class SocketSslGreetingTest extends AbstractSocketTest {
             serverContexts.add(SslContextBuilder.forServer(CERT_FILE, KEY_FILE)
                                                 .sslProvider(SslProvider.OPENSSL).build());
             clientContexts.add(SslContextBuilder.forClient().sslProvider(SslProvider.OPENSSL)
+                                                .endpointIdentificationAlgorithm(null)
                                                 .trustManager(CERT_FILE).build());
         } else {
             logger.warn("OpenSSL is unavailable and thus will not be tested.", OpenSsl.unavailabilityCause());

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketStartTlsTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketStartTlsTest.java
@@ -88,14 +88,21 @@ public class SocketStartTlsTest extends AbstractSocketTest {
         serverContexts.add(SslContextBuilder.forServer(CERT_FILE, KEY_FILE).sslProvider(SslProvider.JDK).build());
 
         List<SslContext> clientContexts = new ArrayList<SslContext>();
-        clientContexts.add(SslContextBuilder.forClient().sslProvider(SslProvider.JDK).trustManager(CERT_FILE).build());
+        clientContexts.add(SslContextBuilder.forClient()
+                .sslProvider(SslProvider.JDK)
+                .trustManager(CERT_FILE)
+                .endpointIdentificationAlgorithm(null)
+                .build());
 
         boolean hasOpenSsl = OpenSsl.isAvailable();
         if (hasOpenSsl) {
             serverContexts.add(SslContextBuilder.forServer(CERT_FILE, KEY_FILE)
                                                 .sslProvider(SslProvider.OPENSSL).build());
-            clientContexts.add(SslContextBuilder.forClient().sslProvider(SslProvider.OPENSSL)
-                                                .trustManager(CERT_FILE).build());
+            clientContexts.add(SslContextBuilder.forClient()
+                    .sslProvider(SslProvider.OPENSSL)
+                    .trustManager(CERT_FILE)
+                    .endpointIdentificationAlgorithm(null)
+                    .build());
         } else {
             logger.warn("OpenSSL is unavailable and thus will not be tested.", OpenSsl.unavailabilityCause());
         }


### PR DESCRIPTION
Motivation:
Hostname validation is an important step for clients, in verifying the identity of the server.

We should make it easy to configure.

Due to its importance, we should also enable it by default. While there are theoretically multiple algorithms to choose from for this purpose, the "HTTPS" algorithm is *by far* the most commonly used one.

Modification:
- Add a SslContextBuilder.endpointIdentificationAlgorithm() method to configure hostname validation.
- Set the endpoint validation algorithm to "HTTPS" by default, when creating SslContextBuilders for clients.

Result:
Hostname validation is now enabled by default for clients, and can easily be configured through the SslContext.