### PR TITLE
Try un-confining the docker-compose builds

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -22,6 +22,8 @@ services:
       - ~/.m2:/root/.m2
       - ..:/code
     working_dir: /code
+    security_opt:
+      - seccomp:unconfined
 
   build-leak:
     <<: *common


### PR DESCRIPTION
Motivation:
Docker is currently disallowing the io_uring family of system calls in their default seccomp profile. This means io_uring isn't available in those builds, and all the io_uring tests are skipped.

Modification:
Disable the seccomp profile by adding the `seccomp:unconfined` security option. This should be fine for our CI builds, because we only use docker to customize environments, not as a security boundary (GitHub Actions does that for us).

Result:
Hopefully the io_uring tests will start running again.
