### PR TITLE
Fix SocketSslClientRenegotiateTest and SocketSslSessionReuseTest

### DIFF
--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
@@ -80,30 +80,29 @@ public class SocketSslClientRenegotiateTest extends AbstractSocketTest {
     public static Collection<Object[]> data() throws Exception {
         List<SslContext> serverContexts = new ArrayList<>();
         List<SslContext> clientContexts = new ArrayList<>();
-        clientContexts.add(
-          SslContextBuilder.forClient()
-            .trustManager(CERT_FILE)
-            .sslProvider(SslProvider.JDK)
-            .build()
+        clientContexts.add(SslContextBuilder.forClient()
+                .trustManager(CERT_FILE)
+                .sslProvider(SslProvider.JDK)
+                .endpointIdentificationAlgorithm("")
+                .build()
         );
 
         boolean hasOpenSsl = OpenSsl.isAvailable();
         if (hasOpenSsl) {
-            serverContexts.add(
-              SslContextBuilder.forServer(CERT_FILE, KEY_FILE)
-                .sslProvider(SslProvider.OPENSSL)
-                .build()
+            serverContexts.add(SslContextBuilder.forServer(CERT_FILE, KEY_FILE)
+                    .sslProvider(SslProvider.OPENSSL)
+                    .build()
             );
         } else {
             logger.warn("OpenSSL is unavailable and thus will not be tested.", OpenSsl.unavailabilityCause());
         }
 
         List<Object[]> params = new ArrayList<>();
-        for (SslContext sc: serverContexts) {
-            for (SslContext cc: clientContexts) {
+        for (SslContext sc : serverContexts) {
+            for (SslContext cc : clientContexts) {
                 for (int i = 0; i < 32; i++) {
-                    params.add(new Object[] { sc, cc, true});
-                    params.add(new Object[] { sc, cc, false});
+                    params.add(new Object[]{sc, cc, true});
+                    params.add(new Object[]{sc, cc, false});
                 }
             }
         }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslSessionReuseTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslSessionReuseTest.java
@@ -73,8 +73,15 @@ public class SocketSslSessionReuseTest extends AbstractSocketTest {
 
     public static Collection<Object[]> data() throws Exception {
         return Collections.singletonList(new Object[] {
-          SslContextBuilder.forServer(CERT_FILE, KEY_FILE).sslProvider(SslProvider.JDK).build(),
-          SslContextBuilder.forClient().trustManager(CERT_FILE).sslProvider(SslProvider.JDK).build()
+          SslContextBuilder.forServer(CERT_FILE, KEY_FILE)
+                  .sslProvider(SslProvider.JDK)
+                  .endpointIdentificationAlgorithm("")
+                  .build(),
+          SslContextBuilder.forClient()
+                  .trustManager(CERT_FILE)
+                  .sslProvider(SslProvider.JDK)
+                  .endpointIdentificationAlgorithm("")
+                  .build()
         });
     }
 


### PR DESCRIPTION
Motivation:
The endpoint verification algorithm was rejecting our self-signed certificate for not having any hostname.

Modification:
Disable the endpoint verification because it's not relevant to the tests, and it's might be more trouble than it's worth to portably add a hostname for localhost in the cert.

Result:
SocketSslClientRenegotiateTest and the SocketSslSessionReuseTest both pass again in builds that use OpenSSL, instead of BoringSSL.
