### PR TITLE
Provides Brotli settings without `com.aayushatharva.brotli4j` dependency

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/BrotliMode.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/BrotliMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Netty Project
+ * Copyright 2024 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -20,9 +20,8 @@ import com.aayushatharva.brotli4j.encoder.Encoder;
 import static com.aayushatharva.brotli4j.encoder.Encoder.Mode;
 
 /**
- *  Provides an interface to specify the Brotli compression mode.
+ *  Provides a way to specify the Brotli compression mode.
  *
- *   @author raccoonback
  */
 public enum BrotliMode {
 

--- a/codec/src/main/java/io/netty/handler/codec/compression/BrotliMode.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/BrotliMode.java
@@ -20,43 +20,42 @@ import com.aayushatharva.brotli4j.encoder.Encoder;
 import static com.aayushatharva.brotli4j.encoder.Encoder.Mode;
 
 /**
- *  Provides a way to specify the Brotli compression mode.
- *
+ * Provides a way to specify the Brotli compression mode.
  */
 public enum BrotliMode {
 
-	/**
-	 *  The compressor does not make any assumptions about the input data's properties,
-	 *  making it suitable for a wide range of data types.
-	 *  default mode.
-	 */
-	GENERIC,
+    /**
+     * The compressor does not make any assumptions about the input data's properties,
+     * making it suitable for a wide range of data types.
+     * default mode.
+     */
+    GENERIC,
 
-	/**
-	 *  Optimized for UTF-8 formatted text input.
-	 */
-	TEXT,
+    /**
+     * Optimized for UTF-8 formatted text input.
+     */
+    TEXT,
 
-	/**
-	 *  Designed specifically for font data compression, as used in WOFF 2.0.
-	 */
-	FONT;
+    /**
+     * Designed specifically for font data compression, as used in WOFF 2.0.
+     */
+    FONT;
 
-	/**
-	 *  Convert to Brotli {@link Encoder.Mode}.
-	 *
-	 * @return a new {@link Encoder.Mode}
-	 */
-	Mode adapt() {
-		switch (this) {
-		case GENERIC:
-			return Mode.GENERIC;
-		case TEXT:
-			return Mode.TEXT;
-		case FONT:
-			return Mode.FONT;
-		default:
-			throw new IllegalStateException("Unsupported enum value: " + this);
-		}
-	}
+    /**
+     * Convert to Brotli {@link Encoder.Mode}.
+     *
+     * @return a new {@link Encoder.Mode}
+     */
+    Mode adapt() {
+        switch (this) {
+            case GENERIC:
+                return Mode.GENERIC;
+            case TEXT:
+                return Mode.TEXT;
+            case FONT:
+                return Mode.FONT;
+            default:
+                throw new IllegalStateException("Unsupported enum value: " + this);
+        }
+    }
 }

--- a/codec/src/main/java/io/netty/handler/codec/compression/BrotliMode.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/BrotliMode.java
@@ -30,24 +30,17 @@ public enum BrotliMode {
 	 *  making it suitable for a wide range of data types.
 	 *  default mode.
 	 */
-	GENERIC(Mode.GENERIC),
+	GENERIC,
 
 	/**
 	 *  Optimized for UTF-8 formatted text input.
 	 */
-	TEXT(Mode.TEXT),
+	TEXT,
 
 	/**
 	 *  Designed specifically for font data compression, as used in WOFF 2.0.
 	 */
-	FONT(Mode.FONT);
-
-	private final Mode encoderMode;
-
-	BrotliMode(Mode encoderMode) {
-		this.encoderMode = encoderMode;
-	}
-
+	FONT;
 
 	/**
 	 *  Convert to Brotli {@link Encoder.Mode}.
@@ -55,6 +48,15 @@ public enum BrotliMode {
 	 * @return a new {@link Encoder.Mode}
 	 */
 	Mode adapt() {
-		return encoderMode;
+		switch (this) {
+		case GENERIC:
+			return Mode.GENERIC;
+		case TEXT:
+			return Mode.TEXT;
+		case FONT:
+			return Mode.FONT;
+		default:
+			throw new IllegalStateException("Unsupported enum value: " + this);
+		}
 	}
 }

--- a/codec/src/main/java/io/netty/handler/codec/compression/BrotliMode.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/BrotliMode.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import com.aayushatharva.brotli4j.encoder.Encoder;
+
+import static com.aayushatharva.brotli4j.encoder.Encoder.Mode;
+
+/**
+ *  Provides an interface to specify the Brotli compression mode.
+ *
+ *   @author raccoonback
+ */
+public enum BrotliMode {
+
+	/**
+	 *  The compressor does not make any assumptions about the input data's properties,
+	 *  making it suitable for a wide range of data types.
+	 *  default mode.
+	 */
+	GENERIC(Mode.GENERIC),
+
+	/**
+	 *  Optimized for UTF-8 formatted text input.
+	 */
+	TEXT(Mode.TEXT),
+
+	/**
+	 *  Designed specifically for font data compression, as used in WOFF 2.0.
+	 */
+	FONT(Mode.FONT);
+
+	private final Mode encoderMode;
+
+	BrotliMode(Mode encoderMode) {
+		this.encoderMode = encoderMode;
+	}
+
+
+	/**
+	 *  Convert to Brotli {@link Encoder.Mode}.
+	 *
+	 * @return a new {@link Encoder.Mode}
+	 */
+	Mode adapt() {
+		return encoderMode;
+	}
+}

--- a/codec/src/main/java/io/netty/handler/codec/compression/StandardCompressionOptions.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/StandardCompressionOptions.java
@@ -49,13 +49,9 @@ public final class StandardCompressionOptions {
     /**
      * Create a new {@link BrotliOptions}
      *
-     * @param  quality
-     *           Specifies the compression level.
-     * @param  window
-     *           Specifies the size of the sliding window when compressing.
-     * @param  mode
-     *           optimizes the compression algorithm based on the type of input data.
-     *
+     * @param quality Specifies the compression level.
+     * @param window  Specifies the size of the sliding window when compressing.
+     * @param mode    optimizes the compression algorithm based on the type of input data.
      * @throws NullPointerException If {@link BrotliMode} is {@code null}
      */
     public static BrotliOptions brotli(int quality, int window, BrotliMode mode) {
@@ -82,12 +78,9 @@ public final class StandardCompressionOptions {
     /**
      * Create a new {@link ZstdOptions}
      *
-     * @param  blockSize
-     *           is used to calculate the compressionLevel
-     * @param  maxEncodeSize
-     *           specifies the size of the largest compressed object
-     * @param  compressionLevel
-     *           specifies the level of the compression
+     * @param blockSize        is used to calculate the compressionLevel
+     * @param maxEncodeSize    specifies the size of the largest compressed object
+     * @param compressionLevel specifies the level of the compression
      */
     public static ZstdOptions zstd(int compressionLevel, int blockSize, int maxEncodeSize) {
         return new ZstdOptions(compressionLevel, blockSize, maxEncodeSize);
@@ -95,13 +88,12 @@ public final class StandardCompressionOptions {
 
     /**
      * Create a new {@link SnappyOptions}
-     *
      */
     public static SnappyOptions snappy() {
         return new SnappyOptions();
     }
 
-     /**
+    /**
      * Default implementation of {@link GzipOptions} with
      * {@code compressionLevel()} set to 6, {@code windowBits()} set to 15 and {@code memLevel()} set to 8.
      */
@@ -115,12 +107,10 @@ public final class StandardCompressionOptions {
      * @param compressionLevel {@code 1} yields the fastest compression and {@code 9} yields the
      *                         best compression.  {@code 0} means no compression.  The default
      *                         compression level is {@code 6}.
-     *
      * @param windowBits       The base two logarithm of the size of the history buffer.  The
      *                         value should be in the range {@code 9} to {@code 15} inclusive.
      *                         Larger values result in better compression at the expense of
      *                         memory usage.  The default value is {@code 15}.
-     *
      * @param memLevel         How much memory should be allocated for the internal compression
      *                         state.  {@code 1} uses minimum memory and {@code 9} uses maximum
      *                         memory.  Larger values result in better and faster compression
@@ -144,12 +134,10 @@ public final class StandardCompressionOptions {
      * @param compressionLevel {@code 1} yields the fastest compression and {@code 9} yields the
      *                         best compression.  {@code 0} means no compression.  The default
      *                         compression level is {@code 6}.
-     *
      * @param windowBits       The base two logarithm of the size of the history buffer.  The
      *                         value should be in the range {@code 9} to {@code 15} inclusive.
      *                         Larger values result in better compression at the expense of
      *                         memory usage.  The default value is {@code 15}.
-     *
      * @param memLevel         How much memory should be allocated for the internal compression
      *                         state.  {@code 1} uses minimum memory and {@code 9} uses maximum
      *                         memory.  Larger values result in better and faster compression

--- a/codec/src/main/java/io/netty/handler/codec/compression/StandardCompressionOptions.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/StandardCompressionOptions.java
@@ -41,7 +41,9 @@ public final class StandardCompressionOptions {
      *
      * @param parameters {@link Encoder.Parameters} Instance
      * @throws NullPointerException If {@link Encoder.Parameters} is {@code null}
+     * @deprecated Use {@link #brotli(int, int, BrotliMode)}
      */
+    @Deprecated
     public static BrotliOptions brotli(Encoder.Parameters parameters) {
         return new BrotliOptions(parameters);
     }

--- a/codec/src/main/java/io/netty/handler/codec/compression/StandardCompressionOptions.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/StandardCompressionOptions.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.compression;
 
 import com.aayushatharva.brotli4j.encoder.Encoder;
+import io.netty.util.internal.ObjectUtil;
 
 /**
  * Standard Compression Options for {@link BrotliOptions},
@@ -42,6 +43,30 @@ public final class StandardCompressionOptions {
      * @throws NullPointerException If {@link Encoder.Parameters} is {@code null}
      */
     public static BrotliOptions brotli(Encoder.Parameters parameters) {
+        return new BrotliOptions(parameters);
+    }
+
+    /**
+     * Create a new {@link BrotliOptions}
+     *
+     * @param  quality
+     *           Specifies the compression level.
+     * @param  window
+     *           Specifies the size of the sliding window when compressing.
+     * @param  mode
+     *           optimizes the compression algorithm based on the type of input data.
+     *
+     * @throws NullPointerException If {@link BrotliMode} is {@code null}
+     */
+    public static BrotliOptions brotli(int quality, int window, BrotliMode mode) {
+        ObjectUtil.checkInRange(quality, 0, 11, "quality");
+        ObjectUtil.checkInRange(window, 10, 24, "window");
+        ObjectUtil.checkNotNull(mode, "mode");
+
+        Encoder.Parameters parameters = new Encoder.Parameters()
+                .setQuality(quality)
+                .setWindow(window)
+                .setMode(mode.adapt());
         return new BrotliOptions(parameters);
     }
 


### PR DESCRIPTION
Motivation:

Hello,

Currently, in Netty, it is difficult to configure **Brotli** compression parameters such as `quality`, `window`, and `mode` without adding the `com.aayushatharva.brotli4j` dependency.

Currently, in other projects that use Netty, it is difficult to configure **Brotli** compression settings such as `quality`, `window`, and `mode` without adding the `com.aayushatharva.brotli4j` dependency.


Modification:

To address this, I have modified Netty to allow these settings to be configured individually without relying on the `Encoder.Parameters` class provided by `com.aayushatharva.brotli4j`.

ref. https://github.com/hyperxpro/Brotli4j

