### PR TITLE
Fix toString() for IoUringocketTestPermution

### DIFF
--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketTestPermutation.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketTestPermutation.java
@@ -143,7 +143,7 @@ public class IoUringSocketTestPermutation extends SocketTestPermutation {
 
                             @Override
                             public String toString() {
-                                return InternetProtocolFamily.class.getSimpleName() + ".class";
+                                return IoUringDatagramChannel.class.getSimpleName() + ".class";
                             }
                         });
                     }


### PR DESCRIPTION
Motivation:

The toString() implementation did print the wrong class name and so was a bit confusing when inspecting the logs

Modifications:

Use the correct class for toString()

Result:

Fix logging
