### PR TITLE
Add seccomp=unconfined to devcontainer setup to allow running io_urin…

### DIFF
--- a/.devcontainer/alpine/devcontainer.json
+++ b/.devcontainer/alpine/devcontainer.json
@@ -6,5 +6,6 @@
   },
   build: {
     dockerfile: "Dockerfile",
-  }
+  },
+  "securityOpt": [ "seccomp=unconfined" ]
 }

--- a/.devcontainer/ubuntu/devcontainer.json
+++ b/.devcontainer/ubuntu/devcontainer.json
@@ -4,6 +4,7 @@
     CPATH: "/usr/lib/jvm/java-21-openjdk-arm64/include/:/usr/lib/jvm/java-21-openjdk-arm64/include/linux/"
   },
   build: {
-    dockerfile: "Dockerfile"
-  }
+    dockerfile: "Dockerfile",
+  },
+  "securityOpt": [ "seccomp=unconfined" ]
 }


### PR DESCRIPTION
…g tests

Motivation:

https://github.com/netty/netty/commit/85c0442436b9bd0423796ec123aa72a8239771b9 changed our docker-compose config to be able to run io_uring tests via the CI. We need to do the same with devcontainers to be able to run io_uring tests when using devcontainers.

Modifications:

Add securityOpt to devcontainer.json

Result:

Be able to run io_uring tests when using devcontainers