### PR TITLE
Add load metrics for event loop

### DIFF
--- a/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
@@ -28,7 +28,6 @@ import java.util.NoSuchElementException;
 import java.util.Queue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadFactory;
-import java.util.function.Supplier;
 
 /**
  * Abstract base class for {@link EventLoop}s that execute all its submitted tasks in a single thread.

--- a/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
@@ -41,6 +41,7 @@ public abstract class SingleThreadEventLoop extends SingleThreadEventExecutor im
 
     protected static final boolean LOOP_LOAD =
             SystemPropertyUtil.getBoolean("io.netty.eventLoop.load", false);
+
     private final Queue<Runnable> tailTasks;
 
     protected SingleThreadEventLoop(EventLoopGroup parent, ThreadFactory threadFactory, boolean addTaskWakesUp) {

--- a/transport/src/test/java/io/netty/channel/SingleThreadEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/SingleThreadEventLoopTest.java
@@ -524,7 +524,7 @@ public class SingleThreadEventLoopTest {
     }
 
     @Test
-    public void testEventLoopLoadCalculator() {
+    public void testEventLoopLoadTracker() {
         SingleThreadEventLoop.EventLoopLoadTracker loadTracker =
                 new SingleThreadEventLoop.EventLoopLoadTracker(new IntSupplier() {
                     @Override


### PR DESCRIPTION
Motivation:

Hello, I recently observed that an Exponential Decay Formula(similar to the implementation of linux's loadavg) seems well-suited for monitoring the load of the EventLoop over a period of time.
![image](https://github.com/user-attachments/assets/0caec117-dfd6-459d-88c2-bb7b0e4c6e0e)
Modification:

Add loadAvg1, loadAvg5, and loadAvg15 for the EventLoop, representing the load situation over the past 1, 5, and 15 minutes, respectively.

Result:

It could potentially serve as a performance monitoring metric, helping us to more easily identify performance bottlenecks based on load values(where a load approaching 1 might indicate optimal throughput and response speed). Therefore, I am attempting to submit this PR.