### PR TITLE
IoUring: IoUringHandler must not manually cancel IoUringHandle on tea…

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -352,12 +352,9 @@ public final class IoUringIoHandler implements IoHandler {
         }
 
         void close() {
+            // Closing the handle will also cancel the registration.
+            // It's important that we not manually cancel as close() might need to submit some work to the ring.
             assert eventLoop.inEventLoop();
-            try {
-                cancel();
-            } catch (Exception e) {
-                logger.debug("Exception during canceling " + this, e);
-            }
             try {
                 handle.close();
             } catch (Exception e) {


### PR DESCRIPTION
…rdown

Motiviation:

We must not manually call cancel() before calling IoUringHandle.close() as the close itself might need to submit work to the ring (like cancelling reads).

Modifications:

Remove manual call to cancel()

Result:

IoUringHandler can correctly close its IoUringHandle