### PR TITLE
IoUring: Allow to configure if POLLIN should be used or not

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -299,7 +299,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
     }
 
     private void doBeginReadNow() {
-        if (socket.isBlocking()) {
+        if (socket.isBlocking() && !((IOUringChannelConfig) config()).getPollInFirst()) {
             // If the socket is blocking we will directly call scheduleFirstReadIfNeeded() as we can use FASTPOLL.
             ioUringUnsafe().scheduleFirstReadIfNeeded();
         } else if ((ioState & POLL_IN_SCHEDULED) == 0) {
@@ -610,9 +610,6 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
         }
 
         final void schedulePollIn() {
-            // This should only be done if the socket is non-blocking.
-            assert !socket.isBlocking();
-
             assert (ioState & POLL_IN_SCHEDULED) == 0;
             if (!isActive() || shouldBreakIoUringInReady(config())) {
                 return;

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IOUringChannelConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IOUringChannelConfig.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.DefaultChannelConfig;
+import io.netty.channel.MessageSizeEstimator;
+import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.WriteBufferWaterMark;
+
+import java.util.Map;
+
+abstract class IOUringChannelConfig extends DefaultChannelConfig {
+    private volatile boolean pollInFirst = true;
+
+    IOUringChannelConfig(Channel channel) {
+        super(channel);
+    }
+
+    IOUringChannelConfig(Channel channel, RecvByteBufAllocator allocator) {
+        super(channel, allocator);
+    }
+
+    @Override
+    public Map<ChannelOption<?>, Object> getOptions() {
+        return getOptions(super.getOptions(), IoUringChannelOption.POLLIN_FIRST);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T getOption(ChannelOption<T> option) {
+        if (option == IoUringChannelOption.POLLIN_FIRST) {
+            return (T) Boolean.valueOf(pollInFirst);
+        }
+        return super.getOption(option);
+    }
+
+    @Override
+    public <T> boolean setOption(ChannelOption<T> option, T value) {
+        validate(option, value);
+
+        if (option == IoUringChannelOption.POLLIN_FIRST) {
+            setPollInFirst((Boolean) value);
+        } else {
+            return super.setOption(option, value);
+        }
+
+        return true;
+    }
+
+    boolean getPollInFirst() {
+        return pollInFirst;
+    }
+
+    void setPollInFirst(boolean pollInFirst) {
+        this.pollInFirst = pollInFirst;
+    }
+
+    @Override
+    public IOUringChannelConfig setConnectTimeoutMillis(int connectTimeoutMillis) {
+        super.setConnectTimeoutMillis(connectTimeoutMillis);
+        return this;
+    }
+
+    @Override
+    @Deprecated
+    public IOUringChannelConfig setMaxMessagesPerRead(int maxMessagesPerRead) {
+        super.setMaxMessagesPerRead(maxMessagesPerRead);
+        return this;
+    }
+
+    @Override
+    public IOUringChannelConfig setWriteSpinCount(int writeSpinCount) {
+        super.setWriteSpinCount(writeSpinCount);
+        return this;
+    }
+
+    @Override
+    public IOUringChannelConfig setAllocator(ByteBufAllocator allocator) {
+        super.setAllocator(allocator);
+        return this;
+    }
+
+    @Override
+    public IOUringChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator) {
+        super.setRecvByteBufAllocator(allocator);
+        return this;
+    }
+
+    @Override
+    public IOUringChannelConfig setAutoRead(boolean autoRead) {
+        super.setAutoRead(autoRead);
+        return this;
+    }
+
+    @Override
+    public IOUringChannelConfig setAutoClose(boolean autoClose) {
+        super.setAutoClose(autoClose);
+        return this;
+    }
+
+    @Override
+    @Deprecated
+    public IOUringChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
+        super.setWriteBufferHighWaterMark(writeBufferHighWaterMark);
+        return this;
+    }
+
+    @Override
+    @Deprecated
+    public IOUringChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
+        super.setWriteBufferLowWaterMark(writeBufferLowWaterMark);
+        return this;
+    }
+
+    @Override
+    public IOUringChannelConfig setWriteBufferWaterMark(WriteBufferWaterMark writeBufferWaterMark) {
+        super.setWriteBufferWaterMark(writeBufferWaterMark);
+        return this;
+    }
+
+    @Override
+    public IOUringChannelConfig setMessageSizeEstimator(MessageSizeEstimator estimator) {
+        super.setMessageSizeEstimator(estimator);
+        return this;
+    }
+}

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IOUringSocketChannelConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IOUringSocketChannelConfig.java
@@ -19,7 +19,6 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelOption;
-import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.WriteBufferWaterMark;
@@ -32,7 +31,7 @@ import java.util.Map;
 import static io.netty.channel.ChannelOption.*;
 
 
-final class IOUringSocketChannelConfig extends DefaultChannelConfig implements SocketChannelConfig {
+final class IOUringSocketChannelConfig extends IOUringChannelConfig implements SocketChannelConfig {
     private volatile boolean allowHalfClosure;
     private volatile boolean tcpFastopen;
 

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringChannelOption.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringChannelOption.java
@@ -42,4 +42,15 @@ public final class IoUringChannelOption<T> extends UnixChannelOption<T> {
     public static final ChannelOption<Boolean> TCP_QUICKACK = valueOf(IoUringChannelOption.class, "TCP_QUICKACK");
 
     public static final ChannelOption<Integer> MAX_DATAGRAM_PAYLOAD_SIZE = valueOf("MAX_DATAGRAM_PAYLOAD_SIZE");
+
+    /**
+     * When set to {@code true} a POLLIN will be scheduled to get notified once there is something to read.
+     * Once the notification is received the actual reading is scheduled. This means one extra operation has to be
+     * scheduled for each read-loop but also means that we will not need to reserve any extra memory until there is
+     * something to read for real.
+     * When set to {@code false} the read is submitted directly, which has the pro that there are less operations that
+     * need to be scheduled per read-loop. That said it also means that the memory for the read needs to be reserved
+     * upfront even if we are not sure yet when exactly the read will happen.
+     */
+    public static final ChannelOption<Boolean> POLLIN_FIRST = valueOf("POLLIN_FIRST");
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringChannelOption.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringChannelOption.java
@@ -48,7 +48,7 @@ public final class IoUringChannelOption<T> extends UnixChannelOption<T> {
      * Once the notification is received the actual reading is scheduled. This means one extra operation has to be
      * scheduled for each read-loop but also means that we will not need to reserve any extra memory until there is
      * something to read for real.
-     * When set to {@code false} the read is submitted directly, which has the pro that there are less operations that
+     * When set to {@code false} the read is submitted directly, which has the benefit that there are fewer operations that
      * need to be scheduled per read-loop. That said it also means that the memory for the read needs to be reserved
      * upfront even if we are not sure yet when exactly the read will happen.
      */

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringChannelOption.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringChannelOption.java
@@ -48,9 +48,9 @@ public final class IoUringChannelOption<T> extends UnixChannelOption<T> {
      * Once the notification is received the actual reading is scheduled. This means one extra operation has to be
      * scheduled for each read-loop but also means that we will not need to reserve any extra memory until there is
      * something to read for real.
-     * When set to {@code false} the read is submitted directly, which has the benefit that there are fewer operations that
-     * need to be scheduled per read-loop. That said it also means that the memory for the read needs to be reserved
-     * upfront even if we are not sure yet when exactly the read will happen.
+     * When set to {@code false} the read is submitted directly, which has the benefit that there are fewer operations
+     * that need to be scheduled per read-loop. That said it also means that the memory for the read needs to be
+     * reserved upfront even if we are not sure yet when exactly the read will happen.
      */
     public static final ChannelOption<Boolean> POLLIN_FIRST = valueOf("POLLIN_FIRST");
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannelConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannelConfig.java
@@ -19,7 +19,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelOption;
-import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.FixedRecvByteBufAllocator;
 import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.RecvByteBufAllocator;
@@ -32,7 +31,7 @@ import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.util.Map;
 
-final class IoUringDatagramChannelConfig extends DefaultChannelConfig implements DatagramChannelConfig {
+final class IoUringDatagramChannelConfig extends IOUringChannelConfig implements DatagramChannelConfig {
     private static final RecvByteBufAllocator DEFAULT_RCVBUF_ALLOCATOR = new FixedRecvByteBufAllocator(2048);
     private boolean activeOnOpen;
     private volatile int maxDatagramSize;

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringServerSocketChannelConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringServerSocketChannelConfig.java
@@ -18,7 +18,6 @@ package io.netty.channel.uring;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelOption;
-import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.ServerChannelRecvByteBufAllocator;
@@ -32,7 +31,7 @@ import java.util.Map;
 import static io.netty.channel.ChannelOption.TCP_FASTOPEN;
 import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 
-final class IoUringServerSocketChannelConfig extends DefaultChannelConfig implements ServerSocketChannelConfig {
+final class IoUringServerSocketChannelConfig extends IOUringChannelConfig implements ServerSocketChannelConfig {
     private volatile int backlog = NetUtil.SOMAXCONN;
     private volatile int pendingFastOpenRequestsThreshold;
 


### PR DESCRIPTION
Motivation:

At the moment we make not use of POLLIN and so always pre-allocate memory. This can be wasteful sometimes

Modifications:

Add ChannelOption which allows to either enable or disable use of POLLIN (default is true for now)

Result:

Fixes https://github.com/netty/netty/issues/14600