### PR TITLE
Preserve ordering of default named groups during conversation (#14447)

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
@@ -154,7 +154,7 @@ public final class OpenSsl {
             boolean useKeyManagerFactory = false;
             boolean tlsv13Supported = false;
             String[] namedGroups = DEFAULT_NAMED_GROUPS;
-            Set<String> defaultConvertedNamedGroups = new HashSet<String>(namedGroups.length);
+            Set<String> defaultConvertedNamedGroups = new LinkedHashSet<String>(namedGroups.length);
             for (int i = 0; i < namedGroups.length; i++) {
                 defaultConvertedNamedGroups.add(GroupsConverter.toOpenSsl(namedGroups[i]));
             }


### PR DESCRIPTION
Motivation:

We should preserve the ordering of the default named groups during conversation to openssl naming as otherwise it might prioritize groups in an unexpected way.

Modifications:

Replace HashSet with LinkedHashSet

Result:

Ordering of default groups is preserved during initialization
