### PR TITLE
Replace usage of mirrorlist with baseurl

### DIFF
--- a/docker/Dockerfile.cross_compile_aarch64
+++ b/docker/Dockerfile.cross_compile_aarch64
@@ -4,6 +4,10 @@ ARG gcc_version=10.2-2020.11
 ENV GCC_VERSION $gcc_version
 ENV SOURCE_DIR /root/source
 
+
+# Update to use the vault
+RUN sed -i -e 's/^mirrorlist/#mirrorlist/g' -e 's/^#baseurl=http:\/\/mirror.centos.org\/centos\/$releasever\//baseurl=https:\/\/linuxsoft.cern.ch\/centos-vault\/\/7.6.1810\//g' /etc/yum.repos.d/CentOS-Base.repo
+
 # Install requirements
 RUN yum install -y wget tar git make redhat-lsb-core autoconf automake libtool glibc-devel libaio-devel openssl-devel apr-devel lksctp-tools unzip zip
 


### PR DESCRIPTION
Motivation:

We can't use the default mirrorlist anymore as it will fail and so fail the docker build

Modifications:

Use baseurl with the correct vault

Result:

Docker image can be build again
