### PR TITLE
Ensure netty-all generation does not override other snapshot jars

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -148,7 +148,7 @@ jobs:
           cat ~/linux-x86_64-java8-local-staging/deferred/.index >>  ~/local-staging/deferred/.index
           cp -r ~/linux-x86_64-java8-local-staging/deferred/* ~/local-staging/deferred/
           cat ~/all-local-staging/deferred/.index >>  ~/local-staging/deferred/.index
-          cp -r ~/all-local-staging/deferred/* ~/local-staging/deferred/
+          cp -r ~/all-local-staging/deferred/io/netty/netty-all/* ~/local-staging/deferred/io/netty/netty-all/
 
       - uses: s4u/maven-settings-action@v3.0.0
         with:


### PR DESCRIPTION
Motivation:

We need to ensure we only copy netty-all jar when merging artifacts as otherwise we will override the native lib and so end up with a different GLIBC dependency

Modifications:

Only copy netty-all jar

Result:

Fixes https://github.com/netty/netty/issues/14410
