### PR TITLE
Fix incorrect cast in NioDomainSocketChannel.parent()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1411,6 +1411,13 @@
                   <old>method io.netty.channel.ChannelFactory&lt;&amp; extends io.netty.channel.socket.DatagramChannel&gt; io.netty.resolver.dns.DnsNameResolverBuilder::channelFactory()</old>
                   <justification>Protected methods of a final class.</justification>
                 </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.returnTypeChanged</code>
+                  <old>method io.netty.channel.socket.ServerSocketChannel io.netty.channel.socket.nio.NioDomainSocketChannel::parent()</old>
+                  <new>method io.netty.channel.ServerChannel io.netty.channel.socket.nio.NioDomainSocketChannel::parent()</new>
+                  <justification>Old return type made no sense, the parent channel is a NioServerDomainSocketChannel which does not implement ServerSocketChannel. The method always threw a ClassCastException (except for null).</justification>
+                </item>
               </differences>
             </revapi.differences>
           </analysisConfiguration>
@@ -1443,6 +1450,7 @@
               <exclude>@io.netty.util.internal.UnstableApi</exclude>
               <exclude>io.netty.util.internal.shaded</exclude>
               <exclude>io.netty.buffer.AdaptivePoolingAllocator$ChunkAllocator</exclude>
+              <exclude>io.netty.channel.socket.nio.NioDomainSocketChannel#parent()</exclude>
             </excludes>
             <overrideCompatibilityChangeParameters>
               <overrideCompatibilityChangeParameter>

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioDomainSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioDomainSocketChannel.java
@@ -30,11 +30,11 @@ import io.netty.channel.EventLoop;
 import io.netty.channel.FileRegion;
 import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.ServerChannel;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.nio.AbstractNioByteChannel;
 import io.netty.channel.socket.DuplexChannel;
 import io.netty.channel.socket.DuplexChannelConfig;
-import io.netty.channel.socket.ServerSocketChannel;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SocketUtils;
 import io.netty.util.internal.SuppressJava6Requirement;
@@ -73,7 +73,7 @@ public final class NioDomainSocketChannel extends AbstractNioByteChannel
     private volatile boolean isInputShutdown;
     private volatile boolean isOutputShutdown;
 
-    private static SocketChannel newChannel(SelectorProvider provider) {
+    static SocketChannel newChannel(SelectorProvider provider) {
         if (PlatformDependent.javaVersion() < 16) {
             throw new UnsupportedOperationException("Only supported on java 16+");
         }
@@ -125,8 +125,8 @@ public final class NioDomainSocketChannel extends AbstractNioByteChannel
     }
 
     @Override
-    public ServerSocketChannel parent() {
-        return (ServerSocketChannel) super.parent();
+    public ServerChannel parent() {
+        return (ServerChannel) super.parent();
     }
 
     @Override

--- a/transport/src/test/java/io/netty/channel/socket/nio/NioDomainSocketChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/socket/nio/NioDomainSocketChannelTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.socket.nio;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+
+import java.io.IOException;
+import java.nio.channels.spi.SelectorProvider;
+
+@EnabledForJreRange(min = JRE.JAVA_16)
+class NioDomainSocketChannelTest {
+    @Test
+    void accessParent() throws IOException {
+        NioServerDomainSocketChannel parent = new NioServerDomainSocketChannel();
+        NioDomainSocketChannel child = new NioDomainSocketChannel(
+                parent,
+                NioDomainSocketChannel.newChannel(SelectorProvider.provider()));
+
+        Assertions.assertSame(parent, child.parent());
+
+        child.close();
+    }
+}

--- a/transport/src/test/java/io/netty/channel/socket/nio/NioDomainSocketChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/socket/nio/NioDomainSocketChannelTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 
 import java.io.IOException;
+import java.nio.channels.SocketChannel;
 import java.nio.channels.spi.SelectorProvider;
 
 @EnabledForJreRange(min = JRE.JAVA_16)
@@ -28,12 +29,9 @@ class NioDomainSocketChannelTest {
     @Test
     void accessParent() throws IOException {
         NioServerDomainSocketChannel parent = new NioServerDomainSocketChannel();
-        NioDomainSocketChannel child = new NioDomainSocketChannel(
-                parent,
-                NioDomainSocketChannel.newChannel(SelectorProvider.provider()));
-
+        SocketChannel ch = NioDomainSocketChannel.newChannel(SelectorProvider.provider());
+        NioDomainSocketChannel child = new NioDomainSocketChannel(parent, ch);
         Assertions.assertSame(parent, child.parent());
-
-        child.close();
+        ch.close();
     }
 }


### PR DESCRIPTION
Motivation:

NioDomainSocketChannel.parent() returned a ServerSocketChannel, which is not implemented by NioServerDomainSocketChannel. This makes the parent method unusable.

Modification:

Change the return type and cast to ServerChannel. Unfortunately this is a binary incompatible change, but there is no way to make this change in a binary compatible way, and the method never worked in the first place.

Result:

parent() becomes usable.