### PR TITLE
IoUring: Ensure buffers don't leak if submission fails

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -348,7 +348,9 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
         IoUringIoOps ops = IoUringIoOps.newPollAdd(
                 fd, 0, Native.POLLOUT, (short) Native.POLLOUT);
         pollOutId = registration.submit(ops);
-        ioState |= POLL_OUT_SCHEDULED;
+        if (pollOutId != 0) {
+            ioState |= POLL_OUT_SCHEDULED;
+        }
     }
 
     final void schedulePollRdHup() {
@@ -358,7 +360,9 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
         IoUringIoOps ops = IoUringIoOps.newPollAdd(
                 fd, 0, Native.POLLRDHUP, (short) Native.POLLRDHUP);
         pollRdhupId = registration.submit(ops);
-        ioState |= POLL_RDHUP_SCHEDULED;
+        if (pollRdhupId != 0) {
+            ioState |= POLL_RDHUP_SCHEDULED;
+        }
     }
 
     final void resetCachedAddresses() {
@@ -654,7 +658,9 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
             IoUringIoOps ops = IoUringIoOps.newPollAdd(
                     fd, 0, Native.POLLIN, (short) Native.POLLIN);
             pollInId = registration.submit(ops);
-            ioState |= POLL_IN_SCHEDULED;
+            if (pollInId != 0) {
+                ioState |= POLL_IN_SCHEDULED;
+            }
         }
 
         private void readComplete(byte op, int res, int flags, short data) {
@@ -973,8 +979,9 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
                 } else {
                     submitConnect(inetSocketAddress);
                 }
-
-                ioState |= CONNECT_SCHEDULED;
+                if (connectId != 0) {
+                    ioState |= CONNECT_SCHEDULED;
+                }
             } catch (Throwable t) {
                 closeIfClosed();
                 promise.tryFailure(annotateConnectException(t, remoteAddress));

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
@@ -501,6 +501,9 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
             // readComplete0(...)
             IoUringIoOps ops = IoUringIoOps.newRecvmsg(fd, 0, msgFlags, msgHdrMemory.address(), msgHdrMemory.idx());
             long id = registration.submit(ops);
+            if (id == 0) {
+                return false;
+            }
             recvmsgHdrs.setId(msgHdrMemory.idx(), id);
             return true;
         }
@@ -600,6 +603,9 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
             IoUringIoRegistration registration = registration();
             IoUringIoOps ops = IoUringIoOps.newSendmsg(fd, 0, msgFlags, hdr.address(), hdr.idx());
             long id = registration.submit(ops);
+            if (id == 0) {
+                return false;
+            }
             sendmsgHdrs.setId(hdr.idx(), id);
             return true;
         }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoRegistration.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoRegistration.java
@@ -28,7 +28,8 @@ public interface IoUringIoRegistration extends IoRegistration {
      *
      * @param   ops ops.
      * @return  the u_data of the {@link IoUringIoOps}. This can be used to cancel a previous submitted
-     * {@link IoUringIoOps}.
+     * {@link IoUringIoOps}. If submission failed as the registration is not valid anymore this method will return
+     * {@code 0}.
      */
     @Override
     long submit(IoOps ops);


### PR DESCRIPTION
Motivation:

When the submission fails we need to ensure we not leak the read buffer

Modification:

- Return 0 when submission fails
- Release buffer if submission fails
- Only update internal state if submission is successful

Result:

No more leaks

