### PR TITLE
Fix netty-all artifact snapshot deployments

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -126,6 +126,15 @@ jobs:
           name: linux-x86_64-java8-local-staging
           path: ~/linux-x86_64-java8-local-staging
 
+      - name: Copy previous build artifacts to local maven repository
+        run: |
+          cp -r ~/linux-aarch64-local-staging/deferred/* ~/.m2/repository/
+          cp -r ~/linux-riscv64-local-staging/deferred/* ~/.m2/repository/
+          cp -r ~/linux-x86_64-java8-local-staging/deferred/* ~/.m2/repository/
+
+      - name: Generate netty-all and deploy to local staging.
+        run: ./mvnw -Plinux-native-dependencies -pl all org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/all-local-staging -DskipRemoteStaging=true -DskipTests=true
+
       - name: Merge staging repositories
         run: |
           mkdir -p ~/local-staging/deferred
@@ -135,6 +144,8 @@ jobs:
           cp -r ~/linux-riscv64-local-staging/deferred/* ~/local-staging/deferred/
           cat ~/linux-x86_64-java8-local-staging/deferred/.index >>  ~/local-staging/deferred/.index
           cp -r ~/linux-x86_64-java8-local-staging/deferred/* ~/local-staging/deferred/
+          cat ~/all-local-staging/deferred/.index >>  ~/local-staging/deferred/.index
+          cp -r ~/all-local-staging/deferred/* ~/local-staging/deferred/
 
       - uses: s4u/maven-settings-action@v3.0.0
         with:

--- a/all/pom.xml
+++ b/all/pom.xml
@@ -111,6 +111,32 @@
         </dependency>
       </dependencies>
     </profile>
+    <profile>
+      <id>linux-native-dependencies</id>
+      <dependencies>
+        <!-- Depend on all our native jars for linux only -->
+        <!-- As this is executed on either macOS or Linux we directly need to specify the classifier -->
+        <!-- These dependencies will also be "merged" into the dependency section by the flatten plugin -->
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>netty-transport-native-epoll</artifactId>
+          <classifier>linux-x86_64</classifier>
+          <scope>runtime</scope>
+        </dependency>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>netty-transport-native-epoll</artifactId>
+          <classifier>linux-aarch_64</classifier>
+          <scope>runtime</scope>
+        </dependency>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>netty-transport-native-epoll</artifactId>
+          <classifier>linux-riscv64</classifier>
+          <scope>runtime</scope>
+        </dependency>
+      </dependencies>
+    </profile>
 
     <!-- The linux profile will only include the native jar for epoll to the all jar.
          If you want to also include the native jar for kqueue use -Puber.


### PR DESCRIPTION
Motivation:

We need to ensure we have all the native dependencies thats we need before we re-generate the netty-all jar as otherwise these willl be missing if people depend on it

Modifications:

- Add extra profile which only add linux native libs
- Add some more steps in the workflow to ensure we regenerate the netty-all jar before deploy everything that was locally staged

Result:

Fix netty-all snapshot build
