### PR TITLE
Add range check for AdaptivePoolingAllocator.CENTRAL_QUEUE_CAPACITY a…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -127,6 +127,17 @@ final class AdaptivePoolingAllocator {
     private final Set<Magazine> liveCachedMagazines;
     private volatile boolean freed;
 
+    static {
+        if (CENTRAL_QUEUE_CAPACITY < 2) {
+            throw new IllegalArgumentException("CENTRAL_QUEUE_CAPACITY: " + CENTRAL_QUEUE_CAPACITY
+                    + " (expected: >= " + 2 + ')');
+        }
+        if (MAGAZINE_BUFFER_QUEUE_CAPACITY < 2) {
+            throw new IllegalArgumentException("MAGAZINE_BUFFER_QUEUE_CAPACITY: " + MAGAZINE_BUFFER_QUEUE_CAPACITY
+                    + " (expected: >= " + 2 + ')');
+        }
+    }
+
     AdaptivePoolingAllocator(ChunkAllocator chunkAllocator, MagazineCaching magazineCaching) {
         ObjectUtil.checkNotNull(chunkAllocator, "chunkAllocator");
         ObjectUtil.checkNotNull(magazineCaching, "magazineCaching");


### PR DESCRIPTION
…nd MAGAZINE_BUFFER_QUEUE_CAPACITY (#14493)

Motivation:

The customizable configurations
`AdaptivePoolingAllocator.CENTRAL_QUEUE_CAPACITY` and `AdaptivePoolingAllocator.MAGAZINE_BUFFER_QUEUE_CAPACITY` MUST NOT less than 2.

Modification:

Add range check in the static block, to fail fast in class load stage with clearer error messages.

Result:

Fixes #14489.
