### PR TITLE
IoUring: Make use of IORING_CQE_F_SOCK_NONEMPTY and IORING_ACCEPT_DON…

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoOps.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoOps.java
@@ -310,16 +310,18 @@ public final class IoUringIoOps implements IoOps {
      *
      * @param fd                                    the filedescriptor
      * @param flags                                 the flags.
+     * @param acceptFlags                           the flags for ACCEPT itself
+     * @param ioPrio                                io_prio
      * @param acceptedAddressMemoryAddress          the memory address of the sockaddr_storage.
      * @param acceptedAddressLengthMemoryAddress    the memory address of the length that will be updated once a new
      *                                              connection was accepted.
      * @param data                                  the data
      * @return                                      ops.
      */
-    static IoUringIoOps newAccept(int fd, byte flags, int acceptFlags, long acceptedAddressMemoryAddress,
+    static IoUringIoOps newAccept(int fd, byte flags, int acceptFlags, short ioPrio, long acceptedAddressMemoryAddress,
                                          long acceptedAddressLengthMemoryAddress, short data) {
 
-        return new IoUringIoOps(Native.IORING_OP_ACCEPT, flags, (short) 0, fd, acceptedAddressLengthMemoryAddress,
+        return new IoUringIoOps(Native.IORING_OP_ACCEPT, flags, ioPrio, fd, acceptedAddressLengthMemoryAddress,
                 acceptedAddressMemoryAddress, 0, acceptFlags, data, (short) 0, (short) 0, 0, 0);
     }
 

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -335,11 +335,6 @@ final class Native {
         return ioUringProbe(ringFd, new int[] { Native.IORING_OP_SOCKET });
     }
 
-    static boolean isIOUringAcceptSupportNoWait(int ringFd) {
-        // IORING_OP_BIND was added one release after (6.11);
-        return ioUringProbe(ringFd, new int[] { Native.IORING_OP_BIND });
-    }
-
     static boolean isIOUringSupportSplice(int ringFd) {
         // IORING_OP_SPLICE Available since 5.7
         return ioUringProbe(ringFd, new int[] { Native.IORING_OP_SPLICE });

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -191,10 +191,13 @@ final class Native {
     static final byte IORING_OP_FUTEX_WAITV = 53;
     static final byte IORING_OP_FIXED_FD_INSTALL = 54;
     static final byte IORING_OP_FTRUNCATE = 55;
+    static final byte IORING_OP_BIND = 56;
     static final byte IORING_CQE_F_SOCK_NONEMPTY = 1 << 2;
 
     static final short IORING_RECVSEND_POLL_FIRST = 1 << 0;
+    static final int IORING_ACCEPT_DONT_WAIT = 1 << 1;
 
+    static final int IORING_FEAT_RECVSEND_BUNDLE = 1 << 14;
     static final int SPLICE_F_MOVE = 1;
 
     static String opToStr(byte op) {
@@ -330,6 +333,11 @@ final class Native {
     static boolean isIOUringCqeFSockNonEmptySupported(int ringFd) {
         // IORING_OP_SOCKET was added in the same release (5.19);
         return ioUringProbe(ringFd, new int[] { Native.IORING_OP_SOCKET });
+    }
+
+    static boolean isIOUringAcceptSupportNoWait(int ringFd) {
+        // IORING_OP_BIND was added one release after (6.11);
+        return ioUringProbe(ringFd, new int[] { Native.IORING_OP_BIND });
     }
 
     static boolean isIOUringSupportSplice(int ringFd) {


### PR DESCRIPTION
…T_WAIT if supported

Modifications:

We can make use of both these features to not use POLLIN in some scenaries and also direclty know when there is no more connections to accept without scheduling another accept.

Modifications:

- Check if we can make use of these features as these are only ready on recent kernels
- enable if possible

Result:

Less overhead on recent kernels