### PR TITLE
Update versions of Commons Logging and Log4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -646,7 +646,7 @@
     <jni.classifier>${os.detected.name}-${os.detected.arch}</jni.classifier>
     <logging.config>${project.basedir}/../common/src/test/resources/logback-test.xml</logging.config>
     <logging.logLevel>debug</logging.logLevel>
-    <log4j2.version>2.17.2</log4j2.version>
+    <log4j2.version>2.23.1</log4j2.version>
     <enforcer.plugin.version>3.0.0</enforcer.plugin.version>
     <junit.version>5.9.0</junit.version>
     <skipTests>false</skipTests>
@@ -945,7 +945,7 @@
       <dependency>
         <groupId>commons-logging</groupId>
         <artifactId>commons-logging</artifactId>
-        <version>1.2</version>
+        <version>1.3.4</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
Motivation:

Some logging libraries integrated by Netty do not support explicit modules in their current version

- Log4j: named automatic
- Commons Logging : automatic module only

Recent versions do support explicit modules

- Log4j 2.23.1 ships a module-info descriptor
- Commons Logging 1.3.4 ships a module-info descriptor

Changes:

Upgrade Log4j to 2.23.1 and Commons Logging to 1.3.4

Results:

More recent logging libraries, note these libraries are optional.

Fixes #14259