### PR TITLE
Replace ArrayDeque::pollFirst with ArrayDeque::pollLast for Recycler.…

### DIFF
--- a/common/src/main/java/io/netty/util/Recycler.java
+++ b/common/src/main/java/io/netty/util/Recycler.java
@@ -325,7 +325,7 @@ public abstract class Recycler<T> {
             if (batch.isEmpty()) {
                 handles.drain(this, chunkSize);
             }
-            DefaultHandle<T> handle = batch.pollFirst();
+            DefaultHandle<T> handle = batch.pollLast();
             if (null != handle) {
                 handle.toClaimed();
             }


### PR DESCRIPTION
…LocalPool batch. (#14268) (#14292)

Motivation:

Improve performance by replacing ArrayDeque::pollFirst with ArrayDeque::pollLast.

Modifications:

Replaced ArrayDeque::pollFirst with ArrayDeque::pollLast for LocalPool batch.

Result:
- The new version shows the best overall performance in benchmarks such as plainNew, recyclerGetAndRecycle, and unguardedProducerConsumer.
- Overall, the new version shows a significant reduction in GC time, improving memory efficiency across most tests.

Fixes #14268
