### PR TITLE
Timer: Add callback users can override to cleanup on cancellation

### DIFF
--- a/common/src/main/java/io/netty/util/HashedWheelTimer.java
+++ b/common/src/main/java/io/netty/util/HashedWheelTimer.java
@@ -552,7 +552,7 @@ public class HashedWheelTimer implements Timer {
                     break;
                 }
                 try {
-                    timeout.remove();
+                    timeout.removeAfterCancellation();
                 } catch (Throwable t) {
                     if (logger.isWarnEnabled()) {
                         logger.warn("An exception was thrown while process a cancellation task", t);
@@ -665,13 +665,14 @@ public class HashedWheelTimer implements Timer {
             return true;
         }
 
-        void remove() {
+        void removeAfterCancellation() {
             HashedWheelBucket bucket = this.bucket;
             if (bucket != null) {
                 bucket.remove(this);
             } else {
                 timer.pendingTimeouts.decrementAndGet();
             }
+            task.cancelled(this);
         }
 
         public boolean compareAndSetState(int expected, int state) {

--- a/common/src/main/java/io/netty/util/TimerTask.java
+++ b/common/src/main/java/io/netty/util/TimerTask.java
@@ -30,4 +30,14 @@ public interface TimerTask {
      * @param timeout a handle which is associated with this task
      */
     void run(Timeout timeout) throws Exception;
+
+    /**
+     * Called for {@link TimerTask}s that are successfully canceled via {@link Timeout#cancel()}. Overriding this
+     * method allows to for example run some cleanup.
+     *
+     * @param timeout a handle which is associated with this task
+     */
+    default void cancelled(Timeout timeout) {
+        // By default do nothing.
+    }
 }

--- a/common/src/test/java/io/netty/util/HashedWheelTimerTest.java
+++ b/common/src/test/java/io/netty/util/HashedWheelTimerTest.java
@@ -298,7 +298,8 @@ public class HashedWheelTimerTest {
         }
     }
 
-    @Test()
+    @Test
+    @org.junit.jupiter.api.Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
     public void cancelWillCallCallback() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
         final HashedWheelTimer timer = new HashedWheelTimer();

--- a/common/src/test/java/io/netty/util/HashedWheelTimerTest.java
+++ b/common/src/test/java/io/netty/util/HashedWheelTimerTest.java
@@ -298,6 +298,30 @@ public class HashedWheelTimerTest {
         }
     }
 
+    @Test()
+    public void cancelWillCallCallback() throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
+        final HashedWheelTimer timer = new HashedWheelTimer();
+        final Timeout t1 = timer.newTimeout(new TimerTask() {
+            @Override
+            public void run(Timeout timeout) {
+                fail();
+            }
+
+            @Override
+            public void cancelled(Timeout timeout) {
+                latch.countDown();
+            }
+        }, 90, TimeUnit.MILLISECONDS);
+
+        assertEquals(1, timer.pendingTimeouts());
+        t1.cancel();
+        latch.await();
+
+        assertEquals(0, timer.pendingTimeouts());
+        timer.stop();
+    }
+
     private static TimerTask createNoOpTimerTask() {
         return new TimerTask() {
             @Override


### PR DESCRIPTION
Motiviation:

When a TimerTask is cancelled it is useful to sometimes do some cleanup.

Modification:

Add new default method that people can use

Result:

Fixes https://github.com/netty/netty/discussions/14566