### PR TITLE
Update the default value of  SO_MAXCONN on Linux from 128 to 4096

### DIFF
--- a/common/src/main/java/io/netty/util/NetUtil.java
+++ b/common/src/main/java/io/netty/util/NetUtil.java
@@ -173,8 +173,9 @@ public final class NetUtil {
             // Determine the default somaxconn (server socket backlog) value of the platform.
             // The known defaults:
             // - Windows NT Server 4.0+: 200
-            // - Linux and Mac OS X: 128
-            int somaxconn = PlatformDependent.isWindows() ? 200 : 128;
+            // - Mac OS X: 128
+            // - Linux kernel > 5.4 : 4096
+            int somaxconn = PlatformDependent.isWindows() ? 200 : (PlatformDependent.isOsx() ? 128 : 4096);
             File file = new File("/proc/sys/net/core/somaxconn");
             BufferedReader in = null;
             try {


### PR DESCRIPTION
Motivation:

Since Linux kernel value >= 5.4, the default value of `SO_MAXCONN` was updated to 4096:
![QQ_1723621912141](https://github.com/user-attachments/assets/f7286372-dac0-4ca6-be28-daaa9a95e80f)
https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt

Linux 5.4 was published 5 years ago, and the default value of SO_MAXCONN = 128 is outdated.

The current default value on Linux = 128 was set 10 years ago(https://github.com/netty/netty/issues/2407), it time to update it.

Modification:

Describe the modifications you've done.

Result:

Fixes #<GitHub issue number>. 

If there is no issue then describe the changes introduced by this PR.
