### PR TITLE
DnsResolverBuilder methods should make it clear that these are for Da…

### DIFF
--- a/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspServerCertificateValidator.java
+++ b/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspServerCertificateValidator.java
@@ -122,7 +122,7 @@ public class OcspServerCertificateValidator extends ChannelInboundHandlerAdapter
     protected static DnsNameResolver createDefaultResolver(final IoTransport ioTransport) {
         return new DnsNameResolverBuilder()
                 .eventLoop(ioTransport.eventLoop())
-                .channelFactory(ioTransport.datagramChannel())
+                .datagramChannelFactory(ioTransport.datagramChannel())
                 .socketChannelFactory(ioTransport.socketChannel())
                 .build();
     }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolverGroup.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolverGroup.java
@@ -52,14 +52,14 @@ public class DnsAddressResolverGroup extends AddressResolverGroup<InetSocketAddr
             Class<? extends DatagramChannel> channelType,
             DnsServerAddressStreamProvider nameServerProvider) {
         this.dnsResolverBuilder = withSharedCaches(new DnsNameResolverBuilder());
-        dnsResolverBuilder.channelType(channelType).nameServerProvider(nameServerProvider);
+        dnsResolverBuilder.datagramChannelType(channelType).nameServerProvider(nameServerProvider);
     }
 
     public DnsAddressResolverGroup(
             ChannelFactory<? extends DatagramChannel> channelFactory,
             DnsServerAddressStreamProvider nameServerProvider) {
         this.dnsResolverBuilder = withSharedCaches(new DnsNameResolverBuilder());
-        dnsResolverBuilder.channelFactory(channelFactory).nameServerProvider(nameServerProvider);
+        dnsResolverBuilder.datagramChannelFactory(channelFactory).nameServerProvider(nameServerProvider);
     }
 
     private static DnsNameResolverBuilder withSharedCaches(DnsNameResolverBuilder dnsResolverBuilder) {
@@ -83,7 +83,7 @@ public class DnsAddressResolverGroup extends AddressResolverGroup<InetSocketAddr
         // but still keep this to ensure backward compatibility with (potentially) override methods
         EventLoop loop = dnsResolverBuilder.eventLoop;
         return newResolver(loop == null ? (EventLoop) executor : loop,
-                dnsResolverBuilder.channelFactory(),
+                dnsResolverBuilder.datagramChannelFactory(),
                 dnsResolverBuilder.nameServerProvider());
     }
 
@@ -117,7 +117,7 @@ public class DnsAddressResolverGroup extends AddressResolverGroup<InetSocketAddr
         // once again, channelFactory and nameServerProvider are most probably set in builder already,
         // but I do reassign them again to avoid corner cases with override methods
         return builder.eventLoop(eventLoop)
-                .channelFactory(channelFactory)
+                .datagramChannelFactory(channelFactory)
                 .nameServerProvider(nameServerProvider)
                 .build();
     }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
