### PR TITLE
Upgrade to netty-tcnative 2.0.66.Final

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -65,7 +65,7 @@
 
   <properties>
     <!-- Keep in sync with ../pom.xml -->
-    <tcnative.version>2.0.65.Final</tcnative.version>
+    <tcnative.version>2.0.66.Final</tcnative.version>
   </properties>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -578,7 +578,7 @@
       <id>boringssl-snapshot</id>
       <properties>
         <tcnative.artifactId>netty-tcnative-boringssl-static</tcnative.artifactId>
-        <tcnative.version>2.0.66.Final-SNAPSHOT</tcnative.version>
+        <tcnative.version>2.0.67.Final-SNAPSHOT</tcnative.version>
         <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
       </properties>
     </profile>
@@ -709,7 +709,7 @@
     <os.detection.classifierWithLikes>fedora,suse,arch</os.detection.classifierWithLikes>
     <tcnative.artifactId>netty-tcnative</tcnative.artifactId>
     <!-- Keep in sync with bom/pom.xml -->
-    <tcnative.version>2.0.65.Final</tcnative.version>
+    <tcnative.version>2.0.66.Final</tcnative.version>
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
     <conscrypt.groupId>org.conscrypt</conscrypt.groupId>
     <conscrypt.artifactId>conscrypt-openjdk-uber</conscrypt.artifactId>


### PR DESCRIPTION
Motivation:

A new release of netty-tcnative is out

Modifications:

Upgrade to 2.0.66.Final

Result:

Use latest netty-tcnative version

