### PR TITLE
SingleThreadEventExecutor：Avoid adding tasks only to remove them later

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -829,7 +829,7 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
     }
 
     private void execute(Runnable task, boolean immediate) {
-        if(isShutdown()){
+        if (isShutdown()) {
             reject();
         }
         boolean inEventLoop = inEventLoop();

--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -830,26 +830,10 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
 
     private void execute(Runnable task, boolean immediate) {
         boolean inEventLoop = inEventLoop();
-        addTask(task);
         if (!inEventLoop) {
             startThread();
-            if (isShutdown()) {
-                boolean reject = false;
-                try {
-                    if (removeTask(task)) {
-                        reject = true;
-                    }
-                } catch (UnsupportedOperationException e) {
-                    // The task queue does not support removal so the best thing we can do is to just move on and
-                    // hope we will be able to pick-up the task before its completely terminated.
-                    // In worst case we will log on termination.
-                }
-                if (reject) {
-                    reject();
-                }
-            }
         }
-
+        addTask(task);
         if (!addTaskWakesUp && immediate) {
             wakeup(inEventLoop);
         }

--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -829,6 +829,9 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
     }
 
     private void execute(Runnable task, boolean immediate) {
+        if(isShutdown()){
+            reject();
+        }
         boolean inEventLoop = inEventLoop();
         if (!inEventLoop) {
             startThread();


### PR DESCRIPTION
Motivation:

The logic here could be simplified for better efficiency. It should avoid the scenario where an external thread adds a task to the task queue, but then the current thread's state is >= shutdown, causing the task to be removed from the queue. 
  
Modification:

1. For external threads, simply attempt to start the current thread and then proceed to add the task.
2. The `addTask` method already performs an effective check on the state using `isShutdown()`.

Result:

Fixes #<GitHub issue number>. 

 
