### PR TITLE
IoUring: Correct update internal state for cancelled operations

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringServerChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringServerChannel.java
@@ -62,8 +62,6 @@ abstract class AbstractIoUringServerChannel extends AbstractIoUringChannel imple
     @Override
     protected final void doClose() throws Exception {
         super.doClose();
-        Buffer.free(acceptedAddressMemory);
-        Buffer.free(acceptedAddressLengthMemory);
     }
 
     @Override
@@ -170,6 +168,13 @@ abstract class AbstractIoUringServerChannel extends AbstractIoUringChannel imple
         public void connect(final SocketAddress remoteAddress, final SocketAddress localAddress,
                             final ChannelPromise promise) {
             promise.setFailure(new UnsupportedOperationException());
+        }
+
+        @Override
+        protected void freeResourcesNow(IoUringIoRegistration reg) {
+            super.freeResourcesNow(reg);
+            Buffer.free(acceptedAddressMemory);
+            Buffer.free(acceptedAddressLengthMemory);
         }
     }
 }


### PR DESCRIPTION
Motivation:

Even if an operation was cancelled we need to handle it as executed and not scheduled anymore

Modifications:

- Always update state before return early.
- Correctly free resources even if the Channel was never registered

Result:

Correctly handled cancelled operations
