### PR TITLE
Add keytool-based self-signed certificate generator

### DIFF
--- a/handler/src/main/java/io/netty5/handler/ssl/util/KeytoolSelfSignedCertGenerator.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/util/KeytoolSelfSignedCertGenerator.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty5.handler.ssl.util;
+
+
+import io.netty5.buffer.Buffer;
+import io.netty5.buffer.BufferAllocator;
+import io.netty5.util.internal.PlatformDependent;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InterruptedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.security.cert.X509Certificate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Self-signed certificate generator based on the keytool CLI.
+ */
+final class KeytoolSelfSignedCertGenerator {
+    private static final DateTimeFormatter DATE_FORMAT =
+            DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss", Locale.ROOT);
+    private static final String ALIAS = "alias";
+    private static final String PASSWORD = "insecurepassword";
+    private static final Path KEYTOOL;
+    private static final String KEY_STORE_TYPE;
+
+    static {
+        String home = System.getProperty("java.home");
+        if (home == null) {
+            KEYTOOL = null;
+        } else {
+            Path likely = Paths.get(home).resolve("bin").resolve("keytool");
+            if (Files.exists(likely)) {
+                KEYTOOL = likely;
+            } else {
+                KEYTOOL = null;
+            }
+        }
+        // Java < 11 does not support encryption for PKCS#12: JDK-8220734
+        // For 11+, we prefer PKCS#12 for FIPS compliance
+        KEY_STORE_TYPE = PlatformDependent.javaVersion() >= 11 ? "PKCS12" : "JKS";
+    }
+
+    private KeytoolSelfSignedCertGenerator() {
+    }
+
+    static boolean isAvailable() {
+        return KEYTOOL != null;
+    }
+
+    static void generate(SelfSignedCertificate.Builder builder) throws IOException, GeneralSecurityException {
+        // Change all asterisk to 'x' for file name safety.
+        String dirFqdn = builder.fqdn.replaceAll("[^\\w.-]", "x");
+
+        Path directory = Files.createTempDirectory("keytool_" + dirFqdn);
+        Path keyStore = directory.resolve("keystore.jks");
+        try {
+            Process process = new ProcessBuilder()
+                    .command(
+                            "keytool",
+                            "-genkeypair",
+                            "-keyalg", builder.algorithm,
+                            "-keysize", String.valueOf(builder.bits),
+                            "-startdate", DATE_FORMAT.format(
+                                    builder.notBefore.toInstant().atZone(ZoneId.systemDefault())),
+                            "-validity", String.valueOf(builder.notBefore.toInstant().until(
+                                    builder.notAfter.toInstant(), ChronoUnit.DAYS)),
+                            "-keystore", keyStore.toString(),
+                            "-alias", ALIAS,
+                            "-keypass", PASSWORD,
+                            "-storepass", PASSWORD,
+                            "-dname", "CN=" + builder.fqdn,
+                            "-storetype", KEY_STORE_TYPE
+                    )
+                    .redirectErrorStream(true)
+                    .start();
+            try {
+                if (!process.waitFor(60, TimeUnit.SECONDS)) {
+                    process.destroyForcibly();
+                    throw new IOException("keytool timeout");
+                }
+            } catch (InterruptedException e) {
+                process.destroyForcibly();
+                Thread.currentThread().interrupt();
+                throw new InterruptedIOException();
+            }
+
+            if (process.exitValue() != 0) {
+                try (Buffer buffer = BufferAllocator.onHeapUnpooled().allocate(1024)) {
+                    byte[] b = new byte[1024];
+                    try (InputStream stream = process.getInputStream()) {
+                        while (true) {
+                            int n = stream.read(b);
+                            if (n == -1) {
+                                break;
+                            }
+                            buffer.writeBytes(b, 0, n);
+                        }
+                    }
+                    String log = buffer.toString(StandardCharsets.UTF_8);
+                    throw new IOException("Keytool exited with status " + process.exitValue() + ": " + log);
+                }
+            }
+
+            KeyStore ks = KeyStore.getInstance(KEY_STORE_TYPE);
+            try (InputStream is = Files.newInputStream(keyStore)) {
+                ks.load(is, PASSWORD.toCharArray());
+            }
+            KeyStore.PrivateKeyEntry entry = (KeyStore.PrivateKeyEntry) ks.getEntry(
+                    ALIAS, new KeyStore.PasswordProtection(PASSWORD.toCharArray()));
+            builder.paths = SelfSignedCertificate.newSelfSignedCertificate(
+                    builder.fqdn, entry.getPrivateKey(), (X509Certificate) entry.getCertificate());
+            builder.privateKey = entry.getPrivateKey();
+        } finally {
+            Files.deleteIfExists(keyStore);
+            Files.delete(directory);
+        }
+    }
+}

--- a/handler/src/test/java/io/netty5/handler/ssl/util/KeytoolSelfSignedCertGeneratorTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/util/KeytoolSelfSignedCertGeneratorTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty5.handler.ssl.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+
+class KeytoolSelfSignedCertGeneratorTest {
+    @BeforeAll
+    static void checkAvailability() {
+        Assumptions.assumeTrue(KeytoolSelfSignedCertGenerator.isAvailable());
+    }
+
+    @Test
+    public void test() throws Exception {
+        SelfSignedCertificate.Builder builder = SelfSignedCertificate.builder()
+                .fqdn("example.com")
+                .algorithm("RSA")
+                .bits(2048);
+        Assertions.assertTrue(builder.generateKeytool());
+        Assertions.assertEquals("RSA", builder.privateKey.getAlgorithm());
+
+        X509Certificate cert;
+        try (InputStream certStream = Files.newInputStream(Paths.get(builder.paths[0]))) {
+            cert = (X509Certificate) CertificateFactory.getInstance("X509").generateCertificate(certStream);
+        }
+        cert.checkValidity();
+        Assertions.assertEquals("CN=example.com", cert.getSubjectX500Principal().getName());
+    }
+}


### PR DESCRIPTION
Forward port of #14198

Motivation:

On newer Java versions, the JDK-based self-signed certificate generator does not work, so adding bcpkix as a dependency was necessary. This is inconvenient for users that want to use self-signed certs as part of their tests.

Modification:

Add a KeytoolSelfSignedCertGenerator which uses the keytool command included in the JDK to generate the key pair and certificate.

Introduce a SelfSignedCertificate.Builder to make the constructor chaos a bit cleaner. Additionally, since the keytool generator uses an external RNG, this Builder allows for the in-vm KeyPair generation to happen lazily, improving performance for the keytool path.

The next step I've thought about doing is to move the unnecessary file system saving (SelfSignedCertificate.newSelfSignedCertificate) to be lazy, so that we can avoid writing the key and cert at all in some cases. But that is for another day, it'd require some exception handling changes.

Result:

Users can generate self-signed certificates without additional dependencies.