### PR TITLE
Cleanup AdaptivePoolingAllocator allocate code to make it easier to r…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -197,8 +197,9 @@ final class AdaptivePoolingAllocator {
             try {
                 if (allocate(size, maxCapacity, currentThread, buf)) {
                     // Allocation did work, the ownership will is transferred to the caller.
+                    AdaptiveByteBuf result = buf;
                     buf = null;
-                    return buf;
+                    return result;
                 }
             } finally {
                 if (buf != null) {

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -195,15 +195,14 @@ final class AdaptivePoolingAllocator {
             boolean willCleanupFastThreadLocals = FastThreadLocalThread.willCleanupFastThreadLocals(currentThread);
             AdaptiveByteBuf buf = AdaptiveByteBuf.newInstance(willCleanupFastThreadLocals);
             try {
-                AdaptiveByteBuf result = allocate(size, maxCapacity, currentThread, buf);
-                if (result != null) {
-                    // The ownership of the buf is now part of the result that we return.
+                if (allocate(size, maxCapacity, currentThread, buf)) {
+                    // Allocation did work, the ownership will is transferred to the caller.
                     buf = null;
-                    return result;
+                    return buf;
                 }
             } finally {
                 if (buf != null) {
-                    // We didnt handover ownership of the buf, release it now so we don't leak.
+                    // We didn't handover ownership of the buf, release it now so we don't leak.
                     buf.release();
                 }
             }
@@ -212,13 +211,14 @@ final class AdaptivePoolingAllocator {
         return chunkAllocator.allocate(size, maxCapacity);
     }
 
-    private AdaptiveByteBuf allocate(int size, int maxCapacity, Thread currentThread, AdaptiveByteBuf buf) {
+    private boolean allocate(int size, int maxCapacity, Thread currentThread, AdaptiveByteBuf buf) {
         int sizeBucket = AllocationStatistics.sizeBucket(size); // Compute outside of Magazine lock for better ILP.
         FastThreadLocal<Object> threadLocalMagazine = this.threadLocalMagazine;
         if (threadLocalMagazine != null && currentThread instanceof FastThreadLocalThread) {
             Object mag = threadLocalMagazine.get();
             if (mag != NO_MAGAZINE) {
-                return ((Magazine) mag).allocate(size, sizeBucket, maxCapacity, buf);
+                ((Magazine) mag).allocate(size, sizeBucket, maxCapacity, buf);
+                return true;
             }
         }
         long threadId = currentThread.getId();
@@ -233,7 +233,8 @@ final class AdaptivePoolingAllocator {
                 long writeLock = mag.tryWriteLock();
                 if (writeLock != 0) {
                     try {
-                        return mag.allocate(size, sizeBucket, maxCapacity, buf);
+                        mag.allocate(size, sizeBucket, maxCapacity, buf);
+                        return true;
                     } finally {
                         mag.unlockWrite(writeLock);
                     }
@@ -241,7 +242,7 @@ final class AdaptivePoolingAllocator {
             }
             expansions++;
         } while (expansions <= EXPANSION_ATTEMPTS && tryExpandMagazines(mags.length));
-        return null;
+        return false;
     }
 
     /**
@@ -249,9 +250,8 @@ final class AdaptivePoolingAllocator {
      */
     void allocate(int size, int maxCapacity, AdaptiveByteBuf into) {
         Magazine magazine = into.chunk.magazine;
-        AdaptiveByteBuf result = allocate(size, maxCapacity, Thread.currentThread(), into);
-        if (result == null) {
-            // Create a one-off chunk for this allocation.
+        if (!allocate(size, maxCapacity, Thread.currentThread(), into)) {
+            // Create a one-off chunk for this allocation as the previous allocate call did not work out.
             AbstractByteBuf innerChunk = (AbstractByteBuf) chunkAllocator.allocate(size, maxCapacity);
             Chunk chunk = new Chunk(innerChunk, magazine, false);
             chunk.readInitInto(into, size, maxCapacity);
@@ -422,19 +422,21 @@ final class AdaptivePoolingAllocator {
             usedMemory = new AtomicLong();
         }
 
-        public AdaptiveByteBuf allocate(int size, int sizeBucket, int maxCapacity, AdaptiveByteBuf buf) {
+        public void allocate(int size, int sizeBucket, int maxCapacity, AdaptiveByteBuf buf) {
             recordAllocationSize(sizeBucket);
             Chunk curr = current;
             if (curr != null && curr.remainingCapacity() >= size) {
                 if (curr.remainingCapacity() == size) {
                     current = null;
                     try {
-                        return curr.readInitInto(buf, size, maxCapacity);
+                        curr.readInitInto(buf, size, maxCapacity);
+                        return;
                     } finally {
                         curr.release();
                     }
                 }
-                return curr.readInitInto(buf, size, maxCapacity);
+                curr.readInitInto(buf, size, maxCapacity);
+                return;
             }
             if (curr != null) {
                 curr.release();
@@ -448,16 +450,15 @@ final class AdaptivePoolingAllocator {
                 }
             }
             current = curr;
-            final AdaptiveByteBuf result;
             if (curr.remainingCapacity() > size) {
-                result = curr.readInitInto(buf, size, maxCapacity);
+                curr.readInitInto(buf, size, maxCapacity);
             } else if (curr.remainingCapacity() == size) {
-                result = curr.readInitInto(buf, size, maxCapacity);
+                curr.readInitInto(buf, size, maxCapacity);
                 curr.release();
                 current = null;
             } else {
                 Chunk newChunk = newChunkAllocation(size);
-                result = newChunk.readInitInto(buf, size, maxCapacity);
+                newChunk.readInitInto(buf, size, maxCapacity);
                 if (curr.remainingCapacity() < RETIRE_CAPACITY) {
                     curr.release();
                     current = newChunk;
@@ -469,7 +470,6 @@ final class AdaptivePoolingAllocator {
                     }
                 }
             }
-            return result;
         }
 
         private Chunk newChunkAllocation(int promptingSize) {
@@ -536,7 +536,7 @@ final class AdaptivePoolingAllocator {
             }
         }
 
-        public AdaptiveByteBuf readInitInto(AdaptiveByteBuf buf, int size, int maxCapacity) {
+        public void readInitInto(AdaptiveByteBuf buf, int size, int maxCapacity) {
             int startIndex = allocatedBytes;
             allocatedBytes = startIndex + size;
             Chunk chunk = this;
@@ -551,7 +551,6 @@ final class AdaptivePoolingAllocator {
                     chunk.release();
                 }
             }
-            return buf;
         }
 
         public int remainingCapacity() {


### PR DESCRIPTION
…eason about owernship

Motivation:

How the code was structured made it haard to follow when the owernship of what is transfered as the passed in ByteBuf was also returned.

Modifications:

Change (internal) method return type to make it easier to follow the allocation code path in terms of ownership

Result:

Cleanup