### PR TITLE
PcapWriteHandler no longer ignores writePcapGlobalHeader

### DIFF
--- a/handler/src/main/java/io/netty/handler/pcap/PcapWriteHandler.java
+++ b/handler/src/main/java/io/netty/handler/pcap/PcapWriteHandler.java
@@ -650,6 +650,10 @@ public final class PcapWriteHandler extends ChannelDuplexHandler implements Clos
         return sharedOutputStream;
     }
 
+    boolean writePcapGlobalHeader() {
+        return writePcapGlobalHeader;
+    }
+
     /**
      * Returns {@code true} if the {@link PcapWriteHandler} is currently
      * writing packets to the {@link OutputStream} else returns {@code false}.

--- a/handler/src/main/java/io/netty/handler/pcap/PcapWriter.java
+++ b/handler/src/main/java/io/netty/handler/pcap/PcapWriter.java
@@ -47,7 +47,7 @@ final class PcapWriter implements Closeable {
         outputStream = pcapWriteHandler.outputStream();
 
         // If OutputStream is not shared then we have to write Global Header.
-        if (!pcapWriteHandler.sharedOutputStream()) {
+        if (pcapWriteHandler.writePcapGlobalHeader() && !pcapWriteHandler.sharedOutputStream()) {
             PcapHeaders.writeGlobalHeader(pcapWriteHandler.outputStream());
         }
     }


### PR DESCRIPTION
Motivation:

PcapWriteHandler.Builder has a boolean for writePcapGlobalHeader so that the handler can support functionality like appending to an existing PCAP file. This boolean is currently not being checked when writing the global header, preventing appending from working.

Modifications:

PcapWriter checks PcapWriteHandler.writePcapGlobalHeader() returned true. Added unit test cases for when writePcapGlobalHeader is set to false.

Result:

PcapWriteHandler only writes the global PCAP header on initialization if writePcapGlobalHeader is true and if sharedOutputStream is false.
