### PR TITLE
Cleanup internals of AdaptiveByteBufAllocator

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptiveByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptiveByteBufAllocator.java
@@ -100,7 +100,7 @@ public final class AdaptiveByteBufAllocator extends AbstractByteBufAllocator
         }
 
         @Override
-        public ByteBuf allocate(int initialCapacity, int maxCapacity) {
+        public AbstractByteBuf allocate(int initialCapacity, int maxCapacity) {
             return PlatformDependent.hasUnsafe() ?
                     new UnpooledUnsafeHeapByteBuf(allocator, initialCapacity, maxCapacity) :
                     new UnpooledHeapByteBuf(allocator, initialCapacity, maxCapacity);
@@ -115,7 +115,7 @@ public final class AdaptiveByteBufAllocator extends AbstractByteBufAllocator
         }
 
         @Override
-        public ByteBuf allocate(int initialCapacity, int maxCapacity) {
+        public AbstractByteBuf allocate(int initialCapacity, int maxCapacity) {
             return PlatformDependent.hasUnsafe() ?
                     UnsafeByteBufUtil.newUnsafeDirectByteBuf(allocator, initialCapacity, maxCapacity) :
                     new UnpooledDirectByteBuf(allocator, initialCapacity, maxCapacity);

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -253,7 +253,7 @@ final class AdaptivePoolingAllocator {
         Magazine magazine = into.chunk.magazine;
         if (!allocate(size, maxCapacity, Thread.currentThread(), into)) {
             // Create a one-off chunk for this allocation as the previous allocate call did not work out.
-            AbstractByteBuf innerChunk = (AbstractByteBuf) chunkAllocator.allocate(size, maxCapacity);
+            AbstractByteBuf innerChunk = chunkAllocator.allocate(size, maxCapacity);
             Chunk chunk = new Chunk(innerChunk, magazine, false);
             chunk.readInitInto(into, size, maxCapacity);
         }
@@ -463,7 +463,7 @@ final class AdaptivePoolingAllocator {
                 if (curr.remainingCapacity() < RETIRE_CAPACITY) {
                     curr.release();
                     current = newChunk;
-                } else if (!(boolean) NEXT_IN_LINE.compareAndSet(this, null, newChunk)) {
+                } else if (!trySetNextInLine(newChunk)) {
                     if (!parent.offerToQueue(newChunk)) {
                         // Next-in-line is occupied AND the central queue is full.
                         // Rare that we should get here, but we'll only do one allocation out of this chunk, then.
@@ -476,12 +476,11 @@ final class AdaptivePoolingAllocator {
         private Chunk newChunkAllocation(int promptingSize) {
             int size = Math.max(promptingSize * BUFS_PER_CHUNK, preferredChunkSize());
             ChunkAllocator chunkAllocator = parent.chunkAllocator;
-            Chunk chunk = new Chunk((AbstractByteBuf) chunkAllocator.allocate(size, size), this, true);
-            return chunk;
+            return new Chunk(chunkAllocator.allocate(size, size), this, true);
         }
 
-        boolean trySetNextInLine(Chunk buffer) {
-            return NEXT_IN_LINE.compareAndSet(this, null, buffer);
+        boolean trySetNextInLine(Chunk chunk) {
+            return NEXT_IN_LINE.compareAndSet(this, null, chunk);
         }
     }
 
@@ -1180,13 +1179,13 @@ final class AdaptivePoolingAllocator {
     /**
      * The strategy for how {@link AdaptivePoolingAllocator} should allocate chunk buffers.
      */
-    public interface ChunkAllocator {
+    interface ChunkAllocator {
         /**
-         * Allocate a buffer for a chunk. This can be any kind of {@link ByteBuf} implementation.
-         * @param initialCapacity The initial capacity of the returned {@link ByteBuf}.
-         * @param maxCapacity The maximum capacity of the returned {@link ByteBuf}.
+         * Allocate a buffer for a chunk. This can be any kind of {@link AbstractByteBuf} implementation.
+         * @param initialCapacity The initial capacity of the returned {@link AbstractByteBuf}.
+         * @param maxCapacity The maximum capacity of the returned {@link AbstractByteBuf}.
          * @return The buffer that represents the chunk memory.
          */
-        ByteBuf allocate(int initialCapacity, int maxCapacity);
+        AbstractByteBuf allocate(int initialCapacity, int maxCapacity);
     }
 }


### PR DESCRIPTION
Motivation:

We depend on the fact that the ChunkAllocator allocates sub-types of AbstractByteBuf, let's better make this explicit and so remove casting

Modifications:

- Change ChunkAllocator interface to package-private
- Make ChunkAllocator.allocate(...) return AbstractByteBuf
- Reuse internal methods to make things more consistent

Result:

Cleanup