### PR TITLE
Make it possible to notify the TrustManager of resumed sessions

### DIFF
--- a/handler/src/main/java/io/netty5/handler/ssl/JdkSslContext.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/JdkSslContext.java
@@ -115,8 +115,8 @@ public class JdkSslContext extends SslContext {
 
             Set<String> suppertedCiphersNonTLSv13 = new LinkedHashSet<>(supportedCiphers);
             for (String defaultTlsv13CipherSuite : SslUtils.DEFAULT_TLSV13_CIPHER_SUITES) {
-            suppertedCiphersNonTLSv13.remove(defaultTlsv13CipherSuite);
-        }
+                suppertedCiphersNonTLSv13.remove(defaultTlsv13CipherSuite);
+            }
             supportedCiphersNonTLSv13 = Collections.unmodifiableSet(suppertedCiphersNonTLSv13);
         }
     }
@@ -205,7 +205,7 @@ public class JdkSslContext extends SslContext {
     public JdkSslContext(SSLContext sslContext, boolean isClient,
                          ClientAuth clientAuth) throws Exception {
         this(sslContext, isClient, null, IdentityCipherSuiteFilter.INSTANCE,
-                JdkDefaultApplicationProtocolNegotiator.INSTANCE, clientAuth, null, false, null);
+                JdkDefaultApplicationProtocolNegotiator.INSTANCE, clientAuth, null, false, null, null);
     }
 
     /**
@@ -254,15 +254,15 @@ public class JdkSslContext extends SslContext {
                 toNegotiator(apn, !isClient),
                 clientAuth,
                 protocols == null ? null : protocols.clone(),
-                startTls, null);
+                startTls, null, null);
     }
 
     @SuppressWarnings("deprecation")
     JdkSslContext(SSLContext sslContext, boolean isClient, Iterable<String> ciphers, CipherSuiteFilter cipherFilter,
                   JdkApplicationProtocolNegotiator apn, ClientAuth clientAuth, String[] protocols, boolean startTls,
-                  String endpointIdentificationAlgorithm)
+                  String endpointIdentificationAlgorithm, ResumptionController resumptionController)
             throws Exception {
-        super(startTls);
+        super(startTls, resumptionController);
         this.apn = requireNonNull(apn, "apn");
         this.clientAuth = requireNonNull(clientAuth, "clientAuth");
         this.sslContext = requireNonNull(sslContext, "sslContext");

--- a/handler/src/main/java/io/netty5/handler/ssl/OpenSslClientContext.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/OpenSslClientContext.java
@@ -39,17 +39,17 @@ final class OpenSslClientContext extends OpenSslContext {
                                 KeyManagerFactory keyManagerFactory, Iterable<String> ciphers,
                                 CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn, String[] protocols,
                                 long sessionCacheSize, long sessionTimeout, boolean enableOcsp, String keyStore,
-                         String endpointIdentificationAlgorithm,
+                         String endpointIdentificationAlgorithm, ResumptionController resumptionController,
                          Map.Entry<SslContextOption<?>, Object>... options)
             throws SSLException {
-        super(ciphers, cipherFilter, apn, SSL.SSL_MODE_CLIENT, keyCertChain,
-                ClientAuth.NONE, protocols, false, enableOcsp, endpointIdentificationAlgorithm, options);
+        super(ciphers, cipherFilter, apn, SSL.SSL_MODE_CLIENT, keyCertChain, ClientAuth.NONE, protocols, false,
+                enableOcsp, endpointIdentificationAlgorithm, resumptionController, options);
         boolean success = false;
         try {
             OpenSslKeyMaterialProvider.validateKeyMaterialSupported(keyCertChain, key, keyPassword);
             sessionContext = newSessionContext(this, ctx, engineMap, trustCertCollection, trustManagerFactory,
                                                keyCertChain, key, keyPassword, keyManagerFactory, keyStore,
-                                               sessionCacheSize, sessionTimeout);
+                                               sessionCacheSize, sessionTimeout, resumptionController);
             success = true;
         } finally {
             if (!success) {

--- a/handler/src/main/java/io/netty5/handler/ssl/OpenSslContext.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/OpenSslContext.java
@@ -31,19 +31,23 @@ public abstract class OpenSslContext extends ReferenceCountedOpenSslContext {
                    int mode, Certificate[] keyCertChain,
                    ClientAuth clientAuth, String[] protocols, boolean startTls,
                    boolean enableOcsp, String endpointIdentificationAlgorithm,
+                   ResumptionController resumptionController,
                    Map.Entry<SslContextOption<?>, Object>... options)
             throws SSLException {
         super(ciphers, cipherFilter, toNegotiator(apnCfg), mode, keyCertChain,
-                clientAuth, protocols, startTls, enableOcsp, false, endpointIdentificationAlgorithm, options);
+                clientAuth, protocols, startTls, enableOcsp, false, endpointIdentificationAlgorithm,
+                resumptionController, options);
     }
 
     OpenSslContext(Iterable<String> ciphers, CipherSuiteFilter cipherFilter, OpenSslApplicationProtocolNegotiator apn,
                    int mode, Certificate[] keyCertChain,
                    ClientAuth clientAuth, String[] protocols, boolean startTls, boolean enableOcsp,
-                   String endpointIdentificationAlgorithm, Map.Entry<SslContextOption<?>, Object>... options)
+                   String endpointIdentificationAlgorithm, ResumptionController resumptionController,
+                   Map.Entry<SslContextOption<?>, Object>... options)
             throws SSLException {
         super(ciphers, cipherFilter, apn, mode, keyCertChain,
-                clientAuth, protocols, startTls, enableOcsp, false, endpointIdentificationAlgorithm, options);
+                clientAuth, protocols, startTls, enableOcsp, false, endpointIdentificationAlgorithm,
+                resumptionController, options);
     }
 
     @Override

--- a/handler/src/main/java/io/netty5/handler/ssl/OpenSslServerContext.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/OpenSslServerContext.java
@@ -39,11 +39,12 @@ final class OpenSslServerContext extends OpenSslContext {
             X509Certificate[] keyCertChain, PrivateKey key, String keyPassword, KeyManagerFactory keyManagerFactory,
             Iterable<String> ciphers, CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn,
             long sessionCacheSize, long sessionTimeout, ClientAuth clientAuth, String[] protocols, boolean startTls,
-            boolean enableOcsp, String keyStore, Map.Entry<SslContextOption<?>, Object>... options)
+            boolean enableOcsp, String keyStore, ResumptionController resumptionController,
+            Map.Entry<SslContextOption<?>, Object>... options)
             throws SSLException {
         this(trustCertCollection, trustManagerFactory, keyCertChain, key, keyPassword, keyManagerFactory, ciphers,
                 cipherFilter, toNegotiator(apn), sessionCacheSize, sessionTimeout, clientAuth, protocols, startTls,
-                enableOcsp, keyStore, options);
+                enableOcsp, keyStore, resumptionController, options);
     }
 
     @SuppressWarnings("deprecation")
@@ -52,17 +53,18 @@ final class OpenSslServerContext extends OpenSslContext {
             X509Certificate[] keyCertChain, PrivateKey key, String keyPassword, KeyManagerFactory keyManagerFactory,
             Iterable<String> ciphers, CipherSuiteFilter cipherFilter, OpenSslApplicationProtocolNegotiator apn,
             long sessionCacheSize, long sessionTimeout, ClientAuth clientAuth, String[] protocols, boolean startTls,
-            boolean enableOcsp, String keyStore, Map.Entry<SslContextOption<?>, Object>... options)
+            boolean enableOcsp, String keyStore, ResumptionController resumptionController,
+            Map.Entry<SslContextOption<?>, Object>... options)
             throws SSLException {
         super(ciphers, cipherFilter, apn, SSL.SSL_MODE_SERVER, keyCertChain,
-                clientAuth, protocols, startTls, enableOcsp, null, options);
+                clientAuth, protocols, startTls, enableOcsp, null, resumptionController, options);
         // Create a new SSL_CTX and configure it.
         boolean success = false;
         try {
             OpenSslKeyMaterialProvider.validateKeyMaterialSupported(keyCertChain, key, keyPassword);
             sessionContext = newSessionContext(this, ctx, engineMap, trustCertCollection, trustManagerFactory,
                                                keyCertChain, key, keyPassword, keyManagerFactory, keyStore,
-                                               sessionCacheSize, sessionTimeout);
+                                               sessionCacheSize, sessionTimeout, resumptionController);
             success = true;
         } finally {
             if (!success) {

--- a/handler/src/main/java/io/netty5/handler/ssl/ResumableX509ExtendedTrustManager.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/ResumableX509ExtendedTrustManager.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.handler.ssl;
+
+import java.security.cert.CertificateException;
+import java.security.cert.PKIXBuilderParameters;
+import java.security.cert.X509Certificate;
+import java.util.Date;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+/**
+ * An interface that {@code TrustManager} instances can implement, to be notified of resumed SSL sessions.
+ * <p>
+ * A {@link TrustManager} is called during the TLS handshake, and make decisions about whether
+ * the connected peer can be trusted or not. TLS include a feature where previously established sessions can
+ * be resumed without going through the trust verification steps.
+ * <p>
+ * When an {@link SSLSession} is resumed, any values added to it in the prior session may be lost.
+ * This interface gives {@link TrustManager} implementations an opportunity to restore any
+ * values they would normally add during the TLS handshake, before the handshake completion is signalled
+ * to the application.
+ * <p>
+ * When a session is resumed, the {@link SslHandler} will call the relevant {@code resume*} method,
+ * before completing the handshake promise and sending a successful {@link SslHandshakeCompletionEvent}
+ * event down the pipeline.
+ * <p>
+ * A trust manager that does not add values to the handshake session in its {@code check*} methods,
+ * will typically not have any need to implement this interface.
+ * <p>
+ * <strong>Note:</strong> The implementing trust manager class must extend {@code X509ExtendedTrustManager},
+ * otherwise this interface will be ignored by the {@link SslHandler}.
+ */
+public interface ResumableX509ExtendedTrustManager extends X509TrustManager {
+    /**
+     * Given the partial or complete certificate chain recovered from the session ticket,
+     * and the {@link SSLEngine} being used, restore the application state of the associated
+     * SSL session.
+     * <p>
+     * This method should obtain the {@link SSLSession} from the {@link SSLEngine#getSession()}
+     * method.
+     * <p>
+     * <strong>Note:</strong> If this method throws {@link CertificateException}, the TLS handshake will not
+     * necessarily be rejected. The TLS handshake "Finished" message may have already been sent to the peer
+     * by the time this method is called.
+     * <p>
+     * Implementors should be aware, that peers may make multiple connection attempts using the same session
+     * ticket. So this method may be called more than once for the same client, even if prior calls have thrown
+     * exceptions or invalidated their sessions.
+     * <p>
+     * The given certificate chain is not guaranteed to be the authenticated chain. Implementations that need the
+     * authenticated certificate chain will have to re-authenticate the certificates. It is recommended to do so
+     * with a {@link PKIXBuilderParameters#setDate(Date)} set to the session creation date from
+     * {@link SSLSession#getCreationTime()}. Otherwise, the authentication may fail due to the certificate expiring
+     * before the session ticket.
+     * <p>
+     * This method is called on the server-side, restoring sessions for clients.
+     *
+     * @param chain The peer certificate chain.
+     * @param engine The begine used for this connection.
+     * @throws CertificateException If the session cannot be restored. Locally, the handshake will appear to have
+     * failed, but the peer may have observed a finished handshake.
+     */
+    void resumeClientTrusted(X509Certificate[] chain, SSLEngine engine) throws CertificateException;
+
+    /**
+     * Given the partial or complete certificate chain recovered of the peer, and the {@link SSLEngine}
+     * being used, restore the application state of the associated SSL session.
+     * <p>
+     * This method should obtain the {@link SSLSession} from the {@link SSLEngine#getSession()}
+     * method.
+     * <p>
+     * <strong>Note:</strong> If this method throws {@link CertificateException}, the TLS handshake will not
+     * necessarily be rejected. The TLS handshake "Finished" message may have already been sent to the peer
+     * by the time this method is called.
+     * <p>
+     * Implementors should be aware, that peers may make multiple connection attempts using the same session
+     * ticket. So this method may be called more than once for the same client, even if prior calls have thrown
+     * exceptions or invalidated their sessions.
+     * <p>
+     * The given certificate chain is not guaranteed to be the authenticated chain. Implementations that need the
+     * authenticated certificate chain will have to re-authenticate the certificates. It is recommended to do so
+     * with a {@link PKIXBuilderParameters#setDate(Date)} set to the session creation date from
+     * {@link SSLSession#getCreationTime()}. Otherwise, the authentication may fail due to the certificate expiring
+     * before the session ticket.
+     * <p>
+     * This method is called on the client-side, restoring sessions for servers.
+     *
+     * @param chain The peer certificate chain.
+     * @param engine The begine used for this connection.
+     * @throws CertificateException If the session cannot be restored. Locally, the handshake will appear to have
+     * failed, but the peer may have observed a finished handshake.
+     */
+    void resumeServerTrusted(X509Certificate[] chain, SSLEngine engine) throws CertificateException;
+}

