### PR TITLE
PooledByteBufAllocator: PooledByteBufAllocator.numThreadLocalCaches()…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -639,7 +639,10 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
      */
     @Deprecated
     public int numThreadLocalCaches() {
-        PoolArena<?>[] arenas = heapArenas != null ? heapArenas : directArenas;
+        return Math.max(numThreadLocalCaches(heapArenas), numThreadLocalCaches(directArenas));
+    }
+
+    private static int numThreadLocalCaches(PoolArena<?>[] arenas) {
         if (arenas == null) {
             return 0;
         }


### PR DESCRIPTION
…… (#14626)

… code is hard to understand

Motivation:

At the moment numThreadLocalCaches() is kind of hard to understand as it seems like it would either only count caches for heap or direct areans. While this is true it is also true that that if one is null it will always be null and so the returned value is correct. Let's make the code a bit easier to understand and add a unit test

Modifications:

- Rewrite implementation to make it easier to understand
- Add unit test

Result:

Fixes https://github.com/netty/netty/issues/14608