### PR TITLE
Optimize List allocation in `IpSubnetFilter`

### DIFF
--- a/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilter.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilter.java
@@ -160,13 +160,13 @@ public class IpSubnetFilter extends AbstractRemoteAddressFilter<InetSocketAddres
             ipFilterRuleTypeIPv6 = null;
         }
 
-        this.ipv4Rules = sortAndFilter(unsortedIPv4Rules);
-        this.ipv6Rules = sortAndFilter(unsortedIPv6Rules);
+        this.ipv4Rules = unsortedIPv4Rules.isEmpty() ? null : sortAndFilter(unsortedIPv4Rules);
+        this.ipv6Rules = unsortedIPv6Rules.isEmpty() ? null : sortAndFilter(unsortedIPv6Rules);
     }
 
     @Override
     protected boolean accept(ChannelHandlerContext ctx, InetSocketAddress remoteAddress) {
-        if (remoteAddress.getAddress() instanceof Inet4Address) {
+        if (ipv4Rules != null && remoteAddress.getAddress() instanceof Inet4Address) {
             int indexOf = Collections.binarySearch(ipv4Rules, remoteAddress, IpSubnetFilterRuleComparator.INSTANCE);
             if (indexOf >= 0) {
                 if (ipFilterRuleTypeIPv4 == null) {
@@ -175,7 +175,7 @@ public class IpSubnetFilter extends AbstractRemoteAddressFilter<InetSocketAddres
                     return ipFilterRuleTypeIPv4 == IpFilterRuleType.ACCEPT;
                 }
             }
-        } else {
+        } else if (ipv6Rules != null) {
             int indexOf = Collections.binarySearch(ipv6Rules, remoteAddress, IpSubnetFilterRuleComparator.INSTANCE);
             if (indexOf >= 0) {
                 if (ipFilterRuleTypeIPv6 == null) {


### PR DESCRIPTION
Motivation:
`IpSubnetFilter` always initializes two Lists, one for IPv4 and one for IPv6. This is fine if we have both types of rules. However, if we only process one or the other, one allocation is useless, and it stays forever since it's a `final` variable.

Modification:
Make a list `null` if there is no specific type of rule.

Result:
Optimize memory allocation