### PR TITLE
Make sure the sentinel `Magazine.MAGAZINE_FREED` not be replaced (#14…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -664,11 +664,10 @@ final class AdaptivePoolingAllocator {
                 return;
             }
             Chunk nextChunk = NEXT_IN_LINE.get(this);
-            if (nextChunk != null && current.remainingCapacity() > nextChunk.remainingCapacity()) {
+            if (nextChunk != null && nextChunk != MAGAZINE_FREED
+                    && current.remainingCapacity() > nextChunk.remainingCapacity()) {
                 if (NEXT_IN_LINE.compareAndSet(this, nextChunk, current)) {
-                    if (nextChunk != MAGAZINE_FREED) {
-                        nextChunk.release();
-                    }
+                    nextChunk.release();
                     return;
                 }
             }


### PR DESCRIPTION
…502)

Motivation:

The sentinel object `Magazine.MAGAZINE_FREED` should not be replaced.

Modification:

Check the `NEXT_IN_LINE` to make sure the `Magazine.MAGAZINE_FREED` not be replaced.

Result:

Fixes #14498.
