### PR TITLE
Spdy: Add UnknownFrame parsing support for SpdyFrameCodec.

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdyUnknownFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdyUnknownFrame.java
@@ -88,9 +88,6 @@ public final class DefaultSpdyUnknownFrame extends DefaultByteBufHolder implemen
         if (!(o instanceof DefaultSpdyUnknownFrame)) {
             return false;
         }
-        if (!super.equals(o)) {
-            return false;
-        }
         final DefaultSpdyUnknownFrame that = (DefaultSpdyUnknownFrame) o;
         return frameType == that.frameType
             && flags == that.flags

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdyUnknownFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdyUnknownFrame.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.spdy;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.DefaultByteBufHolder;
+import io.netty.util.internal.StringUtil;
+
+public final class DefaultSpdyUnknownFrame extends DefaultByteBufHolder implements SpdyUnknownFrame {
+    private final int frameType;
+    private final byte flags;
+
+    public DefaultSpdyUnknownFrame(int frameType, byte flags, ByteBuf data) {
+        super(data);
+        this.frameType = frameType;
+        this.flags = flags;
+    }
+
+    @Override
+    public int frameType() {
+        return frameType;
+    }
+
+    @Override
+    public byte flags() {
+        return flags;
+    }
+
+    @Override
+    public DefaultSpdyUnknownFrame copy() {
+        return replace(content().copy());
+    }
+
+    @Override
+    public DefaultSpdyUnknownFrame duplicate() {
+        return replace(content().duplicate());
+    }
+
+    @Override
+    public DefaultSpdyUnknownFrame retainedDuplicate() {
+        return replace(content().retainedDuplicate());
+    }
+
+    @Override
+    public DefaultSpdyUnknownFrame replace(final ByteBuf content) {
+        return new DefaultSpdyUnknownFrame(frameType, flags, content);
+    }
+
+    @Override
+    public DefaultSpdyUnknownFrame retain() {
+        super.retain();
+        return this;
+    }
+
+    @Override
+    public DefaultSpdyUnknownFrame retain(final int increment) {
+        super.retain(increment);
+        return this;
+    }
+
+    @Override
+    public DefaultSpdyUnknownFrame touch() {
+        super.touch();
+        return this;
+    }
+
+    @Override
+    public DefaultSpdyUnknownFrame touch(final Object hint) {
+        super.touch(hint);
+        return this;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (!(o instanceof DefaultSpdyUnknownFrame)) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        final DefaultSpdyUnknownFrame that = (DefaultSpdyUnknownFrame) o;
+        return frameType == that.frameType
+            && flags == that.flags
+            && super.equals(that);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + frameType;
+        result = 31 * result + flags;
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return StringUtil.simpleClassName(this) + "(" + "frameType=" + frameType +
+            ", flags=" + flags + ", content=" + contentToString() +
+            ')';
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameCodec.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameCodec.java
@@ -32,13 +32,13 @@ import java.util.List;
  * A {@link ChannelHandler} that encodes and decodes SPDY Frames.
  */
 public class SpdyFrameCodec extends ByteToMessageDecoder
-        implements SpdyFrameDecoderDelegate, ChannelOutboundHandler {
+        implements SpdyFrameDecoderExtendedDelegate, ChannelOutboundHandler {
 
-    private static final SpdyProtocolException INVALID_FRAME =
-            new SpdyProtocolException("Received invalid frame");
+    protected static final SpdyProtocolException INVALID_FRAME =
+        new SpdyProtocolException("Received invalid frame");
 
-    private final SpdyFrameDecoder spdyFrameDecoder;
-    private final SpdyFrameEncoder spdyFrameEncoder;
+    protected final SpdyFrameDecoder spdyFrameDecoder;
+    protected final SpdyFrameEncoder spdyFrameEncoder;
     private final SpdyHeaderBlockDecoder spdyHeaderBlockDecoder;
     private final SpdyHeaderBlockEncoder spdyHeaderBlockEncoder;
 
@@ -48,6 +48,7 @@ public class SpdyFrameCodec extends ByteToMessageDecoder
     private ChannelHandlerContext ctx;
     private boolean read;
     private final boolean validateHeaders;
+    private final boolean supportsUnknownFrames;
 
     /**
      * Creates a new instance with the specified {@code version},
@@ -92,17 +93,56 @@ public class SpdyFrameCodec extends ByteToMessageDecoder
             int compressionLevel, int windowBits, int memLevel, boolean validateHeaders) {
         this(version, maxChunkSize,
                 SpdyHeaderBlockDecoder.newInstance(version, maxHeaderSize),
-                SpdyHeaderBlockEncoder.newInstance(version, compressionLevel, windowBits, memLevel), validateHeaders);
+                SpdyHeaderBlockEncoder.newInstance(version, compressionLevel, windowBits, memLevel),
+                validateHeaders, false);
+    }
+
+    /**
+     * Creates a new instance with the specified {@code version}, {@code validateHeaders},
+     * decoder and encoder options.
+     */
+    public SpdyFrameCodec(
+            SpdyVersion version, int maxChunkSize, int maxHeaderSize,
+            int compressionLevel, int windowBits, int memLevel, boolean validateHeaders,
+            boolean supportsUnknownFrames) {
+        this(version, maxChunkSize,
+                SpdyHeaderBlockDecoder.newInstance(version, maxHeaderSize),
+                SpdyHeaderBlockEncoder.newInstance(version, compressionLevel, windowBits, memLevel),
+                validateHeaders, supportsUnknownFrames);
+    }
+
+    protected SpdyFrameCodec(SpdyVersion version, int maxChunkSize,
+                             SpdyHeaderBlockDecoder spdyHeaderBlockDecoder,
+                             SpdyHeaderBlockEncoder spdyHeaderBlockEncoder,
+                             boolean validateHeaders) {
+        this(version, maxChunkSize, spdyHeaderBlockDecoder, spdyHeaderBlockEncoder, validateHeaders, false);
     }
 
     protected SpdyFrameCodec(SpdyVersion version, int maxChunkSize,
             SpdyHeaderBlockDecoder spdyHeaderBlockDecoder, SpdyHeaderBlockEncoder spdyHeaderBlockEncoder,
-            boolean validateHeaders) {
-        spdyFrameDecoder = new SpdyFrameDecoder(version, this, maxChunkSize);
-        spdyFrameEncoder = new SpdyFrameEncoder(version);
+            boolean validateHeaders, boolean supportsUnknownFrames) {
+        this.supportsUnknownFrames = supportsUnknownFrames;
+        spdyFrameDecoder = createDecoder(version, this, maxChunkSize);
+        spdyFrameEncoder = createEncoder(version);
         this.spdyHeaderBlockDecoder = spdyHeaderBlockDecoder;
         this.spdyHeaderBlockEncoder = spdyHeaderBlockEncoder;
         this.validateHeaders = validateHeaders;
+    }
+
+    protected SpdyFrameDecoder createDecoder(SpdyVersion version, SpdyFrameDecoderDelegate delegate, int maxChunkSize) {
+        return new SpdyFrameDecoder(version, delegate, maxChunkSize) {
+            @Override
+            protected boolean isValidUnknownFrameHeader(int streamId, int type, byte flags, int length) {
+                if (supportsUnknownFrames) {
+                    return SpdyFrameCodec.this.isValidUnknownFrameHeader(streamId, type, flags, length);
+                }
+                return super.isValidUnknownFrameHeader(streamId, type, flags, length);
+            }
+        };
+    }
+
+    protected SpdyFrameEncoder createEncoder(SpdyVersion version) {
+        return new SpdyFrameEncoder(version);
     }
 
     @Override
@@ -284,6 +324,14 @@ public class SpdyFrameCodec extends ByteToMessageDecoder
                     spdyWindowUpdateFrame.deltaWindowSize()
             );
             ctx.write(frame, promise);
+        } else if (msg instanceof SpdyUnknownFrame) {
+            SpdyUnknownFrame spdyUnknownFrame = (SpdyUnknownFrame) msg;
+            frame = spdyFrameEncoder.encodeUnknownFrame(
+                ctx.alloc(),
+                spdyUnknownFrame.frameType(),
+                spdyUnknownFrame.flags(),
+                spdyUnknownFrame.content());
+            ctx.write(frame, promise);
         } else {
             throw new UnsupportedMessageTypeException(msg);
         }
@@ -404,7 +452,35 @@ public class SpdyFrameCodec extends ByteToMessageDecoder
     }
 
     @Override
+    public void readUnknownFrame(int frameType, byte flags, ByteBuf payload) {
+        read = true;
+        SpdyUnknownFrame spdyUnknownFrame = new DefaultSpdyUnknownFrame(frameType, flags, payload);
+        ctx.fireChannelRead(spdyUnknownFrame);
+    }
+
+    /**
+     * Check whether the unknown frame is valid, if not, the frame will be discarded,
+     * otherwise, the frame will be passed to {@link SpdyFrameDecoder#decodeUnknownFrame(int, byte, int, ByteBuf)}.
+     *
+     * By default this method always returns {@code false}, sub-classes may override this.
+     **/
+    protected boolean isValidUnknownFrameHeader(@SuppressWarnings("unused") int streamId,
+                                                @SuppressWarnings("unused") int type,
+                                                @SuppressWarnings("unused") byte flags,
+                                                @SuppressWarnings("unused") int length) {
+        return false;
+    }
+
+    @Override
     public void readFrameError(String message) {
         ctx.fireExceptionCaught(INVALID_FRAME);
+    }
+
+    protected SpdyFrameDecoder decoder() {
+        return spdyFrameDecoder;
+    }
+
+    protected SpdyFrameEncoder encoder() {
+        return spdyFrameEncoder;
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameCodec.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameCodec.java
@@ -531,10 +531,13 @@ public class SpdyFrameCodec extends ByteToMessageDecoder
         }
     }
 
