### PR TITLE
chore: use try finally to encode SpdyDataFrame

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameCodec.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameCodec.java
@@ -293,14 +293,17 @@ public class SpdyFrameCodec extends ByteToMessageDecoder
         if (msg instanceof SpdyDataFrame) {
 
             SpdyDataFrame spdyDataFrame = (SpdyDataFrame) msg;
-            frame = spdyFrameEncoder.encodeDataFrame(
+            try {
+                frame = spdyFrameEncoder.encodeDataFrame(
                     ctx.alloc(),
                     spdyDataFrame.streamId(),
                     spdyDataFrame.isLast(),
                     spdyDataFrame.content()
-            );
-            spdyDataFrame.release();
-            ctx.write(frame, promise);
+                );
+                ctx.write(frame, promise);
+            } finally {
+                spdyDataFrame.release();
+            }
 
         } else if (msg instanceof SpdySynStreamFrame) {
 


### PR DESCRIPTION
Motivation:

Make the code style the same with `try finally release` when encoding SpdyDataFrame

Result:
Same code style.
