### PR TITLE
Reject request if NUL is present in the request line

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -951,7 +951,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
         if (isControlOrWhitespaceAsciiChar(asciiBytes[end - 1])) {
             // There should no extra control or whitespace char.
             // See https://datatracker.ietf.org/doc/html/rfc2616#section-5.1
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("Illegal character in request line: 0x" + Integer.ToHexString(char));
         }
 
         final int aStart = findNonSPLenient(asciiBytes, startContent, end);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -948,6 +948,12 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
 
         final int end = startContent + asciiBuffer.readableBytes();
 
+        if (isControlOrWhitespaceAsciiChar(asciiBytes[end - 1])) {
+            // There should no extra control or whitespace char.
+            // See https://datatracker.ietf.org/doc/html/rfc2616#section-5.1
+            throw new IllegalArgumentException();
+        }
+
         final int aStart = findNonSPLenient(asciiBytes, startContent, end);
         final int aEnd = findSPLenient(asciiBytes, aStart, end);
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -948,10 +948,11 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
 
         final int end = startContent + asciiBuffer.readableBytes();
 
-        if (isControlOrWhitespaceAsciiChar(asciiBytes[end - 1])) {
+        byte lastByte = asciiBytes[end - 1];
+        if (isControlOrWhitespaceAsciiChar(lastByte)) {
             // There should no extra control or whitespace char.
             // See https://datatracker.ietf.org/doc/html/rfc2616#section-5.1
-            throw new IllegalArgumentException("Illegal character in request line: 0x" + Integer.ToHexString(char));
+            throw new IllegalArgumentException("Illegal character in request line: 0x" + Integer.toHexString(lastByte));
         }
 
         final int aStart = findNonSPLenient(asciiBytes, startContent, end);

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -674,6 +674,11 @@ public class HttpRequestDecoderTest {
         assertFalse(channel.finish());
     }
 
+    @Test
+    public void testNulInInitialLine() {
+        testInvalidHeaders0("GET / HTTP/1.1\r\u0000\nHost: whatever\r\n\r\n");
+    }
+
     private static void testInvalidHeaders0(String requestStr) {
         testInvalidHeaders0(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII));
     }


### PR DESCRIPTION
Motivation:

We should not allow extra whitespaces or control chars in the request line.

Modifications:

- Check if the there are extra chars at the end.
- Add unit test

Result:

Fix https://github.com/netty/netty/issues/14166