### PR TITLE
Properly free magazine chunks and avoid orphaned magazines

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -298,9 +298,10 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
                 int preferredChunkSize = mags[0].sharedPrefChunkSize;
                 Magazine[] expanded = new Magazine[mags.length * 2];
                 for (int i = 0, m = expanded.length; i < m; i++) {
-                    expanded[i] = new Magazine(this);
-                    expanded[i].localPrefChunkSize = preferredChunkSize;
-                    expanded[i].sharedPrefChunkSize = preferredChunkSize;
+                    Magazine m = new Magazine(this);
+                    m.localPrefChunkSize = preferredChunkSize;
+                    m.sharedPrefChunkSize = preferredChunkSize;
+                    expanded[i] = m
                 }
                 magazines = expanded;
                 for (Magazine magazine : mags) {
@@ -611,10 +612,7 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
 
         void free() {
             // Release the current Chunk and the next that was stored for later usage.
-            Chunk next = NEXT_IN_LINE.getAndSet(this, MAGAZINE_FREED);
-            if (next != null && next != MAGAZINE_FREED) {
-                next.release();
-            }
+            restoreMagazineFreed();
             if (current != null) {
                 current.release();
                 current = null;

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -297,11 +297,11 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
                 }
                 int preferredChunkSize = mags[0].sharedPrefChunkSize;
                 Magazine[] expanded = new Magazine[mags.length * 2];
-                for (int i = 0, m = expanded.length; i < m; i++) {
+                for (int i = 0, l = expanded.length; i < l; i++) {
                     Magazine m = new Magazine(this);
                     m.localPrefChunkSize = preferredChunkSize;
                     m.sharedPrefChunkSize = preferredChunkSize;
-                    expanded[i] = m
+                    expanded[i] = m;
                 }
                 magazines = expanded;
                 for (Magazine magazine : mags) {
@@ -616,9 +616,6 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
             if (current != null) {
                 current.release();
                 current = null;
-            }
-            if (next == MAGAZINE_FREED) {
-                throw new IllegalStateException("Magazine has already been freed");
             }
         }
     }

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -15,7 +15,6 @@
  */
 package io.netty.buffer;
 
-import io.netty.util.AbstractReferenceCounted;
 import io.netty.util.ByteProcessor;
 import io.netty.util.IllegalReferenceCountException;
 import io.netty.util.NettyRuntime;
@@ -121,6 +120,7 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
     private volatile Magazine[] magazines;
     private final FastThreadLocal<Object> threadLocalMagazine;
     private final Set<Magazine> liveCachedMagazines;
+    private volatile boolean freed;
 
     AdaptivePoolingAllocator(ChunkAllocator chunkAllocator, MagazineCaching magazineCaching) {
         ObjectUtil.checkNotNull(chunkAllocator, "chunkAllocator");
@@ -295,11 +295,22 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
                 if (mags.length >= MAX_STRIPES || mags.length > currentLength) {
                     return true;
                 }
-                Magazine[] expanded = Arrays.copyOf(mags, mags.length * 2);
-                for (int i = mags.length, m = expanded.length; i < m; i++) {
+                int preferredChunkSize = mags[0].sharedPrefChunkSize;
+                Magazine[] expanded = new Magazine[mags.length * 2];
+                for (int i = 0, m = expanded.length; i < m; i++) {
                     expanded[i] = new Magazine(this);
+                    expanded[i].localPrefChunkSize = preferredChunkSize;
+                    expanded[i].sharedPrefChunkSize = preferredChunkSize;
                 }
                 magazines = expanded;
+                for (Magazine magazine : mags) {
+                    long stamp = magazine.allocationLock.writeLock();
+                    try {
+                        magazine.free();
+                    } finally {
+                        magazine.allocationLock.unlockWrite(stamp);
+                    }
+                }
             } finally {
                 magazineExpandLock.unlockWrite(writeLock);
             }
@@ -308,6 +319,9 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
     }
 
     private boolean offerToQueue(Chunk buffer) {
+        if (freed) {
+            return false;
+        }
         return centralQueue.offer(buffer);
     }
 
@@ -324,16 +338,16 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
     }
 
     private void free() {
+        freed = true;
+        for (Magazine magazine : magazines) {
+            magazine.free();
+        }
         for (;;) {
             Chunk chunk = centralQueue.poll();
             if (chunk == null) {
                 break;
             }
             chunk.release();
-        }
-
-        for (Magazine magazine : magazines) {
-            magazine.free();
         }
     }
 
@@ -364,7 +378,7 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
         private int histoIndex;
         private int datumCount;
         private int datumTarget = INIT_DATUM_TARGET;
-        private volatile int sharedPrefChunkSize = MIN_CHUNK_SIZE;
+        protected volatile int sharedPrefChunkSize = MIN_CHUNK_SIZE;
         protected volatile int localPrefChunkSize = MIN_CHUNK_SIZE;
 
         private AllocationStatistics(AdaptivePoolingAllocator parent, boolean shareable) {
@@ -450,6 +464,8 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
         static {
             NEXT_IN_LINE = AtomicReferenceFieldUpdater.newUpdater(Magazine.class, Chunk.class, "nextInLine");
         }
+        private static final Chunk MAGAZINE_FREED = new Chunk();
+
         private Chunk current;
         @SuppressWarnings("unused") // updated via NEXT_IN_LINE
         private volatile Chunk nextInLine;
@@ -475,16 +491,14 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
         public boolean tryAllocate(int size, int sizeBucket, int maxCapacity, AdaptiveByteBuf buf) {
             if (allocationLock == null) {
                 // This magazine is not shared across threads, just allocate directly.
-                allocate(size, sizeBucket, maxCapacity, buf);
-                return true;
+                return allocate(size, sizeBucket, maxCapacity, buf);
             }
 
             // Try to retrieve the lock and if successful allocate.
             long writeLock = allocationLock.tryWriteLock();
             if (writeLock != 0) {
                 try {
-                    allocate(size, sizeBucket, maxCapacity, buf);
-                    return true;
+                    return allocate(size, sizeBucket, maxCapacity, buf);
                 } finally {
                     allocationLock.unlockWrite(writeLock);
                 }
@@ -492,14 +506,14 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
             return false;
         }
 
-        private void allocate(int size, int sizeBucket, int maxCapacity, AdaptiveByteBuf buf) {
+        private boolean allocate(int size, int sizeBucket, int maxCapacity, AdaptiveByteBuf buf) {
             recordAllocationSize(sizeBucket);
             Chunk curr = current;
             if (curr != null) {
                 if (curr.remainingCapacity() > size) {
                     curr.readInitInto(buf, size, maxCapacity);
                     // We still have some bytes left that we can use for the next allocation, just early return.
-                    return;
+                    return true;
                 }
 
                 // At this point we know that this will be the last time current will be used, so directly set it to
@@ -508,7 +522,7 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
                 try {
                     if (curr.remainingCapacity() == size) {
                         curr.readInitInto(buf, size, maxCapacity);
-                        return;
+                        return true;
                     }
                 } finally {
                     curr.release();
@@ -526,6 +540,11 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
             // so be "reserved" by this Magazine for exclusive usage.
             if (nextInLine != null) {
                 curr = NEXT_IN_LINE.getAndSet(this, null);
+                if (curr == MAGAZINE_FREED) {
+                    // Allocation raced with a stripe-resize that freed this magazine.
+                    restoreMagazineFreed();
+                    return false;
+                }
             } else {
                 curr = parent.centralQueue.poll();
                 if (curr == null) {
@@ -570,6 +589,14 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
                     }
                 }
             }
+            return true;
+        }
+
+        private void restoreMagazineFreed() {
+            Chunk next = NEXT_IN_LINE.getAndSet(this, MAGAZINE_FREED);
+            if (next != null && next != MAGAZINE_FREED) {
+                next.release(); // A chunk snuck in through a race. Release it after restoring MAGAZINE_FREED state.
+            }
         }
 
         private Chunk newChunkAllocation(int promptingSize) {
@@ -584,13 +611,16 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
 
         void free() {
             // Release the current Chunk and the next that was stored for later usage.
+            Chunk next = NEXT_IN_LINE.getAndSet(this, MAGAZINE_FREED);
+            if (next != null && next != MAGAZINE_FREED) {
+                next.release();
+            }
             if (current != null) {
                 current.release();
                 current = null;
             }
-            Chunk next = NEXT_IN_LINE.getAndSet(this, null);
-            if (next != null) {
-                next.release();
+            if (next == MAGAZINE_FREED) {
+                throw new IllegalStateException("Magazine has already been freed");
             }
         }
     }
@@ -623,11 +653,19 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
         @SuppressWarnings({"unused", "FieldMayBeFinal"})
         private volatile int refCnt;
 
+        Chunk() {
+            // Constructor only used by the MAGAZINE_FREED sentinel.
+            delegate = null;
+            magazine = null;
+            capacity = 0;
+            pooled = false;
+        }
+
         Chunk(AbstractByteBuf delegate, Magazine magazine, boolean pooled) {
             this.delegate = delegate;
             this.magazine = magazine;
             this.pooled = pooled;
-            this.capacity = delegate.capacity();
+            capacity = delegate.capacity();
             magazine.usedMemory.getAndAdd(capacity);
             updater.setInitialValue(this);
         }

--- a/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
@@ -349,13 +349,13 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
     }
 
     @Test
-    @Timeout(value = 4000, unit = MILLISECONDS)
+    @Timeout(value = 10, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
     public void testThreadCacheDestroyedByThreadCleaner() throws InterruptedException {
         testThreadCacheDestroyed(false);
     }
 
     @Test
-    @Timeout(value = 4000, unit = MILLISECONDS)
+    @Timeout(value = 10, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
     public void testThreadCacheDestroyedAfterExitRun() throws InterruptedException {
         testThreadCacheDestroyed(true);
     }


### PR DESCRIPTION
Motivation:
When the AdaptivePoolingAllocator is finalized, it will attempt to release all chunks and free all magazines. However, when chunks are released, they tend to want to return to their magazines or the central queue for reuse. We must prevent chunks from escaping death in this way, in the case of finalization.

There is another problem, produced by magazine array resizing, which turns out to have a solution closely related to the above: The magazines array is indexed into by thread-id modulo the array length. When the array length changes, so potentially does the preferred locality of each thread accessing the array. This can cause some magazines that were previously used often, to no longer be accessed. This can leave unused chunks tied up in unused magazines, wasting memory as a result.

Modification:
First of all, a volatile `freed` field is added to the AdaptivePoolingAllocator which, if true, will bar adding chunks to the central queue. When chunks are denied entrance to the central queue, they will deallocate their memory.

Before chunks attempt to add themselves to the central queue, however, they will try to add themselves to nextInLine for their respective magazines. A new MAGAZINE_FREED sentinel object now marks freed magazines in the nextInLine field, preventing chunks from being added there. The field is modified using getAndSet atomic operations, and thus may briefly show different values. Code has been added to repair these cases, restoring the freed status, and releasing any chunks that might have been added. This also means the `Magazine.allocate` method can now fail, so it now returns the boolean status, similarly to `tryAllocate`. It's a pretty rare data-race, but it's not impossible due to changes described later.

The freeing of magazines now need to happen before the releasing of all chunks, so the `AdaptivePoolingAllocator.free` has been modified to first set the `freed` field, preventing chunks from being added to the central queue. Then free magazines, putting them into the freed state and preventing chunks from getting stowed in the `current` and `nextInLine` fields. Finally, any remaining chunks are pulled from the central queue and released. Since we now know they have nowhere else to go, we are certain their memory will be released.

Lastly, the problem of potentially orphaned magazines is addressed. Instead of simply extending the existing magazine array (leaving any existing magazines at their current index), we now allocate a new array of all new magazines. Then we free all the old magazines, which will send their chunks (at least any next-in-line chunks) to the central queue. When the new magazines gets used, they will pull chunks from the central queue for reuse at that time. This means that any magazine array indexes that are not used, will now no longer be holding to any chunks from before the resize. It also means that magazines can be freed concurrently with allocation (though each magazine is individually protected by their lock) and deallocation (which is truly concurrent). Since the magazines array now contain all-new magazines, we loose all the allocation size statistics we've built up. This can cause the magazines to prefer less-than-ideal chunk sizes. We alleviate some of that by preserving the shared preferred chunk size across array resizes. This will also prevent some churn from chunks being released and finding their size deviating too much from the preferred chunk size. This is important as many of the chunks obtained from the central queue will be sized according to the pre-array-resize preferred chunk size.

The `PooledByteBufAllocatorTest` was changed slightly, so it now captures the stack trace of where the test thread gets stuck, in case of a timeout. During the development of this PR, a bug caused an infinite loop in the finalizer thread, which in turn caused the otherwise unrelated PooledByteBufAllocatorTests to time out.

Result:
We get more robust freeing of chunks when the AdaptivePoolingAllocator is finalized. We also avoid spending memory on any magazines orphaned by resizes.

A consequence of this, however, is that resizes are slightly more disruptive. The new magazines have all their statistics reset, and they all have to visit the central queue to obtain chunks. The central queue might also not be big enough to hold all the chunks for reuse, which can cause some memory churn.