### PR TITLE
Increase test timeout

### DIFF
--- a/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTailTest.java
+++ b/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTailTest.java
@@ -118,7 +118,7 @@ public class DefaultChannelPipelineTailTest {
         myChannel.pipeline().fireChannelActive();
 
         try {
-            assertTrue(latch.await(1L, TimeUnit.SECONDS));
+            assertTrue(latch.await(10L, TimeUnit.SECONDS));
         } finally {
             myChannel.close();
         }


### PR DESCRIPTION
Motivation:
Observed this failing a build. Maybe 1 second is too short.

Modification:
Increase test timeout to ten seconds.

Result:
Hopefully not flaky anymore.