### PR TITLE
IoUring: Run tests with POLLIN_FIRST enabled and disabled

### DIFF
--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringCompositeBufferGatheringWriteTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringCompositeBufferGatheringWriteTest.java
@@ -17,6 +17,7 @@ package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.CompositeBufferGatheringWriteTest;
 import org.junit.jupiter.api.BeforeAll;
@@ -35,5 +36,13 @@ public class IoUringCompositeBufferGatheringWriteTest extends CompositeBufferGat
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return IoUringSocketTestPermutation.INSTANCE.socket();
+    }
+
+    @Override
+    protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(sb, cb, allocator);
+        sb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        sb.childOption(IoUringChannelOption.POLLIN_FIRST, false);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, false);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDatagramConnectNotExistsTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDatagramConnectNotExistsTest.java
@@ -16,6 +16,7 @@
 package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.DatagramConnectNotExistsTest;
 import org.junit.jupiter.api.BeforeAll;
@@ -34,5 +35,11 @@ public class IoUringDatagramConnectNotExistsTest extends DatagramConnectNotExist
     @Override
     protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
         return IoUringSocketTestPermutation.INSTANCE.datagramSocket();
+    }
+
+    @Override
+    protected void configure(Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(cb, allocator);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, false);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDatagramMulticastIPv6Test.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDatagramMulticastIPv6Test.java
@@ -16,6 +16,7 @@
 package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.DatagramMulticastIPv6Test;
 import org.junit.jupiter.api.BeforeAll;
