### PR TITLE
fix ResolvConf initialization with SecurityManager enabled

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/ResolvConf.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/ResolvConf.java
@@ -96,6 +96,8 @@ final class ResolvConf {
                 resolvConf = ResolvConf.fromFile("/etc/resolv.conf");
             } catch (IOException e) {
                 resolvConf = null;
+            } catch (SecurityException ignore) {
+                resolvConf = null;
             }
             machineResolvConf = resolvConf;
         }


### PR DESCRIPTION
Motivation:

JNDI fallback in `DefaultDnsServerAddressStreamProvider` will not work, if SecurityManager blocks access to `/etc/resolv.conf`. Handle Exception for correct `ResolvConf` initialization.

The ResolvConf lookup was added in https://github.com/netty/netty/pull/13884 and the fallback added in https://github.com/netty/netty/pull/13951

Modification:

Catch a SecurityException and keep the `resolvConf` null.

Result:

Initialization will work with restrictive SecurityManager config.
