### PR TITLE
Fix flaky BootstrapTest

### DIFF
--- a/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
+++ b/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
@@ -362,6 +362,7 @@ public class BootstrapTest {
         // Should fail with the UnknownHostException.
         assertThat(connectFuture.await(10000), is(true));
         assertThat(connectFuture.cause(), is(instanceOf(UnknownHostException.class)));
+        connectFuture.channel().closeFuture().await(10000);
         assertThat(connectFuture.channel().isOpen(), is(false));
     }
 
@@ -394,6 +395,7 @@ public class BootstrapTest {
         assertThat(connectFuture.await(10000), is(true));
         assertThat(connectFuture.cause(), instanceOf(IllegalStateException.class));
         assertThat(connectFuture.cause().getCause(), instanceOf(TestException.class));
+        connectFuture.channel().closeFuture().await(10000);
         assertThat(connectFuture.channel().isOpen(), is(false));
     }
 


### PR DESCRIPTION
Motivation:
Calls to Channel.isOpen() should be gated by the channel close future, at least if we expected the channel to be closed.

Modification:
Add some awaits on the channel close future, before asserting that a channel is closed.

Result:
The tests should no longer occasionally fail on that assertion.