### PR TITLE
IoUring: Release memory directly on submission failure

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -1004,6 +1004,10 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
                     IoUringIoOps ops = IoUringIoOps.newSendmsg(fd, (byte) 0, Native.MSG_FASTOPEN,
                             hdr.address(), hdr.idx());
                     connectId = registration.submit(ops);
+                    if (connectId == 0) {
+                        // Directly release the memory if submitting failed.
+                        freeMsgHdrArray();
+                    }
                 } else {
                     submitConnect(inetSocketAddress);
                 }
@@ -1059,6 +1063,10 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
         IoUringIoOps ops = IoUringIoOps.newConnect(
                 fd, (byte) 0, remoteAddressMemoryAddress, nextOpsId());
         connectId = registration.submit(ops);
+        if (connectId == 0) {
+            // Directly release the memory if submitting failed.
+            freeRemoteAddressMemory();
+        }
     }
 
     @Override


### PR DESCRIPTION
Motivation:

If the submission fails we should directly release the memory as otherwise we might never do or do it later then required.

Modifications:

Release on submission falure

Result:

Fix possible memory leaks on submission failure