### PR TITLE
Ensure Chunk will not leak if init of AdaptiveByteBuf fails for whate…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -544,8 +544,18 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
         public AdaptiveByteBuf readInitInto(AdaptiveByteBuf buf, int size, int maxCapacity) {
             int startIndex = allocatedBytes;
             allocatedBytes = startIndex + size;
-            unguardedRetain();
-            buf.init(delegate, this, 0, 0, startIndex, size, maxCapacity);
+            Chunk chunk = this;
+            chunk.unguardedRetain();
+            try {
+                buf.init(delegate, chunk, 0, 0, startIndex, size, maxCapacity);
+                chunk = null;
+            } finally {
+                if (chunk != null) {
+                    // If chunk is not null we know that buf.init(...) failed and so we need to manually release
+                    // the chunk again as we retained it before calling buf.init(...).
+                    chunk.release();
+                }
+            }
             return buf;
         }
 


### PR DESCRIPTION
…… (#14288)

…ver reason

Motivation:

We need to ensure we decrement the reference count of Chunk if we can't transfer ownership to AdaptiveByteBuf

Modifications:

Correctly release() manually in case of failure

Result:

No more leak posible in case of failure
