### PR TITLE
OpenSslSession: Add support to defensively check for peer certs

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ExtendedOpenSslSession.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ExtendedOpenSslSession.java
@@ -31,11 +31,11 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Delegates all operations to a wrapped {@link OpenSslSession} except the methods defined by {@link ExtendedSSLSession}
- * itself.
+ * Delegates all operations to a wrapped {@link OpenSslInternalSession} except the methods defined by
+ * {@link ExtendedSSLSession} itself.
  */
 @SuppressJava6Requirement(reason = "Usage guarded by java version check")
-abstract class ExtendedOpenSslSession extends ExtendedSSLSession implements OpenSslSession {
+abstract class ExtendedOpenSslSession extends ExtendedSSLSession implements OpenSslInternalSession {
 
     // TODO: use OpenSSL API to actually fetch the real data but for now just do what Conscrypt does:
     // https://github.com/google/conscrypt/blob/1.2.0/common/
@@ -46,9 +46,9 @@ abstract class ExtendedOpenSslSession extends ExtendedSSLSession implements Open
             "RSASSA-PSS",
     };
 
-    private final OpenSslSession wrapped;
+    private final OpenSslInternalSession wrapped;
 
-    ExtendedOpenSslSession(OpenSslSession wrapped) {
+    ExtendedOpenSslSession(OpenSslInternalSession wrapped) {
         this.wrapped = wrapped;
     }
 

--- a/handler/src/main/java/io/netty/handler/ssl/ExtendedOpenSslSession.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ExtendedOpenSslSession.java
@@ -175,6 +175,11 @@ abstract class ExtendedOpenSslSession extends ExtendedSSLSession implements Open
     }
 
     @Override
+    public boolean hasPeerCertificates() {
+        return wrapped.hasPeerCertificates();
+    }
+
+    @Override
     public final Certificate[] getLocalCertificates() {
         return wrapped.getLocalCertificates();
     }

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslClientSessionCache.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslClientSessionCache.java
@@ -70,7 +70,7 @@ final class OpenSslClientSessionCache extends OpenSslSessionCache {
     }
 
     @Override
-    boolean setSession(long ssl, OpenSslSession session, String host, int port) {
+    boolean setSession(long ssl, OpenSslInternalSession session, String host, int port) {
         HostPort hostPort = keyFor(host, port);
         if (hostPort == null) {
             return false;
@@ -149,7 +149,7 @@ final class OpenSslClientSessionCache extends OpenSslSessionCache {
     }
 
     /**
-     * Host / Port tuple used to find a {@link OpenSslSession} in the cache.
+     * Host / Port tuple used to find a {@link OpenSslInternalSession} in the cache.
      */
     private static final class HostPort {
         private final int hash;

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslInternalSession.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslInternalSession.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLSession;
+import java.security.cert.Certificate;
+import java.util.Map;
+
+/**
+ * {@link SSLSession} that is specific to our native implementation.
+ */
+interface OpenSslInternalSession extends OpenSslSession {
+
+    /**
+     * Called on a handshake session before being exposed to a {@link javax.net.ssl.TrustManager}.
+     * Session data must be cleared by this call.
+     */
+    void prepareHandshake();
+
+    /**
+     * Return the {@link OpenSslSessionId} that can be used to identify this session.
+     */
+    OpenSslSessionId sessionId();
+
+    /**
+     * Set the local certificate chain that is used. It is not expected that this array will be changed at all
+     * and so its ok to not copy the array.
+     */
+    void setLocalCertificate(Certificate[] localCertificate);
+
+    /**
+     * Set the details for the session which might come from a cache.
+     *
+     * @param creationTime the time at which the session was created.
+     * @param lastAccessedTime the time at which the session was last accessed via the session infrastructure (cache).
+     * @param id the {@link OpenSslSessionId}
+     * @param keyValueStorage the key value store. See {@link #keyValueStorage()}.
+     */
+    void setSessionDetails(long creationTime, long lastAccessedTime, OpenSslSessionId id,
+                           Map<String, Object> keyValueStorage);
+
+    /**
+     * Return the underlying {@link Map} that is used by the following methods:
+     *
+     * <ul>
+     *     <li>{@link #putValue(String, Object)}</li>
+     *     <li>{@link #removeValue(String)}</li>
+     *     <li>{@link #getValue(String)}</li>
+     *     <li> {@link #getValueNames()}</li>
+     * </ul>
+     *
+     * The {@link Map} must be thread-safe!
+     *
+     * @return storage
+     */
+    Map<String, Object> keyValueStorage();
+
+    /**
+     * Set the last access time which will be returned by {@link #getLastAccessedTime()}.
+     *
+     * @param time the time
+     */
+    void setLastAccessedTime(long time);
+
+    /**
+     * Expand (or increase) the value returned by {@link #getApplicationBufferSize()} if necessary.
+     * <p>
+     * This is only called in a synchronized block, so no need to use atomic operations.
+     * @param packetLengthDataOnly The packet size which exceeds the current {@link #getApplicationBufferSize()}.
+     */
+    void tryExpandApplicationBufferSize(int packetLengthDataOnly);
+
+    /**
+     * Called once the handshake has completed.
+     */
+    void handshakeFinished(byte[] id, String cipher, String protocol, byte[] peerCertificate,
+                           byte[][] peerCertificateChain, long creationTime, long timeout) throws SSLException;
+}

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslSession.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslSession.java
@@ -16,6 +16,7 @@
 package io.netty.handler.ssl;
 
 import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
 import java.security.cert.Certificate;
 import java.util.Map;
@@ -41,6 +42,17 @@ interface OpenSslSession extends SSLSession {
      * and so its ok to not copy the array.
      */
     void setLocalCertificate(Certificate[] localCertificate);
+
+    /**
+     * Returns true if the peer has provided certificates during the handshake.
+     * <p>
+     * This method is similar to {@link SSLSession#getPeerCertificates()} but it does not throw a
+     * {@link SSLPeerUnverifiedException} if no certs are provided, making it more efficient to check if a mTLS
+     * connection is used.
+     *
+     * @return true if peer certificates are available.
+     */
+    boolean hasPeerCertificates();
 
     /**
      * Set the details for the session which might come from a cache.

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslSession.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The Netty Project
+ * Copyright 2024 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -15,33 +15,13 @@
  */
 package io.netty.handler.ssl;
 
-import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
-import java.security.cert.Certificate;
-import java.util.Map;
 
 /**
- * {@link SSLSession} that is specific to our native implementation.
+ * {@link SSLSession} sub-type that is used by our native implementation.
  */
-interface OpenSslSession extends SSLSession {
-
-    /**
-     * Called on a handshake session before being exposed to a {@link javax.net.ssl.TrustManager}.
-     * Session data must be cleared by this call.
-     */
-    void prepareHandshake();
-
-    /**
-     * Return the {@link OpenSslSessionId} that can be used to identify this session.
-     */
-    OpenSslSessionId sessionId();
-
-    /**
-     * Set the local certificate chain that is used. It is not expected that this array will be changed at all
-     * and so its ok to not copy the array.
-     */
-    void setLocalCertificate(Certificate[] localCertificate);
+public interface OpenSslSession extends SSLSession {
 
     /**
      * Returns true if the peer has provided certificates during the handshake.
@@ -54,54 +34,6 @@ interface OpenSslSession extends SSLSession {
      */
     boolean hasPeerCertificates();
 
-    /**
-     * Set the details for the session which might come from a cache.
-     *
-     * @param creationTime the time at which the session was created.
-     * @param lastAccessedTime the time at which the session was last accessed via the session infrastructure (cache).
-     * @param id the {@link OpenSslSessionId}
-     * @param keyValueStorage the key value store. See {@link #keyValueStorage()}.
-     */
-    void setSessionDetails(long creationTime, long lastAccessedTime, OpenSslSessionId id,
-                           Map<String, Object> keyValueStorage);
-
-    /**
-     * Return the underlying {@link Map} that is used by the following methods:
-     *
-     * <ul>
-     *     <li>{@link #putValue(String, Object)}</li>
-     *     <li>{@link #removeValue(String)}</li>
-     *     <li>{@link #getValue(String)}</li>
-     *     <li> {@link #getValueNames()}</li>
-     * </ul>
-     *
-     * The {@link Map} must be thread-safe!
-     *
-     * @return storage
-     */
-    Map<String, Object> keyValueStorage();
-
-    /**
-     * Set the last access time which will be returned by {@link #getLastAccessedTime()}.
-     *
-     * @param time the time
-     */
-    void setLastAccessedTime(long time);
-
     @Override
     OpenSslSessionContext getSessionContext();
-
-    /**
-     * Expand (or increase) the value returned by {@link #getApplicationBufferSize()} if necessary.
-     * <p>
-     * This is only called in a synchronized block, so no need to use atomic operations.
-     * @param packetLengthDataOnly The packet size which exceeds the current {@link #getApplicationBufferSize()}.
-     */
-    void tryExpandApplicationBufferSize(int packetLengthDataOnly);
-
-    /**
-     * Called once the handshake has completed.
-     */
-    void handshakeFinished(byte[] id, String cipher, String protocol, byte[] peerCertificate,
-                           byte[][] peerCertificateChain, long creationTime, long timeout) throws SSLException;
 }

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslSessionCache.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslSessionCache.java
@@ -37,7 +37,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * {@link SSLSessionCache} implementation for our native SSL implementation.
  */
 class OpenSslSessionCache implements SSLSessionCache {
-    private static final OpenSslSession[] EMPTY_SESSIONS = new OpenSslSession[0];
+    private static final OpenSslInternalSession[] EMPTY_SESSIONS = new OpenSslInternalSession[0];
 
     private static final int DEFAULT_CACHE_SIZE;
     static {
@@ -92,7 +92,7 @@ class OpenSslSessionCache implements SSLSessionCache {
     }
 
     /**
-     * Called once a new {@link OpenSslSession} was created.
+     * Called once a new {@link OpenSslInternalSession} was created.
      *
      * @param session the new session.
      * @return {@code true} if the session should be cached, {@code false} otherwise.
@@ -102,7 +102,7 @@ class OpenSslSessionCache implements SSLSessionCache {
     }
 
     /**
-     * Called once an {@link OpenSslSession} was removed from the cache.
+     * Called once an {@link OpenSslInternalSession} was removed from the cache.
      *
      * @param session the session to remove.
      */
@@ -147,7 +147,7 @@ class OpenSslSessionCache implements SSLSessionCache {
             // We couldn't find the engine itself.
             return false;
         }
-        OpenSslSession openSslSession = (OpenSslSession) engine.getSession();
+        OpenSslInternalSession openSslSession = (OpenSslInternalSession) engine.getSession();
         // Create the native session that we will put into our cache. We will share the key-value storage
         // with the already existing session instance.
         NativeSslSession session = new NativeSslSession(sslSession, engine.getPeerHost(), engine.getPeerPort(),
@@ -210,7 +210,7 @@ class OpenSslSessionCache implements SSLSessionCache {
         session.setLastAccessedTime(System.currentTimeMillis());
         ReferenceCountedOpenSslEngine engine = engineMap.get(ssl);
         if (engine != null) {
-            OpenSslSession sslSession = (OpenSslSession) engine.getSession();
+            OpenSslInternalSession sslSession = (OpenSslInternalSession) engine.getSession();
             sslSession.setSessionDetails(session.getCreationTime(),
                     session.getLastAccessedTime(), session.sessionId(), session.keyValueStorage);
         }
@@ -218,7 +218,7 @@ class OpenSslSessionCache implements SSLSessionCache {
         return session.session();
     }
 
-    boolean setSession(long ssl, OpenSslSession session, String host, int port) {
+    boolean setSession(long ssl, OpenSslInternalSession session, String host, int port) {
         // Do nothing by default as this needs special handling for the client side.
        return false;
     }
@@ -246,9 +246,9 @@ class OpenSslSessionCache implements SSLSessionCache {
     }
 
     /**
-     * Return the {@link OpenSslSession} which is cached for the given id.
+     * Return the {@link OpenSslInternalSession} which is cached for the given id.
      */
-    final synchronized OpenSslSession getSession(OpenSslSessionId id) {
+    final synchronized OpenSslInternalSession getSession(OpenSslSessionId id) {
         NativeSslSession session = sessions.get(id);
         if (session != null && !session.isValid()) {
             // The session is not valid anymore, let's remove it and just signal back that there is no session
@@ -263,12 +263,12 @@ class OpenSslSessionCache implements SSLSessionCache {
      * Returns a snapshot of the session ids of the current valid sessions.
      */
     final List<OpenSslSessionId> getIds() {
-        final OpenSslSession[] sessionsArray;
+        final OpenSslInternalSession[] sessionsArray;
         synchronized (this) {
             sessionsArray = sessions.values().toArray(EMPTY_SESSIONS);
         }
         List<OpenSslSessionId> ids = new ArrayList<OpenSslSessionId>(sessionsArray.length);
-        for (OpenSslSession session: sessionsArray) {
+        for (OpenSslInternalSession session: sessionsArray) {
             if (session.isValid()) {
                 ids.add(session.sessionId());
             }
@@ -291,9 +291,9 @@ class OpenSslSessionCache implements SSLSessionCache {
     }
 
     /**
-     * {@link OpenSslSession} implementation which wraps the native SSL_SESSION* while in cache.
+     * {@link OpenSslInternalSession} implementation which wraps the native SSL_SESSION* while in cache.
      */
-    static final class NativeSslSession implements OpenSslSession {
+    static final class NativeSslSession implements OpenSslInternalSession {
         static final ResourceLeakDetector<NativeSslSession> LEAK_DETECTOR = ResourceLeakDetectorFactory.instance()
                 .newResourceLeakDetector(NativeSslSession.class);
         private final ResourceLeakTracker<NativeSslSession> leakTracker;
@@ -516,10 +516,10 @@ class OpenSslSessionCache implements SSLSessionCache {
             if (this == o) {
                 return true;
             }
-            if (!(o instanceof OpenSslSession)) {
+            if (!(o instanceof OpenSslInternalSession)) {
                 return false;
             }
-            OpenSslSession session1 = (OpenSslSession) o;
+            OpenSslInternalSession session1 = (OpenSslInternalSession) o;
             return id.equals(session1.sessionId());
         }
     }

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslSessionCache.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslSessionCache.java
@@ -452,6 +452,11 @@ class OpenSslSessionCache implements SSLSessionCache {
         }
 
         @Override
+        public boolean hasPeerCertificates() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public Certificate[] getLocalCertificates() {
             throw new UnsupportedOperationException();
         }

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslSessionContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslSessionContext.java
@@ -206,7 +206,7 @@ public abstract class OpenSslSessionContext implements SSLSessionContext {
     }
 
     /**
-     * Remove the given {@link OpenSslSession} from the cache, and so not re-use it for new connections.
+     * Remove the given {@link OpenSslInternalSession} from the cache, and so not re-use it for new connections.
      */
     final void removeFromCache(OpenSslSessionId id) {
         sessionCache.removeSessionWithId(id);
@@ -216,7 +216,7 @@ public abstract class OpenSslSessionContext implements SSLSessionContext {
         return sessionCache.containsSessionWithId(id);
     }
 
-    boolean setSessionFromCache(long ssl, OpenSslSession session, String host, int port) {
+    boolean setSessionFromCache(long ssl, OpenSslInternalSession session, String host, int port) {
         return sessionCache.setSession(ssl, session, host, port);
     }
 

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslSessionId.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslSessionId.java
@@ -20,7 +20,7 @@ import io.netty.util.internal.EmptyArrays;
 import java.util.Arrays;
 
 /**
- * Represent the session ID used by an {@link OpenSslSession}.
+ * Represent the session ID used by an {@link OpenSslInternalSession}.
  */
 final class OpenSslSessionId {
 

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -204,7 +204,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
     private final OpenSslEngineMap engineMap;
     private final OpenSslApplicationProtocolNegotiator apn;
     private final ReferenceCountedOpenSslContext parentContext;
-    private final OpenSslSession session;
+    private final OpenSslInternalSession session;
     private final ByteBuffer[] singleSrcBuffer = new ByteBuffer[1];
     private final ByteBuffer[] singleDstBuffer = new ByteBuffer[1];
     private final boolean enableOcsp;
@@ -2341,7 +2341,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
 
     private static final X509Certificate[] JAVAX_CERTS_NOT_SUPPORTED = new X509Certificate[0];
 
-    private final class DefaultOpenSslSession implements OpenSslSession  {
+    private final class DefaultOpenSslSession implements OpenSslInternalSession {
         private final OpenSslSessionContext sessionContext;
 
         // These are guarded by synchronized(OpenSslEngine.this) as handshakeFinished() may be triggered by any
@@ -2503,8 +2503,8 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
         }
 
         /**
-         * Finish the handshake and so init everything in the {@link OpenSslSession} that should be accessible by
-         * the user.
+         * Finish the handshake and so init everything in the {@link OpenSslInternalSession} that should be accessible
+         * by the user.
          */
         @Override
         public void handshakeFinished(byte[] id, String cipher, String protocol, byte[] peerCertificate,
@@ -2723,10 +2723,10 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                 return true;
             }
             // We trust all sub-types as we use different types but the interface is package-private
-            if (!(o instanceof OpenSslSession)) {
+            if (!(o instanceof OpenSslInternalSession)) {
                 return false;
             }
-            return sessionId().equals(((OpenSslSession) o).sessionId());
+            return sessionId().equals(((OpenSslInternalSession) o).sessionId());
         }
     }
 

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -2605,6 +2605,13 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
         }
 
         @Override
+        public boolean hasPeerCertificates() {
+            synchronized (ReferenceCountedOpenSslEngine.this) {
+                return !isEmpty(peerCerts);
+            }
+        }
+
+        @Override
         public Certificate[] getLocalCertificates() {
             Certificate[] localCerts = this.localCertificateChain;
             if (localCerts == null) {

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
@@ -56,6 +56,7 @@ import javax.net.ssl.SSLEngineResult.HandshakeStatus;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSession;
 import javax.net.ssl.X509ExtendedKeyManager;
 
 import static io.netty.handler.ssl.OpenSslContextOption.MAX_CERTIFICATE_LIST_BYTES;
@@ -163,6 +164,12 @@ public class OpenSslEngineTest extends SSLEngineTest {
     public void testSupportedSignatureAlgorithms(SSLEngineTestParam param) throws Exception {
         checkShouldUseKeyManagerFactory();
         super.testSupportedSignatureAlgorithms(param);
+    }
+
+    @Override
+    protected void additionalPeerAssertions(SSLSession sslSession, boolean mutualAuth) {
+        assumeTrue(sslSession instanceof OpenSslSession);
+        assertEquals(mutualAuth, ((OpenSslSession) sslSession).hasPeerCertificates());
     }
 
     private static boolean isNpnSupported(String versionString) {

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
@@ -168,8 +168,8 @@ public class OpenSslEngineTest extends SSLEngineTest {
 
     @Override
     protected void additionalPeerAssertions(SSLSession sslSession, boolean mutualAuth) {
-        if (sslSession instanceof OpenSslSession) {
-            assertEquals(mutualAuth, ((OpenSslSession) sslSession).hasPeerCertificates());
+        if (sslSession instanceof OpenSslInternalSession) {
+            assertEquals(mutualAuth, ((OpenSslInternalSession) sslSession).hasPeerCertificates());
         }
     }
 

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
@@ -168,8 +168,9 @@ public class OpenSslEngineTest extends SSLEngineTest {
 
     @Override
     protected void additionalPeerAssertions(SSLSession sslSession, boolean mutualAuth) {
-        assumeTrue(sslSession instanceof OpenSslSession);
-        assertEquals(mutualAuth, ((OpenSslSession) sslSession).hasPeerCertificates());
+        if (sslSession instanceof OpenSslSession) {
+            assertEquals(mutualAuth, ((OpenSslSession) sslSession).hasPeerCertificates());
+        }
     }
 
     private static boolean isNpnSupported(String versionString) {

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
@@ -169,7 +169,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
     @Override
     protected void additionalPeerAssertions(SSLSession sslSession, boolean mutualAuth) {
         if (sslSession instanceof OpenSslSession) {
-            assertEquals(mutualAuth, ((OpenSslInternalSession) sslSession).hasPeerCertificates());
+            assertEquals(mutualAuth, ((OpenSslSession) sslSession).hasPeerCertificates());
         }
     }
 

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
@@ -168,7 +168,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
 
     @Override
     protected void additionalPeerAssertions(SSLSession sslSession, boolean mutualAuth) {
-        if (sslSession instanceof OpenSslInternalSession) {
+        if (sslSession instanceof OpenSslSession) {
             assertEquals(mutualAuth, ((OpenSslInternalSession) sslSession).hasPeerCertificates());
         }
     }

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -3782,6 +3782,7 @@ public abstract class SSLEngineTest {
                 Certificate[] serverPeerCertificates = serverSession.getPeerCertificates();
                 assertEquals(1, serverPeerCertificates.length);
                 assertArrayEquals(clientLocalCertificates[0].getEncoded(), serverPeerCertificates[0].getEncoded());
+                additionalPeerAssertions(serverSession, mutualAuth);
 
                 try {
                     X509Certificate[] serverPeerX509Certificates = serverSession.getPeerCertificateChain();
@@ -3808,6 +3809,8 @@ public abstract class SSLEngineTest {
                 } catch (SSLPeerUnverifiedException expected) {
                     // As we did not use mutual auth this is expected
                 }
+
+                additionalPeerAssertions(serverSession, mutualAuth);
 
                 try {
                     serverSession.getPeerCertificateChain();
@@ -3845,6 +3848,10 @@ public abstract class SSLEngineTest {
             cleanupClientSslEngine(clientEngine);
             cleanupServerSslEngine(serverEngine);
         }
+    }
+
+    protected void additionalPeerAssertions(final SSLSession sslSession, final boolean mutualAuth) {
+        // noop
     }
 
     @Timeout(value = 60, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)


### PR DESCRIPTION
Motivation
----------
In a use-case where an application wants to check if a peer certificate has been provided without throwing an exception if none are found (as is currently the behavior when calling SSLSession#getPeerCertificates) there is currently no API available to do that.

The use-case which prompted this addition is to defensively check if a mTLS connection has been established with access to the SSLSession.

Modifications
-------------
This changeset introduces a new API to the OpenSslSession which allows to check if peer certs are available (hasPeerCertificates) and returns true if this is the case.

Result
------
It is now possible to check if mTLS is enabled (through checking if peer certs are presented) without throwing an exception if not.
