### PR TITLE
Convey autoAckPing in http2 decoder constructor chain

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -104,7 +104,7 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
                                          Http2PromisedRequestVerifier requestVerifier,
                                          boolean autoAckSettings,
                                          boolean autoAckPing) {
-        this(connection, encoder, frameReader, requestVerifier, autoAckSettings, true, true);
+        this(connection, encoder, frameReader, requestVerifier, autoAckSettings, autoAckPing, true);
     }
 
     /**

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
@@ -44,6 +44,7 @@ import static io.netty.buffer.Unpooled.EMPTY_BUFFER;
 import static io.netty.buffer.Unpooled.wrappedBuffer;
 import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_PRIORITY_WEIGHT;
 import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
+import static io.netty.handler.codec.http2.Http2PromisedRequestVerifier.ALWAYS_VERIFY;
 import static io.netty.handler.codec.http2.Http2Stream.State.IDLE;
 import static io.netty.handler.codec.http2.Http2Stream.State.OPEN;
 import static io.netty.handler.codec.http2.Http2Stream.State.RESERVED_REMOTE;
@@ -67,6 +68,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.isNull;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -221,17 +223,23 @@ public class DefaultHttp2ConnectionDecoderTest {
         when(ctx.write(any())).thenReturn(future);
 
         decoder = new DefaultHttp2ConnectionDecoder(connection, encoder, reader);
+        setupCodec(ctx, encoder, decoder, listener);
+    }
+
+    private void setupCodec(
+            ChannelHandlerContext ctx, Http2ConnectionEncoder encoder, Http2ConnectionDecoder decoder,
+            Http2FrameListener listener) throws Exception {
         decoder.lifecycleManager(lifecycleManager);
         decoder.frameListener(listener);
 
         // Simulate receiving the initial settings from the remote endpoint.
-        decode().onSettingsRead(ctx, new Http2Settings());
+        decode(decoder).onSettingsRead(ctx, new Http2Settings());
         verify(listener).onSettingsRead(eq(ctx), eq(new Http2Settings()));
         assertTrue(decoder.prefaceReceived());
         verify(encoder).writeSettingsAck(eq(ctx), eq(promise));
 
         // Simulate receiving the SETTINGS ACK for the initial settings.
-        decode().onSettingsAckRead(ctx);
+        decode(decoder).onSettingsAckRead(ctx);
 
         // Disallow any further flushes now that settings ACK has been sent
         when(ctx.flush()).then(new Answer<ChannelHandlerContext>() {
@@ -850,6 +858,19 @@ public class DefaultHttp2ConnectionDecoderTest {
     }
 
     @Test
+    public void pingReadShouldRespectNoAutoAck() throws Exception {
+        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+        when(ctx.newPromise()).thenReturn(promise);
+        Http2ConnectionEncoder encoder = mock(Http2ConnectionEncoder.class);
+        Http2ConnectionDecoder decoder = new DefaultHttp2ConnectionDecoder(connection, encoder, reader,
+                ALWAYS_VERIFY, true, false);
+        Http2FrameListener listener = mock(Http2FrameListener.class);
+        setupCodec(ctx, encoder, decoder, listener);
+        decode(decoder).onPingRead(ctx, 0L);
+        verify(encoder, never()).writePing(eq(ctx), eq(true), eq(0L), eq(promise));
+    }
+
+    @Test
     public void settingsReadWithAckShouldNotifyListener() throws Exception {
         decode().onSettingsAckRead(ctx);
         // Take into account the time this was called during setup().
@@ -1025,6 +1046,10 @@ public class DefaultHttp2ConnectionDecoderTest {
      * Calls the decode method on the handler and gets back the captured internal listener
      */
     private Http2FrameListener decode() throws Exception {
+        return decode(decoder);
+    }
+
+    private Http2FrameListener decode(Http2ConnectionDecoder decoder) throws Exception {
         ArgumentCaptor<Http2FrameListener> internalListener = ArgumentCaptor.forClass(Http2FrameListener.class);
         doNothing().when(reader).readFrame(eq(ctx), any(ByteBuf.class), internalListener.capture());
         decoder.decodeFrame(ctx, EMPTY_BUFFER, Collections.emptyList());


### PR DESCRIPTION
Make autoAckPing capable of declaring whether an http2 decoder automatically responds to pings in the incomplete constructor chain.

Motivation:

The ackPingFrame parameter in DefaultHttp2ConnectionDecoder is currently ignored for any but the complete call.

Modification:

Routed ackPingFrame through to nested constructor where it will control behavior.

Result:

ackPingFrame is respected in the constructor chain and validated through tests with this change.