### PR TITLE
Explicit disable endpointIdentificationAlgorithm during test

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslSessionReuseTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslSessionReuseTest.java
@@ -93,6 +93,7 @@ public class SocketSslSessionReuseTest extends AbstractSocketTest {
         return Collections.singleton(new Object[]{
                 SslContextBuilder.forServer(CERT_FILE, KEY_FILE).sslProvider(SslProvider.JDK),
                 SslContextBuilder.forClient().trustManager(CERT_FILE).sslProvider(SslProvider.JDK)
+                        .endpointIdentificationAlgorithm(null)
         });
     }
 
@@ -100,10 +101,12 @@ public class SocketSslSessionReuseTest extends AbstractSocketTest {
         return Arrays.asList(new Object[]{
                         SslContextBuilder.forServer(CERT_FILE, KEY_FILE).sslProvider(SslProvider.JDK),
                         SslContextBuilder.forClient().trustManager(CERT_FILE).sslProvider(SslProvider.JDK)
+                                .endpointIdentificationAlgorithm(null)
                 },
                 new Object[]{
                         SslContextBuilder.forServer(CERT_FILE, KEY_FILE).sslProvider(SslProvider.OPENSSL),
                         SslContextBuilder.forClient().trustManager(CERT_FILE).sslProvider(SslProvider.OPENSSL)
+                                .endpointIdentificationAlgorithm(null)
                 });
     }
 


### PR DESCRIPTION
Motivation:

We need to explicit disable the endpointIdentificationAlgorithm during the test as we enforce it in 4.2+

Modifications:

Add endpointIdentificationAlgorithm(null) when building context

Result:

No more test failures
