### PR TITLE
Make handler tests faster by caching self-signed certificates

### DIFF
--- a/handler/src/test/java/io/netty5/handler/ssl/CloseNotifyTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/CloseNotifyTest.java
@@ -20,6 +20,7 @@ import io.netty5.buffer.BufferAllocator;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.SimpleChannelInboundHandler;
 import io.netty5.channel.embedded.EmbeddedChannel;
+import io.netty5.handler.ssl.util.CachedSelfSignedCertificate;
 import io.netty5.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty5.handler.ssl.util.SelfSignedCertificate;
 import org.junit.jupiter.api.Timeout;
@@ -147,7 +148,7 @@ public class CloseNotifyTest {
     private static EmbeddedChannel initChannel(SslProvider provider, String protocol, final boolean useClientMode,
             final BlockingQueue<Object> eventQueue) throws Exception {
 
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         final SslContext sslContext = (useClientMode
                 ? SslContextBuilder.forClient().trustManager(InsecureTrustManagerFactory.INSTANCE)
                 : SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey()))

--- a/handler/src/test/java/io/netty5/handler/ssl/JdkSslEngineTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/JdkSslEngineTest.java
@@ -19,6 +19,7 @@ import io.netty5.handler.ssl.ApplicationProtocolConfig.Protocol;
 import io.netty5.handler.ssl.ApplicationProtocolConfig.SelectedListenerFailureBehavior;
 import io.netty5.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior;
 import io.netty5.handler.ssl.JdkApplicationProtocolNegotiator.ProtocolSelector;
+import io.netty5.handler.ssl.util.CachedSelfSignedCertificate;
 import io.netty5.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty5.handler.ssl.util.SelfSignedCertificate;
 import io.netty5.util.internal.EmptyArrays;
@@ -180,7 +181,7 @@ public class JdkSslEngineTest extends SSLEngineTest {
         try {
             param.providerType.activate(this);
             // ALPN
-            SelfSignedCertificate ssc = new SelfSignedCertificate();
+            SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
             JdkApplicationProtocolNegotiator clientApn = new JdkAlpnApplicationProtocolNegotiator(true, true,
                 PREFERRED_APPLICATION_LEVEL_PROTOCOL);
             JdkApplicationProtocolNegotiator serverApn = new JdkAlpnApplicationProtocolNegotiator(

--- a/handler/src/test/java/io/netty5/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/OpenSslEngineTest.java
@@ -20,6 +20,7 @@ import io.netty5.handler.ssl.ApplicationProtocolConfig.Protocol;
 import io.netty5.handler.ssl.ApplicationProtocolConfig.SelectedListenerFailureBehavior;
 import io.netty5.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior;
 import io.netty5.handler.ssl.util.InsecureTrustManagerFactory;
+import io.netty5.handler.ssl.util.CachedSelfSignedCertificate;
 import io.netty5.handler.ssl.util.SelfSignedCertificate;
 import io.netty5.util.internal.EmptyArrays;
 import org.junit.jupiter.api.AfterEach;
@@ -245,7 +246,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
                                         .protocols(param.protocols())
                                         .ciphers(param.ciphers())
                                         .build());
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         serverSslCtx = wrapContext(param, SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                                         .sslProvider(sslServerProvider())
                                         .protocols(param.protocols())
@@ -284,7 +285,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
                                         .protocols(param.protocols())
                                         .ciphers(param.ciphers())
                                         .build());
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         serverSslCtx = wrapContext(param, SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                                         .sslProvider(sslServerProvider())
                                         .protocols(param.protocols())
@@ -340,7 +341,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
                                         .protocols(param.protocols())
                                         .ciphers(param.ciphers())
                                         .build());
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         serverSslCtx = wrapContext(param, SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                                         .sslProvider(sslServerProvider())
                                         .protocols(param.protocols())
@@ -381,7 +382,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
                                         .protocols(param.protocols())
                                         .ciphers(param.ciphers())
                                         .build());
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         serverSslCtx = wrapContext(param, SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                                         .sslProvider(sslServerProvider())
                                         .protocols(param.protocols())
@@ -475,7 +476,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
 
     private void testCorrectlyCalculateSpaceForAlert(SSLEngineTestParam param, boolean jdkCompatabilityMode)
             throws Exception {
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         serverSslCtx = wrapContext(param, SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                                         .sslProvider(sslServerProvider())
                                         .protocols(param.protocols())
@@ -526,7 +527,6 @@ public class OpenSslEngineTest extends SSLEngineTest {
         } finally {
             cleanupClientSslEngine(clientEngine);
             cleanupServerSslEngine(serverEngine);
-            ssc.delete();
         }
     }
 
@@ -543,7 +543,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
                                         .trustManager(InsecureTrustManagerFactory.INSTANCE)
                                         .sslProvider(sslClientProvider())
                                         .build());
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         serverSslCtx = wrapContext(param, SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                                         .sslProvider(sslServerProvider())
                                         .build());
@@ -575,7 +575,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
                                         .trustManager(InsecureTrustManagerFactory.INSTANCE)
                                         .sslProvider(sslClientProvider())
                                         .build());
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         serverSslCtx = wrapContext(param, SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                                         .sslProvider(sslServerProvider())
                                         .build());
@@ -604,7 +604,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
                 .trustManager(InsecureTrustManagerFactory.INSTANCE)
                 .sslProvider(sslClientProvider())
                 .build());
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         serverSslCtx = wrapContext(param, SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                 .sslProvider(sslServerProvider())
                 .build());
@@ -643,7 +643,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
                 .trustManager(InsecureTrustManagerFactory.INSTANCE)
                 .sslProvider(sslClientProvider())
                 .build());
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         serverSslCtx = wrapContext(param, SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                 .sslProvider(sslServerProvider())
                 .build());
@@ -679,7 +679,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
     @ParameterizedTest
     public void testMultipleRecordsInOneBufferWithNonZeroPositionJDKCompatabilityModeOff(SSLEngineTestParam param)
             throws Exception {
-        SelfSignedCertificate cert = new SelfSignedCertificate();
+        SelfSignedCertificate cert = CachedSelfSignedCertificate.getCachedCertificate();
 
         clientSslCtx = wrapContext(param, SslContextBuilder
                 .forClient()
@@ -753,7 +753,6 @@ public class OpenSslEngineTest extends SSLEngineTest {
             assertEquals(combinedEncClientToServerLen, result.bytesConsumed());
             assertEquals(plainClientOutLen, result.bytesProduced());
         } finally {
-            cert.delete();
             cleanupClientSslEngine(client);
             cleanupServerSslEngine(server);
         }
@@ -762,7 +761,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
     @MethodSource("newTestParams")
     @ParameterizedTest
     public void testInputTooBigAndFillsUpBuffersJDKCompatabilityModeOff(SSLEngineTestParam param) throws Exception {
-        SelfSignedCertificate cert = new SelfSignedCertificate();
+        SelfSignedCertificate cert = CachedSelfSignedCertificate.getCachedCertificate();
 
         clientSslCtx = wrapContext(param, SslContextBuilder
                 .forClient()
@@ -845,7 +844,6 @@ public class OpenSslEngineTest extends SSLEngineTest {
             plainServer.flip();
             assertEquals(plainClientTotal, plainServer);
         } finally {
-            cert.delete();
             cleanupClientSslEngine(client);
             cleanupServerSslEngine(server);
         }
@@ -854,7 +852,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
     @MethodSource("newTestParams")
     @ParameterizedTest
     public void testPartialPacketUnwrapJDKCompatabilityModeOff(SSLEngineTestParam param) throws Exception {
-        SelfSignedCertificate cert = new SelfSignedCertificate();
+        SelfSignedCertificate cert = CachedSelfSignedCertificate.getCachedCertificate();
 
         clientSslCtx = wrapContext(param, SslContextBuilder
                 .forClient()
@@ -927,7 +925,6 @@ public class OpenSslEngineTest extends SSLEngineTest {
             plainServer.flip();
             assertEquals(plainClientTotal, plainServer);
         } finally {
-            cert.delete();
             cleanupClientSslEngine(client);
             cleanupServerSslEngine(server);
         }
@@ -936,7 +933,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
     @MethodSource("newTestParams")
     @ParameterizedTest
     public void testBufferUnderFlowAvoidedIfJDKCompatabilityModeOff(SSLEngineTestParam param) throws Exception {
-        SelfSignedCertificate cert = new SelfSignedCertificate();
+        SelfSignedCertificate cert = CachedSelfSignedCertificate.getCachedCertificate();
 
         clientSslCtx = wrapContext(param, SslContextBuilder
                 .forClient()
@@ -1014,7 +1011,6 @@ public class OpenSslEngineTest extends SSLEngineTest {
             assertEquals(remaining, result.bytesConsumed());
             assertEquals(0, result.bytesProduced());
         } finally {
-            cert.delete();
             cleanupClientSslEngine(client);
             cleanupServerSslEngine(server);
         }
@@ -1078,7 +1074,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
     @MethodSource("newTestParams")
     @ParameterizedTest
     public void testSNIMatchersDoesNotThrow(SSLEngineTestParam param) throws Exception {
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         serverSslCtx = wrapContext(param, SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                                         .sslProvider(sslServerProvider())
                                         .protocols(param.protocols())
@@ -1092,7 +1088,6 @@ public class OpenSslEngineTest extends SSLEngineTest {
             engine.setSSLParameters(parameters);
         } finally {
             cleanupServerSslEngine(engine);
-            ssc.delete();
         }
     }
 
@@ -1100,7 +1095,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
     @ParameterizedTest
     public void testSNIMatchersWithSNINameWithUnderscore(SSLEngineTestParam param) throws Exception {
         byte[] name = "rb8hx3pww30y3tvw0mwy.v1_1".getBytes(UTF_8);
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         serverSslCtx = wrapContext(param, SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                                         .sslProvider(sslServerProvider())
                                         .protocols(param.protocols())
@@ -1115,7 +1110,6 @@ public class OpenSslEngineTest extends SSLEngineTest {
             assertFalse(unwrapEngine(engine).checkSniHostnameMatch("other".getBytes(UTF_8)));
         } finally {
             cleanupServerSslEngine(engine);
-            ssc.delete();
         }
     }
 
@@ -1136,7 +1130,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
     @MethodSource("newTestParams")
     @ParameterizedTest
     public void testAlgorithmConstraintsThrows(SSLEngineTestParam param) throws Exception {
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         serverSslCtx = wrapContext(param, SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                                         .sslProvider(sslServerProvider())
                                         .protocols(param.protocols())
@@ -1172,7 +1166,6 @@ public class OpenSslEngineTest extends SSLEngineTest {
             });
         } finally {
             cleanupServerSslEngine(engine);
-            ssc.delete();
         }
     }
 
@@ -1195,7 +1188,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
         if (param.combo() != ProtocolCipherCombo.tlsv12()) {
             return;
         }
-        SelfSignedCertificate cert = new SelfSignedCertificate();
+        SelfSignedCertificate cert = CachedSelfSignedCertificate.getCachedCertificate();
         serverSslCtx = wrapContext(param, SslContextBuilder.forServer(cert.key(), cert.cert())
                 .protocols(param.protocols())
                 .ciphers(param.ciphers())
@@ -1352,7 +1345,6 @@ public class OpenSslEngineTest extends SSLEngineTest {
         } finally {
             cleanupClientSslEngine(clientEngine);
             cleanupServerSslEngine(serverEngine);
-            cert.delete();
         }
     }
 
@@ -1472,7 +1464,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
             clientCtxBuilder.protocols(clientProtocol);
         }
         clientSslCtx = wrapContext(param, clientCtxBuilder.build());
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
 
         SslContextBuilder serverCtxBuilder = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                 .sslProvider(sslServerProvider())
@@ -1494,7 +1486,6 @@ public class OpenSslEngineTest extends SSLEngineTest {
         } finally {
             cleanupClientSslEngine(client);
             cleanupServerSslEngine(server);
-            ssc.delete();
         }
     }
 
@@ -1603,7 +1594,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
     @Test
     public void testExtraDataInLastSrcBufferForClientUnwrapNonjdkCompatabilityMode() throws Exception {
         SSLEngineTestParam param = new SSLEngineTestParam(BufferType.Direct, ProtocolCipherCombo.tlsv12(), false);
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         clientSslCtx = wrapContext(param, SslContextBuilder.forClient()
                 .trustManager(InsecureTrustManagerFactory.INSTANCE)
                 .sslProvider(sslClientProvider())
@@ -1628,7 +1619,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
     public void testMaxCertificateList(final SSLEngineTestParam param) throws Exception {
         assumeTrue(SslProvider.isOptionSupported(sslClientProvider(), OpenSslContextOption.MAX_CERTIFICATE_LIST_BYTES));
         assumeTrue(SslProvider.isOptionSupported(sslServerProvider(), OpenSslContextOption.MAX_CERTIFICATE_LIST_BYTES));
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         clientSslCtx = wrapContext(param, SslContextBuilder.forClient()
                 .trustManager(InsecureTrustManagerFactory.INSTANCE)
                 .keyManager(ssc.certificate(), ssc.privateKey())
@@ -1666,7 +1657,6 @@ public class OpenSslEngineTest extends SSLEngineTest {
         } finally {
             cleanupClientSslEngine(client);
             cleanupServerSslEngine(server);
-            ssc.delete();
         }
     }
 }

--- a/handler/src/test/java/io/netty5/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/OpenSslEngineTest.java
@@ -83,7 +83,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
     private static final String FALLBACK_APPLICATION_LEVEL_PROTOCOL = "my-protocol-http1_1";
 
     public OpenSslEngineTest() {
-        super(SslProvider.isTlsv13Supported(SslProvider.OPENSSL));
+        super(SslProvider.isTlsv13Supported(OPENSSL));
     }
 
     @Override

--- a/handler/src/test/java/io/netty5/handler/ssl/ParameterizedSslHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/ParameterizedSslHandlerTest.java
@@ -35,6 +35,7 @@ import io.netty5.channel.local.LocalServerChannel;
 import io.netty5.channel.nio.NioIoHandler;
 import io.netty5.channel.socket.nio.NioServerSocketChannel;
 import io.netty5.channel.socket.nio.NioSocketChannel;
+import io.netty5.handler.ssl.util.CachedSelfSignedCertificate;
 import io.netty5.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty5.handler.ssl.util.SelfSignedCertificate;
 import io.netty5.handler.ssl.util.SimpleTrustManagerFactory;
@@ -126,7 +127,7 @@ public class ParameterizedSslHandlerTest {
             final boolean serverDisableWrapSize,
             final boolean letHandlerCreateServerEngine, final boolean letHandlerCreateClientEngine)
             throws CertificateException, SSLException, ExecutionException, InterruptedException {
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
 
         final SslContext sslServerCtx = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                 .sslProvider(serverProvider)
@@ -270,7 +271,6 @@ public class ParameterizedSslHandlerTest {
 
             Resource.dispose(sslServerCtx);
             Resource.dispose(sslClientCtx);
-            ssc.delete();
         }
     }
 
@@ -278,7 +278,7 @@ public class ParameterizedSslHandlerTest {
     @MethodSource("data")
     @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
     public void testAlertProducedAndSend(SslProvider clientProvider, SslProvider serverProvider) throws Exception {
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
 
         final SslContext sslServerCtx = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                 .sslProvider(serverProvider)
@@ -399,7 +399,7 @@ public class ParameterizedSslHandlerTest {
 
     private static void testCloseNotify(SslProvider clientProvider, SslProvider serverProvider,
                                         final long closeNotifyReadTimeout, final boolean timeout) throws Exception {
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
 
         final SslContext sslServerCtx = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                                                          .sslProvider(serverProvider)
@@ -560,7 +560,7 @@ public class ParameterizedSslHandlerTest {
                                                    Class<? extends ServerChannel> serverClass,
                                                    Class<? extends Channel> clientClass, boolean serverAutoRead,
                                                    boolean clientAutoRead) throws Exception {
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         final SslContext sslServerCtx = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                 .sslProvider(serverProvider)
                 .build();

--- a/handler/src/test/java/io/netty5/handler/ssl/PemEncodedTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/PemEncodedTest.java
@@ -29,6 +29,7 @@ import java.security.PrivateKey;
 
 import static io.netty5.util.internal.SilentDispose.autoClosing;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
@@ -61,7 +62,7 @@ public class PemEncodedTest {
         assertFalse(pemKey.isDestroyed());
         assertTrue(pemCert.isAccessible());
         try (AutoCloseable ignore = autoClosing(context)) {
-            assertTrue(context instanceof ReferenceCountedOpenSslContext);
+            assertInstanceOf(ReferenceCountedOpenSslContext.class, context);
         }
         assertRelease(pemKey);
         assertRelease(pemCert);
@@ -98,22 +99,14 @@ public class PemEncodedTest {
     }
 
     private static byte[] toByteArray(File file) throws Exception {
-        FileInputStream in = new FileInputStream(file);
-        try {
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            try {
-                byte[] buf = new byte[1024];
-                int len;
-                while ((len = in.read(buf)) != -1) {
-                    baos.write(buf, 0, len);
-                }
-            } finally {
-                baos.close();
+        try (FileInputStream in = new FileInputStream(file);
+             ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            byte[] buf = new byte[1024];
+            int len;
+            while ((len = in.read(buf)) != -1) {
+                baos.write(buf, 0, len);
             }
-
             return baos.toByteArray();
-        } finally {
-            in.close();
         }
     }
 }

--- a/handler/src/test/java/io/netty5/handler/ssl/PemEncodedTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/PemEncodedTest.java
@@ -17,6 +17,7 @@
 package io.netty5.handler.ssl;
 
 import io.netty5.util.Resource;
+import io.netty5.handler.ssl.util.CachedSelfSignedCertificate;
 import io.netty5.handler.ssl.util.SelfSignedCertificate;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
@@ -47,15 +48,9 @@ public class PemEncodedTest {
     private static void testPemEncoded(SslProvider provider) throws Exception {
         OpenSsl.ensureAvailability();
         assumeFalse(OpenSsl.supportsKeyManagerFactory());
-        PemPrivateKey pemKey;
-        PemX509Certificate pemCert;
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
-        try {
-            pemKey = PemPrivateKey.valueOf(toByteArray(ssc.privateKey()));
-            pemCert = PemX509Certificate.valueOf(toByteArray(ssc.certificate()));
-        } finally {
-            ssc.delete();
-        }
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
+        PemPrivateKey pemKey = PemPrivateKey.valueOf(toByteArray(ssc.privateKey()));
+        PemX509Certificate pemCert = PemX509Certificate.valueOf(toByteArray(ssc.certificate()));
 
         assertTrue(pemKey.content().readOnly());
         assertTrue(pemCert.content().readOnly());

--- a/handler/src/test/java/io/netty5/handler/ssl/RenegotiateTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/RenegotiateTest.java
@@ -27,6 +27,7 @@ import io.netty5.channel.local.LocalAddress;
 import io.netty5.channel.local.LocalChannel;
 import io.netty5.channel.local.LocalIoHandler;
 import io.netty5.channel.local.LocalServerChannel;
+import io.netty5.handler.ssl.util.CachedSelfSignedCertificate;
 import io.netty5.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty5.handler.ssl.util.SelfSignedCertificate;
 import io.netty5.util.Resource;
@@ -44,7 +45,7 @@ public abstract class RenegotiateTest {
     public void testRenegotiateServer() throws Throwable {
         final AtomicReference<Throwable> error = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(2);
-        SelfSignedCertificate cert = new SelfSignedCertificate();
+        SelfSignedCertificate cert = CachedSelfSignedCertificate.getCachedCertificate();
         EventLoopGroup group = new MultithreadEventLoopGroup(LocalIoHandler.newFactory());
         try {
             final SslContext context = SslContextBuilder.forServer(cert.key(), cert.cert())

--- a/handler/src/test/java/io/netty5/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SSLEngineTest.java
@@ -113,6 +113,7 @@ import java.security.Provider;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -147,7 +148,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
-import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.verify;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -2927,18 +2927,18 @@ public abstract class SSLEngineTest {
                                 new X509TrustManager() {
                                     @Override
                                     public void checkClientTrusted(
-                                            java.security.cert.X509Certificate[] x509Certificates, String s) {
+                                            X509Certificate[] x509Certificates, String s) {
                                         // NOOP
                                     }
 
                                     @Override
                                     public void checkServerTrusted(
-                                            java.security.cert.X509Certificate[] x509Certificates, String s) {
+                                            X509Certificate[] x509Certificates, String s) {
                                         // NOOP
                                     }
 
                                     @Override
-                                    public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+                                    public X509Certificate[] getAcceptedIssuers() {
                                         return EmptyArrays.EMPTY_X509_CERTIFICATES;
                                     }
                                 }
@@ -3204,7 +3204,7 @@ public abstract class SSLEngineTest {
         /**
          * The session was reused.
          */
-        REUSED;
+        REUSED
     }
 
     protected SessionReusedState isSessionReused(SSLEngine engine) {
@@ -3451,7 +3451,7 @@ public abstract class SSLEngineTest {
         SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         KeyManagerFactory kmf = useKeyManagerFactory ?
                 SslContext.buildKeyManagerFactory(
-                        new java.security.cert.X509Certificate[] { ssc.cert()}, null,
+                        new X509Certificate[] { ssc.cert()}, null,
                         ssc.key(), null, null, null) : null;
 
         SslContextBuilder clientContextBuilder = SslContextBuilder.forClient();
@@ -3466,7 +3466,7 @@ public abstract class SSLEngineTest {
         final String handshakeKey = "handshake";
         TrustManagerFactory tmf = new ConstantTrustManagerFactory(new EmptyExtendedX509TrustManager() {
             @Override
-            public void checkClientTrusted(java.security.cert.X509Certificate[] chain,
+            public void checkClientTrusted(X509Certificate[] chain,
                                            String authType, SSLEngine engine) {
                 // This is broken in conscrypt.
                 // TODO: Open an issue in the conscrypt project.
@@ -3477,7 +3477,7 @@ public abstract class SSLEngineTest {
             }
 
             @Override
-            public void checkServerTrusted(java.security.cert.X509Certificate[] chain,
+            public void checkServerTrusted(X509Certificate[] chain,
                                            String authType, SSLEngine engine) {
                 // This is broken in conscrypt.
                 // TODO: Open an issue in the conscrypt project.
@@ -3736,7 +3736,7 @@ public abstract class SSLEngineTest {
                                 }
 
                                 @Override
-                                public java.security.cert.X509Certificate[] getCertificateChain(String s) {
+                                public X509Certificate[] getCertificateChain(String s) {
                                     return x509ExtendedKeyManager.getCertificateChain(s);
                                 }
 
@@ -4055,7 +4055,7 @@ public abstract class SSLEngineTest {
             throws UnrecoverableKeyException, KeyStoreException, NoSuchAlgorithmException,
             CertificateException, IOException {
         return SslContext.buildKeyManagerFactory(
-                new java.security.cert.X509Certificate[] { ssc.cert() }, null, ssc.key(), null, null, null);
+                new X509Certificate[] { ssc.cert() }, null, ssc.key(), null, null, null);
     }
 
     private static final class TestTrustManagerFactory extends X509ExtendedTrustManager {
@@ -4072,19 +4072,19 @@ public abstract class SSLEngineTest {
 
         @Override
         public void checkClientTrusted(
-                java.security.cert.X509Certificate[] x509Certificates, String s, Socket socket) {
+                X509Certificate[] x509Certificates, String s, Socket socket) {
             fail();
         }
 
         @Override
         public void checkServerTrusted(
-                java.security.cert.X509Certificate[] x509Certificates, String s, Socket socket) {
+                X509Certificate[] x509Certificates, String s, Socket socket) {
             fail();
         }
 
         @Override
         public void checkClientTrusted(
-                java.security.cert.X509Certificate[] x509Certificates, String s, SSLEngine sslEngine) {
+                X509Certificate[] x509Certificates, String s, SSLEngine sslEngine) {
             verified = true;
             assertFalse(sslEngine.getUseClientMode());
             SSLSession session = sslEngine.getHandshakeSession();
@@ -4098,7 +4098,7 @@ public abstract class SSLEngineTest {
 
         @Override
         public void checkServerTrusted(
-                java.security.cert.X509Certificate[] x509Certificates, String s, SSLEngine sslEngine) {
+                X509Certificate[] x509Certificates, String s, SSLEngine sslEngine) {
             verified = true;
             assertTrue(sslEngine.getUseClientMode());
             SSLSession session = sslEngine.getHandshakeSession();
@@ -4109,18 +4109,18 @@ public abstract class SSLEngineTest {
 
         @Override
         public void checkClientTrusted(
-                java.security.cert.X509Certificate[] x509Certificates, String s) {
+                X509Certificate[] x509Certificates, String s) {
             fail();
         }
 
         @Override
         public void checkServerTrusted(
-                java.security.cert.X509Certificate[] x509Certificates, String s) {
+                X509Certificate[] x509Certificates, String s) {
             fail();
         }
 
         @Override
-        public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+        public X509Certificate[] getAcceptedIssuers() {
             return EmptyArrays.EMPTY_X509_CERTIFICATES;
         }
     }

--- a/handler/src/test/java/io/netty5/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SSLEngineTest.java
@@ -33,6 +33,7 @@ import io.netty5.channel.socket.SocketChannel;
 import io.netty5.channel.socket.nio.NioServerSocketChannel;
 import io.netty5.channel.socket.nio.NioSocketChannel;
 import io.netty5.handler.ssl.ApplicationProtocolConfig.Protocol;
+import io.netty5.handler.ssl.util.CachedSelfSignedCertificate;
 import io.netty5.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty5.handler.ssl.util.SelfSignedCertificate;
 import io.netty5.handler.ssl.util.SimpleTrustManagerFactory;
@@ -441,7 +442,7 @@ public abstract class SSLEngineTest {
         if (param.protocolCipherCombo != ProtocolCipherCombo.tlsv12()) {
             return;
         }
-        SelfSignedCertificate cert = new SelfSignedCertificate();
+        SelfSignedCertificate cert = CachedSelfSignedCertificate.getCachedCertificate();
         serverSslCtx = wrapContext(param, SslContextBuilder.forServer(cert.key(), cert.cert())
             .protocols(param.protocols())
             .ciphers(param.ciphers())
@@ -467,7 +468,6 @@ public abstract class SSLEngineTest {
         } finally {
             cleanupClientSslEngine(clientEngine);
             cleanupServerSslEngine(serverEngine);
-            cert.delete();
         }
     }
 
@@ -477,7 +477,7 @@ public abstract class SSLEngineTest {
         assumeTrue(SslProvider.isTlsv13Supported(sslClientProvider()));
         assumeTrue(SslProvider.isTlsv13Supported(sslServerProvider()));
 
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         // Select a mandatory cipher from the TLSv1.2 RFC https://www.ietf.org/rfc/rfc5246.txt so handshakes won't fail
         // due to no shared/supported cipher.
         clientSslCtx = wrapContext(param, SslContextBuilder.forClient()
@@ -517,7 +517,6 @@ public abstract class SSLEngineTest {
         } finally {
             cleanupClientSslEngine(clientEngine);
             cleanupServerSslEngine(serverEngine);
-            ssc.delete();
         }
     }
 
@@ -1243,7 +1242,7 @@ public abstract class SSLEngineTest {
                 .protocols(param.protocols())
                 .ciphers(param.ciphers())
                 .build());
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         serverSslCtx = wrapContext(param, SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                 .sslProvider(sslServerProvider())
                 .sslContextProvider(serverSslContextProvider())
@@ -1264,7 +1263,6 @@ public abstract class SSLEngineTest {
         } finally {
             cleanupClientSslEngine(clientEngine);
             cleanupServerSslEngine(serverEngine);
-            ssc.delete();
         }
     }
 
@@ -1278,7 +1276,7 @@ public abstract class SSLEngineTest {
                 .protocols(param.protocols())
                 .sslContextProvider(clientSslContextProvider())
                 .build());
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         serverSslCtx = wrapContext(param, SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                 .sslProvider(sslServerProvider())
                 // This test only works for non TLSv1.3 for now
@@ -1348,7 +1346,6 @@ public abstract class SSLEngineTest {
         } finally {
             cleanupClientSslEngine(clientEngine);
             cleanupServerSslEngine(serverEngine);
-            ssc.delete();
         }
     }
 
@@ -1357,7 +1354,7 @@ public abstract class SSLEngineTest {
     @Timeout(30)
     public void clientInitiatedRenegotiationWithFatalAlertDoesNotInfiniteLoopServer(final SSLEngineTestParam param)
             throws Exception {
-        final SelfSignedCertificate ssc = new SelfSignedCertificate();
+        final SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         serverSslCtx = wrapContext(param, SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                                         .sslProvider(sslServerProvider())
                                         .sslContextProvider(serverSslContextProvider())
@@ -1475,7 +1472,6 @@ public abstract class SSLEngineTest {
         clientChannel = ccf.asStage().get();
 
         serverLatch.await();
-        ssc.delete();
     }
 
     protected void testEnablingAnAlreadyDisabledSslProtocol(SSLEngineTestParam param,
@@ -1723,42 +1719,38 @@ public abstract class SSLEngineTest {
     protected void setupHandlers(SSLEngineTestParam param,
                                  ApplicationProtocolConfig serverApn, ApplicationProtocolConfig clientApn)
             throws Exception {
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
 
-        try {
-            SslContextBuilder serverCtxBuilder = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey(), null)
-                                                         .sslProvider(sslServerProvider())
-                                                         .sslContextProvider(serverSslContextProvider())
-                                                         .ciphers(null, IdentityCipherSuiteFilter.INSTANCE)
-                                                         .applicationProtocolConfig(serverApn)
-                                                         .sessionCacheSize(0)
-                                                         .sessionTimeout(0);
-            if (serverApn.protocol() == Protocol.NPN || serverApn.protocol() == Protocol.NPN_AND_ALPN) {
-                // NPN is not really well supported with TLSv1.3 so force to use TLSv1.2
-                // See https://github.com/openssl/openssl/issues/3665
-                serverCtxBuilder.protocols(SslProtocols.TLS_v1_2);
-            }
-
-            SslContextBuilder clientCtxBuilder = SslContextBuilder.forClient()
-                             .sslProvider(sslClientProvider())
-                             .sslContextProvider(clientSslContextProvider())
-                             .applicationProtocolConfig(clientApn)
-                             .trustManager(InsecureTrustManagerFactory.INSTANCE)
-                             .ciphers(null, IdentityCipherSuiteFilter.INSTANCE)
-                             .sessionCacheSize(0)
-                             .sessionTimeout(0);
-
-            if (clientApn.protocol() == Protocol.NPN || clientApn.protocol() == Protocol.NPN_AND_ALPN) {
-                // NPN is not really well supported with TLSv1.3 so force to use TLSv1.2
-                // See https://github.com/openssl/openssl/issues/3665
-                clientCtxBuilder.protocols(SslProtocols.TLS_v1_2);
-            }
-
-            setupHandlers(param.type(), param.delegate(),
-                    wrapContext(param, serverCtxBuilder.build()), wrapContext(param, clientCtxBuilder.build()));
-        } finally {
-          ssc.delete();
+        SslContextBuilder serverCtxBuilder = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey(), null)
+                .sslProvider(sslServerProvider())
+                .sslContextProvider(serverSslContextProvider())
+                .ciphers(null, IdentityCipherSuiteFilter.INSTANCE)
+                .applicationProtocolConfig(serverApn)
+                .sessionCacheSize(0)
+                .sessionTimeout(0);
+        if (serverApn.protocol() == Protocol.NPN || serverApn.protocol() == Protocol.NPN_AND_ALPN) {
+            // NPN is not really well supported with TLSv1.3 so force to use TLSv1.2
+            // See https://github.com/openssl/openssl/issues/3665
+            serverCtxBuilder.protocols(SslProtocols.TLS_v1_2);
         }
+
+        SslContextBuilder clientCtxBuilder = SslContextBuilder.forClient()
+                .sslProvider(sslClientProvider())
+                .sslContextProvider(clientSslContextProvider())
+                .applicationProtocolConfig(clientApn)
+                .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                .ciphers(null, IdentityCipherSuiteFilter.INSTANCE)
+                .sessionCacheSize(0)
+                .sessionTimeout(0);
+
+        if (clientApn.protocol() == Protocol.NPN || clientApn.protocol() == Protocol.NPN_AND_ALPN) {
+            // NPN is not really well supported with TLSv1.3 so force to use TLSv1.2
+            // See https://github.com/openssl/openssl/issues/3665
+            clientCtxBuilder.protocols(SslProtocols.TLS_v1_2);
+        }
+
+        setupHandlers(param.type(), param.delegate(),
+                wrapContext(param, serverCtxBuilder.build()), wrapContext(param, clientCtxBuilder.build()));
     }
 
     protected void setupHandlers(final BufferType type, final boolean delegate,
@@ -1939,7 +1931,7 @@ public abstract class SSLEngineTest {
     @MethodSource("newTestParams")
     @ParameterizedTest
     public void testUnwrapBehavior(SSLEngineTestParam param) throws Exception {
-        SelfSignedCertificate cert = new SelfSignedCertificate();
+        SelfSignedCertificate cert = CachedSelfSignedCertificate.getCachedCertificate();
 
         clientSslCtx = wrapContext(param, SslContextBuilder
                 .forClient()
@@ -2020,7 +2012,6 @@ public abstract class SSLEngineTest {
         } finally {
             cleanupClientSslEngine(client);
             cleanupServerSslEngine(server);
-            cert.delete();
         }
     }
 
@@ -2039,7 +2030,7 @@ public abstract class SSLEngineTest {
     private void testProtocol(final SSLEngineTestParam param, boolean handshakeFails,
                               String[] clientProtocols, String[] serverProtocols)
             throws Exception {
-        SelfSignedCertificate cert = new SelfSignedCertificate();
+        SelfSignedCertificate cert = CachedSelfSignedCertificate.getCachedCertificate();
 
         clientSslCtx = wrapContext(param, SslContextBuilder
                 .forClient()
@@ -2073,7 +2064,6 @@ public abstract class SSLEngineTest {
         } finally {
             cleanupClientSslEngine(client);
             cleanupServerSslEngine(server);
-            cert.delete();
         }
     }
 
@@ -2090,7 +2080,7 @@ public abstract class SSLEngineTest {
     @ParameterizedTest
     public void testHandshakeCompletesWithNonContiguousProtocolsTLSv1_2CipherOnly(SSLEngineTestParam param)
             throws Exception {
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         // Select a mandatory cipher from the TLSv1.2 RFC https://www.ietf.org/rfc/rfc5246.txt so handshakes won't fail
         // due to no shared/supported cipher.
         final String sharedCipher = "TLS_RSA_WITH_AES_128_CBC_SHA";
@@ -2117,14 +2107,13 @@ public abstract class SSLEngineTest {
         } finally {
             cleanupClientSslEngine(clientEngine);
             cleanupServerSslEngine(serverEngine);
-            ssc.delete();
         }
     }
 
     @MethodSource("newTestParams")
     @ParameterizedTest
     public void testHandshakeCompletesWithoutFilteringSupportedCipher(SSLEngineTestParam param) throws Exception {
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         // Select a mandatory cipher from the TLSv1.2 RFC https://www.ietf.org/rfc/rfc5246.txt so handshakes won't fail
         // due to no shared/supported cipher.
         final String sharedCipher = "TLS_RSA_WITH_AES_128_CBC_SHA";
@@ -2151,14 +2140,13 @@ public abstract class SSLEngineTest {
         } finally {
             cleanupClientSslEngine(clientEngine);
             cleanupServerSslEngine(serverEngine);
-            ssc.delete();
         }
     }
 
     @MethodSource("newTestParams")
     @ParameterizedTest
     public void testPacketBufferSizeLimit(SSLEngineTestParam param) throws Exception {
-        SelfSignedCertificate cert = new SelfSignedCertificate();
+        SelfSignedCertificate cert = CachedSelfSignedCertificate.getCachedCertificate();
 
         clientSslCtx = wrapContext(param, SslContextBuilder
                 .forClient()
@@ -2203,7 +2191,6 @@ public abstract class SSLEngineTest {
         } finally {
             cleanupClientSslEngine(client);
             cleanupServerSslEngine(server);
-            cert.delete();
         }
     }
 
@@ -2274,7 +2261,7 @@ public abstract class SSLEngineTest {
     @MethodSource("newTestParams")
     @ParameterizedTest
     public void testBeginHandshakeCloseOutbound(SSLEngineTestParam param) throws Exception {
-        SelfSignedCertificate cert = new SelfSignedCertificate();
+        SelfSignedCertificate cert = CachedSelfSignedCertificate.getCachedCertificate();
 
         clientSslCtx = wrapContext(param, SslContextBuilder
                 .forClient()
@@ -2300,7 +2287,6 @@ public abstract class SSLEngineTest {
         } finally {
             cleanupClientSslEngine(client);
             cleanupServerSslEngine(server);
-            cert.delete();
         }
     }
 
@@ -2328,7 +2314,7 @@ public abstract class SSLEngineTest {
     @MethodSource("newTestParams")
     @ParameterizedTest
     public void testCloseInboundAfterBeginHandshake(SSLEngineTestParam param) throws Exception {
-        SelfSignedCertificate cert = new SelfSignedCertificate();
+        SelfSignedCertificate cert = CachedSelfSignedCertificate.getCachedCertificate();
 
         clientSslCtx = wrapContext(param, SslContextBuilder
                 .forClient()
@@ -2354,7 +2340,6 @@ public abstract class SSLEngineTest {
         } finally {
             cleanupClientSslEngine(client);
             cleanupServerSslEngine(server);
-            cert.delete();
         }
     }
 
@@ -2375,7 +2360,7 @@ public abstract class SSLEngineTest {
     @MethodSource("newTestParams")
     @ParameterizedTest
     public void testCloseNotifySequence(SSLEngineTestParam param) throws Exception {
-        SelfSignedCertificate cert = new SelfSignedCertificate();
+        SelfSignedCertificate cert = CachedSelfSignedCertificate.getCachedCertificate();
 
         clientSslCtx = wrapContext(param, SslContextBuilder
                 .forClient()
@@ -2518,7 +2503,6 @@ public abstract class SSLEngineTest {
             result = client.unwrap(encryptedServerToClient, plainClientOut);
             assertEngineRemainsClosed(result);
         } finally {
-            cert.delete();
             cleanupClientSslEngine(client);
             cleanupServerSslEngine(server);
         }
@@ -2534,7 +2518,7 @@ public abstract class SSLEngineTest {
     @MethodSource("newTestParams")
     @ParameterizedTest
     public void testWrapAfterCloseOutbound(SSLEngineTestParam param) throws Exception {
-        SelfSignedCertificate cert = new SelfSignedCertificate();
+        SelfSignedCertificate cert = CachedSelfSignedCertificate.getCachedCertificate();
 
         clientSslCtx = wrapContext(param, SslContextBuilder
                 .forClient()
@@ -2572,7 +2556,6 @@ public abstract class SSLEngineTest {
             assertTrue(client.isOutboundDone());
             assertFalse(client.isInboundDone());
         } finally {
-            cert.delete();
             cleanupClientSslEngine(client);
             cleanupServerSslEngine(server);
         }
@@ -2581,7 +2564,7 @@ public abstract class SSLEngineTest {
     @MethodSource("newTestParams")
     @ParameterizedTest
     public void testMultipleRecordsInOneBufferWithNonZeroPosition(SSLEngineTestParam param) throws Exception {
-        SelfSignedCertificate cert = new SelfSignedCertificate();
+        SelfSignedCertificate cert = CachedSelfSignedCertificate.getCachedCertificate();
 
         clientSslCtx = wrapContext(param, SslContextBuilder
                 .forClient()
@@ -2655,7 +2638,6 @@ public abstract class SSLEngineTest {
             assertEquals(encClientToServerLen, result.bytesConsumed());
             assertTrue(result.bytesProduced() > 0);
         } finally {
-            cert.delete();
             cleanupClientSslEngine(client);
             cleanupServerSslEngine(server);
         }
@@ -2664,7 +2646,7 @@ public abstract class SSLEngineTest {
     @MethodSource("newTestParams")
     @ParameterizedTest
     public void testMultipleRecordsInOneBufferBiggerThenPacketBufferSize(SSLEngineTestParam param) throws Exception {
-        SelfSignedCertificate cert = new SelfSignedCertificate();
+        SelfSignedCertificate cert = CachedSelfSignedCertificate.getCachedCertificate();
 
         clientSslCtx = wrapContext(param, SslContextBuilder
                 .forClient()
@@ -2727,7 +2709,6 @@ public abstract class SSLEngineTest {
             assertTrue(result.bytesProduced() > 0);
             assertTrue(encClientToServer.hasRemaining());
         } finally {
-            cert.delete();
             cleanupClientSslEngine(client);
             cleanupServerSslEngine(server);
         }
@@ -2736,7 +2717,7 @@ public abstract class SSLEngineTest {
     @MethodSource("newTestParams")
     @ParameterizedTest
     public void testBufferUnderFlow(SSLEngineTestParam param) throws Exception {
-        SelfSignedCertificate cert = new SelfSignedCertificate();
+        SelfSignedCertificate cert = CachedSelfSignedCertificate.getCachedCertificate();
 
         clientSslCtx = wrapContext(param, SslContextBuilder
                 .forClient()
@@ -2800,7 +2781,6 @@ public abstract class SSLEngineTest {
             assertEquals(result.bytesConsumed(), remaining);
             assertTrue(result.bytesProduced() > 0);
         } finally {
-            cert.delete();
             cleanupClientSslEngine(client);
             cleanupServerSslEngine(server);
         }
@@ -2815,7 +2795,7 @@ public abstract class SSLEngineTest {
     @MethodSource("newTestParams")
     @ParameterizedTest
     public void testWrapDoesNotZeroOutSrc(SSLEngineTestParam param) throws Exception {
-        SelfSignedCertificate cert = new SelfSignedCertificate();
+        SelfSignedCertificate cert = CachedSelfSignedCertificate.getCachedCertificate();
 
         clientSslCtx = wrapContext(param, SslContextBuilder
                 .forClient()
@@ -2862,7 +2842,6 @@ public abstract class SSLEngineTest {
         } finally {
             cleanupClientSslEngine(client);
             cleanupServerSslEngine(server);
-            cert.delete();
         }
     }
 
@@ -2881,7 +2860,7 @@ public abstract class SSLEngineTest {
 
     private void testDisableProtocols(SSLEngineTestParam param,
                                       String protocol, String... disabledProtocols) throws Exception {
-        SelfSignedCertificate cert = new SelfSignedCertificate();
+        SelfSignedCertificate cert = CachedSelfSignedCertificate.getCachedCertificate();
 
         SslContext ctx = wrapContext(param, SslContextBuilder
                 .forServer(cert.certificate(), cert.privateKey())
@@ -2912,7 +2891,6 @@ public abstract class SSLEngineTest {
         } finally {
             cleanupServerSslEngine(server);
             cleanupClientSslContext(ctx);
-            cert.delete();
         }
     }
 
@@ -3004,13 +2982,12 @@ public abstract class SSLEngineTest {
         } finally {
             cleanupClientSslEngine(client);
             cleanupServerSslEngine(server);
-            cert.delete();
         }
     }
 
     @Test
     public void testInvalidCipher() throws Exception {
-        SelfSignedCertificate cert = new SelfSignedCertificate();
+        SelfSignedCertificate cert = CachedSelfSignedCertificate.getCachedCertificate();
         List<String> cipherList = new ArrayList<>();
         Collections.addAll(cipherList, ((SSLSocketFactory) SSLSocketFactory.getDefault()).getDefaultCipherSuites());
         cipherList.add("InvalidCipher");
@@ -3025,7 +3002,6 @@ public abstract class SSLEngineTest {
         } catch (IllegalArgumentException | SSLException expected) {
             // Expected when invalid cipher is used.
         } finally {
-            cert.delete();
             cleanupServerSslEngine(server);
         }
     }
@@ -3040,7 +3016,7 @@ public abstract class SSLEngineTest {
                                         .protocols(param.protocols())
                                         .ciphers(param.ciphers())
                                         .build());
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         serverSslCtx = wrapContext(param, SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                                         .sslProvider(sslServerProvider())
                                         .sslContextProvider(serverSslContextProvider())
@@ -3062,7 +3038,6 @@ public abstract class SSLEngineTest {
         } finally {
             cleanupClientSslEngine(clientEngine);
             cleanupServerSslEngine(serverEngine);
-            ssc.delete();
         }
     }
 
@@ -3076,7 +3051,7 @@ public abstract class SSLEngineTest {
                 .protocols(param.protocols())
                 .ciphers(param.ciphers())
                 .build());
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         serverSslCtx = wrapContext(param, SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                 .sslProvider(sslServerProvider())
                 .sslContextProvider(serverSslContextProvider())
@@ -3084,15 +3059,11 @@ public abstract class SSLEngineTest {
                 .ciphers(param.ciphers())
                 .build());
 
-        try {
-            doHandshakeVerifyReusedAndClose(param, "a.netty.io", 9999, false);
-            doHandshakeVerifyReusedAndClose(param, "a.netty.io", 9999, true);
-            doHandshakeVerifyReusedAndClose(param, "b.netty.io", 9999, false);
-            invalidateSessionsAndAssert(serverSslCtx.sessionContext());
-            invalidateSessionsAndAssert(clientSslCtx.sessionContext());
-        } finally {
-            ssc.delete();
-        }
+        doHandshakeVerifyReusedAndClose(param, "a.netty.io", 9999, false);
+        doHandshakeVerifyReusedAndClose(param, "a.netty.io", 9999, true);
+        doHandshakeVerifyReusedAndClose(param, "b.netty.io", 9999, false);
+        invalidateSessionsAndAssert(serverSslCtx.sessionContext());
+        invalidateSessionsAndAssert(clientSslCtx.sessionContext());
     }
 
     protected void invalidateSessionsAndAssert(SSLSessionContext context) {
@@ -3326,7 +3297,7 @@ public abstract class SSLEngineTest {
                 .ciphers(param.ciphers())
                 .sessionTimeout(1)
                 .build());
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         serverSslCtx = wrapContext(param, SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                 .sslProvider(sslServerProvider())
                 .sslContextProvider(serverSslContextProvider())
@@ -3335,17 +3306,13 @@ public abstract class SSLEngineTest {
                 .sessionTimeout(1)
                 .build());
 
-        try {
-            doHandshakeVerifyReusedAndClose(param, "a.netty.io", 9999, false);
+        doHandshakeVerifyReusedAndClose(param, "a.netty.io", 9999, false);
 
-            // Let's sleep for a bit more then 1 second so the cache should timeout the sessions.
-            Thread.sleep(1500);
+        // Let's sleep for a bit more then 1 second so the cache should timeout the sessions.
+        Thread.sleep(1500);
 
-            assertSessionCache(serverSslCtx.sessionContext(), 0);
-            assertSessionCache(clientSslCtx.sessionContext(), 0);
-        } finally {
-            ssc.delete();
-        }
+        assertSessionCache(serverSslCtx.sessionContext(), 0);
+        assertSessionCache(clientSslCtx.sessionContext(), 0);
     }
 
     @MethodSource("newTestParams")
@@ -3359,7 +3326,7 @@ public abstract class SSLEngineTest {
                 .ciphers(param.ciphers())
                 .sessionCacheSize(1)
                 .build());
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         serverSslCtx = wrapContext(param, SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                 .sslProvider(sslServerProvider())
                 .sslContextProvider(serverSslContextProvider())
@@ -3367,16 +3334,12 @@ public abstract class SSLEngineTest {
                 .ciphers(param.ciphers())
                 .build());
 
-        try {
-            doHandshakeVerifyReusedAndClose(param, "a.netty.io", 9999, false);
-            // As we have a cache size of 1 we should never have more then one session in the cache
-            doHandshakeVerifyReusedAndClose(param, "b.netty.io", 9999, false);
+        doHandshakeVerifyReusedAndClose(param, "a.netty.io", 9999, false);
+        // As we have a cache size of 1 we should never have more then one session in the cache
+        doHandshakeVerifyReusedAndClose(param, "b.netty.io", 9999, false);
 
-            // We should at least reuse b.netty.io
-            doHandshakeVerifyReusedAndClose(param, "b.netty.io", 9999, true);
-        } finally {
-            ssc.delete();
-        }
+        // We should at least reuse b.netty.io
+        doHandshakeVerifyReusedAndClose(param, "b.netty.io", 9999, true);
     }
 
     @MethodSource("newTestParams")
@@ -3389,7 +3352,7 @@ public abstract class SSLEngineTest {
                 .protocols(param.protocols())
                 .ciphers(param.ciphers())
                 .build());
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         serverSslCtx = wrapContext(param, SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                 .sslProvider(sslServerProvider())
                 .sslContextProvider(serverSslContextProvider())
@@ -3449,7 +3412,6 @@ public abstract class SSLEngineTest {
         } finally {
             cleanupClientSslEngine(clientEngine);
             cleanupServerSslEngine(serverEngine);
-            ssc.delete();
         }
     }
 
@@ -3486,7 +3448,7 @@ public abstract class SSLEngineTest {
 
     private void testSessionAfterHandshake0(
             SSLEngineTestParam param, boolean useKeyManagerFactory, boolean mutualAuth) throws Exception {
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         KeyManagerFactory kmf = useKeyManagerFactory ?
                 SslContext.buildKeyManagerFactory(
                         new java.security.cert.X509Certificate[] { ssc.cert()}, null,
@@ -3695,14 +3657,13 @@ public abstract class SSLEngineTest {
         } finally {
             cleanupClientSslEngine(clientEngine);
             cleanupServerSslEngine(serverEngine);
-            ssc.delete();
         }
     }
 
     @MethodSource("newTestParams")
     @ParameterizedTest
     public void testSupportedSignatureAlgorithms(SSLEngineTestParam param) throws Exception {
-        final SelfSignedCertificate ssc = new SelfSignedCertificate();
+        final SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
 
         final class TestKeyManagerFactory extends KeyManagerFactory {
             TestKeyManagerFactory(final KeyManagerFactory factory) {
@@ -3818,14 +3779,13 @@ public abstract class SSLEngineTest {
         } finally {
             cleanupClientSslEngine(clientEngine);
             cleanupServerSslEngine(serverEngine);
-            ssc.delete();
         }
     }
 
     @MethodSource("newTestParams")
     @ParameterizedTest
     public void testHandshakeSession(SSLEngineTestParam param) throws Exception {
-        final SelfSignedCertificate ssc = new SelfSignedCertificate();
+        final SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
 
         final TestTrustManagerFactory clientTmf = new TestTrustManagerFactory(ssc.cert());
         final TestTrustManagerFactory serverTmf = new TestTrustManagerFactory(ssc.cert());
@@ -3888,7 +3848,6 @@ public abstract class SSLEngineTest {
         } finally {
             cleanupClientSslEngine(clientEngine);
             cleanupServerSslEngine(serverEngine);
-            ssc.delete();
         }
     }
 
@@ -3905,7 +3864,7 @@ public abstract class SSLEngineTest {
     }
 
     private void testSessionLocalWhenNonMutual(SSLEngineTestParam param, boolean useKeyManager) throws Exception {
-        final SelfSignedCertificate ssc = new SelfSignedCertificate();
+        final SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
 
         SslContextBuilder clientSslCtxBuilder = SslContextBuilder.forClient()
                 .trustManager(InsecureTrustManagerFactory.INSTANCE)
@@ -3952,7 +3911,6 @@ public abstract class SSLEngineTest {
         } finally {
             cleanupClientSslEngine(clientEngine);
             cleanupServerSslEngine(serverEngine);
-            ssc.delete();
         }
     }
 
@@ -3966,7 +3924,7 @@ public abstract class SSLEngineTest {
                 .protocols(param.protocols())
                 .ciphers(param.ciphers())
                 .build());
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         serverSslCtx = wrapContext(param, SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                 .sslProvider(sslServerProvider())
                 .sslContextProvider(serverSslContextProvider())
@@ -3984,7 +3942,6 @@ public abstract class SSLEngineTest {
         } finally {
             cleanupClientSslEngine(clientEngine);
             cleanupServerSslEngine(serverEngine);
-            ssc.delete();
         }
     }
 
@@ -4026,7 +3983,7 @@ public abstract class SSLEngineTest {
         String originalSystemPropertyValue = SystemPropertyUtil.get(SslMasterKeyHandler.SYSTEM_PROP_KEY);
         System.setProperty(SslMasterKeyHandler.SYSTEM_PROP_KEY, Boolean.TRUE.toString());
 
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         serverSslCtx = wrapContext(param, SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                 .sslProvider(sslServerProvider())
                 .sslContextProvider(serverSslContextProvider())
@@ -4081,7 +4038,6 @@ public abstract class SSLEngineTest {
             } else {
                 System.clearProperty(SslMasterKeyHandler.SYSTEM_PROP_KEY);
             }
-            ssc.delete();
         }
     }
 
@@ -4179,7 +4135,7 @@ public abstract class SSLEngineTest {
                 .sslContextProvider(clientSslContextProvider())
                 .ciphers(param.ciphers())
                 .build());
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         serverSslCtx = wrapContext(param, SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                 .sslProvider(sslServerProvider())
                 .sslContextProvider(serverSslContextProvider())
@@ -4197,7 +4153,6 @@ public abstract class SSLEngineTest {
         } finally {
             cleanupClientSslEngine(clientEngine);
             cleanupServerSslEngine(serverEngine);
-            ssc.delete();
         }
 
         assertEquals(SslProvider.isTlsv13EnabledByDefault(sslClientProvider(), clientSslContextProvider()),
@@ -4247,7 +4202,7 @@ public abstract class SSLEngineTest {
                 .protocols(param.protocols())
                 .ciphers(param.ciphers())
                 .build());
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         serverSslCtx = wrapContext(param, SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                 .sslProvider(sslServerProvider())
                 .sslContextProvider(serverSslContextProvider())
@@ -4271,7 +4226,7 @@ public abstract class SSLEngineTest {
     @MethodSource("newTestParams")
     @ParameterizedTest
     public void testBufferUnderflowPacketSizeDependency(SSLEngineTestParam param) throws Exception {
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         clientSslCtx = wrapContext(param, SslContextBuilder.forClient()
                 .keyManager(ssc.certificate(), ssc.privateKey())
                 .trustManager((TrustManagerFactory) null)
@@ -4307,7 +4262,7 @@ public abstract class SSLEngineTest {
     public void testTLSv13DisabledIfNoValidCipherSuiteConfigured() throws Exception {
         // Use a TLSv12 cipher
         List<String> ciphers = Collections.singletonList("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256");
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         clientSslCtx = wrapContext(null, SslContextBuilder.forClient()
                 .trustManager(InsecureTrustManagerFactory.INSTANCE)
                 .sslProvider(sslClientProvider())
@@ -4344,7 +4299,7 @@ public abstract class SSLEngineTest {
             // TLSv1.3 is not supported by either client or server.
             return;
         }
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         clientSslCtx = wrapContext(null, SslContextBuilder.forClient()
                 .trustManager(InsecureTrustManagerFactory.INSTANCE)
                 .sslProvider(sslClientProvider())
@@ -4376,7 +4331,7 @@ public abstract class SSLEngineTest {
     @Test
     public void testExtraDataInLastSrcBufferForClientUnwrap() throws Exception {
         SSLEngineTestParam param = new SSLEngineTestParam(BufferType.Direct, ProtocolCipherCombo.tlsv12(), false);
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         clientSslCtx = wrapContext(param, SslContextBuilder.forClient()
                 .trustManager(InsecureTrustManagerFactory.INSTANCE)
                 .sslProvider(sslClientProvider())

--- a/handler/src/test/java/io/netty5/handler/ssl/SniClientTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SniClientTest.java
@@ -27,6 +27,7 @@ import io.netty5.channel.local.LocalAddress;
 import io.netty5.channel.local.LocalChannel;
 import io.netty5.channel.local.LocalIoHandler;
 import io.netty5.channel.local.LocalServerChannel;
+import io.netty5.handler.ssl.util.CachedSelfSignedCertificate;
 import io.netty5.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty5.handler.ssl.util.SelfSignedCertificate;
 import io.netty5.handler.ssl.util.SimpleTrustManagerFactory;
@@ -125,7 +126,7 @@ public class SniClientTest {
     private static void testSniClient(SslProvider sslClientProvider, SslProvider sslServerProvider, final boolean match)
             throws Throwable {
         final String sniHost = "sni.netty.io";
-        SelfSignedCertificate cert = new SelfSignedCertificate();
+        SelfSignedCertificate cert = CachedSelfSignedCertificate.getCachedCertificate();
         LocalAddress address = new LocalAddress(SniClientTest.class);
         EventLoopGroup group = new MultithreadEventLoopGroup(1, LocalIoHandler.newFactory());
         SslContext sslServerContext = null;
@@ -208,8 +209,6 @@ public class SniClientTest {
 
             Resource.dispose(sslServerContext);
             Resource.dispose(sslClientContext);
-
-            cert.delete();
 
             group.shutdownGracefully();
         }

--- a/handler/src/test/java/io/netty5/handler/ssl/SniHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SniHandlerTest.java
@@ -36,6 +36,7 @@ import io.netty5.channel.socket.nio.NioServerSocketChannel;
 import io.netty5.channel.socket.nio.NioSocketChannel;
 import io.netty5.handler.codec.DecoderException;
 import io.netty5.handler.codec.TooLongFrameException;
+import io.netty5.handler.ssl.util.CachedSelfSignedCertificate;
 import io.netty5.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty5.handler.ssl.util.SelfSignedCertificate;
 import io.netty5.util.DomainNameMapping;
@@ -490,7 +491,7 @@ public class SniHandlerTest {
                 Channel cc = null;
                 SslContext sslContext = null;
 
-                SelfSignedCertificate cert = new SelfSignedCertificate();
+                SelfSignedCertificate cert = CachedSelfSignedCertificate.getCachedCertificate();
 
                 try {
                     final SslContext sslServerContext = SslContextBuilder
@@ -588,8 +589,6 @@ public class SniHandlerTest {
                         Resource.dispose(sslContext);
                     }
                     group.shutdownGracefully();
-
-                    cert.delete();
                 }
             case JDK:
                 return;
@@ -639,7 +638,7 @@ public class SniHandlerTest {
 
     private static void testWithFragmentSize(SslProvider provider, final int maxFragmentSize) throws Exception {
         final String sni = "netty.io";
-        SelfSignedCertificate cert = new SelfSignedCertificate();
+        SelfSignedCertificate cert = CachedSelfSignedCertificate.getCachedCertificate();
         final SslContext context = SslContextBuilder.forServer(cert.key(), cert.cert())
                 .sslProvider(provider)
                 .build();
@@ -660,7 +659,6 @@ public class SniHandlerTest {
             assertTrue(server.finishAndReleaseAll());
         } finally {
             releaseAll(context);
-            cert.delete();
         }
     }
 

--- a/handler/src/test/java/io/netty5/handler/ssl/SslContextBuilderTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SslContextBuilderTest.java
@@ -15,6 +15,7 @@
  */
 package io.netty5.handler.ssl;
 
+import io.netty5.handler.ssl.util.CachedSelfSignedCertificate;
 import io.netty5.handler.ssl.util.SelfSignedCertificate;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
@@ -257,7 +258,7 @@ public class SslContextBuilderTest {
     }
 
     private static void testKeyStoreType(SslProvider provider) throws Exception {
-        SelfSignedCertificate cert = new SelfSignedCertificate();
+        SelfSignedCertificate cert = CachedSelfSignedCertificate.getCachedCertificate();
         SslContextBuilder builder = SslContextBuilder.forServer(cert.certificate(), cert.privateKey())
                 .sslProvider(provider)
                 .keyStoreType("PKCS12");
@@ -268,7 +269,7 @@ public class SslContextBuilderTest {
     }
 
     private static void testInvalidCipher(SslProvider provider) throws Exception {
-        SelfSignedCertificate cert = new SelfSignedCertificate();
+        SelfSignedCertificate cert = CachedSelfSignedCertificate.getCachedCertificate();
         SslContextBuilder builder = SslContextBuilder.forClient()
                 .sslProvider(provider)
                 .ciphers(Collections.singleton("SOME_INVALID_CIPHER"))
@@ -280,7 +281,7 @@ public class SslContextBuilderTest {
     }
 
     private static void testClientContextFromFile(SslProvider provider) throws Exception {
-        SelfSignedCertificate cert = new SelfSignedCertificate();
+        SelfSignedCertificate cert = CachedSelfSignedCertificate.getCachedCertificate();
         SslContextBuilder builder = SslContextBuilder.forClient()
                                                      .sslProvider(provider)
                                                      .keyManager(cert.certificate(),
@@ -296,7 +297,7 @@ public class SslContextBuilderTest {
     }
 
     private static void testClientContext(SslProvider provider) throws Exception {
-        SelfSignedCertificate cert = new SelfSignedCertificate();
+        SelfSignedCertificate cert = CachedSelfSignedCertificate.getCachedCertificate();
         SslContextBuilder builder = SslContextBuilder.forClient()
                                                      .sslProvider(provider)
                                                      .keyManager(cert.key(), cert.cert())
@@ -311,7 +312,7 @@ public class SslContextBuilderTest {
     }
 
     private static void testServerContextFromFile(SslProvider provider) throws Exception {
-        SelfSignedCertificate cert = new SelfSignedCertificate();
+        SelfSignedCertificate cert = CachedSelfSignedCertificate.getCachedCertificate();
         SslContextBuilder builder = SslContextBuilder.forServer(cert.certificate(), cert.privateKey())
                                                      .sslProvider(provider)
                                                      .trustManager(cert.certificate())
@@ -325,7 +326,7 @@ public class SslContextBuilderTest {
     }
 
     private static void testServerContext(SslProvider provider) throws Exception {
-        SelfSignedCertificate cert = new SelfSignedCertificate();
+        SelfSignedCertificate cert = CachedSelfSignedCertificate.getCachedCertificate();
         SslContextBuilder builder = SslContextBuilder.forServer(cert.key(), cert.cert())
                                                      .sslProvider(provider)
                                                      .trustManager(cert.cert())
@@ -340,7 +341,7 @@ public class SslContextBuilderTest {
 
     private static void testServerContextWithSecureRandom(SslProvider provider,
                                                           SpySecureRandom secureRandom) throws Exception {
-        SelfSignedCertificate cert = new SelfSignedCertificate();
+        SelfSignedCertificate cert = CachedSelfSignedCertificate.getCachedCertificate();
         SslContextBuilder builder = SslContextBuilder.forServer(cert.key(), cert.cert())
                 .sslProvider(provider)
                 .secureRandom(secureRandom)
@@ -357,7 +358,7 @@ public class SslContextBuilderTest {
 
     private static void testClientContextWithSecureRandom(SslProvider provider,
                                                           SpySecureRandom secureRandom) throws Exception {
-        SelfSignedCertificate cert = new SelfSignedCertificate();
+        SelfSignedCertificate cert = CachedSelfSignedCertificate.getCachedCertificate();
         SslContextBuilder builder = SslContextBuilder.forClient()
                 .sslProvider(provider)
                 .secureRandom(secureRandom)
@@ -374,7 +375,7 @@ public class SslContextBuilderTest {
     }
 
     private static void testContextFromManagers(SslProvider provider) throws Exception {
-        final SelfSignedCertificate cert = new SelfSignedCertificate();
+        final SelfSignedCertificate cert = CachedSelfSignedCertificate.getCachedCertificate();
         KeyManager customKeyManager = new X509ExtendedKeyManager() {
             @Override
             public String[] getClientAliases(String s,

--- a/handler/src/test/java/io/netty5/handler/ssl/SslErrorTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SslErrorTest.java
@@ -28,6 +28,7 @@ import io.netty5.channel.socket.nio.NioServerSocketChannel;
 import io.netty5.channel.socket.nio.NioSocketChannel;
 import io.netty5.handler.logging.LogLevel;
 import io.netty5.handler.logging.LoggingHandler;
+import io.netty5.handler.ssl.util.CachedSelfSignedCertificate;
 import io.netty5.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty5.handler.ssl.util.SelfSignedCertificate;
 import io.netty5.handler.ssl.util.SimpleTrustManagerFactory;
@@ -118,7 +119,7 @@ public class SslErrorTest {
         // no need to run it if there is no openssl is available at all.
         OpenSsl.ensureAvailability();
 
-        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
 
         SslContextBuilder sslServerCtxBuilder = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                 .sslProvider(serverProvider)

--- a/handler/src/test/java/io/netty5/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SslHandlerTest.java
@@ -96,6 +96,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -576,11 +577,11 @@ public class SslHandlerTest {
         assertTrue(channel.finishAndReleaseAll());
 
         SslCompletionEvent evt = events.take();
-        assertTrue(evt instanceof SslHandshakeCompletionEvent);
+        assertInstanceOf(SslHandshakeCompletionEvent.class, evt);
         assertThat(evt.cause(), instanceOf(ClosedChannelException.class));
 
         evt = events.take();
-        assertTrue(evt instanceof SslCloseCompletionEvent);
+        assertInstanceOf(SslCloseCompletionEvent.class, evt);
         assertThat(evt.cause(), instanceOf(ClosedChannelException.class));
         assertTrue(events.isEmpty());
     }
@@ -666,11 +667,11 @@ public class SslHandlerTest {
             }
 
             SslCompletionEvent evt = (SslCompletionEvent) events.take();
-            assertTrue(evt instanceof SslHandshakeCompletionEvent);
+            assertInstanceOf(SslHandshakeCompletionEvent.class, evt);
             assertThat(evt.cause(), is(instanceOf(SSLException.class)));
 
             evt = (SslCompletionEvent) events.take();
-            assertTrue(evt instanceof SslCloseCompletionEvent);
+            assertInstanceOf(SslCloseCompletionEvent.class, evt);
             assertThat(evt.cause(), is(instanceOf(ClosedChannelException.class)));
 
             Future<Void> future = (Future<Void>) events.take();

--- a/handler/src/test/java/io/netty5/handler/ssl/util/CachedSelfSignedCertificate.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/util/CachedSelfSignedCertificate.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.handler.ssl.util;
+
+import java.security.cert.CertificateException;
+
+public final class CachedSelfSignedCertificate {
+
+    private CachedSelfSignedCertificate() {
+    }
+
+    /**
+     * Obtain a lazily-created, shared {@link SelfSignedCertificate} instance.
+     * @return A shared {@link SelfSignedCertificate}.
+     */
+    public static SelfSignedCertificate getCachedCertificate() {
+        Object instance = LazyDefaultInstance.INSTANCE;
+        if (instance instanceof SelfSignedCertificate) {
+            return (SelfSignedCertificate) instance;
+        }
+        Throwable throwable = (Throwable) instance;
+        throw new IllegalStateException("Could not create default self-signed certificate instance", throwable);
+    }
+
+    private static final class LazyDefaultInstance {
+        public static final Object INSTANCE = createInstance();
+
+        private static Object createInstance() {
+            try {
+                return new SelfSignedCertificate();
+            } catch (CertificateException e) {
+                return e;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Motivation:
In Netty 5, we currently test our SSL code with RSA keys.
These keys are expensive to generate, so it's desirable to cache and
reuse them across multiple tests when possible.

Modification:
Add a CachedSelfSignedCertificate holder class to the test code. Use the
cached certificate in every test that 1) does not already cache its
certificates, and 2) only uses one certificate, and 3) were using the
default SelfSignedCertificate constructor.

Result:
These tests, many of which are parameterized in various ways, now run
much faster, shaving minutes off our builds.

This is a forward port of #14344