### PR TITLE
Remove `public` access modifier from OCSP content types

### DIFF
--- a/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspHttpHandler.java
+++ b/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspHttpHandler.java
@@ -34,8 +34,8 @@ final class OcspHttpHandler extends SimpleChannelInboundHandler<FullHttpResponse
     private static final InternalLogger LOGGER = InternalLoggerFactory.getInstance(OcspHttpHandler.class);
     private final Promise<OCSPResp> responseFuture;
 
-    public static final String OCSP_REQUEST_TYPE = "application/ocsp-request";
-    public static final String OCSP_RESPONSE_TYPE = "application/ocsp-response";
+    static final String OCSP_REQUEST_TYPE = "application/ocsp-request";
+    static final String OCSP_RESPONSE_TYPE = "application/ocsp-response";
 
     /**
      * Create new {@link OcspHttpHandler} instance


### PR DESCRIPTION
Motivation:
`OcspHttpHandler` is package-private but the `OCSP_REQUEST_TYPE` and `OCSP_RESPONSE_TYPE` variables were public which is not required because these variables are only accessed by classes in the same package.

Modification:
Made OCSP content types variables package-private

Result:
Clean access modifiers

