### PR TITLE
ScheduledFutureTask: avoid invoke system clock again

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/ScheduledFutureTask.java
+++ b/common/src/main/java/io/netty/util/concurrent/ScheduledFutureTask.java
@@ -99,7 +99,7 @@ final class ScheduledFutureTask<V> extends PromiseTask<V> implements ScheduledFu
     }
 
     public long delayNanos() {
-        if(deadlineNanos == 0L){
+        if (deadlineNanos == 0L) {
             return 0L;
         }
         return delayNanos(scheduledExecutor().getCurrentTimeNanos());

--- a/common/src/main/java/io/netty/util/concurrent/ScheduledFutureTask.java
+++ b/common/src/main/java/io/netty/util/concurrent/ScheduledFutureTask.java
@@ -99,6 +99,9 @@ final class ScheduledFutureTask<V> extends PromiseTask<V> implements ScheduledFu
     }
 
     public long delayNanos() {
+        if(deadlineNanos == 0L){
+            return 0L;
+        }
         return delayNanos(scheduledExecutor().getCurrentTimeNanos());
     }
 


### PR DESCRIPTION
**Motivation:**
When examining the serialized design of NioEventLoop, during the execution of the runAllTasks method within the run method, expired tasks are first transferred to the taskQueue. After that, tasks are retrieved from the taskQueue and executed.

During the task transfer process, if it is discovered that the current taskQueue is full, the retrieved tasks are put back into the delayed tasks queue. However, upon retrieval, there is a setConsumed method called. In this particular scenario, the task is actually not consumed, which begs the question: Could this have any implications?

 After clicking to view the comments：
“Optimization to avoid checking system clock again，after deadline has passed and task has been dequeued“

Based on the comments, it is speculated that when a task is executed or re-enqueued, it might involve checking the system clock. After conducting a thorough investigation, it was found that this could be related to the task's own run method.
io.netty.util.concurrent.ScheduledFutureTask#run
io.netty.util.concurrent.ScheduledFutureTask#delayNanos()

 `public void run() {
         ...
            if (delayNanos() > 0L) 
        ...
}`

`public long delayNanos() {
        return delayNanos(scheduledExecutor().getCurrentTimeNanos());
    }`

`static long deadlineToDelayNanos(long currentTimeNanos, long deadlineNanos) {
        return deadlineNanos == 0L ? 0L : Math.max(0L, deadlineNanos - currentTimeNanos);
    }`

   ` public long delayNanos(long currentTimeNanos) {
        return deadlineToDelayNanos(currentTimeNanos, deadlineNanos);
    }`
    
If this is indeed the case, then the optimization brought about is merely reducing a single computation and does not involve the system clock.

**Modification:**
Therefore, I suggest adding a pre-check here. If the current delayNanos equals 0L, we can directly return without proceeding, thus reducing the computation involving the system clock.
` public long delayNanos() {
        if(deadlineNanos == 0L){
            return 0L;
        }
        return delayNanos(scheduledExecutor().getCurrentTimeNanos());
    }`

**Result:**
Reducing the number of invocations by the amount of expired tasks that are now bypassed, would lead to an overall significant benefit.
Describe the modifications you've done.
Fixes #<GitHub issue number>. 

If there is no issue then describe the changes introduced by this PR.
