### PR TITLE
Support BouncyCastle FIPS for reading PEM files

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/BouncyCastlePemReader.java
+++ b/handler/src/main/java/io/netty/handler/ssl/BouncyCastlePemReader.java
@@ -44,6 +44,7 @@ import java.security.Provider;
 
 final class BouncyCastlePemReader {
     private static final String BC_PROVIDER = "org.bouncycastle.jce.provider.BouncyCastleProvider";
+    private static final String BC_FIPS_PROVIDER = "org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider";
     private static final String BC_PEMPARSER = "org.bouncycastle.openssl.PEMParser";
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(BouncyCastlePemReader.class);
 
@@ -75,9 +76,18 @@ final class BouncyCastlePemReader {
             public Void run() {
                 try {
                     ClassLoader classLoader = getClass().getClassLoader();
-                    // Check for bcprov-jdk18on:
-                    Class<Provider> bcProviderClass =
-                            (Class<Provider>) Class.forName(BC_PROVIDER, true, classLoader);
+                    // Check for bcprov-jdk18on or bc-fips:
+                    Class<Provider> bcProviderClass;
+                    try {
+                        bcProviderClass = (Class<Provider>) Class.forName(BC_PROVIDER, true, classLoader);
+                    } catch (ClassNotFoundException e) {
+                        try {
+                            bcProviderClass = (Class<Provider>) Class.forName(BC_FIPS_PROVIDER, true, classLoader);
+                        } catch (ClassNotFoundException ex) {
+                            e.addSuppressed(ex);
+                            throw e;
+                        }
+                    }
                     // Check for bcpkix-jdk18on:
                     Class.forName(BC_PEMPARSER, true, classLoader);
                     bcProvider = bcProviderClass.getConstructor().newInstance();


### PR DESCRIPTION
Motivation:
BouncyCastle is available in both FIPS and non-FIPS variants, and we've mostly only been supporting the non-FIPS variant. Our BouncyCastlePemReader, for instance, reflectively only looked for the non-FIPS version. This means that if people use a `java.security` policy file to restrict their environment to, for instance, only allow the FIPS version of BouncyCastle, then we'd fail to load the `PEMParser` class from BouncyCastle for no good reason.

Modification:
Make the BouncyCastlePemReader check for either the non-FIPS or the FIPS provider, and succeed loading if either one is found.

Result:
We can now use BouncyCastle for reading PEM files, even when only the FIPS version of BouncyCastle is available or permitted.

Forward port of #14618