### PR TITLE
Slices / duplicates of AdaptiveByteBuf must not escape the rootParent

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -753,7 +753,7 @@ final class AdaptivePoolingAllocator {
         @Override
         public ByteBuf slice(int index, int length) {
             checkIndex(index, length);
-            return new PooledNonRetainedSlicedByteBuf(this, rootParent, idx(index), length);
+            return new PooledNonRetainedSlicedByteBuf(this, this, index, length);
         }
 
         @Override

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -19,7 +19,6 @@ import io.netty.util.ByteProcessor;
 import io.netty.util.IllegalReferenceCountException;
 import io.netty.util.NettyRuntime;
 import io.netty.util.Recycler;
-import io.netty.util.ReferenceCounted;
 import io.netty.util.concurrent.FastThreadLocal;
 import io.netty.util.concurrent.FastThreadLocalThread;
 import io.netty.util.internal.ObjectPool;
@@ -751,28 +750,6 @@ final class AdaptivePoolingAllocator {
         }
 
         @Override
-        public ByteBuf slice(int index, int length) {
-            checkIndex(index, length);
-            return new PooledNonRetainedSlicedByteBuf(this, this, index, length);
-        }
-
-        @Override
-        public ByteBuf retainedSlice(int index, int length) {
-            return slice(index, length).retain();
-        }
-
-        @Override
-        public ByteBuf duplicate() {
-            ensureAccessible();
-            return new PooledNonRetainedDuplicateByteBuf(this, this).setIndex(readerIndex(), writerIndex());
-        }
-
-        @Override
-        public ByteBuf retainedDuplicate() {
-            return duplicate().retain();
-        }
-
-        @Override
         public int nioBufferCount() {
             return rootParent().nioBufferCount();
         }
@@ -1010,170 +987,6 @@ final class AdaptivePoolingAllocator {
             } else if (handle != null) {
                 handle.recycle(this);
             }
-        }
-    }
-
-    private static final class PooledNonRetainedDuplicateByteBuf extends UnpooledDuplicatedByteBuf {
-        private final ReferenceCounted referenceCountDelegate;
-
-        PooledNonRetainedDuplicateByteBuf(ReferenceCounted referenceCountDelegate, AbstractByteBuf buffer) {
-            super(buffer);
-            this.referenceCountDelegate = referenceCountDelegate;
-        }
-
-        @Override
-        boolean isAccessible0() {
-            return referenceCountDelegate.refCnt() != 0;
-        }
-
-        @Override
-        int refCnt0() {
-            return referenceCountDelegate.refCnt();
-        }
-
-        @Override
-        ByteBuf retain0() {
-            referenceCountDelegate.retain();
-            return this;
-        }
-
-        @Override
-        ByteBuf retain0(int increment) {
-            referenceCountDelegate.retain(increment);
-            return this;
-        }
-
-        @Override
-        ByteBuf touch0() {
-            referenceCountDelegate.touch();
-            return this;
-        }
-
-        @Override
-        ByteBuf touch0(Object hint) {
-            referenceCountDelegate.touch(hint);
-            return this;
-        }
-
-        @Override
-        boolean release0() {
-            return referenceCountDelegate.release();
-        }
-
-        @Override
-        boolean release0(int decrement) {
-            return referenceCountDelegate.release(decrement);
-        }
-
-        @Override
-        public ByteBuf duplicate() {
-            ensureAccessible();
-            return new PooledNonRetainedDuplicateByteBuf(referenceCountDelegate, unwrap());
-        }
-
-        @Override
-        public ByteBuf retainedDuplicate() {
-            return duplicate().retain();
-        }
-
-        @Override
-        public ByteBuf slice(int index, int length) {
-            checkIndex(index, length);
-            return new PooledNonRetainedSlicedByteBuf(referenceCountDelegate, unwrap(), index, length);
-        }
-
-        @Override
-        public ByteBuf retainedSlice() {
-            // Capacity is not allowed to change for a sliced ByteBuf, so length == capacity()
-            return retainedSlice(readerIndex(), capacity());
-        }
-
-        @Override
-        public ByteBuf retainedSlice(int index, int length) {
-            return slice(index, length).retain();
-        }
-    }
-
-    private static final class PooledNonRetainedSlicedByteBuf extends UnpooledSlicedByteBuf {
-        private final ReferenceCounted referenceCountDelegate;
-
-        PooledNonRetainedSlicedByteBuf(ReferenceCounted referenceCountDelegate,
-                                       AbstractByteBuf buffer, int index, int length) {
-            super(buffer, index, length);
-            this.referenceCountDelegate = referenceCountDelegate;
-        }
-
-        @Override
-        boolean isAccessible0() {
-            return referenceCountDelegate.refCnt() != 0;
-        }
-
-        @Override
-        int refCnt0() {
-            return referenceCountDelegate.refCnt();
-        }
-
-        @Override
-        ByteBuf retain0() {
-            referenceCountDelegate.retain();
-            return this;
-        }
-
-        @Override
-        ByteBuf retain0(int increment) {
-            referenceCountDelegate.retain(increment);
-            return this;
-        }
-
-        @Override
-        ByteBuf touch0() {
-            referenceCountDelegate.touch();
-            return this;
-        }
-
-        @Override
-        ByteBuf touch0(Object hint) {
-            referenceCountDelegate.touch(hint);
-            return this;
-        }
-
-        @Override
-        boolean release0() {
-            return referenceCountDelegate.release();
-        }
-
-        @Override
-        boolean release0(int decrement) {
-            return referenceCountDelegate.release(decrement);
-        }
-
-        @Override
-        public ByteBuf duplicate() {
-            ensureAccessible();
-            return new PooledNonRetainedSlicedByteBuf(referenceCountDelegate, unwrap(), idx(0), capacity())
-                    .setIndex(readerIndex(), writerIndex());
-        }
-
-        @Override
-        public ByteBuf retainedDuplicate() {
-            return duplicate().retain();
-        }
-
-        @Override
-        public ByteBuf slice(int index, int length) {
-            checkIndex(index, length);
-            return new PooledNonRetainedSlicedByteBuf(referenceCountDelegate, unwrap(), idx(index), length);
-        }
-
-        @Override
-        public ByteBuf retainedSlice() {
-            // Capacity is not allowed to change for a sliced ByteBuf, so length == capacity()
-            return retainedSlice(0, capacity());
-        }
-
-        @Override
-        public ByteBuf retainedSlice(int index, int length) {
-            return slice(index, length).retain();
         }
     }
 

