### PR TITLE
Correctly detect if KeyManager is not supported by OpenSSL version

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
@@ -269,8 +269,8 @@ public final class OpenSsl {
                             } catch (Throwable ignore) {
                                 logger.debug("Failed to get useKeyManagerFactory system property.");
                             }
-                        } catch (Error ignore) {
-                            logger.debug("KeyManagerFactory not supported.");
+                        } catch (Exception e) {
+                            logger.debug("KeyManagerFactory not supported", e);
                         } finally {
                             privateKey.release();
                         }


### PR DESCRIPTION
Motivation:

We did incorrectly catch Error and not Exception which resulted in some probes not been executed when the OpenSSL version did not support using a KeyManager. This could result in using incorrect defaults in this case

Modifications:

Correct catch Exception

Result:

Use correct defaults even if KeyManager is not supported

