### PR TITLE
AdapativeByteBufAllocator: Reduce memory fragmentation

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/adapt/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/adapt/AdaptivePoolingAllocator.java
@@ -91,7 +91,7 @@ public class AdaptivePoolingAllocator implements BufferAllocator {
      * This number is 10 MiB, and is derived from the limitations of internal histograms.
      */
     protected static final int MAX_CHUNK_SIZE =
-        BUFS_PER_CHUNK * (1 << AllocationStatistics.HISTO_MAX_BUCKET_SHIFT); // 10 MiB.
+            BUFS_PER_CHUNK * (1 << AllocationStatistics.HISTO_MAX_BUCKET_SHIFT); // 10 MiB.
 
     /**
      * The capacity if the central queue that allow chunks to be shared across magazines.
@@ -102,7 +102,7 @@ public class AdaptivePoolingAllocator implements BufferAllocator {
      * 5 * {@link NettyRuntime#availableProcessors()} * {@link #MAX_CHUNK_SIZE} bytes.
      */
     protected static final int CENTRAL_QUEUE_CAPACITY = SystemPropertyUtil.getInt(
-        "io.netty5.allocator.centralQueueCapacity", NettyRuntime.availableProcessors());
+            "io.netty5.allocator.centralQueueCapacity", NettyRuntime.availableProcessors());
 
     private static final Object NO_MAGAZINE = Boolean.TRUE;
 
@@ -290,8 +290,8 @@ public class AdaptivePoolingAllocator implements BufferAllocator {
             throw allocatorClosedException();
         }
         Buffer constantBuffer = manager.allocateShared(
-            allocatorControl, bytes.length, drop -> CleanerDrop.wrapWithoutLeakDetection(drop, manager),
-            allocationType);
+                allocatorControl, bytes.length, drop -> CleanerDrop.wrapWithoutLeakDetection(drop, manager),
+                allocationType);
         constantBuffer.writeBytes(bytes).makeReadOnly();
         return () -> manager.allocateConstChild(constantBuffer);
     }
@@ -364,8 +364,8 @@ public class AdaptivePoolingAllocator implements BufferAllocator {
         protected final AdaptivePoolingAllocator parent;
         protected final EventExecutor ownerEventExecutor;
         private final short[][] histos = {
-            new short[HISTO_BUCKET_COUNT], new short[HISTO_BUCKET_COUNT],
-            new short[HISTO_BUCKET_COUNT], new short[HISTO_BUCKET_COUNT],
+                new short[HISTO_BUCKET_COUNT], new short[HISTO_BUCKET_COUNT],
+                new short[HISTO_BUCKET_COUNT], new short[HISTO_BUCKET_COUNT],
         };
         private short[] histo = histos[0];
         private final int[] sums = new int[HISTO_BUCKET_COUNT];

--- a/buffer/src/main/java/io/netty5/buffer/adapt/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/adapt/AdaptivePoolingAllocator.java
@@ -539,7 +539,9 @@ public class AdaptivePoolingAllocator implements BufferAllocator {
             Buffer nextChunk = (Buffer) NEXT_IN_LINE.get(this);
             if (nextChunk != null && current.capacity() > nextChunk.capacity()) {
                 if (NEXT_IN_LINE.compareAndSet(this, nextChunk, current)) {
-                    nextChunk.close();
+                     if(nextChunk != MAGAZINE_FREED) {
+                        nextChunk.close();
+                    }  
                     return;
                 }
             }

--- a/buffer/src/main/java/io/netty5/buffer/adapt/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/adapt/AdaptivePoolingAllocator.java
@@ -536,8 +536,8 @@ public class AdaptivePoolingAllocator implements BufferAllocator {
                 return;
             }
 
-            Buffer nextChunk = NEXT_IN_LINE.get(this);
-            if (current.capacity() > nextChunk.capacity()) {
+            Buffer nextChunk = (Buffer) NEXT_IN_LINE.get(this);
+            if (nextChunk != null && current.capacity() > nextChunk.capacity()) {
                 if (NEXT_IN_LINE.compareAndSet(this, nextChunk, current)) {
                     nextChunk.close();
                     return;

--- a/buffer/src/main/java/io/netty5/buffer/adapt/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/adapt/AdaptivePoolingAllocator.java
@@ -537,7 +537,7 @@ public class AdaptivePoolingAllocator implements BufferAllocator {
             }
 
             Buffer nextChunk = NEXT_IN_LINE.get(this);
-            if (nextChunk != MAGAZINE_FREED && current.capacity() > nextChunk.capacity()) {
+            if (current.capacity() > nextChunk.capacity()) {
                 if (NEXT_IN_LINE.compareAndSet(this, nextChunk, current)) {
                     nextChunk.close();
                     return;

--- a/buffer/src/main/java/io/netty5/buffer/adapt/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/adapt/AdaptivePoolingAllocator.java
@@ -539,7 +539,7 @@ public class AdaptivePoolingAllocator implements BufferAllocator {
             Buffer nextChunk = (Buffer) NEXT_IN_LINE.get(this);
             if (nextChunk != null && current.capacity() > nextChunk.capacity()) {
                 if (NEXT_IN_LINE.compareAndSet(this, nextChunk, current)) {
-                     if(nextChunk != MAGAZINE_FREED) {
+                     if (nextChunk != MAGAZINE_FREED) {
                         nextChunk.close();
                     }  
                     return;

--- a/buffer/src/main/java/io/netty5/buffer/adapt/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/adapt/AdaptivePoolingAllocator.java
@@ -548,7 +548,6 @@ public class AdaptivePoolingAllocator implements BufferAllocator {
             current.close();
         }
 
-
         private void restoreMagazineFreed() {
             Buffer next = (Buffer) NEXT_IN_LINE.getAndSet(this, MAGAZINE_FREED);
             if (next != null && next != MAGAZINE_FREED) {

--- a/buffer/src/main/java/io/netty5/buffer/adapt/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/adapt/AdaptivePoolingAllocator.java
@@ -541,7 +541,7 @@ public class AdaptivePoolingAllocator implements BufferAllocator {
                 if (NEXT_IN_LINE.compareAndSet(this, nextChunk, current)) {
                      if (nextChunk != MAGAZINE_FREED) {
                         nextChunk.close();
-                    }  
+                    }
                     return;
                 }
             }


### PR DESCRIPTION
Motivation:

Currently, when allocating from a magazine, if the remaining memory of the current chunk is not enough for allocation,
the chunk is directly released.
If the size to be allocated at this time is greater than the remaining memory of the chunk but >= RETIRE_CAPACITY, direct release will result in significant memory fragmentation.

When transferring the current chunk, if the transfer to the central queue ultimately fails, the chunk is chosen to be released.

Modification:

In this scenario, consider transferring the chunk to the nextInLine.

When transferring the chunk, if the transfer to the central queue still fails, consider comparing it with the local nextInLine and retiring the smaller one.

Result:

Better usage of memory