### PR TITLE
Null value doesn't disable endpoint verification for JDK provider

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/JdkSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkSslContext.java
@@ -380,9 +380,7 @@ public class JdkSslContext extends SslContext {
             return ((JdkApplicationProtocolNegotiator.AllocatorAwareSslEngineWrapperFactory) factory)
                     .wrapSslEngine(engine, alloc, apn, isServer());
         }
-        if (endpointIdentificationAlgorithm != null) {
-            engine.getSSLParameters().setEndpointIdentificationAlgorithm(endpointIdentificationAlgorithm);
-        }
+        engine.getSSLParameters().setEndpointIdentificationAlgorithm(endpointIdentificationAlgorithm);
         return factory.wrapSslEngine(engine, apn, isServer());
     }
 


### PR DESCRIPTION
Motivation:

If Java ever changes the default endpoint identification algorithm of if users use a 3-party provider that overrides the default, Netty users won't be able to change it via `SslContextBuilder` API by providing a null value. Only an empty string will disable it, but this behavior is not documented in `endpointIdentificationAlgorithm(String)` javadoc.

Modifications:
- Set `endpointIdentificationAlgorithm` unconditionally in `JdkSslContext`, similar to `ReferenceCountedOpenSslServerContext`.

Result:

`SslContextBuilder.endpointIdentificationAlgorithm(null)` works as expected with `SslProvider.JDK`.

Motivation:

Explain here the context, and why you're making that change.
What is the problem you're trying to solve.

Modification:

Describe the modifications you've done.

Result:

Fixes #<GitHub issue number>. 

If there is no issue then describe the changes introduced by this PR.
