### PR TITLE
IoUring: Reuse the pipeFd and cache it in the channel

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringFileRegion.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringFileRegion.java
@@ -39,10 +39,10 @@ final class IoUringFileRegion implements FileRegion {
         this.fileRegion = fileRegion;
     }
 
-    void open() throws IOException {
+    void open(FileDescriptor[] pipe) throws IOException {
         fileRegion.open();
-        if (pipe == null) {
-            pipe = FileDescriptor.pipe();
+        if (this.pipe == null) {
+            this.pipe = pipe;
         }
     }
 
@@ -158,7 +158,6 @@ final class IoUringFileRegion implements FileRegion {
     @Override
     public boolean release() {
         if (fileRegion.release()) {
-            closePipeIfNeeded();
             return true;
         }
         return false;
@@ -167,24 +166,9 @@ final class IoUringFileRegion implements FileRegion {
     @Override
     public boolean release(int decrement) {
         if (fileRegion.release(decrement)) {
-            closePipeIfNeeded();
             return true;
         }
         return false;
     }
 
-    private void closePipeIfNeeded() {
-        if (pipe != null) {
-            closeSilently(pipe[0]);
-            closeSilently(pipe[1]);
-        }
-    }
-
-    private static void closeSilently(FileDescriptor fd) {
-        try {
-            fd.close();
-        } catch (IOException e) {
-            logger.debug("Error while closing a pipe", e);
-        }
-    }
 }


### PR DESCRIPTION
Motivation:

I think it's possible to initialize a pair of pipes lazily and then store them in the channel so that they can be reused multiple times.
Just like the pipeIn and pipeOut in AbstractEpollStreamChannel.

``` java
  // Lazy init these if we need to splice(...)
    private FileDescriptor pipeIn;
    private FileDescriptor pipeOut;

  // We create the pipe on the target channel as this will allow us to just handle pending writes
                // later in a correct fashion without get into any ordering issues when spliceTo(...) is called
                // on multiple Channels pointing to one target Channel.
                FileDescriptor pipeOut = ch.pipeOut;
                if (pipeOut == null) {
                    // Create a new pipe as non was created before.
                    FileDescriptor[] pipe = pipe();
                    ch.pipeIn = pipe[0];
                    pipeOut = ch.pipeOut = pipe[1];
                }

``` 

Modification:

Reuse the pipeFd and cache it in the channel

Result:

https://github.com/netty/netty/pull/14487#discussion_r1860778681