### PR TITLE
Remove the unnecessary operation of setting the socket to blocking mode.

### DIFF
--- a/testsuite-jpms/pom.xml
+++ b/testsuite-jpms/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.2.0.Alpha5-SNAPSHOT</version>
+    <version>4.2.0.Alpha6-SNAPSHOT</version>
   </parent>
 
   <artifactId>netty-testsuite-jpms</artifactId>

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -47,13 +47,11 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
     private long readId;
 
     AbstractIoUringStreamChannel(Channel parent, LinuxSocket socket, boolean active) {
-        // Use a blocking fd, we can make use of fastpoll.
-        super(parent, LinuxSocket.makeBlocking(socket), active);
+        super(parent, socket, active);
     }
 
     AbstractIoUringStreamChannel(Channel parent, LinuxSocket socket, SocketAddress remote) {
-        // Use a blocking fd, we can make use of fastpoll.
-        super(parent, LinuxSocket.makeBlocking(socket), remote);
+        super(parent, socket, remote);
     }
 
     @Override

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
@@ -100,8 +100,7 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
     }
 
     private IoUringDatagramChannel(LinuxSocket fd, boolean active) {
-        // Always use a blocking fd and so make use of fast-poll.
-        super(null, LinuxSocket.makeBlocking(fd), active);
+        super(null, fd, active);
         config = new IoUringDatagramChannelConfig(this);
     }
 


### PR DESCRIPTION
Motivation:

 Netty forcibly set the socket to blocking mode， but I checked the source code of io_uring in Linux 6.1.112 and found that the FAST_POLL mechanism has nothing to do with whether the socket is in blocking mode.

So it is actually unnecessary to forcibly set the socket to blocking mode


First, look at the opdef of IORING_OP_RECVMSG.
``` c
  [IORING_OP_RECVMSG] = {
        .needs_file     = 1,
        .unbound_nonreg_file    = 1,
        .pollin         = 1,
        .buffer_select      = 1,
        .ioprio         = 1,
        .manual_alloc       = 1,
        .name           = "RECVMSG",
#if defined(CONFIG_NET)
        .async_size     = sizeof(struct io_async_msghdr),
        .prep           = io_recvmsg_prep,
        .issue          = io_recvmsg,
        .prep_async     = io_recvmsg_prep_async,
        .cleanup        = io_sendmsg_recvmsg_cleanup,
        .fail           = io_sendrecv_fail,
 ```      

When io_uring processes the sqe for the first time, it will forcibly call io_recvmsg with IO_URING_F_NONBLOCK.
``` c
static inline void io_queue_sqe(struct io_kiocb *req)
    __must_hold(&req->ctx->uring_lock)
{
    int ret;

    ret = io_issue_sqe(req, IO_URING_F_NONBLOCK|IO_URING_F_COMPLETE_DEFER);

    /*
     * We async punt it if the file wasn't marked NOWAIT, or if the file
     * doesn't support non-blocking read/write attempts
     */
    if (likely(!ret))
        io_arm_ltimeout(req);
    else
        io_queue_async(req, ret);
}
```

For the implementation of recv, if IO_URING_F_NONBLOCK is passed in, MSG_DONTWAIT will be put into the flag by default. For the recvmsg system call, this flag will non-blockingly try to see if there is data.
So the first non-blocking attempt has nothing to do with whether the socket is in blocking mode.

``` c
int io_recvmsg(struct io_kiocb *req, unsigned int issue_flags)
{
   //....
    bool force_nonblock = issue_flags & IO_URING_F_NONBLOCK;
   //....
    flags = sr->msg_flags;
    if (force_nonblock)
        flags |= MSG_DONTWAIT;

    //....
    ret = __sys_recvmsg_sock(sock, &kmsg->msg, sr->umsg,
                     kmsg->uaddr, flags);
    //....                     
 }

```

If no data can be fetched, then io_queue_async -> io_arm_poll_handler -> __io_arm_poll_handler will be executed.

``` c
if (def->pollin) {
//这里的recv op是支持 poll in的
//最后会直接挂载到vfs的poll上去
        mask |= EPOLLIN | EPOLLRDNORM;

        /* If reading from MSG_ERRQUEUE using recvmsg, ignore POLLIN */
        if (req->flags & REQ_F_CLEAR_POLLIN)
            mask &= ~EPOLLIN;
    } else {
        mask |= EPOLLOUT | EPOLLWRNORM;
    }
    if (def->poll_exclusive)
        mask |= EPOLLEXCLUSIVE;

    apoll = io_req_alloc_apoll(req, issue_flags);
    if (!apoll)
        return IO_APOLL_ABORTED;
    req->flags &= ~(REQ_F_SINGLE_POLL | REQ_F_DOUBLE_POLL);
    req->flags |= REQ_F_POLLED;
    ipt.pt._qproc = io_async_queue_proc;

    io_kbuf_recycle(req, issue_flags);
//It Equivalent to ` mask = vfs_poll(req->file, &ipt->pt) & poll->events`;
    ret = __io_arm_poll_handler(req, &apoll->poll, &ipt, mask, issue_flags);
```

So it is actually not necessary to forcibly set the socket to blocking mod

reference: https://github.com/axboe/liburing/issues/487

Modification:

Remove the unnecessary operation of setting the socket to blocking mode.

Result:

Remove the unnecessary operation of setting the socket to blocking mode.
