### PR TITLE
Pass op code through completion callbacks

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringServerChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringServerChannel.java
@@ -109,7 +109,7 @@ abstract class AbstractIoUringServerChannel extends AbstractIoUringChannel imple
         }
 
         @Override
-        boolean writeComplete0(int res, int flags, int data, int outstanding) {
+        boolean writeComplete0(byte op, int res, int flags, int data, int outstanding) {
             throw new UnsupportedOperationException();
         }
 
@@ -128,7 +128,7 @@ abstract class AbstractIoUringServerChannel extends AbstractIoUringChannel imple
         }
 
         @Override
-        protected void readComplete0(int res, int flags, int data, int outstanding) {
+        protected void readComplete0(byte op, int res, int flags, int data, int outstanding) {
             assert acceptId != 0;
             acceptId = 0;
             final IoUringRecvByteAllocatorHandle allocHandle =

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -279,7 +279,7 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
         }
 
         @Override
-        protected void readComplete0(int res, int flags, int data, int outstanding) {
+        protected void readComplete0(byte op, int res, int flags, int data, int outstanding) {
             assert readId != 0;
             readId = 0;
             boolean allDataRead = false;
@@ -361,7 +361,7 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
         }
 
         @Override
-        boolean writeComplete0(int res, int flags, int data, int outstanding) {
+        boolean writeComplete0(byte op, int res, int flags, int data, int outstanding) {
             assert writeId != 0;
             writeId = 0;
             writeOpCode = 0;

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
@@ -381,7 +381,7 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
         }
 
         @Override
-        protected void readComplete0(int res, int flags, int data, int outstanding) {
+        protected void readComplete0(byte op, int res, int flags, int data, int outstanding) {
             final IoUringRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
             final ChannelPipeline pipeline = pipeline();
             ByteBuf byteBuf = this.readBuffer;
@@ -506,7 +506,7 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
         }
 
         @Override
-        boolean writeComplete0(int res, int flags, int data, int outstanding) {
+        boolean writeComplete0(byte op, int res, int flags, int data, int outstanding) {
             ChannelOutboundBuffer outboundBuffer = outboundBuffer();
 
             // Reset the id as this write was completed and so don't need to be cancelled later.
@@ -543,11 +543,11 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
         }
 
         @Override
-        void connectComplete(int res, int flags, short data) {
+        void connectComplete(byte op, int res, int flags, short data) {
             if (res >= 0) {
                 connected = true;
             }
-            super.connectComplete(res, flags, data);
+            super.connectComplete(op, res, flags, data);
         }
 
         @Override


### PR DESCRIPTION
Motivation:

We call the same completion callbacks for various different op codes. As we might want to do different things depending on the operation that was completes in the future we should better just pass the op code as well.

Modifications:

Pass op code to completion methods

Result:

More flexible in the future