### PR TITLE
Ensure required libraries are installed before building netty-transport-native-epoll

### DIFF
--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -144,7 +144,46 @@
               </execution>
             </executions>
           </plugin>
-
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>ensure-required-libraries-are-installed</id>
+                <phase>compile</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <executable>/bin/bash</executable>
+                  <arguments>
+                    <argument>-c</argument>
+                    <argument>
+                      <![CDATA[
+                        if [ -f /etc/fedora-release ]; then
+                          for pkg in autoconf automake libtool make tar glibc-devel libgcc.i686 glibc-devel.i686; do
+                            if ! rpm -q $pkg &>/dev/null; then
+                                echo "Error: Required package '$pkg' is not installed."
+                                exit 1
+                            fi
+                          done
+                        elif [ -f /etc/lsb-release ]; then
+                          for pkg in autoconf automake libtool make tar glibc-devel libgcc.i686 glibc-devel.i686; do
+                            if ! dpkg -s "$pkg" &> /dev/null; then
+                                echo "Error: Required package '$pkg' is not installed."
+                                exit 1
+                            fi
+                          done
+                        else
+                            echo "Double check: https://netty.io/wiki/native-transports.html"
+                        fi
+                      ]]>
+                    </argument>
+                  </arguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
           <plugin>
             <groupId>org.fusesource.hawtjni</groupId>
             <artifactId>hawtjni-maven-plugin</artifactId>


### PR DESCRIPTION
**Motivation:**

I was installing Netty on a fresh computer. Then, the following error started https://github.com/netty/netty/issues/7101#issuecomment-2386630795
I went to https://netty.io/wiki/native-transports.html#building-the-linux-native-transport and saw the required libraries for Fedora. After installing it, it started working.

I believe we can have that check at the source code. If the PR is merged, we can remove the section https://netty.io/wiki/native-transports.html#building-the-linux-native-transport because now it is done at the compiling time.

IMHO, we can also close https://github.com/netty/netty/issues/7101

**Modification:**

Add a Maven exec plugin that ensures that the required libraries are installed.

**Result:**

Fail fast during the netty-transport-native-epoll build

**Observations:**

I don't have an Ubuntu to test this change.