### PR TITLE
Fix typo in PoolThreadCache.java

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/pool/PoolThreadCache.java
+++ b/buffer/src/main/java/io/netty5/buffer/pool/PoolThreadCache.java
@@ -182,7 +182,7 @@ final class PoolThreadCache {
     }
 
     /**
-     *  Should be called if the Thread that uses this cache is about to exist to release resources out of the cache
+     *  Should be called if the Thread that uses this cache is about to exit to release resources out of the cache
      */
     void free() {
         if (arena != null) {


### PR DESCRIPTION
Motivation:

Fix typo in PoolThreadCache.java

```
 Should be called if the Thread that uses this cache is about to exist to release resources out of the cache
 void free() {
```
This comment that above the free() method is confusing