### PR TITLE
DnsNameResolver: allow users to skip bind() during bootstrap

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -383,6 +383,7 @@ public class DnsNameResolver extends InetNameResolver {
              searchDomains, ndots, decodeIdn, false, 0);
     }
 
+    @SuppressWarnings("deprecation")
     DnsNameResolver(
             EventLoop eventLoop,
             ChannelFactory<? extends DatagramChannel> channelFactory,
@@ -501,11 +502,13 @@ public class DnsNameResolver extends InetNameResolver {
             }
         });
 
+        final ChannelFuture future;
         if (localAddress == null) {
-            localAddress = new InetSocketAddress(0);
+            b.option(ChannelOption.DATAGRAM_CHANNEL_ACTIVE_ON_REGISTRATION, true);
+            future = b.register();
+        } else {
+            future = b.bind(localAddress);
         }
-
-        ChannelFuture future = b.bind(localAddress);
         if (future.isDone()) {
             Throwable cause = future.cause();
             if (cause != null) {

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
@@ -29,6 +29,7 @@ import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
+import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -43,6 +44,7 @@ import static io.netty.util.internal.ObjectUtil.intValue;
 public final class DnsNameResolverBuilder {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(DnsNameResolverBuilder.class);
+    static final SocketAddress DEFAULT_LOCAL_ADDRESS = new InetSocketAddress(0);
 
     volatile EventLoop eventLoop;
     private ChannelFactory<? extends DatagramChannel> channelFactory;
@@ -52,7 +54,7 @@ public final class DnsNameResolverBuilder {
     private DnsCache resolveCache;
     private DnsCnameCache cnameCache;
     private AuthoritativeDnsServerCache authoritativeDnsServerCache;
-    private SocketAddress localAddress;
+    private SocketAddress localAddress = DEFAULT_LOCAL_ADDRESS;
     private Integer minTtl;
     private Integer maxTtl;
     private Integer negativeTtl;


### PR DESCRIPTION
Motivation:

We prefer to bind by default for better debug logging (see #13817). However, some users expressed concerns with this behavior change because it eagerly binds a UDP port even when allocated resolver is not used.

Modifications:

- Keep default behavior to bind, but allow configuring `null` for `DnsNameResolverBuilder.localAddress(...)` to preserve pre-existing behavior.

Result:

Users can force pre-existing behavior of lazy port binding on resolve.