### PR TITLE
Initialize `DnsNameResolverBuilder` at runtime for native images

### DIFF
--- a/resolver-dns/src/main/resources/META-INF/native-image/io.netty/netty-resolver-dns/native-image.properties
+++ b/resolver-dns/src/main/resources/META-INF/native-image/io.netty/netty-resolver-dns/native-image.properties
@@ -15,6 +15,7 @@
 Args = --initialize-at-run-time=io.netty.resolver.dns.DefaultDnsServerAddressStreamProvider \
        --initialize-at-run-time=io.netty.resolver.dns.DnsServerAddressStreamProviders$DefaultProviderHolder \
        --initialize-at-run-time=io.netty.resolver.dns.DnsNameResolver \
+       --initialize-at-run-time=io.netty.resolver.dns.DnsNameResolverBuilder \
        --initialize-at-run-time=io.netty.resolver.HostsFileEntriesResolver \
        --initialize-at-run-time=io.netty.resolver.dns.ResolvConf$ResolvConfLazy \
        --initialize-at-run-time=io.netty.resolver.dns.DefaultDnsServerAddressStreamProvider


### PR DESCRIPTION
Motivation:

After #14375 Netty/Testsuite/NativeImage/Client started to fail with: No instances of `java.net.Inet4Address` are allowed in the image heap as this class should be initialized at image runtime.

Modifications:

- Add `DnsNameResolverBuilder` to `native-image.properties`;

Result:

Netty/Testsuite/NativeImage/Client is expected to start working again.
