### PR TITLE
Validate HTTP version while decoding

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpRequestDecoder.java
@@ -196,13 +196,9 @@ public class HttpRequestDecoder extends HttpObjectDecoder {
 
     @Override
     protected HttpMessage createMessage(String[] initialLine) throws Exception {
-        // Check that the version starts with HTTP/. The rest of the validation happens in HttpVersion itself.
-        String httpVersionStr = initialLine[2].trim();
-        if (!httpVersionStr.startsWith("HTTP/")) {
-            throw new IllegalArgumentException("Invalid HTTP version: " + httpVersionStr);
-        }
         return new DefaultHttpRequest(
-                HttpVersion.valueOf(httpVersionStr),
+                // Do strict version checking
+                HttpVersion.valueOf(initialLine[2], true),
                 HttpMethod.valueOf(initialLine[0]), initialLine[1], headersFactory);
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpRequestDecoder.java
@@ -196,8 +196,13 @@ public class HttpRequestDecoder extends HttpObjectDecoder {
 
     @Override
     protected HttpMessage createMessage(String[] initialLine) throws Exception {
+        // Check that the version starts with HTTP/. The rest of the validation happens in HttpVersion itself.
+        String httpVersionStr = initialLine[2].trim();
+        if (!httpVersionStr.startsWith("HTTP/")) {
+            throw new IllegalArgumentException("Invalid HTTP version: " + httpVersionStr);
+        }
         return new DefaultHttpRequest(
-                HttpVersion.valueOf(initialLine[2]),
+                HttpVersion.valueOf(httpVersionStr),
                 HttpMethod.valueOf(initialLine[0]), initialLine[1], headersFactory);
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseDecoder.java
@@ -190,8 +190,13 @@ public class HttpResponseDecoder extends HttpObjectDecoder {
 
     @Override
     protected HttpMessage createMessage(String[] initialLine) {
+        // Check that the version starts with HTTP/. The rest of the validation happens in HttpVersion itself.
+        String httpVersionStr = initialLine[0].trim();
+        if (!httpVersionStr.startsWith("HTTP/")) {
+            throw new IllegalArgumentException("Invalid HTTP version: " + httpVersionStr);
+        }
         return new DefaultHttpResponse(
-                HttpVersion.valueOf(initialLine[0]),
+                HttpVersion.valueOf(httpVersionStr),
                 HttpResponseStatus.valueOf(Integer.parseInt(initialLine[1]), initialLine[2]), headersFactory);
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseDecoder.java
@@ -190,13 +190,9 @@ public class HttpResponseDecoder extends HttpObjectDecoder {
 
     @Override
     protected HttpMessage createMessage(String[] initialLine) {
-        // Check that the version starts with HTTP/. The rest of the validation happens in HttpVersion itself.
-        String httpVersionStr = initialLine[0].trim();
-        if (!httpVersionStr.startsWith("HTTP/")) {
-            throw new IllegalArgumentException("Invalid HTTP version: " + httpVersionStr);
-        }
         return new DefaultHttpResponse(
-                HttpVersion.valueOf(httpVersionStr),
+                // Do strict version checking
+                HttpVersion.valueOf(initialLine[0], true),
                 HttpResponseStatus.valueOf(Integer.parseInt(initialLine[1]), initialLine[2]), headersFactory);
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpVersion.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpVersion.java
@@ -135,8 +135,8 @@ public class HttpVersion implements Comparable<HttpVersion> {
                 throw new IllegalArgumentException("invalid version format: " + text);
             }
             protocolName = "HTTP";
-            majorVersion = Integer.parseInt(text.charAt(5) + "");
-            minorVersion = Integer.parseInt(text.charAt(7) + "");
+            majorVersion = toDecimal(text.charAt(5));
+            minorVersion = toDecimal(text.charAt(7));
         } else {
             Matcher m = VERSION_PATTERN.matcher(text);
             if (!m.matches()) {
@@ -151,6 +151,14 @@ public class HttpVersion implements Comparable<HttpVersion> {
         this.text = protocolName + '/' + majorVersion + '.' + minorVersion;
         this.keepAliveDefault = keepAliveDefault;
         bytes = null;
+    }
+
+    private static int toDecimal(final int value) {
+        if (value < '0' || value > '9') {
+            throw new IllegalArgumentException("Invalid version number, only 0-9 (0x30-0x39) allowed," +
+                    " but received a '" + (char) value + "' (0x" + Integer.toHexString(value) + ")");
+        }
+        return value - '0';
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpVersion.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpVersion.java
@@ -34,7 +34,8 @@ public class HttpVersion implements Comparable<HttpVersion> {
 
     private static final Pattern VERSION_PATTERN =
         Pattern.compile("(\\S+)/(\\d+)\\.(\\d+)");
-
+    private static final Pattern VERSION_PATTERN_STRICT =
+            Pattern.compile("(HTTP)/(\\d+)\\.(\\d+)");
     static final String HTTP_1_0_STRING = "HTTP/1.0";
     static final String HTTP_1_1_STRING = "HTTP/1.1";
 
@@ -57,12 +58,17 @@ public class HttpVersion implements Comparable<HttpVersion> {
      * returned.
      */
     public static HttpVersion valueOf(String text) {
+        return valueOf(text, false);
+    }
+
+    static HttpVersion valueOf(String text, boolean strict) {
         ObjectUtil.checkNotNull(text, "text");
 
         // super fast-path
         if (text == HTTP_1_1_STRING) {
             return HTTP_1_1;
-        } else if (text == HTTP_1_0_STRING) {
+        }
+        if (text == HTTP_1_0_STRING) {
             return HTTP_1_0;
         }
 
@@ -82,7 +88,7 @@ public class HttpVersion implements Comparable<HttpVersion> {
         //
         HttpVersion version = version0(text);
         if (version == null) {
-            version = new HttpVersion(text, true);
+            version = new HttpVersion(text, strict,true);
         }
         return version;
     }
@@ -116,9 +122,13 @@ public class HttpVersion implements Comparable<HttpVersion> {
      *        the {@code "Connection"} header is set to {@code "close"} explicitly.
      */
     public HttpVersion(String text, boolean keepAliveDefault) {
+        this(text, false, keepAliveDefault);
+    }
+
+    HttpVersion(String text, boolean strict, boolean keepAliveDefault) {
         text = checkNonEmptyAfterTrim(text, "text").toUpperCase();
 
-        Matcher m = VERSION_PATTERN.matcher(text);
+        Matcher m = strict ? VERSION_PATTERN_STRICT.matcher(text) : VERSION_PATTERN.matcher(text);
         if (!m.matches()) {
             throw new IllegalArgumentException("invalid version format: " + text);
         }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpVersion.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpVersion.java
@@ -86,7 +86,7 @@ public class HttpVersion implements Comparable<HttpVersion> {
         //
         HttpVersion version = version0(text);
         if (version == null) {
-            version = new HttpVersion(text, strict,true);
+            version = new HttpVersion(text, strict, true);
         }
         return version;
     }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -677,6 +677,12 @@ public class HttpRequestDecoderTest {
     }
 
     @ParameterizedTest
+    @ValueSource(strings = { "HTP/1.1", "HTTP", "HTTP/1x", "Something/1.1" })
+    public void testInvalidVersion(String version) {
+        testInvalidHeaders0("GET / " + version + "\r\nHost: whatever\r\n\r\n");
+    }
+
+    @ParameterizedTest
     // See https://www.unicode.org/charts/nameslist/n_0000.html
     @ValueSource(strings = { "\r", "\u000b", "\u000c" })
     public void testHeaderValueWithInvalidSuffix(String suffix) {

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -677,7 +677,8 @@ public class HttpRequestDecoderTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { "HTP/1.1", "HTTP", "HTTP/1x", "Something/1.1", "HTTP/1", "HTTP/1.11", "HTTP/11.1" })
+    @ValueSource(strings = { "HTP/1.1", "HTTP", "HTTP/1x", "Something/1.1", "HTTP/1",
+            "HTTP/1.11", "HTTP/11.1", "HTTP/A.1", "HTTP/1.B"})
     public void testInvalidVersion(String version) {
         testInvalidHeaders0("GET / " + version + "\r\nHost: whatever\r\n\r\n");
     }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -677,7 +677,7 @@ public class HttpRequestDecoderTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { "HTP/1.1", "HTTP", "HTTP/1x", "Something/1.1" })
+    @ValueSource(strings = { "HTP/1.1", "HTTP", "HTTP/1x", "Something/1.1", "HTTP/1", "HTTP/1.11", "HTTP/11.1" })
     public void testInvalidVersion(String version) {
         testInvalidHeaders0("GET / " + version + "\r\nHost: whatever\r\n\r\n");
     }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
@@ -1132,7 +1132,8 @@ public class HttpResponseDecoderTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { "HTP/1.1", "HTTP", "HTTP/1x", "Something/1.1", "HTTP/1", "HTTP/1.11", "HTTP/11.1" })
+    @ValueSource(strings = { "HTP/1.1", "HTTP", "HTTP/1x", "Something/1.1", "HTTP/1",
+            "HTTP/1.11", "HTTP/11.1", "HTTP/A.1", "HTTP/1.B"})
     public void testInvalidVersion(String version) {
         testInvalidHeaders0(Unpooled.copiedBuffer(
                 version + " 200 OK\n\r\nHost: whatever\r\n\r\n", CharsetUtil.US_ASCII));

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
@@ -23,7 +23,6 @@ import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import sun.nio.cs.US_ASCII;
 
 import java.util.Arrays;
 import java.util.ArrayList;

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
@@ -1132,7 +1132,7 @@ public class HttpResponseDecoderTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { "HTP/1.1", "HTTP", "HTTP/1x", "Something/1.1" })
+    @ValueSource(strings = { "HTP/1.1", "HTTP", "HTTP/1x", "Something/1.1", "HTTP/1", "HTTP/1.11", "HTTP/11.1" })
     public void testInvalidVersion(String version) {
         testInvalidHeaders0(Unpooled.copiedBuffer(
                 version + " 200 OK\n\r\nHost: whatever\r\n\r\n", CharsetUtil.US_ASCII));

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
@@ -21,6 +21,9 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.PrematureChannelClosureException;
 import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import sun.nio.cs.US_ASCII;
 
 import java.util.Arrays;
 import java.util.ArrayList;
@@ -1126,6 +1129,13 @@ public class HttpResponseDecoderTest {
         responseBuffer.writeByte(controlChar);
         responseBuffer.writeCharSequence(": chunked\r\n\r\n", CharsetUtil.US_ASCII);
         testInvalidHeaders0(responseBuffer);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "HTP/1.1", "HTTP", "HTTP/1x", "Something/1.1" })
+    public void testInvalidVersion(String version) {
+        testInvalidHeaders0(Unpooled.copiedBuffer(
+                version + " 200 OK\n\r\nHost: whatever\r\n\r\n", CharsetUtil.US_ASCII));
     }
 
     private static void testInvalidHeaders0(ByteBuf responseBuffer) {


### PR DESCRIPTION
Motivation:

We didnt strictly validate HTTP versions while decoding.

Modifications:

- Add extra validation logic in HttpRequestDecoder / HttpResponseDecoder
- Add unit tests

Result:

Fixes https://github.com/netty/netty/issues/14186
