### PR TITLE
JdkSslContext doesn't set endpoint verification algorithm

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/JdkSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkSslContext.java
@@ -41,11 +41,11 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-
 import javax.crypto.NoSuchPaddingException;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSessionContext;
 
 import static io.netty.handler.ssl.SslUtils.DEFAULT_CIPHER_SUITES;
@@ -375,13 +375,19 @@ public class JdkSslContext extends SslContext {
                     throw new Error("Unknown auth " + clientAuth);
             }
         }
+        configureEndpointVerification(engine);
         JdkApplicationProtocolNegotiator.SslEngineWrapperFactory factory = apn.wrapperFactory();
         if (factory instanceof JdkApplicationProtocolNegotiator.AllocatorAwareSslEngineWrapperFactory) {
             return ((JdkApplicationProtocolNegotiator.AllocatorAwareSslEngineWrapperFactory) factory)
                     .wrapSslEngine(engine, alloc, apn, isServer());
         }
-        engine.getSSLParameters().setEndpointIdentificationAlgorithm(endpointIdentificationAlgorithm);
         return factory.wrapSslEngine(engine, apn, isServer());
+    }
+
+    private void configureEndpointVerification(SSLEngine engine) {
+        SSLParameters params = engine.getSSLParameters();
+        params.setEndpointIdentificationAlgorithm(endpointIdentificationAlgorithm);
+        engine.setSSLParameters(params);
     }
 
     @Override

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslGreetingTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslGreetingTest.java
@@ -84,7 +84,8 @@ public class SocketSslGreetingTest extends AbstractSocketTest {
         serverContexts.add(SslContextBuilder.forServer(CERT_FILE, KEY_FILE).sslProvider(SslProvider.JDK).build());
 
         List<SslContext> clientContexts = new ArrayList<SslContext>();
-        clientContexts.add(SslContextBuilder.forClient().sslProvider(SslProvider.JDK).trustManager(CERT_FILE).build());
+        clientContexts.add(SslContextBuilder.forClient().sslProvider(SslProvider.JDK)
+                .endpointIdentificationAlgorithm(null).trustManager(CERT_FILE).build());
 
         boolean hasOpenSsl = OpenSsl.isAvailable();
         if (hasOpenSsl) {


### PR DESCRIPTION
Motivation:

If users configure ALPN, `JdkSslContext.configureAndWrapEngine` skips endpointIdentificationAlgorithm configuration at all. Otherwise, it only sets it in a new `SSLParameters` object but does not apply parameters changes back to the engine. As a result, engine always returns a new `SSLParameters` object without seeing a change in `endpointIdentificationAlgorithm`.

Modifications:
- Add `configureEndpointVerification(SSLEngine)` method that properly sets identification algorithm and applies the change for `SSLEngine`.
- Move this logic before `JdkApplicationProtocolNegotiator.AllocatorAwareSslEngineWrapperFactory` check.
- Add `endpointIdentificationAlgorithm(null)` for tests where necessary.

Result:

Endpoint identification algorithm is correctly set for `SslProvider.JDK`.