### PR TITLE
Ensure we actually remove an element before placing the id back in th…

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContextManager.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContextManager.java
@@ -176,8 +176,12 @@ final class DnsQueryContextManager {
         }
 
         synchronized DnsQueryContext remove(int id) {
-            idSpace.pushId(id);
-            return map.remove(id);
+            DnsQueryContext result = map.remove(id);
+            if (result != null) {
+                idSpace.pushId(id);
+            }
+            assert result != null : "DnsQueryContext not found, id: "  + id;
+            return result;
         }
     }
 }


### PR DESCRIPTION
…e DnsQueryIdSpace (#14327)

Motivation:

If we accidentially try to remove an id twice it will currently result in corrupting the DnsQueryIdSpace.

Modifications:

Make sure we removed an element before pushing the id back into the id space.

