### PR TITLE
IoUring: data passed to callbacks should be of type short

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -647,7 +647,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
             ioState |= POLL_IN_SCHEDULED;
         }
 
-        private void readComplete(byte op, int res, int flags, int data) {
+        private void readComplete(byte op, int res, int flags, short data) {
             assert numOutstandingReads > 0;
             if (--numOutstandingReads == 0) {
                 readPending = false;
@@ -669,7 +669,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
         /**
          * Called once a read was completed.
          */
-        protected abstract void readComplete0(byte op, int res, int flags, int data, int outstandingCompletes);
+        protected abstract void readComplete0(byte op, int res, int flags, short data, int outstandingCompletes);
 
         /**
          * Called once POLLRDHUP event is ready to be processed
@@ -728,8 +728,8 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
         }
 
         /**
-         * Schedule a read and returns the number of {@link #readComplete(byte, int, int, int)} calls that are expected
-         * because of the scheduled read.
+         * Schedule a read and returns the number of {@link #readComplete(byte, int, int, short)}
+         * calls that are expected because of the scheduled read.
          *
          * @param first {@code true} if this is the first read of a read loop.
          */
@@ -846,7 +846,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
          * @param data          the data that was passed when submitting the op.
          * @param outstanding   the outstanding write completions.
          */
-        abstract boolean writeComplete0(byte op, int res, int flags, int data, int outstanding);
+        abstract boolean writeComplete0(byte op, int res, int flags, short data, int outstanding);
 
         /**
          * Called once a cancel was completed.

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringServerChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringServerChannel.java
@@ -109,7 +109,7 @@ abstract class AbstractIoUringServerChannel extends AbstractIoUringChannel imple
         }
 
         @Override
-        boolean writeComplete0(byte op, int res, int flags, int data, int outstanding) {
+        boolean writeComplete0(byte op, int res, int flags, short data, int outstanding) {
             throw new UnsupportedOperationException();
         }
 
@@ -128,7 +128,7 @@ abstract class AbstractIoUringServerChannel extends AbstractIoUringChannel imple
         }
 
         @Override
-        protected void readComplete0(byte op, int res, int flags, int data, int outstanding) {
+        protected void readComplete0(byte op, int res, int flags, short data, int outstanding) {
             assert acceptId != 0;
             acceptId = 0;
             final IoUringRecvByteAllocatorHandle allocHandle =

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -279,7 +279,7 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
         }
 
         @Override
-        protected void readComplete0(byte op, int res, int flags, int data, int outstanding) {
+        protected void readComplete0(byte op, int res, int flags, short data, int outstanding) {
             assert readId != 0;
             readId = 0;
             boolean allDataRead = false;
@@ -361,7 +361,7 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
         }
 
         @Override
-        boolean writeComplete0(byte op, int res, int flags, int data, int outstanding) {
+        boolean writeComplete0(byte op, int res, int flags, short data, int outstanding) {
             assert writeId != 0;
             writeId = 0;
             writeOpCode = 0;

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
@@ -381,7 +381,7 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
         }
 
         @Override
-        protected void readComplete0(byte op, int res, int flags, int data, int outstanding) {
+        protected void readComplete0(byte op, int res, int flags, short data, int outstanding) {
             final IoUringRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
             final ChannelPipeline pipeline = pipeline();
             ByteBuf byteBuf = this.readBuffer;
@@ -506,7 +506,7 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
         }
 
         @Override
-        boolean writeComplete0(byte op, int res, int flags, int data, int outstanding) {
+        boolean writeComplete0(byte op, int res, int flags, short data, int outstanding) {
             ChannelOutboundBuffer outboundBuffer = outboundBuffer();
 
             // Reset the id as this write was completed and so don't need to be cancelled later.


### PR DESCRIPTION
Motiviation:

IoUringOps allows to add some data to each op that is passed as part of the completion event. The type of this data is short but we used int for the callbacks.

Modification:

Use short for data in callbacks

Result:

Consistent usage of data type for user supplied data
