### PR TITLE
chore: Fix javadoc in Http2FrameCodec.

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
@@ -88,7 +88,7 @@ import static io.netty.util.internal.logging.InternalLogLevel.DEBUG;
  * {@link Http2ChannelDuplexHandler#newStream()}, and then writing a {@link Http2HeadersFrame} object with the stream
  * attached.
  *
- * <pre>
+ * <pre> {@code
  *     final Http2Stream2 stream = handler.newStream();
  *     ctx.write(headersFrame.stream(stream)).addListener(new ChannelFutureListener() {
  *
@@ -108,6 +108,7 @@ import static io.netty.util.internal.logging.InternalLogLevel.DEBUG;
  *                 }
  *             }
  *         }
+ *     }
  *     }
  * </pre>
  *


### PR DESCRIPTION
Motivation:

Fix the javadoc rendering

Modification:

add `{@code }` to the code block.

Result:
<img width="698" alt="image" src="https://github.com/user-attachments/assets/46d6d1f7-fbf1-4ea9-a48c-515ef96cf8b8">

