### PR TITLE
In some scenarios, avoid unnecessary memory allocation

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriter.java
@@ -580,16 +580,16 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
                     if (buf == null) {
                         buf = ctx.alloc().buffer(CONTINUATION_FRAME_HEADER_LENGTH);
                         writeFrameHeaderInternal(buf, fragmentReadableBytes, CONTINUATION, flags, streamId);
-                        ctx.write(buf, promiseAggregator.newPromise());
                     } else {
-                        ctx.write(buf.retainedSlice(), promiseAggregator.newPromise());
+                        assert !flags.endOfHeaders();
+                        buf = buf.retainedSlice();
                     }
                 } else {
                     flags = flags.endOfHeaders(true);
                     buf = ctx.alloc().buffer(CONTINUATION_FRAME_HEADER_LENGTH);
                     writeFrameHeaderInternal(buf, fragmentReadableBytes, CONTINUATION, flags, streamId);
-                    ctx.write(buf, promiseAggregator.newPromise());
                 }
+                ctx.write(buf, promiseAggregator.newPromise());
                 ctx.write(fragment, promiseAggregator.newPromise());
 
             } while (headerBlock.isReadable());

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriter.java
@@ -572,15 +572,15 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
             int fragmentReadableBytes;
             ByteBuf buf = ctx.alloc().buffer(CONTINUATION_FRAME_HEADER_LENGTH);
             // When the headerBlock is readable, use this flag to allocate byteBuf once and re-use
-            boolean readableInit = false;
+            boolean reUse = false;
             do {
                 fragmentReadableBytes = min(headerBlock.readableBytes(), maxFrameSize);
                 ByteBuf fragment = headerBlock.readRetainedSlice(fragmentReadableBytes);
 
                 if (headerBlock.isReadable()) {
-                    if (!readableInit) {
+                    if (!reUse) {
                         writeFrameHeaderInternal(buf, fragmentReadableBytes, CONTINUATION, flags, streamId);
-                        readableInit = true;
+                        reUse = true;
                     } else {
                         ctx.write(buf.retainedSlice(), promiseAggregator.newPromise());
                     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriter.java
@@ -580,15 +580,17 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
                     if (buf == null) {
                         buf = ctx.alloc().buffer(CONTINUATION_FRAME_HEADER_LENGTH);
                         writeFrameHeaderInternal(buf, fragmentReadableBytes, CONTINUATION, flags, streamId);
-                    } else {
-                        buf = buf.retainedSlice();
                     }
+                    ctx.write(buf.retainedSlice(), promiseAggregator.newPromise());
                 } else {
+                    if (buf != null) {
+                       buf.release();
+                    }
                     flags = flags.endOfHeaders(true);
                     buf = ctx.alloc().buffer(CONTINUATION_FRAME_HEADER_LENGTH);
                     writeFrameHeaderInternal(buf, fragmentReadableBytes, CONTINUATION, flags, streamId);
+                    ctx.write(buf, promiseAggregator.newPromise());
                 }
-                ctx.write(buf, promiseAggregator.newPromise());
                 ctx.write(fragment, promiseAggregator.newPromise());
 
             } while (headerBlock.isReadable());

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriter.java
@@ -587,9 +587,8 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
                 } else {
                     flags = flags.endOfHeaders(true);
                     writeFrameHeaderInternal(buf, fragmentReadableBytes, CONTINUATION, flags, streamId);
-                    ctx.write(buf, promiseAggregator.newPromise());
                 }
-
+                ctx.write(buf, promiseAggregator.newPromise());
                 ctx.write(fragment, promiseAggregator.newPromise());
 
             } while (headerBlock.isReadable());

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriter.java
@@ -581,7 +581,6 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
                         buf = ctx.alloc().buffer(CONTINUATION_FRAME_HEADER_LENGTH);
                         writeFrameHeaderInternal(buf, fragmentReadableBytes, CONTINUATION, flags, streamId);
                     } else {
-                        assert !flags.endOfHeaders();
                         buf = buf.retainedSlice();
                     }
                 } else {


### PR DESCRIPTION
**Motivation:**
When the number of readable bytes in the headerBlock is less than or equal to maxFrameSize, it will result in an unnecessary allocation of ByteBuf, as well as logical operations on this ByteBuf.



 