### PR TITLE
Avoid the invalid execution of empty tasks

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -269,6 +269,9 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
                 }
 
                 if (task != null) {
+                    if (task == WAKEUP_TASK) {
+                        task = null;
+                    }
                     return task;
                 }
             }


### PR DESCRIPTION
Motivation:
io.netty.util.concurrent.SingleThreadEventExecutor#takeTask
This method taskQueue.poll(delayNanos, TimeUnit.NANOSECONDS) may return WAKEUP_TASK
 
 

 