-    public void readUnknownFrame(int frameType, byte flags, ByteBuf payload) {
+    private void readUnknownFrame(int frameType, byte flags, ByteBuf payload) {
         read = true;
-        SpdyUnknownFrame spdyUnknownFrame = new DefaultSpdyUnknownFrame(frameType, flags, payload);
-        ctx.fireChannelRead(spdyUnknownFrame);
+        ctx.fireChannelRead(newSpdyUnknownFrame(frameType, flags, payload));
+    }
+
+    protected SpdyUnknownFrame newSpdyUnknownFrame(int frameType, byte flags, ByteBuf payload) {
+        return new DefaultSpdyUnknownFrame(frameType, flags, payload);
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameDecoder.java
@@ -15,6 +15,10 @@
  */
 package io.netty.handler.codec.spdy;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.util.internal.ObjectUtil;
+
 import static io.netty.handler.codec.spdy.SpdyCodecUtil.SPDY_DATA_FLAG_FIN;
 import static io.netty.handler.codec.spdy.SpdyCodecUtil.SPDY_DATA_FRAME;
 import static io.netty.handler.codec.spdy.SpdyCodecUtil.SPDY_FLAG_FIN;
@@ -39,20 +43,16 @@ import static io.netty.handler.codec.spdy.SpdyCodecUtil.getUnsignedInt;
 import static io.netty.handler.codec.spdy.SpdyCodecUtil.getUnsignedMedium;
 import static io.netty.handler.codec.spdy.SpdyCodecUtil.getUnsignedShort;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
-import io.netty.util.internal.ObjectUtil;
-
 /**
  * Decodes {@link ByteBuf}s into SPDY Frames.
  */
 public class SpdyFrameDecoder {
 
-    private final int spdyVersion;
+    protected final SpdyFrameDecoderDelegate delegate;
+    protected final int spdyVersion;
     private final int maxChunkSize;
 
-    private final SpdyFrameDecoderDelegate delegate;
-
+    private int frameType;
     private State state;
 
     // SPDY common header fields
@@ -74,6 +74,7 @@ public class SpdyFrameDecoder {
         READ_GOAWAY_FRAME,
         READ_HEADERS_FRAME,
         READ_WINDOW_UPDATE_FRAME,
+        READ_UNKNOWN_FRAME,
         READ_HEADER_BLOCK,
         DISCARD_FRAME,
         FRAME_ERROR
@@ -116,16 +117,15 @@ public class SpdyFrameDecoder {
                     boolean control = (buffer.getByte(frameOffset) & 0x80) != 0;
 
                     int version;
-                    int type;
                     if (control) {
                         // Decode control frame common header
                         version = getUnsignedShort(buffer, frameOffset) & 0x7FFF;
-                        type = getUnsignedShort(buffer, frameOffset + SPDY_HEADER_TYPE_OFFSET);
+                        frameType = getUnsignedShort(buffer, frameOffset + SPDY_HEADER_TYPE_OFFSET);
                         streamId = 0; // Default to session Stream-ID
                     } else {
                         // Decode data frame common header
                         version = spdyVersion; // Default to expected version
-                        type = SPDY_DATA_FRAME;
+                        frameType = SPDY_DATA_FRAME;
                         streamId = getUnsignedInt(buffer, frameOffset);
                     }
 
@@ -136,11 +136,13 @@ public class SpdyFrameDecoder {
                     if (version != spdyVersion) {
                         state = State.FRAME_ERROR;
                         delegate.readFrameError("Invalid SPDY Version");
-                    } else if (!isValidFrameHeader(streamId, type, flags, length)) {
+                    } else if (!isValidFrameHeader(streamId, frameType, flags, length)) {
                         state = State.FRAME_ERROR;
                         delegate.readFrameError("Invalid Frame Error");
+                    } else if (isValidUnknownFrameHeader(streamId, frameType, flags, length)) {
+                        state = State.READ_UNKNOWN_FRAME;
                     } else {
-                        state = getNextState(type, length);
+                        state = getNextState(frameType, length);
                     }
                     break;
 
@@ -340,6 +342,13 @@ public class SpdyFrameDecoder {
                     }
                     break;
 
+                case READ_UNKNOWN_FRAME:
+                    if (decodeUnknownFrame(frameType, flags, length, buffer)) {
+                        state = State.READ_COMMON_HEADER;
+                        break;
+                    }
+                    return;
+
                 case READ_HEADER_BLOCK:
                     if (length == 0) {
                         state = State.READ_COMMON_HEADER;
@@ -413,12 +422,44 @@ public class SpdyFrameDecoder {
                 return State.READ_WINDOW_UPDATE_FRAME;
 
             default:
+
                 if (length != 0) {
                     return State.DISCARD_FRAME;
                 } else {
                     return State.READ_COMMON_HEADER;
                 }
         }
+    }
+
+    /**
+     * Decode the unknown frame, returns true if parsed something, otherwise false.
+     */
+    protected boolean decodeUnknownFrame(int frameType, byte flags, int length, ByteBuf buffer) {
+        if (length == 0) {
+            if (delegate instanceof SpdyFrameDecoderExtendedDelegate) {
+                ((SpdyFrameDecoderExtendedDelegate) delegate).readUnknownFrame(frameType, flags, Unpooled.EMPTY_BUFFER);
+            }
+            return true;
+        }
+        if (buffer.readableBytes() < length) {
+            return false;
+        }
+        if (delegate instanceof SpdyFrameDecoderExtendedDelegate) {
+            ByteBuf data = buffer.alloc().buffer(length);
+            data.writeBytes(buffer, length);
+            ((SpdyFrameDecoderExtendedDelegate) delegate).readUnknownFrame(frameType, flags, data);
+        } else {
+            buffer.skipBytes(length);
+        }
+        return true;
+    }
+
+    /**
+     * Check whether the unknown frame is valid, if not, the frame will be discarded,
+     * otherwise, the frame will be passed to {@link #decodeUnknownFrame(int, byte, int, ByteBuf)}.
+     * */
+    protected boolean isValidUnknownFrameHeader(int streamId, int type, byte flags, int length) {
+        return false;
     }
 
     private static boolean isValidFrameHeader(int streamId, int type, byte flags, int length) {

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameDecoderExtendedDelegate.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameDecoderExtendedDelegate.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.spdy;
+
+import io.netty.buffer.ByteBuf;
+
+/**
+ * {@link SpdyFrameDecoderDelegate} that also supports unknown frames.
+ */
+public interface SpdyFrameDecoderExtendedDelegate extends SpdyFrameDecoderDelegate {
+
+    /**
+     * Called when an unknown frame is received.
+     *
+     * @param frameType the frame type from the spdy header.
+     * @param flags the flags in the frame header.
+     * @param payload the payload of the frame.
+     */
+    void readUnknownFrame(int frameType, byte flags, ByteBuf payload);
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameDecoderExtendedDelegate.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameDecoderExtendedDelegate.java
@@ -20,7 +20,7 @@ import io.netty.buffer.ByteBuf;
 /**
  * {@link SpdyFrameDecoderDelegate} that also supports unknown frames.
  */
-public interface SpdyFrameDecoderExtendedDelegate extends SpdyFrameDecoderDelegate {
+interface SpdyFrameDecoderExtendedDelegate extends SpdyFrameDecoderDelegate {
 
     /**
      * Called when an unknown frame is received.

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameEncoder.java
@@ -158,4 +158,14 @@ public class SpdyFrameEncoder {
         frame.writeInt(deltaWindowSize);
         return frame;
     }
+
+    public ByteBuf encodeUnknownFrame(ByteBufAllocator allocator, int frameType, byte flags, ByteBuf data) {
+        int length = data.readableBytes();
+        ByteBuf frame = allocator.ioBuffer(SPDY_HEADER_SIZE + length).order(ByteOrder.BIG_ENDIAN);
+        writeControlFrameHeader(frame, frameType, flags, length);
+        if (length > 0) {
+            frame.writeBytes(data, data.readerIndex(), length);
+        }
+        return frame;
+    }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyUnknownFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyUnknownFrame.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.spdy;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufHolder;
+
+/** A SPDY Control frame. */
+
+public interface SpdyUnknownFrame extends SpdyFrame, ByteBufHolder {
+    int frameType();
+
+    byte flags();
+
+    @Override
+    SpdyUnknownFrame copy();
+
+    @Override
+    SpdyUnknownFrame duplicate();
+
+    @Override
+    SpdyUnknownFrame retainedDuplicate();
+
+    @Override
+    SpdyUnknownFrame replace(ByteBuf content);
+
+    @Override
+    SpdyUnknownFrame retain();
+
+    @Override
+    SpdyUnknownFrame retain(int increment);
+
+    @Override
+    SpdyUnknownFrame touch();
+
+    @Override
+    SpdyUnknownFrame touch(Object hint);
+}

--- a/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdyFrameCodecTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdyFrameCodecTest.java
@@ -53,6 +53,7 @@ public class SpdyFrameCodecTest {
         Assertions.assertEquals((byte) 13, frame.flags());
         ByteBuf data = frame.content();
         Assertions.assertEquals("Hello, world!", data.toString(CharsetUtil.UTF_8));
+        data.release();
     }
 
     @Test
@@ -71,6 +72,7 @@ public class SpdyFrameCodecTest {
         Assertions.assertEquals((byte) 13, frame.flags());
         ByteBuf data = frame.content();
         Assertions.assertEquals("Hello, world!", data.toString(CharsetUtil.UTF_8));
+        data.release();
     }
 
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdyFrameCodecTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdyFrameCodecTest.java
@@ -40,7 +40,7 @@ public class SpdyFrameCodecTest {
 
     @Test
     public void testDecodeUnknownFrame() {
-        final SpdyFrameEncoder encoder = codec.encoder();
+        final SpdyFrameEncoder encoder = new SpdyFrameEncoder(SpdyVersion.SPDY_3_1);
         final ByteBuf buf = encoder.encodeUnknownFrame(
             UnpooledByteBufAllocator.DEFAULT,
             200,

--- a/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdyFrameCodecTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdyFrameCodecTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.spdy;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.util.CharsetUtil;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class SpdyFrameCodecTest {
+    private final SpdyFrameCodec codec = new SpdyFrameCodec(
+            SpdyVersion.SPDY_3_1, 8192, 16384, 6, 15, 8, true, true) {
+        @Override
+        protected boolean isValidUnknownFrameHeader(final int streamId,
+                                                    final int type,
+                                                    final byte flags,
+                                                    final int length) {
+            return true;
+        }
+    };
+    private final EmbeddedChannel channel = new EmbeddedChannel(
+        codec
+    );
+
+    @Test
+    public void testDecodeUnknownFrame() {
+        final SpdyFrameEncoder encoder = codec.encoder();
+        final ByteBuf buf = encoder.encodeUnknownFrame(
+            UnpooledByteBufAllocator.DEFAULT,
+            200,
+            (byte) 13,
+            Unpooled.wrappedBuffer("Hello, world!".getBytes(CharsetUtil.UTF_8)));
+        channel.writeInbound(buf);
+        SpdyUnknownFrame frame = channel.readInbound();
+        Assertions.assertNotNull(frame);
+        Assertions.assertEquals(200, frame.frameType());
+        Assertions.assertEquals((byte) 13, frame.flags());
+        ByteBuf data = frame.content();
+        Assertions.assertEquals("Hello, world!", data.toString(CharsetUtil.UTF_8));
+    }
+
+    @Test
+    public void testEncodeUnknownFrame() {
+        final SpdyUnknownFrame spdyUnknownFrame = new DefaultSpdyUnknownFrame(
+            200,
+            (byte) 13,
+            Unpooled.wrappedBuffer("Hello, world!".getBytes(CharsetUtil.UTF_8)));
+        channel.writeOutbound(spdyUnknownFrame);
+        ByteBuf buf = channel.readOutbound();
+        Assertions.assertNotNull(buf);
+        channel.writeInbound(buf);
+        SpdyUnknownFrame frame = channel.readInbound();
+        Assertions.assertNotNull(frame);
+        Assertions.assertEquals(200, frame.frameType());
+        Assertions.assertEquals((byte) 13, frame.flags());
+        ByteBuf data = frame.content();
+        Assertions.assertEquals("Hello, world!", data.toString(CharsetUtil.UTF_8));
+    }
+
+}

--- a/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdyFrameDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdyFrameDecoderTest.java
@@ -22,8 +22,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 
-import java.util.ArrayDeque;
-import java.util.Queue;
 import java.util.Random;
 
 import static io.netty.handler.codec.spdy.SpdyCodecUtil.SPDY_HEADER_SIZE;
@@ -39,8 +37,8 @@ public class SpdyFrameDecoderTest {
 
     private static final Random RANDOM = new Random();
 
-    private final SpdyFrameDecoderDelegate delegate = mock(SpdyFrameDecoderDelegate.class);
-    private final TestSpdyFrameDecoderDelegate testDelegate = new TestSpdyFrameDecoderDelegate();
+    private final SpdyFrameDecoderExtendedDelegate delegate = mock(SpdyFrameDecoderExtendedDelegate.class);
+    private final TestSpdyFrameDecoderDelegate testDelegate = new TestSpdyFrameDecoderDelegate(delegate);
     private SpdyFrameDecoder decoder;
 
     @BeforeEach
@@ -53,100 +51,13 @@ public class SpdyFrameDecoderTest {
         testDelegate.releaseAll();
     }
 
-    private final class TestSpdyFrameDecoderDelegate implements SpdyFrameDecoderDelegate {
-        private final Queue<ByteBuf> buffers = new ArrayDeque<ByteBuf>();
-
-        @Override
-        public void readDataFrame(int streamId, boolean last, ByteBuf data) {
-            delegate.readDataFrame(streamId, last, data);
-            buffers.add(data);
-        }
-
-        @Override
-        public void readSynStreamFrame(int streamId, int associatedToStreamId,
-        byte priority, boolean last, boolean unidirectional) {
-            delegate.readSynStreamFrame(streamId, associatedToStreamId, priority, last, unidirectional);
-        }
-
-        @Override
-        public void readSynReplyFrame(int streamId, boolean last) {
-            delegate.readSynReplyFrame(streamId, last);
-        }
-
-        @Override
-        public void readRstStreamFrame(int streamId, int statusCode) {
-            delegate.readRstStreamFrame(streamId, statusCode);
-        }
-
-        @Override
-        public void readSettingsFrame(boolean clearPersisted) {
-            delegate.readSettingsFrame(clearPersisted);
-        }
-
-        @Override
-        public void readSetting(int id, int value, boolean persistValue, boolean persisted) {
-            delegate.readSetting(id, value, persistValue, persisted);
-        }
-
-        @Override
-        public void readSettingsEnd() {
-            delegate.readSettingsEnd();
-        }
-
-        @Override
-        public void readPingFrame(int id) {
-            delegate.readPingFrame(id);
-        }
-
-        @Override
-        public void readGoAwayFrame(int lastGoodStreamId, int statusCode) {
-            delegate.readGoAwayFrame(lastGoodStreamId, statusCode);
-        }
-
-        @Override
-        public void readHeadersFrame(int streamId, boolean last) {
-            delegate.readHeadersFrame(streamId, last);
-        }
-
-        @Override
-        public void readWindowUpdateFrame(int streamId, int deltaWindowSize) {
-            delegate.readWindowUpdateFrame(streamId, deltaWindowSize);
-        }
-
-        @Override
-        public void readHeaderBlock(ByteBuf headerBlock) {
-            delegate.readHeaderBlock(headerBlock);
-            buffers.add(headerBlock);
-        }
-
-        @Override
-        public void readHeaderBlockEnd() {
-            delegate.readHeaderBlockEnd();
-        }
-
-        @Override
-        public void readFrameError(String message) {
-            delegate.readFrameError(message);
-        }
-
-        void releaseAll() {
-            for (;;) {
-                ByteBuf buf = buffers.poll();
-                if (buf == null) {
-                    return;
-                }
-                buf.release();
-            }
-        }
-    }
-
     private static void encodeDataFrameHeader(ByteBuf buffer, int streamId, byte flags, int length) {
         buffer.writeInt(streamId & 0x7FFFFFFF);
         buffer.writeByte(flags);
         buffer.writeMedium(length);
     }
 
-    private static void encodeControlFrameHeader(ByteBuf buffer, short type, byte flags, int length) {
+    static void encodeControlFrameHeader(ByteBuf buffer, short type, byte flags, int length) {
         buffer.writeShort(0x8000 | SpdyVersion.SPDY_3_1.version());
         buffer.writeShort(type);
         buffer.writeByte(flags);

--- a/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdyUnknownFrameDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdyUnknownFrameDecoderTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.spdy;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+
+import static io.netty.handler.codec.spdy.SpdyCodecUtil.SPDY_HEADER_SIZE;
+import static io.netty.handler.codec.spdy.SpdyFrameDecoderTest.encodeControlFrameHeader;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class SpdyUnknownFrameDecoderTest {
+
+    private static final Random RANDOM = new Random();
+
+    private final SpdyFrameDecoderExtendedDelegate delegate = mock(SpdyFrameDecoderExtendedDelegate.class);
+    private final TestSpdyFrameDecoderDelegate testDelegate = new TestSpdyFrameDecoderDelegate(delegate);
+    private SpdyFrameDecoder decoder;
+
+    @BeforeEach
+    public void createDecoder() {
+        decoder = new SpdyFrameDecoder(SpdyVersion.SPDY_3_1, testDelegate) {
+            @Override
+            protected boolean isValidUnknownFrameHeader(final int streamId,
+                                                        final int type,
+                                                        final byte flags,
+                                                        final int length) {
+                return true;
+            }
+        };
+    }
+
+    @AfterEach
+    public void releaseBuffers() {
+        testDelegate.releaseAll();
+    }
+
+    @Test
+    public void testDecodeUnknownFrame() throws Exception {
+        short type = 200;
+        byte flags = (byte) 0xFF;
+        int length = 8;
+
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
+        encodeControlFrameHeader(buf, type, flags, length);
+        final long value = RANDOM.nextLong();
+        buf.writeLong(value);
+
+        decoder.decode(buf);
+        verify(delegate).readUnknownFrame(type, flags, buf.slice(SPDY_HEADER_SIZE, 8));
+        assertFalse(buf.isReadable());
+    }
+
+}

--- a/codec-http/src/test/java/io/netty/handler/codec/spdy/TestSpdyFrameDecoderDelegate.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/spdy/TestSpdyFrameDecoderDelegate.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.spdy;
+
+import io.netty.buffer.ByteBuf;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
+
+
+final class TestSpdyFrameDecoderDelegate implements SpdyFrameDecoderExtendedDelegate {
+    private final SpdyFrameDecoderExtendedDelegate delegate;
+
+    private final Queue<ByteBuf> buffers = new ArrayDeque<ByteBuf>();
+
+    TestSpdyFrameDecoderDelegate(final SpdyFrameDecoderExtendedDelegate delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void readDataFrame(int streamId, boolean last, ByteBuf data) {
+        delegate.readDataFrame(streamId, last, data);
+        buffers.add(data);
+    }
+
+    @Override
+    public void readSynStreamFrame(int streamId, int associatedToStreamId,
+                                   byte priority, boolean last, boolean unidirectional) {
+        delegate.readSynStreamFrame(streamId, associatedToStreamId, priority, last, unidirectional);
+    }
+
+    @Override
+    public void readSynReplyFrame(int streamId, boolean last) {
+        delegate.readSynReplyFrame(streamId, last);
+    }
+
+    @Override
+    public void readRstStreamFrame(int streamId, int statusCode) {
+        delegate.readRstStreamFrame(streamId, statusCode);
+    }
+
+    @Override
+    public void readSettingsFrame(boolean clearPersisted) {
+        delegate.readSettingsFrame(clearPersisted);
+    }
+
+    @Override
+    public void readSetting(int id, int value, boolean persistValue, boolean persisted) {
+        delegate.readSetting(id, value, persistValue, persisted);
+    }
+
+    @Override
+    public void readSettingsEnd() {
+        delegate.readSettingsEnd();
+    }
+
+    @Override
+    public void readPingFrame(int id) {
+        delegate.readPingFrame(id);
+    }
+
+    @Override
+    public void readGoAwayFrame(int lastGoodStreamId, int statusCode) {
+        delegate.readGoAwayFrame(lastGoodStreamId, statusCode);
+    }
+
+    @Override
+    public void readHeadersFrame(int streamId, boolean last) {
+        delegate.readHeadersFrame(streamId, last);
+    }
+
+    @Override
+    public void readWindowUpdateFrame(int streamId, int deltaWindowSize) {
+        delegate.readWindowUpdateFrame(streamId, deltaWindowSize);
+    }
+
+    @Override
+    public void readHeaderBlock(ByteBuf headerBlock) {
+        delegate.readHeaderBlock(headerBlock);
+        buffers.add(headerBlock);
+    }
+
+    @Override
+    public void readHeaderBlockEnd() {
+        delegate.readHeaderBlockEnd();
+    }
+
+    @Override
+    public void readFrameError(String message) {
+        delegate.readFrameError(message);
+    }
+
+    @Override
+    public void readUnknownFrame(final int frameType, final byte flags, final ByteBuf payload) {
+        delegate.readUnknownFrame(frameType, flags, payload);
+        buffers.add(payload);
+    }
+
+    void releaseAll() {
+        for (;;) {
+            ByteBuf buf = buffers.poll();
+            if (buf == null) {
+                return;
+            }
+            buf.release();
+        }
+    }
+}


### PR DESCRIPTION
Motivation:
To make our codec more flexible we should add support for unknown frames in SPDY.

Modifications:

- Add SpdyFrameDecoderExtendedDelegate that supports unknown frames
- Add new constructor and protected method to SpdyFrameCodec that makes it easy to support it

Result:

More flexible SPDY implementation.