### PR TITLE
Generate empty sources and javadoc jar

### DIFF
--- a/codec/pom.xml
+++ b/codec/pom.xml
@@ -115,6 +115,36 @@
           </execution>
         </executions>
       </plugin>
+
+      <!-- We must generate a -javadoc and -sources JAR file to publish on Maven Central -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>empty-javadoc-jar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classifier>javadoc</classifier>
+              <classesDirectory>${basedir}/javadoc</classesDirectory>
+            </configuration>
+          </execution>
+          <execution>
+            <id>empty-sources-jar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classifier>sources</classifier>
+              <classesDirectory>${basedir}/src/main/java</classesDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Motivation:

We need to generate an empty sources and javadoc jar to be able to release to maven central

Modifications:

Generate empty jars

Result:

Release works as expected
