### PR TITLE
chore: Make SpdyVersion#version public.

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyVersion.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyVersion.java
@@ -26,11 +26,11 @@ public enum SpdyVersion {
         this.minorVersion = minorVersion;
     }
 
-    int getVersion() {
+    public int getVersion() {
         return version;
     }
 
-    int getMinorVersion() {
+    public int getMinorVersion() {
         return minorVersion;
     }
 }


### PR DESCRIPTION
Motivation:

Make these method a public method where it can be accessed out side of `spdy` package.

Modification:

Make `SpdyVersion#version` method a public method.

Result:

User can access `SpdyVersion.version` now.


