### PR TITLE
Add support to suspend EventExecutor

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/AbstractScheduledEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractScheduledEventExecutor.java
@@ -306,8 +306,13 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
             scheduledTaskQueue().removeTyped(task);
         } else {
             // task will remove itself from scheduled task queue when it runs
-            lazyExecute(task);
+            scheduleRemoveScheduled(task);
         }
+    }
+
+    void scheduleRemoveScheduled(final ScheduledFutureTask<?> task) {
+        // task will remove itself from scheduled task queue when it runs
+        lazyExecute(task);
     }
 
     /**

--- a/common/src/main/java/io/netty/util/concurrent/EventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/EventExecutor.java
@@ -15,12 +15,14 @@
  */
 package io.netty.util.concurrent;
 
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
 /**
  * The {@link EventExecutor} is a special {@link EventExecutorGroup} which comes
  * with some handy methods to see if a {@link Thread} is executed in a event loop.
  * Besides this, it also extends the {@link EventExecutorGroup} to allow for a generic
  * way to access methods.
- *
  */
 public interface EventExecutor extends EventExecutorGroup {
 
@@ -72,5 +74,36 @@ public interface EventExecutor extends EventExecutorGroup {
      */
     default <V> Future<V> newFailedFuture(Throwable cause) {
         return new FailedFuture<>(this, cause);
+    }
+
+    /**
+     * Returns {@code true} if the {@link EventExecutor} is considered suspended.
+     *
+     * @return {@code true} if suspended, {@code false} otherwise.
+     */
+    default boolean isSuspended() {
+        return false;
+    }
+
+    /**
+     * Try to suspend this {@link EventExecutor} and return {@code true} if suspension was successful.
+     * Suspending an {@link EventExecutor} will allow it to free up resources (like for example a {@link Thread} that
+     * is backing the {@link EventExecutor}. Once an {@link EventExecutor} was suspended it will be started again
+     * by submitting work to it via one of the following methods:
+     * <ul>
+     *   <li>{@link #execute(Runnable)}</li>
+     *   <li>{@link #schedule(Runnable, long, TimeUnit)}</li>
+     *   <li>{@link #schedule(Callable, long, TimeUnit)}</li>
+     *   <li>{@link #scheduleAtFixedRate(Runnable, long, long, TimeUnit)}</li>
+     *   <li>{@link #scheduleWithFixedDelay(Runnable, long, long, TimeUnit)}</li>
+     * </ul>
+     *
+     * Even if this method returns {@code true} it might take some time for the {@link EventExecutor} to fully suspend
+     * itself.
+     *
+     * @return {@code true} if suspension was successful, {@code false otherwise}.
+     */
+    default boolean trySuspend() {
+        return false;
     }
 }

--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -42,6 +42,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Abstract base class for {@link OrderedEventExecutor}'s that execute all its submitted tasks in a single thread.
@@ -56,10 +58,11 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
             InternalLoggerFactory.getInstance(SingleThreadEventExecutor.class);
 
     private static final int ST_NOT_STARTED = 1;
-    private static final int ST_STARTED = 2;
-    private static final int ST_SHUTTING_DOWN = 3;
-    private static final int ST_SHUTDOWN = 4;
-    private static final int ST_TERMINATED = 5;
+    private static final int ST_SUSPENDED = 2;
+    private static final int ST_STARTED = 3;
+    private static final int ST_SHUTTING_DOWN = 4;
+    private static final int ST_SHUTDOWN = 5;
+    private static final int ST_TERMINATED = 6;
 
     private static final Runnable NOOP_TASK = new Runnable() {
         @Override
@@ -73,7 +76,6 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
     private static final AtomicReferenceFieldUpdater<SingleThreadEventExecutor, ThreadProperties> PROPERTIES_UPDATER =
             AtomicReferenceFieldUpdater.newUpdater(
                     SingleThreadEventExecutor.class, ThreadProperties.class, "threadProperties");
-
     private final Queue<Runnable> taskQueue;
 
     private volatile Thread thread;
@@ -82,11 +84,13 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
     private final Executor executor;
     private volatile boolean interrupted;
 
+    private final Lock processingLock = new ReentrantLock();
     private final CountDownLatch threadLock = new CountDownLatch(1);
     private final Set<Runnable> shutdownHooks = new LinkedHashSet<Runnable>();
     private final boolean addTaskWakesUp;
     private final int maxPendingTasks;
     private final RejectedExecutionHandler rejectedExecutionHandler;
+    private final boolean supportSuspension;
 
     private long lastExecutionTime;
 
@@ -132,6 +136,25 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
      * Create a new instance
      *
      * @param parent            the {@link EventExecutorGroup} which is the parent of this instance and belongs to it
+     * @param threadFactory     the {@link ThreadFactory} which will be used for the used {@link Thread}
+     * @param addTaskWakesUp    {@code true} if and only if invocation of {@link #addTask(Runnable)} will wake up the
+     *                          executor thread
+     * @param supportSuspension {@code true} if suspension of this {@link SingleThreadEventExecutor} is supported.
+     * @param maxPendingTasks   the maximum number of pending tasks before new tasks will be rejected.
+     * @param rejectedHandler   the {@link RejectedExecutionHandler} to use.
+     */
+    protected SingleThreadEventExecutor(
+            EventExecutorGroup parent, ThreadFactory threadFactory,
+            boolean addTaskWakesUp, boolean supportSuspension,
+            int maxPendingTasks, RejectedExecutionHandler rejectedHandler) {
+        this(parent, new ThreadPerTaskExecutor(threadFactory), addTaskWakesUp, supportSuspension,
+                maxPendingTasks, rejectedHandler);
+    }
+
+    /**
+     * Create a new instance
+     *
+     * @param parent            the {@link EventExecutorGroup} which is the parent of this instance and belongs to it
      * @param executor          the {@link Executor} which will be used for executing
      * @param addTaskWakesUp    {@code true} if and only if invocation of {@link #addTask(Runnable)} will wake up the
      *                          executor thread
@@ -153,8 +176,26 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
     protected SingleThreadEventExecutor(EventExecutorGroup parent, Executor executor,
                                         boolean addTaskWakesUp, int maxPendingTasks,
                                         RejectedExecutionHandler rejectedHandler) {
+        this(parent, executor, addTaskWakesUp, false, maxPendingTasks, rejectedHandler);
+    }
+
+    /**
+     * Create a new instance
+     *
+     * @param parent            the {@link EventExecutorGroup} which is the parent of this instance and belongs to it
+     * @param executor          the {@link Executor} which will be used for executing
+     * @param addTaskWakesUp    {@code true} if and only if invocation of {@link #addTask(Runnable)} will wake up the
+     *                          executor thread
+     * @param supportSuspension {@code true} if suspension of this {@link SingleThreadEventExecutor} is supported.
+     * @param maxPendingTasks   the maximum number of pending tasks before new tasks will be rejected.
+     * @param rejectedHandler   the {@link RejectedExecutionHandler} to use.
+     */
+    protected SingleThreadEventExecutor(EventExecutorGroup parent, Executor executor,
+                                        boolean addTaskWakesUp, boolean supportSuspension,
+                                        int maxPendingTasks, RejectedExecutionHandler rejectedHandler) {
         super(parent);
         this.addTaskWakesUp = addTaskWakesUp;
+        this.supportSuspension = supportSuspension;
         this.maxPendingTasks = Math.max(16, maxPendingTasks);
         this.executor = ThreadExecutorMap.apply(executor, this);
         taskQueue = newTaskQueue(this.maxPendingTasks);
@@ -164,8 +205,15 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
     protected SingleThreadEventExecutor(EventExecutorGroup parent, Executor executor,
                                         boolean addTaskWakesUp, Queue<Runnable> taskQueue,
                                         RejectedExecutionHandler rejectedHandler) {
+        this(parent, executor, addTaskWakesUp, false, taskQueue, rejectedHandler);
+    }
+
+    protected SingleThreadEventExecutor(EventExecutorGroup parent, Executor executor,
+                                        boolean addTaskWakesUp, boolean supportSuspension,
+                                        Queue<Runnable> taskQueue, RejectedExecutionHandler rejectedHandler) {
         super(parent);
         this.addTaskWakesUp = addTaskWakesUp;
+        this.supportSuspension = supportSuspension;
         this.maxPendingTasks = DEFAULT_MAX_PENDING_EXECUTOR_TASKS;
         this.executor = ThreadExecutorMap.apply(executor, this);
         this.taskQueue = ObjectUtil.checkNotNull(taskQueue, "taskQueue");
@@ -643,6 +691,7 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
                 switch (oldState) {
                     case ST_NOT_STARTED:
                     case ST_STARTED:
+                    case ST_SUSPENDED:
                         newState = ST_SHUTTING_DOWN;
                         break;
                     default:
@@ -699,6 +748,7 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
                 switch (oldState) {
                     case ST_NOT_STARTED:
                     case ST_STARTED:
+                    case ST_SUSPENDED:
                     case ST_SHUTTING_DOWN:
                         newState = ST_SHUTDOWN;
                         break;
@@ -737,6 +787,32 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
     @Override
     public boolean isTerminated() {
         return state == ST_TERMINATED;
+    }
+
+    @Override
+    public boolean isSuspended() {
+        return state == ST_SUSPENDED;
+    }
+
+    @Override
+    public boolean trySuspend() {
+        if (supportSuspension) {
+            if (STATE_UPDATER.compareAndSet(this, ST_STARTED, ST_SUSPENDED)) {
+                wakeup(inEventLoop());
+                return true;
+            }
+            return state == ST_SUSPENDED;
+        }
+        return false;
+    }
+
+    protected boolean canSuspend() {
+        return canSuspend(state);
+    }
+
+    private boolean canSuspend(int state) {
+        assert inEventLoop();
+        return supportSuspension && state == ST_SUSPENDED && !hasTasks() && nextScheduledTaskDeadlineNanos() == -1;
     }
 
     /**
@@ -826,6 +902,31 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
 
     private void lazyExecute0(@Schedule Runnable task) {
         execute(ObjectUtil.checkNotNull(task, "task"), false);
+    }
+
+    @Override
+    void scheduleRemoveScheduled(final ScheduledFutureTask<?> task) {
+        ObjectUtil.checkNotNull(task, "task");
+        int currentState = state;
+        if (supportSuspension && currentState == ST_SUSPENDED) {
+            // In the case of scheduling for removal we need to also ensure we will recover the "suspend" state
+            // after it if it was set before. Otherwise we will always end up "unsuspending" things on cancellation
+            // which is not optimal.
+            execute(new Runnable() {
+                @Override
+                public void run() {
+                    task.run();
+                    if (canSuspend(currentState)) {
+                        // Try suspending again to recover the state before we submitted the new task that will
+                        // handle cancellation itself.
+                        trySuspend();
+                    }
+                }
+            }, true);
+        } else {
+            // task will remove itself from scheduled task queue when it runs
+            execute(task, false);
+        }
     }
 
     private void execute(Runnable task, boolean immediate) {
@@ -945,8 +1046,9 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
     private static final long SCHEDULE_PURGE_INTERVAL = TimeUnit.SECONDS.toNanos(1);
 
     private void startThread() {
-        if (state == ST_NOT_STARTED) {
-            if (STATE_UPDATER.compareAndSet(this, ST_NOT_STARTED, ST_STARTED)) {
+        int currentState = state;
+        if (currentState == ST_NOT_STARTED || currentState == ST_SUSPENDED) {
+            if (STATE_UPDATER.compareAndSet(this, currentState, ST_STARTED)) {
                 boolean success = false;
                 try {
                     doStartThread();
@@ -961,7 +1063,7 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
     }
 
     private boolean ensureThreadStarted(int oldState) {
-        if (oldState == ST_NOT_STARTED) {
+        if (oldState == ST_NOT_STARTED || oldState == ST_SUSPENDED) {
             try {
                 doStartThread();
             } catch (Throwable cause) {
@@ -979,15 +1081,16 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
     }
 
     private void doStartThread() {
-        assert thread == null;
         executor.execute(new Runnable() {
             @Override
             public void run() {
+                processingLock.lock();
+                assert thread == null;
                 thread = Thread.currentThread();
                 if (interrupted) {
                     thread.interrupt();
+                    interrupted = false;
                 }
-
                 boolean success = false;
                 updateLastExecutionTime();
                 try {
@@ -996,64 +1099,84 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
                 } catch (Throwable t) {
                     logger.warn("Unexpected exception from an event executor: ", t);
                 } finally {
+                    int oldState = state;
                     for (;;) {
-                        int oldState = state;
-                        if (oldState >= ST_SHUTTING_DOWN || STATE_UPDATER.compareAndSet(
+                        if (oldState == ST_SUSPENDED || oldState >= ST_SHUTTING_DOWN || STATE_UPDATER.compareAndSet(
                                 SingleThreadEventExecutor.this, oldState, ST_SHUTTING_DOWN)) {
                             break;
                         }
                     }
 
-                    // Check if confirmShutdown() was called at the end of the loop.
-                    if (success && gracefulShutdownStartTime == 0) {
-                        if (logger.isErrorEnabled()) {
-                            logger.error("Buggy " + EventExecutor.class.getSimpleName() + " implementation; " +
-                                    SingleThreadEventExecutor.class.getSimpleName() + ".confirmShutdown() must " +
-                                    "be called before run() implementation terminates.");
+                    if (success) {
+                        if (oldState != ST_SUSPENDED && gracefulShutdownStartTime == 0) {
+                            // Check if confirmShutdown() was called at the end of the loop.
+                            if (logger.isErrorEnabled()) {
+                                logger.error("Buggy " + EventExecutor.class.getSimpleName() + " implementation; " +
+                                        SingleThreadEventExecutor.class.getSimpleName() + ".confirmShutdown() must " +
+                                        "be called before run() implementation terminates.");
+                            }
                         }
                     }
 
                     try {
-                        // Run all remaining tasks and shutdown hooks. At this point the event loop
-                        // is in ST_SHUTTING_DOWN state still accepting tasks which is needed for
-                        // graceful shutdown with quietPeriod.
-                        for (;;) {
-                            if (confirmShutdown()) {
-                                break;
+                        if (oldState != ST_SUSPENDED) {
+                            // Run all remaining tasks and shutdown hooks. At this point the event loop
+                            // is in ST_SHUTTING_DOWN state still accepting tasks which is needed for
+                            // graceful shutdown with quietPeriod.
+                            for (;;) {
+                                if (confirmShutdown()) {
+                                    break;
+                                }
                             }
-                        }
 
-                        // Now we want to make sure no more tasks can be added from this point. This is
-                        // achieved by switching the state. Any new tasks beyond this point will be rejected.
-                        for (;;) {
-                            int oldState = state;
-                            if (oldState >= ST_SHUTDOWN || STATE_UPDATER.compareAndSet(
-                                    SingleThreadEventExecutor.this, oldState, ST_SHUTDOWN)) {
-                                break;
+                            // Now we want to make sure no more tasks can be added from this point. This is
+                            // achieved by switching the state. Any new tasks beyond this point will be rejected.
+                            for (;;) {
+                                int currentState = state;
+                                if (currentState >= ST_SHUTDOWN || STATE_UPDATER.compareAndSet(
+                                        SingleThreadEventExecutor.this, currentState, ST_SHUTDOWN)) {
+                                    break;
+                                }
                             }
-                        }
 
-                        // We have the final set of tasks in the queue now, no more can be added, run all remaining.
-                        // No need to loop here, this is the final pass.
-                        confirmShutdown();
+                            // We have the final set of tasks in the queue now, no more can be added, run all remaining.
+                            // No need to loop here, this is the final pass.
+                            confirmShutdown();
+                        }
                     } finally {
                         try {
-                            cleanup();
-                        } finally {
-                            // Lets remove all FastThreadLocals for the Thread as we are about to terminate and notify
-                            // the future. The user may block on the future and once it unblocks the JVM may terminate
-                            // and start unloading classes.
-                            // See https://github.com/netty/netty/issues/6596.
-                            FastThreadLocal.removeAll();
+                            if (oldState == ST_SUSPENDED) {
+                                for (;;) {
+                                    if (!runAllTasks()) {
+                                        break;
+                                    }
+                                }
+                                // Lets remove all FastThreadLocals for the Thread as we are about to terminate it.
+                                FastThreadLocal.removeAll();
+                            } else {
+                                try {
+                                    cleanup();
+                                } finally {
+                                    // Lets remove all FastThreadLocals for the Thread as we are about to terminate and
+                                    // notify the future. The user may block on the future and once it unblocks the JVM
+                                    // may terminate and start unloading classes.
+                                    // See https://github.com/netty/netty/issues/6596.
+                                    FastThreadLocal.removeAll();
 
-                            STATE_UPDATER.set(SingleThreadEventExecutor.this, ST_TERMINATED);
-                            threadLock.countDown();
-                            int numUserTasks = drainTasks();
-                            if (numUserTasks > 0 && logger.isWarnEnabled()) {
-                                logger.warn("An event executor terminated with " +
-                                        "non-empty task queue (" + numUserTasks + ')');
+                                    STATE_UPDATER.set(SingleThreadEventExecutor.this, ST_TERMINATED);
+                                    threadLock.countDown();
+                                    int numUserTasks = drainTasks();
+                                    if (numUserTasks > 0 && logger.isWarnEnabled()) {
+                                        logger.warn("An event executor terminated with " +
+                                                "non-empty task queue (" + numUserTasks + ')');
+                                    }
+                                    terminationFuture.setSuccess(null);
+                                }
                             }
-                            terminationFuture.setSuccess(null);
+                        } finally {
+                            thread = null;
+                            // Let the next thread take over if needed.
+                            processingLock.unlock();
                         }
                     }
                 }

--- a/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
@@ -42,12 +42,30 @@ public abstract class SingleThreadEventLoop extends SingleThreadEventExecutor im
         this(parent, threadFactory, addTaskWakesUp, DEFAULT_MAX_PENDING_TASKS, RejectedExecutionHandlers.reject());
     }
 
+    protected SingleThreadEventLoop(EventLoopGroup parent, ThreadFactory threadFactory,
+                                    boolean addTaskWakesUp, boolean supportSuspension) {
+        this(parent, threadFactory, addTaskWakesUp, supportSuspension, DEFAULT_MAX_PENDING_TASKS,
+                RejectedExecutionHandlers.reject());
+    }
+
     protected SingleThreadEventLoop(EventLoopGroup parent, Executor executor, boolean addTaskWakesUp) {
-        this(parent, executor, addTaskWakesUp, DEFAULT_MAX_PENDING_TASKS, RejectedExecutionHandlers.reject());
+        this(parent, executor, addTaskWakesUp, false);
+    }
+
+    protected SingleThreadEventLoop(EventLoopGroup parent, Executor executor,
+                                    boolean addTaskWakesUp, boolean supportSuspension) {
+        this(parent, executor, addTaskWakesUp, supportSuspension, DEFAULT_MAX_PENDING_TASKS,
+                RejectedExecutionHandlers.reject());
     }
 
     protected SingleThreadEventLoop(EventLoopGroup parent, ThreadFactory threadFactory,
                                     boolean addTaskWakesUp, int maxPendingTasks,
+                                    RejectedExecutionHandler rejectedExecutionHandler) {
+        this(parent, threadFactory, addTaskWakesUp, false, maxPendingTasks, rejectedExecutionHandler);
+    }
+
+    protected SingleThreadEventLoop(EventLoopGroup parent, ThreadFactory threadFactory,
+                                    boolean addTaskWakesUp, boolean supportSuspension, int maxPendingTasks,
                                     RejectedExecutionHandler rejectedExecutionHandler) {
         super(parent, threadFactory, addTaskWakesUp, maxPendingTasks, rejectedExecutionHandler);
         tailTasks = newTaskQueue(maxPendingTasks);
@@ -56,14 +74,27 @@ public abstract class SingleThreadEventLoop extends SingleThreadEventExecutor im
     protected SingleThreadEventLoop(EventLoopGroup parent, Executor executor,
                                     boolean addTaskWakesUp, int maxPendingTasks,
                                     RejectedExecutionHandler rejectedExecutionHandler) {
-        super(parent, executor, addTaskWakesUp, maxPendingTasks, rejectedExecutionHandler);
+        this(parent, executor, addTaskWakesUp, false, maxPendingTasks, rejectedExecutionHandler);
+    }
+
+    protected SingleThreadEventLoop(EventLoopGroup parent, Executor executor,
+                                    boolean addTaskWakesUp, boolean supportSuspension, int maxPendingTasks,
+                                    RejectedExecutionHandler rejectedExecutionHandler) {
+        super(parent, executor, addTaskWakesUp, supportSuspension, maxPendingTasks, rejectedExecutionHandler);
         tailTasks = newTaskQueue(maxPendingTasks);
     }
 
     protected SingleThreadEventLoop(EventLoopGroup parent, Executor executor,
                                     boolean addTaskWakesUp, Queue<Runnable> taskQueue, Queue<Runnable> tailTaskQueue,
                                     RejectedExecutionHandler rejectedExecutionHandler) {
-        super(parent, executor, addTaskWakesUp, taskQueue, rejectedExecutionHandler);
+        this(parent, executor, addTaskWakesUp, false, taskQueue, tailTaskQueue, rejectedExecutionHandler);
+    }
+
+    protected SingleThreadEventLoop(EventLoopGroup parent, Executor executor,
+                                    boolean addTaskWakesUp, boolean supportSuspension,
+                                    Queue<Runnable> taskQueue, Queue<Runnable> tailTaskQueue,
+                                    RejectedExecutionHandler rejectedExecutionHandler) {
+        super(parent, executor, addTaskWakesUp, supportSuspension, taskQueue, rejectedExecutionHandler);
         tailTasks = ObjectUtil.checkNotNull(tailTaskQueue, "tailTaskQueue");
     }
 

--- a/transport/src/main/java/io/netty/channel/SingleThreadIoEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/SingleThreadIoEventLoop.java
@@ -68,7 +68,7 @@ public class SingleThreadIoEventLoop extends SingleThreadEventLoop implements Io
      */
     public SingleThreadIoEventLoop(IoEventLoopGroup parent, ThreadFactory threadFactory,
                                    IoHandler ioHandler) {
-        super(parent, threadFactory, false);
+        super(parent, threadFactory, false, true);
         this.ioHandler = ObjectUtil.checkNotNull(ioHandler, "ioHandler");
     }
 
@@ -80,7 +80,7 @@ public class SingleThreadIoEventLoop extends SingleThreadEventLoop implements Io
      * @param ioHandler         the {@link IoHandler} used to run all IO.
      */
     public SingleThreadIoEventLoop(IoEventLoopGroup parent, Executor executor, IoHandler ioHandler) {
-        super(parent, executor, false);
+        super(parent, executor, false, true);
         this.ioHandler = ObjectUtil.checkNotNull(ioHandler, "ioHandler");
     }
 
@@ -99,7 +99,7 @@ public class SingleThreadIoEventLoop extends SingleThreadEventLoop implements Io
     public SingleThreadIoEventLoop(IoEventLoopGroup parent, ThreadFactory threadFactory,
                                    IoHandler ioHandler, int maxPendingTasks,
                                    RejectedExecutionHandler rejectedExecutionHandler) {
-        super(parent, threadFactory, false, maxPendingTasks, rejectedExecutionHandler);
+        super(parent, threadFactory, false, true, maxPendingTasks, rejectedExecutionHandler);
         this.ioHandler = ObjectUtil.checkNotNull(ioHandler, "ioHandler");
     }
 
@@ -118,7 +118,7 @@ public class SingleThreadIoEventLoop extends SingleThreadEventLoop implements Io
     public SingleThreadIoEventLoop(IoEventLoopGroup parent, Executor executor,
                                    IoHandler ioHandler, int maxPendingTasks,
                                    RejectedExecutionHandler rejectedExecutionHandler) {
-        super(parent, executor, false, maxPendingTasks, rejectedExecutionHandler);
+        super(parent, executor, false, true, maxPendingTasks, rejectedExecutionHandler);
         this.ioHandler = ObjectUtil.checkNotNull(ioHandler, "ioHandler");
     }
 
@@ -137,9 +137,8 @@ public class SingleThreadIoEventLoop extends SingleThreadEventLoop implements Io
     protected SingleThreadIoEventLoop(IoEventLoopGroup parent, Executor executor,
                                       IoHandler ioHandler, Queue<Runnable> taskQueue,
                                       Queue<Runnable> tailTaskQueue,
-
                                       RejectedExecutionHandler rejectedExecutionHandler) {
-        super(parent, executor, false, taskQueue, tailTaskQueue, rejectedExecutionHandler);
+        super(parent, executor, false, true, taskQueue, tailTaskQueue, rejectedExecutionHandler);
         this.ioHandler = ObjectUtil.checkNotNull(ioHandler, "ioHandler");
     }
 
@@ -152,7 +151,9 @@ public class SingleThreadIoEventLoop extends SingleThreadEventLoop implements Io
                 ioHandler.prepareToDestroy();
             }
             runAllTasks(maxTasksPerRun);
-        } while (!confirmShutdown());
+
+            // We should continue with our loop until we either confirmed a shutdown or we can suspend it.
+        } while (!confirmShutdown() && !canSuspend());
     }
 
     protected final IoHandler ioHandler() {


### PR DESCRIPTION
Motivation:

At the moment once an EventExecutor is created its impossible to suspend it, which means it will stay alive until shutdown. While this is generally fine it also might result in more system usage then really necessary. For example an EventExecutor might tie up an Thread for its whole life-time where it would be possible to "release" the Thread back one it was suspended.

Modifications:

- Allow to suspend EventExecutors (if supported by the implementation
- Add unit tests

Result:

Allow to suspend EventExecutor (and subtypes)
