### PR TITLE
Use `StandardCompressionOptions` in all constructors of `HttpContentCompressor`

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
@@ -266,7 +266,7 @@ public class HttpContentCompressor extends HttpContentEncoder {
         CompressionEncoderFactory encoderFactory = factories.get(targetContentEncoding);
 
         if (encoderFactory == null) {
-            throw new Error();
+            throw new IllegalStateException("Couldn't find CompressionEncoderFactory: " + targetContentEncoding);
         }
 
         return new Result(targetContentEncoding,


### PR DESCRIPTION
Motivation:
When HttpContentCompressor is created using the default empty constructor or `HttpContentCompressor(int...)`, then some compression algorithms, like Brotli or Zstd, will never work regardless of their presence in the classpath because `factories` will never be initialized.

Modification:
Replaced default empty constructor parameters with `StandardCompressionOptions` and `HttpContentCompressor(int, int, int)` constructor.

Result:
Enabled the usage of Brotli and Zstd even when using the default empty constructor.
