### PR TITLE
IoUring: Refactor IoUringIoOps to better match the underlying io_urin…

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -253,7 +253,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
         if (registration != null) {
             if (socket.markClosed()) {
                 int fd = fd().intValue();
-                IoUringIoOps ops = IoUringIoOps.newClose(fd, 0, nextOpsId());
+                IoUringIoOps ops = IoUringIoOps.newClose(fd, (byte) 0, nextOpsId());
                 registration.submit(ops);
             }
         } else {
@@ -345,7 +345,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
         int fd = fd().intValue();
         IoUringIoRegistration registration = registration();
         IoUringIoOps ops = IoUringIoOps.newPollAdd(
-                fd, 0, Native.POLLOUT, (short) Native.POLLOUT);
+                fd, (byte) 0, Native.POLLOUT, (short) Native.POLLOUT);
         pollOutId = registration.submit(ops);
         if (pollOutId != 0) {
             ioState |= POLL_OUT_SCHEDULED;
@@ -357,7 +357,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
         int fd = fd().intValue();
         IoUringIoRegistration registration = registration();
         IoUringIoOps ops = IoUringIoOps.newPollAdd(
-                fd, 0, Native.POLLRDHUP, (short) Native.POLLRDHUP);
+                fd, (byte) 0, Native.POLLRDHUP, (short) Native.POLLRDHUP);
         pollRdhupId = registration.submit(ops);
         if (pollRdhupId != 0) {
             ioState |= POLL_RDHUP_SCHEDULED;
@@ -533,7 +533,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
                         int fd = fd().intValue();
                         // Best effort to cancel the already submitted connect request.
                         registration.submit(IoUringIoOps.newAsyncCancel(
-                                fd, 0, connectId, Native.IORING_OP_CONNECT));
+                                fd, (byte) 0, connectId, Native.IORING_OP_CONNECT));
                     }
                     cancelOutstandingReads(registration, numOutstandingReads);
                     cancelOutstandingWrites(registration, numOutstandingWrites);
@@ -663,7 +663,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
             int fd = fd().intValue();
             IoUringIoRegistration registration = registration();
             IoUringIoOps ops = IoUringIoOps.newPollAdd(
-                    fd, 0, Native.POLLIN, (short) Native.POLLIN);
+                    fd, (byte) 0, Native.POLLIN, (short) Native.POLLIN);
             pollInId = registration.submit(ops);
             if (pollInId != 0) {
                 ioState |= POLL_IN_SCHEDULED;
@@ -982,7 +982,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
 
                     int fd = fd().intValue();
                     IoUringIoRegistration registration = registration();
-                    IoUringIoOps ops = IoUringIoOps.newSendmsg(fd, 0, Native.MSG_FASTOPEN,
+                    IoUringIoOps ops = IoUringIoOps.newSendmsg(fd, (byte) 0, Native.MSG_FASTOPEN,
                             hdr.address(), hdr.idx());
                     connectId = registration.submit(ops);
                 } else {
@@ -1038,7 +1038,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
         int fd = fd().intValue();
         IoUringIoRegistration registration = registration();
         IoUringIoOps ops = IoUringIoOps.newConnect(
-                fd, 0, remoteAddressMemoryAddress, nextOpsId());
+                fd, (byte) 0, remoteAddressMemoryAddress, nextOpsId());
         connectId = registration.submit(ops);
     }
 
