### PR TITLE
Release AdaptiveByteBuf when ownership could not be transfered.

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -192,12 +192,19 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
             Thread currentThread = Thread.currentThread();
             boolean willCleanupFastThreadLocals = FastThreadLocalThread.willCleanupFastThreadLocals(currentThread);
             AdaptiveByteBuf buf = AdaptiveByteBuf.newInstance(willCleanupFastThreadLocals);
-            AdaptiveByteBuf result = allocate(size, maxCapacity, currentThread, buf);
-            if (result != null) {
-                return result;
+            try {
+                AdaptiveByteBuf result = allocate(size, maxCapacity, currentThread, buf);
+                if (result != null) {
+                    // The ownership of the buf is now part of the result that we return.
+                    buf = null;
+                    return result;
+                }
+            } finally {
+                if (buf != null) {
+                    // We didnt handover ownership of the buf, release it now so we don't leak.
+                    buf.release();
+                }
             }
-            // Return the buffer we pulled from the recycler but didn't use.
-            buf.release();
         }
         // The magazines failed us, or the buffer is too big to be pooled.
         return chunkAllocator.allocate(size, maxCapacity);


### PR DESCRIPTION
Motivation:

We need to ensure we release the AdaptiveByteBuf if we could not hand-over the ownership in all cases as otherwise we will leak.

Modifications:

Always release the buffer if not handed over.

Result:

Correctly release buffer when error happens during allocation
