### PR TITLE
Send `Http2PriorityFrame` through `fireUserEventTriggered` for `Http2MultiplexHandler`

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
@@ -139,10 +139,19 @@ public class Http2MultiplexCodec extends Http2FrameCodec {
     @Override
     final void onHttp2Frame(ChannelHandlerContext ctx, Http2Frame frame) {
         if (frame instanceof Http2StreamFrame) {
-            Http2StreamFrame streamFrame = (Http2StreamFrame) frame;
+            Http2StreamFrame msg = (Http2StreamFrame) frame;
             AbstractHttp2StreamChannel channel  = (AbstractHttp2StreamChannel)
-                    ((DefaultHttp2FrameStream) streamFrame.stream()).attachment;
-            channel.fireChildRead(streamFrame);
+                    ((DefaultHttp2FrameStream) msg.stream()).attachment;
+            if (msg instanceof Http2ResetFrame || msg instanceof Http2PriorityFrame) {
+                // Reset and Priority frames needs to be propagated via user events as these are not flow-controlled and
+                // so must not be controlled by suppressing channel.read() on the child channel.
+                channel.pipeline().fireUserEventTriggered(msg);
+
+                // RST frames will also trigger closing of the streams which then will call
+                // AbstractHttp2StreamChannel.streamClosed()
+            } else {
+                channel.fireChildRead(msg);
+            }
             return;
         }
         if (frame instanceof Http2GoAwayFrame) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
@@ -142,16 +142,7 @@ public class Http2MultiplexCodec extends Http2FrameCodec {
             Http2StreamFrame msg = (Http2StreamFrame) frame;
             AbstractHttp2StreamChannel channel  = (AbstractHttp2StreamChannel)
                     ((DefaultHttp2FrameStream) msg.stream()).attachment;
-            if (msg instanceof Http2ResetFrame || msg instanceof Http2PriorityFrame) {
-                // Reset and Priority frames needs to be propagated via user events as these are not flow-controlled and
-                // so must not be controlled by suppressing channel.read() on the child channel.
-                channel.pipeline().fireUserEventTriggered(msg);
-
-                // RST frames will also trigger closing of the streams which then will call
-                // AbstractHttp2StreamChannel.streamClosed()
-            } else {
-                channel.fireChildRead(msg);
-            }
+            channel.fireChildRead(msg);
             return;
         }
         if (frame instanceof Http2GoAwayFrame) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexHandler.java
@@ -183,8 +183,8 @@ public final class Http2MultiplexHandler extends Http2ChannelDuplexHandler {
 
             AbstractHttp2StreamChannel channel = (AbstractHttp2StreamChannel) s.attachment;
             if (msg instanceof Http2ResetFrame || msg instanceof Http2PriorityFrame) {
-                // Reset and Priority frames needs to be propagated via user events as these are not flow-controlled and so
-                // must not be controlled by suppressing channel.read() on the child channel.
+                // Reset and Priority frames needs to be propagated via user events as these are not flow-controlled and
+                // so must not be controlled by suppressing channel.read() on the child channel.
                 channel.pipeline().fireUserEventTriggered(msg);
 
                 // RST frames will also trigger closing of the streams which then will call

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexHandler.java
@@ -182,8 +182,8 @@ public final class Http2MultiplexHandler extends Http2ChannelDuplexHandler {
                     (DefaultHttp2FrameStream) streamFrame.stream();
 
             AbstractHttp2StreamChannel channel = (AbstractHttp2StreamChannel) s.attachment;
-            if (msg instanceof Http2ResetFrame) {
-                // Reset frames needs to be propagated via user events as these are not flow-controlled and so
+            if (msg instanceof Http2ResetFrame || msg instanceof Http2PriorityFrame) {
+                // Reset and Priority frames needs to be propagated via user events as these are not flow-controlled and so
                 // must not be controlled by suppressing channel.read() on the child channel.
                 channel.pipeline().fireUserEventTriggered(msg);
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexCodecTest.java
@@ -37,4 +37,9 @@ public class Http2MultiplexCodecTest extends Http2MultiplexTest<Http2FrameCodec>
     protected boolean ignoreWindowUpdateFrames() {
         return false;
     }
+
+    @Override
+    protected boolean useUserEventForPriorityFrame() {
+        return false;
+    }
 }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexHandlerTest.java
@@ -51,6 +51,11 @@ public class Http2MultiplexHandlerTest extends Http2MultiplexTest<Http2FrameCode
         return true;
     }
 
+    @Override
+    protected boolean useUserEventForPriorityFrame() {
+        return true;
+    }
+
     @Test
     public void sslExceptionTriggersChildChannelException() {
         final LastInboundHandler inboundHandler = new LastInboundHandler();

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
@@ -221,13 +221,16 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
         frameInboundWriter.writeInboundPriority(channel.stream().id(), 0, (short) 2, false);
 
         // header frame should be multiplexed via fireChannelRead(...)
-        verifyFramesMultiplexedToCorrectChannel(channel, handler, 1);
+        int numFrames = useUserEventForPriorityFrame() ? 1 : 2;
+        verifyFramesMultiplexedToCorrectChannel(channel, handler, numFrames);
 
-        Http2PriorityFrame priorityFrame = handler.readUserEvent();
-        assertEquals(channel.stream(), priorityFrame.stream());
-        assertEquals(0, priorityFrame.streamDependency());
-        assertEquals(2, priorityFrame.weight());
-        assertFalse(priorityFrame.exclusive());
+        if (numFrames == 1) {
+            Http2PriorityFrame priorityFrame = handler.readUserEvent();
+            assertEquals(channel.stream(), priorityFrame.stream());
+            assertEquals(0, priorityFrame.streamDependency());
+            assertEquals(2, priorityFrame.weight());
+            assertFalse(priorityFrame.exclusive());
+        }
     }
 
     @Test
@@ -1317,6 +1320,8 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
 
         childChannel.closeFuture().syncUninterruptibly();
     }
+
+    protected abstract boolean useUserEventForPriorityFrame();
 
     protected abstract boolean useUserEventForResetFrame();
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
@@ -214,6 +214,23 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
     }
 
     @Test
+    public void readPriorityFrame() {
+        LastInboundHandler handler = new LastInboundHandler();
+
+        Http2StreamChannel channel = newInboundStream(3, true, handler);
+        frameInboundWriter.writeInboundPriority(channel.stream().id(), 0, (short) 2, false);
+
+        // header frame should be multiplexed via fireChannelRead(...)
+        verifyFramesMultiplexedToCorrectChannel(channel, handler, 1);
+
+        Http2PriorityFrame priorityFrame = handler.readUserEvent();
+        assertEquals(channel.stream(), priorityFrame.stream());
+        assertEquals(0, priorityFrame.streamDependency());
+        assertEquals(2, priorityFrame.weight());
+        assertFalse(priorityFrame.exclusive());
+    }
+
+    @Test
     public void headerAndDataFramesShouldBeDelivered() {
         LastInboundHandler inboundHandler = new LastInboundHandler();
 


### PR DESCRIPTION
Motivation:

`Http2PriorityFrame` is used to indicate that a stream should be prioritized over others. `Http2MultiplexHandler` can have child channels like `Http2StreamFrameToHttpObjectCodec` which expects `HttpObject` and `Http2PriorityFrame` might be something they should be expecting via `channelRead(...)`. Although this totally depends on the implementation of `Http2StreamFrameToHttpObjectCodec`, it's best to send them through `fireUserEventTriggered` which can be safely ignored if the implementation is not expecting such frames.

Modification:
`Http2PriorityFrame` is now being sent to child channels through `fireUserEventTriggered` instead of `channelRead`.

Result:
Handling of `Http2PriorityFrame` aligns with `Http2ResetFrame` in `Http2MultiplexHandler`
