### PR TITLE
Implement 'inEventLoop' for UnorderedThreadPoolEventExecutor and deprecate it

### DIFF
--- a/common/src/test/java/io/netty/util/concurrent/UnorderedThreadPoolEventExecutorTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/UnorderedThreadPoolEventExecutorTest.java
@@ -132,4 +132,15 @@ public class UnorderedThreadPoolEventExecutorTest {
             executor.shutdownGracefully();
         }
     }
+
+    @Test
+    void tasksRunningInUnorderedExecutorAreInEventLoop() throws Exception {
+        UnorderedThreadPoolEventExecutor executor = new UnorderedThreadPoolEventExecutor(1);
+        try {
+            Future<Boolean> future = executor.submit(() -> executor.inEventLoop());
+            assertTrue(future.get());
+        } finally {
+            executor.shutdownGracefully();
+        }
+    }
 }

--- a/transport/src/main/java/io/netty/channel/ChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/ChannelPipeline.java
@@ -16,9 +16,7 @@
 package io.netty.channel;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.util.concurrent.DefaultEventExecutorGroup;
 import io.netty.util.concurrent.EventExecutorGroup;
-import io.netty.util.concurrent.UnorderedThreadPoolEventExecutor;
 
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;


### PR DESCRIPTION
Motivation:
The `UnorderedThreadPoolEventExecutor` did not implement the `inEventLoop` method, and instead always returned `false`. This can have deleterious consequences to many parts of the Netty code that have optimized code paths for event loop threads.

The `UnorderedThreadPoolEventExecutor` also behaves in a way that deviates from normal Netty event loops in important ways, and it has very little use. Therefor it should be deprecated and removed in Netty 5.

Modification:
Add executor thread-accounting to the `UnorderedThreadPoolEventExecutor` and use the set of event loop threads to implement `inEventLoop` properly.

Result:
The `UnorderedThreadPoolEventExecutor.inEventLoop` method now correctly reports if the current thread is managed by the executor or not.