### PR TITLE
Update small documentation typo

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ServerCookieDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ServerCookieDecoder.java
@@ -45,7 +45,7 @@ public final class ServerCookieDecoder extends CookieDecoder {
     private static final String RFC2965_PORT = "$Port";
 
     /**
-     * Strict encoder that validates that name and value chars are in the valid scope
+     * Strict decoder that validates that name and value chars are in the valid scope
      * defined in RFC6265
      */
     public static final ServerCookieDecoder STRICT = new ServerCookieDecoder(true);


### PR DESCRIPTION
Change the documentation for `ServerCookieDecoder.STRICT` from `Strict encoder that ...` to `Strict decoder that ...`.

Motivation: Incorrect documentation for `ServerCookieDecoder.STRICT`.

Modification: Correcting the documentation for `ServerCookieDecoder.STRICT`.

Result: 
- Correct documentation for `ServerCookieDecoder.STRICT`.
- No code changes.