### PR TITLE
http1, http2 headers: access most used implementations by common type - Headers<CharSequence, CharSequence, ?>.

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
@@ -21,6 +21,7 @@ import io.netty.handler.codec.DefaultHeaders;
 import io.netty.handler.codec.DefaultHeaders.NameValidator;
 import io.netty.handler.codec.DefaultHeaders.ValueValidator;
 import io.netty.handler.codec.DefaultHeadersImpl;
+import io.netty.handler.codec.Headers;
 import io.netty.handler.codec.HeadersUtils;
 import io.netty.handler.codec.ValueConverter;
 
@@ -149,6 +150,10 @@ public class DefaultHttpHeaders extends HttpHeaders {
 
     protected DefaultHttpHeaders(DefaultHeaders<CharSequence, CharSequence, ?> headers) {
         this.headers = headers;
+    }
+
+    public Headers<CharSequence, CharSequence, ?> unwrap() {
+        return headers;
     }
 
     @Override


### PR DESCRIPTION
Motivation:

Http1 and Http2 headers do not have common type, but their most used implementations (DefaultHttpHeaders, DefaultHttp2Headers) can be modified to reference both as Headers<CharSequence, CharSequence, ?>. Common type would be helpful for having common server handler to both http1 and htt2 requests - e.g. websockets.

Modification:

DefaultHttpHeaders: add unwrap() method returning underlying DefaultHeaders as Headers<CharSequence, CharSequence, ?>.

Result:

Most common implementations of Http1 and Http2 headers (DefaultHttpHeaders, DefaultHttp2Headers) can be accessed as Headers<CharSequence, CharSequence, ?>.