### PR TITLE
Make DefaultResourceLeak more resilient against OOM

### DIFF
--- a/common/src/main/java/io/netty/util/ResourceLeakDetector.java
+++ b/common/src/main/java/io/netty/util/ResourceLeakDetector.java
@@ -23,8 +23,8 @@ import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
-import java.lang.ref.WeakReference;
 import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collections;
@@ -415,6 +415,8 @@ public class ResourceLeakDetector<T> {
 
             assert referent != null;
 
+            this.allLeaks = allLeaks;
+
             // Store the hash of the tracked object to later assert it in the close(...) method.
             // It's important that we not store a reference to the referent as this would disallow it from
             // be collected via the WeakReference.
@@ -423,7 +425,6 @@ public class ResourceLeakDetector<T> {
             // Create a new Record so we always have the creation stacktrace included.
             headUpdater.set(this, initialHint == null ?
                     new TraceRecord(TraceRecord.BOTTOM) : new TraceRecord(TraceRecord.BOTTOM, initialHint));
-            this.allLeaks = allLeaks;
         }
 
         @Override

--- a/common/src/test/java/io/netty/util/ResourceLeakDetectorTest.java
+++ b/common/src/test/java/io/netty/util/ResourceLeakDetectorTest.java
@@ -15,7 +15,6 @@
  */
 package io.netty.util;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -29,6 +28,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class ResourceLeakDetectorTest {
     @SuppressWarnings("unused")
@@ -141,9 +141,9 @@ public class ResourceLeakDetectorTest {
         };
         try {
             leakResource();
-            Assertions.fail("expected failure");
+            fail("expected failure");
         } catch (RuntimeException e) {
-            Assertions.assertEquals("expected failure", e.getMessage());
+            assertThat("expected failure").isEqualTo(e.getMessage());
         }
         DefaultResource.detectorWithSetupHint.initialHint = DefaultResource.detectorWithSetupHint.canaryString;
 


### PR DESCRIPTION
Motivation:

When there is an error during the construction of DefaultResourceLeak, such as an OOM or even a failure in the hint toString, we can get a half-finished instance in the ref queue and in the allLeaks set. Then, an exception like this can occur:

```
java.lang.NullPointerException: Cannot invoke "java.util.Set.remove(Object)" because "this.allLeaks" is null
	at io.netty.util.ResourceLeakDetector$DefaultResourceLeak.dispose(ResourceLeakDetector.java:497)
	at io.netty.util.ResourceLeakDetector.reportLeak(ResourceLeakDetector.java:312)
	at io.netty.util.ResourceLeakDetector.track0(ResourceLeakDetector.java:273)
	at io.netty.util.ResourceLeakDetector.track(ResourceLeakDetector.java:250)
	at io.netty.buffer.AbstractByteBufAllocator.toLeakAwareBuffer(AbstractByteBufAllocator.java:51)
	at io.netty.buffer.PooledByteBufAllocator.newDirectBuffer(PooledByteBufAllocator.java:410)
	at io.netty.buffer.AbstractByteBufAllocator.directBuffer(AbstractByteBufAllocator.java:188)
	at io.netty.buffer.AbstractByteBufAllocator.directBuffer(AbstractByteBufAllocator.java:174)
	at io.netty.buffer.AbstractByteBufAllocator.buffer(AbstractByteBufAllocator.java:108)
	at io.micronaut.http.netty.body.NettyJsonHandler.write(NettyJsonHandler.java:138)
	at io.micronaut.http.server.netty.RoutingInBoundHandler.buildFinalResponse(RoutingInBoundHandler.java:401)
	at io.micronaut.http.server.netty.RoutingInBoundHandler.encodeHttpResponse(RoutingInBoundHandler.java:377)
	at io.micronaut.http.server.netty.RoutingInBoundHandler.writeResponse(RoutingInBoundHandler.java:258)
	at io.micronaut.http.server.netty.NettyRequestLifecycle.lambda$handleException$2(NettyRequestLifecycle.java:165)
	at io.micronaut.core.execution.ImperativeExecutionFlowImpl.onComplete(ImperativeExecutionFlowImpl.java:132)
	at io.micronaut.http.server.netty.NettyRequestLifecycle.handleException(NettyRequestLifecycle.java:165)
	at io.micronaut.http.server.netty.RoutingInBoundHandler.accept(RoutingInBoundHandler.java:224)
	at io.micronaut.http.server.netty.handler.PipeliningServerHandler$MessageInboundHandler.read(PipeliningServerHandler.java:394)
	at io.micronaut.http.server.netty.handler.PipeliningServerHandler.channelRead(PipeliningServerHandler.java:218)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.channel.CombinedChannelDuplexHandler$DelegatingChannelHandlerContext.fireChannelRead(CombinedChannelDuplexHandler.java:436)
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:333)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:455)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:290)
	at io.netty.channel.CombinedChannelDuplexHandler.channelRead(CombinedChannelDuplexHandler.java:251)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:289)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.micronaut.http.server.netty.NettyHttpServer$2.channelRead(NettyHttpServer.java:870)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1357)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:868)
	at io.netty.channel.embedded.EmbeddedChannel.writeInbound(EmbeddedChannel.java:347)
	at io.micronaut.fuzzing.http.EmbeddedHttpTarget.lambda$fuzzerTestOneInput$0(EmbeddedHttpTarget.java:68)
	at io.micronaut.fuzzing.http.ByteSeparator.forEachPiece(ByteSeparator.java:39)
	at io.micronaut.fuzzing.http.EmbeddedHttpTarget.fuzzerTestOneInput(EmbeddedHttpTarget.java:66)
	at io.micronaut.fuzzing.http.EmbeddedHttpTarget.main(EmbeddedHttpTarget.java:94)
	Suppressed: java.lang.OutOfMemoryError: Java heap space
```

Modification:

Move the allLeaks field write before any code that can fail. Add a test case with a broken ResourceLeakHint to demonstrate.

Result:

No cluttering of fuzzer logs on OOM conditions.