### PR TITLE
Add details to TooLongFrameException message

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket00FrameDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket00FrameDecoder.java
@@ -97,12 +97,12 @@ public class WebSocket00FrameDecoder extends ReplayingDecoder<Void> implements W
             frameSize <<= 7;
             frameSize |= b & 0x7f;
             if (frameSize > maxFrameSize) {
-                throw new TooLongFrameException();
+                throw new TooLongFrameException("frame length exceeds " + maxFrameSize + ": " + frameSize);
             }
             lengthFieldSize++;
             if (lengthFieldSize > 8) {
                 // Perhaps a malicious peer?
-                throw new TooLongFrameException();
+                throw new TooLongFrameException("frame length field size exceeds 8: " + lengthFieldSize);
             }
         } while ((b & 0x80) == 0x80);
 
@@ -122,7 +122,7 @@ public class WebSocket00FrameDecoder extends ReplayingDecoder<Void> implements W
             // Frame delimiter (0xFF) not found
             if (rbytes > maxFrameSize) {
                 // Frame length exceeded the maximum
-                throw new TooLongFrameException();
+                throw new TooLongFrameException("frame length exceeds " + maxFrameSize + ": " + rbytes);
             } else {
                 // Wait until more data is received
                 return null;
@@ -131,7 +131,7 @@ public class WebSocket00FrameDecoder extends ReplayingDecoder<Void> implements W
 
         int frameSize = delimPos - ridx;
         if (frameSize > maxFrameSize) {
-            throw new TooLongFrameException();
+            throw new TooLongFrameException("frame length exceeds " + maxFrameSize + ": " + frameSize);
         }
 
         ByteBuf binaryData = readBytes(ctx.alloc(), buffer, frameSize);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameDecoder.java
@@ -454,7 +454,7 @@ public class WebSocket08FrameDecoder extends ByteToMessageDecoder
 
     private static int toFrameLength(long l) {
         if (l > Integer.MAX_VALUE) {
-            throw new TooLongFrameException("Length:" + l);
+            throw new TooLongFrameException("frame length exceeds " + Integer.MAX_VALUE + ": " + l);
         } else {
             return (int) l;
         }

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpDecoder.java
@@ -363,7 +363,8 @@ public class SpdyHttpDecoder extends MessageToMessageDecoder<SpdyFrame> {
             if (content.readableBytes() > maxContentLength - spdyDataFrame.content().readableBytes()) {
                 removeMessage(streamId);
                 throw new TooLongFrameException(
-                        "HTTP content length exceeded " + maxContentLength + " bytes.");
+                        "HTTP content length exceeded " + maxContentLength + " bytes: "
+                                + spdyDataFrame.content().readableBytes());
             }
 
             ByteBuf spdyDataFrameData = spdyDataFrame.content();

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
@@ -99,8 +99,8 @@ public final class MqttDecoder extends ReplayingDecoder<DecoderState> {
                 variableHeader = decodeVariableHeader(ctx, buffer, mqttFixedHeader);
                 if (bytesRemainingBeforeVariableHeader > maxBytesInMessage) {
                     buffer.skipBytes(actualReadableBytes());
-                    throw new TooLongFrameException(
-                            "too large message: " + bytesRemainingBeforeVariableHeader + " bytes");
+                    throw new TooLongFrameException("message length exceeds " + maxBytesInMessage + ": "
+                            + bytesRemainingBeforeVariableHeader);
                 }
                 checkpoint(DecoderState.READ_PAYLOAD);
                 // fall through

--- a/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
+++ b/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
@@ -23,6 +23,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.EncoderException;
+import io.netty.handler.codec.TooLongFrameException;
 import io.netty.handler.codec.mqtt.MqttReasonCodes.PubAck;
 import io.netty.util.Attribute;
 import io.netty.util.CharsetUtil;
@@ -1100,9 +1101,7 @@ public class MqttCodecTest {
         assertNull(message.payload());
         assertTrue(message.decoderResult().isFailure());
         Throwable cause = message.decoderResult().cause();
-        assertThat(cause, instanceOf(DecoderException.class));
-
-        assertTrue(cause.getMessage().contains("too large message:"));
+        assertThat(cause, instanceOf(TooLongFrameException.class));
     }
 
     private static void validatePubReplyVariableHeader(


### PR DESCRIPTION
Motiviation:

We should always add some details on why the exception was thrown to make things easier to debug.

Modifications:

Add details where we missed to do so

Result:

Fixes https://github.com/netty/netty/issues/14559