### PR TITLE
Update default benchmark times and homogenise style

### DIFF
--- a/microbench/src/main/java/io/netty5/microbench/buffer/BufferAllocatorBenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/buffer/BufferAllocatorBenchmark.java
@@ -51,7 +51,14 @@ public class BufferAllocatorBenchmark extends AbstractMicrobenchmark {
     private static final Buffer[] pooledAdaptiveBuffers = new Buffer[MAX_LIVE_BUFFERS];
     private static final Buffer[] defaultPooledBuffers = new Buffer[MAX_LIVE_BUFFERS];
 
-    @Param({ "00000", "00256", "01024", "04096", "16384", "65536" })
+    @Param({
+            "00000",
+            "00256",
+            "01024",
+            "04096",
+            "16384",
+            "65536"
+    })
     public int size;
 
     @Benchmark

--- a/microbench/src/main/java/io/netty5/microbench/buffer/BufferAllocatorConcurrentBenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/buffer/BufferAllocatorConcurrentBenchmark.java
@@ -36,7 +36,12 @@ public class BufferAllocatorConcurrentBenchmark extends AbstractMicrobenchmark {
     private static final BufferAllocator pooledAllocator = BufferAllocator.offHeapPooled();
     private static final BufferAllocator adaptiveAllocator = new AdaptivePoolingAllocator(true);
 
-    @Param({ "00064"/*, "00256", "01024", "04096"*/ })
+    @Param({
+            "00064",
+            "00256",
+            "01024",
+            "04096"
+    })
     public int size;
 
     @Benchmark

--- a/microbench/src/main/java/io/netty5/microbench/buffer/BufferBytesBeforeBenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/buffer/BufferBytesBeforeBenchmark.java
@@ -61,7 +61,9 @@ public class BufferBytesBeforeBenchmark extends AbstractMicrobenchmark {
     })
     private int logPermutations;
 
-    @Param({ "1" })
+    @Param({
+            "1"
+    })
     private int seed;
 
     private int permutations;
@@ -69,7 +71,9 @@ public class BufferBytesBeforeBenchmark extends AbstractMicrobenchmark {
     private Buffer[] data;
     private int i;
 
-    @Param({ "-91" })
+    @Param({
+            "-91"
+    })
     private byte needleByte;
     private Buffer needleBuffer;
     private int needleBufferLength = 5;
@@ -79,6 +83,7 @@ public class BufferBytesBeforeBenchmark extends AbstractMicrobenchmark {
             "false",
     })
     private boolean direct;
+
     @Param({
             "false",
             "true",

--- a/microbench/src/main/java/io/netty5/microbench/buffer/BufferCopyBenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/buffer/BufferCopyBenchmark.java
@@ -28,21 +28,54 @@ import java.nio.ByteOrder;
 
 public class BufferCopyBenchmark extends AbstractMicrobenchmark {
 
-    @Param({"7", "36", "128", "512" })
+    @Param({
+            "7",
+            "36",
+            "128",
+            "512",
+    })
     private int size;
-    @Param({"true", "false" })
+
+    @Param({
+            "true",
+            "false",
+    })
     private boolean directByteBuff;
-    @Param({"true", "false" })
+
+    @Param({
+            "true",
+            "false",
+    })
     private boolean directByteBuffer;
-    @Param({"false", "true" })
+
+    @Param({
+            "true",
+            "false",
+    })
     private boolean readonlyByteBuffer;
-    @Param({"true", "false" })
+
+    @Param({
+            "true",
+            "false",
+    })
     private boolean pooledbuffer;
-    @Param({"true", "false" })
+
+    @Param({
+            "true",
+            "false",
+    })
     private boolean alignedCopyByteBuffer;
-    @Param({"true", "false" })
+
+    @Param({
+            "true",
+            "false",
+    })
     private boolean alignedCopyBuffer;
-    @Param({"true", "false" })
+
+    @Param({
+            "true",
+            "false",
+    })
     private boolean nativeOrderByteBuffer;
 
     private ByteBuffer byteBuffer;
@@ -96,5 +129,4 @@ public class BufferCopyBenchmark extends AbstractMicrobenchmark {
     public void tearDown() {
         buffer.close();
     }
-
 }

--- a/microbench/src/main/java/io/netty5/microbench/buffer/Utf8EncodingBenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/buffer/Utf8EncodingBenchmark.java
@@ -76,10 +76,18 @@ public class Utf8EncodingBenchmark extends AbstractMicrobenchmark {
     private StringBuilder[] stringBuilders;
     private AnotherCharSequence[] anotherCharSequences;
     private AsciiString[] asciiStrings;
-    @Param({ "false", "true" })
+
+    @Param({
+            "true",
+            "false",
+    })
     private boolean direct;
     private Buffer buffer;
-    @Param({ "false", "true" })
+
+    @Param({
+            "true",
+            "false",
+    })
     private boolean noUnsafe;
     private int dataSetLength;
 

--- a/microbench/src/main/java/io/netty5/microbench/handler/ssl/SslEngineWrapBenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/handler/ssl/SslEngineWrapBenchmark.java
@@ -28,7 +28,12 @@ import java.nio.ByteBuffer;
 @Threads(1)
 public class SslEngineWrapBenchmark extends AbstractSslEngineThroughputBenchmark {
 
-    @Param({ "1", "2", "5", "10" })
+    @Param({
+            "1",
+            "2",
+            "5",
+            "10",
+    })
     public int numWraps;
 
     @Benchmark

--- a/microbench/src/main/java/io/netty5/microbench/util/AbstractMicrobenchmarkBase.java
+++ b/microbench/src/main/java/io/netty5/microbench/util/AbstractMicrobenchmarkBase.java
@@ -70,7 +70,7 @@ public abstract class AbstractMicrobenchmarkBase {
         String className = getClass().getSimpleName();
 
         ChainedOptionsBuilder runnerOptions = new OptionsBuilder()
-            .include(".*" + className + ".*")
+            .include(".*\\." + className + "\\..*")
             .jvmArgs(jvmArgs());
 
         if (getWarmupIterations() > 0) {

--- a/microbench/src/main/java/io/netty5/util/AsciiStringCaseConversionBenchmark.java
+++ b/microbench/src/main/java/io/netty5/util/AsciiStringCaseConversionBenchmark.java
@@ -37,13 +37,23 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 8, time = 1)
 @State(Scope.Benchmark)
 public class AsciiStringCaseConversionBenchmark {
-    @Param({ "7", "16", "23", "32" })
+    @Param({
+            "7",
+            "16",
+            "23",
+            "32",
+    })
     int size;
 
-    @Param({ "4", "11" })
+    @Param({
+            "4",
+            "11",
+    })
     int logPermutations;
 
-    @Param({ "0" })
+    @Param({
+            "0",
+    })
     int seed;
 
     int permutations;
@@ -56,7 +66,10 @@ public class AsciiStringCaseConversionBenchmark {
 
     private int i;
 
-    @Param({ "true", "false" })
+    @Param({
+            "true",
+            "false",
+    })
     private boolean noUnsafe;
 
     @Setup(Level.Trial)


### PR DESCRIPTION
Motivation:
JMH changed the default iteration warmup/run time from 1 second to 10 seconds. This made many of our benchmarks take forever to complete, complete they fixed the warmup and iteration count to 10 (where JMH lowered their default).

Modification:
Return our defaults to 10 iterations of 1 second each. Also homogenise many `@Param` styles in a way that makes it easy to comment out values from parameter lists.

Result:
Better defaults when running benchmarks.

Forward port of https://github.com/netty/netty/pull/14418
