### PR TITLE
Bump BlockHound version to 1.0.10.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1247,7 +1247,7 @@
       <dependency>
         <groupId>io.projectreactor.tools</groupId>
         <artifactId>blockhound</artifactId>
-        <version>1.0.6.RELEASE</version>
+        <version>1.0.10.RELEASE</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/transport-blockhound-tests/pom.xml
+++ b/transport-blockhound-tests/pom.xml
@@ -113,6 +113,15 @@
         <argLine.common>-XX:+AllowRedefinitionToAddDeleteMethods</argLine.common>
       </properties>
     </profile>
+    <profile>
+      <id>java22</id>
+      <activation>
+        <jdk>22</jdk>
+      </activation>
+      <properties>
+        <argLine.common>-XX:+AllowRedefinitionToAddDeleteMethods</argLine.common>
+      </properties>
+    </profile>
   </profiles>
 
   <properties>

--- a/transport-blockhound-tests/src/test/java/io/netty/util/internal/NettyBlockHoundIntegrationTest.java
+++ b/transport-blockhound-tests/src/test/java/io/netty/util/internal/NettyBlockHoundIntegrationTest.java
@@ -55,7 +55,6 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.condition.DisabledIf;
 import reactor.blockhound.BlockHound;
 import reactor.blockhound.BlockingOperationError;
 import reactor.blockhound.integration.BlockHoundIntegration;
@@ -87,12 +86,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-@DisabledIf("isDisabledIfJavaVersion18OrAbove")
 public class NettyBlockHoundIntegrationTest {
-
-    private static boolean isDisabledIfJavaVersion18OrAbove() {
-        return PlatformDependent.javaVersion() >= 18;
-    }
 
     @BeforeAll
     public static void setUpClass() {


### PR DESCRIPTION
Motivation:
BlockHound version 1.0.10.RELEASE comes with newer byte-buddy dependency

Modification:
- Bump BlockHound version
- Enable BlockHound tests on Java 18 and above as byte-buddy dependency is updated

Result:
Enable BlockHound tests on Java 18 and above
