### PR TITLE
Only delete the socket file for NioServerDomainSocketChannel

### DIFF
--- a/transport/src/main/java/io/netty/channel/socket/nio/NioDomainSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioDomainSocketChannel.java
@@ -342,11 +342,10 @@ public final class NioDomainSocketChannel extends AbstractNioByteChannel
 
     @Override
     protected void doClose() throws Exception {
-        super.doClose();
-        javaChannel().close();
-        SocketAddress local = localAddress();
-        if (local != null) {
-            NioDomainSocketUtil.deleteSocketFile(local);
+        try {
+            super.doClose();
+        } finally {
+            javaChannel().close();
         }
     }
 


### PR DESCRIPTION
Motivation:

We need to ensure we only delete teh sock file when using NioServerDomainSocketChannel as otherwise it is not possible to connect with multiple clients

Modifications:

Only delete file in NioServerDomainSocketChannel

Result:

Fixes https://github.com/netty/netty/issues/14114
