### PR TITLE
Make arenas reuse their last chunk more aggressively

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 
 import static io.netty.buffer.PoolChunk.isSubpage;
@@ -656,9 +657,11 @@ abstract class PoolArena<T> implements PoolArenaMetric {
     }
 
     static final class HeapArena extends PoolArena<byte[]> {
+        private final AtomicReference<PoolChunk<byte[]>> lastDestroyedChunk;
 
         HeapArena(PooledByteBufAllocator parent, SizeClasses sizeClass) {
             super(parent, sizeClass);
+            lastDestroyedChunk = new AtomicReference<>();
         }
 
         private static byte[] newByteArray(int size) {
@@ -672,6 +675,14 @@ abstract class PoolArena<T> implements PoolArenaMetric {
 
         @Override
         protected PoolChunk<byte[]> newChunk(int pageSize, int maxPageIdx, int pageShifts, int chunkSize) {
+            PoolChunk<byte[]> chunk = lastDestroyedChunk.getAndSet(null);
+            if (chunk != null) {
+                assert chunk.chunkSize == chunkSize &&
+                        chunk.pageSize == pageSize &&
+                        chunk.maxPageIdx == maxPageIdx &&
+                        chunk.pageShifts == pageShifts;
+                return chunk; // The parameters are always the same, so it's fine to reuse a previously allocated chunk.
+            }
             return new PoolChunk<byte[]>(
                     this, null, newByteArray(chunkSize), pageSize, pageShifts, chunkSize, maxPageIdx);
         }
@@ -683,7 +694,10 @@ abstract class PoolArena<T> implements PoolArenaMetric {
 
         @Override
         protected void destroyChunk(PoolChunk<byte[]> chunk) {
-            // Rely on GC.
+            // Rely on GC. But keep one chunk for reuse.
+            if (!chunk.unpooled && lastDestroyedChunk.get() == null) {
+                lastDestroyedChunk.set(chunk); // The check-and-set does not need to be atomic.
+            }
         }
 
         @Override
@@ -714,8 +728,7 @@ abstract class PoolArena<T> implements PoolArenaMetric {
         }
 
         @Override
-        protected PoolChunk<ByteBuffer> newChunk(int pageSize, int maxPageIdx,
-            int pageShifts, int chunkSize) {
+        protected PoolChunk<ByteBuffer> newChunk(int pageSize, int maxPageIdx, int pageShifts, int chunkSize) {
             if (sizeClass.directMemoryCacheAlignment == 0) {
                 ByteBuffer memory = allocateDirect(chunkSize);
                 return new PoolChunk<ByteBuffer>(this, memory, memory, pageSize, pageShifts,

--- a/buffer/src/main/java/io/netty/buffer/PoolChunk.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunk.java
@@ -171,9 +171,10 @@ final class PoolChunk<T> implements PoolChunkMetric {
      */
     private final LongCounter pinnedBytes = PlatformDependent.newLongCounter();
 
-    private final int pageSize;
-    private final int pageShifts;
-    private final int chunkSize;
+    final int pageSize;
+    final int pageShifts;
+    final int chunkSize;
+    final int maxPageIdx;
 
     // Use as cache for ByteBuffer created from the memory. These are just duplicates and so are only a container
     // around the memory itself. These are often needed for operations within the Pooled*ByteBuf and so
@@ -200,6 +201,7 @@ final class PoolChunk<T> implements PoolChunkMetric {
         this.pageSize = pageSize;
         this.pageShifts = pageShifts;
         this.chunkSize = chunkSize;
+        this.maxPageIdx = maxPageIdx;
         freeBytes = chunkSize;
 
         runsAvail = newRunsAvailqueueArray(maxPageIdx);
@@ -223,6 +225,7 @@ final class PoolChunk<T> implements PoolChunkMetric {
         this.memory = memory;
         pageSize = 0;
         pageShifts = 0;
+        maxPageIdx = 0;
         runsAvailMap = null;
         runsAvail = null;
         runsAvailLock = null;

--- a/buffer/src/main/java/io/netty/buffer/PoolChunkList.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunkList.java
@@ -28,7 +28,7 @@ import static java.lang.Math.*;
 import java.nio.ByteBuffer;
 
 final class PoolChunkList<T> implements PoolChunkListMetric {
-    private static final Iterator<PoolChunkMetric> EMPTY_METRICS = Collections.<PoolChunkMetric>emptyList().iterator();
+    private static final Iterator<PoolChunkMetric> EMPTY_METRICS = Collections.emptyIterator();
     private final PoolArena<T> arena;
     private final PoolChunkList<T> nextList;
     private final int minUsage;


### PR DESCRIPTION
Motivation:
Particular allocation patterns can cause the PooledByteBufAllocator to continuously allocate and deallocate chunks, leading to high memory churn.

Modification:
When the HeapArena destroys a chunk, it does so while keeping one chunk alive for later reuse. If a chunk is already stowed for reuse, then heap chunks get destroyed like before. When allocating a new chunk, we atomically grab any stowed chunks and set the cache field to null. We assert that the parameters are all the same, which should be the case since they're all derived from the SizeClass.

We only do this caching for the heap chunks, because the direct chunks have explicit lifetimes, and it would be too complicated to do this trick for them. This also respects the opposing desire to release native memory back to the OS with expediency, when it's no longer needed.

Result:
We add a single-chunk cache that acts as a damper for any chunk allocation/deallocation oscillations that might occur with certain allocation patterns.

This fixes #14257