### PR TITLE
#14255: Add metrics to track chunk allocations and deallocations

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -61,6 +61,9 @@ abstract class PoolArena<T> implements PoolArenaMetric {
     private long deallocationsSmall;
     private long deallocationsNormal;
 
+    private long pooledChunkAllocations;
+    private long pooledChunkDeallocations;
+
     // We need to use the LongCounter here as this is not guarded via synchronized block.
     private final LongCounter deallocationsHuge = PlatformDependent.newLongCounter();
 
@@ -213,6 +216,7 @@ abstract class PoolArena<T> implements PoolArenaMetric {
         boolean success = c.allocate(buf, reqCapacity, sizeIdx, threadCache);
         assert success;
         qInit.add(c);
+        ++pooledChunkAllocations;
     }
 
     private void incSmallAllocation() {
@@ -268,6 +272,9 @@ abstract class PoolArena<T> implements PoolArenaMetric {
                 }
             }
             destroyChunk = !chunk.parent.free(chunk, handle, normCapacity, nioBuffer);
+            if (destroyChunk) {
+                ++pooledChunkDeallocations;
+            }
         } finally {
             unlock();
         }
@@ -412,6 +419,16 @@ abstract class PoolArena<T> implements PoolArenaMetric {
     }
 
     @Override
+    public long numChunkAllocations() {
+        lock();
+        try {
+            return pooledChunkAllocations;
+        } finally {
+            unlock();
+        }
+    }
+
+    @Override
     public long numDeallocations() {
         final long deallocs;
         lock();
@@ -443,6 +460,16 @@ abstract class PoolArena<T> implements PoolArenaMetric {
         lock();
         try {
             return deallocationsNormal;
+        } finally {
+            unlock();
+        }
+    }
+
+    @Override
+    public long numChunkDeallocations() {
+        lock();
+        try {
+            return pooledChunkDeallocations;
         } finally {
             unlock();
         }
@@ -487,6 +514,18 @@ abstract class PoolArena<T> implements PoolArenaMetric {
         lock();
         try {
             val = allocationsNormal - deallocationsNormal;
+        } finally {
+            unlock();
+        }
+        return max(val, 0);
+    }
+
+    @Override
+    public long numActiveChunks() {
+        final long val;
+        lock();
+        try {
+            val = pooledChunkAllocations - pooledChunkDeallocations;
         } finally {
             unlock();
         }

--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -273,6 +273,7 @@ abstract class PoolArena<T> implements PoolArenaMetric {
             }
             destroyChunk = !chunk.parent.free(chunk, handle, normCapacity, nioBuffer);
             if (destroyChunk) {
+                // all other destroyChunk calls come from the arena itself being finalized, so don't need to be counted
                 ++pooledChunkDeallocations;
             }
         } finally {

--- a/buffer/src/main/java/io/netty/buffer/PoolArenaMetric.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArenaMetric.java
@@ -93,6 +93,13 @@ public interface PoolArenaMetric extends SizeClassesMetric {
     long numHugeAllocations();
 
     /**
+     * Return the number of chunks allocations done via the arena.
+     */
+    default long numChunkAllocations() {
+        return 0;
+    }
+
+    /**
      * Return the number of deallocations done via the arena. This includes all sizes.
      */
     long numDeallocations();
@@ -121,6 +128,13 @@ public interface PoolArenaMetric extends SizeClassesMetric {
     long numHugeDeallocations();
 
     /**
+     * Return the number of chunk deallocations done via the arena.
+     */
+    default long numChunkDeallocations() {
+        return 0;
+    }
+
+    /**
      * Return the number of currently active allocations.
      */
     long numActiveAllocations();
@@ -147,6 +161,13 @@ public interface PoolArenaMetric extends SizeClassesMetric {
      * Return the number of currently active huge allocations.
      */
     long numActiveHugeAllocations();
+
+    /**
+     * Return the number of currently active chunks.
+     */
+    default long numActiveChunks() {
+        return 0;
+    }
 
     /**
      * Return the number of active bytes that are currently allocated by the arena.

--- a/buffer/src/main/java/io/netty/buffer/PoolArenaMetric.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArenaMetric.java
@@ -93,10 +93,10 @@ public interface PoolArenaMetric extends SizeClassesMetric {
     long numHugeAllocations();
 
     /**
-     * Return the number of chunks allocations done via the arena.
+     * Return the number of chunks allocations done via the arena, or -1 if not defined.
      */
     default long numChunkAllocations() {
-        return 0;
+        return -1;
     }
 
     /**
@@ -128,10 +128,10 @@ public interface PoolArenaMetric extends SizeClassesMetric {
     long numHugeDeallocations();
 
     /**
-     * Return the number of chunk deallocations done via the arena.
+     * Return the number of chunk deallocations done via the arena, or -1 if nor defined.
      */
     default long numChunkDeallocations() {
-        return 0;
+        return -1;
     }
 
     /**
@@ -163,10 +163,10 @@ public interface PoolArenaMetric extends SizeClassesMetric {
     long numActiveHugeAllocations();
 
     /**
-     * Return the number of currently active chunks.
+     * Return the number of currently active chunks, or -1 if not defined
      */
     default long numActiveChunks() {
-        return 0;
+        return -1;
     }
 
     /**

--- a/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
@@ -146,6 +146,10 @@ public class PoolArenaTest {
         assertEquals(1, metric.numSmallAllocations());
         assertEquals(1, metric.numNormalDeallocations());
         assertEquals(1, metric.numNormalAllocations());
+
+        assertEquals(1, metric.numChunkAllocations());
+        assertEquals(0, metric.numChunkDeallocations());
+        assertEquals(1, metric.numActiveChunks());
     }
 
     @Test


### PR DESCRIPTION
Motivation:

Added metrics to track chunk allocations and deallocations so allocation rate by the arena can be tracked.

Modification:

Added `numChunkAllocations`, `numChunkDeallocations`, `numActiveChunks` to `PoolArenaMetric`

Result:

Fixes #14255. 
