### PR TITLE
Add the ability of disable threadlocal on PooledByteBufAllocator, to better support virtual thread

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -651,7 +651,6 @@ abstract class PoolArena<T> implements PoolArenaMetric {
                     }
                 };
             }
-
         }
 
         private static byte[] newByteArray(int size) {
@@ -741,7 +740,6 @@ abstract class PoolArena<T> implements PoolArenaMetric {
                     }
                 };
             }
-
         }
 
         @Override

--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -642,7 +642,6 @@ abstract class PoolArena<T> implements PoolArenaMetric {
                         bufferQueue.offer(self);
                     }
                 };
-
             }
         }
 

--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -17,13 +17,16 @@
 package io.netty.buffer;
 
 import io.netty.util.internal.LongCounter;
+import io.netty.util.internal.ObjectPool;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
+import io.netty.util.internal.SystemPropertyUtil;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Queue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
@@ -74,6 +77,9 @@ abstract class PoolArena<T> implements PoolArenaMetric {
     private final ReentrantLock lock = new ReentrantLock();
 
     final SizeClasses sizeClass;
+
+    private static final int ARENA_BUFFER_QUEUE_CAPACITY = Math.max(SystemPropertyUtil.getInt(
+            "io.netty.allocator.arenaBufferQueueCapacity", 1024), 2);
 
     protected PoolArena(PooledByteBufAllocator parent, SizeClasses sizeClass) {
         assert null != sizeClass;
@@ -146,7 +152,7 @@ abstract class PoolArena<T> implements PoolArenaMetric {
     private void tcacheAllocateSmall(PoolThreadCache cache, PooledByteBuf<T> buf, final int reqCapacity,
                                      final int sizeIdx) {
 
-        if (cache.allocateSmall(this, buf, reqCapacity, sizeIdx)) {
+        if (cache.useThreadLocal() && cache.allocateSmall(this, buf, reqCapacity, sizeIdx)) {
             // was able to allocate out of the cache so move on
             return;
         }
@@ -186,7 +192,7 @@ abstract class PoolArena<T> implements PoolArenaMetric {
 
     private void tcacheAllocateNormal(PoolThreadCache cache, PooledByteBuf<T> buf, final int reqCapacity,
                                       final int sizeIdx) {
-        if (cache.allocateNormal(this, buf, reqCapacity, sizeIdx)) {
+        if (cache.useThreadLocal() && cache.allocateNormal(this, buf, reqCapacity, sizeIdx)) {
             // was able to allocate out of the cache so move on
             return;
         }
@@ -236,7 +242,8 @@ abstract class PoolArena<T> implements PoolArenaMetric {
             deallocationsHuge.increment();
         } else {
             SizeClass sizeClass = sizeClass(handle);
-            if (cache != null && cache.add(this, chunk, nioBuffer, handle, normCapacity, sizeClass)) {
+            if (cache != null && cache.useThreadLocal() &&
+                cache.add(this, chunk, nioBuffer, handle, normCapacity, sizeClass)) {
                 // cached so not free it.
                 return;
             }
@@ -618,10 +625,33 @@ abstract class PoolArena<T> implements PoolArenaMetric {
 
     static final class HeapArena extends PoolArena<byte[]> {
         private final AtomicReference<PoolChunk<byte[]>> lastDestroyedChunk;
+        private final Queue<PooledByteBuf<byte[]>> bufferQueue;
+        private final ObjectPool.Handle<PooledHeapByteBuf> handle;
+        private final ObjectPool.Handle<PooledUnsafeHeapByteBuf> unsafehandle;
 
-        HeapArena(PooledByteBufAllocator parent, SizeClasses sizeClass) {
+        HeapArena(PooledByteBufAllocator parent, SizeClasses sizeClass, boolean useThreadLocal) {
             super(parent, sizeClass);
             lastDestroyedChunk = new AtomicReference<PoolChunk<byte[]>>();
+            if (useThreadLocal) {
+                bufferQueue = null;
+                handle = null;
+                unsafehandle = null;
+            } else {
+                bufferQueue = PlatformDependent.newFixedMpmcQueue(ARENA_BUFFER_QUEUE_CAPACITY);
+                handle = new ObjectPool.Handle<PooledHeapByteBuf>() {
+                    @Override
+                    public void recycle(PooledHeapByteBuf self) {
+                        bufferQueue.offer(self);
+                    }
+                };
+                unsafehandle = new ObjectPool.Handle<PooledUnsafeHeapByteBuf>() {
+                    @Override
+                    public void recycle(PooledUnsafeHeapByteBuf self) {
+                        bufferQueue.offer(self);
+                    }
+                };
+            }
+
         }
 
         private static byte[] newByteArray(int size) {
@@ -662,6 +692,15 @@ abstract class PoolArena<T> implements PoolArenaMetric {
 
         @Override
         protected PooledByteBuf<byte[]> newByteBuf(int maxCapacity) {
+            if (bufferQueue != null) {
+                PooledByteBuf<byte[]> buf = bufferQueue.poll();
+                if (buf == null) {
+                    buf = HAS_UNSAFE ? PooledUnsafeHeapByteBuf.newUnsafeInstanceNoThreadLocal(unsafehandle)
+                            : PooledHeapByteBuf.newInstanceNoThreadLocal(handle);
+                }
+                buf.reuse(maxCapacity);
+                return buf;
+            }
             return HAS_UNSAFE ? PooledUnsafeHeapByteBuf.newUnsafeInstance(maxCapacity)
                     : PooledHeapByteBuf.newInstance(maxCapacity);
         }
@@ -677,9 +716,32 @@ abstract class PoolArena<T> implements PoolArenaMetric {
     }
 
     static final class DirectArena extends PoolArena<ByteBuffer> {
+        private final Queue<PooledByteBuf<ByteBuffer>> bufferQueue;
+        private final ObjectPool.Handle<PooledDirectByteBuf> handle;
+        private final ObjectPool.Handle<PooledUnsafeDirectByteBuf> handleUnsafe;
 
-        DirectArena(PooledByteBufAllocator parent, SizeClasses sizeClass) {
+        DirectArena(PooledByteBufAllocator parent, SizeClasses sizeClass, boolean useThreadLocal) {
             super(parent, sizeClass);
+            if (useThreadLocal) {
+                bufferQueue = null;
+                handle = null;
+                handleUnsafe = null;
+            } else {
+                bufferQueue = PlatformDependent.newFixedMpmcQueue(ARENA_BUFFER_QUEUE_CAPACITY);
+                handle = new ObjectPool.Handle<PooledDirectByteBuf>() {
+                    @Override
+                    public void recycle(PooledDirectByteBuf self) {
+                        bufferQueue.offer(self);
+                    }
+                };
+                handleUnsafe = new ObjectPool.Handle<PooledUnsafeDirectByteBuf>() {
+                    @Override
+                    public void recycle(PooledUnsafeDirectByteBuf self) {
+                        bufferQueue.offer(self);
+                    }
+                };
+            }
+
         }
 
         @Override
@@ -729,6 +791,16 @@ abstract class PoolArena<T> implements PoolArenaMetric {
 
         @Override
         protected PooledByteBuf<ByteBuffer> newByteBuf(int maxCapacity) {
+            if (bufferQueue != null) {
+                PooledByteBuf<ByteBuffer> buf = bufferQueue.poll();
+                if (buf == null) {
+                    buf = HAS_UNSAFE ?
+                            PooledUnsafeDirectByteBuf.newUnsafeInstanceNoThreadLocal(handleUnsafe)
+                            : PooledDirectByteBuf.newInstanceNoThreadLocal(handle);
+                }
+                buf.reuse(maxCapacity);
+                return buf;
+            }
             if (HAS_UNSAFE) {
                 return PooledUnsafeDirectByteBuf.newInstance(maxCapacity);
             } else {

--- a/buffer/src/main/java/io/netty/buffer/PoolThreadCache.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolThreadCache.java
@@ -62,6 +62,7 @@ final class PoolThreadCache {
     private final FreeOnFinalize freeOnFinalize;
 
     private int allocations;
+    // A special `PoolThreadCache` that is not stored in thread-local.
     static final PoolThreadCache THREAD_CACHE_WITHOUT_THREAD_LOCAL = new PoolThreadCache();
 
     // TODO: Test if adding padding helps under contention

--- a/buffer/src/main/java/io/netty/buffer/PoolThreadCache.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolThreadCache.java
@@ -104,7 +104,7 @@ final class PoolThreadCache {
         freeOnFinalize = useFinalizer ? new FreeOnFinalize(this) : null;
     }
 
-    /** Creates a special `PoolThreadCache` that is not using thread-local. */
+    /** Creates a special `PoolThreadCache` that is not stored in thread-local. */
     PoolThreadCache() {
         this.freeSweepAllocationThreshold = 0;
         this.heapArena = null;

--- a/buffer/src/main/java/io/netty/buffer/PoolThreadCache.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolThreadCache.java
@@ -62,6 +62,7 @@ final class PoolThreadCache {
     private final FreeOnFinalize freeOnFinalize;
 
     private int allocations;
+    static final PoolThreadCache THREAD_CACHE_WITHOUT_THREAD_LOCAL = new PoolThreadCache();
 
     // TODO: Test if adding padding helps under contention
     //private long pad0, pad1, pad2, pad3, pad4, pad5, pad6, pad7;
@@ -101,6 +102,18 @@ final class PoolThreadCache {
                     + freeSweepAllocationThreshold + " (expected: > 0)");
         }
         freeOnFinalize = useFinalizer ? new FreeOnFinalize(this) : null;
+    }
+
+    /** Creates a special `PoolThreadCache` that is not using thread-local. */
+    PoolThreadCache() {
+        this.freeSweepAllocationThreshold = 0;
+        this.heapArena = null;
+        this.directArena = null;
+        this.smallSubPageDirectCaches = null;
+        this.normalDirectCaches = null;
+        this.smallSubPageHeapCaches = null;
+        this.normalHeapCaches = null;
+        this.freeOnFinalize = null;
     }
 
     private static <T> MemoryRegionCache<T>[] createSubPageCaches(
@@ -167,6 +180,10 @@ final class PoolThreadCache {
             trim();
         }
         return allocated;
+    }
+
+    boolean useThreadLocal() {
+        return this != THREAD_CACHE_WITHOUT_THREAD_LOCAL;
     }
 
     /**

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
@@ -17,7 +17,6 @@
 package io.netty.buffer;
 
 import io.netty.util.Recycler.EnhancedHandle;
-import io.netty.util.internal.ObjectPool;
 import io.netty.util.internal.ObjectPool.Handle;
 
 import java.io.IOException;
@@ -30,8 +29,7 @@ import java.nio.channels.ScatteringByteChannel;
 
 abstract class PooledByteBuf<T> extends AbstractReferenceCountedByteBuf {
 
-    private final EnhancedHandle<PooledByteBuf<T>> recyclerHandle;
-    private final Handle<PooledByteBuf<T>> handleNoThreadLocal;
+    private final Handle<PooledByteBuf<T>> recyclerHandle;
 
     protected PoolChunk<T> chunk;
     protected long handle;
@@ -46,13 +44,7 @@ abstract class PooledByteBuf<T> extends AbstractReferenceCountedByteBuf {
     @SuppressWarnings("unchecked")
     protected PooledByteBuf(Handle<? extends PooledByteBuf<T>> recyclerHandle, int maxCapacity) {
         super(maxCapacity);
-        if (recyclerHandle instanceof EnhancedHandle) {
-            this.recyclerHandle = (EnhancedHandle<PooledByteBuf<T>>) recyclerHandle;
-            this.handleNoThreadLocal = null;
-        } else {
-            this.recyclerHandle = null;
-            this.handleNoThreadLocal = (Handle<PooledByteBuf<T>>) recyclerHandle;
-        }
+        this.recyclerHandle = (Handle<PooledByteBuf<T>>) recyclerHandle;
     }
 
     void init(PoolChunk<T> chunk, ByteBuffer nioBuffer,
@@ -185,12 +177,11 @@ abstract class PooledByteBuf<T> extends AbstractReferenceCountedByteBuf {
             tmpNioBuf = null;
             chunk = null;
             cache = null;
-            assert (this.recyclerHandle == null && this.handleNoThreadLocal != null) ||
-                    (this.recyclerHandle != null && this.handleNoThreadLocal == null);
-            if (this.recyclerHandle != null) {
-                this.recyclerHandle.unguardedRecycle(this);
+            if (recyclerHandle instanceof EnhancedHandle) {
+                EnhancedHandle<PooledByteBuf<T>> enhancedHandle = (EnhancedHandle<PooledByteBuf<T>>) recyclerHandle;
+                enhancedHandle.unguardedRecycle(this);
             } else {
-                this.handleNoThreadLocal.recycle(this);
+                recyclerHandle.recycle(this);
             }
         }
     }

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
@@ -18,6 +18,7 @@ package io.netty.buffer;
 
 import io.netty.util.Recycler.EnhancedHandle;
 import io.netty.util.internal.ObjectPool.Handle;
+import io.netty.util.internal.ObjectUtil;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -44,7 +45,7 @@ abstract class PooledByteBuf<T> extends AbstractReferenceCountedByteBuf {
     @SuppressWarnings("unchecked")
     protected PooledByteBuf(Handle<? extends PooledByteBuf<T>> recyclerHandle, int maxCapacity) {
         super(maxCapacity);
-        this.recyclerHandle = (Handle<PooledByteBuf<T>>) recyclerHandle;
+        this.recyclerHandle = ObjectUtil.checkNotNull((Handle<PooledByteBuf<T>>) recyclerHandle, "recyclerHandle");
     }
 
     void init(PoolChunk<T> chunk, ByteBuffer nioBuffer,

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
@@ -53,7 +53,6 @@ abstract class PooledByteBuf<T> extends AbstractReferenceCountedByteBuf {
             this.recyclerHandle = null;
             this.handleNoThreadLocal = (Handle<PooledByteBuf<T>>) recyclerHandle;
         }
-
     }
 
     void init(PoolChunk<T> chunk, ByteBuffer nioBuffer,
@@ -186,8 +185,8 @@ abstract class PooledByteBuf<T> extends AbstractReferenceCountedByteBuf {
             tmpNioBuf = null;
             chunk = null;
             cache = null;
-            assert ((this.recyclerHandle == null && this.handleNoThreadLocal != null) ||
-                    (this.recyclerHandle != null && this.handleNoThreadLocal == null));
+            assert (this.recyclerHandle == null && this.handleNoThreadLocal != null) ||
+                    (this.recyclerHandle != null && this.handleNoThreadLocal == null);
             if (this.recyclerHandle != null) {
                 this.recyclerHandle.unguardedRecycle(this);
             } else {

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -398,7 +398,7 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
         if (cache.useThreadLocal()) {
             heapArena = cache.heapArena;
         } else {
-            heapArena = threadCache.attatchHeapArena();
+            heapArena = threadCache.selectHeapArena();
         }
         final ByteBuf buf;
         if (heapArena != null) {
@@ -419,7 +419,7 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
         if (cache.useThreadLocal()) {
             directArena = cache.directArena;
         } else {
-            directArena = threadCache.attatchDirectArena();
+            directArena = threadCache.selectDirectArena();
         }
         final ByteBuf buf;
         if (directArena != null) {
@@ -590,7 +590,7 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
             return PoolThreadCache.THREAD_CACHE_WITHOUT_THREAD_LOCAL;
         }
 
-        private PoolArena<byte[]> attatchHeapArena() {
+        private PoolArena<byte[]> selectHeapArena() {
             if (heapArenas == null || heapArenas.length == 0) {
                 return null;
             }
@@ -601,7 +601,7 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
             }
         }
 
-        private PoolArena<ByteBuffer> attatchDirectArena() {
+        private PoolArena<ByteBuffer> selectDirectArena() {
             if (directArenas == null || directArenas.length == 0) {
                 return null;
             }

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -571,7 +571,7 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
                         }
                         // No caching so just use 0 as sizes.
                         return new PoolThreadCache(heapArena, directArena, 0, 0,
-                                0, 0,false);
+                                0, 0, false);
                     }
                     @Override
                     protected void onRemoval(PoolThreadCache threadCache) {

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -283,8 +283,9 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
     }
 
     /**
-     * @param useThreadLocal If set to {@code false}, then the params {@code smallCacheSize}, {@code normalCacheSize}
-     *                       and {@code useCacheForAllThreads} will not take effect.
+     * @param useThreadLocal If set to {@code false}, then the params {@code smallCacheSize} and {@code normalCacheSize}
+     *                       will both be overwritten to {@code 0}, and the param {@code useCacheForAllThreads}
+     *                       will not take effect.
      */
     public PooledByteBufAllocator(boolean preferDirect, int nHeapArena, int nDirectArena, int pageSize, int maxOrder,
                                   int smallCacheSize, int normalCacheSize, boolean useCacheForAllThreads,

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -282,6 +282,10 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
                 useCacheForAllThreads, directMemoryCacheAlignment, true);
     }
 
+    /**
+     * @param useThreadLocal If set to {@code false}, then the params {@code smallCacheSize}, {@code normalCacheSize}
+     *                       and {@code useCacheForAllThreads} will not take effect.
+     */
     public PooledByteBufAllocator(boolean preferDirect, int nHeapArena, int nDirectArena, int pageSize, int maxOrder,
                                   int smallCacheSize, int normalCacheSize, boolean useCacheForAllThreads,
                                   int directMemoryCacheAlignment, boolean useThreadLocal) {

--- a/buffer/src/main/java/io/netty/buffer/PooledDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledDirectByteBuf.java
@@ -41,6 +41,10 @@ final class PooledDirectByteBuf extends PooledByteBuf<ByteBuffer> {
         return buf;
     }
 
+    static PooledDirectByteBuf newInstanceNoThreadLocal(Handle<PooledDirectByteBuf> unsafehandle) {
+        return new PooledDirectByteBuf(unsafehandle, 0);
+    }
+
     private PooledDirectByteBuf(Handle<PooledDirectByteBuf> recyclerHandle, int maxCapacity) {
         super(recyclerHandle, maxCapacity);
     }

--- a/buffer/src/main/java/io/netty/buffer/PooledDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledDirectByteBuf.java
@@ -41,11 +41,11 @@ final class PooledDirectByteBuf extends PooledByteBuf<ByteBuffer> {
         return buf;
     }
 
-    static PooledDirectByteBuf newInstanceNoThreadLocal(Handle<PooledDirectByteBuf> unsafehandle) {
-        return new PooledDirectByteBuf(unsafehandle, 0);
+    static PooledDirectByteBuf newInstanceNoThreadLocal(Handle<PooledByteBuf<ByteBuffer>> handle) {
+        return new PooledDirectByteBuf(handle, 0);
     }
 
-    private PooledDirectByteBuf(Handle<PooledDirectByteBuf> recyclerHandle, int maxCapacity) {
+    private PooledDirectByteBuf(Handle<? extends PooledByteBuf<ByteBuffer>> recyclerHandle, int maxCapacity) {
         super(recyclerHandle, maxCapacity);
     }
 

--- a/buffer/src/main/java/io/netty/buffer/PooledHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledHeapByteBuf.java
@@ -40,6 +40,10 @@ class PooledHeapByteBuf extends PooledByteBuf<byte[]> {
         return buf;
     }
 
+    static PooledHeapByteBuf newInstanceNoThreadLocal(Handle<PooledHeapByteBuf> handle) {
+        return new PooledHeapByteBuf(handle, 0);
+    }
+
     PooledHeapByteBuf(Handle<? extends PooledHeapByteBuf> recyclerHandle, int maxCapacity) {
         super(recyclerHandle, maxCapacity);
     }

--- a/buffer/src/main/java/io/netty/buffer/PooledUnsafeDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledUnsafeDirectByteBuf.java
@@ -41,13 +41,13 @@ final class PooledUnsafeDirectByteBuf extends PooledByteBuf<ByteBuffer> {
         return buf;
     }
 
-    static PooledUnsafeDirectByteBuf newUnsafeInstanceNoThreadLocal(Handle<PooledUnsafeDirectByteBuf> unsafehandle) {
-        return new PooledUnsafeDirectByteBuf(unsafehandle, 0);
+    static PooledUnsafeDirectByteBuf newInstanceNoThreadLocal(Handle<PooledByteBuf<ByteBuffer>> handle) {
+        return new PooledUnsafeDirectByteBuf(handle, 0);
     }
 
     private long memoryAddress;
 
-    private PooledUnsafeDirectByteBuf(Handle<PooledUnsafeDirectByteBuf> recyclerHandle, int maxCapacity) {
+    private PooledUnsafeDirectByteBuf(Handle<? extends PooledByteBuf<ByteBuffer>> recyclerHandle, int maxCapacity) {
         super(recyclerHandle, maxCapacity);
     }
 

--- a/buffer/src/main/java/io/netty/buffer/PooledUnsafeDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledUnsafeDirectByteBuf.java
@@ -41,6 +41,10 @@ final class PooledUnsafeDirectByteBuf extends PooledByteBuf<ByteBuffer> {
         return buf;
     }
 
+    static PooledUnsafeDirectByteBuf newUnsafeInstanceNoThreadLocal(Handle<PooledUnsafeDirectByteBuf> unsafehandle) {
+        return new PooledUnsafeDirectByteBuf(unsafehandle, 0);
+    }
+
     private long memoryAddress;
 
     private PooledUnsafeDirectByteBuf(Handle<PooledUnsafeDirectByteBuf> recyclerHandle, int maxCapacity) {

--- a/buffer/src/main/java/io/netty/buffer/PooledUnsafeHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledUnsafeHeapByteBuf.java
@@ -36,11 +36,11 @@ final class PooledUnsafeHeapByteBuf extends PooledHeapByteBuf {
         return buf;
     }
 
-    static PooledUnsafeHeapByteBuf newUnsafeInstanceNoThreadLocal(Handle<PooledUnsafeHeapByteBuf> handle) {
+    static PooledUnsafeHeapByteBuf newInstanceNoThreadLocal(Handle<PooledHeapByteBuf> handle) {
         return new PooledUnsafeHeapByteBuf(handle, 0);
     }
 
-    private PooledUnsafeHeapByteBuf(Handle<PooledUnsafeHeapByteBuf> recyclerHandle, int maxCapacity) {
+    private PooledUnsafeHeapByteBuf(Handle<? extends PooledHeapByteBuf> recyclerHandle, int maxCapacity) {
         super(recyclerHandle, maxCapacity);
     }
 

--- a/buffer/src/main/java/io/netty/buffer/PooledUnsafeHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledUnsafeHeapByteBuf.java
@@ -36,6 +36,10 @@ final class PooledUnsafeHeapByteBuf extends PooledHeapByteBuf {
         return buf;
     }
 
+    static PooledUnsafeHeapByteBuf newUnsafeInstanceNoThreadLocal(Handle<PooledUnsafeHeapByteBuf> handle) {
+        return new PooledUnsafeHeapByteBuf(handle, 0);
+    }
+
     private PooledUnsafeHeapByteBuf(Handle<PooledUnsafeHeapByteBuf> recyclerHandle, int maxCapacity) {
         super(recyclerHandle, maxCapacity);
     }

--- a/buffer/src/test/java/io/netty/buffer/NoThreadLocalAlignedPooledByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/NoThreadLocalAlignedPooledByteBufAllocatorTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class NoThreadLocalAlignedPooledByteBufAllocatorTest extends AlignedPooledByteBufAllocatorTest {
+
+    @Override
+    protected PooledByteBufAllocator newAllocator(boolean preferDirect) {
+        assumeTrue(PooledByteBufAllocator.isDirectMemoryCacheAlignmentSupported());
+        int directMemoryCacheAlignment = 1;
+        return new PooledByteBufAllocator(
+                preferDirect,
+                PooledByteBufAllocator.defaultNumHeapArena(),
+                PooledByteBufAllocator.defaultNumDirectArena(),
+                PooledByteBufAllocator.defaultPageSize(),
+                11,
+                PooledByteBufAllocator.defaultSmallCacheSize(),
+                64,
+                PooledByteBufAllocator.defaultUseCacheForAllThreads(),
+                directMemoryCacheAlignment,
+                false);
+    }
+
+    @Override
+    @Test
+    public void testTrim() {
+        PooledByteBufAllocator allocator = newAllocator(true);
+
+        // Should return false as we never allocated from this thread yet.
+        assertFalse(allocator.trimCurrentThreadCache());
+
+        ByteBuf directBuffer = allocator.directBuffer();
+
+        assertTrue(directBuffer.release());
+
+        // Should return false as there is no thread-local cache used.
+        assertFalse(allocator.trimCurrentThreadCache());
+    }
+}

--- a/buffer/src/test/java/io/netty/buffer/NoThreadLocalPoolArenaTest.java
+++ b/buffer/src/test/java/io/netty/buffer/NoThreadLocalPoolArenaTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import org.junit.jupiter.api.Test;
+import java.nio.ByteBuffer;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class NoThreadLocalPoolArenaTest extends PoolArenaTest {
+
+    @Override
+    protected PoolArena<ByteBuffer> newDirectArena(SizeClasses sc) {
+        return new PoolArena.DirectArena(null, sc, false);
+    }
+
+    @Override
+    @Test
+    public void testAllocationCounter() {
+        final PooledByteBufAllocator allocator = new PooledByteBufAllocator(
+                true,   // preferDirect
+                0,      // nHeapArena
+                1,      // nDirectArena
+                8192,   // pageSize
+                11,     // maxOrder
+                10,     // smallCacheSize
+                10,     // normalCacheSize
+                false,  // useCacheForAllThreads
+                0,      // directMemoryCacheAlignment
+                false   // useThreadLocal
+        );
+
+        // create small buffer
+        final ByteBuf b1 = allocator.directBuffer(800);
+        // create normal buffer
+        final ByteBuf b2 = allocator.directBuffer(8192 * 5);
+
+        assertNotNull(b1);
+        assertNotNull(b2);
+
+        // then release buffer to deallocated memory while thread-local has been disabled
+        // allocations counter value must equals deallocations counter value.
+        assertTrue(b1.release());
+        assertTrue(b2.release());
+
+        assertTrue(allocator.directArenas().size() >= 1);
+        final PoolArenaMetric metric = allocator.directArenas().get(0);
+
+        assertEquals(2, metric.numDeallocations());
+        assertEquals(2, metric.numAllocations());
+
+        assertEquals(1, metric.numSmallDeallocations());
+        assertEquals(1, metric.numSmallAllocations());
+        assertEquals(1, metric.numNormalDeallocations());
+        assertEquals(1, metric.numNormalAllocations());
+    }
+
+    @Override
+    @Test
+    public void testDirectArenaMemoryCopy() {
+        ByteBuf src = PooledByteBufAllocator.DEFAULT_NO_TL.directBuffer(512);
+        ByteBuf dst = PooledByteBufAllocator.DEFAULT_NO_TL.directBuffer(512);
+
+        PooledByteBuf<ByteBuffer> pooledSrc = unwrapIfNeeded(src);
+        PooledByteBuf<ByteBuffer> pooledDst = unwrapIfNeeded(dst);
+
+        // This causes the internal reused ByteBuffer duplicate limit to be set to 128
+        pooledDst.writeBytes(ByteBuffer.allocate(128));
+        // Ensure internal ByteBuffer duplicate limit is properly reset (used in memoryCopy non-Unsafe case)
+        pooledDst.chunk.arena.memoryCopy(pooledSrc.memory, 0, pooledDst, 512);
+
+        src.release();
+        dst.release();
+    }
+
+    @SuppressWarnings("unchecked")
+    private PooledByteBuf<ByteBuffer> unwrapIfNeeded(ByteBuf buf) {
+        return (PooledByteBuf<ByteBuffer>) (buf instanceof PooledByteBuf ? buf : buf.unwrap());
+    }
+}

--- a/buffer/src/test/java/io/netty/buffer/NoThreadLocalPooledByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/NoThreadLocalPooledByteBufAllocatorTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class NoThreadLocalPooledByteBufAllocatorTest extends PooledByteBufAllocatorTest {
+
+    @Override
+    protected PooledByteBufAllocator newAllocator(boolean preferDirect) {
+        assumeTrue(PooledByteBufAllocator.isDirectMemoryCacheAlignmentSupported());
+        return new PooledByteBufAllocator(
+                preferDirect,
+                PooledByteBufAllocator.defaultNumHeapArena(),
+                PooledByteBufAllocator.defaultNumDirectArena(),
+                PooledByteBufAllocator.defaultPageSize(),
+                PooledByteBufAllocator.defaultMaxOrder(),
+                PooledByteBufAllocator.defaultSmallCacheSize(),
+                PooledByteBufAllocator.defaultNormalCacheSize(),
+                PooledByteBufAllocator.defaultUseCacheForAllThreads(),
+                0,
+                false);
+    }
+
+    @Override
+    @Test
+    public void testTrim() {
+        PooledByteBufAllocator allocator = newAllocator(true);
+
+        // Should return false as we never allocated from this thread yet.
+        assertFalse(allocator.trimCurrentThreadCache());
+
+        ByteBuf directBuffer = allocator.directBuffer();
+
+        assertTrue(directBuffer.release());
+
+        // Should return false as there is no thread-local cache used.
+        assertFalse(allocator.trimCurrentThreadCache());
+    }
+}

--- a/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
@@ -31,10 +31,14 @@ public class PoolArenaTest {
     //chunkSize = pageSize * (2 ^ pageShifts)
     private static final int CHUNK_SIZE = 16777216;
 
+    protected PoolArena<ByteBuffer> newDirectArena(SizeClasses sc) {
+        return new PoolArena.DirectArena(null, sc, true);
+    }
+
     @Test
     public void testNormalizeCapacity() {
         SizeClasses sc = new SizeClasses(PAGE_SIZE, PAGE_SHIFTS, CHUNK_SIZE, 0);
-        PoolArena<ByteBuffer> arena = new PoolArena.DirectArena(null, sc, true);
+        PoolArena<ByteBuffer> arena = newDirectArena(sc);
         int[] reqCapacities = {0, 15, 510, 1024, 1023, 1025};
         int[] expectedResult = {16, 16, 512, 1024, 1024, 1280};
         for (int i = 0; i < reqCapacities.length; i ++) {
@@ -46,7 +50,7 @@ public class PoolArenaTest {
     @Test
     public void testNormalizeAlignedCapacity() {
         SizeClasses sc = new SizeClasses(PAGE_SIZE, PAGE_SHIFTS, CHUNK_SIZE, 64);
-        PoolArena<ByteBuffer> arena = new PoolArena.DirectArena(null, sc, true);
+        PoolArena<ByteBuffer> arena = newDirectArena(sc);
         int[] reqCapacities = {0, 15, 510, 1024, 1023, 1025};
         int[] expectedResult = {64, 64, 512, 1024, 1024, 1280};
         for (int i = 0; i < reqCapacities.length; i ++) {
@@ -58,7 +62,7 @@ public class PoolArenaTest {
     @Test
     public void testSize2SizeIdx() {
         SizeClasses sc = new SizeClasses(PAGE_SIZE, PAGE_SHIFTS, CHUNK_SIZE, 0);
-        PoolArena<ByteBuffer> arena = new PoolArena.DirectArena(null, sc, true);
+        PoolArena<ByteBuffer> arena = newDirectArena(sc);
 
         for (int sz = 0; sz <= CHUNK_SIZE; sz++) {
             int sizeIdx = arena.sizeClass.size2SizeIdx(sz);
@@ -73,7 +77,7 @@ public class PoolArenaTest {
     public void testPages2PageIdx() {
         int pageShifts = PAGE_SHIFTS;
         SizeClasses sc = new SizeClasses(PAGE_SIZE, PAGE_SHIFTS, CHUNK_SIZE, 0);
-        PoolArena<ByteBuffer> arena = new PoolArena.DirectArena(null, sc, true);
+        PoolArena<ByteBuffer> arena = newDirectArena(sc);
 
         int maxPages = CHUNK_SIZE >> pageShifts;
         for (int pages = 1; pages <= maxPages; pages++) {
@@ -94,7 +98,7 @@ public class PoolArenaTest {
     @Test
     public void testSizeIdx2size() {
         SizeClasses sc = new SizeClasses(PAGE_SIZE, PAGE_SHIFTS, CHUNK_SIZE, 0);
-        PoolArena<ByteBuffer> arena = new PoolArena.DirectArena(null, sc, true);
+        PoolArena<ByteBuffer> arena = newDirectArena(sc);
         for (int i = 0; i < arena.sizeClass.nSizes; i++) {
             assertEquals(arena.sizeClass.sizeIdx2sizeCompute(i), arena.sizeClass.sizeIdx2size(i));
         }
@@ -103,7 +107,7 @@ public class PoolArenaTest {
     @Test
     public void testPageIdx2size() {
         SizeClasses sc = new SizeClasses(PAGE_SIZE, PAGE_SHIFTS, CHUNK_SIZE, 0);
-        PoolArena<ByteBuffer> arena = new PoolArena.DirectArena(null, sc, true);
+        PoolArena<ByteBuffer> arena = newDirectArena(sc);
         for (int i = 0; i < arena.sizeClass.nPSizes; i++) {
             assertEquals(arena.sizeClass.pageIdx2sizeCompute(i), arena.sizeClass.pageIdx2size(i));
         }

--- a/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
@@ -34,7 +34,7 @@ public class PoolArenaTest {
     @Test
     public void testNormalizeCapacity() {
         SizeClasses sc = new SizeClasses(PAGE_SIZE, PAGE_SHIFTS, CHUNK_SIZE, 0);
-        PoolArena<ByteBuffer> arena = new PoolArena.DirectArena(null, sc);
+        PoolArena<ByteBuffer> arena = new PoolArena.DirectArena(null, sc, true);
         int[] reqCapacities = {0, 15, 510, 1024, 1023, 1025};
         int[] expectedResult = {16, 16, 512, 1024, 1024, 1280};
         for (int i = 0; i < reqCapacities.length; i ++) {
@@ -46,7 +46,7 @@ public class PoolArenaTest {
     @Test
     public void testNormalizeAlignedCapacity() {
         SizeClasses sc = new SizeClasses(PAGE_SIZE, PAGE_SHIFTS, CHUNK_SIZE, 64);
-        PoolArena<ByteBuffer> arena = new PoolArena.DirectArena(null, sc);
+        PoolArena<ByteBuffer> arena = new PoolArena.DirectArena(null, sc, true);
         int[] reqCapacities = {0, 15, 510, 1024, 1023, 1025};
         int[] expectedResult = {64, 64, 512, 1024, 1024, 1280};
         for (int i = 0; i < reqCapacities.length; i ++) {
@@ -58,7 +58,7 @@ public class PoolArenaTest {
     @Test
     public void testSize2SizeIdx() {
         SizeClasses sc = new SizeClasses(PAGE_SIZE, PAGE_SHIFTS, CHUNK_SIZE, 0);
-        PoolArena<ByteBuffer> arena = new PoolArena.DirectArena(null, sc);
+        PoolArena<ByteBuffer> arena = new PoolArena.DirectArena(null, sc, true);
 
         for (int sz = 0; sz <= CHUNK_SIZE; sz++) {
             int sizeIdx = arena.sizeClass.size2SizeIdx(sz);
@@ -73,7 +73,7 @@ public class PoolArenaTest {
     public void testPages2PageIdx() {
         int pageShifts = PAGE_SHIFTS;
         SizeClasses sc = new SizeClasses(PAGE_SIZE, PAGE_SHIFTS, CHUNK_SIZE, 0);
-        PoolArena<ByteBuffer> arena = new PoolArena.DirectArena(null, sc);
+        PoolArena<ByteBuffer> arena = new PoolArena.DirectArena(null, sc, true);
 
         int maxPages = CHUNK_SIZE >> pageShifts;
         for (int pages = 1; pages <= maxPages; pages++) {
@@ -94,7 +94,7 @@ public class PoolArenaTest {
     @Test
     public void testSizeIdx2size() {
         SizeClasses sc = new SizeClasses(PAGE_SIZE, PAGE_SHIFTS, CHUNK_SIZE, 0);
-        PoolArena<ByteBuffer> arena = new PoolArena.DirectArena(null, sc);
+        PoolArena<ByteBuffer> arena = new PoolArena.DirectArena(null, sc, true);
         for (int i = 0; i < arena.sizeClass.nSizes; i++) {
             assertEquals(arena.sizeClass.sizeIdx2sizeCompute(i), arena.sizeClass.sizeIdx2size(i));
         }
@@ -103,7 +103,7 @@ public class PoolArenaTest {
     @Test
     public void testPageIdx2size() {
         SizeClasses sc = new SizeClasses(PAGE_SIZE, PAGE_SHIFTS, CHUNK_SIZE, 0);
-        PoolArena<ByteBuffer> arena = new PoolArena.DirectArena(null, sc);
+        PoolArena<ByteBuffer> arena = new PoolArena.DirectArena(null, sc, true);
         for (int i = 0; i < arena.sizeClass.nPSizes; i++) {
             assertEquals(arena.sizeClass.pageIdx2sizeCompute(i), arena.sizeClass.pageIdx2size(i));
         }


### PR DESCRIPTION
Motivation:

Add the ability to disable `threadLocal` on `PooledByteBufAllocator`, this gives the users an option to better deal with virtual thread by using `PooledByteBufAllocator`. For example: https://github.com/netty/netty/issues/12848.

Simply way to use: 
Use `PooledByteBufAllocator.DEFAULT_NO_TL`, it will return a non-threadLocal `PooledByteBufAllocator` using default settings.

For `PooledByteBufAllocator`, there are mainly two places heavily used `threadLocal`:
1. Bind current thread to specific arena.
    
2. Allocate `byteBuf` by using `RECYCLER`.

In this PR, when `threadLocal` been disabled:

For 1: We bind the arena by using thread-id hashing, it is feasible when `threadLocal` is not available, which has also been stated in [Jemalloc doc](https://people.freebsd.org/~jasone/jemalloc/bsdcan2006/jemalloc.pdf):

> Non-PIC code and some architectures do not support TLS, so in those cases, the allocator uses thread identifier hashing.

For 2: We use a `mpmcQueue` for every arena to recycle the `byteBuf`.
