### PR TITLE
Disable Pcap logging for 4GB pcap test

### DIFF
--- a/handler/src/main/java/io/netty/handler/pcap/PcapWriteHandler.java
+++ b/handler/src/main/java/io/netty/handler/pcap/PcapWriteHandler.java
@@ -67,7 +67,7 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
  *    </ul>
  * </p>
  */
-public final class PcapWriteHandler extends ChannelDuplexHandler implements Closeable {
+public class PcapWriteHandler extends ChannelDuplexHandler implements Closeable {
 
     /**
      * Logger for logging events
@@ -177,7 +177,7 @@ public final class PcapWriteHandler extends ChannelDuplexHandler implements Clos
         sharedOutputStream = false;
     }
 
-    private PcapWriteHandler(Builder builder, OutputStream outputStream) {
+    public PcapWriteHandler(Builder builder, OutputStream outputStream) {
         this.outputStream = outputStream;
         captureZeroByte = builder.captureZeroByte;
         sharedOutputStream = builder.sharedOutputStream;
@@ -670,7 +670,7 @@ public final class PcapWriteHandler extends ChannelDuplexHandler implements Clos
     /**
      * Logger for TCP
      */
-    private void logTCP(boolean isWriteOperation, int bytes, long sendSegmentNumber, long receiveSegmentNumber,
+    protected void logTCP(boolean isWriteOperation, int bytes, long sendSegmentNumber, long receiveSegmentNumber,
                         InetSocketAddress srcAddr, InetSocketAddress dstAddr, boolean ackOnly) {
         // If `ackOnly` is `true` when we don't need to write any data so we'll not
         // log number of bytes being written and mark the operation as "TCP ACK".

--- a/handler/src/test/java/io/netty/handler/pcap/PcapWriteHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/pcap/PcapWriteHandlerTest.java
@@ -928,8 +928,9 @@ public class PcapWriteHandlerTest {
                 new DiscardingWritesAndFlushesHandler(), //Discard writes/flushes
                 new PcapWriteHandler(pcapWriteHandlerBuilder, outputStream) {
                     @Override
-                    protected void logTCP(boolean isWriteOperation, int bytes, long sendSegmentNumber, long receiveSegmentNumber,
-                                          InetSocketAddress srcAddr, InetSocketAddress dstAddr, boolean ackOnly) {
+                    protected void logTCP(boolean isWriteOperation, int bytes, long sendSegmentNumber,
+                                          long receiveSegmentNumber, InetSocketAddress srcAddr,
+                                          InetSocketAddress dstAddr, boolean ackOnly) {
                         // Disable logging
                     }
                 },

--- a/handler/src/test/java/io/netty/handler/pcap/PcapWriteHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/pcap/PcapWriteHandlerTest.java
@@ -920,12 +920,19 @@ public class PcapWriteHandlerTest {
             }
         }
 
+        PcapWriteHandler.Builder pcapWriteHandlerBuilder = PcapWriteHandler.builder()
+                .forceTcpChannel(serverAddr, clientAddr, true);
+
         RecordingOutputStream outputStream = new RecordingOutputStream();
         EmbeddedChannel embeddedChannel = new EmbeddedChannel(
                 new DiscardingWritesAndFlushesHandler(), //Discard writes/flushes
-                PcapWriteHandler.builder()
-                                .forceTcpChannel(serverAddr, clientAddr, true)
-                                .build(outputStream),
+                new PcapWriteHandler(pcapWriteHandlerBuilder, outputStream) {
+                    @Override
+                    protected void logTCP(boolean isWriteOperation, int bytes, long sendSegmentNumber, long receiveSegmentNumber,
+                                          InetSocketAddress srcAddr, InetSocketAddress dstAddr, boolean ackOnly) {
+                        // Disable logging
+                    }
+                },
                 new DiscardingReadsHandler() //Discard reads
         );
 


### PR DESCRIPTION
Motivation:
Pcap 4GB log test produces a huge amount of log which is not required and makes debugging other CI failures impossible because the browser just gives up rendering such log files.

Modification:
Disable logging by overriding the `logTCP` and making it NO-OP.

Result:
No more enormous logs