### PR TITLE
AdaptivePoolingAllocator: Resolve the release issue of the currentChu…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -604,13 +604,15 @@ final class AdaptivePoolingAllocator {
             Chunk nextChunk = NEXT_IN_LINE.get(this);
             if (nextChunk != null && current.remainingCapacity() > nextChunk.remainingCapacity()) {
                 if (NEXT_IN_LINE.compareAndSet(this, nextChunk, current)) {
-                    nextChunk.release();
-                } else {
-                    // Next-in-line is occupied AND the central queue is full.
-                    // Rare that we should get here, but we'll only do one allocation out of this chunk, then.
-                    current.release();
+                    if (nextChunk != MAGAZINE_FREED) {
+                        nextChunk.release();
+                    }
+                    return;
                 }
             }
+            // Next-in-line is occupied AND the central queue is full.
+            // Rare that we should get here, but we'll only do one allocation out of this chunk, then.
+            current.release();
         }
 
         private Chunk newChunkAllocation(int promptingSize) {


### PR DESCRIPTION
…nk (#14348)

Motivation:

When the capacity of `currentChunk` is less than or equal to that of `nextChunk`,
 `currentChunk` is not released.

Modification:

When the capacity of `currentChunk` is less than or equal to that of `nextChunk`,
release the currentChunk.

Result:

Prevent memory leaks