### PR TITLE
Fix race in Http2MultiplexTransportTest (#14289)

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTransportTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTransportTest.java
@@ -620,7 +620,7 @@ public class Http2MultiplexTransportTest {
                                         (SslHandshakeCompletionEvent) evt;
                                 if (handshakeCompletionEvent.isSuccess()) {
                                     Http2StreamChannelBootstrap h2Bootstrap =
-                                            new Http2StreamChannelBootstrap(clientChannel);
+                                            new Http2StreamChannelBootstrap(ctx.channel());
                                     h2Bootstrap.handler(new ChannelInboundHandlerAdapter() {
                                         @Override
                                         public void channelRead(ChannelHandlerContext ctx, Object msg) {


### PR DESCRIPTION
Motivation:

There is a race in the test that can lead to a NPE as observed on the CI:

```
2024-09-06T10:05:38.6229506Z java.lang.NullPointerException: channel
2024-09-06T10:05:38.6230131Z 	at io.netty.util.internal.ObjectUtil.checkNotNull(ObjectUtil.java:39)
2024-09-06T10:05:38.6230962Z 	at io.netty.handler.codec.http2.Http2StreamChannelBootstrap.<init>(Http2StreamChannelBootstrap.java:57)
2024-09-06T10:05:38.6232010Z 	at io.netty.handler.codec.http2.Http2MultiplexTransportTest$11$1.userEventTriggered(Http2MultiplexTransportTest.java:624)
2024-09-06T10:05:38.6233119Z 	at io.netty.channel.AbstractChannelHandlerContext.invokeUserEventTriggered(AbstractChannelHandlerContext.java:398)
2024-09-06T10:05:38.6234237Z 	at io.netty.channel.AbstractChannelHandlerContext.invokeUserEventTriggered(AbstractChannelHandlerContext.java:376)
2024-09-06T10:05:38.6235344Z 	at io.netty.channel.AbstractChannelHandlerContext.fireUserEventTriggered(AbstractChannelHandlerContext.java:368)
2024-09-06T10:05:38.6236480Z 	at io.netty.handler.codec.http2.Http2MultiplexHandler.userEventTriggered(Http2MultiplexHandler.java:279)
2024-09-06T10:05:38.6237530Z 	at io.netty.channel.AbstractChannelHandlerContext.invokeUserEventTriggered(AbstractChannelHandlerContext.java:398)
2024-09-06T10:05:38.6238639Z 	at io.netty.channel.AbstractChannelHandlerContext.invokeUserEventTriggered(AbstractChannelHandlerContext.java:376)
2024-09-06T10:05:38.6239723Z 	at io.netty.channel.AbstractChannelHandlerContext.fireUserEventTriggered(AbstractChannelHandlerContext.java:368)
2024-09-06T10:05:38.6240689Z 	at io.netty.handler.codec.http2.Http2FrameCodec.userEventTriggered(Http2FrameCodec.java:292)
2024-09-06T10:05:38.6241675Z 	at io.netty.channel.AbstractChannelHandlerContext.invokeUserEventTriggered(AbstractChannelHandlerContext.java:398)
2024-09-06T10:05:38.6242773Z 	at io.netty.channel.AbstractChannelHandlerContext.invokeUserEventTriggered(AbstractChannelHandlerContext.java:376)
2024-09-06T10:05:38.6243863Z 	at io.netty.channel.AbstractChannelHandlerContext.fireUserEventTriggered(AbstractChannelHandlerContext.java:368)
2024-09-06T10:05:38.6244751Z 	at io.netty.handler.ssl.SslHandler.setHandshakeSuccess(SslHandler.java:1958)
2024-09-06T10:05:38.6245429Z 	at io.netty.handler.ssl.SslHandler.wrapNonAppData(SslHandler.java:996)
2024-09-06T10:05:38.6246032Z 	at io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1529)
2024-09-06T10:05:38.6246687Z 	at io.netty.handler.ssl.SslHandler.decodeNonJdkCompatible(SslHandler.java:1367)
2024-09-06T10:05:38.6247650Z 	at io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1407)
2024-09-06T10:05:38.6248470Z 	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:530)
2024-09-06T10:05:38.6249403Z 	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:469)
2024-09-06T10:05:38.6250232Z 	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:290)
2024-09-06T10:05:38.6251161Z 	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
2024-09-06T10:05:38.6252184Z 	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
2024-09-06T10:05:38.6253195Z 	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
2024-09-06T10:05:38.6254271Z 	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1357)
2024-09-06T10:05:38.6255229Z 	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
2024-09-06T10:05:38.6256246Z 	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
2024-09-06T10:05:38.6257168Z 	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:868)
2024-09-06T10:05:38.6258120Z 	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
2024-09-06T10:05:38.6258994Z 	at io.netty.channel.nio.AbstractNioChannel$AbstractNioUnsafe.handle(AbstractNioChannel.java:445)
2024-09-06T10:05:38.6259810Z 	at io.netty.channel.nio.NioIoHandler$DefaultNioRegistration.handle(NioIoHandler.java:386)
2024-09-06T10:05:38.6260630Z 	at io.netty.channel.nio.NioIoHandler.processSelectedKey(NioIoHandler.java:585)
2024-09-06T10:05:38.6261425Z 	at io.netty.channel.nio.NioIoHandler.processSelectedKeysOptimized(NioIoHandler.java:560)
2024-09-06T10:05:38.6262205Z 	at io.netty.channel.nio.NioIoHandler.processSelectedKeys(NioIoHandler.java:501)
2024-09-06T10:05:38.6262855Z 	at io.netty.channel.nio.NioIoHandler.run(NioIoHandler.java:478)
2024-09-06T10:05:38.6263522Z 	at io.netty.channel.SingleThreadIoEventLoop.runIo(SingleThreadIoEventLoop.java:184)
2024-09-06T10:05:38.6264268Z 	at io.netty.channel.SingleThreadIoEventLoop.run(SingleThreadIoEventLoop.java:156)
2024-09-06T10:05:38.6265082Z 	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:1123)
2024-09-06T10:05:38.6265941Z 	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
2024-09-06T10:05:38.6266681Z 	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
2024-09-06T10:05:38.6267306Z 	at java.base/java.lang.Thread.run(Thread.java:829)
```

Modifications:

Just obtain the Channel from the ChannelHandlerContext and so remove the race

Result:

No more NPE caused of a race in the test code
