### PR TITLE
IoUring: Add assert to ensure the buffer is never leaked

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -448,6 +448,12 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
             }
             return true;
         }
+
+        @Override
+        protected void freeResourcesNow(IoUringIoRegistration reg) {
+            super.freeResourcesNow(reg);
+            assert readBuffer == null;
+        }
     }
 
     @Override


### PR DESCRIPTION
Motivation:
    
The readBuffer should be always released or hand-over before we free everything else
 
Modifications:
    
Add assert
    
Result:
    
Be sure we correctly handle the readBuffer