### PR TITLE
Allow MessageToMessageDecoder to take care of reading more data when …

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/MessageToMessageCodec.java
+++ b/codec/src/main/java/io/netty/handler/codec/MessageToMessageCodec.java
@@ -54,6 +54,24 @@ import java.util.List;
  */
 public abstract class MessageToMessageCodec<INBOUND_IN, OUTBOUND_IN> extends ChannelDuplexHandler {
 
+    private final MessageToMessageDecoder<Object> decoder = new MessageToMessageDecoder<Object>() {
+
+        @Override
+        public boolean acceptInboundMessage(Object msg) throws Exception {
+            return MessageToMessageCodec.this.acceptInboundMessage(msg);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        protected void decode(ChannelHandlerContext ctx, Object msg, List<Object> out) throws Exception {
+            MessageToMessageCodec.this.decode(ctx, (INBOUND_IN) msg, out);
+        }
+
+        @Override
+        public boolean isSharable() {
+            return MessageToMessageCodec.this.isSharable();
+        }
+    };
     private final MessageToMessageEncoder<Object> encoder = new MessageToMessageEncoder<Object>() {
 
         @Override
@@ -66,19 +84,10 @@ public abstract class MessageToMessageCodec<INBOUND_IN, OUTBOUND_IN> extends Cha
         protected void encode(ChannelHandlerContext ctx, Object msg, List<Object> out) throws Exception {
             MessageToMessageCodec.this.encode(ctx, (OUTBOUND_IN) msg, out);
         }
-    };
-
-    private final MessageToMessageDecoder<Object> decoder = new MessageToMessageDecoder<Object>() {
 
         @Override
-        public boolean acceptInboundMessage(Object msg) throws Exception {
-            return MessageToMessageCodec.this.acceptInboundMessage(msg);
-        }
-
-        @Override
-        @SuppressWarnings("unchecked")
-        protected void decode(ChannelHandlerContext ctx, Object msg, List<Object> out) throws Exception {
-            MessageToMessageCodec.this.decode(ctx, (INBOUND_IN) msg, out);
+        public boolean isSharable() {
+            return MessageToMessageCodec.this.isSharable();
         }
     };
 
@@ -109,6 +118,11 @@ public abstract class MessageToMessageCodec<INBOUND_IN, OUTBOUND_IN> extends Cha
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
         decoder.channelRead(ctx, msg);
+    }
+
+    @Override
+    public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
+        decoder.channelReadComplete(ctx);
     }
 
     @Override

--- a/codec/src/main/java/io/netty/handler/codec/MessageToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/MessageToMessageDecoder.java
@@ -52,6 +52,8 @@ import java.util.List;
 public abstract class MessageToMessageDecoder<I> extends ChannelInboundHandlerAdapter {
 
     private final TypeParameterMatcher matcher;
+    private boolean decodeCalled;
+    private boolean messageProduced;
 
     /**
      * Create a new instance which will try to detect the types to match out of the type parameter of the class.
@@ -79,6 +81,7 @@ public abstract class MessageToMessageDecoder<I> extends ChannelInboundHandlerAd
 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        decodeCalled = true;
         CodecOutputList out = CodecOutputList.newInstance();
         try {
             if (acceptInboundMessage(msg)) {
@@ -99,6 +102,7 @@ public abstract class MessageToMessageDecoder<I> extends ChannelInboundHandlerAd
         } finally {
             try {
                 int size = out.size();
+                messageProduced |= size > 0;
                 for (int i = 0; i < size; i++) {
                     ctx.fireChannelRead(out.getUnsafe(i));
                 }
@@ -106,6 +110,19 @@ public abstract class MessageToMessageDecoder<I> extends ChannelInboundHandlerAd
                 out.recycle();
             }
         }
+    }
+
+    @Override
+    public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
+        if (!isSharable()) {
+            // Only use local vars if this decoder is not sharable as otherwise this is not safe to do.
+            if (decodeCalled && !messageProduced && !ctx.channel().config().isAutoRead()) {
+                ctx.read();
+            }
+            decodeCalled = false;
+            messageProduced = false;
+        }
+        ctx.fireChannelReadComplete();
     }
 
     /**

--- a/codec/src/test/java/io/netty/handler/codec/MessageToMessageDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/MessageToMessageDecoderTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class MessageToMessageDecoderTest {
+
+    @Test
+    void testReadIfNotAutoReadWhenNotSharable() {
+        ReadCountHandler readCountHandler = new ReadCountHandler();
+        EmbeddedChannel channel = new EmbeddedChannel(new MessageToMessageDecoder<String>() {
+            private int count;
+            @Override
+            protected void decode(ChannelHandlerContext ctx, String msg, List<Object> out)  {
+                if (count++ == 0) {
+                    return;
+                }
+                out.add(msg);
+            }
+        });
+        channel.config().setAutoRead(false);
+        channel.pipeline().addFirst(readCountHandler);
+        assertFalse(channel.writeInbound("something"));
+        assertEquals(1, readCountHandler.readCount.get());
+        assertTrue(channel.writeInbound("something"));
+        // As we produced a message in the MessageToMessageDecoder we don't expect that there will be any extra
+        // read happen.
+        assertEquals(1, readCountHandler.readCount.get());
+        assertTrue(channel.finishAndReleaseAll());
+    }
+
+    private static final class ReadCountHandler extends ChannelOutboundHandlerAdapter {
+        final AtomicInteger readCount = new AtomicInteger();
+        @Override
+        public void read(ChannelHandlerContext ctx) throws Exception {
+            readCount.incrementAndGet();
+            super.read(ctx);
+        }
+    }
+}


### PR DESCRIPTION
…needed

Motivation:

ByteToMessageDecoder already takes care of calling `read()` if we need to do so to make progress. We should do the same with MessageToMessageDecoder if possible so we make it easier for users and also ensure we do not stall

Modifications:

- Let MessageToMessageDecoder emit reads if needed when the decoder is not sharable
- Let MessageToMessageCodec emit reads if needed when the codec is not sharable

Result:

Ensure we never stall if AUTO_READ is disabled
