### PR TITLE
chore: Make SpdyFrameEncoder#writeControlFrameHeader a protected method.

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameEncoder.java
@@ -38,7 +38,7 @@ public class SpdyFrameEncoder {
         version = ObjectUtil.checkNotNull(spdyVersion, "spdyVersion").getVersion();
     }
 
-    private void writeControlFrameHeader(ByteBuf buffer, int type, byte flags, int length) {
+    protected void writeControlFrameHeader(ByteBuf buffer, int type, byte flags, int length) {
         buffer.writeShort(version | 0x8000);
         buffer.writeShort(type);
         buffer.writeByte(flags);


### PR DESCRIPTION
Motivation:

I'm migrating our internal server from Jetty to Netty, which is using a modified SPDY protocol, make this change will make this method available from a subclass.

Modification:

To avoid a copy, I want to extend `SpdyFrameEncoder` and reuse the `writeControlFrameHeader`.

Result:

Make `writeControlFrameHeader` available in a subclass.

