### PR TITLE
Upgrade com.fasterxml:aalto-xml and org.codehaus.woodstox:stax2-api to version declaring java module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -889,7 +889,7 @@
       <dependency>
         <groupId>com.fasterxml</groupId>
         <artifactId>aalto-xml</artifactId>
-        <version>1.0.0</version>
+        <version>1.3.3</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Upgrade `com.fasterxml:aalto-xml` from 1.0.0 to 1.3.3 and `org.codehaus.woodstox:stax2-api` from 4.0.0 to 4.2.2

Motivation:

Current versions of `com.fasterxml:aalto-xml` and `org.codehaus.woodstox:stax2-api` do not support the java module system. The latest version contain java module declaration (module-info) which are Java 8 binary compatibles.

Result:

The `netty-codec-xml` use `com.fasterxml:aalto-xml` and `org.codehaus.woodstox:stax2-api` versions containing java module declarations.

See #14176