--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufAllocatorTest.java
@@ -19,6 +19,7 @@ import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -93,6 +94,11 @@ public abstract class AbstractByteBufAllocatorTest<T extends AbstractByteBufAllo
     protected static void assertInstanceOf(ByteBuf buffer, Class<? extends ByteBuf> clazz) {
         // Unwrap if needed
         assertTrue(clazz.isInstance(buffer instanceof SimpleLeakAwareByteBuf ? buffer.unwrap() : buffer));
+    }
+
+    protected static void assertSameBuffer(ByteBuf expected, ByteBuf buffer) {
+        // Unwrap if needed
+        assertSame(expected, buffer instanceof SimpleLeakAwareByteBuf ? buffer.unwrap() : buffer);
     }
 
     @Test

--- a/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
@@ -95,11 +95,13 @@ public class AdaptiveByteBufAllocatorTest extends AbstractByteBufAllocatorTest<A
         // When we unwrap the derived buffer we should get our original buffer of type AdaptiveByteBuf back.
         ByteBuf unwrapped = derived.unwrap();
         assertInstanceOf(unwrapped, AdaptivePoolingAllocator.AdaptiveByteBuf.class);
+        assertSameBuffer(buffer, unwrapped);
 
         ByteBuf retainedDerived = slice ? buffer.retainedSlice(0, 4) : buffer.retainedDuplicate();
         // When we unwrap the derived buffer we should get our original buffer of type AdaptiveByteBuf back.
-        ByteBuf unwrappedRetainined = retainedDerived.unwrap();
-        assertInstanceOf(unwrappedRetainined, AdaptivePoolingAllocator.AdaptiveByteBuf.class);
+        ByteBuf unwrappedRetained = retainedDerived.unwrap();
+        assertInstanceOf(unwrappedRetained, AdaptivePoolingAllocator.AdaptiveByteBuf.class);
+        assertSameBuffer(buffer, unwrappedRetained);
         retainedDerived.release();
 
         assertTrue(buffer.release());

--- a/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
@@ -16,9 +16,12 @@
 package io.netty.buffer;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AdaptiveByteBufAllocatorTest extends AbstractByteBufAllocatorTest<AdaptiveByteBufAllocator> {
@@ -78,5 +81,27 @@ public class AdaptiveByteBufAllocatorTest extends AbstractByteBufAllocatorTest<A
         assertEquals(2 * 128 * 1024, allocator.usedHeapMemory());
         b.release();
         assertEquals(2 * 128 * 1024, allocator.usedHeapMemory());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void sliceOrDuplicateUnwrapLetNotEscapeRootParent(boolean slice) {
+        AdaptiveByteBufAllocator allocator = newAllocator(false);
+        ByteBuf buffer = allocator.buffer(8);
+        assertInstanceOf(buffer, AdaptivePoolingAllocator.AdaptiveByteBuf.class);
+        assertNull(buffer.unwrap());
+
+        ByteBuf derived = slice ? buffer.slice(0, 4) : buffer.duplicate();
+        // When we unwrap the derived buffer we should get our original buffer of type AdaptiveByteBuf back.
+        ByteBuf unwrapped = derived.unwrap();
+        assertInstanceOf(unwrapped, AdaptivePoolingAllocator.AdaptiveByteBuf.class);
+
+        ByteBuf retainedDerived = slice ? buffer.retainedSlice(0, 4) : buffer.retainedDuplicate();
+        // When we unwrap the derived buffer we should get our original buffer of type AdaptiveByteBuf back.
+        ByteBuf unwrappedRetainined = retainedDerived.unwrap();
+        assertInstanceOf(unwrappedRetainined, AdaptivePoolingAllocator.AdaptiveByteBuf.class);
+        retainedDerived.release();
+
+        assertTrue(buffer.release());
     }
 }


### PR DESCRIPTION
Motivation:

When a slice or duplicate is create of an AdaptiveByteBuf we need to ensure we never let the rootParent escape.

Modifications:

- Ensure unwrap() will not let the rootParent escape.
- Add unit test

Result:

Return the correct buffer when unwrap a slice or duplicate