### PR TITLE
Add keytool-based self-signed certificate generator

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/util/KeytoolSelfSignedCertGenerator.java
+++ b/handler/src/main/java/io/netty/handler/ssl/util/KeytoolSelfSignedCertGenerator.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.ssl.util;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.util.internal.PlatformDependent;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InterruptedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.security.cert.X509Certificate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Self-signed certificate generator based on the keytool CLI.
+ */
+final class KeytoolSelfSignedCertGenerator {
+    private static final DateTimeFormatter DATE_FORMAT =
+            DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss", Locale.ROOT);
+    private static final String ALIAS = "alias";
+    private static final String PASSWORD = "insecurepassword";
+    private static final Path KEYTOOL;
+    private static final String KEY_STORE_TYPE;
+
+    static {
+        String home = System.getProperty("java.home");
+        if (home == null) {
+            KEYTOOL = null;
+        } else {
+            Path likely = Paths.get(home).resolve("bin").resolve("keytool");
+            if (Files.exists(likely)) {
+                KEYTOOL = likely;
+            } else {
+                KEYTOOL = null;
+            }
+        }
+        // Java < 11 does not support encryption for PKCS#12: JDK-8220734
+        // For 11+, we prefer PKCS#12 for FIPS compliance
+        KEY_STORE_TYPE = PlatformDependent.javaVersion() >= 11 ? "PKCS12" : "JKS";
+    }
+
+    private KeytoolSelfSignedCertGenerator() {
+    }
+
+    static boolean isAvailable() {
+        return KEYTOOL != null;
+    }
+
+    static void generate(SelfSignedCertificate.Builder builder) throws IOException, GeneralSecurityException {
+        // Change all asterisk to 'x' for file name safety.
+        String dirFqdn = builder.fqdn.replaceAll("[^\\w.-]", "x");
+
+        Path directory = Files.createTempDirectory("keytool_" + dirFqdn);
+        Path keyStore = directory.resolve("keystore.jks");
+        try {
+            Process process = new ProcessBuilder()
+                    .command(
+                            "keytool",
+                            "-genkeypair",
+                            "-keyalg", builder.algorithm,
+                            "-keysize", String.valueOf(builder.bits),
+                            "-startdate", DATE_FORMAT.format(
+                                    builder.notBefore.toInstant().atZone(ZoneId.systemDefault())),
+                            "-validity", String.valueOf(builder.notBefore.toInstant().until(
+                                    builder.notAfter.toInstant(), ChronoUnit.DAYS)),
+                            "-keystore", keyStore.toString(),
+                            "-alias", ALIAS,
+                            "-keypass", PASSWORD,
+                            "-storepass", PASSWORD,
+                            "-dname", "CN=" + builder.fqdn,
+                            "-storetype", KEY_STORE_TYPE
+                    )
+                    .redirectErrorStream(true)
+                    .start();
+            try {
+                if (!process.waitFor(60, TimeUnit.SECONDS)) {
+                    process.destroyForcibly();
+                    throw new IOException("keytool timeout");
+                }
+            } catch (InterruptedException e) {
+                process.destroyForcibly();
+                Thread.currentThread().interrupt();
+                throw new InterruptedIOException();
+            }
+
+            if (process.exitValue() != 0) {
+                ByteBuf buffer = Unpooled.buffer();
+                try (InputStream stream = process.getInputStream()) {
+                    while (true) {
+                        if (buffer.writeBytes(stream, 4096) == -1) {
+                            break;
+                        }
+                    }
+                }
+                String log = buffer.toString(StandardCharsets.UTF_8);
+                throw new IOException("Keytool exited with status " + process.exitValue() + ": " + log);
+            }
+
+            KeyStore ks = KeyStore.getInstance(KEY_STORE_TYPE);
+            try (InputStream is = Files.newInputStream(keyStore)) {
+                ks.load(is, PASSWORD.toCharArray());
+            }
+            KeyStore.PrivateKeyEntry entry = (KeyStore.PrivateKeyEntry) ks.getEntry(
+                    ALIAS, new KeyStore.PasswordProtection(PASSWORD.toCharArray()));
+            builder.paths = SelfSignedCertificate.newSelfSignedCertificate(
+                    builder.fqdn, entry.getPrivateKey(), (X509Certificate) entry.getCertificate());
+            builder.privateKey = entry.getPrivateKey();
+        } finally {
+            Files.deleteIfExists(keyStore);
+            Files.delete(directory);
+        }
+    }
+}

