### PR TITLE
Limit the task run per EventLoop tick via a timeout

### DIFF
--- a/transport/src/main/java/io/netty/channel/SingleThreadIoEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/SingleThreadIoEventLoop.java
@@ -35,7 +35,7 @@ import java.util.concurrent.TimeUnit;
 public class SingleThreadIoEventLoop extends SingleThreadEventLoop implements IoEventLoop {
 
     // TODO: Is this a sensible default ?
-    protected static final long DEFAULT_MAX_TASK_PROCESSING_QUANTUM_NS= TimeUnit.MILLISECONDS.toNanos(Math.max(100,
+    private static final long DEFAULT_MAX_TASK_PROCESSING_QUANTUM_NS = TimeUnit.MILLISECONDS.toNanos(Math.max(100,
             SystemPropertyUtil.getInt("io.netty.eventLoop.maxTaskProcessingQuantumMs", 1000)));
 
     private final long maxTaskProcessingQuantumNs = DEFAULT_MAX_TASK_PROCESSING_QUANTUM_NS;

--- a/transport/src/main/java/io/netty/channel/SingleThreadIoEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/SingleThreadIoEventLoop.java
@@ -38,7 +38,7 @@ public class SingleThreadIoEventLoop extends SingleThreadEventLoop implements Io
     private static final long DEFAULT_MAX_TASK_PROCESSING_QUANTUM_NS = TimeUnit.MILLISECONDS.toNanos(Math.max(100,
             SystemPropertyUtil.getInt("io.netty.eventLoop.maxTaskProcessingQuantumMs", 1000)));
 
-    private final long maxTaskProcessingQuantumNs = DEFAULT_MAX_TASK_PROCESSING_QUANTUM_NS;
+    private final long maxTaskProcessingQuantumNs;
     private final IoExecutionContext context = new IoExecutionContext() {
         @Override
         public boolean canBlock() {
@@ -78,6 +78,7 @@ public class SingleThreadIoEventLoop extends SingleThreadEventLoop implements Io
                                    IoHandler ioHandler) {
         super(parent, threadFactory, false, true);
         this.ioHandler = ObjectUtil.checkNotNull(ioHandler, "ioHandler");
+        this.maxTaskProcessingQuantumNs = DEFAULT_MAX_TASK_PROCESSING_QUANTUM_NS;
     }
 
     /**
@@ -90,44 +91,59 @@ public class SingleThreadIoEventLoop extends SingleThreadEventLoop implements Io
     public SingleThreadIoEventLoop(IoEventLoopGroup parent, Executor executor, IoHandler ioHandler) {
         super(parent, executor, false, true);
         this.ioHandler = ObjectUtil.checkNotNull(ioHandler, "ioHandler");
+        this.maxTaskProcessingQuantumNs = DEFAULT_MAX_TASK_PROCESSING_QUANTUM_NS;
     }
 
     /**
      *  Creates a new instance
      *
-     * @param parent                    the parent that holds this {@link IoEventLoop}.
-     * @param threadFactory             the {@link ThreadFactory} that is used to create the underlying {@link Thread}.
-     * @param ioHandler                 the {@link IoHandler} used to run all IO.
-     * @param maxPendingTasks           the maximum pending tasks that are allowed before
-     *                                  {@link RejectedExecutionHandler#rejected(Runnable, SingleThreadEventExecutor)}
-     *                                  is called to handle it.
-     * @param rejectedExecutionHandler  the {@link RejectedExecutionHandler} that handles when more tasks are added
-     *                                  then allowed per {@code maxPendingTasks}.
+     * @param parent                        the parent that holds this {@link IoEventLoop}.
+     * @param threadFactory                 the {@link ThreadFactory} that is used to create the underlying
+     *                                      {@link Thread}.
+     * @param ioHandler                     the {@link IoHandler} used to run all IO.
+     * @param maxPendingTasks               the maximum pending tasks that are allowed before
+     *                                      {@link RejectedExecutionHandler#rejected(Runnable,
+     *                                          SingleThreadEventExecutor)}
+     *                                      is called to handle it.
+     * @param rejectedExecutionHandler      the {@link RejectedExecutionHandler} that handles when more tasks are added
+     *                                      then allowed per {@code maxPendingTasks}.
+     * @param maxTaskProcessingQuantumMs    the maximum number of milliseconds that will be spent to run tasks before
+     *                                      trying to run IO again.
      */
     public SingleThreadIoEventLoop(IoEventLoopGroup parent, ThreadFactory threadFactory,
                                    IoHandler ioHandler, int maxPendingTasks,
-                                   RejectedExecutionHandler rejectedExecutionHandler) {
+                                   RejectedExecutionHandler rejectedExecutionHandler, long maxTaskProcessingQuantumMs) {
         super(parent, threadFactory, false, true, maxPendingTasks, rejectedExecutionHandler);
         this.ioHandler = ObjectUtil.checkNotNull(ioHandler, "ioHandler");
+        this.maxTaskProcessingQuantumNs =
+                ObjectUtil.checkPositiveOrZero(maxTaskProcessingQuantumMs, "maxTaskProcessingQuantumMs") == 0 ?
+                        DEFAULT_MAX_TASK_PROCESSING_QUANTUM_NS : maxTaskProcessingQuantumMs;
     }
 
     /**
      *  Creates a new instance
      *
-     * @param parent                    the parent that holds this {@link IoEventLoop}.
-     * @param ioHandler                 the {@link IoHandler} used to run all IO.
-     * @param executor                  the {@link Executor} that is used for dispatching the work.
-     * @param maxPendingTasks           the maximum pending tasks that are allowed before
-     *                                  {@link RejectedExecutionHandler#rejected(Runnable, SingleThreadEventExecutor)}
-     *                                  is called to handle it.
-     * @param rejectedExecutionHandler  the {@link RejectedExecutionHandler} that handles when more tasks are added
-     *                                  then allowed per {@code maxPendingTasks}.
+     * @param parent                        the parent that holds this {@link IoEventLoop}.
+     * @param ioHandler                     the {@link IoHandler} used to run all IO.
+     * @param executor                      the {@link Executor} that is used for dispatching the work.
+     * @param maxPendingTasks               the maximum pending tasks that are allowed before
+     *                                      {@link RejectedExecutionHandler#rejected(Runnable,
+     *                                          SingleThreadEventExecutor)}
+     *                                      is called to handle it.
+     * @param rejectedExecutionHandler      the {@link RejectedExecutionHandler} that handles when more tasks are added
+     *                                      then allowed per {@code maxPendingTasks}.
+     * @param maxTaskProcessingQuantumMs    the maximum number of milliseconds that will be spent to run tasks before
+     *                                      trying to run IO again.
      */
     public SingleThreadIoEventLoop(IoEventLoopGroup parent, Executor executor,
                                    IoHandler ioHandler, int maxPendingTasks,
-                                   RejectedExecutionHandler rejectedExecutionHandler) {
+                                   RejectedExecutionHandler rejectedExecutionHandler,
+                                   long maxTaskProcessingQuantumMs) {
         super(parent, executor, false, true, maxPendingTasks, rejectedExecutionHandler);
         this.ioHandler = ObjectUtil.checkNotNull(ioHandler, "ioHandler");
+        this.maxTaskProcessingQuantumNs =
+                ObjectUtil.checkPositiveOrZero(maxTaskProcessingQuantumMs, "maxTaskProcessingQuantumMs") == 0 ?
+                        DEFAULT_MAX_TASK_PROCESSING_QUANTUM_NS : maxTaskProcessingQuantumMs;
     }
 
     /**
@@ -148,6 +164,7 @@ public class SingleThreadIoEventLoop extends SingleThreadEventLoop implements Io
                                       RejectedExecutionHandler rejectedExecutionHandler) {
         super(parent, executor, false, true, taskQueue, tailTaskQueue, rejectedExecutionHandler);
         this.ioHandler = ObjectUtil.checkNotNull(ioHandler, "ioHandler");
+        this.maxTaskProcessingQuantumNs = DEFAULT_MAX_TASK_PROCESSING_QUANTUM_NS;
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/SingleThreadIoEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/SingleThreadIoEventLoop.java
@@ -35,10 +35,10 @@ import java.util.concurrent.TimeUnit;
 public class SingleThreadIoEventLoop extends SingleThreadEventLoop implements IoEventLoop {
 
     // TODO: Is this a sensible default ?
-    protected static final long DEFAULT_MAX_TASKS_PER_RUN_NS = TimeUnit.MILLISECONDS.toNanos(Math.max(10,
-            SystemPropertyUtil.getInt("io.netty.eventLoop.maxTaskProcessingDurationPerRun", 1000)));
+    protected static final long DEFAULT_MAX_TASK_PROCESSING_QUANTUM_NS= TimeUnit.MILLISECONDS.toNanos(Math.max(100,
+            SystemPropertyUtil.getInt("io.netty.eventLoop.maxTaskProcessingQuantumMs", 1000)));
 
-    private final long maxTaskDurationPerRun = DEFAULT_MAX_TASKS_PER_RUN_NS;
+    private final long maxTaskProcessingQuantumNs = DEFAULT_MAX_TASK_PROCESSING_QUANTUM_NS;
     private final IoExecutionContext context = new IoExecutionContext() {
         @Override
         public boolean canBlock() {
@@ -159,7 +159,7 @@ public class SingleThreadIoEventLoop extends SingleThreadEventLoop implements Io
                 ioHandler.prepareToDestroy();
             }
             // Now run all tasks for the maximum configured amount of time before trying to run IO again.
-            runAllTasks(maxTaskDurationPerRun);
+            runAllTasks(maxTaskProcessingQuantumNs);
 
             // We should continue with our loop until we either confirmed a shutdown or we can suspend it.
         } while (!confirmShutdown() && !canSuspend());


### PR DESCRIPTION
Motivation:

We should better allow to limit the number of tasks that are run per EventLoop tick via a timeout. This timeout can be adjusted by -Dio.netty.eventLoop.maxTaskProcessingQuantumMs

Modifications:

Change property name and set default to 1 second.

Result:

Fixes https://github.com/netty/netty/issues/14165