### PR TITLE
IoUring: Remove delayed close logic as its not needed

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -250,10 +250,6 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
 
         if (registration != null && registration.isValid()) {
             if (socket.markClosed()) {
-                int fd = fd().intValue();
-                IoUringIoOps ops = IoUringIoOps.newClose(fd, (byte) 0, nextOpsId());
-                registration.submit(ops);
-
                 boolean cancelConnect = false;
                 try {
                     ChannelPromise connectPromise = AbstractIoUringChannel.this.connectPromise;
@@ -270,6 +266,10 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
                     // we will be able to process a delayed close if needed.
                     ioUringUnsafe().cancelOps(cancelConnect);
                 }
+
+                int fd = fd().intValue();
+                IoUringIoOps ops = IoUringIoOps.newClose(fd, (byte) 0, nextOpsId());
+                registration.submit(ops);
             }
         } else {
             // This one was never registered just use a syscall to close.

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -44,7 +44,6 @@ import io.netty.channel.unix.FileDescriptor;
 import io.netty.channel.unix.UnixChannel;
 import io.netty.channel.unix.UnixChannelUtil;
 import io.netty.util.ReferenceCountUtil;
-import io.netty.util.concurrent.PromiseNotifier;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -98,7 +97,6 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
     private boolean readPending;
     private boolean inReadComplete;
 
-    private ChannelPromise delayedClose;
     private boolean inputClosedSeenErrorOnRead;
 
     /**
@@ -250,16 +248,33 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
     protected void doClose() throws Exception {
         active = false;
 
-        if (registration != null) {
+        if (registration != null && registration.isValid()) {
             if (socket.markClosed()) {
                 int fd = fd().intValue();
                 IoUringIoOps ops = IoUringIoOps.newClose(fd, (byte) 0, nextOpsId());
                 registration.submit(ops);
+
+                boolean cancelConnect = false;
+                try {
+                    ChannelPromise connectPromise = AbstractIoUringChannel.this.connectPromise;
+                    if (connectPromise != null) {
+                        // Use tryFailure() instead of setFailure() to avoid the race against cancel().
+                        connectPromise.tryFailure(new ClosedChannelException());
+                        AbstractIoUringChannel.this.connectPromise = null;
+                        cancelConnect = true;
+                    }
+
+                    cancelConnectTimeoutFuture();
+                } finally {
+                    // It's important we cancel all outstanding connect, write and read operations now so
+                    // we will be able to process a delayed close if needed.
+                    ioUringUnsafe().cancelOps(cancelConnect);
+                }
             }
         } else {
             // This one was never registered just use a syscall to close.
             socket.close();
-            ((AbstractUringUnsafe) unsafe()).freeResourcesNowIfNeeded(null);
+            ioUringUnsafe().freeResourcesNowIfNeeded(null);
         }
     }
 
@@ -305,7 +320,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
     }
 
     private int scheduleWrite(ChannelOutboundBuffer in) {
-        if (delayedClose != null || numOutstandingWrites == Short.MAX_VALUE) {
+        if (numOutstandingWrites == Short.MAX_VALUE) {
             return 0;
         }
         if (in == null) {
@@ -401,10 +416,6 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
                 case Native.IORING_OP_RECVMSG:
                 case Native.IORING_OP_READ:
                     readComplete(op, res, flags, data);
-
-                    // We delay the actual close if there is still a write or read scheduled, let's see if there
-                    // was a close that needs to be done now.
-                    handleDelayedClosed();
                     break;
                 case Native.IORING_OP_WRITEV:
                 case Native.IORING_OP_SEND:
@@ -412,10 +423,6 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
                 case Native.IORING_OP_WRITE:
                 case Native.IORING_OP_SPLICE:
                     writeComplete(op, res, flags, data);
-
-                    // We delay the actual close if there is still a write or read scheduled, let's see if there
-                    // was a close that needs to be done now.
-                    handleDelayedClosed();
                     break;
                 case Native.IORING_OP_POLL_ADD:
                     pollAddComplete(res, flags, data);
@@ -429,10 +436,6 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
                     break;
                 case Native.IORING_OP_ASYNC_CANCEL:
                     cancelComplete0(op, res, flags, data);
-
-                    // We delay the actual close if there is still a write or read scheduled, let's see if there
-                    // was a close that needs to be done now.
-                    handleDelayedClosed();
                     break;
                 case Native.IORING_OP_CONNECT:
                     connectComplete(op, res, flags, data);
@@ -443,9 +446,6 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
                     break;
                 case Native.IORING_OP_CLOSE:
                     if (res != Native.ERRNO_ECANCELED_NEGATIVE) {
-                        if (delayedClose != null) {
-                            delayedClose.setSuccess();
-                        }
                         closed = true;
                     }
                     break;
@@ -476,12 +476,6 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
             }
         }
 
-        private void handleDelayedClosed() {
-            if (delayedClose != null && canCloseNow()) {
-                closeNow(newPromise());
-            }
-        }
-
         private void pollAddComplete(int res, int flags, short data) {
             if ((data & Native.POLLOUT) != 0) {
                 pollOut(res);
@@ -497,46 +491,6 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
         @Override
         public final void close() throws Exception {
             close(voidPromise());
-        }
-
-        @Override
-        public final void close(ChannelPromise promise) {
-            if (closeFuture().isDone()) {
-                // Closed already before.
-                safeSetSuccess(promise);
-                return;
-            }
-            if (delayedClose == null) {
-                // We have a write operation pending that should be completed asap.
-                // We will do the actual close operation one this write result is returned as otherwise
-                // we may get into trouble as we may close the fd while we did not process the write yet.
-                delayedClose = promise.isVoid() ? newPromise() : promise;
-            } else {
-                delayedClose.addListener(new PromiseNotifier<>(false, promise));
-                return;
-            }
-
-            boolean cancelConnect = false;
-            try {
-                ChannelPromise connectPromise = AbstractIoUringChannel.this.connectPromise;
-                if (connectPromise != null) {
-                    // Use tryFailure() instead of setFailure() to avoid the race against cancel().
-                    connectPromise.tryFailure(new ClosedChannelException());
-                    AbstractIoUringChannel.this.connectPromise = null;
-                    cancelConnect = true;
-                }
-
-                cancelConnectTimeoutFuture();
-            } finally {
-                // It's important we cancel all outstanding connect, write and read operations now so
-                // we will be able to process a delayed close if needed.
-                cancelOps(cancelConnect);
-            }
-
-            if (canCloseNow()) {
-                // Currently there are is no WRITE and READ scheduled so we can start to teardown the channel.
-                closeNow(newPromise());
-            }
         }
 
         private void cancelOps(boolean cancelConnect) {
@@ -563,16 +517,6 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
             }
             cancelOutstandingReads(registration, numOutstandingReads);
             cancelOutstandingWrites(registration, numOutstandingWrites);
-        }
-
-        private boolean canCloseNow() {
-            // Currently there are is no WRITE and READ scheduled, we can close the channel now without
-            // problems related to re-ordering of completions.
-            return (ioState & (WRITE_SCHEDULED | READ_SCHEDULED)) == 0;
-        }
-
-        private void closeNow(ChannelPromise promise) {
-            super.close(promise);
         }
 
         @Override
@@ -763,7 +707,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
 
         protected final void scheduleRead(boolean first) {
             // Only schedule another read if the fd is still open.
-            if (delayedClose == null && fd().isOpen() && (ioState & READ_SCHEDULED) == 0) {
+            if (fd().isOpen() && (ioState & READ_SCHEDULED) == 0) {
                 numOutstandingReads = (short) scheduleRead0(first);
                 if (numOutstandingReads > 0) {
                     ioState |= READ_SCHEDULED;
@@ -954,7 +898,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
                 return;
             }
 
-            if (delayedClose != null) {
+            if (!isOpen()) {
                 promise.tryFailure(annotateConnectException(new ClosedChannelException(), remoteAddress));
                 return;
             }
@@ -1086,7 +1030,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
     @Override
     protected final void doDeregister() {
         // Cancel all previous submitted ops.
-        ((AbstractUringUnsafe) unsafe()).cancelOps(connectPromise != null);
+        ioUringUnsafe().cancelOps(connectPromise != null);
     }
 
     @Override


### PR DESCRIPTION
Motivation:

It turns out that we actually not need any extra logic for close as the completion will happen in the expected order. So we can remove some code.

Modifications:

- Remove logic that we used to delay the close

Result:

Cleanup and simplify