### PR TITLE
Add assert to ensure the same id is not added multiple times

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryIdSpace.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryIdSpace.java
@@ -62,8 +62,8 @@ final class DnsQueryIdSpace {
             } else if (freeIdx == -1 ||
                     // Let's make it somehow random which free slot is used.
                     PlatformDependent.threadLocalRandom().nextBoolean()) {
-                    // We have a slot that we can use to create a new bucket if we need to.
-                    freeIdx = bucketIdx;
+                // We have a slot that we can use to create a new bucket if we need to.
+                freeIdx = bucketIdx;
             }
         }
         if (freeIdx == -1) {
@@ -180,8 +180,14 @@ final class DnsQueryIdSpace {
             // pick a slot for our index, and whatever was in that slot before will get moved to the tail.
             Random random = PlatformDependent.threadLocalRandom();
             int insertionPosition = random.nextInt(count + 1);
-            ids[count] = ids[insertionPosition];
-            ids[insertionPosition] = (short) id;
+            short moveId = ids[insertionPosition];
+            short insertId = (short) id;
+
+            // Assert that the ids are different or its the same index.
+            assert moveId != insertId || insertionPosition == count;
+
+            ids[count] = moveId;
+            ids[insertionPosition] = insertId;
             count++;
         }
 


### PR DESCRIPTION
Motivation:

Let's add an assert to ensure we never end up with duplicated ids in the DnsQueryIdSpace.

Modifications:

Add assert

Result:

Enforce correct code
