### PR TITLE
AdaptiveByteBufAllocator: Make pooling of AdaptiveByteBuf magazine local

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -116,7 +116,7 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
      * the actual memory and so helps to reduce GC pressure.
      */
     private static final int MAGAZINE_BUFFER_QUEUE_CAPACITY = SystemPropertyUtil.getInt(
-            "io.netty.allocator.magazineBufferQueueCapacity", 256);
+            "io.netty.allocator.magazineBufferQueueCapacity", 1024);
 
     private static final Object NO_MAGAZINE = Boolean.TRUE;
 

--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufAllocatorTest.java
@@ -26,7 +26,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.abort;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -101,7 +100,10 @@ public abstract class AbstractByteBufAllocatorTest<T extends AbstractByteBufAllo
 
     protected static void assertInstanceOf(ByteBuf buffer, Class<? extends ByteBuf> clazz) {
         // Unwrap if needed
-        assertTrue(clazz.isInstance(buffer instanceof SimpleLeakAwareByteBuf ? buffer.unwrap() : buffer));
+        if (buffer instanceof SimpleLeakAwareByteBuf) {
+            buffer = buffer.unwrap();
+        }
+        assertThat(buffer).isInstanceOf(clazz);
     }
 
     protected static void assertSameBuffer(ByteBuf expected, ByteBuf buffer) {


### PR DESCRIPTION
Motivation:

To reduce the usage of FastThreadLocal and make the AdaptiveByteBufAllocator also play nice with virtual threads we should just pool the AdapativeByteBuf instances in the Magazines itself.

Modifications:

Remove usage of Recycler for pooling AdaptiveByteBuf Use a bounded MPMC queue that is stored in the Magazine itself for pooling these instances Result:

Fixes #14279
