### PR TITLE
Update default benchmark times and homogenise style

### DIFF
--- a/microbench/src/main/java/io/netty/buffer/AbstractByteBufGetCharSequenceBenchmark.java
+++ b/microbench/src/main/java/io/netty/buffer/AbstractByteBufGetCharSequenceBenchmark.java
@@ -74,7 +74,10 @@ public class AbstractByteBufGetCharSequenceBenchmark extends AbstractMicrobenchm
     @Param({ "8", "64", "1024", "10240", "1073741824" })
     public int size;
 
-    @Param({ "US-ASCII", "ISO_8859_1" })
+    @Param({
+            "US-ASCII",
+            "ISO_8859_1",
+    })
     public String charsetName;
 
     @Param

--- a/microbench/src/main/java/io/netty/buffer/AbstractReferenceCountedByteBufBenchmark.java
+++ b/microbench/src/main/java/io/netty/buffer/AbstractReferenceCountedByteBufBenchmark.java
@@ -34,7 +34,13 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Benchmark)
 public class AbstractReferenceCountedByteBufBenchmark extends AbstractMicrobenchmark {
 
-    @Param({ "1", "10", "100", "1000", "10000" })
+    @Param({
+            "1",
+            "10",
+            "100",
+            "1000",
+            "10000",
+    })
     public int delay;
 
     AbstractReferenceCountedByteBuf buf;

--- a/microbench/src/main/java/io/netty/buffer/ByteBufAccessBenchmark.java
+++ b/microbench/src/main/java/io/netty/buffer/ByteBufAccessBenchmark.java
@@ -110,13 +110,23 @@ public class ByteBufAccessBenchmark extends AbstractMicrobenchmark {
     @Param
     public ByteBufType bufferType;
 
-    @Param({ "true", "false" })
+
+    @Param({
+            "true",
+            "false",
+    })
     public String checkAccessible;
 
-    @Param({ "true", "false" })
+
+    @Param({
+            "true",
+            "false",
+    })
     public String checkBounds;
 
-    @Param({ "8" })
+    @Param({
+            "8",
+    })
     public int batchSize; // applies only to readBatch benchmark
 
     @Setup

--- a/microbench/src/main/java/io/netty/buffer/ByteBufAccessBenchmark.java
+++ b/microbench/src/main/java/io/netty/buffer/ByteBufAccessBenchmark.java
@@ -110,13 +110,11 @@ public class ByteBufAccessBenchmark extends AbstractMicrobenchmark {
     @Param
     public ByteBufType bufferType;
 
-
     @Param({
             "true",
             "false",
     })
     public String checkAccessible;
-
 
     @Param({
             "true",

--- a/microbench/src/main/java/io/netty/buffer/ByteBufNoCleanerAllocReleaseBenchmark.java
+++ b/microbench/src/main/java/io/netty/buffer/ByteBufNoCleanerAllocReleaseBenchmark.java
@@ -29,7 +29,11 @@ import org.openjdk.jmh.annotations.Warmup;
 @Measurement(iterations = 10)
 public class ByteBufNoCleanerAllocReleaseBenchmark extends AbstractByteBufNoCleanerBenchmark {
 
-    @Param({ "64", "1024", "8192" })
+    @Param({
+            "64",
+            "1024",
+            "8192",
+    })
     public int initialCapacity;
 
     @Benchmark

--- a/microbench/src/main/java/io/netty/buffer/ByteBufUtilDecodeStringBenchmark.java
+++ b/microbench/src/main/java/io/netty/buffer/ByteBufUtilDecodeStringBenchmark.java
@@ -72,10 +72,19 @@ public class ByteBufUtilDecodeStringBenchmark extends AbstractMicrobenchmark {
         abstract ByteBuf newBuffer(byte[] bytes, int length);
     }
 
-    @Param({ "8", "64", "1024", "10240", "1073741824" })
+    @Param({
+            "8",
+            "64",
+            "1024",
+            "10240",
+            "1073741824",
+    })
     public int size;
 
-    @Param({ "US-ASCII", "UTF-8" })
+    @Param({
+            "US-ASCII",
+            "UTF-8",
+    })
     public String charsetName;
 
     @Param

--- a/microbench/src/main/java/io/netty/buffer/ByteBufZeroingBenchmark.java
+++ b/microbench/src/main/java/io/netty/buffer/ByteBufZeroingBenchmark.java
@@ -37,18 +37,42 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 5, time = 200, timeUnit = TimeUnit.MILLISECONDS)
 public class ByteBufZeroingBenchmark extends AbstractMicrobenchmark {
 
-    @Param({ "1", "2", "3", "4", "7", "8", "15", "64", "65", "1024" })
+    @Param({
+            "1",
+            "2",
+            "3",
+            "4",
+            "7",
+            "8",
+            "15",
+            "64",
+            "65",
+            "1024",
+    })
     private int bytes = 1024;
-    @Param({ "true", "false" })
+    @Param({
+            "true",
+            "false",
+    })
     private boolean direct;
-    @Param({ "true", "false" })
+    @Param({
+            "true",
+            "false",
+    })
     private boolean pooled;
-    @Param({ "false" })
+    @Param({
+            "false",
+    })
     public String checkAccessible;
 
-    @Param({ "false" })
+    @Param({
+            "false",
+    })
     public String checkBounds;
-    @Param({ "0", "1" })
+    @Param({
+            "0",
+            "1",
+    })
     public int startOffset;
     private ByteBuf buffer;
     private int offset;

--- a/microbench/src/main/java/io/netty/buffer/CompositeByteBufRandomAccessBenchmark.java
+++ b/microbench/src/main/java/io/netty/buffer/CompositeByteBufRandomAccessBenchmark.java
@@ -52,7 +52,11 @@ public class CompositeByteBufRandomAccessBenchmark extends AbstractMicrobenchmar
         abstract ByteBuf newBuffer(int length);
     }
 
-    @Param({ "64", "10240", "1024000" }) // ({ "64", "1024", "10240", "102400", "1024000" })
+    @Param({
+            "64",
+            "10240",
+            "1024000",
+    }) // ({ "64", "1024", "10240", "102400", "1024000" })
     public int size;
 
     @Param

--- a/microbench/src/main/java/io/netty/buffer/CompositeByteBufSequentialBenchmark.java
+++ b/microbench/src/main/java/io/netty/buffer/CompositeByteBufSequentialBenchmark.java
@@ -52,7 +52,14 @@ public class CompositeByteBufSequentialBenchmark extends AbstractMicrobenchmark 
         abstract ByteBuf newBuffer(int length);
     }
 
-    @Param({ "8", "64", "1024", "10240", "102400", "1024000" })
+    @Param({
+            "8",
+            "64",
+            "1024",
+            "10240",
+            "102400",
+            "1024000",
+    })
     public int size;
 
     @Param

--- a/microbench/src/main/java/io/netty/buffer/CompositeByteBufWriteOutBenchmark.java
+++ b/microbench/src/main/java/io/netty/buffer/CompositeByteBufWriteOutBenchmark.java
@@ -56,7 +56,13 @@ public class CompositeByteBufWriteOutBenchmark extends AbstractMicrobenchmark {
         return new String[] { "-XX:MaxDirectMemorySize=2g", "-Xmx4g", "-Xms4g", "-Xmn3g" };
     }
 
-    @Param({ "64", "1024", "10240", "102400", "1024000" })
+    @Param({
+            "64",
+            "1024",
+            "10240",
+            "102400",
+            "1024000"
+    })
     public int size;
 
     @Param

--- a/microbench/src/main/java/io/netty/microbench/buffer/ByteBufAllocatorBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/ByteBufAllocatorBenchmark.java
@@ -52,7 +52,14 @@ public class ByteBufAllocatorBenchmark extends AbstractMicrobenchmark {
     private static final ByteBuf[] adaptiveHeapBuffers = new ByteBuf[MAX_LIVE_BUFFERS];
     private static final ByteBuf[] adaptiveDirectBuffers = new ByteBuf[MAX_LIVE_BUFFERS];
 
-    @Param({ "00000", "00256", "01024", "04096", "16384", "65536" })
+    @Param({
+            "00000",
+            "00256",
+            "01024",
+            "04096",
+            "16384",
+            "65536",
+    })
     public int size;
 
     @Benchmark

--- a/microbench/src/main/java/io/netty/microbench/buffer/ByteBufAllocatorConcurrentBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/ByteBufAllocatorConcurrentBenchmark.java
@@ -38,7 +38,12 @@ public class ByteBufAllocatorConcurrentBenchmark  extends AbstractMicrobenchmark
     private static final ByteBufAllocator pooledAllocator = PooledByteBufAllocator.DEFAULT;
     private static final ByteBufAllocator adaptiveAllocator = new AdaptiveByteBufAllocator();
 
-    @Param({ "00064", "00256", "01024", "04096" })
+    @Param({
+            "00064",
+            "00256",
+            "01024",
+            "04096",
+    })
     public int size;
 
     @Benchmark

--- a/microbench/src/main/java/io/netty/microbench/buffer/ByteBufBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/ByteBufBenchmark.java
@@ -32,7 +32,10 @@ public class ByteBufBenchmark extends AbstractMicrobenchmark {
     }
     private static final byte BYTE = '0';
 
-    @Param({ "true", "false" })
+    @Param({
+            "true",
+            "false",
+    })
     public String checkBounds;
 
     private ByteBuffer byteBuffer;

--- a/microbench/src/main/java/io/netty/microbench/buffer/ByteBufCopyBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/ByteBufCopyBenchmark.java
@@ -32,21 +32,50 @@ public class ByteBufCopyBenchmark extends AbstractMicrobenchmark {
         System.setProperty("io.netty.buffer.bytebuf.checkAccessible", "false");
     }
 
-    @Param({"7", "36", "128", "512" })
+    @Param({
+            "7",
+            "36",
+            "128",
+            "512",
+    })
     private int size;
-    @Param({"true", "false" })
+
+    @Param({
+            "true",
+            "false",
+    })
     private boolean directByteBuff;
-    @Param({"true", "false" })
+
+    @Param({
+            "true",
+            "false",
+    })
     private boolean directByteBuffer;
     @Param({"false", "true" })
     private boolean readonlyByteBuffer;
-    @Param({"true", "false" })
+
+    @Param({
+            "true",
+            "false",
+    })
     private boolean pooledByteBuf;
-    @Param({"true", "false" })
+
+    @Param({
+            "true",
+            "false",
+    })
     private boolean alignedCopyByteBuffer;
-    @Param({"true", "false" })
+
+    @Param({
+            "true",
+            "false",
+    })
     private boolean alignedCopyByteBuf;
-    @Param({"true", "false" })
+
+    @Param({
+            "true",
+            "false",
+    })
     private boolean nativeOrderByteBuffer;
 
     private ByteBuffer byteBuffer;

--- a/microbench/src/main/java/io/netty/microbench/buffer/ByteBufIndexOfBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/ByteBufIndexOfBenchmark.java
@@ -43,13 +43,23 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 8, time = 1)
 public class ByteBufIndexOfBenchmark extends AbstractMicrobenchmark {
 
-    @Param({ "7", "16", "23", "32" })
+    @Param({
+            "7",
+            "16",
+            "23",
+            "32",
+    })
     int size;
 
-    @Param({ "4", "11" })
+    @Param({
+            "4",
+            "11",
+    })
     int logPermutations;
 
-    @Param({ "1" })
+    @Param({
+            "1",
+    })
     int seed;
 
     int permutations;
@@ -57,15 +67,27 @@ public class ByteBufIndexOfBenchmark extends AbstractMicrobenchmark {
     ByteBuf[] data;
     private int i;
 
-    @Param({ "0" })
+    @Param({
+            "0",
+    })
     private byte needleByte;
 
-    @Param({ "true", "false" })
+    @Param({
+            "true",
+            "false",
+    })
     private boolean direct;
-    @Param({ "false", "true" })
+
+    @Param({
+            "true",
+            "false",
+    })
     private boolean noUnsafe;
 
-    @Param({ "false", "true" })
+    @Param({
+            "true",
+            "false",
+    })
     private boolean pooled;
 
     @Setup(Level.Trial)

--- a/microbench/src/main/java/io/netty/microbench/buffer/ByteBufLastIndexOfBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/ByteBufLastIndexOfBenchmark.java
@@ -42,13 +42,23 @@ import java.util.concurrent.TimeUnit;
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 8, time = 1)
 public class ByteBufLastIndexOfBenchmark extends AbstractMicrobenchmark {
-    @Param({ "7", "16", "23", "32" })
+    @Param({
+            "7",
+            "16",
+            "23",
+            "32",
+    })
     int size;
 
-    @Param({ "4", "11" })
+    @Param({
+            "4",
+            "11",
+    })
     int logPermutations;
 
-    @Param({ "1" })
+    @Param({
+            "1",
+    })
     int seed;
 
     int permutations;
@@ -57,16 +67,27 @@ public class ByteBufLastIndexOfBenchmark extends AbstractMicrobenchmark {
 
     private int i;
 
-    @Param({ "0" })
+    @Param({
+            "0",
+    })
     private byte needleByte;
 
-    @Param({ "true", "false" })
+    @Param({
+            "true",
+            "false",
+    })
     private boolean direct;
 
-    @Param({ "false", "true" })
+    @Param({
+            "true",
+            "false",
+    })
     private boolean noUnsafe;
 
-    @Param({ "false", "true" })
+    @Param({
+            "true",
+            "false",
+    })
     private boolean pooled;
 
     @Setup(Level.Trial)

--- a/microbench/src/main/java/io/netty/microbench/buffer/ByteBufUtilBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/ByteBufUtilBenchmark.java
@@ -36,9 +36,17 @@ import org.openjdk.jmh.annotations.Warmup;
 public class
     ByteBufUtilBenchmark extends AbstractMicrobenchmark {
 
-    @Param({ "true", "false" })
+    @Param({
+            "true",
+            "false",
+    })
     private boolean direct;
-    @Param({ "8", "16", "64", "128" })
+    @Param({
+            "8",
+            "16",
+            "64",
+            "128",
+    })
     private int length;
     private ByteBuf buffer;
     private ByteBuf wrapped;

--- a/microbench/src/main/java/io/netty/microbench/buffer/HeapByteBufBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/HeapByteBufBenchmark.java
@@ -27,7 +27,10 @@ import java.lang.reflect.Constructor;
 
 public class HeapByteBufBenchmark extends AbstractMicrobenchmark {
 
-    @Param({ "true", "false" })
+    @Param({
+            "true",
+            "false",
+    })
     public String checkBounds;
 
     private ByteBuf unsafeBuffer;

--- a/microbench/src/main/java/io/netty/microbench/buffer/PooledByteBufAllocatorAlignBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/PooledByteBufAllocatorAlignBenchmark.java
@@ -58,10 +58,19 @@ public class PooledByteBufAllocatorAlignBenchmark extends
      */
     private static final int BLOCK = 4;
 
-    @Param({ "0", "64" })
+    @Param({
+            "0",
+            "64",
+    })
     private int cacheAlign;
 
-    @Param({ "01024", "04096", "16384", "65536", "1048576" })
+    @Param({
+            "01024",
+            "04096",
+            "16384",
+            "65536",
+            "1048576",
+    })
     private int size;
 
     private ByteBuf pooledDirectBuffer;

--- a/microbench/src/main/java/io/netty/microbench/buffer/SimpleByteBufPooledAllocatorBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/SimpleByteBufPooledAllocatorBenchmark.java
@@ -58,7 +58,6 @@ public class SimpleByteBufPooledAllocatorBenchmark extends AbstractMicrobenchmar
     })
     public long tokens;
 
-
     @Param({
             "true",
             "false",

--- a/microbench/src/main/java/io/netty/microbench/buffer/SimpleByteBufPooledAllocatorBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/SimpleByteBufPooledAllocatorBenchmark.java
@@ -41,13 +41,28 @@ public class SimpleByteBufPooledAllocatorBenchmark extends AbstractMicrobenchmar
         super(true, false);
     }
 
-    @Param({"123", "1234", "12345", "123456", "1234567"})
+    @Param({
+            "123",
+            "1234",
+            "12345",
+            "123456",
+            "1234567",
+    })
     public int size;
 
-    @Param({"0", "5", "10", "100"})
+    @Param({
+            "0",
+            "5",
+            "10",
+            "100",
+    })
     public long tokens;
 
-    @Param({"false", "true"})
+
+    @Param({
+            "true",
+            "false",
+    })
     public boolean useThreadCache;
 
     public ByteBufAllocator allocator;

--- a/microbench/src/main/java/io/netty/microbench/buffer/Utf8EncodingBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/Utf8EncodingBenchmark.java
@@ -72,10 +72,18 @@ public class Utf8EncodingBenchmark extends AbstractMicrobenchmark {
     private StringBuilder[] stringBuilders;
     private AnotherCharSequence[] anotherCharSequences;
     private AsciiString[] asciiStrings;
-    @Param({ "false", "true" })
+
+    @Param({
+            "true",
+            "false",
+    })
     private boolean direct;
     private ByteBuf buffer;
-    @Param({ "false", "true" })
+
+    @Param({
+            "true",
+            "false",
+    })
     private boolean noUnsafe;
     private int dataSetLength;
 

--- a/microbench/src/main/java/io/netty/microbench/util/AbstractMicrobenchmarkBase.java
+++ b/microbench/src/main/java/io/netty/microbench/util/AbstractMicrobenchmarkBase.java
@@ -22,6 +22,7 @@ import io.netty.util.internal.SystemPropertyUtil;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
 import org.openjdk.jmh.annotations.Measurement;
@@ -38,8 +39,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 /**
  * Base class for all JMH benchmarks.
  */
-@Warmup(iterations = AbstractMicrobenchmarkBase.DEFAULT_WARMUP_ITERATIONS)
-@Measurement(iterations = AbstractMicrobenchmarkBase.DEFAULT_MEASURE_ITERATIONS)
+@Warmup(iterations = AbstractMicrobenchmarkBase.DEFAULT_WARMUP_ITERATIONS, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = AbstractMicrobenchmarkBase.DEFAULT_MEASURE_ITERATIONS, time = 1, timeUnit = TimeUnit.SECONDS)
 @State(Scope.Thread)
 public abstract class AbstractMicrobenchmarkBase {
     protected static final int DEFAULT_WARMUP_ITERATIONS = 10;


### PR DESCRIPTION
Motivation:
JMH changed the default iteration warmup/run time from 1 second to 10 seconds. This made many of our benchmarks take forever to complete, complete they fixed the warmup and iteration count to 10 (where JMH lowered their default).

Modification:
Return our defaults to 10 iterations of 1 second each. Also homogenise many `@Param` styles in a way that makes it easy to comment out values from parameter lists.

Result:
Better defaults when running benchmarks.