### PR TITLE
chore: returns a SpdyFrame instead.

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameCodec.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameCodec.java
@@ -536,7 +536,10 @@ public class SpdyFrameCodec extends ByteToMessageDecoder
         ctx.fireChannelRead(newSpdyUnknownFrame(frameType, flags, payload));
     }
 
-    protected SpdyUnknownFrame newSpdyUnknownFrame(int frameType, byte flags, ByteBuf payload) {
+    /**
+     * Create a SpdyUnknownFrame.
+     * */
+    protected SpdyFrame newSpdyUnknownFrame(int frameType, byte flags, ByteBuf payload) {
         return new DefaultSpdyUnknownFrame(frameType, flags, payload);
     }
 


### PR DESCRIPTION
Motivation:

Support customized of the **unknwon** frame

Modification:

Change the returning type of `newSpdyUnknownFrame` from `SpdyUnknownFrame` to `SpdyFrame`

Result:

Users can override to fire a `CustomFrame` instead of the `SpdyUnknownFrame`
