### PR TITLE
IoUring: allow use to switch old recv implement

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -44,7 +44,6 @@ import io.netty.channel.unix.FileDescriptor;
 import io.netty.channel.unix.UnixChannel;
 import io.netty.channel.unix.UnixChannelUtil;
 import io.netty.util.ReferenceCountUtil;
-import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -68,7 +67,6 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 abstract class AbstractIoUringChannel extends AbstractChannel implements UnixChannel {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(AbstractIoUringChannel.class);
-    private static final boolean USE_POLL_IN_FIRST = SystemPropertyUtil.getBoolean("io.netty.iouring.usePollInFirst", false);
     final LinuxSocket socket;
     protected volatile boolean active;
 
@@ -301,7 +299,8 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
     }
 
     private void doBeginReadNow() {
-        if (socket.isBlocking() && !USE_POLL_IN_FIRST) {
+        boolean usePoolInFirst = Boolean.TRUE.equals(config().getOption(IoUringChannelOption.USE_POLL_IN_FIRST));
+        if (socket.isBlocking() && !usePoolInFirst) {
             // If the socket is blocking we will directly call scheduleFirstReadIfNeeded() as we can use FASTPOLL.
             ioUringUnsafe().scheduleFirstReadIfNeeded();
         } else if ((ioState & POLL_IN_SCHEDULED) == 0) {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IOUringSocketChannelConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IOUringSocketChannelConfig.java
@@ -35,6 +35,7 @@ import static io.netty.channel.ChannelOption.*;
 final class IOUringSocketChannelConfig extends DefaultChannelConfig implements SocketChannelConfig {
     private volatile boolean allowHalfClosure;
     private volatile boolean tcpFastopen;
+    private volatile boolean usePoolInFirst;
 
     IOUringSocketChannelConfig(Channel channel) {
         super(channel);
@@ -50,7 +51,7 @@ final class IOUringSocketChannelConfig extends DefaultChannelConfig implements S
                 SO_RCVBUF, SO_SNDBUF, TCP_NODELAY, SO_KEEPALIVE, SO_REUSEADDR, SO_LINGER, IP_TOS,
                 ALLOW_HALF_CLOSURE, IoUringChannelOption.TCP_CORK, IoUringChannelOption.TCP_NOTSENT_LOWAT,
                 IoUringChannelOption.TCP_KEEPCNT, IoUringChannelOption.TCP_KEEPIDLE, IoUringChannelOption.TCP_KEEPINTVL,
-                IoUringChannelOption.TCP_QUICKACK, IoUringChannelOption.IP_TRANSPARENT,
+                IoUringChannelOption.TCP_QUICKACK, IoUringChannelOption.IP_TRANSPARENT, IoUringChannelOption.USE_POLL_IN_FIRST,
                 ChannelOption.TCP_FASTOPEN_CONNECT);
     }
 
@@ -108,6 +109,9 @@ final class IOUringSocketChannelConfig extends DefaultChannelConfig implements S
         if (option == ChannelOption.TCP_FASTOPEN_CONNECT) {
             return (T) Boolean.valueOf(isTcpFastOpenConnect());
         }
+        if (option == IoUringChannelOption.USE_POLL_IN_FIRST) {
+            return (T) Boolean.valueOf(isUsePoolInFirst());
+        }
         return super.getOption(option);
     }
 
@@ -149,6 +153,8 @@ final class IOUringSocketChannelConfig extends DefaultChannelConfig implements S
             setTcpQuickAck((Boolean) value);
         } else if (option == ChannelOption.TCP_FASTOPEN_CONNECT) {
             setTcpFastOpenConnect((Boolean) value);
+        } else if (option == IoUringChannelOption.USE_POLL_IN_FIRST) {
+            setUsePoolInFirst((Boolean) value);
         } else {
             return super.setOption(option, value);
         }
@@ -545,6 +551,15 @@ final class IOUringSocketChannelConfig extends DefaultChannelConfig implements S
      */
     public boolean isTcpFastOpenConnect() {
         return tcpFastopen;
+    }
+
+    public IOUringSocketChannelConfig setUsePoolInFirst(boolean usePoolInFirst) {
+        this.usePoolInFirst = usePoolInFirst;
+        return this;
+    }
+
+    public boolean isUsePoolInFirst() {
+        return usePoolInFirst;
     }
 
     @Override

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringChannelOption.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringChannelOption.java
@@ -42,4 +42,5 @@ public final class IoUringChannelOption<T> extends UnixChannelOption<T> {
     public static final ChannelOption<Boolean> TCP_QUICKACK = valueOf(IoUringChannelOption.class, "TCP_QUICKACK");
 
     public static final ChannelOption<Integer> MAX_DATAGRAM_PAYLOAD_SIZE = valueOf("MAX_DATAGRAM_PAYLOAD_SIZE");
+    public static final ChannelOption<Boolean> USE_POLL_IN_FIRST = valueOf("USE_POLL_IN_FIRST");
 }


### PR DESCRIPTION


Motivation:
However, I noticed that io_uring_setup_buf_ring requires at least Linux 5.19, and using [Incremental provided buffers ](https://github.com/axboe/liburing/wiki/What's-new-with-io_uring-in-6.11-and-6.12)requires Linux 6.11/6.12 or newer.


Therefore, would it be possible to provide a global option to allow users with older kernels to switch back to the previous POLLIN + recv combination?I can try to create a PR to implement it

Modification:

Provide a global option to allow users with older kernels to switch back to the previous POLLIN + recv combination

Result:

Fixes #14600 

