### PR TITLE
PcapWriteHandler no longer ignores writePcapGlobalHeader (#14477)

### DIFF
--- a/handler/src/main/java/io/netty/handler/pcap/PcapWriteHandler.java
+++ b/handler/src/main/java/io/netty/handler/pcap/PcapWriteHandler.java
@@ -650,6 +650,10 @@ public final class PcapWriteHandler extends ChannelDuplexHandler implements Clos
         return sharedOutputStream;
     }
 
+    boolean writePcapGlobalHeader() {
+        return writePcapGlobalHeader;
+    }
+
     /**
      * Returns {@code true} if the {@link PcapWriteHandler} is currently
      * writing packets to the {@link OutputStream} else returns {@code false}.

--- a/handler/src/main/java/io/netty/handler/pcap/PcapWriter.java
+++ b/handler/src/main/java/io/netty/handler/pcap/PcapWriter.java
@@ -47,7 +47,7 @@ final class PcapWriter implements Closeable {
         outputStream = pcapWriteHandler.outputStream();
 
         // If OutputStream is not shared then we have to write Global Header.
-        if (!pcapWriteHandler.sharedOutputStream()) {
+        if (pcapWriteHandler.writePcapGlobalHeader() && !pcapWriteHandler.sharedOutputStream()) {
             PcapHeaders.writeGlobalHeader(pcapWriteHandler.outputStream());
         }
     }

--- a/handler/src/test/java/io/netty/handler/pcap/PcapWriteHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/pcap/PcapWriteHandlerTest.java
@@ -47,6 +47,7 @@ import io.netty.util.CharsetUtil;
 import io.netty.util.NetUtil;
 import io.netty.util.concurrent.Promise;
 
+import java.io.IOException;
 import java.io.OutputStream;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
@@ -68,16 +69,22 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class PcapWriteHandlerTest {
 
     @Test
-    public void udpV4SharedOutputStreamTest() throws InterruptedException {
-        udpV4(true);
+    public void udpV4SharedOutputStreamTest() throws InterruptedException, IOException {
+        udpV4(true, true);
     }
 
     @Test
-    public void udpV4NonOutputStream() throws InterruptedException {
-        udpV4(false);
+    public void udpV4NonOutputStream() throws InterruptedException, IOException {
+        udpV4(false, true);
     }
 
-    private static void udpV4(boolean sharedOutputStream) throws InterruptedException {
+    @Test
+    public void udpV4NoGlobalHeaderOutputStream() throws InterruptedException, IOException {
+        udpV4(false, false);
+    }
+
+    private static void udpV4(boolean sharedOutputStream, boolean writeGlobalHeaders)
+            throws InterruptedException, IOException {
         ByteBuf byteBuf = Unpooled.buffer();
 
         InetSocketAddress serverAddr = new InetSocketAddress("127.0.0.1", 0);
@@ -107,6 +114,7 @@ public class PcapWriteHandlerTest {
                 .channel(NioDatagramChannel.class)
                 .handler(PcapWriteHandler.builder()
                         .sharedOutputStream(sharedOutputStream)
+                        .writePcapGlobalHeader(writeGlobalHeaders)
                         .build(outputStream));
 
         ChannelFuture channelFutureClient =
@@ -117,7 +125,8 @@ public class PcapWriteHandlerTest {
         assertTrue(clientChannel.writeAndFlush(Unpooled.wrappedBuffer("Meow".getBytes())).sync().isSuccess());
         assertTrue(eventLoopGroup.shutdownGracefully().sync().isSuccess());
 
-        verifyUdpCapture(!sharedOutputStream, // if sharedOutputStream is true, we don't verify the global headers.
+        // if sharedOutputStream is true or writeGlobalHeaders is false, we don't verify the global headers.
+        verifyUdpCapture(!sharedOutputStream && writeGlobalHeaders,
                 byteBuf,
                 (InetSocketAddress) clientChannel.remoteAddress(),
                 (InetSocketAddress) clientChannel.localAddress()
@@ -177,15 +186,20 @@ public class PcapWriteHandlerTest {
 
     @Test
     public void tcpV4SharedOutputStreamTest() throws Exception {
-        tcpV4(true);
+        tcpV4(true, true);
+    }
+
+    @Test
+    public void tcpV4NoGlobalHeaderOutputStream() throws Exception {
+        tcpV4(false, false);
     }
 
     @Test
     public void tcpV4NonOutputStream() throws Exception {
-        tcpV4(false);
+        tcpV4(false, true);
     }
 
-    private static void tcpV4(final boolean sharedOutputStream) throws Exception {
+    private static void tcpV4(final boolean sharedOutputStream, final boolean writeGlobalHeaders) throws Exception {
         final ByteBuf byteBuf = Unpooled.buffer();
 
         EventLoopGroup bossGroup = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
@@ -202,6 +216,7 @@ public class PcapWriteHandlerTest {
                     public void initChannel(SocketChannel ch) throws Exception {
                         ChannelPipeline p = ch.pipeline();
                         p.addLast(PcapWriteHandler.builder().sharedOutputStream(sharedOutputStream)
+                                          .writePcapGlobalHeader(writeGlobalHeaders)
                                 .build(new ByteBufOutputStream(byteBuf)));
                         p.addLast(new ChannelInboundHandlerAdapter() {
                             @Override
@@ -266,8 +281,9 @@ public class PcapWriteHandlerTest {
         assertTrue(clientGroup.shutdownGracefully().sync().isSuccess());
         assertTrue(bossGroup.shutdownGracefully().sync().isSuccess());
 
+        // if sharedOutputStream is true or writeGlobalHeaders is false, we don't verify the global headers.
         verifyTcpCapture(
-                !sharedOutputStream, // if sharedOutputStream is true, we don't verify the global headers.
+                writeGlobalHeaders && !sharedOutputStream,
                 byteBuf,
                 (InetSocketAddress) serverChannelFuture.channel().localAddress(),
                 (InetSocketAddress) clientChannelFuture.channel().localAddress()


### PR DESCRIPTION
Motivation:

PcapWriteHandler.Builder has a boolean for writePcapGlobalHeader so that the handler can support functionality like appending to an existing PCAP file. This boolean is currently not being checked when writing the global header, preventing appending from working.

Modifications:

PcapWriter checks PcapWriteHandler.writePcapGlobalHeader() returned true. Added unit test cases for when writePcapGlobalHeader is set to false.

Result:

PcapWriteHandler only writes the global PCAP header on initialization if writePcapGlobalHeader is true and if sharedOutputStream is false.
