### PR TITLE
Fix sizeBucket bug in AdaptivePoolingAllocator

### DIFF
--- a/buffer/src/test/java/io/netty5/buffer/adapt/AdaptivePoolingAllocatorTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/adapt/AdaptivePoolingAllocatorTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.buffer.adapt;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AdaptivePoolingAllocatorTest implements Supplier<String> {
+    private int i;
+
+    @BeforeEach
+    void setUp() {
+        i = 0;
+    }
+
+    @Override
+    public String get() {
+        return "i = " + i;
+    }
+
+    @Test
+    void sizeBucketComputations() throws Exception {
+        assertSizeBucket(0, 8 * 1024);
+        assertSizeBucket(1, 16 * 1024);
+        assertSizeBucket(2, 32 * 1024);
+        assertSizeBucket(3, 64 * 1024);
+        assertSizeBucket(4, 128 * 1024);
+        assertSizeBucket(5, 256 * 1024);
+        assertSizeBucket(6, 512 * 1024);
+        assertSizeBucket(7, 1024 * 1024);
+        // The sizeBucket function will be used for sizes up to 10 MiB
+        assertSizeBucket(7, 2 * 1024 * 1024);
+        assertSizeBucket(7, 3 * 1024 * 1024);
+        assertSizeBucket(7, 4 * 1024 * 1024);
+        assertSizeBucket(7, 5 * 1024 * 1024);
+        assertSizeBucket(7, 6 * 1024 * 1024);
+        assertSizeBucket(7, 7 * 1024 * 1024);
+        assertSizeBucket(7, 8 * 1024 * 1024);
+        assertSizeBucket(7, 9 * 1024 * 1024);
+        assertSizeBucket(7, 10 * 1024 * 1024);
+    }
+
+    private void assertSizeBucket(int expectedSizeBucket, int maxSizeIncluded) {
+        for (; i <= maxSizeIncluded; i++) {
+            assertEquals(expectedSizeBucket, AdaptivePoolingAllocator.sizeBucket(i), this);
+        }
+    }
+}


### PR DESCRIPTION
Motivation:
The sizeBucket() computation was mistakenly masking the normalized size, rather than the bit-count. This made the allocator choose very wrong size buckets for larger buffers. The incorrect size buckets would skew the collected statistics toward smaller allocations, and fool the allocator into optimizing for smaller chunk sizes.

Modification:
The size-bucket masking is moved to the size-bucket number computed from the bits. This ensures the size-bucket number does not exceed the size-bucket arrays and histograms we allocate. Specifically, the masking was in a place where it would penalize buffers bigger than 64 KiB, and compute incorrect (too small) size buckets for them.

Additionally, the INIT_DATUM_TARGET has been reduced dramatically. The datum target decides when the histogram is rotated and the preferred chunk size computed. Chunks are initially sized to fit 10 buffers sized like the first buffer allocated for a given magazine. If this holds true, then it's desirable to compute the preferred chunk size before the first chunk is deallocated and the next one allocated.

This change makes the adaptive allocator update its histograms very aggressively in the beginning, until things settle down.

Result:
The AdaptivePoolingAllocator now computes much better chunk sizes for allocation patterns that prefer their buffers bigger than 64 KiB.
