### PR TITLE
`AdaptiveByteBufAllocator` will not use threadlocal magazine if `FastThreadLocalThread.willCleanupFastThreadLocals()` returns false

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -30,8 +30,6 @@ import io.netty.util.internal.SuppressJava6Requirement;
 import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.ThreadExecutorMap;
 import io.netty.util.internal.UnstableApi;
-import io.netty.util.internal.logging.InternalLogger;
-import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -81,7 +79,6 @@ import java.util.concurrent.locks.StampedLock;
 @SuppressJava6Requirement(reason = "Guarded by version check")
 @UnstableApi
 final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.AdaptiveAllocatorApi {
-    private static final InternalLogger logger = InternalLoggerFactory.getInstance(AdaptivePoolingAllocator.class);
 
     enum MagazineCaching {
         EventLoopThreads,
@@ -150,9 +147,6 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
                     if (cachedMagazinesNonEventLoopThreads || ThreadExecutorMap.currentExecutor() != null) {
                         if (!FastThreadLocalThread.willCleanupFastThreadLocals(Thread.currentThread())) {
                             // To prevent potential leak, we will not use thread-local magazine.
-                            logger.warn("Thread-local magazine will NOT be used, since the current thread:{} " +
-                                            "will not clean up its FastThreadLocal instances once it completes",
-                                    Thread.currentThread());
                             return NO_MAGAZINE;
                         }
                         Magazine mag = new Magazine(AdaptivePoolingAllocator.this, false);

--- a/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorUseCacheForNonEventLoopThreadsTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorUseCacheForNonEventLoopThreadsTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import io.netty.util.concurrent.FastThreadLocalThread;
+import io.netty.util.internal.ObjectUtil;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class AdaptiveByteBufAllocatorUseCacheForNonEventLoopThreadsTest extends AdaptiveByteBufAllocatorTest {
+
+    @Override
+    protected AdaptiveByteBufAllocator newAllocator(final boolean preferDirect) {
+        return new AdaptiveByteBufAllocator(preferDirect, true);
+    }
+
+    @Override
+    protected AdaptiveByteBufAllocator newUnpooledAllocator() {
+        return newAllocator(false);
+    }
+
+    @Test
+    void testFastThreadLocalThreadWithoutCleanupFastThreadLocals() throws InterruptedException {
+        final AtomicReference<Throwable> throwable = new AtomicReference<Throwable>();
+        Runnable task = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    AdaptiveByteBufAllocatorUseCacheForNonEventLoopThreadsTest.super.testUsedHeapMemory();
+                    AdaptiveByteBufAllocatorUseCacheForNonEventLoopThreadsTest.super.testUsedDirectMemory();
+                } catch (Throwable e) {
+                    throwable.set(e);
+                }
+            }
+        };
+        Thread customizefastThreadLocalThread = new CustomizeFastThreadLocalThreadWithoutCleanupFastThreadLocals(task);
+        customizefastThreadLocalThread.start();
+        customizefastThreadLocalThread.join();
+        assertNull(throwable.get());
+    }
+
+    private static final class CustomizeFastThreadLocalThreadWithoutCleanupFastThreadLocals
+            extends FastThreadLocalThread implements Runnable {
+        private final Runnable runnable;
+        private CustomizeFastThreadLocalThreadWithoutCleanupFastThreadLocals(Runnable runnable) {
+            this.runnable = ObjectUtil.checkNotNull(runnable, "runnable");
+        }
+        @Override
+        public boolean willCleanupFastThreadLocals() {
+            return false;
+        }
+        @Override
+        public void run() {
+            runnable.run(); // Without calling `FastThreadLocal.removeAll()`.
+        }
+    }
+}

--- a/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorUseCacheForNonEventLoopThreadsTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorUseCacheForNonEventLoopThreadsTest.java
@@ -58,13 +58,16 @@ public class AdaptiveByteBufAllocatorUseCacheForNonEventLoopThreadsTest extends 
     private static final class CustomizeFastThreadLocalThreadWithoutCleanupFastThreadLocals
             extends FastThreadLocalThread implements Runnable {
         private final Runnable runnable;
+
         private CustomizeFastThreadLocalThreadWithoutCleanupFastThreadLocals(Runnable runnable) {
             this.runnable = ObjectUtil.checkNotNull(runnable, "runnable");
         }
+
         @Override
         public boolean willCleanupFastThreadLocals() {
             return false;
         }
+
         @Override
         public void run() {
             runnable.run(); // Without calling `FastThreadLocal.removeAll()`.

--- a/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorUseCacheForNonEventLoopThreadsTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorUseCacheForNonEventLoopThreadsTest.java
@@ -57,6 +57,7 @@ public class AdaptiveByteBufAllocatorUseCacheForNonEventLoopThreadsTest extends 
 
     private static final class CustomizeFastThreadLocalThreadWithoutCleanupFastThreadLocals
             extends FastThreadLocalThread implements Runnable {
+
         private final Runnable runnable;
 
         private CustomizeFastThreadLocalThreadWithoutCleanupFastThreadLocals(Runnable runnable) {


### PR DESCRIPTION
Motivation:

The method `AdaptiveByteBufAllocator.usedHeapMemory()` does not return a correct value when `FastThreadLocalThread.willCleanupFastThreadLocals(Thread.currentThread()) == false` by using a customized  `FastThreadLocalThread` thread.

Modification:

If `FastThreadLocalThread.willCleanupFastThreadLocals(Thread.currentThread()) == false`, then we will NOT use threadLocal magazine.

Result:

Fixes #14483. 
