### PR TITLE
Add check for IPv6 brackets when address is unresolved

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
@@ -551,7 +551,6 @@ public final class HttpUtil {
                 // If IPv6 address already contains brackets, let's return as is.
                 return hostString;
             }
-            }
 
             return '[' + hostString + ']';
         }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
@@ -547,7 +547,7 @@ public final class HttpUtil {
         if (NetUtil.isValidIpV6Address(hostString)) {
             if (!addr.isUnresolved()) {
                 hostString = NetUtil.toAddressString(addr.getAddress());
-            } else  if (hostString.charAt(0) == '[' && hostString.charAt(hostString.length() - 1) == ']') {
+            } else if (hostString.charAt(0) == '[' && hostString.charAt(hostString.length() - 1) == ']') {
                 // If IPv6 address already contains brackets, let's return as is.
                 return hostString;
             }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
@@ -547,15 +547,14 @@ public final class HttpUtil {
         if (NetUtil.isValidIpV6Address(hostString)) {
             if (!addr.isUnresolved()) {
                 hostString = NetUtil.toAddressString(addr.getAddress());
+            } else {
+                // If IPv6 address already contains brackets, let's return as is.
+                if (hostString.charAt(0) == '[' && hostString.charAt(hostString.length() - 1) == ']') {
+                    return hostString;
+                }
             }
 
-            // If IPv6 address already contains brackets, let's return as is.
-            if (hostString.charAt(0) == '[' && hostString.charAt(hostString.length() - 1) == ']') {
-                return hostString;
-            } else {
-                // Add brackets to the IPv6 address.
-                return '[' + hostString + ']';
-            }
+            return '[' + hostString + ']';
         }
         return hostString;
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
@@ -548,7 +548,14 @@ public final class HttpUtil {
             if (!addr.isUnresolved()) {
                 hostString = NetUtil.toAddressString(addr.getAddress());
             }
-            return '[' + hostString + ']';
+
+            // If IPv6 address already contains brackets, let's return as is.
+            if (hostString.charAt(0) == '[' && hostString.charAt(hostString.length() - 1) == ']') {
+                return hostString;
+            } else {
+                // Add brackets to the IPv6 address.
+                return '[' + hostString + ']';
+            }
         }
         return hostString;
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
@@ -547,11 +547,10 @@ public final class HttpUtil {
         if (NetUtil.isValidIpV6Address(hostString)) {
             if (!addr.isUnresolved()) {
                 hostString = NetUtil.toAddressString(addr.getAddress());
-            } else {
+            } else  if (hostString.charAt(0) == '[' && hostString.charAt(hostString.length() - 1) == ']') {
                 // If IPv6 address already contains brackets, let's return as is.
-                if (hostString.charAt(0) == '[' && hostString.charAt(hostString.length() - 1) == ']') {
-                    return hostString;
-                }
+                return hostString;
+            }
             }
 
             return '[' + hostString + ']';

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpUtilTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpUtilTest.java
@@ -380,6 +380,12 @@ public class HttpUtilTest {
     }
 
     @Test
+    public void testIpv6UnresolvedExplicitAddress()  {
+        InetSocketAddress socketAddress = InetSocketAddress.createUnresolved("[2001:4860:4860:0:0:0:0:8888]", 8080);
+        assertEquals("[2001:4860:4860:0:0:0:0:8888]", HttpUtil.formatHostnameForHttp(socketAddress));
+    }
+
+    @Test
     public void testIpv4() throws Exception  {
         InetSocketAddress socketAddress = new InetSocketAddress(InetAddress.getByName("10.0.0.1"), 8080);
         assertEquals("10.0.0.1", HttpUtil.formatHostnameForHttp(socketAddress));


### PR DESCRIPTION
Motivation:
If IPv6 is unresolved, we add double `[]` to it which leads to a malformed IPv6 address.

Modification:
If unresolved IPv6 already has double brackets `[]` to it then return as it is else add `[]`.

Result:
Fixes #14137
