### PR TITLE
IoUring: Correctly handle cancelletion of close and connect

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -896,10 +896,6 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
                 // connect not complete yet need to wait for poll_out event
                 schedulePollOut();
             } else {
-                if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
-                    // Operation was cancelled, just return.
-                    return;
-                }
                 try {
                     if (res == 0) {
                         fulfillConnectPromise(connectPromise, active);


### PR DESCRIPTION
Motivation:

When a close op is cancelled we need to not handle it the same as when it failed / worked. Also when a connect is cancelled we need to ensure we not cancel the connect timeout ans also not null out the connect promise.

Modification:

Correct handle cancellation.

Result:

Handle cancellation of ops correctly