### PR TITLE
Log when native transports are unavailable

### DIFF
--- a/common/src/test/resources/logback-test.xml
+++ b/common/src/test/resources/logback-test.xml
@@ -13,4 +13,9 @@
   // Disable logging for apacheds to reduce noise.
   <logger name="org.apache.directory" level="OFF"/>
   <logger name="org.apache.mina" level="OFF"/>
+
+  // Enable trace logging for the loading of our native transports
+  <logger name="io.netty.channel.epoll.Epoll" level="trace"/>
+  <logger name="io.netty.channel.kqueue.KQueue" level="trace"/>
+  <logger name="io.netty.channel.uring.IoUring" level="trace"/>
 </configuration>

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/Epoll.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/Epoll.java
@@ -18,6 +18,8 @@ package io.netty.channel.epoll;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.unix.FileDescriptor;
 import io.netty.util.internal.SystemPropertyUtil;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
 
 /**
  * Tells if <a href="https://netty.io/wiki/native-transports.html">{@code netty-transport-native-epoll}</a> is
@@ -58,7 +60,14 @@ public final class Epoll {
                 }
             }
         }
-
+        if (cause != null) {
+            InternalLogger logger = InternalLoggerFactory.getInstance(Epoll.class);
+            if (logger.isTraceEnabled()) {
+                logger.debug("Epoll support is not available", cause);
+            } else if (logger.isDebugEnabled()) {
+                logger.debug("Epoll support is not available: {}", cause.getMessage());
+            }
+        }
         UNAVAILABILITY_CAUSE = cause;
     }
 

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUring.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUring.java
@@ -18,6 +18,8 @@ package io.netty.channel.uring;
 import io.netty.channel.ChannelOption;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SystemPropertyUtil;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
 
 public final class IoUring {
 
@@ -55,6 +57,14 @@ public final class IoUring {
             }
         } catch (Throwable t) {
             cause = t;
+        }
+        if (cause != null) {
+            InternalLogger logger = InternalLoggerFactory.getInstance(IoUring.class);
+            if (logger.isTraceEnabled()) {
+                logger.debug("IoUring support is not available", cause);
+            } else if (logger.isDebugEnabled()) {
+                logger.debug("IoUring support is not available: {}", cause.getMessage());
+            }
         }
         UNAVAILABILITY_CAUSE = cause;
         IORING_CQE_F_SOCK_NONEMPTY_SUPPORTED = supported;

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueue.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueue.java
@@ -18,6 +18,8 @@ package io.netty.channel.kqueue;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.unix.FileDescriptor;
 import io.netty.util.internal.SystemPropertyUtil;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
 
 /**
  * If KQueue is available the JNI resources will be loaded when this class loads.
@@ -46,7 +48,14 @@ public final class KQueue {
                 }
             }
         }
-
+        if (cause != null) {
+            InternalLogger logger = InternalLoggerFactory.getInstance(KQueue.class);
+            if (logger.isTraceEnabled()) {
+                logger.debug("KQueue support is not available", cause);
+            } else if (logger.isDebugEnabled()) {
+                logger.debug("KQueue support is not available: {}", cause.getMessage());
+            }
+        }
         UNAVAILABILITY_CAUSE = cause;
     }
 


### PR DESCRIPTION
Motivation:
When native transports aren't available where one might expect them to be, it'd be useful to have a log line about why. In particular, I've come to find out that our io_uring transport isn't available in our CI builds, and I'd like to know why.

Modification:
Add debug logging code when initializing the Epoll, KQueue, or IoUring classes, and include the complete stack trace when trace logging is enabled. Also enable trace logging for those classes for our tests.

Note that the stack traces are only shown when trace logging is enabled, because many people run with debug logging enabled, and they might get scared to see an unfamiliar stack trace in their logs.

Result:
It should now be clear why, when a native transport isn't available.
