### PR TITLE
Adaptive: Add assert to guard against bugs related to chunk pooling

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -354,6 +354,10 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
         if (freed) {
             return false;
         }
+        // The Buffer should not be used anymore, let's add an assert to so we guard against bugs in the future.
+        assert buffer.allocatedBytes == 0;
+        assert buffer.magazine == null;
+
         boolean isAdded = centralQueue.offer(buffer);
         if (freed && isAdded) {
             // Help to free the centralQueue.


### PR DESCRIPTION
Motivation:

6138a5a39cdbf6e9212d02bd9d02edb36c6618b5 fixed a bug that added Chunks to the entral queue while these were still partly in use. We should add some assert to ensure we never re-introduce such a bug again

Modifications:

Add assert so we guard against bugs in the future

Result:

More future proof implementation