### PR TITLE
fix: Don't make MqttPublishMessage ensure payload accessibility, close #14507

### DIFF
--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttPublishMessage.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttPublishMessage.java
@@ -18,7 +18,6 @@ package io.netty.handler.codec.mqtt;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
-import io.netty.buffer.ByteBufUtil;
 
 /**
  * See <a href="https://public.dhe.ibm.com/software/dw/webservices/ws-mqtt/mqtt-v3r1.html#publish">MQTTV3.1/publish</a>
@@ -44,7 +43,7 @@ public class MqttPublishMessage extends MqttMessage implements ByteBufHolder {
 
     @Override
     public ByteBuf content() {
-        return ByteBufUtil.ensureAccessible((ByteBuf) super.payload());
+        return (ByteBuf) super.payload();
     }
 
     @Override


### PR DESCRIPTION
Motivations:

* it's not the responsibility of MqttPublishMessage, which is a ByteBufHolder to ensure the accessibility of the ByteBuf. The ByteBuf checks it himself.
* the current design is broken and there's no way to check if the content is accessible as refCnt crashes with IllegalReferenceCountException instead of returning 0.

Modification:

Remove ByteBufUtil.ensureAccessible from MqttPublishMessage#content. ByteBuf's methods will check themselves.

Result:

Fixes #14507

It's now possible to check if the payload of a  MqttPublishMessage is accessible.
