### PR TITLE
Cleanup internals of AdaptiveByteBufAllocator (#14299)

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptiveByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptiveByteBufAllocator.java
@@ -111,7 +111,7 @@ public final class AdaptiveByteBufAllocator extends AbstractByteBufAllocator
         }
 
         @Override
-        public ByteBuf allocate(int initialCapacity, int maxCapacity) {
+        public AbstractByteBuf allocate(int initialCapacity, int maxCapacity) {
             return PlatformDependent.hasUnsafe() ?
                     new UnpooledUnsafeHeapByteBuf(allocator, initialCapacity, maxCapacity) :
                     new UnpooledHeapByteBuf(allocator, initialCapacity, maxCapacity);
@@ -126,7 +126,7 @@ public final class AdaptiveByteBufAllocator extends AbstractByteBufAllocator
         }
 
         @Override
-        public ByteBuf allocate(int initialCapacity, int maxCapacity) {
+        public AbstractByteBuf allocate(int initialCapacity, int maxCapacity) {
             return PlatformDependent.hasUnsafe() ?
                     UnsafeByteBufUtil.newUnsafeDirectByteBuf(allocator, initialCapacity, maxCapacity) :
                     new UnpooledDirectByteBuf(allocator, initialCapacity, maxCapacity);


### PR DESCRIPTION
Motivation:

We depend on the fact that the ChunkAllocator allocates sub-types of AbstractByteBuf, let's better make this explicit and so remove casting

Modifications:

- Change ChunkAllocator interface to package-private
- Make ChunkAllocator.allocate(...) return AbstractByteBuf
- Reuse internal methods to make things more consistent

Result:

Cleanup