### PR TITLE
Don't strip whitespaces from header names and let the validator handl…

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -995,7 +995,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
     private void splitHeader(byte[] line, int start, int length) {
         final int end = start + length;
         int nameEnd;
-        final int nameStart = findNonWhitespace(line, start, end);
+        final int nameStart = start;
         // hoist this load out of the loop, because it won't change!
         final boolean isDecodingRequest = isDecodingRequest();
         for (nameEnd = nameStart; nameEnd < end; nameEnd ++) {

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -674,6 +674,11 @@ public class HttpRequestDecoderTest {
         assertFalse(channel.finish());
     }
 
+    @Test
+    public void testLeadingWhitespaceInFirstHeaderName() {
+        testInvalidHeaders0("POST / HTTP/1.1\r\n\tContent-Length: 1\r\n\r\nX");
+    }
+
     private static void testInvalidHeaders0(String requestStr) {
         testInvalidHeaders0(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII));
     }


### PR DESCRIPTION
…e these

Motivation:

We did strip whitespaces from the header names before trying to add these to DefaultHeaderName. We should better not do this as whitespaces as prefix of a header name are not valid in general.

Modifications:

Don't strip leading whitespaces and so let the validator handle it.

Result:

Fixes https://github.com/netty/netty/issues/14177
