### PR TITLE
AdaptivePoolingAllocator: Resolve the release issue of the currentChunk

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -611,7 +611,7 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
                 if (NEXT_IN_LINE.compareAndSet(this, nextChunk, current)) {
                     if (nextChunk != MAGAZINE_FREED) {
                         nextChunk.release();
-                    }  
+                    }
                     return;
                 }
             }

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -609,7 +609,7 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
             Chunk nextChunk = NEXT_IN_LINE.get(this);
             if (nextChunk != null && current.remainingCapacity() > nextChunk.remainingCapacity()) {
                 if (NEXT_IN_LINE.compareAndSet(this, nextChunk, current)) {
-                    if(nextChunk != MAGAZINE_FREED) {
+                    if (nextChunk != MAGAZINE_FREED) {
                         nextChunk.release();
                     }  
                     return;

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -610,12 +610,12 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
             if (nextChunk != null && current.remainingCapacity() > nextChunk.remainingCapacity()) {
                 if (NEXT_IN_LINE.compareAndSet(this, nextChunk, current)) {
                     nextChunk.release();
-                } else {
-                    // Next-in-line is occupied AND the central queue is full.
-                    // Rare that we should get here, but we'll only do one allocation out of this chunk, then.
-                    current.release();
+                    return;
                 }
             }
+            // Next-in-line is occupied AND the central queue is full.
+            // Rare that we should get here, but we'll only do one allocation out of this chunk, then.
+            current.release();
         }
 
         private Chunk newChunkAllocation(int promptingSize) {

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -609,7 +609,9 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
             Chunk nextChunk = NEXT_IN_LINE.get(this);
             if (nextChunk != null && current.remainingCapacity() > nextChunk.remainingCapacity()) {
                 if (NEXT_IN_LINE.compareAndSet(this, nextChunk, current)) {
-                    nextChunk.release();
+                    if(nextChunk != MAGAZINE_FREED) {
+                        nextChunk.release();
+                    }  
                     return;
                 }
             }


### PR DESCRIPTION

Motivation:

When the capacity of `currentChunk` is less than or equal to that of `nextChunk`,
 `currentChunk` is not released.

Modification:

When the capacity of `currentChunk` is less than or equal to that of `nextChunk`, 
release the currentChunk.

Result:

Prevent memory leaks
