### PR TITLE
Add io_uring transport to netty-all

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -86,6 +86,24 @@
           <scope>runtime</scope>
         </dependency>
         <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-io_uring</artifactId>
+          <classifier>linux-x86_64</classifier>
+          <scope>runtime</scope>
+        </dependency>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-io_uring</artifactId>
+          <classifier>linux-aarch_64</classifier>
+          <scope>runtime</scope>
+        </dependency>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-io_uring</artifactId>
+          <classifier>linux-riscv64</classifier>
+          <scope>runtime</scope>
+        </dependency>
+        <dependency>
           <groupId>${project.groupId}</groupId>
           <artifactId>netty-transport-native-kqueue</artifactId>
           <classifier>osx-x86_64</classifier>
@@ -132,6 +150,24 @@
         <dependency>
           <groupId>${project.groupId}</groupId>
           <artifactId>netty-transport-native-epoll</artifactId>
+          <classifier>linux-riscv64</classifier>
+          <scope>runtime</scope>
+        </dependency>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-io_uring</artifactId>
+          <classifier>linux-x86_64</classifier>
+          <scope>runtime</scope>
+        </dependency>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-io_uring</artifactId>
+          <classifier>linux-aarch_64</classifier>
+          <scope>runtime</scope>
+        </dependency>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-io_uring</artifactId>
           <classifier>linux-riscv64</classifier>
           <scope>runtime</scope>
         </dependency>
@@ -407,6 +443,11 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-resolver-dns-classes-macos</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-classes-io_uring</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Motivation:

netty-all should depend on all modules but did miss our io_uring transport

Modifications:

Add io_uring transport modules as dependency

Result:

netty-all correctly depend on everything
