### PR TITLE
IoUring: IoUringRegistration.cancel() didn't remove registration when…

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -319,7 +319,8 @@ public final class IoUringIoHandler implements IoHandler {
 
         @Override
         public void cancel() {
-            if (cancellationPromise.trySuccess(null)) {
+            if (!cancellationPromise.trySuccess(null)) {
+                // Already cancelled.git
                 return;
             }
             if (eventLoop.inEventLoop()) {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -320,7 +320,7 @@ public final class IoUringIoHandler implements IoHandler {
         @Override
         public void cancel() {
             if (!cancellationPromise.trySuccess(null)) {
-                // Already cancelled.git
+                // Already cancelled.
                 return;
             }
             if (eventLoop.inEventLoop()) {


### PR DESCRIPTION
… called only once

Motivation:

There was a bug in the cancel() method that did let it return early by mistake on the first call while it should have only returned early after the first call. This resulted into registrations to not be removed either completely or not in a timely fashion.

Modifications:

Fix early return.

Result:

Registrations are removed correctly