### PR TITLE
Fix bugs in BoundedInputStream (#14479)

### DIFF
--- a/common/src/test/java/io/netty/util/internal/BoundedInputStreamTest.java
+++ b/common/src/test/java/io/netty/util/internal/BoundedInputStreamTest.java
@@ -20,7 +20,9 @@ import org.junit.jupiter.api.function.Executable;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.util.Arrays;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -39,6 +41,17 @@ public class BoundedInputStreamTest {
                 reader.read(new byte[64], 0, 64);
             }
         });
+        reader.close();
+    }
+
+    @Test
+    void testBigReadsPermittedIfUnderlyingStreamIsSmall() throws IOException {
+        final byte[] bytes = new byte[64];
+        PlatformDependent.threadLocalRandom().nextBytes(bytes);
+        final BoundedInputStream reader = new BoundedInputStream(new ByteArrayInputStream(bytes), 8192);
+        final byte[] buffer = new byte[10000];
+        reader.read(buffer, 0, 10000);
+        assertArrayEquals(bytes, Arrays.copyOfRange(buffer, 0, 64));
         reader.close();
     }
 }


### PR DESCRIPTION
Motivation:

A BoundedInputStream was recently introduced to protect against attacks where a large file was placed on the server.  Unfortunately, this has an issue preventing it from reading the last bytes of a file where the buffer size would take the total bytes over the set bound, when reading just the remaining bytes in the file fits underneath the set bound.

Modification:

Adjusted the behaviour of BoundedInputStream to, where appropriate, read 1 more byte than the set bound, to see if the file terminates at this point, in which case there is no need to throw the exception

Result:

Fixes #14479.
