### PR TITLE
EpollDatagramChannel: Read until receiving EWOULDBLOCK / EAGAIN

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -687,14 +687,12 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
 
             int bytesReceived = socket.recvmsg(msg);
             if (!msg.hasSender()) {
+                assert bytesReceived <= 0;
                 allocHandle.lastBytesRead(0);
-                if (bytesReceived == 0) {
-                    // There was nothing left to handle. We will be woken up again when there is more packets to read.
-                    return false;
-                } else {
-                    // just try again.
-                    return true;
-                }
+                // There was nothing left to handle if bytesReceived == 0.
+                // We will be woken up again when there is more packets to read.
+                // Otherwise just try again.
+                return bytesReceived != 0;
             }
 
             byteBuf.writerIndex(bytesReceived);

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -687,12 +687,11 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
 
             int bytesReceived = socket.recvmsg(msg);
             if (!msg.hasSender()) {
+                allocHandle.lastBytesRead(0);
                 if (bytesReceived == 0) {
                     // There was nothing left to handle. We will be woken up again when there is more packets to read.
-                    allocHandle.lastBytesRead(-1);
                     return false;
                 } else {
-                    allocHandle.lastBytesRead(0);
                     // just try again.
                     return true;
                 }
@@ -739,7 +738,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
             int received = socket.recvmmsg(packets, 0, array.count());
             if (received == 0) {
                 // There was nothing left to handle. We will be woken up again when there is more packets to read.
-                allocHandle.lastBytesRead(-1);
+                allocHandle.lastBytesRead(0);
                 return false;
             }
 


### PR DESCRIPTION
Motivation:

We should better try to call recvmmsg / recvmsg until we encounter EWOULDBLOCK / EAGAIN. This will guarantee that we never end up with something left to read for which we will not be notified again because of the usage of edge triggered.

Modifications:

Check if we received EWOULDBLOCK / EAGAIN and only then consider everything drained

Result:

Ensure we always handle every pending packets even when using edge triggered mode
