### PR TITLE
Fix potential DNS cache invalidation in ResolveWithDotSearchDomain scenario

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolveContext.java
@@ -95,8 +95,8 @@ final class DnsAddressResolveContext extends DnsResolveContext<InetAddress> {
     @Override
     void doSearchDomainQuery(String hostname, Promise<List<InetAddress>> nextPromise) {
         // Query the cache for the hostname first and only do a query if we could not find it in the cache.
-        if (!DnsNameResolver.doResolveAllCached(
-                hostname, additionals, nextPromise, resolveCache, parent.resolvedInternetProtocolFamiliesUnsafe())) {
+        if (!DnsNameResolver.doResolveAllCached(hostname, additionals, nextPromise, resolveCache,
+                parent.searchDomains(), parent.ndots(), parent.resolvedInternetProtocolFamiliesUnsafe())) {
             super.doSearchDomainQuery(hostname, nextPromise);
         }
     }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -1102,6 +1102,10 @@ public class DnsNameResolver extends InetNameResolver {
         }
     }
 
+    private static boolean hasEntries(List<? extends DnsCacheEntry> cachedEntries) {
+        return cachedEntries != null && !cachedEntries.isEmpty();
+    }
+
     static boolean doResolveAllCached(String hostname,
                                       DnsRecord[] additionals,
                                       Promise<List<InetAddress>> promise,
@@ -1110,16 +1114,17 @@ public class DnsNameResolver extends InetNameResolver {
                                       int ndots,
                                       InternetProtocolFamily[] resolvedInternetProtocolFamilies) {
         List<? extends DnsCacheEntry> cachedEntries = resolveCache.get(hostname, additionals);
-        if (searchDomains != null && ndots != 0 && !StringUtil.endsWith(hostname, '.')) {
+        if (!hasEntries(cachedEntries) && searchDomains != null && ndots != 0
+                && !StringUtil.endsWith(hostname, '.')) {
             for (String searchDomain : searchDomains) {
-                if (cachedEntries != null && !cachedEntries.isEmpty()) {
-                    break;
-                }
                 final String initialHostname = hostname + '.' + searchDomain;
                 cachedEntries = resolveCache.get(initialHostname, additionals);
+                if (hasEntries(cachedEntries)) {
+                    break;
+                }
             }
         }
-        if (cachedEntries == null || cachedEntries.isEmpty()) {
+        if (!hasEntries(cachedEntries)) {
             return false;
         }
 

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -1095,7 +1095,8 @@ public class DnsNameResolver extends InetNameResolver {
             return;
         }
 
-        if (!doResolveAllCached(hostname, additionals, promise, resolveCache, resolvedInternetProtocolFamilies)) {
+        if (!doResolveAllCached(hostname, additionals, promise, resolveCache, this.searchDomains(),
+                ndots(), resolvedInternetProtocolFamilies)) {
             doResolveAllUncached(hostname, additionals, promise, promise,
                                  resolveCache, completeOncePreferredResolved);
         }
@@ -1105,8 +1106,19 @@ public class DnsNameResolver extends InetNameResolver {
                                       DnsRecord[] additionals,
                                       Promise<List<InetAddress>> promise,
                                       DnsCache resolveCache,
+                                      String[] searchDomains,
+                                      int ndots,
                                       InternetProtocolFamily[] resolvedInternetProtocolFamilies) {
-        final List<? extends DnsCacheEntry> cachedEntries = resolveCache.get(hostname, additionals);
+        List<? extends DnsCacheEntry> cachedEntries = resolveCache.get(hostname, additionals);
+        if (searchDomains != null && ndots != 0 && !StringUtil.endsWith(hostname, '.')) {
+            for (String searchDomain : searchDomains) {
+                if (cachedEntries != null && !cachedEntries.isEmpty()) {
+                    break;
+                }
+                final String initialHostname = hostname + '.' + searchDomain;
+                cachedEntries = resolveCache.get(initialHostname, additionals);
+            }
+        }
         if (cachedEntries == null || cachedEntries.isEmpty()) {
             return false;
         }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
@@ -575,7 +575,7 @@ abstract class DnsResolveContext<T> {
         });
         DnsCache resolveCache = resolveCache();
         if (!DnsNameResolver.doResolveAllCached(nameServerName, additionals, resolverPromise, resolveCache,
-                parent.resolvedInternetProtocolFamiliesUnsafe())) {
+                parent.searchDomains(), parent.ndots(), parent.resolvedInternetProtocolFamiliesUnsafe())) {
 
             new DnsAddressResolveContext(parent, channel, channelReadyFuture,
                     originalPromise, nameServerName, additionals, parent.newNameServerAddressStream(nameServerName),

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -46,6 +46,7 @@ import io.netty.util.CharsetUtil;
 import io.netty.util.NetUtil;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GlobalEventExecutor;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SocketUtils;
@@ -2752,7 +2753,10 @@ public class DnsNameResolverTest {
             assertEquals(1, cached.size());
             assertEquals(cached, cached2);
 
-            resolver.resolve("test").syncUninterruptibly();
+            Promise<List<InetAddress>> promise = GlobalEventExecutor.INSTANCE.newPromise();
+            boolean isCached = DnsNameResolver.doResolveAllCached("test", null, promise, cache,
+                    resolver.searchDomains(), resolver.ndots(), resolver.resolvedInternetProtocolFamiliesUnsafe());
+            assertTrue(isCached);
             List<? extends DnsCacheEntry> entries = cache.cacheHits.get("test.netty.io");
             assertFalse(entries.isEmpty());
         } finally {

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -46,7 +46,7 @@ import io.netty.util.CharsetUtil;
 import io.netty.util.NetUtil;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.GlobalEventExecutor;
+import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SocketUtils;
@@ -2753,10 +2753,12 @@ public class DnsNameResolverTest {
             assertEquals(1, cached.size());
             assertEquals(cached, cached2);
 
-            Promise<List<InetAddress>> promise = GlobalEventExecutor.INSTANCE.newPromise();
+            Promise<List<InetAddress>> promise = ImmediateEventExecutor.INSTANCE.newPromise();
             boolean isCached = DnsNameResolver.doResolveAllCached("test", null, promise, cache,
                     resolver.searchDomains(), resolver.ndots(), resolver.resolvedInternetProtocolFamiliesUnsafe());
             assertTrue(isCached);
+            promise.sync();
+
             List<? extends DnsCacheEntry> entries = cache.cacheHits.get("test.netty.io");
             assertFalse(entries.isEmpty());
         } finally {


### PR DESCRIPTION
Motivation:

+ In the ResolveWithDotSearchDomain scenario, DNSCache is not being hit.

Modification:

+ In the ResolveWithDotSearchDomain scenario, attempt to include the SearchDomain in the cache query.

Modify unit test: testResolveACachedWithDotSearchDomain

Fixes #14046. 