--- a/handler/src/main/java/io/netty5/handler/ssl/ResumptionController.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/ResumptionController.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.handler.ssl;
+
+import java.net.Socket;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Collections;
+import java.util.Set;
+import java.util.WeakHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509ExtendedTrustManager;
+
+final class ResumptionController {
+    private final Set<SSLEngine> confirmedValidations;
+    private final AtomicReference<ResumableX509ExtendedTrustManager> resumableTm;
+
+    ResumptionController() {
+        confirmedValidations = Collections.synchronizedSet(
+                Collections.newSetFromMap(new WeakHashMap<SSLEngine, Boolean>()));
+        resumableTm = new AtomicReference<ResumableX509ExtendedTrustManager>();
+    }
+
+    public TrustManager wrapIfNeeded(TrustManager tm) {
+        if (tm instanceof ResumableX509ExtendedTrustManager) {
+            if (!(tm instanceof X509ExtendedTrustManager)) {
+                throw new IllegalStateException("ResumableX509ExtendedTrustManager implementation must be a " +
+                        "subclass of X509ExtendedTrustManager, found: " + tm.getClass());
+            }
+            if (!resumableTm.compareAndSet(null, (ResumableX509ExtendedTrustManager) tm)) {
+                throw new IllegalStateException(
+                        "Only one ResumableX509ExtendedTrustManager can be configured for resumed sessions");
+            }
+            return new X509ExtendedWrapTrustManager((X509ExtendedTrustManager) tm, confirmedValidations);
+        }
+        return tm;
+    }
+
+    public void remove(SSLEngine engine) {
+        if (resumableTm.get() != null) {
+            confirmedValidations.remove(unwrapEngine(engine));
+        }
+    }
+
+    public boolean validateResumeIfNeeded(SSLEngine engine)
+            throws CertificateException, SSLPeerUnverifiedException {
+        ResumableX509ExtendedTrustManager tm;
+        boolean valid = engine.getSession().isValid();
+        if (valid && (tm = resumableTm.get()) != null) {
+            Certificate[] peerCertificates = engine.getSession().getPeerCertificates();
+
+            // Unwrap JdkSslEngines because they add their inner JDK SSLEngine objects to the set.
+            engine = unwrapEngine(engine);
+
+            if (!confirmedValidations.remove(engine)) {
+                // This is a resumed session.
+                if (engine.getUseClientMode()) {
+                    // We are the client, resuming a session trusting the server
+                    tm.resumeServerTrusted(chainOf(peerCertificates), engine);
+                } else {
+                    // We are the server, resuming a session trusting the client
+                    tm.resumeClientTrusted(chainOf(peerCertificates), engine);
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static SSLEngine unwrapEngine(SSLEngine engine) {
+        if (engine instanceof JdkSslEngine) {
+            return ((JdkSslEngine) engine).getWrappedEngine();
+        }
+        return engine;
+    }
+
+    private static X509Certificate[] chainOf(Certificate[] peerCertificates) {
+        if (peerCertificates instanceof X509Certificate[]) {
+            //noinspection SuspiciousArrayCast
+            return (X509Certificate[]) peerCertificates;
+        }
+        X509Certificate[] chain = new X509Certificate[peerCertificates.length];
+        for (int i = 0; i < peerCertificates.length; i++) {
+            Certificate cert = peerCertificates[i];
+            if (cert instanceof X509Certificate || cert == null) {
+                chain[i] = (X509Certificate) cert;
+            } else {
+                throw new IllegalArgumentException("Only X509Certificates are supported, found: " + cert.getClass());
+            }
+        }
+        return chain;
+    }
+
+    private static final class X509ExtendedWrapTrustManager extends X509ExtendedTrustManager {
+        private final X509ExtendedTrustManager trustManager;
+        private final Set<SSLEngine> confirmedValidations;
+
+        X509ExtendedWrapTrustManager(X509ExtendedTrustManager trustManager, Set<SSLEngine> confirmedValidations) {
+            this.trustManager = trustManager;
+            this.confirmedValidations = confirmedValidations;
+        }
+
+        private static void unsupported() throws CertificateException {
+            throw new CertificateException(
+                    new UnsupportedOperationException("Resumable trust managers require the SSLEngine parameter"));
+        }
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType, Socket socket)
+                throws CertificateException {
+            unsupported();
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType, Socket socket)
+                throws CertificateException {
+            unsupported();
+        }
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+            unsupported();
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+            unsupported();
+        }
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType, SSLEngine engine)
+                throws CertificateException {
+            trustManager.checkClientTrusted(chain, authType, engine);
+            confirmedValidations.add(engine);
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType, SSLEngine engine)
+                throws CertificateException {
+            trustManager.checkServerTrusted(chain, authType, engine);
+            confirmedValidations.add(engine);
+        }
+
+        @Override
+        public X509Certificate[] getAcceptedIssuers() {
+            return trustManager.getAcceptedIssuers();
+        }
+    }
+}

--- a/handler/src/main/java/io/netty5/handler/ssl/ResumptionController.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/ResumptionController.java
@@ -25,6 +25,7 @@ import java.util.WeakHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509ExtendedTrustManager;
 
@@ -62,14 +63,34 @@ final class ResumptionController {
     public boolean validateResumeIfNeeded(SSLEngine engine)
             throws CertificateException, SSLPeerUnverifiedException {
         ResumableX509ExtendedTrustManager tm;
-        boolean valid = engine.getSession().isValid();
-        if (valid && (tm = resumableTm.get()) != null) {
-            Certificate[] peerCertificates = engine.getSession().getPeerCertificates();
+        SSLSession session = engine.getSession();
+        boolean valid = session.isValid();
 
+        // Look for resumption if the session is valid, and we expect to authenticate our peer:
+        //   1.   Clients always authenticate the server.
+        //   2.a. Servers only authenticate the client if they need auth,
+        //   2.b. or if they requested auth and the client provided.
+        //
+        // If a server only "want" but don't "need" auth (ClientAuth.OPTIONAL) and the client didn't provide
+        // any certificates, then `session.getPeerCertificates()` will throw `SSLPeerUnverifiedException`.
+        if (valid && (engine.getUseClientMode() || engine.getNeedClientAuth() || engine.getWantClientAuth()) &&
+                (tm = resumableTm.get()) != null) {
             // Unwrap JdkSslEngines because they add their inner JDK SSLEngine objects to the set.
             engine = unwrapEngine(engine);
 
             if (!confirmedValidations.remove(engine)) {
+                Certificate[] peerCertificates;
+                try {
+                    peerCertificates = session.getPeerCertificates();
+                } catch (SSLPeerUnverifiedException e) {
+                    if (engine.getUseClientMode() || engine.getNeedClientAuth()) {
+                        // Auth is required, and we got none.
+                        throw e;
+                    }
+                    // Auth is optional, and none were provided. Skip out; session resumed but nothing to authenticate.
+                    return false;
+                }
+
                 // This is a resumed session.
                 if (engine.getUseClientMode()) {
                     // We are the client, resuming a session trusting the server

--- a/handler/src/main/java/io/netty5/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslHandler.java
@@ -1227,9 +1227,12 @@ public class SslHandler extends ByteToMessageDecoder {
                         engine().getSession(), applicationProtocol(), cause));
             }
 
-            // We need to flush one time as there may be an alert that we should send to the remote peer because
-            // of the SSLException reported here.
-            wrapAndFlush(ctx);
+            // Let's check if the handler was removed in the meantime and so pendingUnencryptedWrites is null.
+            if (pendingUnencryptedWrites != null) {
+                // We need to flush one time as there may be an alert that we should send to the remote peer because
+                // of the SSLException reported here.
+                wrapAndFlush(ctx);
+            }
         } catch (SSLException ex) {
             logger.debug("SSLException during trying to call SSLEngine.wrap(...)" +
                     " because of an previous SSLException, ignoring...", ex);

--- a/handler/src/main/java/io/netty5/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslHandler.java
@@ -1324,7 +1324,7 @@ public class SslHandler extends ByteToMessageDecoder {
                 if (handshakeStatus == HandshakeStatus.FINISHED || handshakeStatus == HandshakeStatus.NOT_HANDSHAKING) {
                     wrapLater |= (decodeOut.readableBytes() > 0 ?
                             setHandshakeSuccessUnwrapMarkReentry() : setHandshakeSuccess()) ||
-                            handshakeStatus == HandshakeStatus.FINISHED;
+                            handshakeStatus == HandshakeStatus.FINISHED || !pendingUnencryptedWrites.isEmpty();
                 }
 
                 // Dispatch decoded data after we have notified of handshake success. If this method has been invoked

--- a/handler/src/test/java/io/netty5/handler/ssl/ConscryptJdkSslEngineInteropTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/ConscryptJdkSslEngineInteropTest.java
@@ -94,4 +94,10 @@ public class ConscryptJdkSslEngineInteropTest extends SSLEngineTest {
     public void testTLSv13DisabledIfNoValidCipherSuiteConfigured() throws Exception {
         super.testTLSv13DisabledIfNoValidCipherSuiteConfigured();
     }
+
+    @Disabled("Disabled due a conscrypt bug")
+    @Override
+    public void mustCallResumeTrustedOnSessionResumption(SSLEngineTestParam param) throws Exception {
+        super.mustCallResumeTrustedOnSessionResumption(param);
+    }
 }

--- a/handler/src/test/java/io/netty5/handler/ssl/ConscryptJdkSslEngineInteropTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/ConscryptJdkSslEngineInteropTest.java
@@ -17,7 +17,6 @@ package io.netty5.handler.ssl;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -98,7 +97,7 @@ public class ConscryptJdkSslEngineInteropTest extends SSLEngineTest {
 
     @Disabled("Disabled due a conscrypt bug")
     @Override
-    public void mustCallResumeTrustedOnSessionResumption(SSLEngineTestParam param, TestInfo info) throws Exception {
-        super.mustCallResumeTrustedOnSessionResumption(param, info);
+    public void mustCallResumeTrustedOnSessionResumption(SSLEngineTestParam param) throws Exception {
+        super.mustCallResumeTrustedOnSessionResumption(param);
     }
 }

--- a/handler/src/test/java/io/netty5/handler/ssl/ConscryptJdkSslEngineInteropTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/ConscryptJdkSslEngineInteropTest.java
@@ -17,6 +17,7 @@ package io.netty5.handler.ssl;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -97,7 +98,7 @@ public class ConscryptJdkSslEngineInteropTest extends SSLEngineTest {
 
     @Disabled("Disabled due a conscrypt bug")
     @Override
-    public void mustCallResumeTrustedOnSessionResumption(SSLEngineTestParam param) throws Exception {
-        super.mustCallResumeTrustedOnSessionResumption(param);
+    public void mustCallResumeTrustedOnSessionResumption(SSLEngineTestParam param, TestInfo info) throws Exception {
+        super.mustCallResumeTrustedOnSessionResumption(param, info);
     }
 }

--- a/handler/src/test/java/io/netty5/handler/ssl/ConscryptOpenSslEngineInteropTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/ConscryptOpenSslEngineInteropTest.java
@@ -39,8 +39,7 @@ public class ConscryptOpenSslEngineInteropTest extends ConscryptSslEngineTest {
         List<SSLEngineTestParam> params = super.newTestParams();
         List<SSLEngineTestParam> testParams = new ArrayList<SSLEngineTestParam>();
         for (SSLEngineTestParam param: params) {
-            testParams.add(new OpenSslEngineTestParam(true, param));
-            testParams.add(new OpenSslEngineTestParam(false, param));
+            OpenSslEngineTestParam.expandCombinations(param, testParams);
         }
         return testParams;
     }
@@ -211,16 +210,8 @@ public class ConscryptOpenSslEngineInteropTest extends ConscryptSslEngineTest {
         return SslTestUtils.wrapSSLEngineForTesting(engine);
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     protected SslContext wrapContext(SSLEngineTestParam param, SslContext context) {
-        if (context instanceof OpenSslContext) {
-            if (param instanceof OpenSslEngineTestParam) {
-                ((OpenSslContext) context).setUseTasks(((OpenSslEngineTestParam) param).useTasks);
-            }
-            // Explicit enable the session cache as its disabled by default on the client side.
-            ((OpenSslContext) context).sessionContext().setSessionCacheEnabled(true);
-        }
-        return context;
+        return OpenSslEngineTestParam.wrapContext(param, context);
     }
 }

--- a/handler/src/test/java/io/netty5/handler/ssl/ConscryptSslEngineTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/ConscryptSslEngineTest.java
@@ -18,7 +18,6 @@ package io.netty5.handler.ssl;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -108,7 +107,7 @@ public class ConscryptSslEngineTest extends SSLEngineTest {
 
     @Disabled("Disabled due a conscrypt bug")
     @Override
-    public void mustCallResumeTrustedOnSessionResumption(SSLEngineTestParam param, TestInfo info) throws Exception {
-        super.mustCallResumeTrustedOnSessionResumption(param, info);
+    public void mustCallResumeTrustedOnSessionResumption(SSLEngineTestParam param) throws Exception {
+        super.mustCallResumeTrustedOnSessionResumption(param);
     }
 }

--- a/handler/src/test/java/io/netty5/handler/ssl/ConscryptSslEngineTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/ConscryptSslEngineTest.java
@@ -18,6 +18,7 @@ package io.netty5.handler.ssl;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -107,7 +108,7 @@ public class ConscryptSslEngineTest extends SSLEngineTest {
 
     @Disabled("Disabled due a conscrypt bug")
     @Override
-    public void mustCallResumeTrustedOnSessionResumption(SSLEngineTestParam param) throws Exception {
-        super.mustCallResumeTrustedOnSessionResumption(param);
+    public void mustCallResumeTrustedOnSessionResumption(SSLEngineTestParam param, TestInfo info) throws Exception {
+        super.mustCallResumeTrustedOnSessionResumption(param, info);
     }
 }

--- a/handler/src/test/java/io/netty5/handler/ssl/ConscryptSslEngineTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/ConscryptSslEngineTest.java
@@ -104,4 +104,10 @@ public class ConscryptSslEngineTest extends SSLEngineTest {
     public void testTLSv13DisabledIfNoValidCipherSuiteConfigured() throws Exception {
         super.testTLSv13DisabledIfNoValidCipherSuiteConfigured();
     }
+
+    @Disabled("Disabled due a conscrypt bug")
+    @Override
+    public void mustCallResumeTrustedOnSessionResumption(SSLEngineTestParam param) throws Exception {
+        super.mustCallResumeTrustedOnSessionResumption(param);
+    }
 }

--- a/handler/src/test/java/io/netty5/handler/ssl/JdkConscryptSslEngineInteropTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/JdkConscryptSslEngineInteropTest.java
@@ -17,6 +17,7 @@ package io.netty5.handler.ssl;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -112,7 +113,7 @@ public class JdkConscryptSslEngineInteropTest extends SSLEngineTest {
 
     @Disabled("Disabled due a conscrypt bug")
     @Override
-    public void mustCallResumeTrustedOnSessionResumption(SSLEngineTestParam param) throws Exception {
-        super.mustCallResumeTrustedOnSessionResumption(param);
+    public void mustCallResumeTrustedOnSessionResumption(SSLEngineTestParam param, TestInfo info) throws Exception {
+        super.mustCallResumeTrustedOnSessionResumption(param, info);
     }
 }

--- a/handler/src/test/java/io/netty5/handler/ssl/JdkConscryptSslEngineInteropTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/JdkConscryptSslEngineInteropTest.java
@@ -17,7 +17,6 @@ package io.netty5.handler.ssl;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -113,7 +112,7 @@ public class JdkConscryptSslEngineInteropTest extends SSLEngineTest {
 
     @Disabled("Disabled due a conscrypt bug")
     @Override
-    public void mustCallResumeTrustedOnSessionResumption(SSLEngineTestParam param, TestInfo info) throws Exception {
-        super.mustCallResumeTrustedOnSessionResumption(param, info);
+    public void mustCallResumeTrustedOnSessionResumption(SSLEngineTestParam param) throws Exception {
+        super.mustCallResumeTrustedOnSessionResumption(param);
     }
 }

--- a/handler/src/test/java/io/netty5/handler/ssl/JdkConscryptSslEngineInteropTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/JdkConscryptSslEngineInteropTest.java
@@ -109,4 +109,10 @@ public class JdkConscryptSslEngineInteropTest extends SSLEngineTest {
     public void testTLSv13DisabledIfNoValidCipherSuiteConfigured() throws Exception {
         super.testTLSv13DisabledIfNoValidCipherSuiteConfigured();
     }
+
+    @Disabled("Disabled due a conscrypt bug")
+    @Override
+    public void mustCallResumeTrustedOnSessionResumption(SSLEngineTestParam param) throws Exception {
+        super.mustCallResumeTrustedOnSessionResumption(param);
+    }
 }

--- a/handler/src/test/java/io/netty5/handler/ssl/JdkOpenSslEngineInteroptTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/JdkOpenSslEngineInteroptTest.java
@@ -40,8 +40,7 @@ public class JdkOpenSslEngineInteroptTest extends SSLEngineTest {
         List<SSLEngineTestParam> params = super.newTestParams();
         List<SSLEngineTestParam> testParams = new ArrayList<SSLEngineTestParam>();
         for (SSLEngineTestParam param: params) {
-            testParams.add(new OpenSslEngineTestParam(true, param));
-            testParams.add(new OpenSslEngineTestParam(false, param));
+            OpenSslEngineTestParam.expandCombinations(param, testParams);
         }
         return testParams;
     }
@@ -242,14 +241,8 @@ public class JdkOpenSslEngineInteroptTest extends SSLEngineTest {
         return SslTestUtils.wrapSSLEngineForTesting(engine);
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     protected SslContext wrapContext(SSLEngineTestParam param, SslContext context) {
-        if (context instanceof OpenSslContext && param instanceof OpenSslEngineTestParam) {
-            ((OpenSslContext) context).setUseTasks(((OpenSslEngineTestParam) param).useTasks);
-            // Explicit enable the session cache as its disabled by default on the client side.
-            ((OpenSslContext) context).sessionContext().setSessionCacheEnabled(true);
-        }
-        return context;
+        return OpenSslEngineTestParam.wrapContext(param, context);
     }
 }

--- a/handler/src/test/java/io/netty5/handler/ssl/OpenSslConscryptSslEngineInteropTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/OpenSslConscryptSslEngineInteropTest.java
@@ -38,8 +38,7 @@ public class OpenSslConscryptSslEngineInteropTest extends ConscryptSslEngineTest
         List<SSLEngineTestParam> params = super.newTestParams();
         List<SSLEngineTestParam> testParams = new ArrayList<SSLEngineTestParam>();
         for (SSLEngineTestParam param: params) {
-            testParams.add(new OpenSslEngineTestParam(true, param));
-            testParams.add(new OpenSslEngineTestParam(false, param));
+            OpenSslEngineTestParam.expandCombinations(param, testParams);
         }
         return testParams;
     }
@@ -184,16 +183,8 @@ public class OpenSslConscryptSslEngineInteropTest extends ConscryptSslEngineTest
         return SslTestUtils.wrapSSLEngineForTesting(engine);
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     protected SslContext wrapContext(SSLEngineTestParam param, SslContext context) {
-        if (context instanceof OpenSslContext) {
-            if (param instanceof OpenSslEngineTestParam) {
-                ((OpenSslContext) context).setUseTasks(((OpenSslEngineTestParam) param).useTasks);
-            }
-            // Explicit enable the session cache as its disabled by default on the client side.
-            ((OpenSslContext) context).sessionContext().setSessionCacheEnabled(true);
-        }
-        return context;
+        return OpenSslEngineTestParam.wrapContext(param, context);
     }
 }

--- a/handler/src/test/java/io/netty5/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/OpenSslEngineTest.java
@@ -91,8 +91,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
         List<SSLEngineTestParam> params = super.newTestParams();
         List<SSLEngineTestParam> testParams = new ArrayList<SSLEngineTestParam>();
         for (SSLEngineTestParam param: params) {
-            testParams.add(new OpenSslEngineTestParam(true, param));
-            testParams.add(new OpenSslEngineTestParam(false, param));
+            OpenSslEngineTestParam.expandCombinations(param, testParams);
         }
         return testParams;
     }
@@ -1519,17 +1518,9 @@ public class OpenSslEngineTest extends SSLEngineTest {
         return (ReferenceCountedOpenSslEngine) engine;
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     protected SslContext wrapContext(SSLEngineTestParam param, SslContext context) {
-        if (context instanceof OpenSslContext) {
-            if (param instanceof OpenSslEngineTestParam) {
-                ((OpenSslContext) context).setUseTasks(((OpenSslEngineTestParam) param).useTasks);
-            }
-            // Explicit enable the session cache as its disabled by default on the client side.
-            ((OpenSslContext) context).sessionContext().setSessionCacheEnabled(true);
-        }
-        return context;
+        return OpenSslEngineTestParam.wrapContext(param, context);
     }
 
     @MethodSource("newTestParams")

--- a/handler/src/test/java/io/netty5/handler/ssl/OpenSslEngineTestParam.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/OpenSslEngineTestParam.java
@@ -15,11 +15,50 @@
  */
 package io.netty5.handler.ssl;
 
+import java.util.List;
+
 final class OpenSslEngineTestParam extends SSLEngineTest.SSLEngineTestParam {
     final boolean useTasks;
-    OpenSslEngineTestParam(boolean useTasks, SSLEngineTest.SSLEngineTestParam param) {
+    final boolean useTickets;
+
+    static void expandCombinations(SSLEngineTest.SSLEngineTestParam param,
+                                   List<? super OpenSslEngineTestParam> output) {
+        output.add(new OpenSslEngineTestParam(true, false, param));
+        output.add(new OpenSslEngineTestParam(false, false, param));
+        if (OpenSsl.isBoringSSL()) {
+            output.add(new OpenSslEngineTestParam(true, true, param));
+            output.add(new OpenSslEngineTestParam(false, true, param));
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    static SslContext wrapContext(SSLEngineTest.SSLEngineTestParam param, SslContext context) {
+        if (context instanceof OpenSslContext) {
+            OpenSslContext ctx = (OpenSslContext) context;
+            if (param instanceof OpenSslEngineTestParam) {
+                OpenSslEngineTestParam openSslParam = (OpenSslEngineTestParam) param;
+                ctx.setUseTasks(openSslParam.useTasks);
+                if (openSslParam.useTickets) {
+                    ctx.sessionContext().setTicketKeys();
+                }
+            }
+            // Explicit enable the session cache as its disabled by default on the client side.
+            ctx.sessionContext().setSessionCacheEnabled(true);
+        }
+        return context;
+    }
+
+    static boolean isUsingTickets(SSLEngineTest.SSLEngineTestParam param) {
+        if (param instanceof OpenSslEngineTestParam) {
+            return ((OpenSslEngineTestParam) param).useTickets;
+        }
+        return false;
+    }
+
+    OpenSslEngineTestParam(boolean useTasks, boolean useTickets, SSLEngineTest.SSLEngineTestParam param) {
         super(param.type(), param.combo(), param.delegate());
         this.useTasks = useTasks;
+        this.useTickets = useTickets;
     }
 
     @Override
@@ -29,6 +68,7 @@ final class OpenSslEngineTestParam extends SSLEngineTest.SSLEngineTestParam {
                 ", protocolCipherCombo=" + combo() +
                 ", delegate=" + delegate() +
                 ", useTasks=" + useTasks +
+                ", useTickets=" + useTickets +
                 '}';
     }
 }

--- a/handler/src/test/java/io/netty5/handler/ssl/OpenSslJdkSslEngineInteroptTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/OpenSslJdkSslEngineInteroptTest.java
@@ -39,8 +39,7 @@ public class OpenSslJdkSslEngineInteroptTest extends SSLEngineTest {
         List<SSLEngineTestParam> params = super.newTestParams();
         List<SSLEngineTestParam> testParams = new ArrayList<SSLEngineTestParam>();
         for (SSLEngineTestParam param: params) {
-            testParams.add(new OpenSslEngineTestParam(true, param));
-            testParams.add(new OpenSslEngineTestParam(false, param));
+            OpenSslEngineTestParam.expandCombinations(param, testParams);
         }
         return testParams;
     }
@@ -188,14 +187,8 @@ public class OpenSslJdkSslEngineInteroptTest extends SSLEngineTest {
         return SslTestUtils.wrapSSLEngineForTesting(engine);
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     protected SslContext wrapContext(SSLEngineTestParam param, SslContext context) {
-        if (context instanceof OpenSslContext && param instanceof OpenSslEngineTestParam) {
-            ((OpenSslContext) context).setUseTasks(((OpenSslEngineTestParam) param).useTasks);
-            // Explicit enable the session cache as its disabled by default on the client side.
-            ((OpenSslContext) context).sessionContext().setSessionCacheEnabled(true);
-        }
-        return context;
+        return OpenSslEngineTestParam.wrapContext(param, context);
     }
 }

--- a/handler/src/test/java/io/netty5/handler/ssl/ReferenceCountedOpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/ReferenceCountedOpenSslEngineTest.java
@@ -78,17 +78,9 @@ public class ReferenceCountedOpenSslEngineTest extends OpenSslEngineTest {
         });
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     protected SslContext wrapContext(SSLEngineTestParam param, SslContext context) {
-        if (context instanceof ReferenceCountedOpenSslContext) {
-            if (param instanceof OpenSslEngineTestParam) {
-                ((ReferenceCountedOpenSslContext) context).setUseTasks(((OpenSslEngineTestParam) param).useTasks);
-            }
-            // Explicit enable the session cache as its disabled by default on the client side.
-            ((ReferenceCountedOpenSslContext) context).sessionContext().setSessionCacheEnabled(true);
-        }
-        return context;
+        return OpenSslEngineTestParam.wrapContext(param, context);
     }
 
     @MethodSource("newTestParams")

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslSessionReuseTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslSessionReuseTest.java
@@ -21,15 +21,19 @@ import io.netty5.buffer.Buffer;
 import io.netty5.buffer.BufferUtil;
 import io.netty5.buffer.DefaultBufferAllocators;
 import io.netty5.channel.Channel;
+import io.netty5.channel.ChannelFutureListeners;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelInitializer;
 import io.netty5.channel.SimpleChannelInboundHandler;
 import io.netty5.channel.socket.SocketChannel;
+import io.netty5.handler.ssl.ResumableX509ExtendedTrustManager;
 import io.netty5.handler.ssl.SslContext;
 import io.netty5.handler.ssl.SslContextBuilder;
 import io.netty5.handler.ssl.SslHandler;
+import io.netty5.handler.ssl.SslHandshakeCompletionEvent;
 import io.netty5.handler.ssl.SslProvider;
 import io.netty5.handler.ssl.util.SelfSignedCertificate;
+import io.netty5.util.concurrent.Future;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -38,20 +42,31 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSessionContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509ExtendedTrustManager;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.net.Socket;
 import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SocketSslSessionReuseTest extends AbstractSocketTest {
 
@@ -71,25 +86,45 @@ public class SocketSslSessionReuseTest extends AbstractSocketTest {
         KEY_FILE = ssc.privateKey();
     }
 
-    public static Collection<Object[]> data() throws Exception {
+    public static Collection<Object[]> jdkOnly() throws Exception {
         return Collections.singletonList(new Object[] {
           SslContextBuilder.forServer(CERT_FILE, KEY_FILE)
                   .sslProvider(SslProvider.JDK)
-                  .endpointIdentificationAlgorithm("")
-                  .build(),
+                  .endpointIdentificationAlgorithm(""),
           SslContextBuilder.forClient()
                   .trustManager(CERT_FILE)
                   .sslProvider(SslProvider.JDK)
                   .endpointIdentificationAlgorithm("")
-                  .build()
         });
     }
 
+    public static Collection<Object[]> jdkAndOpenSSL() throws Exception {
+        return Arrays.asList(new Object[]{
+                        SslContextBuilder.forServer(CERT_FILE, KEY_FILE)
+                                .sslProvider(SslProvider.JDK)
+                                .endpointIdentificationAlgorithm(""),
+                        SslContextBuilder.forClient()
+                                .trustManager(CERT_FILE)
+                                .sslProvider(SslProvider.JDK)
+                                .endpointIdentificationAlgorithm("")
+                },
+                new Object[]{
+                        SslContextBuilder.forServer(CERT_FILE, KEY_FILE)
+                                .sslProvider(SslProvider.OPENSSL)
+                                .endpointIdentificationAlgorithm(""),
+                        SslContextBuilder.forClient()
+                                .trustManager(CERT_FILE)
+                                .sslProvider(SslProvider.OPENSSL)
+                                .endpointIdentificationAlgorithm("")
+                });
+    }
+
     @ParameterizedTest(name = "{index}: serverEngine = {0}, clientEngine = {1}")
-    @MethodSource("data")
+    @MethodSource("jdkOnly")
     @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
-    public void testSslSessionReuse(SslContext serverCtx, SslContext clientCtx, TestInfo testInfo) throws Throwable {
-        run(testInfo, (sb, cb) -> testSslSessionReuse(sb, cb, serverCtx, clientCtx));
+    public void testSslSessionReuse(SslContextBuilder serverCtx, SslContextBuilder clientCtx, TestInfo testInfo)
+            throws Throwable {
+        run(testInfo, (sb, cb) -> testSslSessionReuse(sb, cb, serverCtx.build(), clientCtx.build()));
     }
 
     public void testSslSessionReuse(ServerBootstrap sb, Bootstrap cb,
@@ -129,14 +164,14 @@ public class SocketSslSessionReuseTest extends AbstractSocketTest {
             SSLSessionContext clientSessionCtx = clientCtx.sessionContext();
             Buffer msg = DefaultBufferAllocators.preferredAllocator().copyOf(new byte[] { 0xa, 0xb, 0xc, 0xd });
             Channel cc = cb.connect(sc.localAddress()).asStage().get();
-            cc.writeAndFlush(msg).asStage().sync();
+            cc.writeAndFlush(msg).addListener(cc, ChannelFutureListeners.CLOSE).asStage().sync();
             cc.closeFuture().asStage().sync();
             rethrowHandlerExceptions(sh, ch);
             Set<String> sessions = sessionIdSet(clientSessionCtx.getIds());
 
             msg = DefaultBufferAllocators.preferredAllocator().copyOf(new byte[] { 0xa, 0xb, 0xc, 0xd });
             cc = cb.connect(sc.localAddress()).asStage().get();
-            cc.writeAndFlush(msg).asStage().sync();
+            cc.writeAndFlush(msg).addListener(cc, ChannelFutureListeners.CLOSE).asStage().sync();
             cc.closeFuture().asStage().sync();
             assertEquals(sessions, sessionIdSet(clientSessionCtx.getIds()), "Expected no new sessions");
             rethrowHandlerExceptions(sh, ch);
@@ -145,18 +180,100 @@ public class SocketSslSessionReuseTest extends AbstractSocketTest {
         }
     }
 
+    @ParameterizedTest(name = "{index}: serverEngine = {0}, clientEngine = {1}")
+    @MethodSource("jdkAndOpenSSL")
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    public void testSslSessionTrustManagerResumption(
+            final SslContextBuilder serverCtx, final SslContextBuilder clientCtx, TestInfo testInfo) throws Throwable {
+        run(testInfo, new Runner<ServerBootstrap, Bootstrap>() {
+            @Override
+            public void run(ServerBootstrap serverBootstrap, Bootstrap bootstrap) throws Throwable {
+                testSslSessionTrustManagerResumption(sb, cb, serverCtx, clientCtx);
+            }
+        });
+    }
+
+    public void testSslSessionTrustManagerResumption(
+            ServerBootstrap sb, Bootstrap cb,
+            SslContextBuilder serverCtxBldr, final SslContextBuilder clientCtxBldr) throws Throwable {
+        final String[] protocols = { "TLSv1", "TLSv1.1", "TLSv1.2" };
+        serverCtxBldr.protocols(protocols);
+        clientCtxBldr.protocols(protocols);
+        TrustManager clientTrustManager = new SessionSettingTrustManager();
+        clientCtxBldr.trustManager(clientTrustManager);
+        final SslContext serverContext = serverCtxBldr.build();
+        final SslContext clientContext = clientCtxBldr.build();
+
+        final BlockingQueue<String> sessionValue = new LinkedBlockingQueue<String>();
+        final ReadAndDiscardHandler sh = new ReadAndDiscardHandler(true, true);
+        final ReadAndDiscardHandler ch = new ReadAndDiscardHandler(false, true) {
+            @Override
+            public Future<Void> sendOutboundEvent(ChannelHandlerContext ctx, Object evt) {
+                if (evt instanceof SslHandshakeCompletionEvent) {
+                    SslHandshakeCompletionEvent handshakeCompletionEvent = (SslHandshakeCompletionEvent) evt;
+                    if (handshakeCompletionEvent.isSuccess()) {
+                        SSLSession session = ctx.pipeline().get(SslHandler.class).engine().getSession();
+                        assertTrue(sessionValue.offer(String.valueOf(session.getValue("key"))));
+                    } else {
+                        logger.error("SSL handshake failed", handshakeCompletionEvent.cause());
+                    }
+                }
+                return super.sendOutboundEvent(ctx, evt);
+            }
+        };
+
+        sb.childHandler(new ChannelInitializer<SocketChannel>() {
+            @Override
+            protected void initChannel(SocketChannel sch) throws Exception {
+                sch.pipeline().addLast(serverContext.newHandler(sch.bufferAllocator()));
+                sch.pipeline().addLast(sh);
+            }
+        });
+        final Channel sc = sb.bind().asStage().get();
+
+        cb.handler(new ChannelInitializer<SocketChannel>() {
+            @Override
+            protected void initChannel(SocketChannel sch) throws Exception {
+                InetSocketAddress serverAddr = (InetSocketAddress) sc.localAddress();
+                SslHandler sslHandler = clientContext.newHandler(
+                        sch.bufferAllocator(), serverAddr.getHostString(), serverAddr.getPort());
+
+                sch.pipeline().addLast(sslHandler);
+                sch.pipeline().addLast(ch);
+            }
+        });
+
+        try {
+            Buffer msg = DefaultBufferAllocators.preferredAllocator().copyOf(new byte[] { 0xa, 0xb, 0xc, 0xd });
+            Channel cc = cb.connect(sc.localAddress()).asStage().get();
+            cc.writeAndFlush(msg).addListener(cc, ChannelFutureListeners.CLOSE).asStage().sync();
+            cc.closeFuture().asStage().sync();
+            rethrowHandlerExceptions(sh, ch);
+            assertEquals("value", sessionValue.poll(10, TimeUnit.SECONDS));
+
+            msg = DefaultBufferAllocators.preferredAllocator().copyOf(new byte[] { 0xa, 0xb, 0xc, 0xd });
+            cc = cb.connect(sc.localAddress()).asStage().get();
+            cc.writeAndFlush(msg).addListener(cc, ChannelFutureListeners.CLOSE).asStage().sync();
+            cc.closeFuture().asStage().sync();
+            rethrowHandlerExceptions(sh, ch);
+            assertEquals("value", sessionValue.poll(10, TimeUnit.SECONDS));
+        } finally {
+            sc.close().asStage().await();
+        }
+    }
+
     private static void rethrowHandlerExceptions(ReadAndDiscardHandler sh, ReadAndDiscardHandler ch) throws Throwable {
         if (sh.exception.get() != null && !(sh.exception.get() instanceof IOException)) {
-            throw sh.exception.get();
+            throw new ExecutionException(sh.exception.get());
         }
         if (ch.exception.get() != null && !(ch.exception.get() instanceof IOException)) {
-            throw ch.exception.get();
+            throw new ExecutionException(ch.exception.get());
         }
         if (sh.exception.get() != null) {
-            throw sh.exception.get();
+            throw new ExecutionException(sh.exception.get());
         }
         if (ch.exception.get() != null) {
-            throw ch.exception.get();
+            throw new ExecutionException(ch.exception.get());
         }
     }
 
@@ -187,8 +304,7 @@ public class SocketSslSessionReuseTest extends AbstractSocketTest {
 
         @Override
         public void messageReceived(ChannelHandlerContext ctx, Buffer in) throws Exception {
-            byte[] actual = new byte[in.readableBytes()];
-            in.readBytes(actual, 0, actual.length);
+            in.skipReadableBytes(in.readableBytes());
             ctx.close();
         }
 
@@ -204,8 +320,7 @@ public class SocketSslSessionReuseTest extends AbstractSocketTest {
         }
 
         @Override
-        public void channelExceptionCaught(ChannelHandlerContext ctx,
-                                           Throwable cause) throws Exception {
+        public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
             if (logger.isWarnEnabled()) {
                 logger.warn(
                         "Unexpected exception from the " +
@@ -214,6 +329,58 @@ public class SocketSslSessionReuseTest extends AbstractSocketTest {
 
             exception.compareAndSet(null, cause);
             ctx.close();
+        }
+    }
+
+    private static final class SessionSettingTrustManager extends X509ExtendedTrustManager
+            implements ResumableX509ExtendedTrustManager {
+        @Override
+        public void resumeServerTrusted(X509Certificate[] chain, SSLEngine engine) throws CertificateException {
+            engine.getSession().putValue("key", "value");
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType, SSLEngine engine)
+                throws CertificateException {
+            engine.getHandshakeSession().putValue("key", "value");
+        }
+
+        @Override
+        public void resumeClientTrusted(X509Certificate[] chain, SSLEngine engine) throws CertificateException {
+            throw new CertificateException("Unsupported operation");
+        }
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType, SSLEngine engine)
+                throws CertificateException {
+            throw new CertificateException("Unsupported operation");
+        }
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType, Socket socket)
+                throws CertificateException {
+            throw new CertificateException("Unsupported operation");
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType, Socket socket)
+                throws CertificateException {
+            throw new CertificateException("Unsupported operation");
+        }
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+            throw new CertificateException("Unsupported operation");
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+            throw new CertificateException("Unsupported operation");
+        }
+
+        @Override
+        public X509Certificate[] getAcceptedIssuers() {
+            return new X509Certificate[0];
         }
     }
 }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslSessionReuseTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslSessionReuseTest.java
@@ -33,7 +33,6 @@ import io.netty5.handler.ssl.SslHandler;
 import io.netty5.handler.ssl.SslHandshakeCompletionEvent;
 import io.netty5.handler.ssl.SslProvider;
 import io.netty5.handler.ssl.util.SelfSignedCertificate;
-import io.netty5.util.concurrent.Future;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -208,7 +207,7 @@ public class SocketSslSessionReuseTest extends AbstractSocketTest {
         final ReadAndDiscardHandler sh = new ReadAndDiscardHandler(true, true);
         final ReadAndDiscardHandler ch = new ReadAndDiscardHandler(false, true) {
             @Override
-            public Future<Void> sendOutboundEvent(ChannelHandlerContext ctx, Object evt) {
+            public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
                 if (evt instanceof SslHandshakeCompletionEvent) {
                     SslHandshakeCompletionEvent handshakeCompletionEvent = (SslHandshakeCompletionEvent) evt;
                     if (handshakeCompletionEvent.isSuccess()) {
@@ -218,7 +217,7 @@ public class SocketSslSessionReuseTest extends AbstractSocketTest {
                         logger.error("SSL handshake failed", handshakeCompletionEvent.cause());
                     }
                 }
-                return super.sendOutboundEvent(ctx, evt);
+                super.channelInboundEvent(ctx, evt);
             }
         };
 


### PR DESCRIPTION
Motivation:
Some trust manager implementations produce custom user principals and store them in the SSLSession. Resumed TLS sessions, however, don't always recover the stored contents. For instance, with TLSv1.3 stateless session resumption, our TLS implementations only store the peer certificate chain (or even just the leaf cert) in the session ticket. In such a case, the trust manager would like to be notified of the resumption, so that the peer principal can be recreated and stored in the session once again.

Modification:
Add a ResumableX509ExtendedTrustManager interface, with callbacks for resumed client and server sessions. Add infrastructure (the ResumptionController) to detect session resumption in an SSLEngine implementation agnostic way; if a TLS handshake completed without any calls to the TrustManager, then we've made a "stateless resumption" (hand-wave details) and should call the appropriate resume method. The JDK APIs don't provide a method to reliably discern if a session has been resumed, so we instead detect if the trust manager was called during the handshake. We do this by wrapping user-supplied trust managers that implement the ResumableX509ExtendedTrustManager interface. The wrapper will monitor calls to the trust manager and register the relevant SSLEngine in the controller — the engine is the object that the trust manager and the SslHandler both have access to, which reliably identifies the specific TLS session. Before finished the handshake, the SslHandler queries the ResumptionController to see if the trust manager has already been called, or if it needs to be notified of resumption. Since it's possible that the peer certificates have expired since the initial session, the trust manager gets another change to throw CertificateException.

Result:
Handlers that expect to find user principals in the authenticated SSLSessions no longer find empty sessions, provided they use a trust manager that correctly implements ResumableX509ExtendedTrustManager.

This is a forward port of https://github.com/netty/netty/pull/14358, https://github.com/netty/netty/pull/14404, and https://github.com/netty/netty/pull/14411