### PR TITLE
Allocate bytebuf without magazine lock when threads get collisions

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -596,7 +596,7 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
             try {
                 if (curr.remainingCapacity() >= RETIRE_CAPACITY) {
                     transferToNextInLineOrRelease(curr);
-                    cur = null;
+                    curr = null;
                 }
             } finally {
                 if (curr != null) {

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -573,7 +573,40 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
                     allocationLock.unlockWrite(writeLock);
                 }
             }
-            return false;
+            return allocateWithoutLock(size, sizeBucket, maxCapacity, buf);
+        }
+
+        private boolean allocateWithoutLock(int size, int sizeBucket, int maxCapacity, AdaptiveByteBuf buf) {
+            Chunk curr = NEXT_IN_LINE.getAndSet(this, null);
+            if (curr == MAGAZINE_FREED) {
+                // Allocation raced with a stripe-resize that freed this magazine.
+                restoreMagazineFreed();
+                return false;
+            }
+            if (curr == null) {
+                curr = parent.centralQueue.poll();
+                if (curr == null) {
+                    return false;
+                }
+                curr.attachToMagazine(this);
+            }
+            if (curr.remainingCapacity() >= size) {
+                curr.readInitInto(buf, size, maxCapacity);
+            }
+            try {
+                if (curr.remainingCapacity() < RETIRE_CAPACITY) {
+                    curr.release();
+                } else {
+                    transferToNextInLineOrRelease(curr);
+                }
+                curr = null;
+            } finally {
+                if (curr != null) {
+                    // Something went wrong, let's ensure we not leak the 'curr' chunk.
+                    curr.release();
+                }
+            }
+            return true;
         }
 
         private boolean allocate(int size, int sizeBucket, int maxCapacity, AdaptiveByteBuf buf) {
@@ -617,8 +650,8 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
             //
             // In any case we will store the Chunk as the current so it will be used again for the next allocation and
             // so be "reserved" by this Magazine for exclusive usage.
-            if (nextInLine != null) {
-                curr = NEXT_IN_LINE.getAndSet(this, null);
+            curr = NEXT_IN_LINE.getAndSet(this, null);
+            if (curr != null) {
                 if (curr == MAGAZINE_FREED) {
                     // Allocation raced with a stripe-resize that freed this magazine.
                     restoreMagazineFreed();

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -594,15 +594,12 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
                 curr.readInitInto(buf, size, maxCapacity);
             }
             try {
-                if (curr.remainingCapacity() < RETIRE_CAPACITY) {
-                    curr.release();
-                } else {
+                if (curr.remainingCapacity() >= RETIRE_CAPACITY) {
                     transferToNextInLineOrRelease(curr);
+                    cur = null;
                 }
-                curr = null;
             } finally {
                 if (curr != null) {
-                    // Something went wrong, let's ensure we not leak the 'curr' chunk.
                     curr.release();
                 }
             }

--- a/microbench/src/main/java/io/netty/microbench/buffer/AdaptiveByteBufAllocatorConcurrentNoCacheBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/AdaptiveByteBufAllocatorConcurrentNoCacheBenchmark.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.microbench.buffer;
+
+import io.netty.buffer.AdaptiveByteBufAllocator;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.microbench.util.AbstractMicrobenchmark;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@State(Scope.Benchmark)
+@Warmup(iterations = 10, time = 1)
+@Measurement(iterations = 10, time = 1)
+public class AdaptiveByteBufAllocatorConcurrentNoCacheBenchmark extends AbstractMicrobenchmark {
+
+    private static final ByteBufAllocator adaptiveAllocator =
+            new AdaptiveByteBufAllocator(true, false);
+
+    @Param({
+            "00064",
+            "00256",
+            "01024",
+            "04096",
+    })
+    private int size;
+
+    public AdaptiveByteBufAllocatorConcurrentNoCacheBenchmark() {
+        super(false, true);
+    }
+
+    @Benchmark
+    @Threads(32)
+    public void allocateReleaseHeapAdaptive(Blackhole blackhole) {
+        blackhole.consume(adaptiveAllocator.heapBuffer(size).release());
+    }
+
+    @Benchmark
+    @Threads(32)
+    public void allocateReleaseDirectAdaptive(Blackhole blackhole) {
+        blackhole.consume(adaptiveAllocator.directBuffer(size).release());
+    }
+}


### PR DESCRIPTION
This PR continued from https://github.com/netty/netty/pull/14534 which was mis-closed.
