### PR TITLE
Refactor DnsNameResolver to be able to use different strategies when …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7159,6 +7159,13 @@
                   <old>class io.netty.handler.ssl.ocsp.OcspClientHandler</old>
                   <justification>OcspClientHandler moved to netty-codec-ssl-ocsp</justification>
                 </item>
+
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.removed</code>
+                  <old>method io.netty.channel.ChannelFactory&lt;&amp; extends io.netty.channel.socket.DatagramChannel&gt; io.netty.resolver.dns.DnsNameResolverBuilder::channelFactory()</old>
+                  <justification>Protected methods of a final class.</justification>
+                </item>
               </differences>
             </revapi.differences>
           </analysisConfiguration>

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DatagramDnsQueryContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DatagramDnsQueryContext.java
@@ -18,6 +18,7 @@ package io.netty.resolver.dns;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.AddressedEnvelope;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
 import io.netty.handler.codec.dns.DatagramDnsQuery;
 import io.netty.handler.codec.dns.DnsQuery;
 import io.netty.handler.codec.dns.DnsQuestion;
@@ -30,7 +31,7 @@ import java.net.InetSocketAddress;
 
 final class DatagramDnsQueryContext extends DnsQueryContext {
 
-    DatagramDnsQueryContext(Channel channel, Future<? extends Channel> channelReadyFuture,
+    DatagramDnsQueryContext(Channel channel,
                             InetSocketAddress nameServerAddr,
                             DnsQueryContextManager queryContextManager,
                             int maxPayLoadSize, boolean recursionDesired,
@@ -38,7 +39,7 @@ final class DatagramDnsQueryContext extends DnsQueryContext {
                             DnsQuestion question, DnsRecord[] additionals,
                             Promise<AddressedEnvelope<DnsResponse, InetSocketAddress>> promise,
                             Bootstrap socketBootstrap, boolean retryWithTcpOnTimeout) {
-        super(channel, channelReadyFuture, nameServerAddr, queryContextManager, maxPayLoadSize, recursionDesired,
+        super(channel, nameServerAddr, queryContextManager, maxPayLoadSize, recursionDesired,
                 queryTimeoutMillis, question, additionals, promise, socketBootstrap, retryWithTcpOnTimeout);
     }
 

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolveContext.java
@@ -26,7 +26,6 @@ import io.netty.channel.Channel;
 import io.netty.channel.EventLoop;
 import io.netty.handler.codec.dns.DnsRecord;
 import io.netty.handler.codec.dns.DnsRecordType;
-import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 
 final class DnsAddressResolveContext extends DnsResolveContext<InetAddress> {
@@ -35,12 +34,12 @@ final class DnsAddressResolveContext extends DnsResolveContext<InetAddress> {
     private final AuthoritativeDnsServerCache authoritativeDnsServerCache;
     private final boolean completeEarlyIfPossible;
 
-    DnsAddressResolveContext(DnsNameResolver parent, Channel channel, Future<? extends Channel> channelReadyFuture,
+    DnsAddressResolveContext(DnsNameResolver parent, Channel channel,
                              Promise<?> originalPromise, String hostname, DnsRecord[] additionals,
                              DnsServerAddressStream nameServerAddrs, int allowedQueries, DnsCache resolveCache,
                              AuthoritativeDnsServerCache authoritativeDnsServerCache,
                              boolean completeEarlyIfPossible) {
-        super(parent, channel, channelReadyFuture, originalPromise, hostname, DnsRecord.CLASS_IN,
+        super(parent, channel, originalPromise, hostname, DnsRecord.CLASS_IN,
               parent.resolveRecordTypes(), additionals, nameServerAddrs, allowedQueries);
         this.resolveCache = resolveCache;
         this.authoritativeDnsServerCache = authoritativeDnsServerCache;
@@ -49,13 +48,12 @@ final class DnsAddressResolveContext extends DnsResolveContext<InetAddress> {
 
     @Override
     DnsResolveContext<InetAddress> newResolverContext(DnsNameResolver parent, Channel channel,
-                                                      Future<? extends Channel> channelReadyFuture,
                                                       Promise<?> originalPromise,
                                                       String hostname,
                                                       int dnsClass, DnsRecordType[] expectedTypes,
                                                       DnsRecord[] additionals,
                                                       DnsServerAddressStream nameServerAddrs, int allowedQueries) {
-        return new DnsAddressResolveContext(parent, channel, channelReadyFuture, originalPromise, hostname, additionals,
+        return new DnsAddressResolveContext(parent, channel, originalPromise, hostname, additionals,
                 nameServerAddrs, allowedQueries, resolveCache, authoritativeDnsServerCache, completeEarlyIfPossible);
     }
 
@@ -85,7 +83,8 @@ final class DnsAddressResolveContext extends DnsResolveContext<InetAddress> {
     @Override
     void cache(String hostname, DnsRecord[] additionals,
                DnsRecord result, InetAddress convertedResult) {
-        resolveCache.cache(hostname, additionals, convertedResult, result.timeToLive(), channel().eventLoop());
+        resolveCache.cache(hostname, additionals, convertedResult, result.timeToLive(),
+                channel().eventLoop());
     }
 
     @Override

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -59,6 +59,7 @@ import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.GenericFutureListener;
 import io.netty.util.concurrent.Promise;
+import io.netty.util.concurrent.PromiseNotifier;
 import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
@@ -73,6 +74,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.NetworkInterface;
 import java.net.SocketAddress;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -235,9 +237,6 @@ public class DnsNameResolver extends InetNameResolver {
     };
     private static final DatagramDnsQueryEncoder DATAGRAM_ENCODER = new DatagramDnsQueryEncoder();
 
-    private final Promise<Channel> channelReadyPromise;
-    private final Channel ch;
-
     // Comparator that ensures we will try first to use the nameservers that use our preferred address type.
     private final Comparator<InetSocketAddress> nameServerComparator;
     /**
@@ -271,6 +270,7 @@ public class DnsNameResolver extends InetNameResolver {
     private final boolean decodeIdn;
     private final DnsQueryLifecycleObserverFactory dnsQueryLifecycleObserverFactory;
     private final boolean completeOncePreferredResolved;
+    private final DnsResolveChannelProvider resolveChannelProvider;
     private final Bootstrap socketBootstrap;
     private final boolean retryWithTcpOnTimeout;
 
@@ -381,7 +381,7 @@ public class DnsNameResolver extends InetNameResolver {
              dnsQueryLifecycleObserverFactory, queryTimeoutMillis, resolvedAddressTypes, recursionDesired,
              maxQueriesPerResolve, traceEnabled, maxPayloadSize, optResourceEnabled, hostsFileEntriesResolver,
              dnsServerAddressStreamProvider, new ThreadLocalNameServerAddressStream(dnsServerAddressStreamProvider),
-             searchDomains, ndots, decodeIdn, false, 0);
+             searchDomains, ndots, decodeIdn, false, 0, DnsNameResolverChannelStrategy.ChannelPerResolver);
     }
 
     @SuppressWarnings("deprecation")
@@ -400,7 +400,7 @@ public class DnsNameResolver extends InetNameResolver {
             boolean recursionDesired,
             int maxQueriesPerResolve,
             boolean traceEnabled,
-            int maxPayloadSize,
+            final int maxPayloadSize,
             boolean optResourceEnabled,
             HostsFileEntriesResolver hostsFileEntriesResolver,
             DnsServerAddressStreamProvider dnsServerAddressStreamProvider,
@@ -409,7 +409,7 @@ public class DnsNameResolver extends InetNameResolver {
             int ndots,
             boolean decodeIdn,
             boolean completeOncePreferredResolved,
-            int maxNumConsolidation) {
+            int maxNumConsolidation, DnsNameResolverChannelStrategy datagramChannelStrategy) {
         super(eventLoop);
         this.queryTimeoutMillis = queryTimeoutMillis >= 0
             ? queryTimeoutMillis
@@ -489,60 +489,34 @@ public class DnsNameResolver extends InetNameResolver {
             inflightLookups = null;
         }
 
-        Bootstrap b = new Bootstrap()
-                .group(executor())
+        final DnsResponseHandler responseHandler = new DnsResponseHandler(queryContextManager);
+        Bootstrap bootstrap = new Bootstrap()
                 .channelFactory(channelFactory)
-                .attr(DNS_PIPELINE_ATTRIBUTE, Boolean.TRUE);
-        this.channelReadyPromise = executor().newPromise();
-        final DnsResponseHandler responseHandler =
-                new DnsResponseHandler(channelReadyPromise);
-        b.handler(new ChannelInitializer<DatagramChannel>() {
-            @Override
-            protected void initChannel(DatagramChannel ch) {
-                ch.pipeline().addLast(DATAGRAM_ENCODER, DATAGRAM_DECODER, responseHandler);
-            }
-        });
-
-        final ChannelFuture future;
-        if (localAddress == null) {
-            b.option(ChannelOption.DATAGRAM_CHANNEL_ACTIVE_ON_REGISTRATION, true);
-            future = b.register();
-        } else {
-            future = b.bind(localAddress);
-        }
-        if (future.isDone()) {
-            Throwable cause = future.cause();
-            if (cause != null) {
-                if (cause instanceof RuntimeException) {
-                    throw (RuntimeException) cause;
-                }
-                if (cause instanceof Error) {
-                    throw (Error) cause;
-                }
-                throw new IllegalStateException("Unable to create / register Channel", cause);
-            }
-        } else {
-            future.addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) {
-                    Throwable cause = future.cause();
-                    if (cause != null) {
-                        channelReadyPromise.tryFailure(cause);
+                .group(eventLoop)
+                .attr(DNS_PIPELINE_ATTRIBUTE, Boolean.TRUE)
+                .handler(new ChannelInitializer<DatagramChannel>() {
+                    @Override
+                    protected void initChannel(DatagramChannel ch) {
+                        ch.config().setRecvByteBufAllocator(new FixedRecvByteBufAllocator(maxPayloadSize));
+                        ch.pipeline().addLast(DATAGRAM_ENCODER, DATAGRAM_DECODER, responseHandler);
                     }
-                }
-            });
+                });
+        if (localAddress == null) {
+            bootstrap.option(ChannelOption.DATAGRAM_CHANNEL_ACTIVE_ON_REGISTRATION, true);
         }
-        ch = future.channel();
-        ch.config().setRecvByteBufAllocator(new FixedRecvByteBufAllocator(maxPayloadSize));
+        this.resolveChannelProvider = newProvider(datagramChannelStrategy, bootstrap, localAddress);
+    }
 
-        ch.closeFuture().addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                resolveCache.clear();
-                cnameCache.clear();
-                authoritativeDnsServerCache.clear();
-            }
-        });
+    private static DnsResolveChannelProvider newProvider(DnsNameResolverChannelStrategy channelStrategy,
+                                                         Bootstrap bootstrap, SocketAddress localAddress) {
+        switch (channelStrategy) {
+            case ChannelPerResolver:
+                return new DnsResolveChannelPerResolverProvider(bootstrap, localAddress);
+            case ChannelPerResolution:
+                return new DnsResolveChannelPerResolutionProvider(bootstrap, localAddress);
+            default:
+                throw new IllegalArgumentException("Unknown DnsNameResolverChannelStrategy: " + channelStrategy);
+        }
     }
 
     static SocketProtocolFamily preferredAddressType(ResolvedAddressTypes resolvedAddressTypes) {
@@ -712,9 +686,10 @@ public class DnsNameResolver extends InetNameResolver {
      */
     @Override
     public void close() {
-        if (ch.isOpen()) {
-            ch.close();
-        }
+        resolveChannelProvider.close();
+        resolveCache.clear();
+        cnameCache.clear();
+        authoritativeDnsServerCache.clear();
     }
 
     @Override
@@ -880,8 +855,8 @@ public class DnsNameResolver extends InetNameResolver {
         return resolveAll(question, additionalsArray, promise);
     }
 
-    private Future<List<DnsRecord>> resolveAll(DnsQuestion question, DnsRecord[] additionals,
-                                               Promise<List<DnsRecord>> promise) {
+    private Future<List<DnsRecord>> resolveAll(final DnsQuestion question, final DnsRecord[] additionals,
+                                               final Promise<List<DnsRecord>> promise) {
         checkNotNull(question, "question");
         checkNotNull(promise, "promise");
 
@@ -923,12 +898,48 @@ public class DnsNameResolver extends InetNameResolver {
             }
         }
 
-        // It was not A/AAAA question or there was no entry in /etc/hosts.
-        final DnsServerAddressStream nameServerAddrs =
-                dnsServerAddressStreamProvider.nameServerAddressStream(hostname);
-        new DnsRecordResolveContext(this, ch, channelReadyPromise, promise, question, additionals,
-                nameServerAddrs, maxQueriesPerResolve).resolve(promise);
+        ChannelFuture f = resolveChannelProvider.nextResolveChannel(promise);
+        if (f.isDone()) {
+            resolveAllNow(f, hostname, question, additionals, promise);
+        } else {
+            f.addListener(new ChannelFutureListener() {
+                @Override
+                public void operationComplete(ChannelFuture f) {
+                    resolveAllNow(f, hostname, question, additionals, promise);
+                }
+            });
+        }
         return promise;
+    }
+
+    private void resolveAllNow(ChannelFuture f, String hostname, final DnsQuestion question,
+                               final DnsRecord[] additionals, final Promise<List<DnsRecord>> promise) {
+        if (f.isSuccess()) {
+            // It was not A/AAAA question or there was no entry in /etc/hosts.
+            final DnsServerAddressStream nameServerAddrs =
+                    dnsServerAddressStreamProvider.nameServerAddressStream(hostname);
+
+            new DnsRecordResolveContext(DnsNameResolver.this, f.channel(), promise, question, additionals,
+                    nameServerAddrs, maxQueriesPerResolve).resolve(promise);
+        } else {
+            UnknownHostException e = toException(f, hostname, question, additionals);
+            promise.setFailure(e);
+        }
+    }
+
+    private static UnknownHostException toException(
+            ChannelFuture f, String hostname, DnsQuestion question, DnsRecord[] additionals) {
+        UnknownHostException e = new UnknownHostException(
+                "Failed to resolve '" + hostname + "', couldn't setup transport: " + f.channel());
+        e.initCause(f.cause());
+
+        if (question != null) {
+            ReferenceCountUtil.release(question);
+        }
+        for (DnsRecord record : additionals) {
+            ReferenceCountUtil.release(record);
+        }
+        return e;
     }
 
     private static DnsRecord[] toArray(Iterable<DnsRecord> additionals, boolean validateType) {
@@ -978,9 +989,9 @@ public class DnsNameResolver extends InetNameResolver {
      * instead of using the global one.
      */
     protected void doResolve(String inetHost,
-                             DnsRecord[] additionals,
-                             Promise<InetAddress> promise,
-                             DnsCache resolveCache) throws Exception {
+                             final DnsRecord[] additionals,
+                             final Promise<InetAddress> promise,
+                             final DnsCache resolveCache) throws Exception {
         if (inetHost == null || inetHost.isEmpty()) {
             // If an empty hostname is used we should use "localhost", just like InetAddress.getByName(...) does.
             promise.setSuccess(loopbackAddress());
@@ -1002,7 +1013,29 @@ public class DnsNameResolver extends InetNameResolver {
         }
 
         if (!doResolveCached(hostname, additionals, promise, resolveCache)) {
-            doResolveUncached(hostname, additionals, promise, resolveCache, completeOncePreferredResolved);
+            ChannelFuture f = resolveChannelProvider.nextResolveChannel(promise);
+            if (f.isDone()) {
+                doResolveNow(f, hostname, additionals, promise, resolveCache);
+            } else {
+                f.addListener(new ChannelFutureListener() {
+                    @Override
+                    public void operationComplete(ChannelFuture f) {
+                        doResolveNow(f, hostname, additionals, promise, resolveCache);
+                    }
+                });
+            }
+        }
+    }
+
+    private void doResolveNow(ChannelFuture f, final String hostname, final DnsRecord[] additionals,
+                              final Promise<InetAddress> promise,
+                              final DnsCache resolveCache) {
+        if (f.isSuccess()) {
+            doResolveUncached(f.channel(), hostname, additionals, promise,
+                    resolveCache, completeOncePreferredResolved);
+        } else {
+            UnknownHostException e = toException(f, hostname, null, additionals);
+            promise.setFailure(e);
         }
     }
 
@@ -1067,12 +1100,14 @@ public class DnsNameResolver extends InetNameResolver {
         }
     }
 
-    private void doResolveUncached(String hostname,
+    private void doResolveUncached(Channel channel,
+                                   String hostname,
                                    DnsRecord[] additionals,
                                    final Promise<InetAddress> promise,
                                    DnsCache resolveCache, boolean completeEarlyIfPossible) {
         final Promise<List<InetAddress>> allPromise = executor().newPromise();
-        doResolveAllUncached(hostname, additionals, promise, allPromise, resolveCache, completeEarlyIfPossible);
+        doResolveAllUncached(channel, hostname, additionals, promise, allPromise,
+                resolveCache, completeEarlyIfPossible);
         allPromise.addListener(new FutureListener<List<InetAddress>>() {
             @Override
             public void operationComplete(Future<List<InetAddress>> future) {
@@ -1095,9 +1130,9 @@ public class DnsNameResolver extends InetNameResolver {
      * instead of using the global one.
      */
     protected void doResolveAll(String inetHost,
-                                DnsRecord[] additionals,
-                                Promise<List<InetAddress>> promise,
-                                DnsCache resolveCache) throws Exception {
+                                final DnsRecord[] additionals,
+                                final Promise<List<InetAddress>> promise,
+                                final DnsCache resolveCache) throws Exception {
         if (inetHost == null || inetHost.isEmpty()) {
             // If an empty hostname is used we should use "localhost", just like InetAddress.getAllByName(...) does.
             promise.setSuccess(Collections.singletonList(loopbackAddress()));
@@ -1120,8 +1155,29 @@ public class DnsNameResolver extends InetNameResolver {
 
         if (!doResolveAllCached(hostname, additionals, promise, resolveCache, this.searchDomains(),
                 ndots(), resolvedInternetProtocolFamilies)) {
-            doResolveAllUncached(hostname, additionals, promise, promise,
-                                 resolveCache, completeOncePreferredResolved);
+            ChannelFuture f = resolveChannelProvider.nextResolveChannel(promise);
+            if (f.isDone()) {
+                doResolveAllNow(f, hostname, additionals, promise, resolveCache);
+            } else {
+                f.addListener(new ChannelFutureListener() {
+                    @Override
+                    public void operationComplete(ChannelFuture f) {
+                        doResolveAllNow(f, hostname, additionals, promise, resolveCache);
+                    }
+                });
+            }
+        }
+    }
+
+    private void doResolveAllNow(ChannelFuture f, final String hostname, final DnsRecord[] additionals,
+                              final Promise<List<InetAddress>> promise,
+                              final DnsCache resolveCache) {
+        if (f.isSuccess()) {
+            doResolveAllUncached(f.channel(), hostname, additionals, promise, promise,
+                    resolveCache, completeOncePreferredResolved);
+        } else {
+            UnknownHostException e = toException(f, hostname, null, additionals);
+            promise.setFailure(e);
         }
     }
 
@@ -1178,7 +1234,8 @@ public class DnsNameResolver extends InetNameResolver {
         }
     }
 
-    private void doResolveAllUncached(final String hostname,
+    private void doResolveAllUncached(final Channel channel,
+                                      final String hostname,
                                       final DnsRecord[] additionals,
                                       final Promise<?> originalPromise,
                                       final Promise<List<InetAddress>> promise,
@@ -1188,20 +1245,21 @@ public class DnsNameResolver extends InetNameResolver {
         // to submit multiple Runnable at the end if we are not already on the EventLoop.
         EventExecutor executor = executor();
         if (executor.inEventLoop()) {
-            doResolveAllUncached0(hostname, additionals, originalPromise,
+            doResolveAllUncached0(channel, hostname, additionals, originalPromise,
                                   promise, resolveCache, completeEarlyIfPossible);
         } else {
             executor.execute(new Runnable() {
                 @Override
                 public void run() {
-                    doResolveAllUncached0(hostname, additionals, originalPromise,
+                    doResolveAllUncached0(channel, hostname, additionals, originalPromise,
                                           promise, resolveCache, completeEarlyIfPossible);
                 }
             });
         }
     }
 
-    private void doResolveAllUncached0(final String hostname,
+    private void doResolveAllUncached0(final Channel channel,
+                                       final String hostname,
                                        final DnsRecord[] additionals,
                                        final Promise<?> originalPromise,
                                        final Promise<List<InetAddress>> promise,
@@ -1226,7 +1284,7 @@ public class DnsNameResolver extends InetNameResolver {
                                 // the remote server be overloaded for some short amount of time or because
                                 // UDP packets were dropped on the floor. In this case lets try to just do the
                                 // query explicit and don't cascade this possible temporary failure.
-                                resolveNow(hostname, additionals, originalPromise, promise,
+                                resolveNow(channel, hostname, additionals, originalPromise, promise,
                                         resolveCache, completeEarlyIfPossible);
                             } else {
                                 promise.setFailure(cause);
@@ -1246,10 +1304,12 @@ public class DnsNameResolver extends InetNameResolver {
                 });
             }
         }
-        resolveNow(hostname, additionals, originalPromise, promise, resolveCache, completeEarlyIfPossible);
+        resolveNow(channel, hostname, additionals, originalPromise, promise,
+                resolveCache, completeEarlyIfPossible);
     }
 
-    private void resolveNow(final String hostname,
+    private void resolveNow(final Channel channel,
+                            final String hostname,
                             final DnsRecord[] additionals,
                             final Promise<?> originalPromise,
                             final Promise<List<InetAddress>> promise,
@@ -1257,7 +1317,7 @@ public class DnsNameResolver extends InetNameResolver {
                             final boolean completeEarlyIfPossible) {
         final DnsServerAddressStream nameServerAddrs =
                 dnsServerAddressStreamProvider.nameServerAddressStream(hostname);
-        DnsAddressResolveContext ctx = new DnsAddressResolveContext(this, ch, channelReadyPromise,
+        DnsAddressResolveContext ctx = new DnsAddressResolveContext(this, channel,
                 originalPromise, hostname, additionals, nameServerAddrs, maxQueriesPerResolve, resolveCache,
                 authoritativeDnsServerCache, completeEarlyIfPossible);
         ctx.resolve(promise);
@@ -1303,45 +1363,67 @@ public class DnsNameResolver extends InetNameResolver {
      * Sends a DNS query with the specified question using the specified name server list.
      */
     public Future<AddressedEnvelope<DnsResponse, InetSocketAddress>> query(
-            InetSocketAddress nameServerAddr, DnsQuestion question) {
-
-        return doQuery(ch, channelReadyPromise, nameServerAddr, question, NoopDnsQueryLifecycleObserver.INSTANCE,
-                EMPTY_ADDITIONALS, true,
-                ch.eventLoop().<AddressedEnvelope<? extends DnsResponse, InetSocketAddress>>newPromise());
+            final InetSocketAddress nameServerAddr, final DnsQuestion question) {
+        return query(nameServerAddr, question, Collections.<DnsRecord>emptyList());
     }
 
     /**
      * Sends a DNS query with the specified question with additional records using the specified name server list.
      */
     public Future<AddressedEnvelope<DnsResponse, InetSocketAddress>> query(
-            InetSocketAddress nameServerAddr, DnsQuestion question, Iterable<DnsRecord> additionals) {
-
-        return doQuery(ch, channelReadyPromise, nameServerAddr, question, NoopDnsQueryLifecycleObserver.INSTANCE,
-                toArray(additionals, false), true,
-                ch.eventLoop().<AddressedEnvelope<? extends DnsResponse, InetSocketAddress>>newPromise());
+            final InetSocketAddress nameServerAddr, final DnsQuestion question, final Iterable<DnsRecord> additionals) {
+        return query(nameServerAddr, question, additionals,
+                executor().<AddressedEnvelope<? extends DnsResponse, InetSocketAddress>>newPromise());
     }
 
     /**
      * Sends a DNS query with the specified question using the specified name server list.
      */
     public Future<AddressedEnvelope<DnsResponse, InetSocketAddress>> query(
-            InetSocketAddress nameServerAddr, DnsQuestion question,
-            Promise<AddressedEnvelope<? extends DnsResponse, InetSocketAddress>> promise) {
-
-        return doQuery(ch, channelReadyPromise, nameServerAddr, question, NoopDnsQueryLifecycleObserver.INSTANCE,
-                EMPTY_ADDITIONALS, true, promise);
+            final InetSocketAddress nameServerAddr, final DnsQuestion question,
+            final Promise<AddressedEnvelope<? extends DnsResponse, InetSocketAddress>> promise) {
+        return query(nameServerAddr, question, Collections.<DnsRecord>emptyList(), promise);
     }
 
     /**
      * Sends a DNS query with the specified question with additional records using the specified name server list.
      */
     public Future<AddressedEnvelope<DnsResponse, InetSocketAddress>> query(
-            InetSocketAddress nameServerAddr, DnsQuestion question,
-            Iterable<DnsRecord> additionals,
-            Promise<AddressedEnvelope<? extends DnsResponse, InetSocketAddress>> promise) {
+            final InetSocketAddress nameServerAddr, final DnsQuestion question,
+            final Iterable<DnsRecord> additionals,
+            final Promise<AddressedEnvelope<? extends DnsResponse, InetSocketAddress>> promise) {
 
-        return doQuery(ch, channelReadyPromise, nameServerAddr, question, NoopDnsQueryLifecycleObserver.INSTANCE,
-                toArray(additionals, false), true, promise);
+        ChannelFuture f = resolveChannelProvider.nextResolveChannel(promise);
+        final DnsRecord[] additionalsArray = toArray(additionals, false);
+        if (f.isDone()) {
+            if (f.isSuccess()) {
+                return doQuery(f.channel(), nameServerAddr, question,
+                        NoopDnsQueryLifecycleObserver.INSTANCE, additionalsArray,
+                        true, promise);
+            } else {
+                UnknownHostException e = toException(f, question.name(), question, additionalsArray);
+                promise.setFailure(e);
+                return executor().newFailedFuture(e);
+            }
+        } else {
+            final Promise<AddressedEnvelope<DnsResponse, InetSocketAddress>> p = executor().newPromise();
+            f.addListener(new ChannelFutureListener() {
+                @Override
+                public void operationComplete(ChannelFuture f) {
+                    if (f.isSuccess()) {
+                        Future<AddressedEnvelope<DnsResponse, InetSocketAddress>> qf = doQuery(
+                                f.channel(), nameServerAddr, question, NoopDnsQueryLifecycleObserver.INSTANCE,
+                                additionalsArray, true, promise);
+                        PromiseNotifier.cascade(qf, p);
+                    } else {
+                        UnknownHostException e = toException(f, question.name(), question, additionalsArray);
+                        promise.setFailure(e);
+                        p.setFailure(e);
+                    }
+                }
+            });
+            return p;
+        }
     }
 
     /**
@@ -1363,7 +1445,7 @@ public class DnsNameResolver extends InetNameResolver {
     }
 
     final Future<AddressedEnvelope<DnsResponse, InetSocketAddress>> doQuery(
-            Channel channel, Future<? extends Channel> channelReadyFuture,
+            Channel channel,
             InetSocketAddress nameServerAddr, DnsQuestion question,
             final DnsQueryLifecycleObserver queryLifecycleObserver,
             DnsRecord[] additionals, boolean flush,
@@ -1373,7 +1455,7 @@ public class DnsNameResolver extends InetNameResolver {
                 checkNotNull(promise, "promise"));
         final int payloadSize = isOptResourceEnabled() ? maxPayloadSize() : 0;
         try {
-            DnsQueryContext queryContext = new DatagramDnsQueryContext(channel, channelReadyFuture, nameServerAddr,
+            DnsQueryContext queryContext = new DatagramDnsQueryContext(channel, nameServerAddr,
                     queryContextManager, payloadSize, isRecursionDesired(), queryTimeoutMillis(), question, additionals,
                     castPromise, socketBootstrap, retryWithTcpOnTimeout);
             ChannelFuture future = queryContext.writeQuery(flush);
@@ -1393,12 +1475,17 @@ public class DnsNameResolver extends InetNameResolver {
         return dnsServerAddressStreamProvider.nameServerAddressStream(hostname);
     }
 
-    private final class DnsResponseHandler extends ChannelInboundHandlerAdapter {
+    private static final class DnsResponseHandler extends ChannelInboundHandlerAdapter {
 
-        private final Promise<Channel> channelActivePromise;
+        private final DnsQueryContextManager queryContextManager;
 
-        DnsResponseHandler(Promise<Channel> channelActivePromise) {
-            this.channelActivePromise = channelActivePromise;
+        DnsResponseHandler(DnsQueryContextManager queryContextManager) {
+            this.queryContextManager = queryContextManager;
+        }
+
+        @Override
+        public boolean isSharable() {
+            return true;
         }
 
         @Override
@@ -1426,18 +1513,81 @@ public class DnsNameResolver extends InetNameResolver {
         }
 
         @Override
-        public void channelActive(ChannelHandlerContext ctx) throws Exception {
-            super.channelActive(ctx);
-            channelActivePromise.trySuccess(ctx.channel());
-        }
-
-        @Override
         public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
             if (cause instanceof CorruptedFrameException) {
                 logger.debug("{} Unable to decode DNS response: UDP", ctx.channel(), cause);
             } else {
                 logger.warn("{} Unexpected exception: UDP", ctx.channel(), cause);
             }
+        }
+    }
+
+    private interface DnsResolveChannelProvider {
+
+        /**
+         * Return the next {@link ChannelFuture} that contains the {@link Channel} that should be used for resolving
+         * a chain of queries.
+         *
+         * @param resolutionFuture  the {@link Future} that will be notified once th resolution completes.
+         * @return                  the {@link ChannelFuture}
+         */
+        <T> ChannelFuture nextResolveChannel(Future<T> resolutionFuture);
+
+        /**
+         * Close the {@link DnsResolveChannelProvider} and so cleanup resources if needed.
+         */
+        void close();
+    }
+
+    private static ChannelFuture registerOrBind(Bootstrap bootstrap, SocketAddress localAddress) {
+        return localAddress == null ? bootstrap.register() : bootstrap.bind(localAddress);
+    }
+
+    private static final class DnsResolveChannelPerResolverProvider implements DnsResolveChannelProvider {
+
+        private final ChannelFuture resolveChannelFuture;
+
+        DnsResolveChannelPerResolverProvider(Bootstrap bootstrap, SocketAddress localAddress) {
+            resolveChannelFuture = registerOrBind(bootstrap, localAddress);
+        }
+
+        @Override
+        public <T> ChannelFuture nextResolveChannel(Future<T> resolutionFuture) {
+            return resolveChannelFuture;
+        }
+
+        @Override
+        public void close() {
+            resolveChannelFuture.channel().close();
+        }
+    }
+
+    private static final class DnsResolveChannelPerResolutionProvider implements DnsResolveChannelProvider {
+
+        private final Bootstrap bootstrap;
+        private final SocketAddress localAddress;
+
+        DnsResolveChannelPerResolutionProvider(Bootstrap bootstrap, SocketAddress localAddress) {
+            this.bootstrap = bootstrap;
+            this.localAddress = localAddress;
+        }
+
+        @Override
+        public <T> ChannelFuture nextResolveChannel(Future<T> resolutionFuture) {
+            final ChannelFuture f = registerOrBind(bootstrap, localAddress);
+            resolutionFuture.addListener(new FutureListener<T>() {
+                @Override
+                public void operationComplete(Future<T> future) {
+                    // Always just close the Channel once the resolution is considered complete.
+                    f.channel().close();
+                }
+            });
+            return f;
+        }
+
+        @Override
+        public void close() {
+            // NOOP
         }
     }
 }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
@@ -78,6 +78,7 @@ public final class DnsNameResolverBuilder {
     private boolean decodeIdn = true;
 
     private int maxNumConsolidation;
+    private DnsNameResolverChannelStrategy datagramChannelStrategy = DnsNameResolverChannelStrategy.ChannelPerResolver;
 
     /**
      * Creates a new builder.
@@ -646,6 +647,19 @@ public final class DnsNameResolverBuilder {
     }
 
     /**
+     * Set the strategy that is used to determine how a {@link DatagramChannel} is used by the resolver for sending
+     * queries over UDP protocol.
+     *
+     * @param datagramChannelStrategy  the {@link DnsNameResolverChannelStrategy} to use when doing queries over
+     *                                 UDP protocol.
+     * @return {@code this}
+     */
+    public DnsNameResolverBuilder datagramChannelStrategy(DnsNameResolverChannelStrategy datagramChannelStrategy) {
+        this.datagramChannelStrategy = ObjectUtil.checkNotNull(datagramChannelStrategy, "datagramChannelStrategy");
+        return this;
+    }
+
+    /**
      * Returns a new {@link DnsNameResolver} instance.
      *
      * @return a {@link DnsNameResolver}
@@ -698,7 +712,8 @@ public final class DnsNameResolverBuilder {
                 ndots,
                 decodeIdn,
                 completeOncePreferredResolved,
-                maxNumConsolidation);
+                maxNumConsolidation,
+                datagramChannelStrategy);
     }
 
     /**
@@ -768,6 +783,7 @@ public final class DnsNameResolverBuilder {
         copiedBuilder.completeOncePreferredResolved(completeOncePreferredResolved);
         copiedBuilder.localAddress(localAddress);
         copiedBuilder.consolidateCacheSize(maxNumConsolidation);
+        copiedBuilder.datagramChannelStrategy(datagramChannelStrategy);
         return copiedBuilder;
     }
 }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverChannelStrategy.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverChannelStrategy.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+/**
+ * Strategy that influence how {@link io.netty.channel.Channel}s are used during queries.
+ */
+public enum DnsNameResolverChannelStrategy {
+    /**
+     * Use the same underlying {@link io.netty.channel.Channel} for all queries produced by a single
+     {@link DnsNameResolver} instance.
+     */
+    ChannelPerResolver,
+    /**
+     * Use a new {@link io.netty.channel.Channel} per resolution or per explicit query. As of today this is similar
+     * to what the {@link io.netty.resolver.DefaultNameResolver} (JDK default) does. As we will need to open and close
+     * a new socket for each resolution it will come with a performance overhead. That said using this strategy should
+     * be the most robust and also guard against problems that can arise in kubernetes (or similar) setups.
+     */
+    ChannelPerResolution
+}

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsRecordResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsRecordResolveContext.java
@@ -24,39 +24,37 @@ import io.netty.handler.codec.dns.DnsQuestion;
 import io.netty.handler.codec.dns.DnsRecord;
 import io.netty.handler.codec.dns.DnsRecordType;
 import io.netty.util.ReferenceCountUtil;
-import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 
 final class DnsRecordResolveContext extends DnsResolveContext<DnsRecord> {
 
-    DnsRecordResolveContext(DnsNameResolver parent, Channel channel, Future<? extends Channel> channelReadyFuture,
+    DnsRecordResolveContext(DnsNameResolver parent, Channel channel,
                             Promise<?> originalPromise, DnsQuestion question, DnsRecord[] additionals,
                             DnsServerAddressStream nameServerAddrs, int allowedQueries) {
-        this(parent, channel, channelReadyFuture, originalPromise, question.name(), question.dnsClass(),
+        this(parent, channel, originalPromise, question.name(), question.dnsClass(),
              new DnsRecordType[] { question.type() },
              additionals, nameServerAddrs, allowedQueries);
     }
 
     private DnsRecordResolveContext(DnsNameResolver parent, Channel channel,
-                                    Future<? extends Channel> channelReadyFuture, Promise<?> originalPromise,
+                                    Promise<?> originalPromise,
                                     String hostname, int dnsClass, DnsRecordType[] expectedTypes,
                                     DnsRecord[] additionals,
                                     DnsServerAddressStream nameServerAddrs,
                                     int allowedQueries) {
-        super(parent, channel, channelReadyFuture, originalPromise, hostname, dnsClass, expectedTypes,
+        super(parent, channel, originalPromise, hostname, dnsClass, expectedTypes,
                 additionals, nameServerAddrs, allowedQueries);
     }
 
     @Override
     DnsResolveContext<DnsRecord> newResolverContext(DnsNameResolver parent, Channel channel,
-                                                    Future<? extends Channel> channelReadyFuture,
                                                     Promise<?> originalPromise,
                                                     String hostname,
                                                     int dnsClass, DnsRecordType[] expectedTypes,
                                                     DnsRecord[] additionals,
                                                     DnsServerAddressStream nameServerAddrs,
                                                     int allowedQueries) {
-        return new DnsRecordResolveContext(parent, channel, channelReadyFuture, originalPromise, hostname, dnsClass,
+        return new DnsRecordResolveContext(parent, channel, originalPromise, hostname, dnsClass,
                                            expectedTypes, additionals, nameServerAddrs, allowedQueries);
     }
 

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/TcpDnsQueryContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/TcpDnsQueryContext.java
@@ -17,6 +17,7 @@ package io.netty.resolver.dns;
 
 import io.netty.channel.AddressedEnvelope;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
 import io.netty.handler.codec.dns.DefaultDnsQuery;
 import io.netty.handler.codec.dns.DnsQuery;
 import io.netty.handler.codec.dns.DnsQuestion;
@@ -29,14 +30,14 @@ import java.net.InetSocketAddress;
 
 final class TcpDnsQueryContext extends DnsQueryContext {
 
-    TcpDnsQueryContext(Channel channel, Future<? extends Channel> channelReadyFuture,
+    TcpDnsQueryContext(Channel channel,
                        InetSocketAddress nameServerAddr,
                        DnsQueryContextManager queryContextManager,
                        int maxPayLoadSize, boolean recursionDesired,
                        long queryTimeoutMillis,
                        DnsQuestion question, DnsRecord[] additionals,
                        Promise<AddressedEnvelope<DnsResponse, InetSocketAddress>> promise) {
-        super(channel, channelReadyFuture, nameServerAddr, queryContextManager, maxPayLoadSize, recursionDesired,
+        super(channel, nameServerAddr, queryContextManager, maxPayLoadSize, recursionDesired,
                 // No retry via TCP.
                 queryTimeoutMillis, question, additionals, promise, null, false);
     }

--- a/resolver-dns/src/main/resources/META-INF/native-image/io.netty/netty-resolver-dns/generated/handlers/reflect-config.json
+++ b/resolver-dns/src/main/resources/META-INF/native-image/io.netty/netty-resolver-dns/generated/handlers/reflect-config.json
@@ -28,9 +28,9 @@
     "queryAllPublicMethods": true
   },
   {
-    "name": "io.netty.resolver.dns.DnsQueryContext$6$1",
+    "name": "io.netty.resolver.dns.DnsQueryContext$5$1",
     "condition": {
-      "typeReachable": "io.netty.resolver.dns.DnsQueryContext$6$1"
+      "typeReachable": "io.netty.resolver.dns.DnsQueryContext$5$1"
     },
     "queryAllPublicMethods": true
   }

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -113,6 +113,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
 import static io.netty.handler.codec.dns.DnsRecordType.A;
 import static io.netty.handler.codec.dns.DnsRecordType.AAAA;
 import static io.netty.handler.codec.dns.DnsRecordType.CNAME;
@@ -138,7 +141,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -273,7 +275,7 @@ public class DnsNameResolverTest {
     }
 
     /**
-     * The list of the domain names to exclude from {@link #testResolveAorAAAA()}.
+     * The list of the domain names to exclude from {@link #testResolveAorAAAA(DnsNameResolverChannelStrategy)}.
      */
     private static final Set<String> EXCLUSIONS_RESOLVE_A = new HashSet<String>();
 
@@ -286,7 +288,7 @@ public class DnsNameResolverTest {
     }
 
     /**
-     * The list of the domain names to exclude from {@link #testResolveAAAA()}.
+     * The list of the domain names to exclude from {@link #testResolveAAAA(DnsNameResolverChannelStrategy)}.
      * Unfortunately, there are only handful of domain names with IPv6 addresses.
      */
     private static final Set<String> EXCLUSIONS_RESOLVE_AAAA = new HashSet<String>();
@@ -325,7 +327,7 @@ public class DnsNameResolverTest {
     }
 
     /**
-     * The list of the domain names to exclude from {@link #testQueryMx()}.
+     * The list of the domain names to exclude from {@link #testQueryMx(DnsNameResolverChannelStrategy)}.
      */
     private static final Set<String> EXCLUSIONS_QUERY_MX = new HashSet<String>();
 
@@ -382,16 +384,17 @@ public class DnsNameResolverTest {
     private static final TestDnsServer dnsServer = new TestDnsServer(DOMAINS_ALL);
     private static final EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
 
-    private static DnsNameResolverBuilder newResolver(boolean decodeToUnicode) {
-        return newResolver(decodeToUnicode, null);
+    private static DnsNameResolverBuilder newResolver(DnsNameResolverChannelStrategy strategy,
+                                                      boolean decodeToUnicode) {
+        return newResolver(strategy, decodeToUnicode, null);
     }
 
-    private static DnsNameResolverBuilder newResolver(boolean decodeToUnicode,
+    private static DnsNameResolverBuilder newResolver(DnsNameResolverChannelStrategy strategy, boolean decodeToUnicode,
                                                       DnsServerAddressStreamProvider dnsServerAddressStreamProvider) {
-        return newResolver(decodeToUnicode, dnsServerAddressStreamProvider, dnsServer);
+        return newResolver(strategy, decodeToUnicode, dnsServerAddressStreamProvider, dnsServer);
     }
 
-    private static DnsNameResolverBuilder newResolver(boolean decodeToUnicode,
+    private static DnsNameResolverBuilder newResolver(DnsNameResolverChannelStrategy strategy, boolean decodeToUnicode,
                                                       DnsServerAddressStreamProvider dnsServerAddressStreamProvider,
                                                       TestDnsServer dnsServer) {
         DnsNameResolverBuilder builder = new DnsNameResolverBuilder(group.next())
@@ -400,7 +403,8 @@ public class DnsNameResolverTest {
                 .maxQueriesPerResolve(1)
                 .decodeIdn(decodeToUnicode)
                 .optResourceEnabled(false)
-                .ndots(1);
+                .ndots(1)
+                .datagramChannelStrategy(strategy);
 
         if (dnsServerAddressStreamProvider == null) {
             builder.nameServerProvider(new SingletonDnsServerAddressStreamProvider(dnsServer.localAddress()));
@@ -412,17 +416,19 @@ public class DnsNameResolverTest {
         return builder;
     }
 
-    private static DnsNameResolverBuilder newResolver() {
-        return newResolver(true);
+    private static DnsNameResolverBuilder newResolver(DnsNameResolverChannelStrategy strategy) {
+        return newResolver(strategy, true);
     }
 
-    private static DnsNameResolverBuilder newResolver(ResolvedAddressTypes resolvedAddressTypes) {
-        return newResolver()
+    private static DnsNameResolverBuilder newResolver(DnsNameResolverChannelStrategy strategy,
+                                                      ResolvedAddressTypes resolvedAddressTypes) {
+        return newResolver(strategy)
                 .resolvedAddressTypes(resolvedAddressTypes);
     }
 
-    private static DnsNameResolverBuilder newNonCachedResolver(ResolvedAddressTypes resolvedAddressTypes) {
-        return newResolver()
+    private static DnsNameResolverBuilder newNonCachedResolver(DnsNameResolverChannelStrategy strategy,
+                                                               ResolvedAddressTypes resolvedAddressTypes) {
+        return newResolver(strategy)
                 .resolveCache(NoopDnsCache.INSTANCE)
                 .resolvedAddressTypes(resolvedAddressTypes);
     }
@@ -438,9 +444,10 @@ public class DnsNameResolverTest {
         group.shutdownGracefully();
     }
 
-    @Test
-    public void testResolveAorAAAA() throws Exception {
-        DnsNameResolver resolver = newResolver(ResolvedAddressTypes.IPV4_PREFERRED).build();
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testResolveAorAAAA(DnsNameResolverChannelStrategy strategy) throws Exception {
+        DnsNameResolver resolver = newResolver(strategy, ResolvedAddressTypes.IPV4_PREFERRED).build();
         try {
             testResolve0(resolver, EXCLUSIONS_RESOLVE_A, AAAA);
         } finally {
@@ -448,9 +455,10 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
-    public void testResolveAAAAorA() throws Exception {
-        DnsNameResolver resolver = newResolver(ResolvedAddressTypes.IPV6_PREFERRED).build();
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testResolveAAAAorA(DnsNameResolverChannelStrategy strategy) throws Exception {
+        DnsNameResolver resolver = newResolver(strategy, ResolvedAddressTypes.IPV6_PREFERRED).build();
         try {
             testResolve0(resolver, EXCLUSIONS_RESOLVE_A, A);
         } finally {
@@ -464,8 +472,10 @@ public class DnsNameResolverTest {
      * test to ensure that some hostnames can be directed toward both the primary and secondary DNS test servers
      * simultaneously.
      */
-    @Test
-    public void testNameServerCache() throws IOException, InterruptedException {
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testNameServerCache(DnsNameResolverChannelStrategy channelStrategy)
+            throws IOException, InterruptedException {
         final String overriddenIP = "12.34.12.34";
         final TestDnsServer dnsServer2 = new TestDnsServer(new RecordStore() {
             @Override
@@ -493,7 +503,7 @@ public class DnsNameResolverTest {
                     overriddenHostnames.add(name);
                 }
             }
-            DnsNameResolver resolver = newResolver(false, new DnsServerAddressStreamProvider() {
+            DnsNameResolver resolver = newResolver(channelStrategy, false, new DnsServerAddressStreamProvider() {
                 @Override
                 public DnsServerAddressStream nameServerAddressStream(String hostname) {
                     return overriddenHostnames.contains(hostname) ? sequential(dnsServer2.localAddress()).stream() :
@@ -522,9 +532,10 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
-    public void testResolveA() throws Exception {
-        DnsNameResolver resolver = newResolver(ResolvedAddressTypes.IPV4_ONLY)
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testResolveA(DnsNameResolverChannelStrategy strategy) throws Exception {
+        DnsNameResolver resolver = newResolver(strategy, ResolvedAddressTypes.IPV4_ONLY)
                 // Cache for eternity
                 .ttl(Integer.MAX_VALUE, Integer.MAX_VALUE)
                 .build();
@@ -550,9 +561,10 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
-    public void testResolveAAAA() throws Exception {
-        DnsNameResolver resolver = newResolver(ResolvedAddressTypes.IPV6_ONLY).build();
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testResolveAAAA(DnsNameResolverChannelStrategy strategy) throws Exception {
+        DnsNameResolver resolver = newResolver(strategy, ResolvedAddressTypes.IPV6_ONLY).build();
         try {
             testResolve0(resolver, EXCLUSIONS_RESOLVE_AAAA, null);
         } finally {
@@ -560,9 +572,10 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
-    public void testNonCachedResolve() throws Exception {
-        DnsNameResolver resolver = newNonCachedResolver(ResolvedAddressTypes.IPV4_ONLY).build();
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testNonCachedResolve(DnsNameResolverChannelStrategy strategy) throws Exception {
+        DnsNameResolver resolver = newNonCachedResolver(strategy, ResolvedAddressTypes.IPV4_ONLY).build();
         try {
             testResolve0(resolver, EXCLUSIONS_RESOLVE_A, null);
         } finally {
@@ -570,20 +583,23 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
     @Timeout(value = DEFAULT_TEST_TIMEOUT_MS, unit = TimeUnit.MILLISECONDS)
-    public void testNonCachedResolveEmptyHostName() throws Exception {
-        testNonCachedResolveEmptyHostName("");
+    public void testNonCachedResolveEmptyHostName(DnsNameResolverChannelStrategy strategy) throws Exception {
+        testNonCachedResolveEmptyHostName(strategy, "");
     }
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
     @Timeout(value = DEFAULT_TEST_TIMEOUT_MS, unit = TimeUnit.MILLISECONDS)
-    public void testNonCachedResolveNullHostName() throws Exception {
-        testNonCachedResolveEmptyHostName(null);
+    public void testNonCachedResolveNullHostName(DnsNameResolverChannelStrategy strategy) throws Exception {
+        testNonCachedResolveEmptyHostName(strategy, null);
     }
 
-    private static void testNonCachedResolveEmptyHostName(String inetHost) throws Exception {
-        DnsNameResolver resolver = newNonCachedResolver(ResolvedAddressTypes.IPV4_ONLY).build();
+    private static void testNonCachedResolveEmptyHostName(DnsNameResolverChannelStrategy strategy, String inetHost)
+            throws Exception {
+        DnsNameResolver resolver = newNonCachedResolver(strategy, ResolvedAddressTypes.IPV4_ONLY).build();
         try {
             InetAddress addr = resolver.resolve(inetHost).syncUninterruptibly().getNow();
             assertEquals(SocketUtils.addressByName(inetHost), addr);
@@ -592,20 +608,23 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
     @Timeout(value = DEFAULT_TEST_TIMEOUT_MS, unit = TimeUnit.MILLISECONDS)
-    public void testNonCachedResolveAllEmptyHostName() throws Exception {
-        testNonCachedResolveAllEmptyHostName("");
+    public void testNonCachedResolveAllEmptyHostName(DnsNameResolverChannelStrategy strategy) throws Exception {
+        testNonCachedResolveAllEmptyHostName(strategy, "");
     }
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
     @Timeout(value = DEFAULT_TEST_TIMEOUT_MS, unit = TimeUnit.MILLISECONDS)
-    public void testNonCachedResolveAllNullHostName() throws Exception {
-        testNonCachedResolveAllEmptyHostName(null);
+    public void testNonCachedResolveAllNullHostName(DnsNameResolverChannelStrategy strategy) throws Exception {
+        testNonCachedResolveAllEmptyHostName(strategy, null);
     }
 
-    private static void testNonCachedResolveAllEmptyHostName(String inetHost) throws UnknownHostException {
-        DnsNameResolver resolver = newNonCachedResolver(ResolvedAddressTypes.IPV4_ONLY).build();
+    private static void testNonCachedResolveAllEmptyHostName(DnsNameResolverChannelStrategy strategy, String inetHost)
+            throws UnknownHostException {
+        DnsNameResolver resolver = newNonCachedResolver(strategy, ResolvedAddressTypes.IPV4_ONLY).build();
         try {
             List<InetAddress> addrs = resolver.resolveAll(inetHost).syncUninterruptibly().getNow();
             assertEquals(asList(
@@ -661,9 +680,10 @@ public class DnsNameResolverTest {
         return results;
     }
 
-    @Test
-    public void testQueryMx() {
-        DnsNameResolver resolver = newResolver().build();
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testQueryMx(DnsNameResolverChannelStrategy strategy) {
+        DnsNameResolver resolver = newResolver(strategy).build();
         try {
             assertThat(resolver.isRecursionDesired(), is(true));
 
@@ -721,9 +741,10 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
-    public void testNegativeTtl() throws Exception {
-        final DnsNameResolver resolver = newResolver().negativeTtl(10).build();
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testNegativeTtl(DnsNameResolverChannelStrategy strategy) throws Exception {
+        final DnsNameResolver resolver = newResolver(strategy).negativeTtl(10).build();
         try {
             resolveNonExistentDomain(resolver);
 
@@ -784,9 +805,10 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
-    public void testResolveIp() {
-        DnsNameResolver resolver = newResolver().build();
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testResolveIp(DnsNameResolverChannelStrategy strategy) {
+        DnsNameResolver resolver = newResolver(strategy).build();
         try {
             InetAddress address = resolver.resolve("10.0.0.1").syncUninterruptibly().getNow();
 
@@ -799,60 +821,69 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
-    public void testResolveEmptyIpv4() {
-        testResolve0(ResolvedAddressTypes.IPV4_ONLY, NetUtil.LOCALHOST4, StringUtil.EMPTY_STRING);
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testResolveEmptyIpv4(DnsNameResolverChannelStrategy strategy) {
+        testResolve0(strategy, ResolvedAddressTypes.IPV4_ONLY, NetUtil.LOCALHOST4, StringUtil.EMPTY_STRING);
     }
 
-    @Test
-    public void testResolveEmptyIpv6() {
-        testResolve0(ResolvedAddressTypes.IPV6_ONLY, NetUtil.LOCALHOST6, StringUtil.EMPTY_STRING);
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testResolveEmptyIpv6(DnsNameResolverChannelStrategy strategy) {
+        testResolve0(strategy, ResolvedAddressTypes.IPV6_ONLY, NetUtil.LOCALHOST6, StringUtil.EMPTY_STRING);
     }
 
-    @Test
-    public void testResolveLocalhostIpv4() {
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testResolveLocalhostIpv4(DnsNameResolverChannelStrategy strategy) {
         assumeThat(PlatformDependent.isWindows()).isTrue();
         assumeThat(WINDOWS_HOSTS_FILE_LOCALHOST_ENTRY_EXISTS).isFalse();
         assumeThat(DEFAULT_RESOLVE_ADDRESS_TYPES).isNotEqualTo(ResolvedAddressTypes.IPV6_PREFERRED);
-        testResolve0(ResolvedAddressTypes.IPV4_ONLY, NetUtil.LOCALHOST4, "localhost");
+        testResolve0(strategy, ResolvedAddressTypes.IPV4_ONLY, NetUtil.LOCALHOST4, "localhost");
     }
 
-    @Test
-    public void testResolveLocalhostIpv6() {
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testResolveLocalhostIpv6(DnsNameResolverChannelStrategy strategy) {
         assumeThat(PlatformDependent.isWindows()).isTrue();
         assumeThat(WINDOWS_HOSTS_FILE_LOCALHOST_ENTRY_EXISTS).isFalse();
         assumeThat(DEFAULT_RESOLVE_ADDRESS_TYPES).isEqualTo(ResolvedAddressTypes.IPV6_PREFERRED);
-        testResolve0(ResolvedAddressTypes.IPV6_ONLY, NetUtil.LOCALHOST6, "localhost");
+        testResolve0(strategy, ResolvedAddressTypes.IPV6_ONLY, NetUtil.LOCALHOST6, "localhost");
     }
 
-    @Test
-    public void testResolveHostNameIpv4() {
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testResolveHostNameIpv4(DnsNameResolverChannelStrategy strategy) {
         assumeThat(PlatformDependent.isWindows()).isTrue();
         assumeThat(WINDOWS_HOSTS_FILE_HOST_NAME_ENTRY_EXISTS).isFalse();
         assumeThat(DEFAULT_RESOLVE_ADDRESS_TYPES).isNotEqualTo(ResolvedAddressTypes.IPV6_PREFERRED);
-        testResolve0(ResolvedAddressTypes.IPV4_ONLY, NetUtil.LOCALHOST4, WINDOWS_HOST_NAME);
+        testResolve0(strategy, ResolvedAddressTypes.IPV4_ONLY, NetUtil.LOCALHOST4, WINDOWS_HOST_NAME);
     }
 
-    @Test
-    public void testResolveHostNameIpv6() {
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testResolveHostNameIpv6(DnsNameResolverChannelStrategy strategy) {
         assumeThat(PlatformDependent.isWindows()).isTrue();
         assumeThat(WINDOWS_HOSTS_FILE_HOST_NAME_ENTRY_EXISTS).isFalse();
         assumeThat(DEFAULT_RESOLVE_ADDRESS_TYPES).isEqualTo(ResolvedAddressTypes.IPV6_PREFERRED);
-        testResolve0(ResolvedAddressTypes.IPV6_ONLY, NetUtil.LOCALHOST6, WINDOWS_HOST_NAME);
+        testResolve0(strategy, ResolvedAddressTypes.IPV6_ONLY, NetUtil.LOCALHOST6, WINDOWS_HOST_NAME);
     }
 
-    @Test
-    public void testResolveNullIpv4() {
-        testResolve0(ResolvedAddressTypes.IPV4_ONLY, NetUtil.LOCALHOST4, null);
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testResolveNullIpv4(DnsNameResolverChannelStrategy strategy) {
+        testResolve0(strategy, ResolvedAddressTypes.IPV4_ONLY, NetUtil.LOCALHOST4, null);
     }
 
-    @Test
-    public void testResolveNullIpv6() {
-        testResolve0(ResolvedAddressTypes.IPV6_ONLY, NetUtil.LOCALHOST6, null);
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testResolveNullIpv6(DnsNameResolverChannelStrategy strategy) {
+        testResolve0(strategy, ResolvedAddressTypes.IPV6_ONLY, NetUtil.LOCALHOST6, null);
     }
 
-    private static void testResolve0(ResolvedAddressTypes addressTypes, InetAddress expectedAddr, String name) {
-        DnsNameResolver resolver = newResolver(addressTypes).build();
+    private static void testResolve0(DnsNameResolverChannelStrategy strategy, ResolvedAddressTypes addressTypes,
+                                     InetAddress expectedAddr, String name) {
+        DnsNameResolver resolver = newResolver(strategy, addressTypes).build();
         try {
             InetAddress address = resolver.resolve(name).syncUninterruptibly().getNow();
             assertEquals(expectedAddr, address);
@@ -864,59 +895,68 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
-    public void testResolveAllEmptyIpv4() {
-        testResolveAll0(ResolvedAddressTypes.IPV4_ONLY, NetUtil.LOCALHOST4, StringUtil.EMPTY_STRING);
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testResolveAllEmptyIpv4(DnsNameResolverChannelStrategy strategy) {
+        testResolveAll0(strategy, ResolvedAddressTypes.IPV4_ONLY, NetUtil.LOCALHOST4, StringUtil.EMPTY_STRING);
     }
 
-    @Test
-    public void testResolveAllEmptyIpv6() {
-        testResolveAll0(ResolvedAddressTypes.IPV6_ONLY, NetUtil.LOCALHOST6, StringUtil.EMPTY_STRING);
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testResolveAllEmptyIpv6(DnsNameResolverChannelStrategy strategy) {
+        testResolveAll0(strategy, ResolvedAddressTypes.IPV6_ONLY, NetUtil.LOCALHOST6, StringUtil.EMPTY_STRING);
     }
 
-    @Test
-    public void testResolveAllLocalhostIpv4() {
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testResolveAllLocalhostIpv4(DnsNameResolverChannelStrategy strategy) {
         assumeThat(PlatformDependent.isWindows()).isTrue();
         assumeThat(WINDOWS_HOSTS_FILE_LOCALHOST_ENTRY_EXISTS).isFalse();
         assumeThat(DEFAULT_RESOLVE_ADDRESS_TYPES).isNotEqualTo(ResolvedAddressTypes.IPV6_PREFERRED);
-        testResolveAll0(ResolvedAddressTypes.IPV4_ONLY, NetUtil.LOCALHOST4, "localhost");
+        testResolveAll0(strategy, ResolvedAddressTypes.IPV4_ONLY, NetUtil.LOCALHOST4, "localhost");
     }
 
-    @Test
-    public void testResolveAllLocalhostIpv6() {
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testResolveAllLocalhostIpv6(DnsNameResolverChannelStrategy strategy) {
         assumeThat(PlatformDependent.isWindows()).isTrue();
         assumeThat(WINDOWS_HOSTS_FILE_LOCALHOST_ENTRY_EXISTS).isFalse();
         assumeThat(DEFAULT_RESOLVE_ADDRESS_TYPES).isEqualTo(ResolvedAddressTypes.IPV6_PREFERRED);
-        testResolveAll0(ResolvedAddressTypes.IPV6_ONLY, NetUtil.LOCALHOST6, "localhost");
+        testResolveAll0(strategy, ResolvedAddressTypes.IPV6_ONLY, NetUtil.LOCALHOST6, "localhost");
     }
 
-    @Test
-    public void testResolveAllHostNameIpv4() {
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testResolveAllHostNameIpv4(DnsNameResolverChannelStrategy strategy) {
         assumeThat(PlatformDependent.isWindows()).isTrue();
         assumeThat(WINDOWS_HOSTS_FILE_HOST_NAME_ENTRY_EXISTS).isFalse();
         assumeThat(DEFAULT_RESOLVE_ADDRESS_TYPES).isNotEqualTo(ResolvedAddressTypes.IPV6_PREFERRED);
-        testResolveAll0(ResolvedAddressTypes.IPV4_ONLY, NetUtil.LOCALHOST4, WINDOWS_HOST_NAME);
+        testResolveAll0(strategy, ResolvedAddressTypes.IPV4_ONLY, NetUtil.LOCALHOST4, WINDOWS_HOST_NAME);
     }
 
-    @Test
-    public void testResolveAllHostNameIpv6() {
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testResolveAllHostNameIpv6(DnsNameResolverChannelStrategy strategy) {
         assumeThat(PlatformDependent.isWindows()).isTrue();
         assumeThat(WINDOWS_HOSTS_FILE_HOST_NAME_ENTRY_EXISTS).isFalse();
         assumeThat(DEFAULT_RESOLVE_ADDRESS_TYPES).isEqualTo(ResolvedAddressTypes.IPV6_PREFERRED);
-        testResolveAll0(ResolvedAddressTypes.IPV6_ONLY, NetUtil.LOCALHOST6, WINDOWS_HOST_NAME);
+        testResolveAll0(strategy, ResolvedAddressTypes.IPV6_ONLY, NetUtil.LOCALHOST6, WINDOWS_HOST_NAME);
     }
 
-    @Test
-    public void testCNAMEResolveAllIpv4() throws IOException {
-        testCNAMERecursiveResolve(true);
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testCNAMEResolveAllIpv4(DnsNameResolverChannelStrategy strategy) throws IOException {
+        testCNAMERecursiveResolve(strategy, true);
     }
 
-    @Test
-    public void testCNAMEResolveAllIpv6() throws IOException {
-        testCNAMERecursiveResolve(false);
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testCNAMEResolveAllIpv6(DnsNameResolverChannelStrategy strategy) throws IOException {
+        testCNAMERecursiveResolve(strategy, false);
     }
 
-    private static void testCNAMERecursiveResolve(boolean ipv4Preferred) throws IOException {
+    private static void testCNAMERecursiveResolve(DnsNameResolverChannelStrategy strategy, boolean ipv4Preferred)
+            throws IOException {
         final String firstName = "firstname.com";
         final String secondName = "secondname.com";
         final String lastName = "lastname.com";
@@ -956,7 +996,7 @@ public class DnsNameResolverTest {
         dnsServer2.start();
         DnsNameResolver resolver = null;
         try {
-            DnsNameResolverBuilder builder = newResolver()
+            DnsNameResolverBuilder builder = newResolver(strategy)
                     .recursionDesired(true)
                     .maxQueriesPerResolve(16)
                     .nameServerProvider(new SingletonDnsServerAddressStreamProvider(dnsServer2.localAddress()));
@@ -981,17 +1021,22 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
-    public void testCNAMERecursiveResolveMultipleNameServersIPv4() throws IOException {
-        testCNAMERecursiveResolveMultipleNameServers(true);
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testCNAMERecursiveResolveMultipleNameServersIPv4(DnsNameResolverChannelStrategy strategy)
+            throws IOException {
+        testCNAMERecursiveResolveMultipleNameServers(strategy, true);
     }
 
-    @Test
-    public void testCNAMERecursiveResolveMultipleNameServersIPv6() throws IOException {
-        testCNAMERecursiveResolveMultipleNameServers(false);
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testCNAMERecursiveResolveMultipleNameServersIPv6(DnsNameResolverChannelStrategy strategy)
+            throws IOException {
+        testCNAMERecursiveResolveMultipleNameServers(strategy, false);
     }
 
-    private static void testCNAMERecursiveResolveMultipleNameServers(boolean ipv4Preferred) throws IOException {
+    private static void testCNAMERecursiveResolveMultipleNameServers(DnsNameResolverChannelStrategy strategy,
+                                                                     boolean ipv4Preferred) throws IOException {
         final String firstName = "firstname.nettyfoo.com";
         final String lastName = "lastname.nettybar.com";
         final String ipv4Addr = "1.2.3.4";
@@ -1055,13 +1100,16 @@ public class DnsNameResolverTest {
             // so no port), so we only specify the name server in the cache, and then specify both name servers in the
             // fallback name server provider.
             nsCache.cache("nettyfoo.com.", dnsServer2.localAddress(), 10000, group.next());
+            SequentialDnsServerAddressStreamProvider provider =
+                    new SequentialDnsServerAddressStreamProvider(dnsServer2.localAddress(), dnsServer3.localAddress());
             resolver = new DnsNameResolver(
-                    group.next(), new ReflectiveChannelFactory<DatagramChannel>(NioDatagramChannel.class),
-                    NoopDnsCache.INSTANCE, nsCache, NoopDnsQueryLifecycleObserverFactory.INSTANCE, 3000,
+                    group.next(), new ReflectiveChannelFactory<DatagramChannel>(NioDatagramChannel.class), null,
+                    false, NoopDnsCache.INSTANCE, NoopDnsCnameCache.INSTANCE, nsCache, null,
+                    NoopDnsQueryLifecycleObserverFactory.INSTANCE, 3000,
                     ipv4Preferred ? ResolvedAddressTypes.IPV4_ONLY : ResolvedAddressTypes.IPV6_ONLY, true,
                     10, true, 4096, false, HostsFileEntriesResolver.DEFAULT,
-                    new SequentialDnsServerAddressStreamProvider(dnsServer2.localAddress(), dnsServer3.localAddress()),
-                    DnsNameResolver.DEFAULT_SEARCH_DOMAINS, 0, true) {
+                    provider, new ThreadLocalNameServerAddressStream(provider),
+                    DnsNameResolver.DEFAULT_SEARCH_DOMAINS, 0, true, false, 0, strategy) {
                 @Override
                 InetSocketAddress newRedirectServerAddress(InetAddress server) {
                     int port = hitServer2.get() ? dnsServer3.localAddress().getPort() :
@@ -1085,18 +1133,21 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
-    public void testResolveAllNullIpv4() {
-        testResolveAll0(ResolvedAddressTypes.IPV4_ONLY, NetUtil.LOCALHOST4, null);
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testResolveAllNullIpv4(DnsNameResolverChannelStrategy strategy) {
+        testResolveAll0(strategy, ResolvedAddressTypes.IPV4_ONLY, NetUtil.LOCALHOST4, null);
     }
 
-    @Test
-    public void testResolveAllNullIpv6() {
-        testResolveAll0(ResolvedAddressTypes.IPV6_ONLY, NetUtil.LOCALHOST6, null);
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testResolveAllNullIpv6(DnsNameResolverChannelStrategy strategy) {
+        testResolveAll0(strategy, ResolvedAddressTypes.IPV6_ONLY, NetUtil.LOCALHOST6, null);
     }
 
-    private static void testResolveAll0(ResolvedAddressTypes addressTypes, InetAddress expectedAddr, String name) {
-        DnsNameResolver resolver = newResolver(addressTypes).build();
+    private static void testResolveAll0(DnsNameResolverChannelStrategy strategy, ResolvedAddressTypes addressTypes,
+                                        InetAddress expectedAddr, String name) {
+        DnsNameResolver resolver = newResolver(strategy, addressTypes).build();
         try {
             List<InetAddress> addresses = resolver.resolveAll(name).syncUninterruptibly().getNow();
             assertEquals(1, addresses.size());
@@ -1109,9 +1160,10 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
-    public void testResolveAllMx() {
-        final DnsNameResolver resolver = newResolver().build();
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testResolveAllMx(DnsNameResolverChannelStrategy strategy) {
+        final DnsNameResolver resolver = newResolver(strategy).build();
         try {
             assertThat(resolver.isRecursionDesired(), is(true));
 
@@ -1154,8 +1206,9 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
-    public void testResolveAllHostsFile() {
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testResolveAllHostsFile(DnsNameResolverChannelStrategy strategy) {
         final DnsNameResolver resolver = new DnsNameResolverBuilder(group.next())
                 .datagramChannelType(NioDatagramChannel.class)
                 .hostsFileEntriesResolver(new HostsFileEntriesResolver() {
@@ -1170,7 +1223,9 @@ public class DnsNameResolverTest {
                         }
                         return null;
                     }
-                }).build();
+                })
+                .datagramChannelStrategy(strategy)
+                .build();
 
         final List<DnsRecord> records = resolver.resolveAll(new DefaultDnsQuestion("foo.com.", A))
                 .syncUninterruptibly().getNow();
@@ -1187,18 +1242,20 @@ public class DnsNameResolverTest {
         record.release();
     }
 
-    @Test
-    public void testResolveDecodeUnicode() {
-        testResolveUnicode(true);
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testResolveDecodeUnicode(DnsNameResolverChannelStrategy strategy) {
+        testResolveUnicode(strategy, true);
     }
 
-    @Test
-    public void testResolveNotDecodeUnicode() {
-        testResolveUnicode(false);
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testResolveNotDecodeUnicode(DnsNameResolverChannelStrategy strategy) {
+        testResolveUnicode(strategy, false);
     }
 
-    private static void testResolveUnicode(boolean decode) {
-        DnsNameResolver resolver = newResolver(decode).build();
+    private static void testResolveUnicode(DnsNameResolverChannelStrategy strategy, boolean decode) {
+        DnsNameResolver resolver = newResolver(strategy, decode).build();
         try {
             for (Entry<String, String> entries : DOMAINS_PUNYCODE.entrySet()) {
                 InetAddress address = resolver.resolve(entries.getKey()).syncUninterruptibly().getNow();
@@ -1211,19 +1268,24 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
     @Timeout(value = DEFAULT_TEST_TIMEOUT_MS, unit = TimeUnit.MILLISECONDS)
-    public void secondDnsServerShouldBeUsedBeforeCNAMEFirstServerNotStarted() throws IOException {
-        secondDnsServerShouldBeUsedBeforeCNAME(false);
+    public void secondDnsServerShouldBeUsedBeforeCNAMEFirstServerNotStarted(DnsNameResolverChannelStrategy strategy)
+            throws IOException {
+        secondDnsServerShouldBeUsedBeforeCNAME(strategy, false);
     }
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
     @Timeout(value = DEFAULT_TEST_TIMEOUT_MS, unit = TimeUnit.MILLISECONDS)
-    public void secondDnsServerShouldBeUsedBeforeCNAMEFirstServerFailResolve() throws IOException {
-        secondDnsServerShouldBeUsedBeforeCNAME(true);
+    public void secondDnsServerShouldBeUsedBeforeCNAMEFirstServerFailResolve(DnsNameResolverChannelStrategy strategy)
+            throws IOException {
+        secondDnsServerShouldBeUsedBeforeCNAME(strategy, true);
     }
 
-    private static void secondDnsServerShouldBeUsedBeforeCNAME(boolean startDnsServer1) throws IOException {
+    private static void secondDnsServerShouldBeUsedBeforeCNAME(
+            DnsNameResolverChannelStrategy strategy, boolean startDnsServer1) throws IOException {
         final String knownHostName = "netty.io";
         final TestDnsServer dnsServer1 = new TestDnsServer(Collections.singleton("notnetty.com"));
         final TestDnsServer dnsServer2 = new TestDnsServer(Collections.singleton(knownHostName));
@@ -1248,7 +1310,8 @@ public class DnsNameResolverTest {
                     .datagramChannelType(NioDatagramChannel.class)
                     .queryTimeoutMillis(1000) // We expect timeouts if startDnsServer1 is false
                     .optResourceEnabled(false)
-                    .ndots(1);
+                    .ndots(1)
+                    .datagramChannelStrategy(strategy);
 
             builder.nameServerProvider(new SequentialDnsServerAddressStreamProvider(dnsServer1Address,
                     dnsServer2.localAddress()));
@@ -1277,9 +1340,11 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
     @Timeout(value = DEFAULT_TEST_TIMEOUT_MS, unit = TimeUnit.MILLISECONDS)
-    public void aAndAAAAQueryShouldTryFirstDnsServerBeforeSecond() throws IOException {
+    public void aAndAAAAQueryShouldTryFirstDnsServerBeforeSecond(DnsNameResolverChannelStrategy strategy)
+            throws IOException {
         final String knownHostName = "netty.io";
         final TestDnsServer dnsServer1 = new TestDnsServer(Collections.singleton("notnetty.com"));
         final TestDnsServer dnsServer2 = new TestDnsServer(Collections.singleton(knownHostName));
@@ -1296,7 +1361,8 @@ public class DnsNameResolverTest {
                     .dnsQueryLifecycleObserverFactory(lifecycleObserverFactory)
                     .datagramChannelType(NioDatagramChannel.class)
                     .optResourceEnabled(false)
-                    .ndots(1);
+                    .ndots(1)
+                    .datagramChannelStrategy(strategy);
 
             builder.nameServerProvider(new SequentialDnsServerAddressStreamProvider(dnsServer1.localAddress(),
                     dnsServer2.localAddress()));
@@ -1325,27 +1391,32 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
-    public void testRecursiveResolveNoCache() throws Exception {
-        testRecursiveResolveCache(false);
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testRecursiveResolveNoCache(DnsNameResolverChannelStrategy strategy) throws Exception {
+        testRecursiveResolveCache(strategy, false);
     }
 
-    @Test
-    public void testRecursiveResolveCache() throws Exception {
-        testRecursiveResolveCache(true);
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testRecursiveResolveCache(DnsNameResolverChannelStrategy strategy) throws Exception {
+        testRecursiveResolveCache(strategy, true);
     }
 
-    @Test
-    public void testIpv4PreferredWhenIpv6First() throws Exception {
-        testResolvesPreferredWhenNonPreferredFirst0(ResolvedAddressTypes.IPV4_PREFERRED);
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testIpv4PreferredWhenIpv6First(DnsNameResolverChannelStrategy strategy) throws Exception {
+        testResolvesPreferredWhenNonPreferredFirst0(strategy, ResolvedAddressTypes.IPV4_PREFERRED);
     }
 
-    @Test
-    public void testIpv6PreferredWhenIpv4First() throws Exception {
-        testResolvesPreferredWhenNonPreferredFirst0(ResolvedAddressTypes.IPV6_PREFERRED);
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testIpv6PreferredWhenIpv4First(DnsNameResolverChannelStrategy strategy) throws Exception {
+        testResolvesPreferredWhenNonPreferredFirst0(strategy, ResolvedAddressTypes.IPV6_PREFERRED);
     }
 
-    private static void testResolvesPreferredWhenNonPreferredFirst0(ResolvedAddressTypes types) throws Exception {
+    private static void testResolvesPreferredWhenNonPreferredFirst0(
+            DnsNameResolverChannelStrategy strategy, ResolvedAddressTypes types) throws Exception {
         final String name = "netty.com";
         // This store is non-compliant, returning records of the wrong type for a query.
         // It works since we don't verify the type of the result when resolving to deal with
@@ -1370,7 +1441,7 @@ public class DnsNameResolverTest {
         TestDnsServer nonCompliantDnsServer = new TestDnsServer(arbitrarilyOrderedStore);
         nonCompliantDnsServer.start();
         try {
-            DnsNameResolver resolver = newResolver(types)
+            DnsNameResolver resolver = newResolver(strategy, types)
                     .maxQueriesPerResolve(2)
                     .nameServerProvider(new SingletonDnsServerAddressStreamProvider(
                             nonCompliantDnsServer.localAddress()))
@@ -1395,7 +1466,7 @@ public class DnsNameResolverTest {
         }
     }
 
-    private static void testRecursiveResolveCache(boolean cache)
+    private static void testRecursiveResolveCache(DnsNameResolverChannelStrategy strategy, boolean cache)
             throws Exception {
         final String hostname = "some.record.netty.io";
         final String hostname2 = "some2.record.netty.io";
@@ -1412,13 +1483,17 @@ public class DnsNameResolverTest {
                 cache ? new DefaultAuthoritativeDnsServerCache() : NoopAuthoritativeDnsServerCache.INSTANCE);
         TestRecursiveCacheDnsQueryLifecycleObserverFactory lifecycleObserverFactory =
                 new TestRecursiveCacheDnsQueryLifecycleObserverFactory();
+
         EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+        SingletonDnsServerAddressStreamProvider provider =
+                new SingletonDnsServerAddressStreamProvider(dnsServer.localAddress());
         final DnsNameResolver resolver = new DnsNameResolver(
-                group.next(), new ReflectiveChannelFactory<DatagramChannel>(NioDatagramChannel.class),
-                NoopDnsCache.INSTANCE, nsCache, lifecycleObserverFactory, 3000, ResolvedAddressTypes.IPV4_ONLY, true,
+                group.next(), new ReflectiveChannelFactory<DatagramChannel>(NioDatagramChannel.class), null,
+                false, NoopDnsCache.INSTANCE, NoopDnsCnameCache.INSTANCE, nsCache, null,
+                lifecycleObserverFactory, 3000, ResolvedAddressTypes.IPV4_ONLY, true,
                 10, true, 4096, false, HostsFileEntriesResolver.DEFAULT,
-                new SingletonDnsServerAddressStreamProvider(dnsServer.localAddress()),
-                DnsNameResolver.DEFAULT_SEARCH_DOMAINS, 0, true) {
+                provider, new ThreadLocalNameServerAddressStream(provider), DnsNameResolver.DEFAULT_SEARCH_DOMAINS,
+                0, true, false, 0, strategy) {
             @Override
             InetSocketAddress newRedirectServerAddress(InetAddress server) {
                 if (server.equals(dnsServerAuthority.localAddress().getAddress())) {
@@ -1496,38 +1571,47 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
-    public void testFollowNsRedirectsNoopCaches() throws Exception {
-        testFollowNsRedirects(NoopDnsCache.INSTANCE, NoopAuthoritativeDnsServerCache.INSTANCE, false);
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testFollowNsRedirectsNoopCaches(DnsNameResolverChannelStrategy strategy) throws Exception {
+        testFollowNsRedirects(strategy, NoopDnsCache.INSTANCE, NoopAuthoritativeDnsServerCache.INSTANCE, false);
     }
 
-    @Test
-    public void testFollowNsRedirectsNoopDnsCache() throws Exception {
-        testFollowNsRedirects(NoopDnsCache.INSTANCE, new DefaultAuthoritativeDnsServerCache(), false);
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testFollowNsRedirectsNoopDnsCache(DnsNameResolverChannelStrategy strategy) throws Exception {
+        testFollowNsRedirects(strategy, NoopDnsCache.INSTANCE, new DefaultAuthoritativeDnsServerCache(), false);
     }
 
-    @Test
-    public void testFollowNsRedirectsNoopAuthoritativeDnsServerCache() throws Exception {
-        testFollowNsRedirects(new DefaultDnsCache(), NoopAuthoritativeDnsServerCache.INSTANCE, false);
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testFollowNsRedirectsNoopAuthoritativeDnsServerCache(DnsNameResolverChannelStrategy strategy)
+            throws Exception {
+        testFollowNsRedirects(strategy, new DefaultDnsCache(), NoopAuthoritativeDnsServerCache.INSTANCE, false);
     }
 
-    @Test
-    public void testFollowNsRedirectsDefaultCaches() throws Exception {
-        testFollowNsRedirects(new DefaultDnsCache(), new DefaultAuthoritativeDnsServerCache(), false);
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testFollowNsRedirectsDefaultCaches(DnsNameResolverChannelStrategy strategy) throws Exception {
+        testFollowNsRedirects(strategy, new DefaultDnsCache(), new DefaultAuthoritativeDnsServerCache(), false);
     }
 
-    @Test
-    public void testFollowNsRedirectAndTrySecondNsOnTimeout() throws Exception {
-        testFollowNsRedirects(NoopDnsCache.INSTANCE, NoopAuthoritativeDnsServerCache.INSTANCE, true);
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testFollowNsRedirectAndTrySecondNsOnTimeout(DnsNameResolverChannelStrategy strategy) throws Exception {
+        testFollowNsRedirects(strategy, NoopDnsCache.INSTANCE, NoopAuthoritativeDnsServerCache.INSTANCE, true);
     }
 
-    @Test
-    public void testFollowNsRedirectAndTrySecondNsOnTimeoutDefaultCaches() throws Exception {
-        testFollowNsRedirects(new DefaultDnsCache(), new DefaultAuthoritativeDnsServerCache(), true);
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testFollowNsRedirectAndTrySecondNsOnTimeoutDefaultCaches(DnsNameResolverChannelStrategy strategy)
+            throws Exception {
+        testFollowNsRedirects(strategy, new DefaultDnsCache(), new DefaultAuthoritativeDnsServerCache(), true);
     }
 
-    private void testFollowNsRedirects(DnsCache cache, AuthoritativeDnsServerCache authoritativeDnsServerCache,
-            final boolean invalidNsFirst) throws Exception {
+    private void testFollowNsRedirects(DnsNameResolverChannelStrategy strategy, DnsCache cache,
+                                       AuthoritativeDnsServerCache authoritativeDnsServerCache,
+                                       final boolean invalidNsFirst) throws Exception {
         final String domain = "netty.io";
         final String ns1Name = "ns1." + domain;
         final String ns2Name = "ns2." + domain;
@@ -1571,13 +1655,15 @@ public class DnsNameResolverTest {
         };
         redirectServer.start();
         EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+        SingletonDnsServerAddressStreamProvider provider =
+                new SingletonDnsServerAddressStreamProvider(redirectServer.localAddress());
         final DnsNameResolver resolver = new DnsNameResolver(
-                group.next(), new ReflectiveChannelFactory<DatagramChannel>(NioDatagramChannel.class),
-                cache, authoritativeDnsServerCache, NoopDnsQueryLifecycleObserverFactory.INSTANCE, 2000,
-                ResolvedAddressTypes.IPV4_ONLY, true, 10, true, 4096,
-                false, HostsFileEntriesResolver.DEFAULT,
-                new SingletonDnsServerAddressStreamProvider(redirectServer.localAddress()),
-                DnsNameResolver.DEFAULT_SEARCH_DOMAINS, 0, true) {
+                group.next(), new ReflectiveChannelFactory<DatagramChannel>(NioDatagramChannel.class), null, false,
+                cache, NoopDnsCnameCache.INSTANCE, authoritativeDnsServerCache, null,
+                NoopDnsQueryLifecycleObserverFactory.INSTANCE, 2000, ResolvedAddressTypes.IPV4_ONLY, true,
+                10, true, 4096, false, HostsFileEntriesResolver.DEFAULT,
+                provider, new ThreadLocalNameServerAddressStream(provider), DnsNameResolver.DEFAULT_SEARCH_DOMAINS,
+                0, true, false, 0, strategy) {
 
             @Override
             InetSocketAddress newRedirectServerAddress(InetAddress server) {
@@ -1656,17 +1742,21 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
-    public void testMultipleAdditionalRecordsForSameNSRecord() throws Exception {
-        testMultipleAdditionalRecordsForSameNSRecord(false);
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testMultipleAdditionalRecordsForSameNSRecord(DnsNameResolverChannelStrategy strategy) throws Exception {
+        testMultipleAdditionalRecordsForSameNSRecord(strategy, false);
     }
 
-    @Test
-    public void testMultipleAdditionalRecordsForSameNSRecordReordered() throws Exception {
-        testMultipleAdditionalRecordsForSameNSRecord(true);
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testMultipleAdditionalRecordsForSameNSRecordReordered(DnsNameResolverChannelStrategy strategy)
+            throws Exception {
+        testMultipleAdditionalRecordsForSameNSRecord(strategy, true);
     }
 
-    private static void testMultipleAdditionalRecordsForSameNSRecord(final boolean reversed) throws Exception {
+    private static void testMultipleAdditionalRecordsForSameNSRecord(
+            DnsNameResolverChannelStrategy strategy, final boolean reversed) throws Exception {
         final String domain = "netty.io";
         final String hostname = "test.netty.io";
         final String ns1Name = "ns1." + domain;
@@ -1732,14 +1822,16 @@ public class DnsNameResolverTest {
         };
 
         final AtomicReference<DnsServerAddressStream> redirectedRef = new AtomicReference<DnsServerAddressStream>();
+        SingletonDnsServerAddressStreamProvider provider =
+                new SingletonDnsServerAddressStreamProvider(redirectServer.localAddress());
         final DnsNameResolver resolver = new DnsNameResolver(
-                group.next(), new ReflectiveChannelFactory<DatagramChannel>(NioDatagramChannel.class),
-                NoopDnsCache.INSTANCE, authoritativeDnsServerCache,
+                group.next(), new ReflectiveChannelFactory<DatagramChannel>(NioDatagramChannel.class), null, false,
+                NoopDnsCache.INSTANCE, NoopDnsCnameCache.INSTANCE, authoritativeDnsServerCache, null,
                 NoopDnsQueryLifecycleObserverFactory.INSTANCE, 2000, ResolvedAddressTypes.IPV4_ONLY,
                 true, 10, true, 4096,
                 false, HostsFileEntriesResolver.DEFAULT,
-                new SingletonDnsServerAddressStreamProvider(redirectServer.localAddress()),
-                DnsNameResolver.DEFAULT_SEARCH_DOMAINS, 0, true) {
+                provider, new ThreadLocalNameServerAddressStream(provider), DnsNameResolver.DEFAULT_SEARCH_DOMAINS, 0,
+                true, false, 0, strategy) {
 
             @Override
             protected DnsServerAddressStream newRedirectDnsServerStream(
@@ -1785,8 +1877,9 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
-    public void testNSRecordsFromCache() throws Exception {
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testNSRecordsFromCache(DnsNameResolverChannelStrategy strategy) throws Exception {
         final String domain = "netty.io";
         final String hostname = "test.netty.io";
         final String ns0Name = "ns0." + domain + '.';
@@ -1869,14 +1962,16 @@ public class DnsNameResolverTest {
         cache.cache(ns1Name, null, ns4Address.getAddress(), 10000, loop);
 
         final AtomicReference<DnsServerAddressStream> redirectedRef = new AtomicReference<DnsServerAddressStream>();
+        SingletonDnsServerAddressStreamProvider provider =
+                new SingletonDnsServerAddressStreamProvider(redirectServer.localAddress());
         final DnsNameResolver resolver = new DnsNameResolver(
-                loop, new ReflectiveChannelFactory<DatagramChannel>(NioDatagramChannel.class),
-                cache, authoritativeDnsServerCache,
+                loop, new ReflectiveChannelFactory<DatagramChannel>(NioDatagramChannel.class), null, false,
+                cache, NoopDnsCnameCache.INSTANCE, authoritativeDnsServerCache, null,
                 NoopDnsQueryLifecycleObserverFactory.INSTANCE, 2000, ResolvedAddressTypes.IPV4_ONLY,
                 true, 10, true, 4096,
                 false, HostsFileEntriesResolver.DEFAULT,
-                new SingletonDnsServerAddressStreamProvider(redirectServer.localAddress()),
-                DnsNameResolver.DEFAULT_SEARCH_DOMAINS, 0, true) {
+                provider, new ThreadLocalNameServerAddressStream(provider),
+                DnsNameResolver.DEFAULT_SEARCH_DOMAINS, 0, true, false, 0, strategy) {
 
             @Override
             protected DnsServerAddressStream newRedirectDnsServerStream(
@@ -1917,42 +2012,54 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
-    public void testNsLoopFailsResolveWithAuthoritativeDnsServerCache() throws Exception {
-        testNsLoopFailsResolve(new DefaultAuthoritativeDnsServerCache());
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testNsLoopFailsResolveWithAuthoritativeDnsServerCache(DnsNameResolverChannelStrategy strategy)
+            throws Exception {
+        testNsLoopFailsResolve(strategy, new DefaultAuthoritativeDnsServerCache());
     }
 
-    @Test
-    public void testNsLoopFailsResolveWithoutAuthoritativeDnsServerCache() throws Exception {
-        testNsLoopFailsResolve(NoopAuthoritativeDnsServerCache.INSTANCE);
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testNsLoopFailsResolveWithoutAuthoritativeDnsServerCache(DnsNameResolverChannelStrategy strategy)
+            throws Exception {
+        testNsLoopFailsResolve(strategy, NoopAuthoritativeDnsServerCache.INSTANCE);
     }
 
-    @Test
-    public void testRRNameContainsDifferentSearchDomainNoDomains() {
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testRRNameContainsDifferentSearchDomainNoDomains(final DnsNameResolverChannelStrategy strategy) {
         assertThrows(UnknownHostException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
-                testRRNameContainsDifferentSearchDomain(Collections.<String>emptyList(), "netty");
+                testRRNameContainsDifferentSearchDomain(strategy, Collections.<String>emptyList(), "netty");
             }
         });
     }
 
-    @Test
-    public void testRRNameContainsDifferentSearchDomainEmptyExtraDomain() throws Exception {
-        testRRNameContainsDifferentSearchDomain(asList("io", ""), "netty");
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testRRNameContainsDifferentSearchDomainEmptyExtraDomain(DnsNameResolverChannelStrategy strategy)
+            throws Exception {
+        testRRNameContainsDifferentSearchDomain(strategy, asList("io", ""), "netty");
     }
 
-    @Test
-    public void testRRNameContainsDifferentSearchDomainSingleExtraDomain() throws Exception {
-        testRRNameContainsDifferentSearchDomain(asList("io", "foo.dom"), "netty");
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testRRNameContainsDifferentSearchDomainSingleExtraDomain(DnsNameResolverChannelStrategy strategy)
+            throws Exception {
+        testRRNameContainsDifferentSearchDomain(strategy, asList("io", "foo.dom"), "netty");
     }
 
-    @Test
-    public void testRRNameContainsDifferentSearchDomainMultiExtraDomains() throws Exception {
-        testRRNameContainsDifferentSearchDomain(asList("com", "foo.dom", "bar.dom"), "google");
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testRRNameContainsDifferentSearchDomainMultiExtraDomains(DnsNameResolverChannelStrategy strategy)
+            throws Exception {
+        testRRNameContainsDifferentSearchDomain(strategy, asList("com", "foo.dom", "bar.dom"), "google");
     }
 
-    private static void testRRNameContainsDifferentSearchDomain(final List<String> searchDomains, String unresolved)
+    private static void testRRNameContainsDifferentSearchDomain(DnsNameResolverChannelStrategy strategy,
+                                                                final List<String> searchDomains, String unresolved)
             throws Exception {
         final String ipAddrPrefix = "1.2.3.";
         TestDnsServer searchDomainServer = new TestDnsServer(new RecordStore() {
@@ -1974,7 +2081,7 @@ public class DnsNameResolverTest {
         });
         searchDomainServer.start();
 
-        final DnsNameResolver resolver = newResolver(false, null, searchDomainServer)
+        final DnsNameResolver resolver = newResolver(strategy, false, null, searchDomainServer)
                 .searchDomains(searchDomains)
                 .build();
 
@@ -1991,7 +2098,8 @@ public class DnsNameResolverTest {
         }
     }
 
-    private void testNsLoopFailsResolve(AuthoritativeDnsServerCache authoritativeDnsServerCache) throws Exception {
+    private void testNsLoopFailsResolve(DnsNameResolverChannelStrategy strategy,
+                                        AuthoritativeDnsServerCache authoritativeDnsServerCache) throws Exception {
         final String domain = "netty.io";
         final String ns1Name = "ns1." + domain;
         final String ns2Name = "ns2." + domain;
@@ -2016,7 +2124,7 @@ public class DnsNameResolverTest {
             }
         };
         testDnsServer.start();
-        DnsNameResolverBuilder builder = newResolver();
+        DnsNameResolverBuilder builder = newResolver(strategy);
 
         final DnsNameResolver resolver = builder.resolveCache(NoopDnsCache.INSTANCE)
                 .authoritativeDnsServerCache(authoritativeDnsServerCache)
@@ -2289,9 +2397,10 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
     @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
-    public void testTimeoutNotCached() {
+    public void testTimeoutNotCached(DnsNameResolverChannelStrategy strategy) {
         DnsCache cache = new DnsCache() {
             @Override
             public void clear() {
@@ -2321,7 +2430,7 @@ public class DnsNameResolverTest {
                 return null;
             }
         };
-        DnsNameResolverBuilder builder = newResolver();
+        DnsNameResolverBuilder builder = newResolver(strategy);
         builder.queryTimeoutMillis(100)
                 .authoritativeDnsServerCache(cache)
                 .resolveCache(cache)
@@ -2338,25 +2447,32 @@ public class DnsNameResolverTest {
         resolver.close();
     }
 
-    @Test
-    public void testTimeoutIpv4PreferredA() throws IOException {
-        testTimeoutOneQuery(ResolvedAddressTypes.IPV4_PREFERRED, RecordType.A, RecordType.AAAA);
-    }
-    @Test
-    public void testTimeoutIpv4PreferredAAAA() throws IOException {
-        testTimeoutOneQuery(ResolvedAddressTypes.IPV4_PREFERRED, RecordType.AAAA, RecordType.A);
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testTimeoutIpv4PreferredA(DnsNameResolverChannelStrategy strategy) throws IOException {
+        testTimeoutOneQuery(strategy, ResolvedAddressTypes.IPV4_PREFERRED, RecordType.A, RecordType.AAAA);
     }
 
-    @Test
-    public void testTimeoutIpv6PreferredA() throws IOException {
-        testTimeoutOneQuery(ResolvedAddressTypes.IPV6_PREFERRED, RecordType.A, RecordType.AAAA);
-    }
-    @Test
-    public void testTimeoutIpv6PreferredAAAA() throws IOException {
-        testTimeoutOneQuery(ResolvedAddressTypes.IPV6_PREFERRED, RecordType.AAAA, RecordType.A);
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testTimeoutIpv4PreferredAAAA(DnsNameResolverChannelStrategy strategy) throws IOException {
+        testTimeoutOneQuery(strategy, ResolvedAddressTypes.IPV4_PREFERRED, RecordType.AAAA, RecordType.A);
     }
 
-    private static void testTimeoutOneQuery(ResolvedAddressTypes type, final RecordType recordType, RecordType dropType)
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testTimeoutIpv6PreferredA(DnsNameResolverChannelStrategy strategy) throws IOException {
+        testTimeoutOneQuery(strategy, ResolvedAddressTypes.IPV6_PREFERRED, RecordType.A, RecordType.AAAA);
+    }
+
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testTimeoutIpv6PreferredAAAA(DnsNameResolverChannelStrategy strategy) throws IOException {
+        testTimeoutOneQuery(strategy, ResolvedAddressTypes.IPV6_PREFERRED, RecordType.AAAA, RecordType.A);
+    }
+
+    private static void testTimeoutOneQuery(DnsNameResolverChannelStrategy strategy, ResolvedAddressTypes type,
+                                            final RecordType recordType, RecordType dropType)
             throws IOException {
 
         TestDnsServer dnsServer2 = new TestDnsServer(new RecordStore() {
@@ -2378,7 +2494,7 @@ public class DnsNameResolverTest {
         dnsServer2.start(dropType);
         DnsNameResolver resolver = null;
         try {
-            DnsNameResolverBuilder builder = newResolver()
+            DnsNameResolverBuilder builder = newResolver(strategy)
                     .recursionDesired(true)
                     .queryTimeoutMillis(500)
                     .resolvedAddressTypes(type)
@@ -2419,8 +2535,9 @@ public class DnsNameResolverTest {
         assertEquals(newChannelFactory, builder.datagramChannelFactory());
     }
 
-    @Test
-    public void testFollowCNAMEEvenIfARecordIsPresent() throws IOException {
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testFollowCNAMEEvenIfARecordIsPresent(DnsNameResolverChannelStrategy strategy) throws IOException {
         TestDnsServer dnsServer2 = new TestDnsServer(new RecordStore() {
 
             @Override
@@ -2448,7 +2565,7 @@ public class DnsNameResolverTest {
         dnsServer2.start();
         DnsNameResolver resolver = null;
         try {
-            DnsNameResolverBuilder builder = newResolver()
+            DnsNameResolverBuilder builder = newResolver(strategy)
                     .recursionDesired(true)
                     .resolvedAddressTypes(ResolvedAddressTypes.IPV4_ONLY)
                     .maxQueriesPerResolve(16)
@@ -2475,8 +2592,9 @@ public class DnsNameResolverTest {
     // cname.netty.io.        9042   IN    CNAME    cname2.netty.io.
     // cname2.netty.io.       1312   IN    CNAME    cname3.netty.io.io.
     // cname3.netty.io.       20     IN    A        10.0.0.2
-    @Test
-    public void testCNAMEFollowInResponseWithoutExtraQuery() throws IOException {
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testCNAMEFollowInResponseWithoutExtraQuery(DnsNameResolverChannelStrategy strategy) throws IOException {
         final AtomicInteger queryCount = new AtomicInteger();
         TestDnsServer dnsServer2 = new TestDnsServer(new RecordStore() {
 
@@ -2512,7 +2630,7 @@ public class DnsNameResolverTest {
         dnsServer2.start();
         DnsNameResolver resolver = null;
         try {
-            DnsNameResolverBuilder builder = newResolver()
+            DnsNameResolverBuilder builder = newResolver(strategy)
                     .recursionDesired(true)
                     .resolvedAddressTypes(ResolvedAddressTypes.IPV4_ONLY)
                     .maxQueriesPerResolve(16)
@@ -2532,8 +2650,9 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
-    public void testFollowCNAMELoop() throws IOException {
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testFollowCNAMELoop(DnsNameResolverChannelStrategy strategy) throws IOException {
         TestDnsServer dnsServer2 = new TestDnsServer(new RecordStore() {
 
             @Override
@@ -2561,7 +2680,7 @@ public class DnsNameResolverTest {
         dnsServer2.start();
         DnsNameResolver resolver = null;
         try {
-            DnsNameResolverBuilder builder = newResolver()
+            DnsNameResolverBuilder builder = newResolver(strategy)
                     .recursionDesired(false)
                     .resolvedAddressTypes(ResolvedAddressTypes.IPV4_ONLY)
                     .maxQueriesPerResolve(16)
@@ -2583,11 +2702,12 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
-    public void testCNAMELoopInCache() throws Throwable {
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testCNAMELoopInCache(DnsNameResolverChannelStrategy strategy) throws Throwable {
         DnsNameResolver resolver = null;
         try {
-            DnsNameResolverBuilder builder = newResolver()
+            DnsNameResolverBuilder builder = newResolver(strategy)
                     .recursionDesired(false)
                     .resolvedAddressTypes(ResolvedAddressTypes.IPV4_ONLY)
                     .maxQueriesPerResolve(16)
@@ -2614,28 +2734,33 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
-    public void testSearchDomainQueryFailureForSingleAddressTypeCompletes() {
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testSearchDomainQueryFailureForSingleAddressTypeCompletes(
+            final DnsNameResolverChannelStrategy strategy) {
         assertThrows(UnknownHostException.class, new Executable() {
             @Override
             public void execute() {
-                testSearchDomainQueryFailureCompletes(ResolvedAddressTypes.IPV4_ONLY);
+                testSearchDomainQueryFailureCompletes(strategy, ResolvedAddressTypes.IPV4_ONLY);
             }
         });
     }
 
-    @Test
-    public void testSearchDomainQueryFailureForMultipleAddressTypeCompletes() {
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testSearchDomainQueryFailureForMultipleAddressTypeCompletes(
+            final DnsNameResolverChannelStrategy strategy) {
         assertThrows(UnknownHostException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
-                testSearchDomainQueryFailureCompletes(ResolvedAddressTypes.IPV4_PREFERRED);
+                testSearchDomainQueryFailureCompletes(strategy, ResolvedAddressTypes.IPV4_PREFERRED);
             }
         });
     }
 
-    private void testSearchDomainQueryFailureCompletes(ResolvedAddressTypes types) {
-        DnsNameResolver resolver = newResolver()
+    private void testSearchDomainQueryFailureCompletes(
+            DnsNameResolverChannelStrategy strategy, ResolvedAddressTypes types) {
+        DnsNameResolver resolver = newResolver(strategy)
                 .resolvedAddressTypes(types)
                 .ndots(1)
                 .searchDomains(singletonList(".")).build();
@@ -2646,13 +2771,14 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
     @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
-    public void testCachesClearedOnClose() throws Exception {
+    public void testCachesClearedOnClose(DnsNameResolverChannelStrategy strategy) throws Exception {
         final CountDownLatch resolveLatch = new CountDownLatch(1);
         final CountDownLatch authoritativeLatch = new CountDownLatch(1);
 
-        DnsNameResolver resolver = newResolver().resolveCache(new DnsCache() {
+        DnsNameResolver resolver = newResolver(strategy).resolveCache(new DnsCache() {
             @Override
             public void clear() {
                 resolveLatch.countDown();
@@ -2712,10 +2838,11 @@ public class DnsNameResolverTest {
         authoritativeLatch.await();
     }
 
-    @Test
-    public void testResolveACachedWithDot() {
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testResolveACachedWithDot(DnsNameResolverChannelStrategy strategy) {
         final DnsCache cache = new DefaultDnsCache();
-        DnsNameResolver resolver = newResolver(ResolvedAddressTypes.IPV4_ONLY)
+        DnsNameResolver resolver = newResolver(strategy, ResolvedAddressTypes.IPV4_ONLY)
                 .resolveCache(cache).build();
 
         try {
@@ -2733,12 +2860,13 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
-    public void testResolveACachedWithDotSearchDomain() throws Exception {
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testResolveACachedWithDotSearchDomain(DnsNameResolverChannelStrategy strategy) throws Exception {
         final TestDnsCache cache = new TestDnsCache(new DefaultDnsCache());
         TestDnsServer server = new TestDnsServer(Collections.singleton("test.netty.io"));
         server.start();
-        DnsNameResolver resolver = newResolver(ResolvedAddressTypes.IPV4_ONLY)
+        DnsNameResolver resolver = newResolver(strategy, ResolvedAddressTypes.IPV4_ONLY)
                 .searchDomains(Collections.singletonList("netty.io"))
                 .nameServerProvider(new SingletonDnsServerAddressStreamProvider(server.localAddress()))
                 .resolveCache(cache).build();
@@ -2766,24 +2894,9 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
-    public void testChannelFactoryException() {
-        final IllegalStateException exception = new IllegalStateException();
-        try {
-            newResolver().datagramChannelFactory(new ChannelFactory<DatagramChannel>() {
-                @Override
-                public DatagramChannel newChannel() {
-                    throw exception;
-                }
-            }).build();
-            fail();
-        } catch (Exception e) {
-            assertSame(exception, e);
-        }
-    }
-
-    @Test
-    public void testCNameCached() throws Exception {
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testCNameCached(DnsNameResolverChannelStrategy strategy) throws Exception {
         final Map<String, String> cache = new ConcurrentHashMap<String, String>();
         final AtomicInteger cnameQueries = new AtomicInteger();
         final AtomicInteger aQueries = new AtomicInteger();
@@ -2822,7 +2935,7 @@ public class DnsNameResolverTest {
         dnsServer2.start();
         DnsNameResolver resolver = null;
         try {
-            DnsNameResolverBuilder builder = newResolver()
+            DnsNameResolverBuilder builder = newResolver(strategy)
                     .recursionDesired(true)
                     .resolvedAddressTypes(ResolvedAddressTypes.IPV4_ONLY)
                     .maxQueriesPerResolve(16)
@@ -2920,8 +3033,9 @@ public class DnsNameResolverTest {
         ).close();
     }
 
-    @Test
-    public void testQueryTxt() throws Exception {
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testQueryTxt(DnsNameResolverChannelStrategy strategy) throws Exception {
         final String hostname = "txt.netty.io";
         final String txt1 = "some text";
         final String txt2 = "some more text";
@@ -2946,7 +3060,7 @@ public class DnsNameResolverTest {
             }
         });
         server.start();
-        DnsNameResolver resolver = newResolver(ResolvedAddressTypes.IPV4_ONLY)
+        DnsNameResolver resolver = newResolver(strategy, ResolvedAddressTypes.IPV4_ONLY)
                 .nameServerProvider(new SingletonDnsServerAddressStreamProvider(server.localAddress()))
                 .build();
         try {
@@ -2991,8 +3105,9 @@ public class DnsNameResolverTest {
         return list;
     }
 
-    @Test
-    public void testNotIncludeDuplicates() throws IOException {
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testNotIncludeDuplicates(DnsNameResolverChannelStrategy strategy) throws IOException {
         final String name = "netty.io";
         final String ipv4Addr = "1.2.3.4";
         TestDnsServer dnsServer2 = new TestDnsServer(new RecordStore() {
@@ -3019,7 +3134,7 @@ public class DnsNameResolverTest {
         dnsServer2.start();
         DnsNameResolver resolver = null;
         try {
-            DnsNameResolverBuilder builder = newResolver()
+            DnsNameResolverBuilder builder = newResolver(strategy)
                     .recursionDesired(true)
                     .maxQueriesPerResolve(16)
                     .nameServerProvider(new SingletonDnsServerAddressStreamProvider(dnsServer2.localAddress()));
@@ -3037,8 +3152,9 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
-    public void testIncludeDuplicates() throws IOException {
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testIncludeDuplicates(DnsNameResolverChannelStrategy strategy) throws IOException {
         final String name = "netty.io";
         final String ipv4Addr = "1.2.3.4";
         TestDnsServer dnsServer2 = new TestDnsServer(new RecordStore() {
@@ -3058,7 +3174,7 @@ public class DnsNameResolverTest {
         dnsServer2.start();
         DnsNameResolver resolver = null;
         try {
-            DnsNameResolverBuilder builder = newResolver()
+            DnsNameResolverBuilder builder = newResolver(strategy)
                     .recursionDesired(true)
                     .maxQueriesPerResolve(16)
                     .nameServerProvider(new SingletonDnsServerAddressStreamProvider(dnsServer2.localAddress()));
@@ -3079,14 +3195,15 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
-    public void testDropAAAA() throws IOException {
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testDropAAAA(DnsNameResolverChannelStrategy strategy) throws IOException {
         String host = "somehost.netty.io";
         TestDnsServer dnsServer2 = new TestDnsServer(Collections.singleton(host));
         dnsServer2.start(RecordType.AAAA);
         DnsNameResolver resolver = null;
         try {
-            DnsNameResolverBuilder builder = newResolver()
+            DnsNameResolverBuilder builder = newResolver(strategy)
                     .recursionDesired(false)
                     .queryTimeoutMillis(500)
                     .resolvedAddressTypes(ResolvedAddressTypes.IPV4_PREFERRED)
@@ -3105,15 +3222,16 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
     @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
-    public void testDropAAAAResolveFast() throws IOException {
+    public void testDropAAAAResolveFast(DnsNameResolverChannelStrategy strategy) throws IOException {
         String host = "somehost.netty.io";
         TestDnsServer dnsServer2 = new TestDnsServer(Collections.singleton(host));
         dnsServer2.start(RecordType.AAAA);
         DnsNameResolver resolver = null;
         try {
-            DnsNameResolverBuilder builder = newResolver()
+            DnsNameResolverBuilder builder = newResolver(strategy)
                     .recursionDesired(false)
                     .queryTimeoutMillis(10000)
                     .resolvedAddressTypes(ResolvedAddressTypes.IPV4_PREFERRED)
@@ -3132,9 +3250,10 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
     @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
-    public void testDropAAAAResolveAllFast() throws IOException {
+    public void testDropAAAAResolveAllFast(DnsNameResolverChannelStrategy strategy) throws IOException {
         final String host = "somehost.netty.io";
         TestDnsServer dnsServer2 = new TestDnsServer(new RecordStore() {
             @Override
@@ -3156,7 +3275,7 @@ public class DnsNameResolverTest {
         dnsServer2.start(RecordType.AAAA);
         DnsNameResolver resolver = null;
         try {
-            DnsNameResolverBuilder builder = newResolver()
+            DnsNameResolverBuilder builder = newResolver(strategy)
                     .recursionDesired(false)
                     .queryTimeoutMillis(10000)
                     .resolvedAddressTypes(ResolvedAddressTypes.IPV4_PREFERRED)
@@ -3179,22 +3298,25 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
     @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
-    public void testTruncatedWithoutTcpFallback() throws IOException {
-        testTruncated0(false, false);
+    public void testTruncatedWithoutTcpFallback(DnsNameResolverChannelStrategy strategy) throws IOException {
+        testTruncated0(strategy, false, false);
     }
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
     @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
-    public void testTruncatedWithTcpFallback() throws IOException {
-        testTruncated0(true, false);
+    public void testTruncatedWithTcpFallback(DnsNameResolverChannelStrategy strategy) throws IOException {
+        testTruncated0(strategy, true, false);
     }
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
     @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
-    public void testTruncatedWithTcpFallbackBecauseOfMtu() throws IOException {
-        testTruncated0(true, true);
+    public void testTruncatedWithTcpFallbackBecauseOfMtu(DnsNameResolverChannelStrategy strategy) throws IOException {
+        testTruncated0(strategy, true, true);
     }
 
     private static DnsMessageModifier modifierFrom(DnsMessage message) {
@@ -3216,7 +3338,8 @@ public class DnsNameResolverTest {
         return modifier;
     }
 
-    private static void testTruncated0(boolean tcpFallback, final boolean truncatedBecauseOfMtu) throws IOException {
+    private static void testTruncated0(DnsNameResolverChannelStrategy strategy,
+                                       boolean tcpFallback, final boolean truncatedBecauseOfMtu) throws IOException {
         ServerSocket serverSocket = null;
         final String host = "somehost.netty.io";
         final String txt = "this is a txt record";
@@ -3251,7 +3374,7 @@ public class DnsNameResolverTest {
         };
         DnsNameResolver resolver = null;
         try {
-            DnsNameResolverBuilder builder = newResolver();
+            DnsNameResolverBuilder builder = newResolver(strategy);
             final DatagramChannel datagramChannel = new NioDatagramChannel();
             ChannelFactory<DatagramChannel> channelFactory = new ChannelFactory<DatagramChannel>() {
                 @Override
@@ -3355,14 +3478,16 @@ public class DnsNameResolverTest {
         socket.getOutputStream().flush();
     }
 
-    @Test
-    public void testTcpFallbackWhenTimeout() throws IOException {
-        testTcpFallbackWhenTimeout(true);
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testTcpFallbackWhenTimeout(DnsNameResolverChannelStrategy strategy) throws IOException {
+        testTcpFallbackWhenTimeout(strategy, true);
     }
 
-    @Test
-    public void testTcpFallbackFailedWhenTimeout() throws IOException {
-        testTcpFallbackWhenTimeout(false);
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testTcpFallbackFailedWhenTimeout(DnsNameResolverChannelStrategy strategy) throws IOException {
+        testTcpFallbackWhenTimeout(strategy, false);
     }
 
     private static ServerSocket startDnsServerAndCreateServerSocket(TestDnsServer dns) throws IOException {
@@ -3386,7 +3511,8 @@ public class DnsNameResolverTest {
         }
     }
 
-    private void testTcpFallbackWhenTimeout(boolean tcpSuccess) throws IOException {
+    private void testTcpFallbackWhenTimeout(DnsNameResolverChannelStrategy strategy, boolean tcpSuccess)
+            throws IOException {
         final String host = "somehost.netty.io";
         final String txt = "this is a txt record";
         final AtomicReference<DnsMessage> messageRef = new AtomicReference<DnsMessage>();
@@ -3414,7 +3540,7 @@ public class DnsNameResolverTest {
         DnsNameResolver resolver = null;
         ServerSocket serverSocket = null;
         try {
-            DnsNameResolverBuilder builder = newResolver();
+            DnsNameResolverBuilder builder = newResolver(strategy);
             final DatagramChannel datagramChannel = new NioDatagramChannel();
             ChannelFactory<DatagramChannel> channelFactory = new ChannelFactory<DatagramChannel>() {
                 @Override
@@ -3430,7 +3556,8 @@ public class DnsNameResolverTest {
             builder.queryTimeoutMillis(1000)
                     .resolvedAddressTypes(ResolvedAddressTypes.IPV4_PREFERRED)
                     .maxQueriesPerResolve(16)
-                    .nameServerProvider(new SingletonDnsServerAddressStreamProvider(dnsServer2.localAddress()));
+                    .nameServerProvider(new SingletonDnsServerAddressStreamProvider(dnsServer2.localAddress()))
+                    .datagramChannelStrategy(strategy);
             resolver = builder.build();
             Future<AddressedEnvelope<DnsResponse, InetSocketAddress>> envelopeFuture = resolver.query(
                     new DefaultDnsQuestion(host, DnsRecordType.TXT));
@@ -3480,8 +3607,9 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
-    public void testCancelPromise() throws Exception {
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testCancelPromise(DnsNameResolverChannelStrategy strategy) throws Exception {
         final EventLoop eventLoop = group.next();
         final Promise<InetAddress> promise = eventLoop.newPromise();
         final TestDnsServer dnsServer1 = new TestDnsServer(Collections.<String>emptySet()) {
@@ -3509,6 +3637,7 @@ public class DnsNameResolverTest {
                 .datagramChannelType(NioDatagramChannel.class)
                 .optResourceEnabled(false)
                 .nameServerProvider(nameServerProvider)
+                .datagramChannelStrategy(strategy)
                 .build();
 
         try {
@@ -3520,8 +3649,10 @@ public class DnsNameResolverTest {
         assertThat(isQuerySentToSecondServer.get(), is(false));
     }
 
-    @Test
-    public void testCNAMERecursiveResolveDifferentNameServersForDomains() throws IOException {
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testCNAMERecursiveResolveDifferentNameServersForDomains(DnsNameResolverChannelStrategy strategy)
+            throws IOException {
         final String firstName = "firstname.com";
         final String secondName = "secondname.com";
         final String lastName = "lastname.com";
@@ -3565,7 +3696,7 @@ public class DnsNameResolverTest {
         dnsServer3.start();
         DnsNameResolver resolver = null;
         try {
-            resolver = newResolver()
+            resolver = newResolver(strategy)
                     .resolveCache(NoopDnsCache.INSTANCE)
                     .cnameCache(NoopDnsCnameCache.INSTANCE)
                     .recursionDesired(true)
@@ -3596,8 +3727,9 @@ public class DnsNameResolverTest {
         assertEquals(hostname, resolvedAddress.getHostName());
     }
 
-    @Test
-    public void testAllNameServers() throws IOException {
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testAllNameServers(DnsNameResolverChannelStrategy strategy) throws IOException {
         final String domain = "netty.io";
         final String ipv4Addr = "1.2.3.4";
         final AtomicInteger server2Counter = new AtomicInteger();
@@ -3635,7 +3767,7 @@ public class DnsNameResolverTest {
         dnsServer3.start();
         DnsNameResolver resolver = null;
         try {
-            resolver = newResolver()
+            resolver = newResolver(strategy)
                     .resolveCache(NoopDnsCache.INSTANCE)
                     .cnameCache(NoopDnsCnameCache.INSTANCE)
                     .recursionDesired(true)
@@ -3671,9 +3803,10 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
     @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
-    public void testSrvWithCnameNotCached() throws Exception {
+    public void testSrvWithCnameNotCached(DnsNameResolverChannelStrategy strategy) throws Exception {
         final AtomicBoolean alias = new AtomicBoolean();
         TestDnsServer dnsServer2 = new TestDnsServer(new RecordStore() {
             @Override
@@ -3729,7 +3862,7 @@ public class DnsNameResolverTest {
         dnsServer2.start();
         DnsNameResolver resolver = null;
         try {
-            DnsNameResolverBuilder builder = newResolver()
+            DnsNameResolverBuilder builder = newResolver(strategy)
                     .recursionDesired(false)
                     .queryTimeoutMillis(10000)
                     .resolvedAddressTypes(ResolvedAddressTypes.IPV4_PREFERRED)
@@ -3751,23 +3884,26 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
-    public void testCNAMENotTriedOnAddressLookupsWhenDisabled() throws Exception {
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testCNAMENotTriedOnAddressLookupsWhenDisabled(DnsNameResolverChannelStrategy strategy)
+            throws Exception {
         TRY_FINAL_CNAME_ON_ADDRESS_LOOKUPS = false;
-        testFollowUpCNAME(false);
+        testFollowUpCNAME(strategy, false);
     }
 
-    @Test
-    public void testCNAMEOnlyTriedOnAddressLookups() throws Exception {
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testCNAMEOnlyTriedOnAddressLookups(DnsNameResolverChannelStrategy strategy) throws Exception {
         TRY_FINAL_CNAME_ON_ADDRESS_LOOKUPS = true;
         try {
-            testFollowUpCNAME(true);
+            testFollowUpCNAME(strategy, true);
         } finally {
             TRY_FINAL_CNAME_ON_ADDRESS_LOOKUPS = false;
         }
     }
 
-    private void testFollowUpCNAME(final boolean enabled) throws Exception {
+    private void testFollowUpCNAME(DnsNameResolverChannelStrategy strategy, final boolean enabled) throws Exception {
         final AtomicInteger cnameQueries = new AtomicInteger();
 
         TestDnsServer dnsServer2 = new TestDnsServer(new RecordStore() {
@@ -3784,7 +3920,7 @@ public class DnsNameResolverTest {
         DnsNameResolver resolver = null;
         try {
             dnsServer2.start();
-            resolver = newNonCachedResolver(ResolvedAddressTypes.IPV4_PREFERRED)
+            resolver = newNonCachedResolver(strategy, ResolvedAddressTypes.IPV4_PREFERRED)
                     .maxQueriesPerResolve(4)
                     .searchDomains(Collections.<String>emptyList())
                     .nameServerProvider(new SingletonDnsServerAddressStreamProvider(dnsServer2.localAddress()))
@@ -3831,18 +3967,21 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
-    public void testResolveIpv6WithScopeId() throws Exception {
-        testResolveIpv6WithScopeId0(false);
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testResolveIpv6WithScopeId(DnsNameResolverChannelStrategy strategy) throws Exception {
+        testResolveIpv6WithScopeId0(strategy, false);
     }
 
-    @Test
-    public void testResolveAllIpv6WithScopeId() throws Exception {
-        testResolveIpv6WithScopeId0(true);
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testResolveAllIpv6WithScopeId(DnsNameResolverChannelStrategy strategy) throws Exception {
+        testResolveIpv6WithScopeId0(strategy, true);
     }
 
-    private void testResolveIpv6WithScopeId0(boolean resolveAll) throws Exception {
-        DnsNameResolver resolver = newResolver().build();
+    private void testResolveIpv6WithScopeId0(DnsNameResolverChannelStrategy strategy, boolean resolveAll)
+            throws Exception {
+        DnsNameResolver resolver = newResolver(strategy).build();
         String address = "fe80:0:0:0:1c31:d1d1:4824:72a9";
         int scopeId = 15;
         String addressString = address + '%' + scopeId;
@@ -3863,18 +4002,21 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
-    public void testResolveIpv6WithoutScopeId() throws Exception {
-        testResolveIpv6WithoutScopeId0(false);
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testResolveIpv6WithoutScopeId(DnsNameResolverChannelStrategy strategy) throws Exception {
+        testResolveIpv6WithoutScopeId0(strategy, false);
     }
 
-    @Test
-    public void testResolveAllIpv6WithoutScopeId() throws Exception {
-        testResolveIpv6WithoutScopeId0(true);
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testResolveAllIpv6WithoutScopeId(DnsNameResolverChannelStrategy strategy) throws Exception {
+        testResolveIpv6WithoutScopeId0(strategy, true);
     }
 
-    private void testResolveIpv6WithoutScopeId0(boolean resolveAll) throws Exception {
-        DnsNameResolver resolver = newResolver().build();
+    private void testResolveIpv6WithoutScopeId0(DnsNameResolverChannelStrategy strategy, boolean resolveAll)
+            throws Exception {
+        DnsNameResolver resolver = newResolver(strategy).build();
         String addressString = "fe80:0:0:0:1c31:d1d1:4824:72a9";
         byte[] bytes =  NetUtil.createByteArrayFromIpAddressString(addressString);
         Inet6Address inet6Address = (Inet6Address) InetAddress.getByAddress(bytes);
@@ -3893,18 +4035,20 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
-    public void testResolveIp4() throws Exception {
-        testResolveIp4(false);
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testResolveIp4(DnsNameResolverChannelStrategy strategy) throws Exception {
+        testResolveIp4(strategy, false);
     }
 
-    @Test
-    public void testResolveAllIp4() throws Exception {
-        testResolveIp4(true);
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testResolveAllIp4(DnsNameResolverChannelStrategy strategy) throws Exception {
+        testResolveIp4(strategy, true);
     }
 
-    private void testResolveIp4(boolean resolveAll) throws Exception {
-        DnsNameResolver resolver = newResolver().build();
+    private void testResolveIp4(DnsNameResolverChannelStrategy strategy, boolean resolveAll) throws Exception {
+        DnsNameResolver resolver = newResolver(strategy).build();
         String addressString = "10.0.0.1";
         byte[] bytes =  NetUtil.createByteArrayFromIpAddressString(addressString);
         InetAddress inetAddress = InetAddress.getByAddress(bytes);
@@ -3923,8 +4067,9 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
-    public void testResolveSearchDomainStopOnFirstSuccess() throws Exception {
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testResolveSearchDomainStopOnFirstSuccess(DnsNameResolverChannelStrategy strategy) throws Exception {
         final String addressString = "10.0.0.1";
         final Queue<String> names = new ConcurrentLinkedQueue<String>();
         final TestDnsServer dnsServer2 = new TestDnsServer(new RecordStore() {
@@ -3947,7 +4092,7 @@ public class DnsNameResolverTest {
         });
         dnsServer2.start();
 
-        DnsNameResolver resolver = newResolver().searchDomains(
+        DnsNameResolver resolver = newResolver(strategy).searchDomains(
                 Arrays.asList("search1.netty.io", "search2.netty.io", "search3.netty.io"))
                 .ndots(2).nameServerProvider(new SingletonDnsServerAddressStreamProvider(dnsServer2.localAddress()))
                 .resolvedAddressTypes(ResolvedAddressTypes.IPV4_ONLY)
@@ -3967,17 +4112,21 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
-    public void testResolveTryWithoutSearchDomainFirst() throws Exception {
-        testResolveTryWithoutSearchDomainFirst(true);
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testResolveTryWithoutSearchDomainFirst(DnsNameResolverChannelStrategy strategy) throws Exception {
+        testResolveTryWithoutSearchDomainFirst(strategy, true);
     }
 
-    @Test
-    public void testResolveTryWithoutSearchDomainFirstButContinue() throws Exception {
-        testResolveTryWithoutSearchDomainFirst(false);
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testResolveTryWithoutSearchDomainFirstButContinue(DnsNameResolverChannelStrategy strategy)
+            throws Exception {
+        testResolveTryWithoutSearchDomainFirst(strategy, false);
     }
 
-    private static void testResolveTryWithoutSearchDomainFirst(final boolean absoluteSuccess) throws Exception {
+    private static void testResolveTryWithoutSearchDomainFirst(
+            DnsNameResolverChannelStrategy strategy, final boolean absoluteSuccess) throws Exception {
         final String addressString = "10.0.0.1";
         final Queue<String> names = new ConcurrentLinkedQueue<String>();
         final TestDnsServer dnsServer2 = new TestDnsServer(new RecordStore() {
@@ -4001,7 +4150,7 @@ public class DnsNameResolverTest {
         });
         dnsServer2.start();
 
-        DnsNameResolver resolver = newResolver().searchDomains(
+        DnsNameResolver resolver = newResolver(strategy).searchDomains(
                         Arrays.asList("search1.netty.io", "search2.netty.io", "search3.netty.io"))
                 .ndots(1).nameServerProvider(new SingletonDnsServerAddressStreamProvider(dnsServer2.localAddress()))
                 .resolvedAddressTypes(ResolvedAddressTypes.IPV4_ONLY)
@@ -4024,8 +4173,9 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
-    public void testInflightQueries() throws Exception {
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testInflightQueries(DnsNameResolverChannelStrategy strategy) throws Exception {
         final String addressString = "10.0.0.1";
         final AtomicInteger called = new AtomicInteger();
         final CountDownLatch latch = new CountDownLatch(1);
@@ -4050,7 +4200,7 @@ public class DnsNameResolverTest {
         });
         dnsServer2.start();
 
-        DnsNameResolver resolver = newResolver()
+        DnsNameResolver resolver = newResolver(strategy)
                 .nameServerProvider(new SingletonDnsServerAddressStreamProvider(dnsServer2.localAddress()))
                 .resolvedAddressTypes(ResolvedAddressTypes.IPV4_ONLY)
                 .consolidateCacheSize(2)
@@ -4076,13 +4226,14 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
-    public void testAddressAlreadyInUse() throws Exception {
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testAddressAlreadyInUse(DnsNameResolverChannelStrategy strategy) throws Exception {
         DatagramSocket datagramSocket = new DatagramSocket();
         try {
             assertTrue(datagramSocket.isBound());
             try {
-                final DnsNameResolver resolver = newResolver()
+                final DnsNameResolver resolver = newResolver(strategy)
                         .localAddress(datagramSocket.getLocalSocketAddress()).build();
                 try {
                     Throwable cause = assertThrows(UnknownHostException.class, new Executable() {
@@ -4104,12 +4255,13 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
-    public void testResponseFeedbackStream() {
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testResponseFeedbackStream(DnsNameResolverChannelStrategy strategy) {
         final AtomicBoolean successCalled = new AtomicBoolean();
         final AtomicBoolean failureCalled = new AtomicBoolean();
         final AtomicBoolean returnSuccess = new AtomicBoolean(false);
-        final DnsNameResolver resolver = newResolver(true, new DnsServerAddressStreamProvider() {
+        final DnsNameResolver resolver = newResolver(strategy, true, new DnsServerAddressStreamProvider() {
             @Override
             public DnsServerAddressStream nameServerAddressStream(String hostname) {
                 return new DnsServerResponseFeedbackAddressStream() {
@@ -4183,8 +4335,9 @@ public class DnsNameResolverTest {
         }
     }
 
-    @Test
-    public void testCnameWithAAndAdditionalsAndAuthorities() throws Exception {
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testCnameWithAAndAdditionalsAndAuthorities(DnsNameResolverChannelStrategy strategy) throws Exception {
         final String hostname = "test.netty.io";
         final String cname = "cname.netty.io";
 
@@ -4233,14 +4386,17 @@ public class DnsNameResolverTest {
         server.start();
         EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
 
+        SingletonDnsServerAddressStreamProvider provider =
+                new SingletonDnsServerAddressStreamProvider(server.localAddress());
         final DnsNameResolver resolver = new DnsNameResolver(
-                group.next(), new ReflectiveChannelFactory<DatagramChannel>(NioDatagramChannel.class),
-                NoopDnsCache.INSTANCE, NoopAuthoritativeDnsServerCache.INSTANCE,
+                group.next(), new ReflectiveChannelFactory<DatagramChannel>(NioDatagramChannel.class), null, false,
+                NoopDnsCache.INSTANCE, NoopDnsCnameCache.INSTANCE, NoopAuthoritativeDnsServerCache.INSTANCE, null,
                 NoopDnsQueryLifecycleObserverFactory.INSTANCE, 2000, ResolvedAddressTypes.IPV4_ONLY,
                 true, 8, true, 4096,
                 false, HostsFileEntriesResolver.DEFAULT,
-                new SingletonDnsServerAddressStreamProvider(server.localAddress()),
-                new String [] { "k8se-apps.svc.cluster.local, svc.cluster.local, cluster.local" }, 1, true);
+                provider, new ThreadLocalNameServerAddressStream(provider),
+                new String [] { "k8se-apps.svc.cluster.local, svc.cluster.local, cluster.local" }, 1,
+                true, false, 0, strategy);
         try {
             InetAddress address = resolver.resolve(hostname).sync().getNow();
             assertArrayEquals(new byte[] { 10, 0, 0, 2 }, address.getAddress());
@@ -4250,5 +4406,4 @@ public class DnsNameResolverTest {
             server.stop();
         }
     }
-
 }


### PR DESCRIPTION
…… (#14374)

…it comes to creating Channels for queries.

Motivation:

At the moment we reuse the same Channel (and so underyling socket) for all queries. It has show that this can cause problems in some deployments, we should allow to use different strategies.

Modifications:

- Refactor code to make it possible to use different strategies when it comes to creating / reusing channels for resolve operations

Result:

More flexible configuration and possible fix for
https://github.com/netty/netty/issues/14364
