### PR TITLE
Refactor DnsNameResolver to be able to use different strategies when …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1405,6 +1405,12 @@
                   <new>method io.netty.handler.codec.http2.HttpToHttp2ConnectionHandlerBuilder io.netty.handler.codec.http2.HttpToHttp2ConnectionHandlerBuilder::encoderIgnoreMaxHeaderListSize(boolean)</new>
                   <justification>Acceptable incompatibility for required change, because the method was not previously exposed; protected visiblity in super-class, not made public in final sub-class until now</justification>
                 </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.removed</code>
+                  <old>method io.netty.channel.ChannelFactory&lt;&amp; extends io.netty.channel.socket.DatagramChannel&gt; io.netty.resolver.dns.DnsNameResolverBuilder::channelFactory()</old>
+                  <justification>Protected methods of a final class.</justification>
+                </item>
               </differences>
             </revapi.differences>
           </analysisConfiguration>

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DatagramDnsQueryContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DatagramDnsQueryContext.java
@@ -18,6 +18,7 @@ package io.netty.resolver.dns;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.AddressedEnvelope;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
 import io.netty.handler.codec.dns.DatagramDnsQuery;
 import io.netty.handler.codec.dns.DnsQuery;
 import io.netty.handler.codec.dns.DnsQuestion;
