### PR TITLE
Ensure we not store the DnsQueryContext for later removal when we cou…

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContextManager.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContextManager.java
@@ -161,6 +161,11 @@ final class DnsQueryContextManager {
 
         synchronized int add(DnsQueryContext ctx) {
             int id = idSpace.nextId();
+            if (id == -1) {
+                // -1 means that we couldn't reserve an id to use. In this case return early and not store the
+                // context in the map.
+                return -1;
+            }
             DnsQueryContext oldCtx = map.put(id, ctx);
             assert oldCtx == null;
             return id;


### PR DESCRIPTION
…ldnt obtain a query id

Motivation:

We need to ensure we don't store the context in the map if we couldn'T obtain a query id as otherwise it will stay there until we are not able to obtain an id again, which then will trigger an assertion failure at the end.

Modifications:

Return early in case of not be able to obtain an id

Result:

No more assertion failure when we don't be able to obtain an query id twice for the same nameserver
