### PR TITLE
Rename methods to match naming conventations

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameDecoder.java
@@ -91,7 +91,7 @@ public class SpdyFrameDecoder {
      * Creates a new instance with the specified parameters.
      */
     public SpdyFrameDecoder(SpdyVersion spdyVersion, SpdyFrameDecoderDelegate delegate, int maxChunkSize) {
-        this.spdyVersion = ObjectUtil.checkNotNull(spdyVersion, "spdyVersion").getVersion();
+        this.spdyVersion = ObjectUtil.checkNotNull(spdyVersion, "spdyVersion").version();
         this.delegate = ObjectUtil.checkNotNull(delegate, "delegate");
         this.maxChunkSize = ObjectUtil.checkPositive(maxChunkSize, "maxChunkSize");
         state = State.READ_COMMON_HEADER;

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameEncoder.java
@@ -35,7 +35,7 @@ public class SpdyFrameEncoder {
      * Creates a new instance with the specified {@code spdyVersion}.
      */
     public SpdyFrameEncoder(SpdyVersion spdyVersion) {
-        version = ObjectUtil.checkNotNull(spdyVersion, "spdyVersion").getVersion();
+        version = ObjectUtil.checkNotNull(spdyVersion, "spdyVersion").version();
     }
 
     private void writeControlFrameHeader(ByteBuf buffer, int type, byte flags, int length) {

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHeaderBlockRawEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHeaderBlockRawEncoder.java
@@ -30,7 +30,7 @@ public class SpdyHeaderBlockRawEncoder extends SpdyHeaderBlockEncoder {
     private final int version;
 
     public SpdyHeaderBlockRawEncoder(SpdyVersion version) {
-        this.version = ObjectUtil.checkNotNull(version, "version").getVersion();
+        this.version = ObjectUtil.checkNotNull(version, "version").version();
     }
 
     private static void setLengthField(ByteBuf buffer, int writerIndex, int length) {

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpDecoder.java
@@ -131,7 +131,7 @@ public class SpdyHttpDecoder extends MessageToMessageDecoder<SpdyFrame> {
      */
     protected SpdyHttpDecoder(SpdyVersion version, int maxContentLength, Map<Integer,
             FullHttpMessage> messageMap, HttpHeadersFactory headersFactory, HttpHeadersFactory trailersFactory) {
-        spdyVersion = ObjectUtil.checkNotNull(version, "version").getVersion();
+        spdyVersion = ObjectUtil.checkNotNull(version, "version").version();
         this.maxContentLength = checkPositive(maxContentLength, "maxContentLength");
         this.messageMap = messageMap;
         this.headersFactory = headersFactory;

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdySessionHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdySessionHandler.java
@@ -70,7 +70,7 @@ public class SpdySessionHandler extends ChannelDuplexHandler {
      *                handle the client endpoint of the connection.
      */
     public SpdySessionHandler(SpdyVersion version, boolean server) {
-        this.minorVersion = ObjectUtil.checkNotNull(version, "version").getMinorVersion();
+        this.minorVersion = ObjectUtil.checkNotNull(version, "version").minorVersion();
         this.server = server;
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyVersion.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyVersion.java
@@ -26,11 +26,11 @@ public enum SpdyVersion {
         this.minorVersion = minorVersion;
     }
 
-    public int getVersion() {
+    public int version() {
         return version;
     }
 
-    public int getMinorVersion() {
+    public int minorVersion() {
         return minorVersion;
     }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdyFrameDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdyFrameDecoderTest.java
@@ -147,7 +147,7 @@ public class SpdyFrameDecoderTest {
     }
 
     private static void encodeControlFrameHeader(ByteBuf buffer, short type, byte flags, int length) {
-        buffer.writeShort(0x8000 | SpdyVersion.SPDY_3_1.getVersion());
+        buffer.writeShort(0x8000 | SpdyVersion.SPDY_3_1.version());
         buffer.writeShort(type);
         buffer.writeByte(flags);
         buffer.writeMedium(length);


### PR DESCRIPTION
Motivation:

914ba08673867750d65ddd63cbfd92df504e7bc4 made the methods public but did not change the naming of the methods. Usually we don't use the get* prefix in netty.

Modifications:

Remove get prefix from methods

Result:

Cleanup
