### PR TITLE
Allow to reuse more then one session per host / port mapping (#14356)

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslClientSessionCache.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslClientSessionCache.java
@@ -18,16 +18,18 @@ package io.netty.handler.ssl;
 import io.netty.internal.tcnative.SSL;
 import io.netty.util.AsciiString;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * {@link OpenSslSessionCache} that is used by the client-side.
  */
 final class OpenSslClientSessionCache extends OpenSslSessionCache {
-    // TODO: Should we support to have a List of OpenSslSessions for a Host/Port key and so be able to
-    // support sessions for different protocols / ciphers to the same remote peer ?
-    private final Map<HostPort, NativeSslSession> sessions = new HashMap<HostPort, NativeSslSession>();
+    private final Map<HostPort, Set<NativeSslSession>> sessions = new HashMap<HostPort, Set<NativeSslSession>>();
 
     OpenSslClientSessionCache(OpenSslEngineMap engineMap) {
         super(engineMap);
@@ -37,10 +39,17 @@ final class OpenSslClientSessionCache extends OpenSslSessionCache {
     protected boolean sessionCreated(NativeSslSession session) {
         assert Thread.holdsLock(this);
         HostPort hostPort = keyFor(session.getPeerHost(), session.getPeerPort());
-        if (hostPort == null || sessions.containsKey(hostPort)) {
+        if (hostPort == null) {
             return false;
         }
-        sessions.put(hostPort, session);
+        Set<NativeSslSession> sessionsForHost = sessions.get(hostPort);
+        if (sessionsForHost == null) {
+            // Let's start with something small as usually the server does not provide too many of these per hostPort
+            // mapping.
+            sessionsForHost = new HashSet<NativeSslSession>(4);
+            sessions.put(hostPort, sessionsForHost);
+        }
+        sessionsForHost.add(session);
         return true;
     }
 
@@ -51,7 +60,13 @@ final class OpenSslClientSessionCache extends OpenSslSessionCache {
         if (hostPort == null) {
             return;
         }
-        sessions.remove(hostPort);
+        Set<NativeSslSession> sessionsForHost = sessions.get(hostPort);
+        if (sessionsForHost != null) {
+            sessionsForHost.remove(session);
+            if (sessionsForHost.isEmpty()) {
+                sessions.remove(hostPort);
+            }
+        }
     }
 
     @Override
@@ -60,18 +75,45 @@ final class OpenSslClientSessionCache extends OpenSslSessionCache {
         if (hostPort == null) {
             return false;
         }
-        final NativeSslSession nativeSslSession;
+        NativeSslSession nativeSslSession = null;
         final boolean reused;
         boolean singleUsed = false;
         synchronized (this) {
-            nativeSslSession = sessions.get(hostPort);
+            Set<NativeSslSession> sessionsForHost = sessions.get(hostPort);
+            if (sessionsForHost == null) {
+                return false;
+            }
+            if (sessionsForHost.isEmpty()) {
+                sessions.remove(hostPort);
+                // There is no session that we can use.
+                return false;
+            }
+
+            List<NativeSslSession> toBeRemoved = null;
+            // Loop through all the sessions that might be usable and check if we can use one of these.
+            for (NativeSslSession sslSession : sessionsForHost) {
+                if (sslSession.isValid()) {
+                    nativeSslSession = sslSession;
+                    break;
+                } else {
+                    if (toBeRemoved == null) {
+                        toBeRemoved = new ArrayList<NativeSslSession>(2);
+                    }
+                    toBeRemoved.add(nativeSslSession);
+                }
+            }
+
+            // Remove everything that is not valid anymore
+            if (toBeRemoved != null) {
+                for (NativeSslSession sslSession : toBeRemoved) {
+                    removeSessionWithId(sslSession.sessionId());
+                }
+            }
             if (nativeSslSession == null) {
+                // Couldn't find a valid session that could be used.
                 return false;
             }
-            if (!nativeSslSession.isValid()) {
-                removeSessionWithId(nativeSslSession.sessionId());
-                return false;
-            }
+
             // Try to set the session, if true is returned OpenSSL incremented the reference count
             // of the underlying SSL_SESSION*.
             reused = SSL.setSession(ssl, nativeSslSession.session());


### PR DESCRIPTION
Motivation:

A server might return more then one session id for a given host / port mapping when using SSL. We should allow to resume all of these sessions and not only one.

Modifications:

- Store a List of session per host / port mapping

Result:

Be able to resume all sessions that will be provided by a server for a host / port mapping