### PR TITLE
Ensure freeResourcesNow(...) can only be called once and so guard against undefined behavior

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -382,6 +382,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
         protected abstract int scheduleWriteSingle(Object msg);
 
         private boolean closed;
+        private boolean freed;
 
         @Override
         public final void handle(IoRegistration registration, IoEvent ioEvent) {
@@ -440,7 +441,8 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
                     break;
             }
 
-            if (ioState == 0 && closed) {
+            if (ioState == 0 && closed && !freed) {
+                freed = true;
                 freeResourcesNow(reg);
             }
         }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/MsgHdrMemoryArray.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/MsgHdrMemoryArray.java
@@ -23,7 +23,7 @@ final class MsgHdrMemoryArray {
     private final MsgHdrMemory[] hdrs;
     private final int capacity;
     private final long[] ids;
-
+    private boolean released;
     private int idx;
 
     MsgHdrMemoryArray(short capacity) {
@@ -66,6 +66,8 @@ final class MsgHdrMemoryArray {
     }
 
     void release() {
+        assert !released;
+        released = true;
         for (MsgHdrMemory hdr: hdrs) {
             hdr.release();
         }

--- a/transport-native-io_uring/pom.xml
+++ b/transport-native-io_uring/pom.xml
@@ -346,6 +346,12 @@
       <artifactId>bcpkix-jdk18on</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>${tcnative.artifactId}</artifactId>
+      <classifier>${tcnative.classifier}</classifier>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION

Motivation:

We need to ensure freeResourcesNow(...) is only called once as otherwise it might lead to undefined behavior that can cause crashes etc.

Modifications:

- Add assert to debug double free
- Add boolean flag to guard against calling freeResourcesNow(...) multiple times

Result:

No more crashes, fixes https://github.com/netty/netty/issues/14385.