### PR TITLE
Dns: Correctly encode DnsPtrRecord (#14628)

### DIFF
--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsRecordEncoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsRecordEncoder.java
@@ -68,7 +68,13 @@ public class DefaultDnsRecordEncoder implements DnsRecordEncoder {
 
     private void encodePtrRecord(DnsPtrRecord record, ByteBuf out) throws Exception {
         encodeRecord0(record, out);
+        int writerIndex = out.writerIndex();
+        // Skip 2 bytes as these will be used to encode the rdataLen after we know how many bytes were written.
+        // See https://www.rfc-editor.org/rfc/rfc1035.html#section-3.2.1
+        out.writerIndex(writerIndex + 2);
         encodeName(record.hostname(), out);
+        int rdLength = out.writerIndex() - (writerIndex + 2);
+        out.setShort(writerIndex, rdLength);
     }
 
     private void encodeOptPseudoRecord(DnsOptPseudoRecord record, ByteBuf out) throws Exception {

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/DefaultDnsRecordEncoderTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/DefaultDnsRecordEncoderTest.java
@@ -30,6 +30,42 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class DefaultDnsRecordEncoderTest {
 
     @Test
+    public void testEncodePtr() throws Exception {
+        DefaultDnsRecordEncoder encoder = new DefaultDnsRecordEncoder();
+        DnsPtrRecord ptrRecord = new DefaultDnsPtrRecord("131.186.250.142.in-addr.arpa.",
+                DnsRecord.CLASS_IN, 80, "fra24s07-in-f3.1e100.net.");
+        ByteBuf out = Unpooled.buffer();
+        ByteBuf expectedBuf = Unpooled.buffer();
+        expectedBuf.writeBytes(
+                new byte[] {
+                        3, '1', '3', '1',
+                        3, '1', '8', '6',
+                        3, '2', '5', '0',
+                        3, '1', '4', '2',
+                        7, 'i', 'n', '-', 'a', 'd', 'd', 'r',
+                        4, 'a', 'r', 'p', 'a',
+                        0
+        });
+        expectedBuf.writeShort(DnsRecordType.PTR.intValue());
+        expectedBuf.writeShort(DnsRecord.CLASS_IN);
+        expectedBuf.writeInt(80);
+        byte[] hostname = new byte[] {
+                14, 'f', 'r', 'a', '2', '4', 's', '0', '7', '-', 'i', 'n', '-', 'f', '3',
+                5, '1', 'e', '1', '0', '0', 3, 'n', 'e', 't',
+                0
+        };
+        expectedBuf.writeShort(hostname.length);
+        expectedBuf.writeBytes(hostname);
+        try {
+            encoder.encodeRecord(ptrRecord, out);
+            assertEquals(expectedBuf, out);
+        } finally {
+            out.release();
+            expectedBuf.release();
+        }
+    }
+
+    @Test
     public void testEncodeName() throws Exception {
         testEncodeName(new byte[] { 5, 'n', 'e', 't', 't', 'y', 2, 'i', 'o', 0 }, "netty.io.");
     }


### PR DESCRIPTION
Motivation:

We did miss to also include the RDLENGTH and so produced an malformated packet.

Modifications:

- Correctly also encode the RDLENGH into the packet
- Add unit test

Result:

Fixes https://github.com/netty/netty/issues/14627