### PR TITLE
Release message before failing promise when multiple requests are wri…

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientUpgradeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientUpgradeHandler.java
@@ -18,6 +18,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandler;
 import io.netty.channel.ChannelPromise;
 import io.netty.util.AsciiString;
+import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.ObjectUtil;
 
 import java.net.SocketAddress;
@@ -160,6 +161,8 @@ public class HttpClientUpgradeHandler extends HttpObjectAggregator implements Ch
         }
 
         if (upgradeRequested) {
+            // Release message before failing the promise.
+            ReferenceCountUtil.release(msg);
             promise.setFailure(new IllegalStateException(
                     "Attempting to write HTTP request with upgrade in progress"));
             return;


### PR DESCRIPTION
…tten while upgrade is in progress.

Motivation:

We need to ensure we correctly release the message before we return and fail the promise as otherwise we will leak memory.

Modifications:

- Correct release before return
- Add unit test

Result:

Fixes https://github.com/netty/netty/issues/14339
