### PR TITLE
Ensure classifier for corretto is always computed the correct way

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -744,7 +744,12 @@
     <conscrypt.version>2.5.2</conscrypt.version>
     <conscrypt.classifier />
     <corretto.version>2.4.1</corretto.version>
-    <corretto.classifier>${os.detected.classifier}</corretto.classifier>
+    <!--
+      Don't use os.detected.classifier as it will also add the "likes" as configure above.
+      ${os.detected.name}-${os.detected.arch} is the same but without "likes".
+      See https://github.com/trustin/os-maven-plugin/blob/os-maven-plugin-1.7.1/README.md#property-osdetectedclassifier
+    -->
+    <corretto.classifier>${os.detected.name}-${os.detected.arch}</corretto.classifier>
     <jni.classifier>${os.detected.name}-${os.detected.arch}</jni.classifier>
     <logging.config>${project.basedir}/../common/src/test/resources/logback-test.xml</logging.config>
     <logging.logLevel>debug</logging.logLevel>


### PR DESCRIPTION
Motivation:

Corretto does not use "likes" and so we need to ensure we compute it without these.

Modifications:

Manually compose the classifier to use

Result:

Always use the correct classifier no matter on which linux system we compile
