### PR TITLE
Ensure flushes are not discarded by ChunkedWriteHandler for passed th…

### DIFF
--- a/handler/src/main/java/io/netty/handler/stream/ChunkedWriteHandler.java
+++ b/handler/src/main/java/io/netty/handler/stream/ChunkedWriteHandler.java
@@ -207,7 +207,11 @@ public class ChunkedWriteHandler extends ChannelDuplexHandler {
     private void doFlush(final ChannelHandlerContext ctx) {
         final Channel channel = ctx.channel();
         if (!channel.isActive()) {
+            // Even after discarding all previous queued objects we should propagate the flush through
+            // to ensure previous written objects via writeAndFlush(...) that were not queued will be flushed and
+            // so eventually fail the promise.
             discard(null);
+            ctx.flush();
             return;
         }
 


### PR DESCRIPTION
…rough messages

Motivation:

We need to ensure we not discard flushed for provious passed through messages as otherwise we might never notify the promise

Modifications:

Always call ctx.flush() after discarding queued messages because of inactive Channel

Result:

Fixes https://github.com/netty/netty/issues/14236
