### PR TITLE
Alpine devcontainer fixes

### DIFF
--- a/.devcontainer/alpine/Dockerfile
+++ b/.devcontainer/alpine/Dockerfile
@@ -1,8 +1,9 @@
-FROM mcr.microsoft.com/devcontainers/base:alpine
+# Pin alpine version to 3.18, because JetBrains Runtime (OpenJDK distro) requires posix_fallocate64()
+# which was removed in 3.19. The real fix is for JBR to use posix_fallocate() without the '64' suffix.
+FROM mcr.microsoft.com/devcontainers/base:alpine-3.18
 RUN apk -U upgrade && apk add \
     autoconf automake linux-headers libtool make tar libaio-dev openssl-dev apr-dev gcc \
     mandoc man-pages autoconf-doc automake-doc libtool-doc make-doc tar-doc gcc-doc \
-    perf perf-bash-completion htop htop-doc strace strace-doc ripgrep ripgrep-doc \
-    openjdk8-jdk openjdk8-doc openjdk8-src openjdk11-jdk openjdk11-doc openjdk11-src \
-    openjdk17-jdk openjdk17-doc openjdk1-src openjdk21-jdk openjdk21-doc openjdk21-src \
-    maven
+    perf perf-bash-completion htop htop-doc strace strace-doc ripgrep ripgrep-doc gcompat \
+    openjdk17-jdk openjdk17-doc openjdk17-src maven
+# Once Intellij has connected to the devconainer, run `unset LD_LIBRARY_PATH` to fix Java broken by incompatible JBR.


### PR DESCRIPTION
Motivation:
Intellij still doesn't really support running alpine-based devcontainers. However, things are close enough these days, that a container can be started and command-line based builds can run.

Modification:
- Pin alpine version to 3.18 because newer ones have removed `posix_fallocate64()` and `gcompat` doesn't fix that.
- Use JDK 17 in the container because it's new enough to actually support alpine, yet old enough to be included in 3.18.
- Add `gcompat` which supports Intellij just enough to start and connect to the devcontainer.
- Add a note on how to fix the `LD_LIBRARY_PATH` that Intellij breaks in the container. Fixing this allow java-based tools to run again.

Result:
It's now possible to start and connect to an alpine-based devcontainer from Intellij. However, many intellij features still don't work, because the JBR that Intellij installs into the container doesn't support alpine. It's enough to run builds from the command-line, though.