### PR TITLE
AdaptiveByteBufAllocator: Cleanup internals and make code easier to r…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -217,7 +217,8 @@ final class AdaptivePoolingAllocator {
         if (threadLocalMagazine != null && currentThread instanceof FastThreadLocalThread) {
             Object mag = threadLocalMagazine.get();
             if (mag != NO_MAGAZINE) {
-                ((Magazine) mag).allocate(size, sizeBucket, maxCapacity, buf);
+                boolean allocated = ((Magazine) mag).tryAllocate(size, sizeBucket, maxCapacity, buf);
+                assert allocated : "Allocation of threadLocalMagazine must always succeed";
                 return true;
             }
         }
@@ -230,14 +231,9 @@ final class AdaptivePoolingAllocator {
             int index = (int) (threadId & mask);
             for (int i = 0, m = Integer.numberOfTrailingZeros(~mask); i < m; i++) {
                 Magazine mag = mags[index + i & mask];
-                long writeLock = mag.tryWriteLock();
-                if (writeLock != 0) {
-                    try {
-                        mag.allocate(size, sizeBucket, maxCapacity, buf);
-                        return true;
-                    } finally {
-                        mag.unlockWrite(writeLock);
-                    }
+                if (mag.tryAllocate(size, sizeBucket, maxCapacity, buf)) {
+                    // Was able to allocate.
+                    return true;
                 }
             }
             expansions++;
@@ -339,8 +335,7 @@ final class AdaptivePoolingAllocator {
     }
 
     @SuppressWarnings("checkstyle:finalclass") // Checkstyle mistakenly believes this class should be final.
-    private static class AllocationStatistics extends StampedLock {
-        private static final long serialVersionUID = -8319929980932269688L;
+    private static class AllocationStatistics {
         private static final int MIN_DATUM_TARGET = 1024;
         private static final int MAX_DATUM_TARGET = 65534;
         private static final int INIT_DATUM_TARGET = 9;
@@ -442,10 +437,9 @@ final class AdaptivePoolingAllocator {
         }
     }
 
+    @SuppressJava6Requirement(reason = "Guarded by version check")
     private static final class Magazine extends AllocationStatistics {
-        private static final long serialVersionUID = -4068223712022528165L;
         private static final AtomicReferenceFieldUpdater<Magazine, Chunk> NEXT_IN_LINE;
-
         static {
             NEXT_IN_LINE = AtomicReferenceFieldUpdater.newUpdater(Magazine.class, Chunk.class, "nextInLine");
         }
@@ -453,6 +447,7 @@ final class AdaptivePoolingAllocator {
         @SuppressWarnings("unused") // updated via NEXT_IN_LINE
         private volatile Chunk nextInLine;
         private final AtomicLong usedMemory;
+        private final StampedLock allocationLock;
 
         Magazine(AdaptivePoolingAllocator parent) {
             this(parent, true);
@@ -460,10 +455,37 @@ final class AdaptivePoolingAllocator {
 
         Magazine(AdaptivePoolingAllocator parent, boolean shareable) {
             super(parent, shareable);
+
+            // We only need the StampedLock if this Magazine will be shared across threads.
+            if (shareable) {
+                allocationLock = new StampedLock();
+            } else {
+                allocationLock = null;
+            }
             usedMemory = new AtomicLong();
         }
 
-        public void allocate(int size, int sizeBucket, int maxCapacity, AdaptiveByteBuf buf) {
+        public boolean tryAllocate(int size, int sizeBucket, int maxCapacity, AdaptiveByteBuf buf) {
+            if (allocationLock == null) {
+                // This magazine is not shared across threads, just allocate directly.
+                allocate(size, sizeBucket, maxCapacity, buf);
+                return true;
+            }
+
+            // Try to retrieve the lock and if successful allocate.
+            long writeLock = allocationLock.tryWriteLock();
+            if (writeLock != 0) {
+                try {
+                    allocate(size, sizeBucket, maxCapacity, buf);
+                    return true;
+                } finally {
+                    allocationLock.unlockWrite(writeLock);
+                }
+            }
+            return false;
+        }
+
+        private void allocate(int size, int sizeBucket, int maxCapacity, AdaptiveByteBuf buf) {
             recordAllocationSize(sizeBucket);
             Chunk curr = current;
             if (curr != null && curr.remainingCapacity() >= size) {


### PR DESCRIPTION
…… (#14316)

…eason about in terms of locking of the internal Magazine

Motivation:

We can cleanup the code and make things easier to understand in terms of when locking is needed inside the Magazine.

Modifications:

- Don't extend StampedLock directly but just define it inside of the Magazine.
- Move the locking logic to a new method in Magazine and make a decision on if locking is needed based on of the Magazine is shared or not

Result:

Cleaner and easier to understand code
