### PR TITLE
IoUring: Also make use of IORING_RECVSEND_POLL_FIRST for accept

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -1087,4 +1087,8 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
             pollRdhupId = 0;
         }
      }
+
+    static boolean socketWasEmptyForSure(int flags) {
+        return IoUring.isIOUringCqeFSockNonEmptySupported() &&  (flags & Native.IORING_CQE_F_SOCK_NONEMPTY) == 0;
+    }
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -1094,6 +1094,6 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
      }
 
     protected static boolean socketIsEmpty(int flags) {
-        return IoUring.isIOUringCqeFSockNonEmptySupported() &&  (flags & Native.IORING_CQE_F_SOCK_NONEMPTY) == 0;
+        return IoUring.isIOUringCqeFSockNonEmptySupported() && (flags & Native.IORING_CQE_F_SOCK_NONEMPTY) == 0;
     }
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -380,6 +380,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
 
     abstract class AbstractUringUnsafe extends AbstractUnsafe implements IoUringIoHandle {
         private IoUringRecvByteAllocatorHandle allocHandle;
+        private boolean socketIsEmpty;
 
         /**
          * Schedule the write of multiple messages in the {@link ChannelOutboundBuffer} and returns the number of
@@ -625,8 +626,11 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
             }
             inReadComplete = true;
             try {
+                socketIsEmpty = socketIsEmpty(flags);
+
                 readComplete0(op, res, flags, data, numOutstandingReads);
             } finally {
+                socketIsEmpty = false;
                 inReadComplete = false;
                 // There is a pending read and readComplete0(...) also did stop issue read request.
                 // Let's trigger the requested read now.
@@ -692,7 +696,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
         protected final void scheduleRead(boolean first) {
             // Only schedule another read if the fd is still open.
             if (fd().isOpen() && (ioState & READ_SCHEDULED) == 0) {
-                numOutstandingReads = (short) scheduleRead0(first);
+                numOutstandingReads = (short) scheduleRead0(first, socketIsEmpty);
                 if (numOutstandingReads > 0) {
                     ioState |= READ_SCHEDULED;
                 }
@@ -703,9 +707,10 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
          * Schedule a read and returns the number of {@link #readComplete(byte, int, int, short)}
          * calls that are expected because of the scheduled read.
          *
-         * @param first {@code true} if this is the first read of a read loop.
+         * @param first             {@code true} if this is the first read of a read loop.
+         * @param socketIsEmpty     {@code true} if the socket is guaranteed to be empty, {@code false} otherwise.
          */
-        protected abstract int scheduleRead0(boolean first);
+        protected abstract int scheduleRead0(boolean first, boolean socketIsEmpty);
 
         /**
          * Called once POLLOUT event is ready to be processed
@@ -1088,7 +1093,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
         }
      }
 
-    static boolean socketWasEmptyForSure(int flags) {
+    protected static boolean socketIsEmpty(int flags) {
         return IoUring.isIOUringCqeFSockNonEmptySupported() &&  (flags & Native.IORING_CQE_F_SOCK_NONEMPTY) == 0;
     }
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringServerChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringServerChannel.java
@@ -97,8 +97,6 @@ abstract class AbstractIoUringServerChannel extends AbstractIoUringChannel imple
 
     private final class UringServerChannelUnsafe extends AbstractIoUringChannel.AbstractUringUnsafe {
 
-        private boolean socketWasEmpty;
-
         @Override
         protected int scheduleWriteMultiple(ChannelOutboundBuffer in) {
             throw new UnsupportedOperationException();

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -396,10 +396,6 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
             }
         }
 
-        private boolean socketWasEmptyForSure(int flags) {
-            return IoUring.isIOUringCqeFSockNonEmptySupported() &&  (flags & Native.IORING_CQE_F_SOCK_NONEMPTY) == 0;
-        }
-
         private void handleReadException(ChannelPipeline pipeline, ByteBuf byteBuf,
                                          Throwable cause, boolean allDataRead,
                                          IoUringRecvByteAllocatorHandle allocHandle) {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
@@ -446,7 +446,7 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
         }
 
         @Override
-        protected int scheduleRead0(boolean first) {
+        protected int scheduleRead0(boolean first, boolean socketIsEmpty) {
             final IoUringRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
             ByteBuf byteBuf = allocHandle.allocate(alloc());
             assert readBuffer == null;


### PR DESCRIPTION
Motivation:

We can use IORING_RECVSEND_POLL_FIRST to signal if we should try to poll first or not.

Modifications:

Make use of IORING_RECVSEND_POLL_FIRST (the same as we do when recving bytes)

Result:

Less overhead when we already know that there is nothing to accept.