### PR TITLE
Reduce noise when running PcapWriteHandlerTest (#14596)

### DIFF
--- a/common/src/test/resources/logback-test.xml
+++ b/common/src/test/resources/logback-test.xml
@@ -13,6 +13,8 @@
   // Disable logging for apacheds to reduce noise.
   <logger name="org.apache.directory" level="OFF"/>
   <logger name="org.apache.mina" level="OFF"/>
+  <!-- Force info logging to reduce noise -->
+  <logger name="io.netty.handler.pcap" level="INFO"/>
 
   // Enable trace logging for the loading of our native transports
   <logger name="io.netty.channel.epoll.Epoll" level="trace"/>

--- a/handler/src/test/java/io/netty/handler/pcap/PcapWriteHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/pcap/PcapWriteHandlerTest.java
@@ -556,6 +556,7 @@ public class PcapWriteHandlerTest {
             assertTrue(clientChannelFuture.isSuccess());
 
             InetSocketAddress clientAddress = (InetSocketAddress) clientChannelFuture.channel().localAddress();
+
             assertTrue(serverLatch.await(5, TimeUnit.SECONDS));
             assertTrue(clientLatch.await(5, TimeUnit.SECONDS));
 


### PR DESCRIPTION
Motivation:

PcapWriteHandlerTest produces a lot of noise when debug logging is enabled. This makes it very hard to inspect the build log.

Modifications:

- Force INFO logging level for pcap
- Remove println left-over

Result:

Be able to inspect build log again