### PR TITLE
Ensure we test BIG_ENDIAN and LITTLE_ENDIAN variants for AdaptiveByte…

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/AbstractAdaptiveByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractAdaptiveByteBufTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+public abstract class AbstractAdaptiveByteBufTest extends AbstractPooledByteBufTest {
+    private final AdaptiveByteBufAllocator allocator = new AdaptiveByteBufAllocator();
+
+    @Override
+    protected final ByteBuf alloc(int length, int maxCapacity) {
+        return alloc(allocator, length, maxCapacity);
+    }
+
+    protected abstract ByteBuf alloc(AdaptiveByteBufAllocator allocator, int length, int maxCapacity);
+
+    @Disabled("Assumes the ByteBuf can be cast to PooledByteBuf")
+    @Test
+    @Override
+    public void testMaxFastWritableBytes() {
+    }
+
+    @Disabled("Assumes the ByteBuf can be cast to PooledByteBuf")
+    @Test
+    @Override
+    public void testEnsureWritableDoesntGrowTooMuch() {
+    }
+}

--- a/buffer/src/test/java/io/netty/buffer/AdaptiveBigEndianDirectByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptiveBigEndianDirectByteBufTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AdaptiveBigEndianDirectByteBufTest extends AbstractAdaptiveByteBufTest {
+
+    @Override
+    protected ByteBuf alloc(AdaptiveByteBufAllocator allocator, int length, int maxCapacity) {
+        ByteBuf buffer = allocator.directBuffer(length, maxCapacity);
+        assertTrue(buffer.isDirect());
+        return buffer;
+    }
+}

--- a/buffer/src/test/java/io/netty/buffer/AdaptiveBigEndianHeapByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptiveBigEndianHeapByteBufTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class AdaptiveBigEndianHeapByteBufTest extends AbstractAdaptiveByteBufTest {
+
+    @Override
+    protected ByteBuf alloc(AdaptiveByteBufAllocator allocator, int length, int maxCapacity) {
+        ByteBuf buffer = allocator.heapBuffer(length, maxCapacity);
+        assertFalse(buffer.isDirect());
+        return buffer;
+    }
+}

--- a/buffer/src/test/java/io/netty/buffer/AdaptiveLittleEndianDirectByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptiveLittleEndianDirectByteBufTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+
+import java.nio.ByteOrder;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AdaptiveLittleEndianDirectByteBufTest extends AbstractAdaptiveByteBufTest {
+
+    @Override
+    protected ByteBuf alloc(AdaptiveByteBufAllocator allocator, int length, int maxCapacity) {
+        ByteBuf buffer = allocator.directBuffer(length, maxCapacity)
+                .order(ByteOrder.LITTLE_ENDIAN);
+        assertSame(ByteOrder.LITTLE_ENDIAN, buffer.order());
+        assertTrue(buffer.isDirect());
+        return buffer;
+    }
+}

--- a/buffer/src/test/java/io/netty/buffer/AdaptiveLittleEndianHeapByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptiveLittleEndianHeapByteBufTest.java
@@ -15,26 +15,20 @@
  */
 package io.netty.buffer;
 
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 
-public class AdaptivePooledByteBufTest extends AbstractPooledByteBufTest {
-    private final AdaptiveByteBufAllocator allocator = new AdaptiveByteBufAllocator();
+import java.nio.ByteOrder;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public class AdaptiveLittleEndianHeapByteBufTest extends AbstractAdaptiveByteBufTest {
 
     @Override
-    protected ByteBuf alloc(int length, int maxCapacity) {
-        return allocator.buffer(length, maxCapacity);
-    }
-
-    @Disabled("Assumes the ByteBuf can be cast to PooledByteBuf")
-    @Test
-    @Override
-    public void testMaxFastWritableBytes() {
-    }
-
-    @Disabled("Assumes the ByteBuf can be cast to PooledByteBuf")
-    @Test
-    @Override
-    public void testEnsureWritableDoesntGrowTooMuch() {
+    protected ByteBuf alloc(AdaptiveByteBufAllocator allocator, int length, int maxCapacity) {
+        ByteBuf buffer = allocator.heapBuffer(length, maxCapacity)
+                .order(ByteOrder.LITTLE_ENDIAN);
+        assertSame(ByteOrder.LITTLE_ENDIAN, buffer.order());
+        assertFalse(buffer.isDirect());
+        return buffer;
     }
 }


### PR DESCRIPTION
…Buf (#14315)

Motivation:

We should follow the same patterns as for other ByteBuf implementation tests and test for both orders.

Modifications:

Add more testing for AdaptiveByteBuf

Result:

More complete testsuite for new allocator
