### PR TITLE
Add assert and restore reference count when releasing Chunks (#14391)

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -749,8 +749,11 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
                 allocatedBytes = 0;
                 if (!mag.trySetNextInLine(this)) {
                     if (!parent.offerToQueue(this)) {
-                        // The central queue is full. Drop the memory with the original Drop instance.
+                        // The central queue is full. Ensure we release again as we previously did use resetRefCnt()
+                        // which did increase the reference count by 1.
+                        boolean released = updater.release(this);
                         delegate.release();
+                        assert released;
                     }
                 }
             }


### PR DESCRIPTION
Motivation:

Let's restore the original reference count if we fail to queue the Chunk for reuse.

Modifications:

- Restore reference count and so make code more robust
- Add assert to ensure there is no race

Result:

Cleanup code
