### PR TITLE
Ensure AbstractCoalescingBufferQueue does not end up in inconsistent …

### DIFF
--- a/transport/src/main/java/io/netty/channel/AbstractCoalescingBufferQueue.java
+++ b/transport/src/main/java/io/netty/channel/AbstractCoalescingBufferQueue.java
@@ -197,6 +197,11 @@ public abstract class AbstractCoalescingBufferQueue {
                 }
             }
         } catch (Throwable cause) {
+            // Always decrement to keep things consistent. We decrement directly here and not in a finally-block
+            // to ensure that the state is consistent even if it would be accessed via a listener that is
+            // attached to the promise that we fail below.
+            decrementReadableBytes(originalBytes - bytes);
+
             if (entry instanceof ByteBuf) {
                 // Poll the next element if it's a listener that belongs to the ByteBuf.
                 entry = bufAndListenerPairs.peek();
@@ -209,10 +214,8 @@ public abstract class AbstractCoalescingBufferQueue {
             safeRelease(toReturn);
             aggregatePromise.setFailure(cause);
             throwException(cause);
-        } finally {
-            // Always decrement to keep things consistent
-            decrementReadableBytes(originalBytes - bytes);
         }
+        decrementReadableBytes(originalBytes - bytes);
         return toReturn;
     }
 

--- a/transport/src/main/java/io/netty/channel/AbstractCoalescingBufferQueue.java
+++ b/transport/src/main/java/io/netty/channel/AbstractCoalescingBufferQueue.java
@@ -202,14 +202,13 @@ public abstract class AbstractCoalescingBufferQueue {
             // attached to the promise that we fail below.
             decrementReadableBytes(originalBytes - bytes);
 
-            if (entry instanceof ByteBuf) {
-                // Poll the next element if it's a listener that belongs to the ByteBuf.
-                entry = bufAndListenerPairs.peek();
-                if (entry instanceof ChannelFutureListener) {
-                    aggregatePromise.addListener((ChannelFutureListener) entry);
-                    bufAndListenerPairs.poll();
-                }
+            // Poll the next element if it's a listener that belongs to the ByteBuf.
+            entry = bufAndListenerPairs.peek();
+            if (entry instanceof ChannelFutureListener) {
+                aggregatePromise.addListener((ChannelFutureListener) entry);
+                bufAndListenerPairs.poll();
             }
+
             safeRelease(entryBuffer);
             safeRelease(toReturn);
             aggregatePromise.setFailure(cause);


### PR DESCRIPTION
…state on error

Motivation:

The code in AbstractCoalescingBufferQueue.remove(...) could lead to inconsistent internal state when for example an exception is thrown because of reference counting problems. Because of this is was possible that while the queue was empty it still showed readableBytes() > 0. This could then lead to various issues internally within netty where we depend on that the queue will eventually returns readableBytes() == 0.

Modifications:

- Ensure we always decrement readable bytes, even in the cause of an error
- Also correctly remove the listener if an error happens during handling the buffer.

Result:

Fixes https://github.com/netty/netty/issues/11959
