### PR TITLE
Include details on why it was not possible to configure accepted issu…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslServerContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslServerContext.java
@@ -167,7 +167,12 @@ public final class ReferenceCountedOpenSslServerContext extends ReferenceCounted
                     try {
                         bio = toBIO(ByteBufAllocator.DEFAULT, issuers);
                         if (!SSLContext.setCACertificateBio(ctx, bio)) {
-                            throw new SSLException("unable to setup accepted issuers for trustmanager " + manager);
+                            String msg = "unable to setup accepted issuers for trustmanager " + manager;
+                            int error = SSL.getLastErrorNumber();
+                            if (error != 0) {
+                                msg += ". " + SSL.getErrorString(error);
+                            }
+                            throw new SSLException(msg);
                         }
                     } finally {
                         freeBio(bio);


### PR DESCRIPTION
…ers in the SSLException

Motivation:

At the moment it's hard to understand why the configuration of the SSLContext fails when we can not configure the accepted issuers. Let's include more details if possible to make debugging easier.

Modifications:

Check if we have more details and if so include it in the exception message

Result:

Related to https://github.com/netty/netty-tcnative/issues/883
