### PR TITLE
chore: use readRetainedSlice to avoid copy in SpdyFrameDecoder (#14573)

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameDecoder.java
@@ -441,7 +441,6 @@ public class SpdyFrameDecoder {
             return false;
         }
         ByteBuf data = buffer.readRetainedSlice(length);
-        data.writeBytes(buffer, length);
         delegate.readUnknownFrame(frameType, flags, data);
         return true;
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameDecoder.java
@@ -161,8 +161,7 @@ public class SpdyFrameDecoder {
                         return;
                     }
 
-                    ByteBuf data = buffer.alloc().buffer(dataLength);
-                    data.writeBytes(buffer, dataLength);
+                    ByteBuf data = buffer.readRetainedSlice(dataLength);
                     length -= dataLength;
 
                     if (length == 0) {
@@ -361,8 +360,7 @@ public class SpdyFrameDecoder {
                     }
 
                     int compressedBytes = Math.min(buffer.readableBytes(), length);
-                    ByteBuf headerBlock = buffer.alloc().buffer(compressedBytes);
-                    headerBlock.writeBytes(buffer, compressedBytes);
+                    ByteBuf headerBlock = buffer.readRetainedSlice(compressedBytes);
                     length -= compressedBytes;
 
                     delegate.readHeaderBlock(headerBlock);
@@ -442,7 +440,7 @@ public class SpdyFrameDecoder {
         if (buffer.readableBytes() < length) {
             return false;
         }
-        ByteBuf data = buffer.alloc().buffer(length);
+        ByteBuf data = buffer.readRetainedSlice(length);
         data.writeBytes(buffer, length);
         delegate.readUnknownFrame(frameType, flags, data);
         return true;


### PR DESCRIPTION
Motivation:

We can use readRetainedSlice to reduce the copy of bytes in `SpdyFrameDecoder`.

Modification:

Make use of `readRetainedSlice` instead of new a byteBuf and copy data to it.

Result:
Less copy
