### PR TITLE
Verify default named groups before using them with native SSL impleme…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -51,6 +51,7 @@ import java.security.cert.CertificateNotYetValidException;
 import java.security.cert.CertificateRevokedException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -433,8 +434,17 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
             if (maxCertificateList != null) {
                 SSLContext.setMaxCertList(ctx, maxCertificateList);
             }
-            // Set the curves.
-            SSLContext.setCurvesList(ctx, OpenSsl.NAMED_GROUPS);
+
+            // Set the curves / groups if anything is configured.
+            if (OpenSsl.NAMED_GROUPS.length > 0 && !SSLContext.setCurvesList(ctx, OpenSsl.NAMED_GROUPS)) {
+                String msg = "failed to set curves / groups suite: " + Arrays.toString(OpenSsl.NAMED_GROUPS);
+                int err = SSL.getLastErrorNumber();
+                if (err != 0) {
+                    // We have some more details about why the operations failed, include these into the message.
+                    msg += ". " + SSL.getErrorString(err);
+                }
+                throw new SSLException(msg);
+            }
             success = true;
         } finally {
             if (!success) {


### PR DESCRIPTION
…ntation

Motivation:

We should verify that the default named groups are actually supported by our native SSL implementation. This might not always be the case as for example when FIPS is used.

Modifications:

- Verify that default named groups are supported
- Fail creation of ReferenceCountedOpenSslContext if setting of groups fails and also include details about why it failed if possible

Result:

Easier to debug miss-configuration of groups and make things work out of the box even if FIPS is used. Related to https://github.com/netty/netty-tcnative/issues/883
