### PR TITLE
Add BlockHound exceptions for AdaptivePoolingAllocator

### DIFF
--- a/common/src/main/java/io/netty/util/internal/Hidden.java
+++ b/common/src/main/java/io/netty/util/internal/Hidden.java
@@ -96,6 +96,16 @@ class Hidden {
             );
 
             builder.allowBlockingCallsInside(
+                    "io.netty.buffer.AdaptivePoolingAllocator$1",
+                    "initialValue"
+            );
+
+            builder.allowBlockingCallsInside(
+                    "io.netty.buffer.AdaptivePoolingAllocator$1",
+                    "onRemoval"
+            );
+
+            builder.allowBlockingCallsInside(
                     "io.netty.handler.ssl.SslHandler",
                     "handshake"
             );


### PR DESCRIPTION
Motivation:
`AdaptivePoolingAllocator` uses internally `CopyOnWriteArraySet`. This will cause the errors below when `BlockHound` is enabled.

```
reactor.blockhound.BlockingOperationError: Blocking call! sun.misc.Unsafe#park
	at sun.misc.Unsafe.park(Unsafe.java)
	at java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.parkAndCheckInterrupt(AbstractQueuedSynchronizer.java:836)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireQueued(AbstractQueuedSynchronizer.java:870)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(AbstractQueuedSynchronizer.java:1199)
	at java.util.concurrent.locks.ReentrantLock$NonfairSync.lock(ReentrantLock.java:209)
	at java.util.concurrent.locks.ReentrantLock.lock(ReentrantLock.java:285)
	at java.util.concurrent.CopyOnWriteArrayList.addIfAbsent(CopyOnWriteArrayList.java:624)
	at java.util.concurrent.CopyOnWriteArrayList.addIfAbsent(CopyOnWriteArrayList.java:615)
	at java.util.concurrent.CopyOnWriteArraySet.add(CopyOnWriteArraySet.java:261)
	at io.netty.buffer.AdaptivePoolingAllocator$1.initialValue(AdaptivePoolingAllocator.java:164)
	at io.netty.util.concurrent.FastThreadLocal.initialize(FastThreadLocal.java:177)
	at io.netty.util.concurrent.FastThreadLocal.get(FastThreadLocal.java:142)
	at io.netty.buffer.AdaptivePoolingAllocator.allocate(AdaptivePoolingAllocator.java:223)
	at io.netty.buffer.AdaptivePoolingAllocator.allocate(AdaptivePoolingAllocator.java:215)
	at io.netty.buffer.AdaptiveByteBufAllocator.newDirectBuffer(AdaptiveByteBufAllocator.java:78)
	at io.netty.buffer.AbstractByteBufAllocator.directBuffer(AbstractByteBufAllocator.java:188)
	at io.netty.buffer.AbstractByteBufAllocator.directBuffer(AbstractByteBufAllocator.java:179)
	at io.netty.buffer.AbstractByteBufAllocator.buffer(AbstractByteBufAllocator.java:116)
```

```
reactor.blockhound.BlockingOperationError: Blocking call! sun.misc.Unsafe#park
	at sun.misc.Unsafe.park(Unsafe.java)
	at java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.parkAndCheckInterrupt(AbstractQueuedSynchronizer.java:836)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireQueued(AbstractQueuedSynchronizer.java:870)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(AbstractQueuedSynchronizer.java:1199)
	at java.util.concurrent.locks.ReentrantLock$NonfairSync.lock(ReentrantLock.java:209)
	at java.util.concurrent.locks.ReentrantLock.lock(ReentrantLock.java:285)
	at java.util.concurrent.CopyOnWriteArrayList.remove(CopyOnWriteArrayList.java:537)
	at java.util.concurrent.CopyOnWriteArrayList.remove(CopyOnWriteArrayList.java:528)
	at java.util.concurrent.CopyOnWriteArraySet.remove(CopyOnWriteArraySet.java:245)
	at io.netty.buffer.AdaptivePoolingAllocator$1.onRemoval(AdaptivePoolingAllocator.java:163)
	at io.netty.util.concurrent.FastThreadLocal.remove(FastThreadLocal.java:259)
	at io.netty.util.concurrent.FastThreadLocal.removeAll(FastThreadLocal.java:67)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:1050)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.run(Thread.java:750)
```

Modification:
Allow blocking calls in some methods in `AdaptivePoolingAllocator`

Result:
No `BlockHound` exceptions

Fixes #14560