### PR TITLE
reduce memory fragmentation 

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -569,7 +569,7 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
                         assert current == null;
                         // Something went wrong, let's ensure we not leak the newChunk.
                         newChunk.release();
-                    } 
+                    }
                 }
             }
         }

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -484,7 +484,7 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
                 curr.readInitInto(buf, size, maxCapacity);
                 return;
             }
-            int transResult = 0;
+            int transResult = TransResult.NO_TRANS;
             if (curr != null) {
                 if (curr.remainingCapacity() < RETIRE_CAPACITY) {
                     curr.release();
@@ -570,6 +570,7 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
 
     private interface TransResult{
         int TO_RELEASE = -1;
+        int NO_TRANS = 0;
         int TO_NEXT_IN_LINE = 1;
         int TO_CENTER_QUEUE = 2;
     }

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -514,9 +514,7 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
                     curr.release();
                 }
             }
- 
             assert current == null;
-            
             int transResult = TransResult.NO_TRANS;
             if (curr != null) {
                 if (curr.remainingCapacity() < RETIRE_CAPACITY) {
@@ -525,7 +523,6 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
                     transResult = transChunk(curr);
                 }
             }
-           
             // The fast-path for allocations did not work.
             //
             // Try to fetch the next "Magazine local" Chunk first, if this this fails as we don't have
@@ -576,7 +573,6 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
                 }
             }
         }
-
         /**
          * Returns an integer type result for the caller to perceive the transfer situation.*
          * @param current
@@ -626,7 +622,7 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
         }
     }
 
-    private interface TransResult{
+    private interface TransResult {
         int TO_RELEASE = -1;
         int NO_TRANS = 0;
         int TO_NEXT_IN_LINE = 1;

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -559,7 +559,7 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
                         curr.release();
                         current = newChunk;
                     } else {
-                        transChunk(newChunk);
+                        transferChunk(newChunk);
                     }
                     newChunk = null;
                 } finally {

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -537,7 +537,7 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
                 if (last.remainingCapacity() < RETIRE_CAPACITY) {
                     last.release();
                 } else {
-                    transChunk(last);
+                    transferChunk(last);
                 }
             }
             if (curr.remainingCapacity() > size) {

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -572,7 +572,7 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
             }
         }
 
-        private void transChunk(Chunk current) {
+        private void transferChunk(Chunk current) {
             if (NEXT_IN_LINE.compareAndSet(this, null, current)
                     || parent.offerToQueue(current)) {
                 return;

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -578,7 +578,7 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
                 return;
             }
             Chunk nextChunk = NEXT_IN_LINE.get(this);
-            if (current.remainingCapacity() > nextChunk.remainingCapacity()) {
+            if (nextChunk != null && current.remainingCapacity() > nextChunk.remainingCapacity()) {
                 if (NEXT_IN_LINE.compareAndSet(this, nextChunk, current)) {
                     nextChunk.release();
                 } else {

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -533,7 +533,6 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
             }
             current = curr;
             assert current != null;
-            
             if (least != null) {
                 if (least.remainingCapacity() < RETIRE_CAPACITY) {
                     least.release();
@@ -541,7 +540,6 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
                     transChunk(least);
                 }
             }
-            
             if (curr.remainingCapacity() > size) {
                 curr.readInitInto(buf, size, maxCapacity);
             } else if (curr.remainingCapacity() == size) {

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -130,7 +130,7 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
         magazineExpandLock = new StampedLock();
         if (magazineCaching != MagazineCaching.None) {
             assert magazineCaching == MagazineCaching.EventLoopThreads ||
-                    magazineCaching == MagazineCaching.FastThreadLocalThreads;
+                   magazineCaching == MagazineCaching.FastThreadLocalThreads;
             final boolean cachedMagazinesNonEventLoopThreads =
                     magazineCaching == MagazineCaching.FastThreadLocalThreads;
             final Set<Magazine> liveMagazines = new CopyOnWriteArraySet<Magazine>();
@@ -514,7 +514,7 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
                     }
                 }
             }
-            Chunk least = curr;
+            Chunk last = curr;
             assert current == null;
             // The fast-path for allocations did not work.
             //
@@ -533,11 +533,11 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
             }
             current = curr;
             assert current != null;
-            if (least != null) {
-                if (least.remainingCapacity() < RETIRE_CAPACITY) {
-                    least.release();
+            if (last != null) {
+                if (last.remainingCapacity() < RETIRE_CAPACITY) {
+                    last.release();
                 } else {
-                    transChunk(least);
+                    transChunk(last);
                 }
             }
             if (curr.remainingCapacity() > size) {

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -513,6 +513,7 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
                 } finally {
                     curr.release();
                 }
+            }
  
             assert current == null;
             

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -130,7 +130,7 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
         magazineExpandLock = new StampedLock();
         if (magazineCaching != MagazineCaching.None) {
             assert magazineCaching == MagazineCaching.EventLoopThreads ||
-                    magazineCaching == MagazineCaching.FastThreadLocalThreads;
+                   magazineCaching == MagazineCaching.FastThreadLocalThreads;
             final boolean cachedMagazinesNonEventLoopThreads =
                     magazineCaching == MagazineCaching.FastThreadLocalThreads;
             final Set<Magazine> liveMagazines = new CopyOnWriteArraySet<Magazine>();
@@ -539,6 +539,7 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
                 } else {
                     transChunk(least);
                 }
+                least = null;
             }
             if (curr.remainingCapacity() > size) {
                 curr.readInitInto(buf, size, maxCapacity);


### PR DESCRIPTION
Motivation:
  
1. Currently, when allocating from a magazine, if the remaining memory of the current chunk is not enough for allocation,
   the chunk is directly released.
   If the size to be allocated at this time is greater than the remaining memory of the chunk but >= RETIRE_CAPACITY, direct release will result in significant memory fragmentation.

2. When transferring the current chunk, if the transfer to the central queue ultimately fails, the chunk is chosen to be released.

Modification:
1. In this scenario, consider transferring the chunk to the nextInLine.

2. When transferring the chunk, if the transfer to the central queue still fails, consider comparing it with the local nextInLine and retiring the smaller one.