@@ -30,7 +31,7 @@ import java.net.InetSocketAddress;
 
 final class DatagramDnsQueryContext extends DnsQueryContext {
 
-    DatagramDnsQueryContext(Channel channel, Future<? extends Channel> channelReadyFuture,
+    DatagramDnsQueryContext(Channel channel,
                             InetSocketAddress nameServerAddr,
                             DnsQueryContextManager queryContextManager,
                             int maxPayLoadSize, boolean recursionDesired,
@@ -38,7 +39,7 @@ final class DatagramDnsQueryContext extends DnsQueryContext {
                             DnsQuestion question, DnsRecord[] additionals,
                             Promise<AddressedEnvelope<DnsResponse, InetSocketAddress>> promise,
                             Bootstrap socketBootstrap, boolean retryWithTcpOnTimeout) {
-        super(channel, channelReadyFuture, nameServerAddr, queryContextManager, maxPayLoadSize, recursionDesired,
+        super(channel, nameServerAddr, queryContextManager, maxPayLoadSize, recursionDesired,
                 queryTimeoutMillis, question, additionals, promise, socketBootstrap, retryWithTcpOnTimeout);
     }
 

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolveContext.java
@@ -26,7 +26,6 @@ import io.netty.channel.Channel;
 import io.netty.channel.EventLoop;
 import io.netty.handler.codec.dns.DnsRecord;
 import io.netty.handler.codec.dns.DnsRecordType;
-import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 
 final class DnsAddressResolveContext extends DnsResolveContext<InetAddress> {
@@ -35,12 +34,12 @@ final class DnsAddressResolveContext extends DnsResolveContext<InetAddress> {
     private final AuthoritativeDnsServerCache authoritativeDnsServerCache;
     private final boolean completeEarlyIfPossible;
 
-    DnsAddressResolveContext(DnsNameResolver parent, Channel channel, Future<? extends Channel> channelReadyFuture,
+    DnsAddressResolveContext(DnsNameResolver parent, Channel channel,
                              Promise<?> originalPromise, String hostname, DnsRecord[] additionals,
                              DnsServerAddressStream nameServerAddrs, int allowedQueries, DnsCache resolveCache,
                              AuthoritativeDnsServerCache authoritativeDnsServerCache,
                              boolean completeEarlyIfPossible) {
-        super(parent, channel, channelReadyFuture, originalPromise, hostname, DnsRecord.CLASS_IN,
+        super(parent, channel, originalPromise, hostname, DnsRecord.CLASS_IN,
               parent.resolveRecordTypes(), additionals, nameServerAddrs, allowedQueries);
         this.resolveCache = resolveCache;
         this.authoritativeDnsServerCache = authoritativeDnsServerCache;
@@ -49,13 +48,12 @@ final class DnsAddressResolveContext extends DnsResolveContext<InetAddress> {
 
     @Override
     DnsResolveContext<InetAddress> newResolverContext(DnsNameResolver parent, Channel channel,
-                                                      Future<? extends Channel> channelReadyFuture,
                                                       Promise<?> originalPromise,
                                                       String hostname,
                                                       int dnsClass, DnsRecordType[] expectedTypes,
                                                       DnsRecord[] additionals,
                                                       DnsServerAddressStream nameServerAddrs, int allowedQueries) {
-        return new DnsAddressResolveContext(parent, channel, channelReadyFuture, originalPromise, hostname, additionals,
+        return new DnsAddressResolveContext(parent, channel, originalPromise, hostname, additionals,
                 nameServerAddrs, allowedQueries, resolveCache, authoritativeDnsServerCache, completeEarlyIfPossible);
     }
 
@@ -84,7 +82,8 @@ final class DnsAddressResolveContext extends DnsResolveContext<InetAddress> {
     @Override
     void cache(String hostname, DnsRecord[] additionals,
                DnsRecord result, InetAddress convertedResult) {
-        resolveCache.cache(hostname, additionals, convertedResult, result.timeToLive(), channel().eventLoop());
+        resolveCache.cache(hostname, additionals, convertedResult, result.timeToLive(),
+                channel().eventLoop());
     }
 
     @Override

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -1507,7 +1507,7 @@ public class DnsNameResolver extends InetNameResolver {
          * Return the next {@link ChannelFuture} that contains the {@link Channel} that should be used for resolving
          * a chain of queries.
          *
-         * @param resolutionFuture the {@link Future} that will be notified once th resolution completes.
+         * @param resolutionFuture  the {@link Future} that will be notified once th resolution completes.
          * @return                  the {@link ChannelFuture}
          */
         <T> ChannelFuture nextResolveChannel(Future<T> resolutionFuture);
@@ -1557,13 +1557,12 @@ public class DnsNameResolver extends InetNameResolver {
             resolutionFuture.addListener(new FutureListener<T>() {
                 @Override
                 public void operationComplete(Future<T> future) {
-                    // Always just close the Channel.
+                    // Always just close the Channel once the resolution is considered complete.
                     f.channel().close();
                 }
             });
             return f;
         }
-
 
         @Override
         public void close() {

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
@@ -77,6 +77,7 @@ public final class DnsNameResolverBuilder {
     private boolean decodeIdn = true;
 
     private int maxNumConsolidation;
+    private DnsNameResolverChannelStrategy datagramChannelStrategy = DnsNameResolverChannelStrategy.ChannelPerResolver;
 
     /**
      * Creates a new builder.
@@ -613,6 +614,19 @@ public final class DnsNameResolverBuilder {
     }
 
     /**
+     * Set the strategy that is used to determine how a {@link DatagramChannel} is used by the resolver for sending
+     * queries over UDP protocol.
+     *
+     * @param datagramChannelStrategy  the {@link DnsNameResolverChannelStrategy} to use when doing queries over
+     *                                 UDP protocol.
+     * @return {@code this}
+     */
+    public DnsNameResolverBuilder datagramChannelStrategy(DnsNameResolverChannelStrategy datagramChannelStrategy) {
+        this.datagramChannelStrategy = ObjectUtil.checkNotNull(datagramChannelStrategy, "datagramChannelStrategy");
+        return this;
+    }
+
+    /**
      * Returns a new {@link DnsNameResolver} instance.
      *
      * @return a {@link DnsNameResolver}
@@ -665,7 +679,8 @@ public final class DnsNameResolverBuilder {
                 ndots,
                 decodeIdn,
                 completeOncePreferredResolved,
-                maxNumConsolidation);
+                maxNumConsolidation,
+                datagramChannelStrategy);
     }
 
     /**
@@ -735,6 +750,7 @@ public final class DnsNameResolverBuilder {
         copiedBuilder.completeOncePreferredResolved(completeOncePreferredResolved);
         copiedBuilder.localAddress(localAddress);
         copiedBuilder.consolidateCacheSize(maxNumConsolidation);
+        copiedBuilder.datagramChannelStrategy(datagramChannelStrategy);
         return copiedBuilder;
     }
 }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverChannelStrategy.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverChannelStrategy.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+/**
+ * Strategy that influence how {@link io.netty.channel.Channel}s are used during queries.
+ */
+public enum DnsNameResolverChannelStrategy {
+    /**
+     * Use the same underlying {@link io.netty.channel.Channel} for all queries produced by a single
+     {@link DnsNameResolver} instance.
+     */
+    ChannelPerResolver,
+    /**
+     * Use a new {@link io.netty.channel.Channel} per resolution or per explicit query. As of today this is similar
+     * to what the {@link io.netty.resolver.DefaultNameResolver} (JDK default) does. As we will need to open and close
+     * a new socket for each resolution it will come with a performance overhead. That said using this strategy should
+     * be the most robust and also guard against problems that can arise in kubernetes (or similar) setups.
+     */
+    ChannelPerResolution
+}

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsRecordResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsRecordResolveContext.java
@@ -24,39 +24,37 @@ import io.netty.handler.codec.dns.DnsQuestion;
 import io.netty.handler.codec.dns.DnsRecord;
 import io.netty.handler.codec.dns.DnsRecordType;
 import io.netty.util.ReferenceCountUtil;
-import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 
 final class DnsRecordResolveContext extends DnsResolveContext<DnsRecord> {
 
-    DnsRecordResolveContext(DnsNameResolver parent, Channel channel, Future<? extends Channel> channelReadyFuture,
+    DnsRecordResolveContext(DnsNameResolver parent, Channel channel,
                             Promise<?> originalPromise, DnsQuestion question, DnsRecord[] additionals,
                             DnsServerAddressStream nameServerAddrs, int allowedQueries) {
-        this(parent, channel, channelReadyFuture, originalPromise, question.name(), question.dnsClass(),
+        this(parent, channel, originalPromise, question.name(), question.dnsClass(),
              new DnsRecordType[] { question.type() },
              additionals, nameServerAddrs, allowedQueries);
     }
 
     private DnsRecordResolveContext(DnsNameResolver parent, Channel channel,
-                                    Future<? extends Channel> channelReadyFuture, Promise<?> originalPromise,
+                                    Promise<?> originalPromise,
                                     String hostname, int dnsClass, DnsRecordType[] expectedTypes,
                                     DnsRecord[] additionals,
                                     DnsServerAddressStream nameServerAddrs,
                                     int allowedQueries) {
-        super(parent, channel, channelReadyFuture, originalPromise, hostname, dnsClass, expectedTypes,
+        super(parent, channel, originalPromise, hostname, dnsClass, expectedTypes,
                 additionals, nameServerAddrs, allowedQueries);
     }
 
     @Override
     DnsResolveContext<DnsRecord> newResolverContext(DnsNameResolver parent, Channel channel,
-                                                    Future<? extends Channel> channelReadyFuture,
                                                     Promise<?> originalPromise,
                                                     String hostname,
                                                     int dnsClass, DnsRecordType[] expectedTypes,
                                                     DnsRecord[] additionals,
                                                     DnsServerAddressStream nameServerAddrs,
                                                     int allowedQueries) {
-        return new DnsRecordResolveContext(parent, channel, channelReadyFuture, originalPromise, hostname, dnsClass,
+        return new DnsRecordResolveContext(parent, channel, originalPromise, hostname, dnsClass,
                                            expectedTypes, additionals, nameServerAddrs, allowedQueries);
     }
 

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
@@ -20,6 +20,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.channel.AddressedEnvelope;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
 import io.netty.channel.EventLoop;
 import io.netty.handler.codec.CorruptedFrameException;
 import io.netty.handler.codec.dns.DefaultDnsQuestion;
@@ -105,7 +106,6 @@ abstract class DnsResolveContext<T> {
 
     final DnsNameResolver parent;
     private final Channel channel;
-    private final Future<? extends Channel> channelReadyFuture;
     private final Promise<?> originalPromise;
     private final DnsServerAddressStream nameServerAddrs;
     private final String hostname;
@@ -122,14 +122,13 @@ abstract class DnsResolveContext<T> {
     private boolean triedCNAME;
     private boolean completeEarly;
 
-    DnsResolveContext(DnsNameResolver parent, Channel channel, Future<? extends Channel> channelReadyFuture,
+    DnsResolveContext(DnsNameResolver parent, Channel channel,
                       Promise<?> originalPromise, String hostname, int dnsClass, DnsRecordType[] expectedTypes,
                       DnsRecord[] additionals, DnsServerAddressStream nameServerAddrs, int allowedQueries) {
         assert expectedTypes.length > 0;
 
         this.parent = parent;
         this.channel = channel;
-        this.channelReadyFuture = channelReadyFuture;
         this.originalPromise = originalPromise;
         this.hostname = hostname;
         this.dnsClass = dnsClass;
@@ -205,7 +204,6 @@ abstract class DnsResolveContext<T> {
      * Creates a new context with the given parameters.
      */
     abstract DnsResolveContext<T> newResolverContext(DnsNameResolver parent, Channel channel,
-                                                     Future<? extends Channel> channelReadyFuture,
                                                      Promise<?> originalPromise,
                                                      String hostname,
                                                      int dnsClass, DnsRecordType[] expectedTypes,
@@ -316,7 +314,7 @@ abstract class DnsResolveContext<T> {
     }
 
     void doSearchDomainQuery(String hostname, Promise<List<T>> nextPromise) {
-        DnsResolveContext<T> nextContext = newResolverContext(parent, channel, channelReadyFuture,
+        DnsResolveContext<T> nextContext = newResolverContext(parent, channel,
                 originalPromise, hostname, dnsClass,
                 expectedTypes, additionals, nameServerAddrs,
                 parent.maxQueriesPerResolve());
@@ -481,7 +479,7 @@ abstract class DnsResolveContext<T> {
         }
 
         final Future<AddressedEnvelope<DnsResponse, InetSocketAddress>> f =
-                parent.doQuery(channel, channelReadyFuture, nameServerAddr, question,
+                parent.doQuery(channel, nameServerAddr, question,
                         queryLifecycleObserver, additionals, flush, queryPromise);
 
         queriesInProgress.add(f);
@@ -577,7 +575,7 @@ abstract class DnsResolveContext<T> {
         if (!DnsNameResolver.doResolveAllCached(nameServerName, additionals, resolverPromise, resolveCache,
                 parent.searchDomains(), parent.ndots(), parent.resolvedInternetProtocolFamiliesUnsafe())) {
 
-            new DnsAddressResolveContext(parent, channel, channelReadyFuture,
+            new DnsAddressResolveContext(parent, channel,
                     originalPromise, nameServerName, additionals, parent.newNameServerAddressStream(nameServerName),
                     // Resolving the unresolved nameserver must be limited by allowedQueries
                     // so we eventually fail
@@ -895,8 +893,8 @@ abstract class DnsResolveContext<T> {
                         if (logger.isDebugEnabled()) {
                             logger.debug("{} Ignoring record {} for [{}: {}] as it contains a different name than " +
                                             "the question name [{}]. Cnames: {}, Search domains: {}",
-                                    channel, r.toString(), response.id(), envelope.sender(), questionName, cnames,
-                                    parent.searchDomains());
+                                    channel, r.toString(), response.id(), envelope.sender(),
+                                    questionName, cnames, parent.searchDomains());
                         }
                         continue;
                     }
@@ -908,7 +906,8 @@ abstract class DnsResolveContext<T> {
                 if (logger.isDebugEnabled()) {
                     logger.debug("{} Ignoring record {} for [{}: {}] as the converted record is null. "
                                     + "Hostname [{}], Additionals: {}",
-                            channel, r.toString(), response.id(), envelope.sender(), hostname, additionals);
+                            channel, r.toString(), response.id(),
+                            envelope.sender(), hostname, additionals);
                 }
                 continue;
             }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/TcpDnsQueryContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/TcpDnsQueryContext.java
@@ -17,6 +17,7 @@ package io.netty.resolver.dns;
 
 import io.netty.channel.AddressedEnvelope;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
 import io.netty.handler.codec.dns.DefaultDnsQuery;
 import io.netty.handler.codec.dns.DnsQuery;
 import io.netty.handler.codec.dns.DnsQuestion;
@@ -29,14 +30,14 @@ import java.net.InetSocketAddress;
 
 final class TcpDnsQueryContext extends DnsQueryContext {
 
-    TcpDnsQueryContext(Channel channel, Future<? extends Channel> channelReadyFuture,
+    TcpDnsQueryContext(Channel channel,
                        InetSocketAddress nameServerAddr,
                        DnsQueryContextManager queryContextManager,
                        int maxPayLoadSize, boolean recursionDesired,
                        long queryTimeoutMillis,
                        DnsQuestion question, DnsRecord[] additionals,
                        Promise<AddressedEnvelope<DnsResponse, InetSocketAddress>> promise) {
-        super(channel, channelReadyFuture, nameServerAddr, queryContextManager, maxPayLoadSize, recursionDesired,
+        super(channel, nameServerAddr, queryContextManager, maxPayLoadSize, recursionDesired,
                 // No retry via TCP.
                 queryTimeoutMillis, question, additionals, promise, null, false);
     }

--- a/resolver-dns/src/main/resources/META-INF/native-image/io.netty/netty-resolver-dns/generated/handlers/reflect-config.json
+++ b/resolver-dns/src/main/resources/META-INF/native-image/io.netty/netty-resolver-dns/generated/handlers/reflect-config.json
@@ -28,9 +28,9 @@
     "queryAllPublicMethods": true
   },
   {
-    "name": "io.netty.resolver.dns.DnsQueryContext$6$1",
+    "name": "io.netty.resolver.dns.DnsQueryContext$5$1",
     "condition": {
-      "typeReachable": "io.netty.resolver.dns.DnsQueryContext$6$1"
+      "typeReachable": "io.netty.resolver.dns.DnsQueryContext$5$1"
     },
     "queryAllPublicMethods": true
   }


### PR DESCRIPTION
…it comes to creating Channels for queries.

Motivation:

At the moment we reuse the same Channel (and so underyling socket) for all queries. It has show that this can cause problems in some deployments, we should allow to use different strategies.

Modifications:

- Refactor code to make it possible to use different strategies when it comes to creating / reusing channels for resolve operations

Result:

More flexible configuration and possible fix for https://github.com/netty/netty/issues/14364
