### PR TITLE
Fix sizeBucket bug in AdaptivePoolingAllocator (#14306)

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -338,6 +338,10 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
         }
     }
 
+    static int sizeBucket(int size) {
+        return AllocationStatistics.sizeBucket(size);
+    }
+
     @SuppressJava6Requirement(reason = "Guarded by version check")
     @SuppressWarnings("checkstyle:finalclass") // Checkstyle mistakenly believes this class should be final.
     private static class AllocationStatistics extends StampedLock {
@@ -349,6 +353,7 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
         private static final int HISTO_MAX_BUCKET_SHIFT = 20; // Biggest bucket is 1 << 20 = 1 MiB bytes in size.
         private static final int HISTO_BUCKET_COUNT = 1 + HISTO_MAX_BUCKET_SHIFT - HISTO_MIN_BUCKET_SHIFT; // 8 buckets.
         private static final int HISTO_MAX_BUCKET_MASK = HISTO_BUCKET_COUNT - 1;
+        private static final int SIZE_MAX_MASK = MAX_CHUNK_SIZE - 1;
 
         protected final AdaptivePoolingAllocator parent;
         private final boolean shareable;
@@ -378,12 +383,15 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
         }
 
         static int sizeBucket(int size) {
+            if (size == 0) {
+                return 0;
+            }
             // Minimum chunk size is 128 KiB. We'll only make bigger chunks if the 99-percentile is 16 KiB or greater,
             // so we truncate and roll up the bottom part of the histogram to 8 KiB.
             // The upper size band is 1 MiB, and that gives us exactly 8 size buckets,
             // which is a magical number for JIT optimisations.
-            int normalizedSize = size - 1 >> HISTO_MIN_BUCKET_SHIFT;
-            return Integer.SIZE - Integer.numberOfLeadingZeros(normalizedSize) & HISTO_MAX_BUCKET_MASK;
+            int normalizedSize = size - 1 >> HISTO_MIN_BUCKET_SHIFT & SIZE_MAX_MASK;
+            return Math.min(Integer.SIZE - Integer.numberOfLeadingZeros(normalizedSize), HISTO_MAX_BUCKET_MASK);
         }
 
         private void rotateHistograms() {

--- a/buffer/src/test/java/io/netty/buffer/AdaptivePoolingAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptivePoolingAllocatorTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AdaptivePoolingAllocatorTest implements Supplier<String> {
+    private int i;
+
+    @BeforeEach
+    void setUp() {
+        i = 0;
+    }
+
+    @Override
+    public String get() {
+        return "i = " + i;
+    }
+
+    @Test
+    void sizeBucketComputations() throws Exception {
+        assertSizeBucket(0, 8 * 1024);
+        assertSizeBucket(1, 16 * 1024);
+        assertSizeBucket(2, 32 * 1024);
+        assertSizeBucket(3, 64 * 1024);
+        assertSizeBucket(4, 128 * 1024);
+        assertSizeBucket(5, 256 * 1024);
+        assertSizeBucket(6, 512 * 1024);
+        assertSizeBucket(7, 1024 * 1024);
+        // The sizeBucket function will be used for sizes up to 10 MiB
+        assertSizeBucket(7, 2 * 1024 * 1024);
+        assertSizeBucket(7, 3 * 1024 * 1024);
+        assertSizeBucket(7, 4 * 1024 * 1024);
+        assertSizeBucket(7, 5 * 1024 * 1024);
+        assertSizeBucket(7, 6 * 1024 * 1024);
+        assertSizeBucket(7, 7 * 1024 * 1024);
+        assertSizeBucket(7, 8 * 1024 * 1024);
+        assertSizeBucket(7, 9 * 1024 * 1024);
+        assertSizeBucket(7, 10 * 1024 * 1024);
+    }
+
+    private void assertSizeBucket(int expectedSizeBucket, int maxSizeIncluded) {
+        for (; i <= maxSizeIncluded; i++) {
+            assertEquals(expectedSizeBucket, AdaptivePoolingAllocator.sizeBucket(i), this);
+        }
+    }
+}


### PR DESCRIPTION
Motivation:
The sizeBucket() computation was mistakenly masking the normalized size, rather than the bit-count. This made the allocator choose very wrong size buckets for larger buffers. The incorrect size buckets would skew the collected statistics toward smaller allocations, and fool the allocator into optimizing for smaller chunk sizes.

Modification:
The size-bucket masking is moved to the size-bucket number computed from the bits. This ensures the size-bucket number does not exceed the size-bucket arrays and histograms we allocate. Specifically, the masking was in a place where it would penalize buffers bigger than 64 KiB, and compute incorrect (too small) size buckets for them.

Additionally, the INIT_DATUM_TARGET has been reduced dramatically. The datum target decides when the histogram is rotated and the preferred chunk size computed. Chunks are initially sized to fit 10 buffers sized like the first buffer allocated for a given magazine. If this holds true, then it's desirable to compute the preferred chunk size before the first chunk is deallocated and the next one allocated.

This change makes the adaptive allocator update its histograms very aggressively in the beginning, until things settle down.

Result:
The AdaptivePoolingAllocator now computes much better chunk sizes for allocation patterns that prefer their buffers bigger than 64 KiB.

This is a back-port of https://github.com/netty/netty/pull/14305, which in turn is a forward-port and refinement of some of the changes in https://github.com/netty/netty/pull/14291