### PR TITLE
Fix possible leak in HttpResponseDecoderTest

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
@@ -20,6 +20,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.PrematureChannelClosureException;
 import io.netty.util.CharsetUtil;
+import io.netty.util.ReferenceCountUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -1144,6 +1145,7 @@ public class HttpResponseDecoderTest {
         HttpResponse response = channel.readInbound();
         assertThat(response.decoderResult().cause(), instanceOf(IllegalArgumentException.class));
         assertTrue(response.decoderResult().isFailure());
+        ReferenceCountUtil.release(response);
         assertFalse(channel.finish());
     }
 }


### PR DESCRIPTION
Motivation:
The HttpResponses produced can carry data, and thus needs to be disposed.

Modification:
Dispose of the http responses we get from EmbeddedChannel.readInbound(). They will not be closed by the channel.finish() because we've read them.

Result:
No more leak from HttpResponseDecoderTest. This is a backport of https://github.com/netty/netty/pull/14307
