### PR TITLE
Default hostname validation, configured via SslContextBuilder (#14127)

### DIFF
--- a/handler/src/main/java/io/netty5/handler/ssl/JdkSslClientContext.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/JdkSslClientContext.java
@@ -46,7 +46,7 @@ final class JdkSslClientContext extends JdkSslContext {
         super(newSSLContext(provider, toX509CertificatesInternal(trustCertCollectionFile),
           trustManagerFactory, null, null,
           null, null, sessionCacheSize, sessionTimeout, null, KeyStore.getDefaultType()), true,
-          ciphers, cipherFilter, apn, ClientAuth.NONE, null, false);
+          ciphers, cipherFilter, apn, ClientAuth.NONE, null, false, null);
     }
 
     JdkSslClientContext(Provider sslContextProvider,
@@ -63,11 +63,13 @@ final class JdkSslClientContext extends JdkSslContext {
                         long sessionCacheSize,
                         long sessionTimeout,
                         SecureRandom secureRandom,
-                        String keyStore)
+                        String keyStore,
+                        String endpointIdentificationAlgorithm)
       throws Exception {
         super(newSSLContext(sslContextProvider, trustCertCollection, trustManagerFactory,
           keyCertChain, key, keyPassword, keyManagerFactory, sessionCacheSize, sessionTimeout, secureRandom, keyStore),
-          true, ciphers, cipherFilter, toNegotiator(apn, false), ClientAuth.NONE, protocols, false);
+          true, ciphers, cipherFilter, toNegotiator(apn, false), ClientAuth.NONE, protocols, false,
+                endpointIdentificationAlgorithm);
     }
 
     private static SSLContext newSSLContext(Provider sslContextProvider,

--- a/handler/src/main/java/io/netty5/handler/ssl/JdkSslServerContext.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/JdkSslServerContext.java
@@ -93,7 +93,7 @@ final class JdkSslServerContext extends JdkSslContext {
         super(newSSLContext(provider, null, null,
           toX509CertificatesInternal(certChainFile), toPrivateKeyInternal(keyFile, keyPassword),
           keyPassword, null, sessionCacheSize, sessionTimeout, null, KeyStore.getDefaultType()),
-          false, ciphers, cipherFilter, apn, ClientAuth.NONE, null, false);
+          false, ciphers, cipherFilter, apn, ClientAuth.NONE, null, false, null);
     }
 
     JdkSslServerContext(Provider provider,
@@ -116,7 +116,7 @@ final class JdkSslServerContext extends JdkSslContext {
       throws Exception {
         super(newSSLContext(provider, trustCertCollection, trustManagerFactory, keyCertChain, key,
           keyPassword, keyManagerFactory, sessionCacheSize, sessionTimeout, secureRandom, keyStore), false,
-          ciphers, cipherFilter, toNegotiator(apn, true), clientAuth, protocols, startTls);
+          ciphers, cipherFilter, toNegotiator(apn, true), clientAuth, protocols, startTls, null);
     }
 
     private static SSLContext newSSLContext(Provider sslContextProvider, X509Certificate[] trustCertCollection,

--- a/handler/src/main/java/io/netty5/handler/ssl/OpenSslClientContext.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/OpenSslClientContext.java
@@ -39,10 +39,11 @@ final class OpenSslClientContext extends OpenSslContext {
                                 KeyManagerFactory keyManagerFactory, Iterable<String> ciphers,
                                 CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn, String[] protocols,
                                 long sessionCacheSize, long sessionTimeout, boolean enableOcsp, String keyStore,
+                         String endpointIdentificationAlgorithm,
                          Map.Entry<SslContextOption<?>, Object>... options)
             throws SSLException {
         super(ciphers, cipherFilter, apn, SSL.SSL_MODE_CLIENT, keyCertChain,
-                ClientAuth.NONE, protocols, false, enableOcsp, options);
+                ClientAuth.NONE, protocols, false, enableOcsp, endpointIdentificationAlgorithm, options);
         boolean success = false;
         try {
             OpenSslKeyMaterialProvider.validateKeyMaterialSupported(keyCertChain, key, keyPassword);

--- a/handler/src/main/java/io/netty5/handler/ssl/OpenSslContext.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/OpenSslContext.java
@@ -29,25 +29,27 @@ import java.util.Map;
 public abstract class OpenSslContext extends ReferenceCountedOpenSslContext {
     OpenSslContext(Iterable<String> ciphers, CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apnCfg,
                    int mode, Certificate[] keyCertChain,
-                   ClientAuth clientAuth, String[] protocols, boolean startTls, boolean enableOcsp,
+                   ClientAuth clientAuth, String[] protocols, boolean startTls,
+                   boolean enableOcsp, String endpointIdentificationAlgorithm,
                    Map.Entry<SslContextOption<?>, Object>... options)
             throws SSLException {
         super(ciphers, cipherFilter, toNegotiator(apnCfg), mode, keyCertChain,
-                clientAuth, protocols, startTls, enableOcsp, false, options);
+                clientAuth, protocols, startTls, enableOcsp, false, endpointIdentificationAlgorithm, options);
     }
 
     OpenSslContext(Iterable<String> ciphers, CipherSuiteFilter cipherFilter, OpenSslApplicationProtocolNegotiator apn,
                    int mode, Certificate[] keyCertChain,
                    ClientAuth clientAuth, String[] protocols, boolean startTls, boolean enableOcsp,
-                   Map.Entry<SslContextOption<?>, Object>... options)
+                   String endpointIdentificationAlgorithm, Map.Entry<SslContextOption<?>, Object>... options)
             throws SSLException {
         super(ciphers, cipherFilter, apn, mode, keyCertChain,
-                clientAuth, protocols, startTls, enableOcsp, false, options);
+                clientAuth, protocols, startTls, enableOcsp, false, endpointIdentificationAlgorithm, options);
     }
 
     @Override
     final SSLEngine newEngine0(BufferAllocator alloc, String peerHost, int peerPort, boolean jdkCompatibilityMode) {
-        return new OpenSslEngine(this, alloc, peerHost, peerPort, jdkCompatibilityMode);
+        return new OpenSslEngine(this, alloc, peerHost, peerPort, jdkCompatibilityMode,
+                endpointIdentificationAlgorithm);
     }
 
     @Override

--- a/handler/src/main/java/io/netty5/handler/ssl/OpenSslEngine.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/OpenSslEngine.java
@@ -28,8 +28,8 @@ import javax.net.ssl.SSLEngine;
  */
 public final class OpenSslEngine extends ReferenceCountedOpenSslEngine {
     OpenSslEngine(OpenSslContext context, BufferAllocator alloc, String peerHost, int peerPort,
-                  boolean jdkCompatibilityMode) {
-        super(context, alloc, peerHost, peerPort, jdkCompatibilityMode, false);
+                  boolean jdkCompatibilityMode,  String endpointIdentificationAlgorithm) {
+        super(context, alloc, peerHost, peerPort, jdkCompatibilityMode, false, endpointIdentificationAlgorithm);
     }
 
     @Override

--- a/handler/src/main/java/io/netty5/handler/ssl/OpenSslServerContext.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/OpenSslServerContext.java
@@ -55,7 +55,7 @@ final class OpenSslServerContext extends OpenSslContext {
             boolean enableOcsp, String keyStore, Map.Entry<SslContextOption<?>, Object>... options)
             throws SSLException {
         super(ciphers, cipherFilter, apn, SSL.SSL_MODE_SERVER, keyCertChain,
-                clientAuth, protocols, startTls, enableOcsp, options);
+                clientAuth, protocols, startTls, enableOcsp, null, options);
         // Create a new SSL_CTX and configure it.
         boolean success = false;
         try {

--- a/handler/src/main/java/io/netty5/handler/ssl/ReferenceCountedOpenSslClientContext.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/ReferenceCountedOpenSslClientContext.java
@@ -60,10 +60,11 @@ public final class ReferenceCountedOpenSslClientContext extends ReferenceCounted
                                          KeyManagerFactory keyManagerFactory, Iterable<String> ciphers,
                                          CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn,
                                          String[] protocols, long sessionCacheSize, long sessionTimeout,
-                                         boolean enableOcsp, String keyStore,
+                                         boolean enableOcsp, String keyStore, String endpointIdentificationAlgorithm,
                                          Map.Entry<SslContextOption<?>, Object>... options) throws SSLException {
         super(ciphers, cipherFilter, toNegotiator(apn), SSL.SSL_MODE_CLIENT, keyCertChain,
-              ClientAuth.NONE, protocols, false, enableOcsp, true, options);
+              ClientAuth.NONE, protocols, false, enableOcsp, true, endpointIdentificationAlgorithm,
+                options);
         boolean success = false;
         try {
             sessionContext = newSessionContext(this, ctx, engineMap, trustCertCollection, trustManagerFactory,

--- a/handler/src/main/java/io/netty5/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -152,6 +152,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
     final Certificate[] keyCertChain;
     final ClientAuth clientAuth;
     final String[] protocols;
+    final String endpointIdentificationAlgorithm;
     final boolean hasTLSv13Cipher;
 
     final boolean enableOcsp;
@@ -208,7 +209,8 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
     ReferenceCountedOpenSslContext(Iterable<String> ciphers, CipherSuiteFilter cipherFilter,
                                    OpenSslApplicationProtocolNegotiator apn, int mode, Certificate[] keyCertChain,
                                    ClientAuth clientAuth, String[] protocols, boolean startTls, boolean enableOcsp,
-                                   boolean leakDetection, Map.Entry<SslContextOption<?>, Object>... ctxOptions)
+                                   boolean leakDetection, String endpointIdentificationAlgorithm,
+                                   Map.Entry<SslContextOption<?>, Object>... ctxOptions)
             throws SSLException {
         super(startTls);
 
@@ -263,6 +265,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
         this.mode = mode;
         this.clientAuth = isServer() ? requireNonNull(clientAuth, "clientAuth") : ClientAuth.NONE;
         this.protocols = protocols == null ? OpenSsl.defaultProtocols(mode == SSL.SSL_MODE_CLIENT) : protocols;
+        this.endpointIdentificationAlgorithm = endpointIdentificationAlgorithm;
         this.enableOcsp = enableOcsp;
 
         this.keyCertChain = keyCertChain == null ? null : keyCertChain.clone();
@@ -490,7 +493,8 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
     }
 
     SSLEngine newEngine0(BufferAllocator alloc, String peerHost, int peerPort, boolean jdkCompatibilityMode) {
-        return new ReferenceCountedOpenSslEngine(this, alloc, peerHost, peerPort, jdkCompatibilityMode, true);
+        return new ReferenceCountedOpenSslEngine(this, alloc, peerHost, peerPort, jdkCompatibilityMode, true,
+                endpointIdentificationAlgorithm);
     }
 
     /**

--- a/handler/src/main/java/io/netty5/handler/ssl/ReferenceCountedOpenSslServerContext.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/ReferenceCountedOpenSslServerContext.java
@@ -69,7 +69,10 @@ public final class ReferenceCountedOpenSslServerContext extends ReferenceCounted
             boolean enableOcsp, String keyStore, Map.Entry<SslContextOption<?>, Object>... options)
             throws SSLException {
         super(ciphers, cipherFilter, apn, SSL.SSL_MODE_SERVER, keyCertChain,
-              clientAuth, protocols, startTls, enableOcsp, true, options);
+                clientAuth, protocols, startTls,
+                enableOcsp, true,
+                null, // No endpoint validation for servers.
+                options);
         // Create a new SSL_CTX and configure it.
         boolean success = false;
         try {

--- a/handler/src/main/java/io/netty5/handler/ssl/SslContext.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslContext.java
@@ -807,7 +807,7 @@ public abstract class SslContext {
                                             toX509Certificates(keyCertChainFile), toPrivateKey(keyFile, keyPassword),
                                             keyPassword, keyManagerFactory, ciphers, cipherFilter,
                                             apn, null, sessionCacheSize, sessionTimeout, false,
-                                            null, KeyStore.getDefaultType());
+                                            null, KeyStore.getDefaultType(), "HTTPS");
         } catch (Exception e) {
             if (e instanceof SSLException) {
                 throw (SSLException) e;
@@ -823,7 +823,7 @@ public abstract class SslContext {
             X509Certificate[] keyCertChain, PrivateKey key, String keyPassword, KeyManagerFactory keyManagerFactory,
             Iterable<String> ciphers, CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn, String[] protocols,
             long sessionCacheSize, long sessionTimeout, boolean enableOcsp,
-            SecureRandom secureRandom, String keyStoreType,
+            SecureRandom secureRandom, String keyStoreType, String endpointIdentificationAlgorithm,
             Map.Entry<SslContextOption<?>, Object>... options) throws SSLException {
         if (provider == null) {
             provider = defaultClientProvider();
@@ -837,7 +837,7 @@ public abstract class SslContext {
                     return new JdkSslClientContext(sslContextProvider,
                             trustCert, trustManagerFactory, keyCertChain, key, keyPassword,
                             keyManagerFactory, ciphers, cipherFilter, apn, protocols, sessionCacheSize,
-                            sessionTimeout, secureRandom, keyStoreType);
+                            sessionTimeout, secureRandom, keyStoreType, endpointIdentificationAlgorithm);
                 } catch (SSLException e) {
                     throw e;
                 } catch (Exception e) {
@@ -849,14 +849,14 @@ public abstract class SslContext {
                 return new OpenSslClientContext(
                         trustCert, trustManagerFactory, keyCertChain, key, keyPassword,
                         keyManagerFactory, ciphers, cipherFilter, apn, protocols, sessionCacheSize, sessionTimeout,
-                        enableOcsp, keyStoreType, options);
+                        enableOcsp, keyStoreType, endpointIdentificationAlgorithm, options);
             case OPENSSL_REFCNT:
                 verifyNullSslContextProvider(provider, sslContextProvider);
                 OpenSsl.ensureAvailability();
                 return new ReferenceCountedOpenSslClientContext(
                         trustCert, trustManagerFactory, keyCertChain, key, keyPassword,
                         keyManagerFactory, ciphers, cipherFilter, apn, protocols, sessionCacheSize, sessionTimeout,
-                        enableOcsp, keyStoreType, options);
+                        enableOcsp, keyStoreType, endpointIdentificationAlgorithm, options);
             default:
                 throw new Error(provider.toString());
         }

--- a/handler/src/main/java/io/netty5/handler/ssl/SslContextBuilder.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslContextBuilder.java
@@ -208,10 +208,14 @@ public final class SslContextBuilder {
     private boolean enableOcsp;
     private SecureRandom secureRandom;
     private String keyStoreType = KeyStore.getDefaultType();
+    private String endpointIdentificationAlgorithm;
     private final Map<SslContextOption<?>, Object> options = new HashMap<>();
 
     private SslContextBuilder(boolean forServer) {
         this.forServer = forServer;
+        if (!forServer) {
+            endpointIdentificationAlgorithm = "HTTPS";
+        }
     }
 
     /**
@@ -618,6 +622,21 @@ public final class SslContextBuilder {
     }
 
     /**
+     * Specify the endpoint identification algorithm (aka. hostname verification algorithm) that clients will use as
+     * part of authenticating servers.
+     * <p>
+     * See <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#jssenames">
+     *     Java Security Standard Names</a> for a list of supported algorithms.
+     *
+     * @param algorithm either {@code "HTTPS"}, {@code "LDAPS"}, or {@code null} (disables hostname verification).
+     * @see javax.net.ssl.SSLParameters#setEndpointIdentificationAlgorithm(String)
+     */
+    public SslContextBuilder endpointIdentificationAlgorithm(String algorithm) {
+        endpointIdentificationAlgorithm = algorithm;
+        return this;
+    }
+
+    /**
      * Create new {@code SslContext} instance with configured settings.
      * <p>If {@link #sslProvider(SslProvider)} is set to {@link SslProvider#OPENSSL_REFCNT} then the caller is
      * responsible for releasing this object, or else native memory may leak.
@@ -632,7 +651,7 @@ public final class SslContextBuilder {
             return SslContext.newClientContextInternal(provider, sslContextProvider, trustCertCollection,
                 trustManagerFactory, keyCertChain, key, keyPassword, keyManagerFactory,
                 ciphers, cipherFilter, apn, protocols, sessionCacheSize,
-                    sessionTimeout, enableOcsp, secureRandom, keyStoreType,
+                    sessionTimeout, enableOcsp, secureRandom, keyStoreType, endpointIdentificationAlgorithm,
                     toArray(options.entrySet(), EMPTY_ENTRIES));
         }
     }

--- a/handler/src/test/java/io/netty5/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/OpenSslEngineTest.java
@@ -687,6 +687,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
                 .sslProvider(sslClientProvider())
                 .protocols(param.protocols())
                 .ciphers(param.ciphers())
+                .endpointIdentificationAlgorithm(null)
                 .build());
         SSLEngine client = wrapEngine(clientSslCtx.newHandler(offHeapAllocator()).engine());
 
@@ -769,6 +770,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
                 .sslProvider(sslClientProvider())
                 .protocols(param.protocols())
                 .ciphers(param.ciphers())
+                .endpointIdentificationAlgorithm(null)
                 .build());
         SSLEngine client = wrapEngine(clientSslCtx.newHandler(offHeapAllocator()).engine());
 
@@ -860,6 +862,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
                 .sslProvider(sslClientProvider())
                 .protocols(param.protocols())
                 .ciphers(param.ciphers())
+                .endpointIdentificationAlgorithm(null)
                 .build());
         SSLEngine client = wrapEngine(clientSslCtx.newHandler(offHeapAllocator()).engine());
 
@@ -941,6 +944,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
                 .sslProvider(sslClientProvider())
                 .protocols(param.protocols())
                 .ciphers(param.ciphers())
+                .endpointIdentificationAlgorithm(null)
                 .build());
         SSLEngine client = wrapEngine(clientSslCtx.newHandler(offHeapAllocator()).engine());
 
@@ -1202,6 +1206,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
                 .trustManager(cert.certificate())
                 .protocols(param.protocols())
                 .ciphers(param.ciphers())
+                .endpointIdentificationAlgorithm(null)
                 .sslProvider(OPENSSL).build());
         final SSLEngine clientEngine =
                 wrapEngine(clientSslCtx.newEngine(offHeapAllocator()));

--- a/handler/src/test/java/io/netty5/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SSLEngineTest.java
@@ -146,6 +146,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.verify;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -699,17 +700,17 @@ public abstract class SSLEngineTest {
                                  .sessionCacheSize(0)
                                  .sessionTimeout(0).build());
 
-        clientSslCtx =
-                wrapContext(param, SslContextBuilder.forClient()
-                                 .protocols(param.protocols())
-                                 .ciphers(param.ciphers())
-                                 .sslProvider(sslClientProvider())
-                                 .sslContextProvider(clientSslContextProvider())
-                                 .trustManager(clientTrustManager)
-                                 .keyManager(clientKMF)
-                                 .ciphers(null, IdentityCipherSuiteFilter.INSTANCE)
-                                 .sessionCacheSize(0)
-                                 .sessionTimeout(0).build());
+        clientSslCtx = wrapContext(param, SslContextBuilder.forClient()
+                .protocols(param.protocols())
+                .ciphers(param.ciphers())
+                .sslProvider(sslClientProvider())
+                .sslContextProvider(clientSslContextProvider())
+                .trustManager(clientTrustManager)
+                .keyManager(clientKMF)
+                .ciphers(null, IdentityCipherSuiteFilter.INSTANCE)
+                .sessionCacheSize(0)
+                .endpointIdentificationAlgorithm(null)
+                .sessionTimeout(0).build());
 
         serverConnectedChannel = null;
         sb = new ServerBootstrap();
@@ -1066,6 +1067,7 @@ public abstract class SSLEngineTest {
                                  .keyManager(clientCrtFile, clientKeyFile, clientKeyPassword)
                                  .ciphers(null, IdentityCipherSuiteFilter.INSTANCE)
                                  .sessionCacheSize(0)
+                                 .endpointIdentificationAlgorithm(null)
                                  .sessionTimeout(0).build());
 
         serverConnectedChannel = null;
@@ -1906,14 +1908,16 @@ public abstract class SSLEngineTest {
         chainStream.write(Files.readAllBytes(clientCert.certificate().toPath()));
         chainStream.write(Files.readAllBytes(serverCert.certificate().toPath()));
 
-        clientSslCtx =
-                wrapContext(param, SslContextBuilder.forClient().keyManager(
+        clientSslCtx = wrapContext(param, SslContextBuilder.forClient().keyManager(
                         new ByteArrayInputStream(chainStream.toByteArray()),
                         new FileInputStream(clientCert.privateKey()))
                 .trustManager(new FileInputStream(serverCert.certificate()))
                 .sslProvider(sslClientProvider())
                 .sslContextProvider(clientSslContextProvider())
-                .protocols(param.protocols()).ciphers(param.ciphers()).build());
+                .endpointIdentificationAlgorithm(null)
+                .protocols(param.protocols())
+                .ciphers(param.ciphers())
+                .build());
         cb = new Bootstrap();
         cb.group(new MultithreadEventLoopGroup(NioIoHandler.newFactory()));
         cb.channel(NioSocketChannel.class);
@@ -1943,6 +1947,7 @@ public abstract class SSLEngineTest {
                 .sslProvider(sslClientProvider())
                 .protocols(param.protocols())
                 .ciphers(param.ciphers())
+                .endpointIdentificationAlgorithm(null)
                 .build());
         SSLEngine client = wrapEngine(clientSslCtx.newEngine(offHeapAllocator()));
 
@@ -2041,6 +2046,7 @@ public abstract class SSLEngineTest {
                 .trustManager(cert.cert())
                 .sslProvider(sslClientProvider())
                 .protocols(clientProtocols)
+                .endpointIdentificationAlgorithm(null)
                 .build());
         SSLEngine client = wrapEngine(clientSslCtx.newEngine(offHeapAllocator()));
 
@@ -2161,6 +2167,7 @@ public abstract class SSLEngineTest {
                 .sslProvider(sslClientProvider())
                 .protocols(param.protocols())
                 .ciphers(param.ciphers())
+                .endpointIdentificationAlgorithm(null)
                 .build());
         SSLEngine client = wrapEngine(clientSslCtx.newEngine(offHeapAllocator()));
 
@@ -2375,6 +2382,7 @@ public abstract class SSLEngineTest {
                 .trustManager(cert.cert())
                 .sslContextProvider(clientSslContextProvider())
                 .sslProvider(sslClientProvider())
+                .endpointIdentificationAlgorithm(null)
                 // This test only works for non TLSv1.3 for now
                 .protocols(SslProtocols.TLS_v1_2)
                 .build());
@@ -2535,6 +2543,7 @@ public abstract class SSLEngineTest {
                 .sslContextProvider(clientSslContextProvider())
                 .protocols(param.protocols())
                 .ciphers(param.ciphers())
+                .endpointIdentificationAlgorithm(null)
                 .build());
         SSLEngine client = wrapEngine(clientSslCtx.newEngine(offHeapAllocator()));
 
@@ -2581,6 +2590,7 @@ public abstract class SSLEngineTest {
                 .sslProvider(sslClientProvider())
                 .protocols(param.protocols())
                 .ciphers(param.ciphers())
+                .endpointIdentificationAlgorithm(null)
                 .build());
         SSLEngine client = wrapEngine(clientSslCtx.newEngine(offHeapAllocator()));
 
@@ -2663,6 +2673,7 @@ public abstract class SSLEngineTest {
                 .sslProvider(sslClientProvider())
                 .protocols(param.protocols())
                 .ciphers(param.ciphers())
+                .endpointIdentificationAlgorithm(null)
                 .build());
         SSLEngine client = wrapEngine(clientSslCtx.newEngine(offHeapAllocator()));
 
@@ -2734,6 +2745,7 @@ public abstract class SSLEngineTest {
                 .sslProvider(sslClientProvider())
                 .protocols(param.protocols())
                 .ciphers(param.ciphers())
+                .endpointIdentificationAlgorithm(null)
                 .build());
         SSLEngine client = wrapEngine(clientSslCtx.newEngine(offHeapAllocator()));
 
@@ -2812,6 +2824,7 @@ public abstract class SSLEngineTest {
                 .sslProvider(sslClientProvider())
                 .protocols(param.protocols())
                 .ciphers(param.ciphers())
+                .endpointIdentificationAlgorithm(null)
                 .build());
         SSLEngine client = wrapEngine(clientSslCtx.newEngine(offHeapAllocator()));
 

--- a/handler/src/test/java/io/netty5/handler/ssl/SniHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SniHandlerTest.java
@@ -133,7 +133,10 @@ public class SniHandlerTest {
 
         File crtFile = ResourcesUtil.getFile(SniHandlerTest.class, "test.crt");
 
-        SslContextBuilder sslCtxBuilder = SslContextBuilder.forClient().trustManager(crtFile).sslProvider(provider);
+        SslContextBuilder sslCtxBuilder = SslContextBuilder.forClient()
+                .trustManager(crtFile)
+                .endpointIdentificationAlgorithm(null)
+                .sslProvider(provider);
         if (alpn) {
             sslCtxBuilder.applicationProtocolConfig(newAlpnConfig());
         }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslEchoTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslEchoTest.java
@@ -134,6 +134,7 @@ public class SocketSslEchoTest extends AbstractSocketTest {
                                             .trustManager(CERT_FILE)
                                             // As we test renegotiation we should use a protocol that support it.
                                             .protocols("TLSv1.2")
+                                            .endpointIdentificationAlgorithm(null)
                                             .build());
 
         boolean hasOpenSsl = OpenSsl.isAvailable();
@@ -148,6 +149,7 @@ public class SocketSslEchoTest extends AbstractSocketTest {
                                                 .trustManager(CERT_FILE)
                                                 // As we test renegotiation we should use a protocol that support it.
                                                 .protocols("TLSv1.2")
+                                                .endpointIdentificationAlgorithm(null)
                                                 .build());
         } else {
             logger.warn("OpenSSL is unavailable and thus will not be tested.", OpenSsl.unavailabilityCause());

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslGreetingTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslGreetingTest.java
@@ -90,6 +90,7 @@ public class SocketSslGreetingTest extends AbstractSocketTest {
             serverContexts.add(SslContextBuilder.forServer(CERT_FILE, KEY_FILE)
                                                 .sslProvider(SslProvider.OPENSSL).build());
             clientContexts.add(SslContextBuilder.forClient().sslProvider(SslProvider.OPENSSL)
+                                                .endpointIdentificationAlgorithm(null)
                                                 .trustManager(CERT_FILE).build());
         } else {
             logger.warn("OpenSSL is unavailable and thus will not be tested.", OpenSsl.unavailabilityCause());

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketStartTlsTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketStartTlsTest.java
@@ -82,14 +82,20 @@ public class SocketStartTlsTest extends AbstractSocketTest {
         serverContexts.add(SslContextBuilder.forServer(CERT_FILE, KEY_FILE).sslProvider(SslProvider.JDK).build());
 
         List<SslContext> clientContexts = new ArrayList<>();
-        clientContexts.add(SslContextBuilder.forClient().sslProvider(SslProvider.JDK).trustManager(CERT_FILE).build());
-
+        clientContexts.add(SslContextBuilder.forClient()
+                .sslProvider(SslProvider.JDK)
+                .trustManager(CERT_FILE)
+                .endpointIdentificationAlgorithm(null)
+                .build());
         boolean hasOpenSsl = OpenSsl.isAvailable();
         if (hasOpenSsl) {
             serverContexts.add(SslContextBuilder.forServer(CERT_FILE, KEY_FILE)
                                                 .sslProvider(SslProvider.OPENSSL).build());
-            clientContexts.add(SslContextBuilder.forClient().sslProvider(SslProvider.OPENSSL)
-                                                .trustManager(CERT_FILE).build());
+            clientContexts.add(SslContextBuilder.forClient()
+                    .sslProvider(SslProvider.OPENSSL)
+                    .trustManager(CERT_FILE)
+                    .endpointIdentificationAlgorithm(null)
+                    .build());
         } else {
             logger.warn("OpenSSL is unavailable and thus will not be tested.", OpenSsl.unavailabilityCause());
         }


### PR DESCRIPTION
Motivation:
Hostname validation is an important step for clients, in verifying the identity of the server.

We should make it easy to configure.

Due to its importance, we should also enable it by default. While there are theoretically multiple algorithms to choose from for this purpose, the "HTTPS" algorithm is *by far* the most commonly used one.

Modification:
- Add a SslContextBuilder.endpointIdentificationAlgorithm() method to configure hostname validation.
- Set the endpoint validation algorithm to "HTTPS" by default, when creating SslContextBuilders for clients.

Result:
Hostname validation is now enabled by default for clients, and can easily be configured through the SslContext.
