### PR TITLE
Port socket half-closed test with no read pending to 4.1

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -29,6 +29,8 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.oio.OioEventLoopGroup;
 import io.netty.channel.socket.ChannelInputShutdownEvent;
 import io.netty.channel.socket.ChannelInputShutdownReadComplete;
 import io.netty.channel.socket.ChannelOutputShutdownEvent;
@@ -52,6 +54,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
+@Timeout(value = 20000, unit = MILLISECONDS)
 public class SocketHalfClosedTest extends AbstractSocketTest {
 
     protected int maxReadCompleteWithNoDataAfterInputShutdown() {
@@ -59,7 +62,141 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
     }
 
     @Test
-    @Timeout(value = 5000, unit = MILLISECONDS)
+    public void testAllDataReadEventTriggeredAfterHalfClosure(TestInfo testInfo) throws Throwable {
+        run(testInfo, new Runner<ServerBootstrap, Bootstrap>() {
+            @Override
+            public void run(ServerBootstrap serverBootstrap, Bootstrap bootstrap) throws Throwable {
+                if (bootstrap.config().group() instanceof OioEventLoopGroup) {
+                    logger.debug("Ignoring test for incompatible OIO event system");
+                    return;
+                } else if (bootstrap.config().group() instanceof NioEventLoopGroup) {
+                    logger.debug("Ignoring test for incompatible NioHandler");
+                    return;
+                }
+                allDataReadEventTriggeredAfterHalfClosure(serverBootstrap, bootstrap);
+            }
+        });
+    }
+
+    private void allDataReadEventTriggeredAfterHalfClosure(ServerBootstrap sb, Bootstrap cb) throws Throwable {
+        final int totalServerBytesWritten = 1;
+        final CountDownLatch clientReadAllDataLatch = new CountDownLatch(1);
+        final CountDownLatch clientHalfClosedLatch = new CountDownLatch(1);
+        final CountDownLatch clientHalfClosedAllBytesRead = new CountDownLatch(1);
+        final AtomicInteger clientReadCompletes = new AtomicInteger();
+        final AtomicInteger clientZeroDataReadCompletes = new AtomicInteger();
+        Channel serverChannel = null;
+        Channel clientChannel = null;
+        AtomicReference<Channel> serverChildChannel = new AtomicReference<>();
+        try {
+            cb.option(ChannelOption.ALLOW_HALF_CLOSURE, true)
+                    .option(ChannelOption.AUTO_CLOSE, false)
+                    .option(ChannelOption.AUTO_READ, false);
+
+            sb.option(ChannelOption.ALLOW_HALF_CLOSURE, true)
+                    .option(ChannelOption.AUTO_CLOSE, false)
+                    .childOption(ChannelOption.TCP_NODELAY, true);
+
+            sb.childHandler(new ChannelInitializer<Channel>() {
+                @Override
+                protected void initChannel(Channel ch) throws Exception {
+                    serverChildChannel.set(ch);
+                    ch.pipeline().addLast(new ChannelInboundHandlerAdapter() {
+                        @Override
+                        public void channelActive(ChannelHandlerContext ctx) throws Exception {
+                            ByteBuf buf = ctx.alloc().buffer(totalServerBytesWritten);
+                            buf.writerIndex(buf.capacity());
+                            ctx.writeAndFlush(buf);
+                        }
+
+                        @Override
+                        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                            ctx.close();
+                        }
+                    });
+                }
+            });
+
+            // client.
+            cb.handler(new ChannelInitializer<Channel>() {
+                @Override
+                protected void initChannel(Channel ch) {
+                    ch.pipeline().addLast(new ChannelInboundHandlerAdapter() {
+                        private int bytesRead;
+                        private int bytesSinceReadComplete;
+
+                        @Override
+                        public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                            ByteBuf buf = (ByteBuf) msg;
+                            bytesRead += buf.readableBytes();
+                            bytesSinceReadComplete += buf.readableBytes();
+                            buf.release();
+                        }
+
+                        @Override
+                        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                            if (evt == ChannelInputShutdownEvent.INSTANCE) {
+                                clientHalfClosedLatch.countDown();
+                            } else if (evt == ChannelInputShutdownReadComplete.INSTANCE) {
+                                clientHalfClosedAllBytesRead.countDown();
+                                ctx.close();
+                            }
+                        }
+
+                        @Override
+                        public void channelReadComplete(ChannelHandlerContext ctx) {
+                            if (bytesSinceReadComplete == 0) {
+                                clientZeroDataReadCompletes.incrementAndGet();
+                            } else {
+                                bytesSinceReadComplete = 0;
+                            }
+                            clientReadCompletes.incrementAndGet();
+                            if (bytesRead == totalServerBytesWritten) {
+                                // Bounce this through the event loop to make sure it happens after we're done
+                                // with the read operation.
+                                ch.eventLoop().execute(new Runnable() {
+                                    @Override
+                                    public void run() {
+                                        clientReadAllDataLatch.countDown();
+                                    }
+                                });
+                            } else {
+                                ctx.read();
+                            }
+                        }
+
+                        @Override
+                        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                            ctx.fireExceptionCaught(cause);
+                            ctx.close();
+                        }
+                    });
+                    ch.read();
+                }
+            });
+
+            serverChannel = sb.bind().sync().channel();
+            clientChannel = cb.connect(serverChannel.localAddress()).sync().channel();
+            clientChannel.read();
+
+            clientReadAllDataLatch.await();
+
+            // Now we need to trigger server half-close
+            ((DuplexChannel) serverChildChannel.get()).shutdownOutput();
+
+            clientHalfClosedLatch.await();
+            clientHalfClosedAllBytesRead.await();
+        } finally {
+            if (clientChannel != null) {
+                clientChannel.close().sync();
+            }
+            if (serverChannel != null) {
+                serverChannel.close().sync();
+            }
+        }
+    }
+
+    @Test
     public void testHalfClosureReceiveDataOnFinalWait2StateWhenSoLingerSet(TestInfo testInfo) throws Throwable {
         run(testInfo, new Runner<ServerBootstrap, Bootstrap>() {
             @Override

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -87,7 +87,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
         final AtomicInteger clientZeroDataReadCompletes = new AtomicInteger();
         Channel serverChannel = null;
         Channel clientChannel = null;
-        AtomicReference<Channel> serverChildChannel = new AtomicReference<Channel>();
+        final AtomicReference<Channel> serverChildChannel = new AtomicReference<Channel>();
         try {
             cb.option(ChannelOption.ALLOW_HALF_CLOSURE, true)
                     .option(ChannelOption.AUTO_CLOSE, false)
@@ -120,7 +120,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
             // client.
             cb.handler(new ChannelInitializer<Channel>() {
                 @Override
-                protected void initChannel(Channel ch) {
+                protected void initChannel(final Channel ch) {
                     ch.pipeline().addLast(new ChannelInboundHandlerAdapter() {
                         private int bytesRead;
                         private int bytesSinceReadComplete;

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -87,7 +87,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
         final AtomicInteger clientZeroDataReadCompletes = new AtomicInteger();
         Channel serverChannel = null;
         Channel clientChannel = null;
-        AtomicReference<Channel> serverChildChannel = new AtomicReference<>();
+        AtomicReference<Channel> serverChildChannel = new AtomicReference<Channel>();
         try {
             cb.option(ChannelOption.ALLOW_HALF_CLOSURE, true)
                     .option(ChannelOption.AUTO_CLOSE, false)


### PR DESCRIPTION
Motivation:

We added a test to 4.2 in PR #14193 to ensure we're receiving the ChannelInputShutdownReadComplete when the socket is half closed. We should also include it in the 4.1 test suite.

Modifications:

- Copy the test to 4.1 as well.

Result:

Better test coverage.
