### PR TITLE
IoUring: Correctly handle accept submit failures

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringServerChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringServerChannel.java
@@ -123,6 +123,9 @@ abstract class AbstractIoUringServerChannel extends AbstractIoUringChannel imple
             IoUringIoOps ops = IoUringIoOps.newAccept(fd, (byte) 0, 0,
                     acceptedAddressMemoryAddress, acceptedAddressLengthMemoryAddress, nextOpsId());
             acceptId = registration.submit(ops);
+            if (acceptId == 0) {
+                return 0;
+            }
             return 1;
         }
 


### PR DESCRIPTION
Motivation:

When submitting an accept fails we should return 0 and so let the caller know that we did not schedule anything.

Modification:

Return 0 if submission fails.

Result:

Use correct return value when submission of accept fails