### PR TITLE
IoUring: Use 0 as MsgHdrMemoryArray.NO_ID

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
@@ -417,7 +417,7 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
             }
 
             // Reset the id as this read was completed and so don't need to be cancelled later.
-            recvmsgHdrs.setId(idx, -1);
+            recvmsgHdrs.setId(idx, MsgHdrMemoryArray.NO_ID);
             if (outstanding == 0) {
                 // There are no outstanding completion events, release the readBuffer and see if we need to schedule
                 // another one or if the user will do it.

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoRegistration.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoRegistration.java
@@ -34,5 +34,6 @@ public interface IoUringIoRegistration extends IoRegistration {
     @Override
     long submit(IoOps ops);
 
+    @Override
     void cancel();
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/MsgHdrMemoryArray.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/MsgHdrMemoryArray.java
@@ -18,7 +18,7 @@ package io.netty.channel.uring;
 import java.util.Arrays;
 
 final class MsgHdrMemoryArray {
-    static final long NO_ID = -1;
+    static final long NO_ID = 0;
 
     private final MsgHdrMemory[] hdrs;
     private final int capacity;


### PR DESCRIPTION
Motivation:

0 is not a valid id that is returned by IoUringRegistration.submit(...) so use the same value as MsgHsrMemoryArray.NO_ID

Modifications:

- Replaece usage of -1 by 0

Result:

No risk of misshandling correct ids