### PR TITLE
AdaptiveByteBufAllocator: Correctly manage used memory strategy in al…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -259,7 +259,7 @@ final class AdaptivePoolingAllocator {
         if (buf != null) {
             Chunk chunk = buf.chunk;
             magazine = chunk != null && chunk != Magazine.MAGAZINE_FREED?
-                    chunk.magazine : getFallbackMagazine(currentThread);
+                    chunk.currentMagazine() : getFallbackMagazine(currentThread);
         } else {
             magazine = getFallbackMagazine(currentThread);
             buf = magazine.newBuffer();
@@ -608,6 +608,8 @@ final class AdaptivePoolingAllocator {
                 curr = parent.centralQueue.poll();
                 if (curr == null) {
                     curr = newChunkAllocation(size);
+                } else {
+                    curr.attachToMagazine(this);
                 }
             }
             current = curr;
@@ -660,10 +662,17 @@ final class AdaptivePoolingAllocator {
         }
 
         private void transferChunk(Chunk current) {
-            if (NEXT_IN_LINE.compareAndSet(this, null, current)
-                    || parent.offerToQueue(current)) {
+            if (NEXT_IN_LINE.compareAndSet(this, null, current)) {
                 return;
             }
+
+            // Detach the chunk as we are about to offer it back for reuse.
+            current.detachFromMagazine();
+            if (parent.offerToQueue(current)) {
+                return;
+            }
+            // Attach it again
+            current.attachToMagazine(this);
             Chunk nextChunk = NEXT_IN_LINE.get(this);
             if (nextChunk != null && nextChunk != MAGAZINE_FREED
                     && current.remainingCapacity() > nextChunk.remainingCapacity()) {
@@ -720,7 +729,8 @@ final class AdaptivePoolingAllocator {
     private static final class Chunk implements ReferenceCounted {
 
         private final AbstractByteBuf delegate;
-        final Magazine magazine;
+        private Magazine magazine;
+        private final AdaptivePoolingAllocator allocator;
         private final int capacity;
         private final boolean pooled;
         private int allocatedBytes;
@@ -749,17 +759,33 @@ final class AdaptivePoolingAllocator {
             // Constructor only used by the MAGAZINE_FREED sentinel.
             delegate = null;
             magazine = null;
+            allocator = null;
             capacity = 0;
             pooled = false;
         }
 
         Chunk(AbstractByteBuf delegate, Magazine magazine, boolean pooled) {
             this.delegate = delegate;
-            this.magazine = magazine;
             this.pooled = pooled;
             capacity = delegate.capacity();
-            magazine.usedMemory.getAndAdd(capacity);
             updater.setInitialValue(this);
+            allocator = magazine.parent;
+            attachToMagazine(magazine);
+        }
+
+        Magazine currentMagazine()  {
+            return magazine;
+        }
+
+        void detachFromMagazine() {
+            magazine.usedMemory.getAndAdd(-capacity);
+            magazine = null;
+        }
+
+        void attachToMagazine(Magazine magazine) {
+            assert this.magazine == null;
+            this.magazine = magazine;
+            magazine.usedMemory.getAndAdd(capacity);
         }
 
         @Override
@@ -813,7 +839,7 @@ final class AdaptivePoolingAllocator {
             if (!pooled || memSize < chunkSize || memSize > chunkSize + (chunkSize >> 1)) {
                 // Drop the chunk if the parent allocator is closed, or if the chunk is smaller than the
                 // preferred chunk size, or over 50% larger than the preferred chunk size.
-                mag.usedMemory.getAndAdd(-capacity());
+                detachFromMagazine();
                 delegate.release();
             } else {
                 updater.resetRefCnt(this);
@@ -821,7 +847,7 @@ final class AdaptivePoolingAllocator {
                 allocatedBytes = 0;
                 if (!mag.trySetNextInLine(this)) {
                     // As this Chunk does not belong to the mag anymore we need to decrease the used memory .
-                    mag.usedMemory.getAndAdd(-capacity());
+                    detachFromMagazine();
                     if (!parent.offerToQueue(this)) {
                         // The central queue is full. Ensure we release again as we previously did use resetRefCnt()
                         // which did increase the reference count by 1.
@@ -920,8 +946,7 @@ final class AdaptivePoolingAllocator {
             data.clear();
             tmpNioBuf = null;
             Chunk chunk = this.chunk;
-            Magazine magazine = chunk.magazine;
-            AdaptivePoolingAllocator allocator = magazine.parent;
+            AdaptivePoolingAllocator allocator = chunk.allocator;
             int readerIndex = this.readerIndex;
             int writerIndex = this.writerIndex;
             allocator.allocate(newCapacity, maxCapacity(), this);

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -779,8 +779,10 @@ final class AdaptivePoolingAllocator {
         }
 
         void detachFromMagazine() {
-            magazine.usedMemory.getAndAdd(-capacity);
-            magazine = null;
+            if (magazine != null) {
+                magazine.usedMemory.getAndAdd(-capacity);
+                magazine = null;
+            }
         }
 
         void attachToMagazine(Magazine magazine) {

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -258,8 +258,9 @@ final class AdaptivePoolingAllocator {
         Magazine magazine;
         if (buf != null) {
             Chunk chunk = buf.chunk;
-            magazine = chunk != null && chunk != Magazine.MAGAZINE_FREED?
-                    chunk.currentMagazine() : getFallbackMagazine(currentThread);
+            if (chunk == null || chunk == Magazine.MAGAZINE_FREED || (magazine = chunk.currentMagazine()) == null) {
+                magazine = getFallbackMagazine(currentThread);
+            }
         } else {
             magazine = getFallbackMagazine(currentThread);
             buf = magazine.newBuffer();


### PR DESCRIPTION
…l cases

Motivation:

The allocator uses different strategies when it comes to reusing previous allocated Chunks. In some cases we did not always correctly increment / degrement the zsed memory counters.

Modifications;

- Correctly update counters in all cases
- Null out attached Magazine before adding Chunk to central queue

Result:

Fixes https://github.com/netty/netty/issues/14513