@@ -48,7 +48,7 @@ public final class DnsNameResolverBuilder {
     static final SocketAddress DEFAULT_LOCAL_ADDRESS = new InetSocketAddress(0);
 
     volatile EventLoop eventLoop;
-    private ChannelFactory<? extends DatagramChannel> channelFactory;
+    private ChannelFactory<? extends DatagramChannel> datagramChannelFactory;
     private ChannelFactory<? extends SocketChannel> socketChannelFactory;
     private boolean retryOnTimeout;
 
@@ -106,40 +106,75 @@ public final class DnsNameResolverBuilder {
         return this;
     }
 
-    protected ChannelFactory<? extends DatagramChannel> channelFactory() {
-        return this.channelFactory;
+    ChannelFactory<? extends DatagramChannel> datagramChannelFactory() {
+        return this.datagramChannelFactory;
     }
 
     /**
      * Sets the {@link ChannelFactory} that will create a {@link DatagramChannel}.
+     * <p>
      * If <a href="https://tools.ietf.org/html/rfc7766">TCP fallback</a> should be supported as well it is required
      * to call the {@link #socketChannelFactory(ChannelFactory) or {@link #socketChannelType(Class)}} method.
      *
-     * @param channelFactory the {@link ChannelFactory}
+     * @param datagramChannelFactory the {@link ChannelFactory}
+     * @return {@code this}
+     * @deprecated use {@link #datagramChannelFactory(ChannelFactory)}
+     */
+    @Deprecated
+    public DnsNameResolverBuilder channelFactory(ChannelFactory<? extends DatagramChannel> datagramChannelFactory) {
+        datagramChannelFactory(datagramChannelFactory);
+        return this;
+    }
+
+    /**
+     * Sets the {@link ChannelFactory} that will create a {@link DatagramChannel}.
+     * <p>
+     * If <a href="https://tools.ietf.org/html/rfc7766">TCP fallback</a> should be supported as well it is required
+     * to call the {@link #socketChannelFactory(ChannelFactory) or {@link #socketChannelType(Class)}} method.
+     *
+     * @param datagramChannelFactory the {@link ChannelFactory}
      * @return {@code this}
      */
-    public DnsNameResolverBuilder channelFactory(ChannelFactory<? extends DatagramChannel> channelFactory) {
-        this.channelFactory = channelFactory;
+    public DnsNameResolverBuilder datagramChannelFactory(
+            ChannelFactory<? extends DatagramChannel> datagramChannelFactory) {
+        this.datagramChannelFactory = datagramChannelFactory;
         return this;
     }
 
     /**
      * Sets the {@link ChannelFactory} as a {@link ReflectiveChannelFactory} of this type.
      * Use as an alternative to {@link #channelFactory(ChannelFactory)}.
+     * <p>
+     * If <a href="https://tools.ietf.org/html/rfc7766">TCP fallback</a> should be supported as well it is required
+     * to call the {@link #socketChannelFactory(ChannelFactory) or {@link #socketChannelType(Class)}} method.
+     *
+     * @param channelType the type
+     * @return {@code this}
+     * @deprecated use {@link #datagramChannelType(Class)}
+     */
+    @Deprecated
+    public DnsNameResolverBuilder channelType(Class<? extends DatagramChannel> channelType) {
+        return datagramChannelFactory(new ReflectiveChannelFactory<DatagramChannel>(channelType));
+    }
+
+    /**
+     * Sets the {@link ChannelFactory} as a {@link ReflectiveChannelFactory} of this type.
+     * Use as an alternative to {@link #datagramChannelFactory(ChannelFactory)}.
+     * <p>
      * If <a href="https://tools.ietf.org/html/rfc7766">TCP fallback</a> should be supported as well it is required
      * to call the {@link #socketChannelFactory(ChannelFactory) or {@link #socketChannelType(Class)}} method.
      *
      * @param channelType the type
      * @return {@code this}
      */
-    public DnsNameResolverBuilder channelType(Class<? extends DatagramChannel> channelType) {
-        return channelFactory(new ReflectiveChannelFactory<DatagramChannel>(channelType));
+    public DnsNameResolverBuilder datagramChannelType(Class<? extends DatagramChannel> channelType) {
+        return datagramChannelFactory(new ReflectiveChannelFactory<DatagramChannel>(channelType));
     }
 
     /**
      * Sets the {@link ChannelFactory} that will create a {@link SocketChannel} for
      * <a href="https://tools.ietf.org/html/rfc7766">TCP fallback</a> if needed.
-     *
+     * <p>
      * TCP fallback is <strong>not</strong> enabled by default and must be enabled by providing a non-null
      * {@link ChannelFactory} for this method.
      *
@@ -156,7 +191,7 @@ public final class DnsNameResolverBuilder {
      * Sets the {@link ChannelFactory} as a {@link ReflectiveChannelFactory} of this type for
      * <a href="https://tools.ietf.org/html/rfc7766">TCP fallback</a> if needed.
      * Use as an alternative to {@link #socketChannelFactory(ChannelFactory)}.
-     *
+     * <p>
      * TCP fallback is <strong>not</strong> enabled by default and must be enabled by providing a non-null
      * {@code channelType} for this method.
      *
@@ -171,7 +206,7 @@ public final class DnsNameResolverBuilder {
     /**
      * Sets the {@link ChannelFactory} that will create a {@link SocketChannel} for
      * <a href="https://tools.ietf.org/html/rfc7766">TCP fallback</a> if needed.
-     *
+     * <p>
      * TCP fallback is <strong>not</strong> enabled by default and must be enabled by providing a non-null
      * {@link ChannelFactory} for this method.
      *
@@ -194,7 +229,7 @@ public final class DnsNameResolverBuilder {
      * Sets the {@link ChannelFactory} as a {@link ReflectiveChannelFactory} of this type for
      * <a href="https://tools.ietf.org/html/rfc7766">TCP fallback</a> if needed.
      * Use as an alternative to {@link #socketChannelFactory(ChannelFactory)}.
-     *
+     * <p>
      * TCP fallback is <strong>not</strong> enabled by default and must be enabled by providing a non-null
      * {@code channelType} for this method.
      *
@@ -636,7 +671,7 @@ public final class DnsNameResolverBuilder {
 
         return new DnsNameResolver(
                 eventLoop,
-                channelFactory,
+                datagramChannelFactory,
                 socketChannelFactory,
                 retryOnTimeout,
                 resolveCache,
@@ -673,8 +708,8 @@ public final class DnsNameResolverBuilder {
             copiedBuilder.eventLoop(eventLoop);
         }
 
-        if (channelFactory != null) {
-            copiedBuilder.channelFactory(channelFactory);
+        if (datagramChannelFactory != null) {
+            copiedBuilder.datagramChannelFactory(datagramChannelFactory);
         }
 
         copiedBuilder.socketChannelFactory(socketChannelFactory, retryOnTimeout);

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsAddressResolverGroupTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsAddressResolverGroupTest.java
@@ -46,7 +46,7 @@ public class DnsAddressResolverGroupTest {
         final EventLoop loop = group.next();
         DefaultEventLoopGroup defaultEventLoopGroup = new DefaultEventLoopGroup(1);
         DnsNameResolverBuilder builder = new DnsNameResolverBuilder()
-                .eventLoop(loop).channelType(NioDatagramChannel.class);
+                .eventLoop(loop).datagramChannelType(NioDatagramChannel.class);
         DnsAddressResolverGroup resolverGroup = new DnsAddressResolverGroup(builder);
         try {
             final Promise<?> promise = loop.newPromise();
@@ -79,7 +79,7 @@ public class DnsAddressResolverGroupTest {
         MultiThreadIoEventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
         final EventLoop loop = group.next();
         DnsNameResolverBuilder builder = new DnsNameResolverBuilder()
-                .eventLoop(loop).channelType(NioDatagramChannel.class);
+                .eventLoop(loop).datagramChannelType(NioDatagramChannel.class);
         DnsAddressResolverGroup resolverGroup = new DnsAddressResolverGroup(builder);
         DefaultEventLoopGroup defaultEventLoopGroup = new DefaultEventLoopGroup(2);
         EventLoop eventLoop1 = defaultEventLoopGroup.next();

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverBuilderTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverBuilderTest.java
@@ -41,7 +41,7 @@ class DnsNameResolverBuilderTest {
 
     @BeforeEach
     void setUp() {
-        builder = new DnsNameResolverBuilder(GROUP.next()).channelType(NioDatagramChannel.class);
+        builder = new DnsNameResolverBuilder(GROUP.next()).datagramChannelType(NioDatagramChannel.class);
     }
 
     @AfterEach

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverClientSubnetTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverClientSubnetTest.java
@@ -60,7 +60,7 @@ public class DnsNameResolverClientSubnetTest {
 
     private static DnsNameResolverBuilder newResolver(EventLoopGroup group) {
         return new DnsNameResolverBuilder(group.next())
-                .channelType(NioDatagramChannel.class)
+                .datagramChannelType(NioDatagramChannel.class)
                 .nameServerProvider(
                         new SingletonDnsServerAddressStreamProvider(SocketUtils.socketAddress("8.8.8.8", 53)))
                 .maxQueriesPerResolve(1)

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -396,7 +396,7 @@ public class DnsNameResolverTest {
                                                       TestDnsServer dnsServer) {
         DnsNameResolverBuilder builder = new DnsNameResolverBuilder(group.next())
                 .dnsQueryLifecycleObserverFactory(new TestRecursiveCacheDnsQueryLifecycleObserverFactory())
-                .channelType(NioDatagramChannel.class)
+                .datagramChannelType(NioDatagramChannel.class)
                 .maxQueriesPerResolve(1)
                 .decodeIdn(decodeToUnicode)
                 .optResourceEnabled(false)
@@ -1157,7 +1157,7 @@ public class DnsNameResolverTest {
     @Test
     public void testResolveAllHostsFile() {
         final DnsNameResolver resolver = new DnsNameResolverBuilder(group.next())
-                .channelType(NioDatagramChannel.class)
+                .datagramChannelType(NioDatagramChannel.class)
                 .hostsFileEntriesResolver(new HostsFileEntriesResolver() {
                     @Override
                     public InetAddress address(String inetHost, ResolvedAddressTypes resolvedAddressTypes) {
@@ -1245,7 +1245,7 @@ public class DnsNameResolverTest {
             DnsNameResolverBuilder builder = new DnsNameResolverBuilder(group.next())
                     .dnsQueryLifecycleObserverFactory(lifecycleObserverFactory)
                     .resolvedAddressTypes(ResolvedAddressTypes.IPV4_ONLY)
-                    .channelType(NioDatagramChannel.class)
+                    .datagramChannelType(NioDatagramChannel.class)
                     .queryTimeoutMillis(1000) // We expect timeouts if startDnsServer1 is false
                     .optResourceEnabled(false)
                     .ndots(1);
@@ -1294,7 +1294,7 @@ public class DnsNameResolverTest {
             DnsNameResolverBuilder builder = new DnsNameResolverBuilder(group.next())
                     .resolvedAddressTypes(ResolvedAddressTypes.IPV4_ONLY)
                     .dnsQueryLifecycleObserverFactory(lifecycleObserverFactory)
-                    .channelType(NioDatagramChannel.class)
+                    .datagramChannelType(NioDatagramChannel.class)
                     .optResourceEnabled(false)
                     .ndots(1);
 
@@ -2408,15 +2408,15 @@ public class DnsNameResolverTest {
         ChannelFactory<DatagramChannel> channelFactory =
                 new ReflectiveChannelFactory<DatagramChannel>(NioDatagramChannel.class);
         DnsNameResolverBuilder builder = new DnsNameResolverBuilder(group.next())
-                .channelFactory(channelFactory);
+                .datagramChannelFactory(channelFactory);
         DnsNameResolverBuilder copiedBuilder = builder.copy();
 
         // change channel factory does not propagate to previously made copy
         ChannelFactory<DatagramChannel> newChannelFactory =
                 new ReflectiveChannelFactory<DatagramChannel>(NioDatagramChannel.class);
-        builder.channelFactory(newChannelFactory);
-        assertEquals(channelFactory, copiedBuilder.channelFactory());
-        assertEquals(newChannelFactory, builder.channelFactory());
+        builder.datagramChannelFactory(newChannelFactory);
+        assertEquals(channelFactory, copiedBuilder.datagramChannelFactory());
+        assertEquals(newChannelFactory, builder.datagramChannelFactory());
     }
 
     @Test
@@ -2770,7 +2770,7 @@ public class DnsNameResolverTest {
     public void testChannelFactoryException() {
         final IllegalStateException exception = new IllegalStateException();
         try {
-            newResolver().channelFactory(new ChannelFactory<DatagramChannel>() {
+            newResolver().datagramChannelFactory(new ChannelFactory<DatagramChannel>() {
                 @Override
                 public DatagramChannel newChannel() {
                     throw exception;
@@ -3259,7 +3259,7 @@ public class DnsNameResolverTest {
                     return datagramChannel;
                 }
             };
-            builder.channelFactory(channelFactory);
+            builder.datagramChannelFactory(channelFactory);
             if (tcpFallback) {
                 // If we are configured to use TCP as a fallback also bind a TCP socket
                 serverSocket = startDnsServerAndCreateServerSocket(dnsServer2);
@@ -3422,7 +3422,7 @@ public class DnsNameResolverTest {
                     return datagramChannel;
                 }
             };
-            builder.channelFactory(channelFactory);
+            builder.datagramChannelFactory(channelFactory);
             serverSocket = startDnsServerAndCreateServerSocket(dnsServer2);
             // If we are configured to use TCP as a fallback also bind a TCP socket
             builder.socketChannelType(NioSocketChannel.class, true);
@@ -3506,7 +3506,7 @@ public class DnsNameResolverTest {
                                                              dnsServer2.localAddress());
         final DnsNameResolver resolver = new DnsNameResolverBuilder(group.next())
                 .dnsQueryLifecycleObserverFactory(new TestRecursiveCacheDnsQueryLifecycleObserverFactory())
-                .channelType(NioDatagramChannel.class)
+                .datagramChannelType(NioDatagramChannel.class)
                 .optResourceEnabled(false)
                 .nameServerProvider(nameServerProvider)
                 .build();

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/SearchDomainTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/SearchDomainTest.java
@@ -46,7 +46,7 @@ public class SearchDomainTest {
 
     private DnsNameResolverBuilder newResolver() {
         return new DnsNameResolverBuilder(group.next())
-            .channelType(NioDatagramChannel.class)
+            .datagramChannelType(NioDatagramChannel.class)
             .nameServerProvider(new SingletonDnsServerAddressStreamProvider(dnsServer.localAddress()))
             .maxQueriesPerResolve(1)
             .optResourceEnabled(false)

--- a/transport-blockhound-tests/src/test/java/io/netty/util/internal/NettyBlockHoundIntegrationTest.java
+++ b/transport-blockhound-tests/src/test/java/io/netty/util/internal/NettyBlockHoundIntegrationTest.java
@@ -415,7 +415,7 @@ public class NettyBlockHoundIntegrationTest {
         EventLoopGroup group = new MultiThreadIoEventLoopGroup(NioIoHandler.newFactory());
         try {
             DnsNameResolverBuilder builder = new DnsNameResolverBuilder(group.next())
-                    .channelFactory(NioDatagramChannel::new);
+                    .datagramChannelFactory(NioDatagramChannel::new);
             doTestParseResolverFilesAllowsBlockingCalls(builder::build);
         } finally {
             group.shutdownGracefully();


### PR DESCRIPTION
…… (#14379)

…tagramChannel

Motivation:

We should add new methods (and deprecate the old ones) to make it more clear that these are responsible for creating DatagramChannels.

Modifications:

- Add datagramChannelType(...) and datagramChannelFactory(...) and deprecate the old channelType(...) and channelFactory(...) methods
- Adjust code to use the new methods in favor of the new deprecated methods

Result:

Cleanup