### PR TITLE
Fix for http request smuggling cause by obfuscating te header fix

### DIFF
--- a/src/main/java/org/jboss/netty/handler/codec/http/HttpMessageDecoder.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/HttpMessageDecoder.java
@@ -711,7 +711,7 @@ public abstract class HttpMessageDecoder extends ReplayingDecoder<State> {
         nameStart = findNonWhitespace(sb, 0);
         for (nameEnd = nameStart; nameEnd < length; nameEnd ++) {
             char ch = sb.charAt(nameEnd);
-            if (ch == ':' || Character.isWhitespace(ch)) {
+            if (ch == ':') {
                 break;
             }
         }

--- a/src/main/java/org/jboss/netty/handler/codec/http/HttpMessageDecoder.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/HttpMessageDecoder.java
@@ -700,7 +700,7 @@ public abstract class HttpMessageDecoder extends ReplayingDecoder<State> {
                 cStart < cEnd? sb.substring(cStart, cEnd) : "" };
     }
 
-    private static String[] splitHeader(String sb) {
+    private String[] splitHeader(String sb) {
         final int length = sb.length();
         int nameStart;
         int nameEnd;
@@ -711,7 +711,21 @@ public abstract class HttpMessageDecoder extends ReplayingDecoder<State> {
         nameStart = findNonWhitespace(sb, 0);
         for (nameEnd = nameStart; nameEnd < length; nameEnd ++) {
             char ch = sb.charAt(nameEnd);
-            if (ch == ':') {
+            // https://tools.ietf.org/html/rfc7230#section-3.2.4
+            //
+            // No whitespace is allowed between the header field-name and colon. In
+            // the past, differences in the handling of such whitespace have led to
+            // security vulnerabilities in request routing and response handling. A
+            // server MUST reject any received request message that contains
+            // whitespace between a header field-name and colon with a response code
+            // of 400 (Bad Request). A proxy MUST remove any such whitespace from a
+            // response message before forwarding the message downstream.
+            if (ch == ':' ||
+              // In case of decoding a request we will just continue processing and header validation
+              // is done in the DefaultHttpHeaders implementation.
+              //
+              // In the case of decoding a response we will "skip" the whitespace.
+              (!isDecodingRequest() && Character.isWhitespace(ch))) {
                 break;
             }
         }

--- a/src/main/java/org/jboss/netty/handler/codec/http/HttpMessageDecoder.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/HttpMessageDecoder.java
@@ -711,6 +711,7 @@ public abstract class HttpMessageDecoder extends ReplayingDecoder<State> {
         nameStart = findNonWhitespace(sb, 0);
         for (nameEnd = nameStart; nameEnd < length; nameEnd ++) {
             char ch = sb.charAt(nameEnd);
+            // https://github.com/netty/netty/pull/9585
             // https://tools.ietf.org/html/rfc7230#section-3.2.4
             //
             // No whitespace is allowed between the header field-name and colon. In


### PR DESCRIPTION
Backport [PR-9585](https://github.com/netty/netty/pull/9585)


When parsing HTTP headers special care needs to be taken when a whitespace is detected in the header name.

Modifications:

Ignore whitespace when decoding response (just like before)
Throw exception when whitespace is detected during parsing
Add unit tests
Result:

Fixes https://github.com/netty/netty/issues/9571