### PR TITLE
Add new SslHandler.isEncrypted(...) variant that will not produce fal…

### DIFF
--- a/example/src/main/java/io/netty/example/portunification/PortUnificationServerHandler.java
+++ b/example/src/main/java/io/netty/example/portunification/PortUnificationServerHandler.java
@@ -82,7 +82,7 @@ public class PortUnificationServerHandler extends ByteToMessageDecoder {
 
     private boolean isSsl(ByteBuf buf) {
         if (detectSsl) {
-            return SslHandler.isEncrypted(buf);
+            return SslHandler.isEncrypted(buf, false);
         }
         return false;
     }

--- a/handler/src/main/java/io/netty/handler/ssl/OptionalSslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OptionalSslHandler.java
@@ -44,7 +44,7 @@ public class OptionalSslHandler extends ByteToMessageDecoder {
         if (in.readableBytes() < SslUtils.SSL_RECORD_HEADER_LENGTH) {
             return;
         }
-        if (SslHandler.isEncrypted(in)) {
+        if (SslHandler.isEncrypted(in, false)) {
             handleSsl(context);
         } else {
             handleNonSsl(context);

--- a/handler/src/main/java/io/netty/handler/ssl/SslClientHelloHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslClientHelloHandler.java
@@ -79,7 +79,7 @@ public abstract class SslClientHelloHandler<T> extends ByteToMessageDecoder impl
                         case SslUtils.SSL_CONTENT_TYPE_CHANGE_CIPHER_SPEC:
                             // fall-through
                         case SslUtils.SSL_CONTENT_TYPE_ALERT:
-                            final int len = SslUtils.getEncryptedPacketLength(in, readerIndex);
+                            final int len = SslUtils.getEncryptedPacketLength(in, readerIndex, true);
 
                             // Not an SSL/TLS packet
                             if (len == SslUtils.NOT_ENCRYPTED) {

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -1283,13 +1283,35 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
      *                  {@code true} if the {@link ByteBuf} is encrypted, {@code false} otherwise.
      * @throws IllegalArgumentException
      *                  Is thrown if the given {@link ByteBuf} has not at least 5 bytes to read.
+     * @deprecated use {@link #isEncrypted(ByteBuf, boolean)}.
      */
+    @Deprecated
     public static boolean isEncrypted(ByteBuf buffer) {
+        return isEncrypted(buffer, true);
+    }
+
+    /**
+     * Returns {@code true} if the given {@link ByteBuf} is encrypted. Be aware that this method
+     * will not increase the readerIndex of the given {@link ByteBuf}.
+     *
+     * @param   buffer
+     *                  The {@link ByteBuf} to read from. Be aware that it must have at least 5 bytes to read,
+     *                  otherwise it will throw an {@link IllegalArgumentException}.
+     * @return encrypted
+     *                  {@code true} if the {@link ByteBuf} is encrypted, {@code false} otherwise.
+     * @param probeSSLv2
+     *                  {@code true} if the input {@code buffer} might be SSLv2. If {@code true} is used this
+     *                  methods might produce false-positives in some cases so it's strongly suggested to
+     *                  use {@code false}.
+     * @throws IllegalArgumentException
+     *                  Is thrown if the given {@link ByteBuf} has not at least 5 bytes to read.
+     */
+    public static boolean isEncrypted(ByteBuf buffer, boolean probeSSLv2) {
         if (buffer.readableBytes() < SslUtils.SSL_RECORD_HEADER_LENGTH) {
             throw new IllegalArgumentException(
                     "buffer must have at least " + SslUtils.SSL_RECORD_HEADER_LENGTH + " readable bytes");
         }
-        return getEncryptedPacketLength(buffer, buffer.readerIndex()) != SslUtils.NOT_ENCRYPTED;
+        return getEncryptedPacketLength(buffer, buffer.readerIndex(), probeSSLv2) != SslUtils.NOT_ENCRYPTED;
     }
 
     private void decodeJdkCompatible(ChannelHandlerContext ctx, ByteBuf in) throws NotSslRecordException {
@@ -1305,7 +1327,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
             if (readableBytes < SslUtils.SSL_RECORD_HEADER_LENGTH) {
                 return;
             }
-            packetLength = getEncryptedPacketLength(in, in.readerIndex());
+            packetLength = getEncryptedPacketLength(in, in.readerIndex(), true);
             if (packetLength == SslUtils.NOT_ENCRYPTED) {
                 // Not an SSL/TLS packet
                 NotSslRecordException e = new NotSslRecordException(

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -1287,7 +1287,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
      */
     @Deprecated
     public static boolean isEncrypted(ByteBuf buffer) {
-        return isEncrypted(buffer, true);
+        return isEncrypted(buffer, false);
     }
 
     /**

--- a/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
@@ -305,15 +305,15 @@ final class SslUtils {
      * Return how much bytes can be read out of the encrypted data. Be aware that this method will not increase
      * the readerIndex of the given {@link ByteBuf}.
      *
-     * @param   buffer
-     *                  The {@link ByteBuf} to read from.
-     * @return length
-     *                  The length of the encrypted packet that is included in the buffer or
-     *                  {@link #SslUtils#NOT_ENOUGH_DATA} if not enough data is present in the
-     *                  {@link ByteBuf}. This will return {@link SslUtils#NOT_ENCRYPTED} if
-     *                  the given {@link ByteBuf} is not encrypted at all.
+     * @param   buffer      The {@link ByteBuf} to read from.
+     * @param   offset      The offset to start from.
+     * @param   probeSSLv2  {@code true} if the input {@code buffer} might be SSLv2.
+     * @return              The length of the encrypted packet that is included in the buffer or
+     *                      {@link #SslUtils#NOT_ENOUGH_DATA} if not enough data is present in the
+     *                      {@link ByteBuf}. This will return {@link SslUtils#NOT_ENCRYPTED} if
+     *                      the given {@link ByteBuf} is not encrypted at all.
      */
-    static int getEncryptedPacketLength(ByteBuf buffer, int offset) {
+    static int getEncryptedPacketLength(ByteBuf buffer, int offset, boolean probeSSLv2) {
         int packetLength = 0;
 
         // SSLv3 or TLS - Check ContentType
@@ -328,6 +328,9 @@ final class SslUtils {
                 break;
             default:
                 // SSLv2 or bad data
+                if (!probeSSLv2) {
+                    return NOT_ENCRYPTED;
+                }
                 tls = false;
         }
 


### PR DESCRIPTION
…se-positives

Motivation:

SslHandler.isEncrypted(...) could produce false-positives as it might assumed that a buffer contained SSLv2. We should provide a variant of this method which is more robust

Modifications:

- Add new new variant of this method which allows to disable probing for SSLv2
- Add unit test

Result:

Fixes https://github.com/netty/netty/issues/14238
