### PR TITLE
Only add Magazine to Set if we can ensure its removed again

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -135,7 +135,12 @@ final class AdaptivePoolingAllocator {
                 protected Object initialValue() {
                     if (cachedMagazinesNonEventLoopThreads || ThreadExecutorMap.currentExecutor() != null) {
                         Magazine mag = new Magazine(AdaptivePoolingAllocator.this, false);
-                        liveMagazines.add(mag);
+
+                        if (FastThreadLocalThread.willCleanupFastThreadLocals(Thread.currentThread())) {
+                            // Only add it to the liveMagazines if we can guarantee that onRemoval(...) is called,
+                            // as otherwise we might end up holding the reference forever.
+                            liveMagazines.add(mag);
+                        }
                         return mag;
                     }
                     return NO_MAGAZINE;


### PR DESCRIPTION
Motivation:

We need to ensure we only add the Magazine to the Set if we are sure it is removed again once the Thread exit. Otherwise we will end up with a leak as the Magazine will only be able to collected once the whole allocator is GC'ed

Modifications:

- Only add Magazine if we are sure onRemoval(...) is called

Result:

No more leak when used from non FastThreadLocalThread.
