### PR TITLE
`AdaptiveByteBufAllocator` will not use threadlocal magazine if `Fast…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -143,13 +143,12 @@ final class AdaptivePoolingAllocator {
                 @Override
                 protected Object initialValue() {
                     if (cachedMagazinesNonEventLoopThreads || ThreadExecutorMap.currentExecutor() != null) {
-                        Magazine mag = new Magazine(AdaptivePoolingAllocator.this, false);
-
-                        if (FastThreadLocalThread.willCleanupFastThreadLocals(Thread.currentThread())) {
-                            // Only add it to the liveMagazines if we can guarantee that onRemoval(...) is called,
-                            // as otherwise we might end up holding the reference forever.
-                            liveMagazines.add(mag);
+                        if (!FastThreadLocalThread.willCleanupFastThreadLocals(Thread.currentThread())) {
+                            // To prevent potential leak, we will not use thread-local magazine.
+                            return NO_MAGAZINE;
                         }
+                        Magazine mag = new Magazine(AdaptivePoolingAllocator.this, false);
+                        liveMagazines.add(mag);
                         return mag;
                     }
                     return NO_MAGAZINE;

--- a/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorUseCacheForNonEventLoopThreadsTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorUseCacheForNonEventLoopThreadsTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import io.netty.util.concurrent.FastThreadLocalThread;
+import io.netty.util.internal.ObjectUtil;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class AdaptiveByteBufAllocatorUseCacheForNonEventLoopThreadsTest extends AdaptiveByteBufAllocatorTest {
+
+    @Override
+    protected AdaptiveByteBufAllocator newAllocator(final boolean preferDirect) {
+        return new AdaptiveByteBufAllocator(preferDirect, true);
+    }
+
+    @Override
+    protected AdaptiveByteBufAllocator newUnpooledAllocator() {
+        return newAllocator(false);
+    }
+
+    @Test
+    void testFastThreadLocalThreadWithoutCleanupFastThreadLocals() throws InterruptedException {
+        final AtomicReference<Throwable> throwable = new AtomicReference<Throwable>();
+        Runnable task = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    AdaptiveByteBufAllocatorUseCacheForNonEventLoopThreadsTest.super.testUsedHeapMemory();
+                    AdaptiveByteBufAllocatorUseCacheForNonEventLoopThreadsTest.super.testUsedDirectMemory();
+                } catch (Throwable e) {
+                    throwable.set(e);
+                }
+            }
+        };
+        Thread customizefastThreadLocalThread = new CustomizeFastThreadLocalThreadWithoutCleanupFastThreadLocals(task);
+        customizefastThreadLocalThread.start();
+        customizefastThreadLocalThread.join();
+        assertNull(throwable.get());
+    }
+
+    private static final class CustomizeFastThreadLocalThreadWithoutCleanupFastThreadLocals
+            extends FastThreadLocalThread implements Runnable {
+
+        private final Runnable runnable;
+
+        private CustomizeFastThreadLocalThreadWithoutCleanupFastThreadLocals(Runnable runnable) {
+            this.runnable = ObjectUtil.checkNotNull(runnable, "runnable");
+        }
+
+        @Override
+        public boolean willCleanupFastThreadLocals() {
+            return false;
+        }
+
+        @Override
+        public void run() {
+            runnable.run(); // Without calling `FastThreadLocal.removeAll()`.
+        }
+    }
+}


### PR DESCRIPTION
…ThreadLocalThread.willCleanupFastThreadLocals()` returns false (#14486)

Motivation:

The method `AdaptiveByteBufAllocator.usedHeapMemory()` does not return a correct value when
`FastThreadLocalThread.willCleanupFastThreadLocals(Thread.currentThread()) == false` by using a customized `FastThreadLocalThread` thread.

Modification:

If
`FastThreadLocalThread.willCleanupFastThreadLocals(Thread.currentThread()) == false`, then we will NOT use threadLocal magazine.

Result:

Fixes #14483.

