### PR TITLE
Reject http header values with non SP / HTAB chars

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -1113,8 +1113,14 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
 
     private static int findEndOfString(byte[] sb, int start, int end) {
         for (int result = end - 1; result > start; --result) {
-            if (!isWhitespace(sb[result])) {
+            byte c = sb[result];
+            if (!isWhitespace(c)) {
                 return result + 1;
+            } else if (!isOWS(c)) {
+                // Only OWS is supported for whitespace
+                // See https://datatracker.ietf.org/doc/html/rfc9110#section-5.5
+                throw new IllegalArgumentException("Invalid end of value, only a space or horizontal tab allowed," +
+                        " but received a '" + c + "' (0x" + Integer.toHexString(c) + ")");
             }
         }
         return 0;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -1113,14 +1113,9 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
 
     private static int findEndOfString(byte[] sb, int start, int end) {
         for (int result = end - 1; result > start; --result) {
-            byte c = sb[result];
-            if (!isWhitespace(c)) {
+            if (!isOWS(sb[result])) {
                 return result + 1;
-            } else if (!isOWS(c)) {
-                // Only OWS is supported for whitespace
-                // See https://datatracker.ietf.org/doc/html/rfc9110#section-5.5
-                throw new IllegalArgumentException("Invalid end of value, only a space or horizontal tab allowed," +
-                        " but received a '" + c + "' (0x" + Integer.toHexString(c) + ")");
+            }
             }
         }
         return 0;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -1116,7 +1116,6 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
             if (!isOWS(sb[result])) {
                 return result + 1;
             }
-            }
         }
         return 0;
     }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -21,6 +21,8 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.AsciiString;
 import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -674,8 +676,15 @@ public class HttpRequestDecoderTest {
         assertFalse(channel.finish());
     }
 
+    @ParameterizedTest
+    // See https://www.unicode.org/charts/nameslist/n_0000.html
+    @ValueSource(strings = { "\r", "\u000b", "\u000c" })
+    public void testHeaderValueWithInvalidSuffix(String suffix) {
+        testInvalidHeaders0("GET / HTTP/1.1\r\nHost: whatever\r\nTest-Key: test-value" + suffix + "\r\n\r\n");
+    }
+
     private static void testInvalidHeaders0(String requestStr) {
-        testInvalidHeaders0(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII));
+        testInvalidHeaders0(Unpooled.copiedBuffer(requestStr, CharsetUtil.UTF_8));
     }
 
     private static void testInvalidHeaders0(ByteBuf requestBuffer) {

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -684,7 +684,7 @@ public class HttpRequestDecoderTest {
     }
 
     private static void testInvalidHeaders0(String requestStr) {
-        testInvalidHeaders0(Unpooled.copiedBuffer(requestStr, CharsetUtil.UTF_8));
+        testInvalidHeaders0(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII));
     }
 
     private static void testInvalidHeaders0(ByteBuf requestBuffer) {


### PR DESCRIPTION
Motivation:

We should not allow any other whitespace chars then SP / HTAB

Modifications:

- Reject other values
- Add unit test to proof validation works as expected

Result:

Fixes https://github.com/netty/netty/issues/14167
