### PR TITLE
Adapt: Don't fail when we run on a host with 1 core (#14582)

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -109,8 +109,8 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
      * This means the maximum amount of memory that we can have allocated-but-not-in-use is
      * 5 * {@link NettyRuntime#availableProcessors()} * {@link #MAX_CHUNK_SIZE} bytes.
      */
-    private static final int CENTRAL_QUEUE_CAPACITY = SystemPropertyUtil.getInt(
-            "io.netty.allocator.centralQueueCapacity", NettyRuntime.availableProcessors());
+    private static final int CENTRAL_QUEUE_CAPACITY = Math.min(2, SystemPropertyUtil.getInt(
+            "io.netty.allocator.centralQueueCapacity", NettyRuntime.availableProcessors()));
 
     /**
      * The capacity if the magazine local buffer queue. This queue just pools the outer ByteBuf instance and not


### PR DESCRIPTION
Motivation:

We require that the minimum queue size is 2 and use the number of cores as default value which can be less.

Modifications:

If we see less then 2 cores just use 2 as default size

Result:

Fixes https://github.com/netty/netty/issues/14579