### PR TITLE
IoUring: Use IORING_RECVSEND_POLL_FIRST when we are sure there is no …

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoOps.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoOps.java
@@ -362,6 +362,7 @@ public final class IoUringIoOps implements IoOps {
      *
      * @param fd                                    the filedescriptor
      * @param flags                                 the flags.
+     * @param ioPrio                                the ioPrio.
      * @param recvFlags                             the recv flags.
      * @param memoryAddress                         the memory address of the buffer
      * @param length                                the length of the buffer.
@@ -369,8 +370,8 @@ public final class IoUringIoOps implements IoOps {
      * @return                                      ops.
      */
     static IoUringIoOps newRecv(
-            int fd, byte flags, int recvFlags, long memoryAddress, int length, short data) {
-        return new IoUringIoOps(Native.IORING_OP_RECV, flags, (short) 0, fd,
+            int fd, byte flags, short ioPrio, int recvFlags, long memoryAddress, int length, short data) {
+        return new IoUringIoOps(Native.IORING_OP_RECV, flags, ioPrio, fd,
                 0, memoryAddress, length, recvFlags, data, (short) 0, (short) 0, 0, 0);
     }
 

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -194,6 +194,8 @@ final class Native {
     static final byte IORING_OP_FTRUNCATE = 55;
     static final byte IORING_CQE_F_SOCK_NONEMPTY = 1 << 2;
 
+    static final short IORING_RECVSEND_POLL_FIRST = 1 << 0;
+
     static final int SPLICE_F_MOVE = 1;
 
     static String opToStr(byte op) {


### PR DESCRIPTION
…more data on the Socket to read

Motivation:

We can use IORING_RECVSEND_POLL_FIRST to tell io_uring to directly arm and skip the initial transfer attempt if we are sure there is nothing to read anymore. This reduces some overhead. See https://github.com/axboe/liburing/wiki/io_uring-and-networking-in-2023#socket-state

Modifications:

Use IORING_RECVSEND_POLL_FIRST when applicable

Result:

Less overhead