### PR TITLE
feat: Support for IP_BIND_ADDRESS_NO_PORT socket option, close #14195…

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollChannelOption.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollChannelOption.java
@@ -31,6 +31,7 @@ public final class EpollChannelOption<T> extends UnixChannelOption<T> {
     public static final ChannelOption<Integer> TCP_USER_TIMEOUT =
             valueOf(EpollChannelOption.class, "TCP_USER_TIMEOUT");
     public static final ChannelOption<Boolean> IP_FREEBIND = valueOf("IP_FREEBIND");
+    public static final ChannelOption<Boolean> IP_BIND_ADDRESS_NO_PORT = valueOf("IP_BIND_ADDRESS_NO_PORT");
     public static final ChannelOption<Boolean> IP_TRANSPARENT = valueOf("IP_TRANSPARENT");
     public static final ChannelOption<Boolean> IP_RECVORIGDSTADDR = valueOf("IP_RECVORIGDSTADDR");
     /**

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollSocketChannel.java
@@ -106,6 +106,8 @@ import static java.util.Objects.requireNonNull;
  * </tr><tr>
  * <td>{@link ChannelOption#TCP_FASTOPEN_CONNECT}</td><td>X</td><td>X</td><td>-</td>
  * </tr><tr>
+ * <td>{@link EpollChannelOption#IP_BIND_ADDRESS_NO_PORT}</td><td>X</td><td>X</td><td>-</td>
+ * </tr><tr>
  * <td>{@link EpollChannelOption#IP_TRANSPARENT}</td><td>X</td><td>X</td><td>-</td>
  * </tr><tr>
  * <td>{@link EpollChannelOption#SO_BUSY_POLL}</td><td>X</td><td>X</td><td>-</td>
@@ -518,6 +520,9 @@ public final class EpollSocketChannel
             if (option == EpollChannelOption.TCP_QUICKACK) {
                 return (T) Boolean.valueOf(isTcpQuickAck());
             }
+            if (option == EpollChannelOption.IP_BIND_ADDRESS_NO_PORT) {
+                return (T) Boolean.valueOf(isIpBindAddressNoPort());
+            }
             if (option == EpollChannelOption.IP_TRANSPARENT) {
                 return (T) Boolean.valueOf(isIpTransparent());
             }
@@ -570,6 +575,8 @@ public final class EpollSocketChannel
                 setTcpKeepIntvl((Integer) value);
             } else if (option == EpollChannelOption.TCP_USER_TIMEOUT) {
                 setTcpUserTimeout((Integer) value);
+            } else if (option == EpollChannelOption.IP_BIND_ADDRESS_NO_PORT) {
+                setIpBindAddressNoPort((Boolean) value);
             } else if (option == EpollChannelOption.IP_TRANSPARENT) {
                 setIpTransparent((Boolean) value);
             } else if (option == EpollChannelOption.TCP_MD5SIG) {
@@ -610,9 +617,9 @@ public final class EpollSocketChannel
         return newSupportedIdentityOptionsSet(SO_RCVBUF, SO_SNDBUF, TCP_NODELAY, SO_KEEPALIVE, SO_REUSEADDR, SO_LINGER,
                 IP_TOS, EpollChannelOption.TCP_CORK, EpollChannelOption.TCP_KEEPIDLE, EpollChannelOption.TCP_KEEPCNT,
                 EpollChannelOption.TCP_KEEPINTVL, EpollChannelOption.TCP_USER_TIMEOUT,
-                EpollChannelOption.IP_TRANSPARENT, EpollChannelOption.TCP_MD5SIG, EpollChannelOption.TCP_QUICKACK,
-                ChannelOption.TCP_FASTOPEN_CONNECT, EpollChannelOption.SO_BUSY_POLL,
-                EpollChannelOption.TCP_NOTSENT_LOWAT, EpollChannelOption.TCP_INFO);
+                EpollChannelOption.IP_BIND_ADDRESS_NO_PORT, EpollChannelOption.IP_TRANSPARENT,
+                EpollChannelOption.TCP_MD5SIG, EpollChannelOption.TCP_QUICKACK, ChannelOption.TCP_FASTOPEN_CONNECT,
+                EpollChannelOption.SO_BUSY_POLL, EpollChannelOption.TCP_NOTSENT_LOWAT, EpollChannelOption.TCP_INFO);
     }
 
     private static Set<ChannelOption<?>> supportedOptionsDomainSocket() {
@@ -889,12 +896,36 @@ public final class EpollSocketChannel
     }
 
     /**
+     * Returns {@code true} if <a href="https://man7.org/linux/man-pages/man7/ip.7.html">IP_BIND_ADDRESS_NO_PORT</a> is
+     * enabled, {@code false} otherwise.
+     */
+    public boolean isIpBindAddressNoPort() {
+        try {
+            return socket.isIpBindAddressNoPort();
+        } catch (IOException e) {
+            throw new ChannelException(e);
+        }
+    }
+
+    /**
      * Returns {@code true} if <a href="https://man7.org/linux/man-pages/man7/ip.7.html">IP_TRANSPARENT</a> is enabled,
      * {@code false} otherwise.
      */
     public boolean isIpTransparent() {
         try {
             return socket.isIpTransparent();
+        } catch (IOException e) {
+            throw new ChannelException(e);
+        }
+    }
+
+    /**
+     * If {@code true} is used <a href="https://man7.org/linux/man-pages/man7/ip.7.html">IP_BIND_ADDRESS_NO_PORT</a> is
+     * enabled, {@code false} for disable it. Default is disabled.
+     */
+    private void setIpBindAddressNoPort(boolean ipBindAddressNoPort) {
+        try {
+            socket.setIpBindAddressNoPort(ipBindAddressNoPort);
         } catch (IOException e) {
             throw new ChannelException(e);
         }

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/LinuxSocket.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/LinuxSocket.java
@@ -201,6 +201,10 @@ public final class LinuxSocket extends Socket {
         setTcpUserTimeout(intValue(), milliseconds);
     }
 
+    void setIpBindAddressNoPort(boolean enabled) throws IOException {
+        setIpBindAddressNoPort(intValue(), enabled ? 1 : 0);
+    }
+
     void setIpFreeBind(boolean enabled) throws IOException {
         setIpFreeBind(intValue(), enabled ? 1 : 0);
     }
@@ -260,6 +264,10 @@ public final class LinuxSocket extends Socket {
 
     int getTcpUserTimeout() throws IOException {
         return getTcpUserTimeout(intValue());
+    }
+
+    boolean isIpBindAddressNoPort() throws IOException {
+        return isIpBindAddressNoPort(intValue()) != 0;
     }
 
     boolean isIpFreeBind() throws IOException {
@@ -469,6 +477,7 @@ public final class LinuxSocket extends Socket {
     private static native int getTcpKeepCnt(int fd) throws IOException;
     private static native int getTcpUserTimeout(int fd) throws IOException;
     private static native int getTimeToLive(int fd) throws IOException;
+    private static native int isIpBindAddressNoPort(int fd) throws IOException;
     private static native int isIpFreeBind(int fd) throws IOException;
     private static native int isIpTransparent(int fd) throws IOException;
     private static native int isIpRecvOrigDestAddr(int fd) throws IOException;
@@ -485,6 +494,7 @@ public final class LinuxSocket extends Socket {
     private static native void setTcpKeepIntvl(int fd, int seconds) throws IOException;
     private static native void setTcpKeepCnt(int fd, int probes) throws IOException;
     private static native void setTcpUserTimeout(int fd, int milliseconds)throws IOException;
+    private static native void setIpBindAddressNoPort(int fd, int ipBindAddressNoPort) throws IOException;
     private static native void setIpFreeBind(int fd, int freeBind) throws IOException;
     private static native void setIpTransparent(int fd, int transparent) throws IOException;
     private static native void setIpRecvOrigDestAddr(int fd, int transparent) throws IOException;

--- a/transport-native-epoll/src/main/c/netty5_epoll_linuxsocket.c
+++ b/transport-native-epoll/src/main/c/netty5_epoll_linuxsocket.c
@@ -63,6 +63,11 @@
 #define UDP_GRO 104
 #endif
 
+// IP_BIND_ADDRESS_NO_PORT is defined in linux 4.2. We define this here so older kernels can compile.
+#ifndef IP_BIND_ADDRESS_NO_PORT
+#define IP_BIND_ADDRESS_NO_PORT 24
+#endif
+
 static jweak peerCredentialsClassWeak = NULL;
 static jmethodID peerCredentialsMethodId = NULL;
 
@@ -230,6 +235,10 @@ static void netty5_epoll_linuxsocket_setTcpKeepCnt(JNIEnv* env, jclass clazz, ji
 
 static void netty5_epoll_linuxsocket_setTcpUserTimeout(JNIEnv* env, jclass clazz, jint fd, jint optval) {
     netty5_unix_socket_setOption(env, fd, IPPROTO_TCP, TCP_USER_TIMEOUT, &optval, sizeof(optval));
+}
+
+static void netty5_epoll_linuxsocket_setIpBindAddressNoPort(JNIEnv* env, jclass clazz, jint fd, jint optval) {
+    netty5_unix_socket_setOption(env, fd, IPPROTO_IP, IP_BIND_ADDRESS_NO_PORT, &optval, sizeof(optval));
 }
 
 static void netty5_epoll_linuxsocket_setIpFreeBind(JNIEnv* env, jclass clazz, jint fd, jint optval) {
@@ -585,6 +594,14 @@ static jint netty5_epoll_linuxsocket_getTcpUserTimeout(JNIEnv* env, jclass clazz
      return optval;
 }
 
+static jint netty5_epoll_linuxsocket_isIpBindAddressNoPort(JNIEnv* env, jclass clazz, jint fd) {
+     int optval;
+     if (netty5_unix_socket_getOption(env, fd, IPPROTO_IP, IP_BIND_ADDRESS_NO_PORT, &optval, sizeof(optval)) == -1) {
+         return -1;
+     }
+     return optval;
+}
+
 static jint netty5_epoll_linuxsocket_isIpFreeBind(JNIEnv* env, jclass clazz, jint fd) {
      int optval;
      if (netty5_unix_socket_getOption(env, fd, IPPROTO_IP, IP_FREEBIND, &optval, sizeof(optval)) == -1) {
@@ -790,6 +807,7 @@ static const JNINativeMethod fixed_method_table[] = {
   { "setTcpKeepIntvl", "(II)V", (void *) netty5_epoll_linuxsocket_setTcpKeepIntvl },
   { "setTcpKeepCnt", "(II)V", (void *) netty5_epoll_linuxsocket_setTcpKeepCnt },
   { "setTcpUserTimeout", "(II)V", (void *) netty5_epoll_linuxsocket_setTcpUserTimeout },
+  { "setIpBindAddressNoPort", "(II)V", (void *) netty5_epoll_linuxsocket_setIpBindAddressNoPort },
   { "setIpFreeBind", "(II)V", (void *) netty5_epoll_linuxsocket_setIpFreeBind },
   { "setIpTransparent", "(II)V", (void *) netty5_epoll_linuxsocket_setIpTransparent },
   { "setIpRecvOrigDestAddr", "(II)V", (void *) netty5_epoll_linuxsocket_setIpRecvOrigDestAddr },
@@ -797,6 +815,7 @@ static const JNINativeMethod fixed_method_table[] = {
   { "getTcpKeepIntvl", "(I)I", (void *) netty5_epoll_linuxsocket_getTcpKeepIntvl },
   { "getTcpKeepCnt", "(I)I", (void *) netty5_epoll_linuxsocket_getTcpKeepCnt },
   { "getTcpUserTimeout", "(I)I", (void *) netty5_epoll_linuxsocket_getTcpUserTimeout },
+  { "isIpBindAddressNoPort", "(I)I", (void *) netty5_epoll_linuxsocket_isIpBindAddressNoPort },
   { "isIpFreeBind", "(I)I", (void *) netty5_epoll_linuxsocket_isIpFreeBind },
   { "isIpTransparent", "(I)I", (void *) netty5_epoll_linuxsocket_isIpTransparent },
   { "isIpRecvOrigDestAddr", "(I)I", (void *) netty5_epoll_linuxsocket_isIpRecvOrigDestAddr },


### PR DESCRIPTION
Motivation:

From https://man7.org/linux/man-pages/man7/ip.7.html:

> IP_BIND_ADDRESS_NO_PORT (since Linux 4.2)
Inform the kernel to not reserve an ephemeral port when using bind(2) with a port number of 0. The port will later be automatically chosen at connect(2) time, in a way that allows sharing a source port as long as the 4-tuple is unique.

See also these great blog posts from Cloudflare:

*
https://blog.cloudflare.com/how-to-stop-running-out-of-ephemeral-ports-and-start-to-love-long-lived-connections
* https://blog.cloudflare.com/the-quantum-state-of-a-tcp-port

Supporting this option, introduced in Kernel 4.2, would help with use cases where a client is binding from multiple local addresses.
