### PR TITLE
Correctly release one-off allocated chunks (#14298)

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -258,7 +258,14 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
             // Create a one-off chunk for this allocation as the previous allocate call did not work out.
             AbstractByteBuf innerChunk = (AbstractByteBuf) chunkAllocator.allocate(size, maxCapacity);
             Chunk chunk = new Chunk(innerChunk, magazine, false);
-            chunk.readInitInto(into, size, maxCapacity);
+            try {
+                chunk.readInitInto(into, size, maxCapacity);
+            } finally {
+                // As the chunk is an one-off we need to always call release explicitly as readInitInto(...)
+                // will take care of retain once when successful. Once The AdaptiveByteBuf is released it will
+                // completely release the Chunk and so the contained innerChunk.
+                chunk.release();
+            }
         }
     }
 


### PR DESCRIPTION
Motivation:

We failed to correctly release one-off allocated chunks which lead to leaking the ByteBuf that is used internally by these chunks

Modifications:

- Ensure we correctly release one-off chunks directly after we allocated these once so once the AdaptiveByteBuf that holds a reference to it is released we will take care of completely release the Chunk and the contained ByteBuf.

Result:

No more leaks when using the AdapativeByteBufAllocator.
