### PR TITLE
Revapi should only compare with dot-Final versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1235,6 +1235,7 @@
           </dependency>
         </dependencies>
         <configuration>
+          <versionFormat>.*\.Final</versionFormat>
           <analysisConfiguration>
             <revapi.filter>
               <elements>


### PR DESCRIPTION
Motivation:
By default, revapi will compare with the immediately previous release. In the case of 4.2.0.Alpha2, that would be 4.2.0.Alpha1, which is a pre-release. It should instead only use Final releases for its compatibility checks, and allow us to freely change APIs between alpha-versions.

Modification:
Tell revapi to use a version format that ends with ".Final"

Result:
Revapi now compares our Alpha2-SNAPSHOT builds against 4.1.111, or whatever is the latest 4.1, until we release  4.2.0.Final.