@@ -1075,21 +1075,21 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
         int fd = fd().intValue();
         if ((ioState & POLL_RDHUP_SCHEDULED) != 0) {
             registration.submit(IoUringIoOps.newPollRemove(
-                    fd, 0, pollRdhupId, (short) Native.POLLRDHUP));
+                    fd, (byte) 0, pollRdhupId, (short) Native.POLLRDHUP));
         }
         if ((ioState & POLL_IN_SCHEDULED) != 0) {
             registration.submit(IoUringIoOps.newPollRemove(
-                    fd, 0, pollInId, (short) Native.POLLIN));
+                    fd, (byte) 0, pollInId, (short) Native.POLLIN));
         }
         if ((ioState & POLL_OUT_SCHEDULED) != 0) {
             registration.submit(IoUringIoOps.newPollRemove(
-                    fd,  0, pollOutId, (short) Native.POLLOUT));
+                    fd,  (byte) 0, pollOutId, (short) Native.POLLOUT));
         }
 
         if (AbstractIoUringChannel.this.connectPromise != null && connectId != 0) {
             // Best effort to cancel the already submitted connect request.
             registration.submit(IoUringIoOps.newAsyncCancel(
-                    fd, 0, connectId, Native.IORING_OP_CONNECT));
+                    fd, (byte) 0, connectId, Native.IORING_OP_CONNECT));
         }
         cancelOutstandingReads(registration, numOutstandingReads);
         cancelOutstandingWrites(registration, numOutstandingWrites);

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringServerChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringServerChannel.java
@@ -80,7 +80,7 @@ abstract class AbstractIoUringServerChannel extends AbstractIoUringChannel imple
             assert numOutstandingReads == 1;
             int fd = fd().intValue();
             IoUringIoOps ops = IoUringIoOps.newAsyncCancel(
-                    fd, 0, acceptId, Native.IORING_OP_ACCEPT);
+                    fd, (byte) 0, acceptId, Native.IORING_OP_ACCEPT);
             registration.submit(ops);
         } else {
             assert numOutstandingReads == 0;
@@ -120,7 +120,7 @@ abstract class AbstractIoUringServerChannel extends AbstractIoUringChannel imple
 
             int fd = fd().intValue();
             IoUringIoRegistration registration = registration();
-            IoUringIoOps ops = IoUringIoOps.newAccept(fd, 0, 0,
+            IoUringIoOps ops = IoUringIoOps.newAccept(fd, (byte) 0, 0,
                     acceptedAddressMemoryAddress, acceptedAddressLengthMemoryAddress, nextOpsId());
             acceptId = registration.submit(ops);
             return 1;

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -234,7 +234,7 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
 
                 int fd = fd().intValue();
                 IoUringIoRegistration registration = registration();
-                IoUringIoOps ops = IoUringIoOps.newWritev(fd, 0, 0, iovArray.memoryAddress(offset),
+                IoUringIoOps ops = IoUringIoOps.newWritev(fd, (byte) 0, 0, iovArray.memoryAddress(offset),
                         iovArray.count() - offset, nextOpsId());
                 byte opCode = ops.opcode();
                 writeId = registration.submit(ops);
@@ -271,7 +271,7 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
                 ops = fileRegion.splice(fd);
             } else {
                 ByteBuf buf = (ByteBuf) msg;
-                ops = IoUringIoOps.newWrite(fd, 0, 0,
+                ops = IoUringIoOps.newWrite(fd, (byte) 0, 0,
                         buf.memoryAddress() + buf.readerIndex(), buf.readableBytes(), nextOpsId());
             }
 
@@ -301,7 +301,7 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
                 // be possible directly we schedule these with Native.MSG_DONTWAIT. This allows us to still be
                 // able to signal the fireChannelReadComplete() in a timely manner and be consistent with other
                 // transports.
-                IoUringIoOps ops = IoUringIoOps.newRecv(fd, 0, first ? 0 : Native.MSG_DONTWAIT,
+                IoUringIoOps ops = IoUringIoOps.newRecv(fd, (byte) 0, first ? 0 : Native.MSG_DONTWAIT,
                         byteBuf.memoryAddress() + byteBuf.writerIndex(), byteBuf.writableBytes(), nextOpsId());
                 readId = registration.submit(ops);
                 if (readId == 0) {
@@ -456,7 +456,7 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
             // Let's try to cancel outstanding reads as these might be submitted and waiting for data (via fastpoll).
             assert numOutstandingReads == 1;
             int fd = fd().intValue();
-            IoUringIoOps ops = IoUringIoOps.newAsyncCancel(fd, 0, readId, Native.IORING_OP_RECV);
+            IoUringIoOps ops = IoUringIoOps.newAsyncCancel(fd, (byte) 0, readId, Native.IORING_OP_RECV);
             registration.submit(ops);
         } else {
             assert numOutstandingReads == 0;
@@ -471,7 +471,7 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
             assert numOutstandingWrites == 1;
             assert writeOpCode != 0;
             int fd = fd().intValue();
-            registration.submit(IoUringIoOps.newAsyncCancel(fd, 0, writeId, writeOpCode));
+            registration.submit(IoUringIoOps.newAsyncCancel(fd, (byte) 0, writeId, writeOpCode));
         } else {
             assert numOutstandingWrites == 0;
         }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
@@ -499,7 +499,8 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
             IoUringIoRegistration registration = registration();
             // We always use idx here so we can detect if no idx was used by checking if data < 0 in
             // readComplete0(...)
-            IoUringIoOps ops = IoUringIoOps.newRecvmsg(fd, 0, msgFlags, msgHdrMemory.address(), msgHdrMemory.idx());
+            IoUringIoOps ops = IoUringIoOps.newRecvmsg(
+                    fd, (byte) 0, msgFlags, msgHdrMemory.address(), msgHdrMemory.idx());
             long id = registration.submit(ops);
             if (id == 0) {
                 return false;
@@ -601,7 +602,7 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
             int fd = fd().intValue();
             int msgFlags = first ? 0 : Native.MSG_DONTWAIT;
             IoUringIoRegistration registration = registration();
-            IoUringIoOps ops = IoUringIoOps.newSendmsg(fd, 0, msgFlags, hdr.address(), hdr.idx());
+            IoUringIoOps ops = IoUringIoOps.newSendmsg(fd, (byte) 0, msgFlags, hdr.address(), hdr.idx());
             long id = registration.submit(ops);
             if (id == 0) {
                 return false;
@@ -663,7 +664,7 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
             }
             // Let's try to cancel outstanding op as these might be submitted and waiting for data
             // (via fastpoll).
-            IoUringIoOps ops = IoUringIoOps.newAsyncCancel(fd, 0, id, op);
+            IoUringIoOps ops = IoUringIoOps.newAsyncCancel(fd, (byte) 0, id, op);
             registration.submit(ops);
             cancelled++;
         }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -145,7 +145,7 @@ public final class IoUringIoHandler implements IoHandler {
 
         List<DefaultIoUringIoRegistration> copy = new ArrayList<>(registrations.values());
         // Ensure all previously submitted IOs get to complete before closing all fds.
-        submissionQueue.addNop(ringBuffer.fd(), Native.IOSQE_IO_DRAIN, RINGFD_ID, (short) 0);
+        submissionQueue.addNop(ringBuffer.fd(), (byte) Native.IOSQE_IO_DRAIN, RINGFD_ID, (short) 0);
 
         for (DefaultIoUringIoRegistration registration: copy) {
             registration.close();
@@ -169,7 +169,7 @@ public final class IoUringIoHandler implements IoHandler {
             submissionQueue.submit();
         }
         // Try to drain all the IO from the queue first...
-        submissionQueue.addNop(ringBuffer.fd(), Native.IOSQE_IO_DRAIN, RINGFD_ID, (short) 0);
+        submissionQueue.addNop(ringBuffer.fd(), (byte) Native.IOSQE_IO_DRAIN, RINGFD_ID, (short) 0);
         // ... but only wait for 200 milliseconds on this
         submissionQueue.addLinkTimeout(ringBuffer.fd(), TimeUnit.MILLISECONDS.toNanos(200), RINGFD_ID, (short) 0);
         submissionQueue.submitAndWait();
@@ -306,8 +306,8 @@ public final class IoUringIoHandler implements IoHandler {
 
         private void submit0(IoUringIoOps ioOps, long udata) {
             ringBuffer.ioUringSubmissionQueue().enqueueSqe(ioOps.opcode(), ioOps.flags(), ioOps.ioPrio(),
-                    ioOps.rwFlags(), ioOps.fd(), ioOps.bufferAddress(),
-                    ioOps.length(), ioOps.offset(), udata, ioOps.spliceFdIn()
+                    ioOps.fd(), ioOps.union1(), ioOps.union2(), ioOps.len(), ioOps.union3(), udata,
+                    ioOps.union4(), ioOps.personality(), ioOps.union5(), ioOps.union6()
             );
             outstandingCompletions++;
         }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/SubmissionQueue.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/SubmissionQueue.java
@@ -38,14 +38,15 @@ final class SubmissionQueue {
     private static final int SQE_FLAGS_FIELD = 1;
     private static final int SQE_IOPRIO_FIELD = 2; // u16
     private static final int SQE_FD_FIELD = 4; // s32
-    private static final int SQE_OFFSET_FIELD = 8;
-    private static final int SQE_ADDRESS_FIELD = 16;
+    private static final int SQE_UNION1_FIELD = 8;
+    private static final int SQE_UNION2_FIELD = 16;
     private static final int SQE_LEN_FIELD = 24;
-    private static final int SQE_RW_FLAGS_FIELD = 28;
+    private static final int SQE_UNION3_FIELD = 28;
     private static final int SQE_USER_DATA_FIELD = 32;
-    private static final int SQE_FIXED_BUFFER = 40;
-    private static final int SQE_PERSONALITY = 42;
-    private static final int SQE_SPLICE_FD_IN = 44;
+    private static final int SQE_UNION4_FIELD = 40;
+    private static final int SQE_PERSONALITY_FIELD = 42;
+    private static final int SQE_UNION5_FIELD = 44;
+    private static final int SQE_UNION6_FIELD = 48;
 
     private static final int KERNEL_TIMESPEC_TV_SEC_FIELD = 0;
     private static final int KERNEL_TIMESPEC_TV_NSEC_FIELD = 8;
@@ -110,8 +111,8 @@ final class SubmissionQueue {
         assert numHandledFds >= 0;
     }
 
-    private long enqueueSqe(byte op, int flags, short ioPrio, int rwFlags, int fd,
-                               long bufferAddress, int length, long offset, int id, short data, int spliceIn) {
+    private long enqueueSqe0(int id, byte opcode, byte flags, short ioPrio, int fd, long union1, long union2, int len,
+                             int union3, short data, short union4, short personality, int union5, long union6) {
         int pending = tail - head;
         if (pending == ringEntries) {
             int submitted = submit();
@@ -121,14 +122,14 @@ final class SubmissionQueue {
             }
         }
         long sqe = submissionQueueArrayAddress + (tail++ & ringMask) * SQE_SIZE;
-        long udata = UserData.encode(id, op, data);
-        setData(sqe, op, flags, ioPrio, rwFlags, fd,
-                bufferAddress, length, offset, udata, spliceIn);
+        long udata = UserData.encode(id, opcode, data);
+        setData(sqe, opcode, flags, ioPrio, fd, union1, union2, len,
+                union3, udata, union4, personality, union5, union6);
         return udata;
     }
 
-    void enqueueSqe(byte op, int flags, short ioPrio, int rwFlags, int fd,
-                    long bufferAddress, int length, long offset, long udata, int spliceIn) {
+    void enqueueSqe(byte opcode, byte flags, short ioPrio, int fd, long union1, long union2, int len, int union3,
+                    long udata, short union4, short personality, int union5, long union6) {
         int pending = tail - head;
         if (pending == ringEntries) {
             int submitted = submit();
@@ -138,32 +139,36 @@ final class SubmissionQueue {
             }
         }
         long sqe = submissionQueueArrayAddress + (tail++ & ringMask) * SQE_SIZE;
-        setData(sqe, op, flags, ioPrio, rwFlags, fd, bufferAddress, length, offset, udata, spliceIn);
+        setData(sqe, opcode, flags, ioPrio, fd, union1, union2, len,
+                union3, udata, union4, personality, union5, union6);
     }
 
-    private void setData(long sqe, byte op, int flags, short ioPrio, int rwFlags, int fd, long bufferAddress,
-                         int length, long offset, long udata, int spliceIn) {
+    private void setData(long sqe, byte opcode, byte flags, short ioPrio, int fd, long union1, long union2, int len,
+                         int union3, long udata, short union4, short personality, int union5, long union6) {
         //set sqe(submission queue) properties
 
-        PlatformDependent.putByte(sqe + SQE_OP_CODE_FIELD, op);
-        PlatformDependent.putByte(sqe + SQE_FLAGS_FIELD, (byte) flags);
+        PlatformDependent.putByte(sqe + SQE_OP_CODE_FIELD, opcode);
+        PlatformDependent.putByte(sqe + SQE_FLAGS_FIELD, flags);
         // This constant is set up-front
         PlatformDependent.putShort(sqe + SQE_IOPRIO_FIELD, ioPrio);
         PlatformDependent.putInt(sqe + SQE_FD_FIELD, fd);
-        PlatformDependent.putLong(sqe + SQE_OFFSET_FIELD, offset);
-        PlatformDependent.putLong(sqe + SQE_ADDRESS_FIELD, bufferAddress);
-        PlatformDependent.putInt(sqe + SQE_LEN_FIELD, length);
-        PlatformDependent.putInt(sqe + SQE_RW_FLAGS_FIELD, rwFlags);
+        PlatformDependent.putLong(sqe + SQE_UNION1_FIELD, union1);
+        PlatformDependent.putLong(sqe + SQE_UNION2_FIELD, union2);
+        PlatformDependent.putInt(sqe + SQE_LEN_FIELD, len);
+        PlatformDependent.putInt(sqe + SQE_UNION3_FIELD, union3);
         PlatformDependent.putLong(sqe + SQE_USER_DATA_FIELD, udata);
-        PlatformDependent.putInt(sqe + SQE_SPLICE_FD_IN, spliceIn);
+        PlatformDependent.putShort(sqe + SQE_UNION4_FIELD, union4);
+        PlatformDependent.putShort(sqe + SQE_PERSONALITY_FIELD, personality);
+        PlatformDependent.putInt(sqe + SQE_UNION5_FIELD, union5);
+        PlatformDependent.putLong(sqe + SQE_UNION6_FIELD, union6);
 
         if (logger.isTraceEnabled()) {
-            if (op == Native.IORING_OP_WRITEV || op == Native.IORING_OP_READV) {
+            if (opcode == Native.IORING_OP_WRITEV || opcode == Native.IORING_OP_READV) {
                 logger.trace("add(ring {}): {}(fd={}, len={} ({} bytes), off={}, data={})",
-                        ringFd, Native.opToStr(op), fd, length, Iov.sumSize(bufferAddress, length), offset, udata);
+                        ringFd, Native.opToStr(opcode), fd, len, Iov.sumSize(union2, len), union1, udata);
             } else {
                 logger.trace("add(ring {}): {}(fd={}, len={}, off={}, data={})",
-                        ringFd, Native.opToStr(op), fd, length, offset, udata);
+                        ringFd, Native.opToStr(opcode), fd, len, union1, udata);
             }
         }
     }
@@ -180,29 +185,31 @@ final class SubmissionQueue {
         return sb.toString();
     }
 
-    long addNop(int fd, int flags, int id, short data) {
-        return enqueueSqe(Native.IORING_OP_NOP, flags, (short) 0, 0, fd, 0, 0, 0, id, data, 0);
+    long addNop(int fd, byte flags, int id, short data) {
+        return enqueueSqe0(id, Native.IORING_OP_NOP, flags, (short) 0, fd, 0, 0, 0, 0, data,
+                (short) 0, (short) 0, 0, 0);
     }
 
     long addTimeout(int fd, long nanoSeconds, int id, short extraData) {
         setTimeout(nanoSeconds);
-        return enqueueSqe(Native.IORING_OP_TIMEOUT, 0, (short) 0, 0, fd,
-                timeoutMemoryAddress, 1, 0, id, extraData, 0);
+        return enqueueSqe0(id, Native.IORING_OP_TIMEOUT, (byte) 0, (short) 0, fd, 0, timeoutMemoryAddress, 1,
+                0, extraData, (short) 0, (short) 0, 0, 0);
     }
 
     long addLinkTimeout(int fd, long nanoSeconds, int id, short extraData) {
         setTimeout(nanoSeconds);
-        return enqueueSqe(Native.IORING_OP_LINK_TIMEOUT, 0, (short) 0, 0, fd,
-                timeoutMemoryAddress, 1, 0, id, extraData, 0);
+        return enqueueSqe0(id, Native.IORING_OP_LINK_TIMEOUT, (byte) 0, (short) 0, fd, 0, timeoutMemoryAddress, 1,
+                0, extraData, (short) 0, (short) 0, 0, 0);
     }
 
     long addEventFdRead(int fd, long bufferAddress, int pos, int limit, int id, short extraData) {
-        return enqueueSqe(Native.IORING_OP_READ, 0, (short) 0, 0, fd,
-                bufferAddress + pos, limit - pos, 0, id, extraData, 0);
+        return enqueueSqe0(id, Native.IORING_OP_READ, (byte) 0, (short) 0, fd, 0, bufferAddress + pos, limit - pos,
+                0, extraData, (short) 0, (short) 0, 0, 0);
     }
 
     long addCancel(int fd, long sqeToCancel, int id) {
-        return enqueueSqe(Native.IORING_OP_ASYNC_CANCEL, 0, (short) 0, 0, fd, sqeToCancel, 0, 0, id, (short) 0, 0);
+        return enqueueSqe0(id, Native.IORING_OP_ASYNC_CANCEL, (byte) 0, (short) 0, fd, 0, sqeToCancel, 0, 0,
+                (short) 0, (short) 0, (short) 0, 0, 0);
     }
 
     int submit() {

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/SubmissionQueueTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/SubmissionQueueTest.java
@@ -43,12 +43,12 @@ public class SubmissionQueueTest {
 
             int counter = 0;
             while (submissionQueue.remaining() > 0) {
-                assertThat(submissionQueue.addNop(0, 0, 0, (short) 1)).isNotZero();
+                assertThat(submissionQueue.addNop(0, (byte) 0, 0, (short) 1)).isNotZero();
                 counter++;
             }
             assertEquals(8, counter);
             assertEquals(8, submissionQueue.count());
-            assertThat(submissionQueue.addNop(0, 0, 0, (short) 1)).isNotZero();
+            assertThat(submissionQueue.addNop(0, (byte) 0, 0, (short) 1)).isNotZero();
             assertEquals(1, submissionQueue.count());
             submissionQueue.submitAndWait();
             assertEquals(9, completionQueue.count());


### PR DESCRIPTION
…g_sqe

Modification:

We should be able to support any io_uring operation in the future for this we should allow to setup the right struct.

Modifications:

- Change constructor to match underlying struct
- Remove public getters as these are only used internally and might change in the future
- Rename static fields

Result:

More flexible implementation for io_uring