### PR TITLE
Use unpadded JCtools qs for MemoryRegionCache (#12496)

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolThreadCache.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolThreadCache.java
@@ -334,7 +334,7 @@ final class PoolThreadCache {
 
         MemoryRegionCache(int size, SizeClass sizeClass) {
             this.size = MathUtil.safeFindNextPositivePowerOfTwo(size);
-            queue = PlatformDependent.newFixedMpscQueue(this.size);
+            queue = PlatformDependent.newFixedMpscUnpaddedQueue(this.size);
             this.sizeClass = sizeClass;
         }
 

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -1104,10 +1104,10 @@ public final class PlatformDependent {
     }
 
 
-        /**
-         * Create a new {@link Queue} which is safe to use for multiple producers (different threads) and multiple
-         * consumers with the given fixes {@code capacity}.
-         */
+    /**
+     * Create a new {@link Queue} which is safe to use for multiple producers (different threads) and multiple
+     * consumers with the given fixes {@code capacity}.
+     */
     public static <T> Queue<T> newFixedMpmcQueue(int capacity) {
         return hasUnsafe() ? new MpmcArrayQueue<T>(capacity) : new MpmcAtomicArrayQueue<T>(capacity);
     }

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -1100,9 +1100,8 @@ public final class PlatformDependent {
      * This should be preferred to {@link #newFixedMpscQueue(int)} when the queue is not to be heavily contended.
      */
     public static <T> Queue<T> newFixedMpscUnpaddedQueue(int capacity) {
-        return hasUnsafe()? new MpscUnpaddedArrayQueue<T>(capacity) : new MpscAtomicUnpaddedArrayQueue<T>(capacity);
+        return hasUnsafe() ? new MpscUnpaddedArrayQueue<T>(capacity) : new MpscAtomicUnpaddedArrayQueue<T>(capacity);
     }
-
 
     /**
      * Create a new {@link Queue} which is safe to use for multiple producers (different threads) and multiple

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -28,6 +28,8 @@ import org.jctools.queues.atomic.MpscAtomicArrayQueue;
 import org.jctools.queues.atomic.MpscChunkedAtomicArrayQueue;
 import org.jctools.queues.atomic.MpscUnboundedAtomicArrayQueue;
 import org.jctools.queues.atomic.SpscLinkedAtomicQueue;
+import org.jctools.queues.atomic.unpadded.MpscAtomicUnpaddedArrayQueue;
+import org.jctools.queues.unpadded.MpscUnpaddedArrayQueue;
 import org.jctools.util.Pow2;
 import org.jctools.util.UnsafeAccess;
 
@@ -1093,9 +1095,19 @@ public final class PlatformDependent {
     }
 
     /**
-     * Create a new {@link Queue} which is safe to use for multiple producers (different threads) and multiple
-     * consumers with the given fixes {@code capacity}.
+     * Create a new un-padded {@link Queue} which is safe to use for multiple producers (different threads) and a single
+     * consumer (one thread!) with the given fixes {@code capacity}.<br>
+     * This should be preferred to {@link #newFixedMpscQueue(int)} when the queue is not to be heavily contended.
      */
+    public static <T> Queue<T> newFixedMpscUnpaddedQueue(int capacity) {
+        return hasUnsafe()? new MpscUnpaddedArrayQueue<T>(capacity) : new MpscAtomicUnpaddedArrayQueue<T>(capacity);
+    }
+
+
+        /**
+         * Create a new {@link Queue} which is safe to use for multiple producers (different threads) and multiple
+         * consumers with the given fixes {@code capacity}.
+         */
     public static <T> Queue<T> newFixedMpmcQueue(int capacity) {
         return hasUnsafe() ? new MpmcArrayQueue<T>(capacity) : new MpmcAtomicArrayQueue<T>(capacity);
     }


### PR DESCRIPTION
Motivation:
MemoryRegionCache's queue shouldn't be highly contended, hence there is no point to have padding among JCtools "hot" fields: this will lower the footprint of the many memory regions which can be created.

Modification:
Just replace the existing padded JCtools qs with the new unpadded ones.

Result:
Some free memory saving on the pooled allocator