### PR TITLE
Narrow the lock scope of `AdaptivePoolingAllocator.magazineExpandLock`

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -311,10 +311,11 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
         if (currentLength >= MAX_STRIPES) {
             return true;
         }
+        final Magazine[] mags;
         long writeLock = magazineExpandLock.tryWriteLock();
         if (writeLock != 0) {
             try {
-                Magazine[] mags = magazines;
+                mags = magazines;
                 if (mags.length >= MAX_STRIPES || mags.length > currentLength || freed) {
                     return true;
                 }
@@ -327,11 +328,11 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
                     expanded[i] = m;
                 }
                 magazines = expanded;
-                for (Magazine magazine : mags) {
-                    magazine.free();
-                }
             } finally {
                 magazineExpandLock.unlockWrite(writeLock);
+            }
+            for (Magazine magazine : mags) {
+                magazine.free();
             }
         }
         return true;


### PR DESCRIPTION
Motivation:

It's better to narrow the lock scope and avoid using nested lock when possible.

The lock scope of `magazineExpandLock` in method `AdaptivePoolingAllocator.tryExpandMagazines(...)` can be narrowed.

The `magazineExpandLock` guard the current(newest) version of `magazines`, but no need to guard the old version of `magazines`.

We can get out of the `magazineExpandLock` immediately once the newest `magazines` is assigned, which means we can move the 'free-old-magazines' operation out of the `magazineExpandLock` scope.

Another reason for doing this is that the 'free-old-magazines' operation required another lock(`Magazine.allocationLock`), which make it becomes a nested lock inside `magazineExpandLock`, it's better to avoid using the nested lock.

Modification:

Moved the 'free-old-magazines' operation out of the `magazineExpandLock` scope.

Result:

Narrowed the `magazineExpandLock` scope and avoided nest the `Magazine.allocationLock`.
