### PR TITLE
Ensure we actually remove an element before placing the id back in the DnsQueryIdSpace

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContextManager.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContextManager.java
@@ -171,8 +171,11 @@ final class DnsQueryContextManager {
         }
 
         synchronized DnsQueryContext remove(int id) {
-            idSpace.pushId(id);
-            return map.remove(id);
+            DnsQueryContext result = map.remove(id);
+            if (result != null) {
+                idSpace.pushId(id);
+            }
+            return result;
         }
     }
 }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContextManager.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContextManager.java
@@ -175,6 +175,7 @@ final class DnsQueryContextManager {
             if (result != null) {
                 idSpace.pushId(id);
             }
+            assert result != null : "DnsQueryContext not found, id: "  + id;
             return result;
         }
     }


### PR DESCRIPTION
Motivation:

If we accidentially try to remove an id twice it will currently result in corrupting the DnsQueryIdSpace.

Modifications:

Make sure we removed an element before pushing the id back into the id space.