--- a/handler/src/main/java/io/netty/handler/ssl/util/KeytoolSelfSignedCertGenerator.java
+++ b/handler/src/main/java/io/netty/handler/ssl/util/KeytoolSelfSignedCertGenerator.java
@@ -110,15 +110,19 @@ final class KeytoolSelfSignedCertGenerator {
 
             if (process.exitValue() != 0) {
                 ByteBuf buffer = Unpooled.buffer();
-                try (InputStream stream = process.getInputStream()) {
-                    while (true) {
-                        if (buffer.writeBytes(stream, 4096) == -1) {
-                            break;
+                try {
+                    try (InputStream stream = process.getInputStream()) {
+                        while (true) {
+                            if (buffer.writeBytes(stream, 4096) == -1) {
+                                break;
+                            }
                         }
                     }
+                    String log = buffer.toString(StandardCharsets.UTF_8);
+                    throw new IOException("Keytool exited with status " + process.exitValue() + ": " + log);
+                } finally {
+                    buffer.release();
                 }
-                String log = buffer.toString(StandardCharsets.UTF_8);
-                throw new IOException("Keytool exited with status " + process.exitValue() + ": " + log);
             }
 
             KeyStore ks = KeyStore.getInstance(KEY_STORE_TYPE);

--- a/handler/src/main/java/io/netty/handler/ssl/util/SelfSignedCertificate.java
+++ b/handler/src/main/java/io/netty/handler/ssl/util/SelfSignedCertificate.java
@@ -20,9 +20,9 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.base64.Base64;
 import io.netty.util.CharsetUtil;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SystemPropertyUtil;
-import io.netty.util.internal.ThrowableUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -87,7 +87,7 @@ public final class SelfSignedCertificate {
      * <p> Algorithm: RSA </p>
      */
     public SelfSignedCertificate() throws CertificateException {
-        this(DEFAULT_NOT_BEFORE, DEFAULT_NOT_AFTER, "RSA", DEFAULT_KEY_LENGTH_BITS);
+        this(new Builder());
     }
 
     /**
@@ -99,7 +99,7 @@ public final class SelfSignedCertificate {
      */
     public SelfSignedCertificate(Date notBefore, Date notAfter)
             throws CertificateException {
-        this("localhost", notBefore, notAfter, "RSA", DEFAULT_KEY_LENGTH_BITS);
+        this(new Builder().notBefore(notBefore).notAfter(notAfter));
     }
 
     /**
@@ -112,7 +112,7 @@ public final class SelfSignedCertificate {
      */
     public SelfSignedCertificate(Date notBefore, Date notAfter, String algorithm, int bits)
             throws CertificateException {
-        this("localhost", notBefore, notAfter, algorithm, bits);
+        this(new Builder().notBefore(notBefore).notAfter(notAfter).algorithm(algorithm).bits(bits));
     }
 
     /**
@@ -122,7 +122,7 @@ public final class SelfSignedCertificate {
      * @param fqdn a fully qualified domain name
      */
     public SelfSignedCertificate(String fqdn) throws CertificateException {
-        this(fqdn, DEFAULT_NOT_BEFORE, DEFAULT_NOT_AFTER, "RSA", DEFAULT_KEY_LENGTH_BITS);
+        this(new Builder().fqdn(fqdn));
     }
 
     /**
@@ -133,7 +133,7 @@ public final class SelfSignedCertificate {
      * @param bits      the number of bits of the generated private key
      */
     public SelfSignedCertificate(String fqdn, String algorithm, int bits) throws CertificateException {
-        this(fqdn, DEFAULT_NOT_BEFORE, DEFAULT_NOT_AFTER, algorithm, bits);
+        this(new Builder().fqdn(fqdn).algorithm(algorithm).bits(bits));
     }
 
     /**
@@ -145,9 +145,7 @@ public final class SelfSignedCertificate {
      * @param notAfter  Certificate is not valid after this time
      */
     public SelfSignedCertificate(String fqdn, Date notBefore, Date notAfter) throws CertificateException {
-        // Bypass entropy collection by using insecure random generator.
-        // We just want to generate it without any delay because it's for testing purposes only.
-        this(fqdn, ThreadLocalInsecureRandom.current(), DEFAULT_KEY_LENGTH_BITS, notBefore, notAfter, "RSA");
+        this(new Builder().fqdn(fqdn).notBefore(notBefore).notAfter(notAfter));
     }
 
     /**
@@ -161,9 +159,7 @@ public final class SelfSignedCertificate {
      */
     public SelfSignedCertificate(String fqdn, Date notBefore, Date notAfter, String algorithm, int bits)
             throws CertificateException {
-        // Bypass entropy collection by using insecure random generator.
-        // We just want to generate it without any delay because it's for testing purposes only.
-        this(fqdn, ThreadLocalInsecureRandom.current(), bits, notBefore, notAfter, algorithm);
+        this(new Builder().fqdn(fqdn).notBefore(notBefore).notAfter(notAfter).algorithm(algorithm).bits(bits));
     }
 
     /**
@@ -176,7 +172,7 @@ public final class SelfSignedCertificate {
      */
     public SelfSignedCertificate(String fqdn, SecureRandom random, int bits)
             throws CertificateException {
-        this(fqdn, random, bits, DEFAULT_NOT_BEFORE, DEFAULT_NOT_AFTER, "RSA");
+        this(new Builder().fqdn(fqdn).random(random).bits(bits));
     }
 
     /**
@@ -189,7 +185,7 @@ public final class SelfSignedCertificate {
      */
     public SelfSignedCertificate(String fqdn, SecureRandom random, String algorithm, int bits)
             throws CertificateException {
-        this(fqdn, random, bits, DEFAULT_NOT_BEFORE, DEFAULT_NOT_AFTER, algorithm);
+        this(new Builder().fqdn(fqdn).random(random).algorithm(algorithm).bits(bits));
     }
 
     /**
@@ -204,7 +200,7 @@ public final class SelfSignedCertificate {
      */
     public SelfSignedCertificate(String fqdn, SecureRandom random, int bits, Date notBefore, Date notAfter)
             throws CertificateException {
-        this(fqdn, random, bits, notBefore, notAfter, "RSA");
+        this(new Builder().fqdn(fqdn).notBefore(notBefore).notAfter(notAfter).random(random).bits(bits));
     }
 
     /**
@@ -219,66 +215,32 @@ public final class SelfSignedCertificate {
      */
     public SelfSignedCertificate(String fqdn, SecureRandom random, int bits, Date notBefore, Date notAfter,
                                  String algorithm) throws CertificateException {
+        this(new Builder().fqdn(fqdn).random(random).algorithm(algorithm).bits(bits)
+                .notBefore(notBefore).notAfter(notAfter));
+    }
 
-        if (!"EC".equalsIgnoreCase(algorithm) && !"RSA".equalsIgnoreCase(algorithm)) {
-            throw new IllegalArgumentException("Algorithm not valid: " + algorithm);
-        }
-
-        final KeyPair keypair;
-        try {
-            KeyPairGenerator keyGen = KeyPairGenerator.getInstance(algorithm);
-            keyGen.initialize(bits, random);
-            keypair = keyGen.generateKeyPair();
-        } catch (NoSuchAlgorithmException e) {
-            // Should not reach here because every Java implementation must have RSA and EC key pair generator.
-            throw new Error(e);
-        }
-
-        String[] paths;
-        try {
-            // Try Bouncy Castle first as otherwise we will see an IllegalAccessError on more recent JDKs.
-            paths = BouncyCastleSelfSignedCertGenerator.generate(
-                    fqdn, keypair, random, notBefore, notAfter, algorithm);
-        } catch (Throwable t) {
-            if (!isBouncyCastleAvailable()) {
-                logger.debug("Failed to generate a self-signed X.509 certificate because " +
-                        "BouncyCastle PKIX is not available in classpath");
-            } else {
-                logger.debug("Failed to generate a self-signed X.509 certificate using Bouncy Castle:", t);
-            }
-            try {
-                // Try the OpenJDK's proprietary implementation.
-                paths = OpenJdkSelfSignedCertGenerator.generate(fqdn, keypair, random, notBefore, notAfter, algorithm);
-            } catch (Throwable t2) {
-                logger.debug("Failed to generate a self-signed X.509 certificate using sun.security.x509:", t2);
-                final CertificateException certificateException = new CertificateException(
-                        "No provider succeeded to generate a self-signed certificate. " +
-                                "See debug log for the root cause.", t2);
-                ThrowableUtil.addSuppressed(certificateException, t);
-                throw certificateException;
-            }
-        }
-
-        certificate = new File(paths[0]);
-        privateKey = new File(paths[1]);
-        key = keypair.getPrivate();
-        FileInputStream certificateInput = null;
-        try {
-            certificateInput = new FileInputStream(certificate);
-            cert = (X509Certificate) CertificateFactory.getInstance("X509").generateCertificate(certificateInput);
-        } catch (Exception e) {
-            throw new CertificateEncodingException(e);
-        } finally {
-            if (certificateInput != null) {
-                try {
-                    certificateInput.close();
-                } catch (IOException e) {
-                    if (logger.isWarnEnabled()) {
-                        logger.warn("Failed to close a file: " + certificate, e);
-                    }
+    private SelfSignedCertificate(Builder builder) throws CertificateException {
+        if (!builder.generateBc()) {
+            if (!builder.generateKeytool()) {
+                if (!builder.generateSunMiscSecurity()) {
+                    // last exception is always from generateSunMiscSecurity, so we can cast here
+                    throw (CertificateException) builder.failure;
                 }
             }
         }
+
+        certificate = new File(builder.paths[0]);
+        privateKey = new File(builder.paths[1]);
+        key = builder.privateKey;
+        try (FileInputStream certificateInput = new FileInputStream(certificate)) {
+            cert = (X509Certificate) CertificateFactory.getInstance("X509").generateCertificate(certificateInput);
+        } catch (Exception e) {
+            throw new CertificateEncodingException(e);
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
     }
 
     /**
@@ -414,6 +376,196 @@ public final class SelfSignedCertificate {
             return true;
         } catch (ClassNotFoundException e) {
             return false;
+        }
+    }
+
+    public static final class Builder {
+        // user fields
+        String fqdn = "localhost";
+        SecureRandom random;
+        int bits = DEFAULT_KEY_LENGTH_BITS;
+        Date notBefore = DEFAULT_NOT_BEFORE;
+        Date notAfter = DEFAULT_NOT_AFTER;
+        String algorithm = "RSA";
+
+        // fields that are populated on demand
+        Throwable failure;
+        KeyPair keypair;
+        PrivateKey privateKey;
+        String[] paths;
+
+        private Builder() {
+        }
+
+        /**
+         * Set the fully-qualified domain name of the certificate that should be generated.
+         *
+         * @param fqdn The FQDN
+         * @return This builder
+         */
+        public Builder fqdn(String fqdn) {
+            ObjectUtil.checkNotNullWithIAE(fqdn, "fqdn");
+            this.fqdn = fqdn;
+            return this;
+        }
+
+        /**
+         * Set the RNG to use for key generation. This setting is not supported by the keytool-based generator.
+         *
+         * @param random The CSPRNG
+         * @return This builder
+         */
+        public Builder random(SecureRandom random) {
+            this.random = random;
+            return this;
+        }
+
+        /**
+         * Set the key size.
+         *
+         * @param bits The key size
+         * @return This builder
+         */
+        public Builder bits(int bits) {
+            this.bits = bits;
+            return this;
+        }
+
+        /**
+         * Set the start of the certificate validity period.
+         *
+         * @param notBefore The start date
+         * @return This builder
+         */
+        public Builder notBefore(Date notBefore) {
+            ObjectUtil.checkNotNullWithIAE(notBefore, "notBefore");
+            this.notBefore = notBefore;
+            return this;
+        }
+
+        /**
+         * Set the end of the certificate validity period.
+         *
+         * @param notAfter The start date
+         * @return This builder
+         */
+        public Builder notAfter(Date notAfter) {
+            ObjectUtil.checkNotNullWithIAE(notAfter, "notAfter");
+            this.notAfter = notAfter;
+            return this;
+        }
+
+        /**
+         * Set the key algorithm. Only RSA and EC are supported.
+         *
+         * @param algorithm The key algorithm
+         * @return This builder
+         */
+        public Builder algorithm(String algorithm) {
+            if ("EC".equalsIgnoreCase(algorithm)) {
+                this.algorithm = "EC";
+            } else if ("RSA".equalsIgnoreCase(algorithm)) {
+                this.algorithm = "RSA";
+            } else {
+                throw new IllegalArgumentException("Algorithm not valid: " + algorithm);
+            }
+            return this;
+        }
+
+        private SecureRandom randomOrDefault() {
+            // Bypass entropy collection by using insecure random generator.
+            // We just want to generate it without any delay because it's for testing purposes only.
+            return random == null ? ThreadLocalInsecureRandom.current() : random;
+        }
+
+        private void generateKeyPairLocally() {
+            if (keypair != null) {
+                return;
+            }
+
+            try {
+                KeyPairGenerator keyGen = KeyPairGenerator.getInstance(algorithm);
+                keyGen.initialize(bits, randomOrDefault());
+                keypair = keyGen.generateKeyPair();
+            } catch (NoSuchAlgorithmException e) {
+                // Should not reach here because every Java implementation must have RSA and EC key pair generator.
+                throw new Error(e);
+            }
+            privateKey = keypair.getPrivate();
+        }
+
+        private void addFailure(Throwable t) {
+            if (failure != null) {
+                t.addSuppressed(failure);
+            }
+            failure = t;
+        }
+
+        boolean generateBc() {
+            if (!isBouncyCastleAvailable()) {
+                // no need to even try. We can avoid generating the key pair with this check.
+                logger.debug("Failed to generate a self-signed X.509 certificate because " +
+                        "BouncyCastle PKIX is not available in classpath");
+                return false;
+            }
+            generateKeyPairLocally();
+            try {
+                // Try Bouncy Castle first as otherwise we will see an IllegalAccessError on more recent JDKs.
+                paths = BouncyCastleSelfSignedCertGenerator.generate(
+                        fqdn, keypair, randomOrDefault(), notBefore, notAfter, algorithm);
+                return true;
+            } catch (Throwable t) {
+                logger.debug("Failed to generate a self-signed X.509 certificate using Bouncy Castle:", t);
+                addFailure(t);
+                return false;
+            }
+        }
+
+        boolean generateKeytool() {
+            if (!KeytoolSelfSignedCertGenerator.isAvailable()) {
+                logger.debug("Not attempting to generate certificate with keytool because keytool is missing");
+                return false;
+            }
+            if (random != null) {
+                logger.debug("Not attempting to generate certificate with keytool because of explicitly set " +
+                        "SecureRandom");
+                return false;
+            }
+            try {
+                KeytoolSelfSignedCertGenerator.generate(this);
+                return true;
+            } catch (Throwable t) {
+                logger.debug("Failed to generate a self-signed X.509 certificate using keytool:", t);
+                addFailure(t);
+                return false;
+            }
+        }
+
+        boolean generateSunMiscSecurity() {
+            generateKeyPairLocally();
+            try {
+                // Try the OpenJDK's proprietary implementation.
+                paths = OpenJdkSelfSignedCertGenerator.generate(
+                        fqdn, keypair, randomOrDefault(), notBefore, notAfter, algorithm);
+                return true;
+            } catch (Throwable t2) {
+                logger.debug("Failed to generate a self-signed X.509 certificate using sun.security.x509:", t2);
+                final CertificateException certificateException = new CertificateException(
+                        "No provider succeeded to generate a self-signed certificate. " +
+                                "See debug log for the root cause.", t2);
+                addFailure(certificateException);
+                return false;
+            }
+        }
+
+        /**
+         * Build the certificate. This builder must not be used again after this method is called.
+         *
+         * @return The certificate
+         * @throws CertificateException If generation fails
+         */
+        public SelfSignedCertificate build() throws CertificateException {
+            return new SelfSignedCertificate(this);
         }
     }
 }

--- a/handler/src/main/java/io/netty/handler/ssl/util/SelfSignedCertificate.java
+++ b/handler/src/main/java/io/netty/handler/ssl/util/SelfSignedCertificate.java
@@ -404,8 +404,7 @@ public final class SelfSignedCertificate {
          * @return This builder
          */
         public Builder fqdn(String fqdn) {
-            ObjectUtil.checkNotNullWithIAE(fqdn, "fqdn");
-            this.fqdn = fqdn;
+            this.fqdn = ObjectUtil.checkNotNullWithIAE(fqdn, "fqdn");
             return this;
         }
 
@@ -438,8 +437,7 @@ public final class SelfSignedCertificate {
          * @return This builder
          */
         public Builder notBefore(Date notBefore) {
-            ObjectUtil.checkNotNullWithIAE(notBefore, "notBefore");
-            this.notBefore = notBefore;
+            this.notBefore = ObjectUtil.checkNotNullWithIAE(notBefore, "notBefore");
             return this;
         }
 
@@ -450,8 +448,7 @@ public final class SelfSignedCertificate {
          * @return This builder
          */
         public Builder notAfter(Date notAfter) {
-            ObjectUtil.checkNotNullWithIAE(notAfter, "notAfter");
-            this.notAfter = notAfter;
+            this.notAfter = ObjectUtil.checkNotNullWithIAE(notAfter, "notAfter");
             return this;
         }
 
@@ -489,7 +486,7 @@ public final class SelfSignedCertificate {
                 keypair = keyGen.generateKeyPair();
             } catch (NoSuchAlgorithmException e) {
                 // Should not reach here because every Java implementation must have RSA and EC key pair generator.
-                throw new Error(e);
+                throw new IllegalStateException(e);
             }
             privateKey = keypair.getPrivate();
         }

--- a/handler/src/test/java/io/netty/handler/ssl/util/KeytoolSelfSignedCertGeneratorTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/util/KeytoolSelfSignedCertGeneratorTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.ssl.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+
+class KeytoolSelfSignedCertGeneratorTest {
+    @BeforeAll
+    static void checkAvailability() {
+        Assumptions.assumeTrue(KeytoolSelfSignedCertGenerator.isAvailable());
+    }
+
+    @Test
+    public void test() throws Exception {
+        SelfSignedCertificate.Builder builder = SelfSignedCertificate.builder()
+                .fqdn("example.com")
+                .algorithm("RSA")
+                .bits(2048);
+        Assertions.assertTrue(builder.generateKeytool());
+        Assertions.assertEquals("RSA", builder.privateKey.getAlgorithm());
+
+        X509Certificate cert;
+        try (InputStream certStream = Files.newInputStream(Paths.get(builder.paths[0]))) {
+            cert = (X509Certificate) CertificateFactory.getInstance("X509").generateCertificate(certStream);
+        }
+        cert.checkValidity();
+        Assertions.assertEquals("CN=example.com", cert.getSubjectX500Principal().getName());
+    }
+}


### PR DESCRIPTION
Motivation:

On newer Java versions, the JDK-based self-signed certificate generator does not work, so adding bcpkix as a dependency was necessary. This is inconvenient for users that want to use self-signed certs as part of their tests.

Modification:

Add a KeytoolSelfSignedCertGenerator which uses the `keytool` command included in the JDK to generate the key pair and certificate.

Introduce a SelfSignedCertificate.Builder to make the constructor chaos a bit cleaner. Additionally, since the `keytool` generator uses an external RNG, this Builder allows for the in-vm KeyPair generation to happen lazily, improving performance for the keytool path.

The next step I've thought about doing is to move the unnecessary file system saving (SelfSignedCertificate.newSelfSignedCertificate) to be lazy, so that we can avoid writing the key and cert at all in some cases. But that is for another day, it'd require some exception handling changes.

Result:

Users can generate self-signed certificates without additional dependencies.