### PR TITLE
IoUring: Fix AssertionError when closing IoUringServerChannel twice.

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringServerChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringServerChannel.java
@@ -84,8 +84,9 @@ abstract class AbstractIoUringServerChannel extends AbstractIoUringChannel imple
             IoUringIoOps ops = IoUringIoOps.newAsyncCancel(
                     fd, 0, acceptId, Native.IORING_OP_ACCEPT);
             registration.submit(ops);
+        } else {
+            assert numOutstandingReads == 0;
         }
-        assert numOutstandingReads == 0;
     }
 
     @Override


### PR DESCRIPTION
Modivation:

It should be possible to call close() multiple times without an error

Modifications:

- Add missing else block to fix assert
- Add unit test

Result:

No more error when closing twice