### PR TITLE
Explicit specify the platform for Docker files (#14448)

### DIFF
--- a/docker/Dockerfile.centos6
+++ b/docker/Dockerfile.centos6
@@ -1,4 +1,4 @@
-FROM centos:6.10
+FROM --platform=linux/amd64 centos:6.10
 
 # Update as we need to use the vault now.
 RUN sed -i -e 's/^mirrorlist/#mirrorlist/g' -e 's/^#baseurl=http:\/\/mirror.centos.org\/centos\/$releasever\//baseurl=https:\/\/linuxsoft.cern.ch\/centos-vault\/\/6.10\//g' /etc/yum.repos.d/CentOS-Base.repo

--- a/docker/Dockerfile.cross_compile_aarch64
+++ b/docker/Dockerfile.cross_compile_aarch64
@@ -1,4 +1,4 @@
-FROM centos:7.6.1810
+FROM --platform=linux/amd64 centos:7.6.1810
 
 ARG gcc_version=10.2-2020.11
 ENV GCC_VERSION $gcc_version

--- a/docker/Dockerfile.cross_compile_riscv64
+++ b/docker/Dockerfile.cross_compile_riscv64
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM --platform=linux/amd64 ubuntu:20.04
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
Motivation:

We should explicit specify the platform we use for docker to ensure our build produce the correct artifacts

Modifications:

Add --platform=linux/amd64 to docker files

Result:

Ensure build produces correct artifacts