@@ -34,5 +35,12 @@ public class IoUringDatagramMulticastIPv6Test extends DatagramMulticastIPv6Test 
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<Bootstrap, Bootstrap>> newFactories() {
         return IoUringSocketTestPermutation.INSTANCE.datagram(socketProtocolFamily());
+    }
+
+    @Override
+    protected void configure(Bootstrap bootstrap, Bootstrap bootstrap2, ByteBufAllocator allocator) {
+        super.configure(bootstrap, bootstrap2, allocator);
+        bootstrap.option(IoUringChannelOption.POLLIN_FIRST, false);
+        bootstrap2.option(IoUringChannelOption.POLLIN_FIRST, false);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDatagramMulticastTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDatagramMulticastTest.java
@@ -16,6 +16,7 @@
 package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.DatagramMulticastTest;
 import org.junit.jupiter.api.BeforeAll;
@@ -34,5 +35,12 @@ public class IoUringDatagramMulticastTest extends DatagramMulticastTest {
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<Bootstrap, Bootstrap>> newFactories() {
         return IoUringSocketTestPermutation.INSTANCE.datagram(socketProtocolFamily());
+    }
+
+    @Override
+    protected void configure(Bootstrap bootstrap, Bootstrap bootstrap2, ByteBufAllocator allocator) {
+        super.configure(bootstrap, bootstrap2, allocator);
+        bootstrap.option(IoUringChannelOption.POLLIN_FIRST, false);
+        bootstrap2.option(IoUringChannelOption.POLLIN_FIRST, false);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDatagramUnicastIPv6MappedTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDatagramUnicastIPv6MappedTest.java
@@ -16,6 +16,7 @@
 package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation.BootstrapComboFactory;
 import io.netty.testsuite.transport.socket.DatagramUnicastIPv6MappedTest;
 import org.junit.jupiter.api.BeforeAll;
@@ -34,5 +35,12 @@ public class IoUringDatagramUnicastIPv6MappedTest extends DatagramUnicastIPv6Map
     @Override
     protected List<BootstrapComboFactory<Bootstrap, Bootstrap>> newFactories() {
         return IoUringSocketTestPermutation.INSTANCE.datagram(socketProtocolFamily());
+    }
+
+    @Override
+    protected void configure(Bootstrap bootstrap, Bootstrap bootstrap2, ByteBufAllocator allocator) {
+        super.configure(bootstrap, bootstrap2, allocator);
+        bootstrap.option(IoUringChannelOption.POLLIN_FIRST, false);
+        bootstrap2.option(IoUringChannelOption.POLLIN_FIRST, false);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDatagramUnicastIPv6Test.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDatagramUnicastIPv6Test.java
@@ -16,6 +16,7 @@
 package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.DatagramUnicastIPv6Test;
 import org.junit.jupiter.api.BeforeAll;
@@ -36,4 +37,10 @@ public class IoUringDatagramUnicastIPv6Test extends DatagramUnicastIPv6Test {
         return IoUringSocketTestPermutation.INSTANCE.datagram(socketProtocolFamily());
     }
 
+    @Override
+    protected void configure(Bootstrap bootstrap, Bootstrap bootstrap2, ByteBufAllocator allocator) {
+        super.configure(bootstrap, bootstrap2, allocator);
+        bootstrap.option(IoUringChannelOption.POLLIN_FIRST, false);
+        bootstrap2.option(IoUringChannelOption.POLLIN_FIRST, false);
+    }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstCompositeBufferGatheringWriteTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstCompositeBufferGatheringWriteTest.java
@@ -16,16 +16,17 @@
 package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
-import io.netty.testsuite.transport.socket.WriteBeforeRegisteredTest;
+import io.netty.testsuite.transport.socket.CompositeBufferGatheringWriteTest;
 import org.junit.jupiter.api.BeforeAll;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest {
+public class IoUringPollinFirstCompositeBufferGatheringWriteTest extends CompositeBufferGatheringWriteTest  {
 
     @BeforeAll
     public static void loadJNI() {
@@ -33,13 +34,15 @@ public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest 
     }
 
     @Override
-    protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
-        return IoUringSocketTestPermutation.INSTANCE.clientSocket();
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IoUringSocketTestPermutation.INSTANCE.socket();
     }
 
     @Override
-    protected void configure(Bootstrap bootstrap, ByteBufAllocator allocator) {
-        super.configure(bootstrap, allocator);
-        bootstrap.option(IoUringChannelOption.POLLIN_FIRST, false);
+    protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(sb, cb, allocator);
+        sb.option(IoUringChannelOption.POLLIN_FIRST, true);
+        sb.childOption(IoUringChannelOption.POLLIN_FIRST, true);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, true);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstDatagramConnectNotExistsTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstDatagramConnectNotExistsTest.java
@@ -18,14 +18,14 @@ package io.netty.channel.uring;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
-import io.netty.testsuite.transport.socket.WriteBeforeRegisteredTest;
+import io.netty.testsuite.transport.socket.DatagramConnectNotExistsTest;
 import org.junit.jupiter.api.BeforeAll;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest {
+public class IoUringPollinFirstDatagramConnectNotExistsTest extends DatagramConnectNotExistsTest {
 
     @BeforeAll
     public static void loadJNI() {
@@ -34,12 +34,12 @@ public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest 
 
     @Override
     protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
-        return IoUringSocketTestPermutation.INSTANCE.clientSocket();
+        return IoUringSocketTestPermutation.INSTANCE.datagramSocket();
     }
 
     @Override
-    protected void configure(Bootstrap bootstrap, ByteBufAllocator allocator) {
-        super.configure(bootstrap, allocator);
-        bootstrap.option(IoUringChannelOption.POLLIN_FIRST, false);
+    protected void configure(Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(cb, allocator);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, true);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstDatagramMulticastIPv6Test.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstDatagramMulticastIPv6Test.java
@@ -18,14 +18,14 @@ package io.netty.channel.uring;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
-import io.netty.testsuite.transport.socket.WriteBeforeRegisteredTest;
+import io.netty.testsuite.transport.socket.DatagramMulticastIPv6Test;
 import org.junit.jupiter.api.BeforeAll;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest {
+public class IoUringPollinFirstDatagramMulticastIPv6Test extends DatagramMulticastIPv6Test {
 
     @BeforeAll
     public static void loadJNI() {
@@ -33,13 +33,14 @@ public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest 
     }
 
     @Override
-    protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
-        return IoUringSocketTestPermutation.INSTANCE.clientSocket();
+    protected List<TestsuitePermutation.BootstrapComboFactory<Bootstrap, Bootstrap>> newFactories() {
+        return IoUringSocketTestPermutation.INSTANCE.datagram(socketProtocolFamily());
     }
 
     @Override
-    protected void configure(Bootstrap bootstrap, ByteBufAllocator allocator) {
-        super.configure(bootstrap, allocator);
-        bootstrap.option(IoUringChannelOption.POLLIN_FIRST, false);
+    protected void configure(Bootstrap bootstrap, Bootstrap bootstrap2, ByteBufAllocator allocator) {
+        super.configure(bootstrap, bootstrap2, allocator);
+        bootstrap.option(IoUringChannelOption.POLLIN_FIRST, true);
+        bootstrap2.option(IoUringChannelOption.POLLIN_FIRST, true);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstDatagramMulticastTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstDatagramMulticastTest.java
@@ -18,14 +18,14 @@ package io.netty.channel.uring;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
-import io.netty.testsuite.transport.socket.WriteBeforeRegisteredTest;
+import io.netty.testsuite.transport.socket.DatagramMulticastTest;
 import org.junit.jupiter.api.BeforeAll;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest {
+public class IoUringPollinFirstDatagramMulticastTest extends DatagramMulticastTest {
 
     @BeforeAll
     public static void loadJNI() {
@@ -33,13 +33,14 @@ public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest 
     }
 
     @Override
-    protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
-        return IoUringSocketTestPermutation.INSTANCE.clientSocket();
+    protected List<TestsuitePermutation.BootstrapComboFactory<Bootstrap, Bootstrap>> newFactories() {
+        return IoUringSocketTestPermutation.INSTANCE.datagram(socketProtocolFamily());
     }
 
     @Override
-    protected void configure(Bootstrap bootstrap, ByteBufAllocator allocator) {
-        super.configure(bootstrap, allocator);
-        bootstrap.option(IoUringChannelOption.POLLIN_FIRST, false);
+    protected void configure(Bootstrap bootstrap, Bootstrap bootstrap2, ByteBufAllocator allocator) {
+        super.configure(bootstrap, bootstrap2, allocator);
+        bootstrap.option(IoUringChannelOption.POLLIN_FIRST, true);
+        bootstrap2.option(IoUringChannelOption.POLLIN_FIRST, true);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstDatagramUnicastIPv6MappedTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstDatagramUnicastIPv6MappedTest.java
@@ -17,15 +17,15 @@ package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.testsuite.transport.TestsuitePermutation;
-import io.netty.testsuite.transport.socket.WriteBeforeRegisteredTest;
+import io.netty.testsuite.transport.TestsuitePermutation.BootstrapComboFactory;
+import io.netty.testsuite.transport.socket.DatagramUnicastIPv6MappedTest;
 import org.junit.jupiter.api.BeforeAll;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest {
+public class IoUringPollinFirstDatagramUnicastIPv6MappedTest extends DatagramUnicastIPv6MappedTest {
 
     @BeforeAll
     public static void loadJNI() {
@@ -33,13 +33,14 @@ public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest 
     }
 
     @Override
-    protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
-        return IoUringSocketTestPermutation.INSTANCE.clientSocket();
+    protected List<BootstrapComboFactory<Bootstrap, Bootstrap>> newFactories() {
+        return IoUringSocketTestPermutation.INSTANCE.datagram(socketProtocolFamily());
     }
 
     @Override
-    protected void configure(Bootstrap bootstrap, ByteBufAllocator allocator) {
-        super.configure(bootstrap, allocator);
-        bootstrap.option(IoUringChannelOption.POLLIN_FIRST, false);
+    protected void configure(Bootstrap bootstrap, Bootstrap bootstrap2, ByteBufAllocator allocator) {
+        super.configure(bootstrap, bootstrap2, allocator);
+        bootstrap.option(IoUringChannelOption.POLLIN_FIRST, true);
+        bootstrap2.option(IoUringChannelOption.POLLIN_FIRST, true);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstDatagramUnicastIPv6Test.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstDatagramUnicastIPv6Test.java
@@ -18,14 +18,14 @@ package io.netty.channel.uring;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
-import io.netty.testsuite.transport.socket.WriteBeforeRegisteredTest;
+import io.netty.testsuite.transport.socket.DatagramUnicastIPv6Test;
 import org.junit.jupiter.api.BeforeAll;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest {
+public class IoUringPollinFirstDatagramUnicastIPv6Test extends DatagramUnicastIPv6Test {
 
     @BeforeAll
     public static void loadJNI() {
@@ -33,13 +33,14 @@ public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest 
     }
 
     @Override
-    protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
-        return IoUringSocketTestPermutation.INSTANCE.clientSocket();
+    protected List<TestsuitePermutation.BootstrapComboFactory<Bootstrap, Bootstrap>> newFactories() {
+        return IoUringSocketTestPermutation.INSTANCE.datagram(socketProtocolFamily());
     }
 
     @Override
-    protected void configure(Bootstrap bootstrap, ByteBufAllocator allocator) {
-        super.configure(bootstrap, allocator);
-        bootstrap.option(IoUringChannelOption.POLLIN_FIRST, false);
+    protected void configure(Bootstrap bootstrap, Bootstrap bootstrap2, ByteBufAllocator allocator) {
+        super.configure(bootstrap, bootstrap2, allocator);
+        bootstrap.option(IoUringChannelOption.POLLIN_FIRST, true);
+        bootstrap2.option(IoUringChannelOption.POLLIN_FIRST, true);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstDatagramUnicastTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstDatagramUnicastTest.java
@@ -39,7 +39,7 @@ import java.util.concurrent.CountDownLatch;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class IoUringDatagramUnicastTest extends DatagramUnicastInetTest {
+public class IoUringPollinFirstDatagramUnicastTest extends DatagramUnicastInetTest {
 
     @BeforeAll
     public static void loadJNI() {
@@ -54,8 +54,8 @@ public class IoUringDatagramUnicastTest extends DatagramUnicastInetTest {
     @Override
     protected void configure(Bootstrap bootstrap, Bootstrap bootstrap2, ByteBufAllocator allocator) {
         super.configure(bootstrap, bootstrap2, allocator);
-        bootstrap.option(IoUringChannelOption.POLLIN_FIRST, false);
-        bootstrap2.option(IoUringChannelOption.POLLIN_FIRST, false);
+        bootstrap.option(IoUringChannelOption.POLLIN_FIRST, true);
+        bootstrap2.option(IoUringChannelOption.POLLIN_FIRST, true);
     }
 
     @Test

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketAutoReadTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketAutoReadTest.java
@@ -16,16 +16,17 @@
 package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
-import io.netty.testsuite.transport.socket.WriteBeforeRegisteredTest;
+import io.netty.testsuite.transport.socket.SocketAutoReadTest;
 import org.junit.jupiter.api.BeforeAll;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest {
+public class IoUringPollinFirstSocketAutoReadTest extends SocketAutoReadTest {
 
     @BeforeAll
     public static void loadJNI() {
@@ -33,13 +34,15 @@ public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest 
     }
 
     @Override
-    protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
-        return IoUringSocketTestPermutation.INSTANCE.clientSocket();
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IoUringSocketTestPermutation.INSTANCE.socket();
     }
 
     @Override
-    protected void configure(Bootstrap bootstrap, ByteBufAllocator allocator) {
-        super.configure(bootstrap, allocator);
-        bootstrap.option(IoUringChannelOption.POLLIN_FIRST, false);
+    protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(sb, cb, allocator);
+        sb.option(IoUringChannelOption.POLLIN_FIRST, true);
+        sb.childOption(IoUringChannelOption.POLLIN_FIRST, true);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, true);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketChannelNotYetConnectedTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketChannelNotYetConnectedTest.java
@@ -18,14 +18,14 @@ package io.netty.channel.uring;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
-import io.netty.testsuite.transport.socket.WriteBeforeRegisteredTest;
+import io.netty.testsuite.transport.socket.SocketChannelNotYetConnectedTest;
 import org.junit.jupiter.api.BeforeAll;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest {
+public class IoUringPollinFirstSocketChannelNotYetConnectedTest extends SocketChannelNotYetConnectedTest {
 
     @BeforeAll
     public static void loadJNI() {
@@ -38,8 +38,8 @@ public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest 
     }
 
     @Override
-    protected void configure(Bootstrap bootstrap, ByteBufAllocator allocator) {
-        super.configure(bootstrap, allocator);
-        bootstrap.option(IoUringChannelOption.POLLIN_FIRST, false);
+    protected void configure(Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(cb, allocator);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, true);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketConditionalWritabilityTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketConditionalWritabilityTest.java
@@ -16,16 +16,19 @@
 package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
-import io.netty.testsuite.transport.socket.WriteBeforeRegisteredTest;
+import io.netty.testsuite.transport.socket.SocketConditionalWritabilityTest;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest {
+public class IoUringPollinFirstSocketConditionalWritabilityTest extends SocketConditionalWritabilityTest {
 
     @BeforeAll
     public static void loadJNI() {
@@ -33,13 +36,22 @@ public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest 
     }
 
     @Override
-    protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
-        return IoUringSocketTestPermutation.INSTANCE.clientSocket();
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IoUringSocketTestPermutation.INSTANCE.socket();
+    }
+
+    @Test
+    @Override
+    public void testConditionalWritability(TestInfo testInfo) throws Throwable {
+        // Ignore as it does not pass on QEMU atm
+        // super.testConditionalWritability();
     }
 
     @Override
-    protected void configure(Bootstrap bootstrap, ByteBufAllocator allocator) {
-        super.configure(bootstrap, allocator);
-        bootstrap.option(IoUringChannelOption.POLLIN_FIRST, false);
+    protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(sb, cb, allocator);
+        sb.option(IoUringChannelOption.POLLIN_FIRST, true);
+        sb.childOption(IoUringChannelOption.POLLIN_FIRST, true);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, true);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketConnectTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketConnectTest.java
@@ -16,16 +16,17 @@
 package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
-import io.netty.testsuite.transport.socket.WriteBeforeRegisteredTest;
+import io.netty.testsuite.transport.socket.SocketConnectTest;
 import org.junit.jupiter.api.BeforeAll;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest {
+public class IoUringPollinFirstSocketConnectTest extends SocketConnectTest {
 
     @BeforeAll
     public static void loadJNI() {
@@ -33,13 +34,15 @@ public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest 
     }
 
     @Override
-    protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
-        return IoUringSocketTestPermutation.INSTANCE.clientSocket();
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IoUringSocketTestPermutation.INSTANCE.socket();
     }
 
     @Override
-    protected void configure(Bootstrap bootstrap, ByteBufAllocator allocator) {
-        super.configure(bootstrap, allocator);
-        bootstrap.option(IoUringChannelOption.POLLIN_FIRST, false);
+    protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(sb, cb, allocator);
+        sb.option(IoUringChannelOption.POLLIN_FIRST, true);
+        sb.childOption(IoUringChannelOption.POLLIN_FIRST, true);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, true);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketConnectionAttemptTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketConnectionAttemptTest.java
@@ -18,14 +18,14 @@ package io.netty.channel.uring;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
-import io.netty.testsuite.transport.socket.WriteBeforeRegisteredTest;
+import io.netty.testsuite.transport.socket.SocketConnectionAttemptTest;
 import org.junit.jupiter.api.BeforeAll;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest {
+public class IoUringPollinFirstSocketConnectionAttemptTest extends SocketConnectionAttemptTest {
 
     @BeforeAll
     public static void loadJNI() {
@@ -38,8 +38,8 @@ public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest 
     }
 
     @Override
-    protected void configure(Bootstrap bootstrap, ByteBufAllocator allocator) {
-        super.configure(bootstrap, allocator);
-        bootstrap.option(IoUringChannelOption.POLLIN_FIRST, false);
+    protected void configure(Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(cb, allocator);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, true);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketDataReadInitialStateTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketDataReadInitialStateTest.java
@@ -16,16 +16,17 @@
 package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
-import io.netty.testsuite.transport.socket.WriteBeforeRegisteredTest;
+import io.netty.testsuite.transport.socket.SocketDataReadInitialStateTest;
 import org.junit.jupiter.api.BeforeAll;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest {
+public class IoUringPollinFirstSocketDataReadInitialStateTest extends SocketDataReadInitialStateTest {
 
     @BeforeAll
     public static void loadJNI() {
@@ -33,13 +34,15 @@ public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest 
     }
 
     @Override
-    protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
-        return IoUringSocketTestPermutation.INSTANCE.clientSocket();
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IoUringSocketTestPermutation.INSTANCE.socket();
     }
 
     @Override
-    protected void configure(Bootstrap bootstrap, ByteBufAllocator allocator) {
-        super.configure(bootstrap, allocator);
-        bootstrap.option(IoUringChannelOption.POLLIN_FIRST, false);
+    protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(sb, cb, allocator);
+        sb.option(IoUringChannelOption.POLLIN_FIRST, true);
+        sb.childOption(IoUringChannelOption.POLLIN_FIRST, true);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, true);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketEchoTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketEchoTest.java
@@ -16,16 +16,17 @@
 package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.testsuite.transport.TestsuitePermutation;
-import io.netty.testsuite.transport.socket.WriteBeforeRegisteredTest;
+import io.netty.testsuite.transport.TestsuitePermutation.BootstrapComboFactory;
+import io.netty.testsuite.transport.socket.SocketEchoTest;
 import org.junit.jupiter.api.BeforeAll;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest {
+public class IoUringPollinFirstSocketEchoTest extends SocketEchoTest {
 
     @BeforeAll
     public static void loadJNI() {
@@ -33,13 +34,15 @@ public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest 
     }
 
     @Override
-    protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
-        return IoUringSocketTestPermutation.INSTANCE.clientSocket();
+    protected List<BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IoUringSocketTestPermutation.INSTANCE.socket();
     }
 
     @Override
-    protected void configure(Bootstrap bootstrap, ByteBufAllocator allocator) {
-        super.configure(bootstrap, allocator);
-        bootstrap.option(IoUringChannelOption.POLLIN_FIRST, false);
+    protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(sb, cb, allocator);
+        sb.option(IoUringChannelOption.POLLIN_FIRST, true);
+        sb.childOption(IoUringChannelOption.POLLIN_FIRST, true);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, true);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketExceptionHandlingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketExceptionHandlingTest.java
@@ -16,16 +16,17 @@
 package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
-import io.netty.testsuite.transport.socket.WriteBeforeRegisteredTest;
+import io.netty.testsuite.transport.socket.SocketExceptionHandlingTest;
 import org.junit.jupiter.api.BeforeAll;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest {
+public class IoUringPollinFirstSocketExceptionHandlingTest extends SocketExceptionHandlingTest {
 
     @BeforeAll
     public static void loadJNI() {
@@ -33,13 +34,15 @@ public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest 
     }
 
     @Override
-    protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
-        return IoUringSocketTestPermutation.INSTANCE.clientSocket();
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IoUringSocketTestPermutation.INSTANCE.socket();
     }
 
     @Override
-    protected void configure(Bootstrap bootstrap, ByteBufAllocator allocator) {
-        super.configure(bootstrap, allocator);
-        bootstrap.option(IoUringChannelOption.POLLIN_FIRST, false);
+    protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(sb, cb, allocator);
+        sb.option(IoUringChannelOption.POLLIN_FIRST, true);
+        sb.childOption(IoUringChannelOption.POLLIN_FIRST, true);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, true);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketFileRegionTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketFileRegionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Netty Project
+ * Copyright 2014 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -19,11 +19,8 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
-import io.netty.testsuite.transport.socket.SocketHalfClosedTest;
-import io.netty.util.internal.PlatformDependent;
-import org.junit.jupiter.api.Assumptions;
+import io.netty.testsuite.transport.socket.SocketFileRegionTest;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
@@ -31,7 +28,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class IoUringSocketHalfClosedTest extends SocketHalfClosedTest {
+public class IoUringPollinFirstSocketFileRegionTest extends SocketFileRegionTest {
 
     @BeforeAll
     public static void loadJNI() {
@@ -43,23 +40,22 @@ public class IoUringSocketHalfClosedTest extends SocketHalfClosedTest {
         return IoUringSocketTestPermutation.INSTANCE.socket();
     }
 
-    @Disabled
+    @Override
+    protected boolean supportsCustomFileRegion() {
+        return false;
+    }
+
+    //@Disabled("Fix me")
     @Test
-    public void testAutoCloseFalseDoesShutdownOutput(TestInfo testInfo) throws Throwable {
-        // This test only works on Linux / BSD / MacOS as we assume some semantics that are not true for Windows.
-        Assumptions.assumeFalse(PlatformDependent.isWindows());
-        this.run(testInfo, new Runner<ServerBootstrap, Bootstrap>() {
-            public void run(ServerBootstrap serverBootstrap, Bootstrap bootstrap) throws Throwable {
-                testAutoCloseFalseDoesShutdownOutput(serverBootstrap, bootstrap);
-            }
-        });
+    public void testFileRegionCountLargerThenFile(TestInfo testInfo) throws Throwable {
+        super.testFileRegionCountLargerThenFile(testInfo);
     }
 
     @Override
     protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
         super.configure(sb, cb, allocator);
-        sb.option(IoUringChannelOption.POLLIN_FIRST, false);
-        sb.childOption(IoUringChannelOption.POLLIN_FIRST, false);
-        cb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        sb.option(IoUringChannelOption.POLLIN_FIRST, true);
+        sb.childOption(IoUringChannelOption.POLLIN_FIRST, true);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, true);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketFixedLengthEchoTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketFixedLengthEchoTest.java
@@ -16,16 +16,17 @@
 package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
-import io.netty.testsuite.transport.socket.WriteBeforeRegisteredTest;
+import io.netty.testsuite.transport.socket.SocketFixedLengthEchoTest;
 import org.junit.jupiter.api.BeforeAll;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest {
+public class IoUringPollinFirstSocketFixedLengthEchoTest extends SocketFixedLengthEchoTest {
 
     @BeforeAll
     public static void loadJNI() {
@@ -33,13 +34,15 @@ public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest 
     }
 
     @Override
-    protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
-        return IoUringSocketTestPermutation.INSTANCE.clientSocket();
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IoUringSocketTestPermutation.INSTANCE.socket();
     }
 
     @Override
-    protected void configure(Bootstrap bootstrap, ByteBufAllocator allocator) {
-        super.configure(bootstrap, allocator);
-        bootstrap.option(IoUringChannelOption.POLLIN_FIRST, false);
+    protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(sb, cb, allocator);
+        sb.option(IoUringChannelOption.POLLIN_FIRST, true);
+        sb.childOption(IoUringChannelOption.POLLIN_FIRST, true);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, true);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketGatheringWriteTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketGatheringWriteTest.java
@@ -16,16 +16,17 @@
 package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
-import io.netty.testsuite.transport.socket.WriteBeforeRegisteredTest;
+import io.netty.testsuite.transport.socket.SocketGatheringWriteTest;
 import org.junit.jupiter.api.BeforeAll;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest {
+public class IoUringPollinFirstSocketGatheringWriteTest extends SocketGatheringWriteTest {
 
     @BeforeAll
     public static void loadJNI() {
@@ -33,13 +34,15 @@ public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest 
     }
 
     @Override
-    protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
-        return IoUringSocketTestPermutation.INSTANCE.clientSocket();
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IoUringSocketTestPermutation.INSTANCE.socket();
     }
 
     @Override
-    protected void configure(Bootstrap bootstrap, ByteBufAllocator allocator) {
-        super.configure(bootstrap, allocator);
-        bootstrap.option(IoUringChannelOption.POLLIN_FIRST, false);
+    protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(sb, cb, allocator);
+        sb.option(IoUringChannelOption.POLLIN_FIRST, true);
+        sb.childOption(IoUringChannelOption.POLLIN_FIRST, true);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, true);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketHalfClosedTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketHalfClosedTest.java
@@ -31,7 +31,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class IoUringSocketHalfClosedTest extends SocketHalfClosedTest {
+public class IoUringPollinFirstSocketHalfClosedTest extends SocketHalfClosedTest {
 
     @BeforeAll
     public static void loadJNI() {
@@ -58,8 +58,8 @@ public class IoUringSocketHalfClosedTest extends SocketHalfClosedTest {
     @Override
     protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
         super.configure(sb, cb, allocator);
-        sb.option(IoUringChannelOption.POLLIN_FIRST, false);
-        sb.childOption(IoUringChannelOption.POLLIN_FIRST, false);
-        cb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        sb.option(IoUringChannelOption.POLLIN_FIRST, true);
+        sb.childOption(IoUringChannelOption.POLLIN_FIRST, true);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, true);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketReadPendingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketReadPendingTest.java
@@ -16,16 +16,17 @@
 package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
-import io.netty.testsuite.transport.socket.WriteBeforeRegisteredTest;
+import io.netty.testsuite.transport.socket.SocketReadPendingTest;
 import org.junit.jupiter.api.BeforeAll;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest {
+public class IoUringPollinFirstSocketReadPendingTest extends SocketReadPendingTest {
 
     @BeforeAll
     public static void loadJNI() {
@@ -33,13 +34,15 @@ public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest 
     }
 
     @Override
-    protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
-        return IoUringSocketTestPermutation.INSTANCE.clientSocket();
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IoUringSocketTestPermutation.INSTANCE.socket();
     }
 
     @Override
-    protected void configure(Bootstrap bootstrap, ByteBufAllocator allocator) {
-        super.configure(bootstrap, allocator);
-        bootstrap.option(IoUringChannelOption.POLLIN_FIRST, false);
+    protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(sb, cb, allocator);
+        sb.option(IoUringChannelOption.POLLIN_FIRST, true);
+        sb.childOption(IoUringChannelOption.POLLIN_FIRST, true);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, true);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketShutdownOutputByPeerTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketShutdownOutputByPeerTest.java
@@ -15,17 +15,17 @@
  */
 package io.netty.channel.uring;
 
-import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
-import io.netty.testsuite.transport.socket.WriteBeforeRegisteredTest;
+import io.netty.testsuite.transport.socket.SocketShutdownOutputByPeerTest;
 import org.junit.jupiter.api.BeforeAll;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest {
+public class IoUringPollinFirstSocketShutdownOutputByPeerTest extends SocketShutdownOutputByPeerTest {
 
     @BeforeAll
     public static void loadJNI() {
@@ -33,13 +33,13 @@ public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest 
     }
 
     @Override
-    protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
-        return IoUringSocketTestPermutation.INSTANCE.clientSocket();
+    protected List<TestsuitePermutation.BootstrapFactory<ServerBootstrap>> newFactories() {
+        return IoUringSocketTestPermutation.INSTANCE.serverSocket();
     }
 
     @Override
-    protected void configure(Bootstrap bootstrap, ByteBufAllocator allocator) {
+    protected void configure(ServerBootstrap bootstrap, ByteBufAllocator allocator) {
         super.configure(bootstrap, allocator);
-        bootstrap.option(IoUringChannelOption.POLLIN_FIRST, false);
+        bootstrap.option(IoUringChannelOption.POLLIN_FIRST, true);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketShutdownOutputBySelfTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketShutdownOutputBySelfTest.java
@@ -16,16 +16,17 @@
 package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
-import io.netty.testsuite.transport.socket.WriteBeforeRegisteredTest;
+import io.netty.testsuite.transport.socket.SocketShutdownOutputBySelfTest;
 import org.junit.jupiter.api.BeforeAll;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest {
+public class IoUringPollinFirstSocketShutdownOutputBySelfTest extends SocketShutdownOutputBySelfTest {
 
     @BeforeAll
     public static void loadJNI() {
@@ -40,6 +41,6 @@ public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest 
     @Override
     protected void configure(Bootstrap bootstrap, ByteBufAllocator allocator) {
         super.configure(bootstrap, allocator);
-        bootstrap.option(IoUringChannelOption.POLLIN_FIRST, false);
+        bootstrap.option(IoUringChannelOption.POLLIN_FIRST, true);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketSslClientRenegotiateTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketSslClientRenegotiateTest.java
@@ -16,16 +16,17 @@
 package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
-import io.netty.testsuite.transport.socket.WriteBeforeRegisteredTest;
+import io.netty.testsuite.transport.socket.SocketSslClientRenegotiateTest;
 import org.junit.jupiter.api.BeforeAll;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest {
+public class IoUringPollinFirstSocketSslClientRenegotiateTest extends SocketSslClientRenegotiateTest {
 
     @BeforeAll
     public static void loadJNI() {
@@ -33,13 +34,15 @@ public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest 
     }
 
     @Override
-    protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
-        return IoUringSocketTestPermutation.INSTANCE.clientSocket();
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IoUringSocketTestPermutation.INSTANCE.socket();
     }
 
     @Override
-    protected void configure(Bootstrap bootstrap, ByteBufAllocator allocator) {
-        super.configure(bootstrap, allocator);
-        bootstrap.option(IoUringChannelOption.POLLIN_FIRST, false);
+    protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(sb, cb, allocator);
+        sb.option(IoUringChannelOption.POLLIN_FIRST, true);
+        sb.childOption(IoUringChannelOption.POLLIN_FIRST, true);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, true);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketSslEchoTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketSslEchoTest.java
@@ -16,16 +16,17 @@
 package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
-import io.netty.testsuite.transport.socket.WriteBeforeRegisteredTest;
+import io.netty.testsuite.transport.socket.SocketSslEchoTest;
 import org.junit.jupiter.api.BeforeAll;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest {
+public class IoUringPollinFirstSocketSslEchoTest extends SocketSslEchoTest {
 
     @BeforeAll
     public static void loadJNI() {
@@ -33,13 +34,15 @@ public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest 
     }
 
     @Override
-    protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
-        return IoUringSocketTestPermutation.INSTANCE.clientSocket();
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IoUringSocketTestPermutation.INSTANCE.socket();
     }
 
     @Override
-    protected void configure(Bootstrap bootstrap, ByteBufAllocator allocator) {
-        super.configure(bootstrap, allocator);
-        bootstrap.option(IoUringChannelOption.POLLIN_FIRST, false);
+    protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(sb, cb, allocator);
+        sb.option(IoUringChannelOption.POLLIN_FIRST, true);
+        sb.childOption(IoUringChannelOption.POLLIN_FIRST, true);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, true);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketSslGreetingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketSslGreetingTest.java
@@ -16,16 +16,17 @@
 package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
-import io.netty.testsuite.transport.socket.WriteBeforeRegisteredTest;
+import io.netty.testsuite.transport.socket.SocketSslGreetingTest;
 import org.junit.jupiter.api.BeforeAll;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest {
+public class IoUringPollinFirstSocketSslGreetingTest extends SocketSslGreetingTest {
 
     @BeforeAll
     public static void loadJNI() {
@@ -33,13 +34,15 @@ public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest 
     }
 
     @Override
-    protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
-        return IoUringSocketTestPermutation.INSTANCE.clientSocket();
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IoUringSocketTestPermutation.INSTANCE.socket();
     }
 
     @Override
-    protected void configure(Bootstrap bootstrap, ByteBufAllocator allocator) {
-        super.configure(bootstrap, allocator);
-        bootstrap.option(IoUringChannelOption.POLLIN_FIRST, false);
+    protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(sb, cb, allocator);
+        sb.option(IoUringChannelOption.POLLIN_FIRST, true);
+        sb.childOption(IoUringChannelOption.POLLIN_FIRST, true);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, true);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketSslSessionReuseTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketSslSessionReuseTest.java
@@ -16,16 +16,17 @@
 package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
-import io.netty.testsuite.transport.socket.WriteBeforeRegisteredTest;
+import io.netty.testsuite.transport.socket.SocketSslSessionReuseTest;
 import org.junit.jupiter.api.BeforeAll;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest {
+public class IoUringPollinFirstSocketSslSessionReuseTest extends SocketSslSessionReuseTest {
 
     @BeforeAll
     public static void loadJNI() {
@@ -33,13 +34,15 @@ public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest 
     }
 
     @Override
-    protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
-        return IoUringSocketTestPermutation.INSTANCE.clientSocket();
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IoUringSocketTestPermutation.INSTANCE.socket();
     }
 
     @Override
-    protected void configure(Bootstrap bootstrap, ByteBufAllocator allocator) {
-        super.configure(bootstrap, allocator);
-        bootstrap.option(IoUringChannelOption.POLLIN_FIRST, false);
+    protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(sb, cb, allocator);
+        sb.option(IoUringChannelOption.POLLIN_FIRST, true);
+        sb.childOption(IoUringChannelOption.POLLIN_FIRST, true);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, true);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketStartTlsTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketStartTlsTest.java
@@ -16,16 +16,17 @@
 package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
-import io.netty.testsuite.transport.socket.WriteBeforeRegisteredTest;
+import io.netty.testsuite.transport.socket.SocketStartTlsTest;
 import org.junit.jupiter.api.BeforeAll;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest {
+public class IoUringPollinFirstSocketStartTlsTest extends SocketStartTlsTest {
 
     @BeforeAll
     public static void loadJNI() {
@@ -33,13 +34,15 @@ public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest 
     }
 
     @Override
-    protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
-        return IoUringSocketTestPermutation.INSTANCE.clientSocket();
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IoUringSocketTestPermutation.INSTANCE.socket();
     }
 
     @Override
-    protected void configure(Bootstrap bootstrap, ByteBufAllocator allocator) {
-        super.configure(bootstrap, allocator);
-        bootstrap.option(IoUringChannelOption.POLLIN_FIRST, false);
+    protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(sb, cb, allocator);
+        sb.option(IoUringChannelOption.POLLIN_FIRST, true);
+        sb.childOption(IoUringChannelOption.POLLIN_FIRST, true);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, true);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketStringEchoTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstSocketStringEchoTest.java
@@ -16,16 +16,17 @@
 package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
-import io.netty.testsuite.transport.socket.WriteBeforeRegisteredTest;
+import io.netty.testsuite.transport.socket.SocketStringEchoTest;
 import org.junit.jupiter.api.BeforeAll;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest {
+public class IoUringPollinFirstSocketStringEchoTest extends SocketStringEchoTest {
 
     @BeforeAll
     public static void loadJNI() {
@@ -33,13 +34,15 @@ public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest 
     }
 
     @Override
-    protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
-        return IoUringSocketTestPermutation.INSTANCE.clientSocket();
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IoUringSocketTestPermutation.INSTANCE.socket();
     }
 
     @Override
-    protected void configure(Bootstrap bootstrap, ByteBufAllocator allocator) {
-        super.configure(bootstrap, allocator);
-        bootstrap.option(IoUringChannelOption.POLLIN_FIRST, false);
+    protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(sb, cb, allocator);
+        sb.option(IoUringChannelOption.POLLIN_FIRST, true);
+        sb.childOption(IoUringChannelOption.POLLIN_FIRST, true);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, true);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstWriteBeforeRegisteredTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringPollinFirstWriteBeforeRegisteredTest.java
@@ -25,7 +25,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest {
+public class IoUringPollinFirstWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest {
 
     @BeforeAll
     public static void loadJNI() {
@@ -40,6 +40,6 @@ public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest 
     @Override
     protected void configure(Bootstrap bootstrap, ByteBufAllocator allocator) {
         super.configure(bootstrap, allocator);
-        bootstrap.option(IoUringChannelOption.POLLIN_FIRST, false);
+        bootstrap.option(IoUringChannelOption.POLLIN_FIRST, true);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketAutoReadTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketAutoReadTest.java
@@ -17,6 +17,7 @@ package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketAutoReadTest;
 import org.junit.jupiter.api.BeforeAll;
@@ -35,5 +36,13 @@ public class IoUringSocketAutoReadTest extends SocketAutoReadTest {
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return IoUringSocketTestPermutation.INSTANCE.socket();
+    }
+
+    @Override
+    protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(sb, cb, allocator);
+        sb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        sb.childOption(IoUringChannelOption.POLLIN_FIRST, false);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, false);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketChannelNotYetConnectedTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketChannelNotYetConnectedTest.java
@@ -16,6 +16,7 @@
 package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketChannelNotYetConnectedTest;
 import org.junit.jupiter.api.BeforeAll;
@@ -34,5 +35,11 @@ public class IoUringSocketChannelNotYetConnectedTest extends SocketChannelNotYet
     @Override
     protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
         return IoUringSocketTestPermutation.INSTANCE.clientSocket();
+    }
+
+    @Override
+    protected void configure(Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(cb, allocator);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, false);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketConditionalWritabilityTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketConditionalWritabilityTest.java
@@ -17,6 +17,7 @@ package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketConditionalWritabilityTest;
 import org.junit.jupiter.api.BeforeAll;
@@ -44,5 +45,13 @@ public class IoUringSocketConditionalWritabilityTest extends SocketConditionalWr
     public void testConditionalWritability(TestInfo testInfo) throws Throwable {
         // Ignore as it does not pass on QEMU atm
         // super.testConditionalWritability();
+    }
+
+    @Override
+    protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(sb, cb, allocator);
+        sb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        sb.childOption(IoUringChannelOption.POLLIN_FIRST, false);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, false);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketConnectTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketConnectTest.java
@@ -17,6 +17,7 @@ package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketConnectTest;
 import org.junit.jupiter.api.BeforeAll;
@@ -35,5 +36,13 @@ public class IoUringSocketConnectTest extends SocketConnectTest {
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return IoUringSocketTestPermutation.INSTANCE.socket();
+    }
+
+    @Override
+    protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(sb, cb, allocator);
+        sb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        sb.childOption(IoUringChannelOption.POLLIN_FIRST, false);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, false);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketConnectionAttemptTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketConnectionAttemptTest.java
@@ -16,6 +16,8 @@
 package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketConnectionAttemptTest;
 import org.junit.jupiter.api.BeforeAll;
@@ -34,5 +36,11 @@ public class IoUringSocketConnectionAttemptTest extends SocketConnectionAttemptT
     @Override
     protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
         return IoUringSocketTestPermutation.INSTANCE.clientSocket();
+    }
+
+    @Override
+    protected void configure(Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(cb, allocator);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, false);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketDataReadInitialStateTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketDataReadInitialStateTest.java
@@ -17,6 +17,7 @@ package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketDataReadInitialStateTest;
 import org.junit.jupiter.api.BeforeAll;
@@ -35,5 +36,13 @@ public class IoUringSocketDataReadInitialStateTest extends SocketDataReadInitial
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return IoUringSocketTestPermutation.INSTANCE.socket();
+    }
+
+    @Override
+    protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(sb, cb, allocator);
+        sb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        sb.childOption(IoUringChannelOption.POLLIN_FIRST, false);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, false);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketEchoTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketEchoTest.java
@@ -17,6 +17,7 @@ package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation.BootstrapComboFactory;
 import io.netty.testsuite.transport.socket.SocketEchoTest;
 import org.junit.jupiter.api.BeforeAll;
@@ -35,5 +36,13 @@ public class IoUringSocketEchoTest extends SocketEchoTest {
     @Override
     protected List<BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return IoUringSocketTestPermutation.INSTANCE.socket();
+    }
+
+    @Override
+    protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(sb, cb, allocator);
+        sb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        sb.childOption(IoUringChannelOption.POLLIN_FIRST, false);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, false);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketExceptionHandlingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketExceptionHandlingTest.java
@@ -17,6 +17,7 @@ package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketExceptionHandlingTest;
 import org.junit.jupiter.api.BeforeAll;
@@ -35,5 +36,13 @@ public class IoUringSocketExceptionHandlingTest extends SocketExceptionHandlingT
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return IoUringSocketTestPermutation.INSTANCE.socket();
+    }
+
+    @Override
+    protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(sb, cb, allocator);
+        sb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        sb.childOption(IoUringChannelOption.POLLIN_FIRST, false);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, false);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketFileRegionTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketFileRegionTest.java
@@ -17,6 +17,7 @@ package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketFileRegionTest;
 import org.junit.jupiter.api.BeforeAll;
@@ -49,5 +50,13 @@ public class IoUringSocketFileRegionTest extends SocketFileRegionTest {
     @Test
     public void testFileRegionCountLargerThenFile(TestInfo testInfo) throws Throwable {
         super.testFileRegionCountLargerThenFile(testInfo);
+    }
+
+    @Override
+    protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(sb, cb, allocator);
+        sb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        sb.childOption(IoUringChannelOption.POLLIN_FIRST, false);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, false);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketFixedLengthEchoTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketFixedLengthEchoTest.java
@@ -17,6 +17,7 @@ package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketFixedLengthEchoTest;
 import org.junit.jupiter.api.BeforeAll;
@@ -35,5 +36,13 @@ public class IoUringSocketFixedLengthEchoTest extends SocketFixedLengthEchoTest 
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return IoUringSocketTestPermutation.INSTANCE.socket();
+    }
+
+    @Override
+    protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(sb, cb, allocator);
+        sb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        sb.childOption(IoUringChannelOption.POLLIN_FIRST, false);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, false);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketGatheringWriteTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketGatheringWriteTest.java
@@ -17,6 +17,7 @@ package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketGatheringWriteTest;
 import org.junit.jupiter.api.BeforeAll;
@@ -35,5 +36,13 @@ public class IoUringSocketGatheringWriteTest extends SocketGatheringWriteTest {
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return IoUringSocketTestPermutation.INSTANCE.socket();
+    }
+
+    @Override
+    protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(sb, cb, allocator);
+        sb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        sb.childOption(IoUringChannelOption.POLLIN_FIRST, false);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, false);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketMultipleConnectTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketMultipleConnectTest.java
@@ -17,6 +17,7 @@ package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.IoEventLoopGroup;
 import io.netty.channel.nio.NioIoHandler;
@@ -50,5 +51,13 @@ public class IoUringSocketMultipleConnectTest extends SocketMultipleConnectTest 
             }
         }
         return factories;
+    }
+
+    @Override
+    protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(sb, cb, allocator);
+        sb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        sb.childOption(IoUringChannelOption.POLLIN_FIRST, false);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, false);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketReadPendingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketReadPendingTest.java
@@ -17,6 +17,7 @@ package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketReadPendingTest;
 import org.junit.jupiter.api.BeforeAll;
@@ -35,5 +36,13 @@ public class IoUringSocketReadPendingTest extends SocketReadPendingTest {
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return IoUringSocketTestPermutation.INSTANCE.socket();
+    }
+
+    @Override
+    protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(sb, cb, allocator);
+        sb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        sb.childOption(IoUringChannelOption.POLLIN_FIRST, false);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, false);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketRstTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketRstTest.java
@@ -17,6 +17,7 @@ package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.unix.Errors;
 import io.netty.testsuite.transport.TestsuitePermutation;
@@ -52,5 +53,13 @@ public class IoUringSocketRstTest extends SocketRstTest {
         assertTrue(cause instanceof Errors.NativeIoException,
                 "actual [type, message]: [" + cause.getClass() + ", " + cause.getMessage() + ']');
         assertEquals(Errors.ERRNO_ECONNRESET_NEGATIVE, ((Errors.NativeIoException) cause).expectedErr());
+    }
+
+    @Override
+    protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(sb, cb, allocator);
+        sb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        sb.childOption(IoUringChannelOption.POLLIN_FIRST, false);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, false);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketShutdownOutputByPeerTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketShutdownOutputByPeerTest.java
@@ -15,7 +15,9 @@
  */
 package io.netty.channel.uring;
 
+import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketShutdownOutputByPeerTest;
 import org.junit.jupiter.api.BeforeAll;
@@ -34,5 +36,11 @@ public class IoUringSocketShutdownOutputByPeerTest extends SocketShutdownOutputB
     @Override
     protected List<TestsuitePermutation.BootstrapFactory<ServerBootstrap>> newFactories() {
         return IoUringSocketTestPermutation.INSTANCE.serverSocket();
+    }
+
+    @Override
+    protected void configure(ServerBootstrap bootstrap, ByteBufAllocator allocator) {
+        super.configure(bootstrap, allocator);
+        bootstrap.option(IoUringChannelOption.POLLIN_FIRST, false);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketShutdownOutputBySelfTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketShutdownOutputBySelfTest.java
@@ -16,6 +16,8 @@
 package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketShutdownOutputBySelfTest;
 import org.junit.jupiter.api.BeforeAll;
@@ -34,5 +36,11 @@ public class IoUringSocketShutdownOutputBySelfTest extends SocketShutdownOutputB
     @Override
     protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
         return IoUringSocketTestPermutation.INSTANCE.clientSocket();
+    }
+
+    @Override
+    protected void configure(Bootstrap bootstrap, ByteBufAllocator allocator) {
+        super.configure(bootstrap, allocator);
+        bootstrap.option(IoUringChannelOption.POLLIN_FIRST, true);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketSslClientRenegotiateTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketSslClientRenegotiateTest.java
@@ -17,6 +17,7 @@ package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketSslClientRenegotiateTest;
 import org.junit.jupiter.api.BeforeAll;
@@ -35,5 +36,13 @@ public class IoUringSocketSslClientRenegotiateTest extends SocketSslClientRenego
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return IoUringSocketTestPermutation.INSTANCE.socket();
+    }
+
+    @Override
+    protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(sb, cb, allocator);
+        sb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        sb.childOption(IoUringChannelOption.POLLIN_FIRST, false);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, false);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketSslEchoTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketSslEchoTest.java
@@ -17,6 +17,7 @@ package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketSslEchoTest;
 import org.junit.jupiter.api.BeforeAll;
@@ -35,5 +36,13 @@ public class IoUringSocketSslEchoTest extends SocketSslEchoTest {
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return IoUringSocketTestPermutation.INSTANCE.socket();
+    }
+
+    @Override
+    protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(sb, cb, allocator);
+        sb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        sb.childOption(IoUringChannelOption.POLLIN_FIRST, false);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, false);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketSslGreetingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketSslGreetingTest.java
@@ -17,6 +17,7 @@ package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketSslGreetingTest;
 import org.junit.jupiter.api.BeforeAll;
@@ -35,5 +36,13 @@ public class IoUringSocketSslGreetingTest extends SocketSslGreetingTest {
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return IoUringSocketTestPermutation.INSTANCE.socket();
+    }
+
+    @Override
+    protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(sb, cb, allocator);
+        sb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        sb.childOption(IoUringChannelOption.POLLIN_FIRST, false);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, false);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketSslSessionReuseTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketSslSessionReuseTest.java
@@ -17,6 +17,7 @@ package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketSslSessionReuseTest;
 import org.junit.jupiter.api.BeforeAll;
@@ -35,5 +36,13 @@ public class IoUringSocketSslSessionReuseTest extends SocketSslSessionReuseTest 
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return IoUringSocketTestPermutation.INSTANCE.socket();
+    }
+
+    @Override
+    protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(sb, cb, allocator);
+        sb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        sb.childOption(IoUringChannelOption.POLLIN_FIRST, false);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, false);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketStartTlsTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketStartTlsTest.java
@@ -17,6 +17,7 @@ package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketStartTlsTest;
 import org.junit.jupiter.api.BeforeAll;
@@ -35,5 +36,13 @@ public class IoUringSocketStartTlsTest extends SocketStartTlsTest {
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return IoUringSocketTestPermutation.INSTANCE.socket();
+    }
+
+    @Override
+    protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(sb, cb, allocator);
+        sb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        sb.childOption(IoUringChannelOption.POLLIN_FIRST, false);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, false);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketStringEchoTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketStringEchoTest.java
@@ -17,6 +17,7 @@ package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketStringEchoTest;
 import org.junit.jupiter.api.BeforeAll;
@@ -35,5 +36,13 @@ public class IoUringSocketStringEchoTest extends SocketStringEchoTest {
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return IoUringSocketTestPermutation.INSTANCE.socket();
+    }
+
+    @Override
+    protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(sb, cb, allocator);
+        sb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        sb.childOption(IoUringChannelOption.POLLIN_FIRST, false);
+        cb.option(IoUringChannelOption.POLLIN_FIRST, false);
     }
 }


### PR DESCRIPTION
Motivation:

We recently added support to either use POLLIN or not. We should run all tests with both

Modifications:

Explict enable / disable POLLIN_FIRST for all tests

Result:

Better test coverage