### PR TITLE
Decrease usedMemory of magazine when the chunk get deallocated or mov…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -820,6 +820,8 @@ final class AdaptivePoolingAllocator {
                 delegate.setIndex(0, 0);
                 allocatedBytes = 0;
                 if (!mag.trySetNextInLine(this)) {
+                    // As this Chunk does not belong to the mag anymore we need to decrease the used memory .
+                    mag.usedMemory.getAndAdd(-capacity());
                     if (!parent.offerToQueue(this)) {
                         // The central queue is full. Ensure we release again as we previously did use resetRefCnt()
                         // which did increase the reference count by 1.


### PR DESCRIPTION
…ed to central queue (#14508)

Motivation:

For `AdaptivePoolingAllocator`, the `magazine.usedMemory` should be decreased when the chunk be deallocated or be offered to the `centralQueue`.

Modification:

Decreased the `magazine.usedMemory` when the chunk be deallocated or be offered to the `centralQueue`.

Result:

The `magazine.usedMemory` becomes more accurate.
