### PR TITLE
Update java versions to latest release

### DIFF
--- a/docker/docker-compose.centos-6.111.yaml
+++ b/docker/docker-compose.centos-6.111.yaml
@@ -6,7 +6,7 @@ services:
     image: netty:centos-6-1.11
     build:
       args:
-        java_version : "11.0.22-zulu"
+        java_version : "11.0.23-zulu"
 
   build:
     image: netty:centos-6-1.11

--- a/docker/docker-compose.centos-6.18.yaml
+++ b/docker/docker-compose.centos-6.18.yaml
@@ -6,7 +6,7 @@ services:
     image: netty:centos-6-1.8
     build:
       args:
-        java_version : "8.0.402-zulu"
+        java_version : "8.0.412-zulu"
 
   build:
     image: netty:centos-6-1.8

--- a/docker/docker-compose.centos-6.21.yaml
+++ b/docker/docker-compose.centos-6.21.yaml
@@ -6,7 +6,7 @@ services:
     image: netty:centos-6-21
     build:
       args:
-        java_version : "21.0.2-zulu"
+        java_version : "21.0.3-zulu"
 
   build:
     image: netty:centos-6-21

--- a/docker/docker-compose.centos-6.22.yaml
+++ b/docker/docker-compose.centos-6.22.yaml
@@ -6,7 +6,7 @@ services:
     image: netty:centos-6-22
     build:
       args:
-        java_version : "22-zulu"
+        java_version : "22.0.1-zulu"
 
   build:
     image: netty:centos-6-22

--- a/docker/docker-compose.centos-7.117.yaml
+++ b/docker/docker-compose.centos-7.117.yaml
@@ -6,7 +6,7 @@ services:
     image: netty:centos-7-1.17
     build:
       args:
-        java_version : "17.0.10-zulu"
+        java_version : "17.0.11-zulu"
 
   build:
     image: netty:centos-7-1.17

--- a/docker/docker-compose.centos-7.yaml
+++ b/docker/docker-compose.centos-7.yaml
@@ -9,7 +9,7 @@ services:
       dockerfile: docker/Dockerfile.cross_compile_aarch64
       args:
         gcc_version: "10.2-2020.11"
-        java_version: "8.0.402-zulu"
+        java_version: "8.0.412-zulu"
 
   cross-compile-aarch64-common: &cross-compile-aarch64-common
     depends_on: [ cross-compile-aarch64-runtime-setup ]


### PR DESCRIPTION
Motivation:

The used java versions in our docker-compose file were outdated

Modifications:

Update all versions to latest release

Result:

Use latest versions on CI
