### PR TITLE
AdapativeByteBufAllocator: Reduce memory fragmentation  (#14333)

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -516,18 +516,17 @@ final class AdaptivePoolingAllocator {
                 // At this point we know that this will be the last time current will be used, so directly set it to
                 // null and release it once we are done.
                 current = null;
-                try {
-                    if (curr.remainingCapacity() == size) {
+                if (curr.remainingCapacity() == size) {
+                    try {
                         curr.readInitInto(buf, size, maxCapacity);
                         return true;
+                    } finally {
+                        curr.release();
                     }
-                } finally {
-                    curr.release();
                 }
             }
-
+            Chunk last = curr;
             assert current == null;
-
             // The fast-path for allocations did not work.
             //
             // Try to fetch the next "Magazine local" Chunk first, if this this fails as we don't have
@@ -549,9 +548,14 @@ final class AdaptivePoolingAllocator {
                 }
             }
             current = curr;
-
             assert current != null;
-
+            if (last != null) {
+                if (last.remainingCapacity() < RETIRE_CAPACITY) {
+                    last.release();
+                } else {
+                    transferChunk(last);
+                }
+            }
             if (curr.remainingCapacity() > size) {
                 curr.readInitInto(buf, size, maxCapacity);
             } else if (curr.remainingCapacity() == size) {
@@ -570,12 +574,8 @@ final class AdaptivePoolingAllocator {
                     if (curr.remainingCapacity() < RETIRE_CAPACITY) {
                         curr.release();
                         current = newChunk;
-                    } else if (!trySetNextInLine(newChunk)) {
-                        if (!parent.offerToQueue(newChunk)) {
-                            // Next-in-line is occupied AND the central queue is full.
-                            // Rare that we should get here, but we'll only do one allocation out of this chunk, then.
-                            newChunk.release();
-                        }
+                    } else {
+                        transferChunk(newChunk);
                     }
                     newChunk = null;
                 } finally {
@@ -593,6 +593,23 @@ final class AdaptivePoolingAllocator {
             Chunk next = NEXT_IN_LINE.getAndSet(this, MAGAZINE_FREED);
             if (next != null && next != MAGAZINE_FREED) {
                 next.release(); // A chunk snuck in through a race. Release it after restoring MAGAZINE_FREED state.
+            }
+        }
+
+        private void transferChunk(Chunk current) {
+            if (NEXT_IN_LINE.compareAndSet(this, null, current)
+                    || parent.offerToQueue(current)) {
+                return;
+            }
+            Chunk nextChunk = NEXT_IN_LINE.get(this);
+            if (nextChunk != null && current.remainingCapacity() > nextChunk.remainingCapacity()) {
+                if (NEXT_IN_LINE.compareAndSet(this, nextChunk, current)) {
+                    nextChunk.release();
+                } else {
+                    // Next-in-line is occupied AND the central queue is full.
+                    // Rare that we should get here, but we'll only do one allocation out of this chunk, then.
+                    current.release();
+                }
             }
         }
 


### PR DESCRIPTION
Motivation:
  
1. Currently, when allocating from a magazine, if the remaining memory of the current chunk is not enough for allocation,
   the chunk is directly released.
If the size to be allocated at this time is greater than the remaining memory of the chunk but >= RETIRE_CAPACITY, direct release will result in significant memory fragmentation.

2. When transferring the current chunk, if the transfer to the central queue ultimately fails, the chunk is chosen to be released.

Modification:
1. In this scenario, consider transferring the chunk to the nextInLine.

2. When transferring the chunk, if the transfer to the central queue still fails, consider comparing it with the local nextInLine and retiring the smaller one.

Result:

Better usage of memory
