### PR TITLE
Remove reference to parent in recycled buffers for leak detection

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractPooledDerivedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractPooledDerivedByteBuf.java
@@ -16,6 +16,7 @@
 
 package io.netty.buffer;
 
+import io.netty.util.IllegalReferenceCountException;
 import io.netty.util.Recycler.EnhancedHandle;
 import io.netty.util.internal.ObjectPool.Handle;
 
@@ -51,6 +52,10 @@ abstract class AbstractPooledDerivedByteBuf extends AbstractReferenceCountedByte
 
     @Override
     public final AbstractByteBuf unwrap() {
+        AbstractByteBuf rootParent = this.rootParent;
+        if (rootParent == null) {
+            throw new IllegalReferenceCountException();
+        }
         return rootParent;
     }
 

--- a/buffer/src/main/java/io/netty/buffer/AbstractPooledDerivedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractPooledDerivedByteBuf.java
@@ -83,6 +83,8 @@ abstract class AbstractPooledDerivedByteBuf extends AbstractReferenceCountedByte
         // otherwise it is possible that the same AbstractPooledDerivedByteBuf is again obtained and init(...) is
         // called before we actually have a chance to call release(). This leads to call release() on the wrong parent.
         ByteBuf parent = this.parent;
+        // Remove references to parent and root so that they can be GCed for leak detection [netty/netty#14247]
+        this.parent = this.rootParent = null;
         recyclerHandle.unguardedRecycle(this);
         parent.release();
     }


### PR DESCRIPTION
Motivation:

When a derived, pooled buffer holds a reference to a parent and is released, the buffer instance is returned to a class-specific recycler. The recycler retains a strong reference to the buffer. If the parent has a resource leak, the recycled buffer still has a reference to the parent which prevents GC of the parent and thus leak detection.

Modification:

Clear the reference to the parent and rootParent on deallocate.

I don't think a test is feasible, unfortunately.

Result:

The parent becomes unreferenced, gets GCed, and triggers leak detection.

Fixes #14247