### PR TITLE
Reentrant close in EmbeddedChannel

### DIFF
--- a/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
@@ -767,7 +767,7 @@ public class EmbeddedChannelTest {
     void testReentrantClose() {
         EmbeddedChannel channel = new EmbeddedChannel();
         channel.pipeline().addLast(new ChannelInboundHandlerAdapter() {
-            boolean runningRead = false;
+            boolean runningRead;
 
             @Override
             public void channelRead(ChannelHandlerContext ctx, Object msg) {

--- a/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
@@ -763,6 +763,33 @@ public class EmbeddedChannelTest {
         assertFalse(channel.hasPendingTasks());
     }
 
+    @Test
+    void testReentrantClose() {
+        EmbeddedChannel channel = new EmbeddedChannel();
+        channel.pipeline().addLast(new ChannelInboundHandlerAdapter() {
+            boolean runningRead = false;
+
+            @Override
+            public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                runningRead = true;
+                try {
+                    ctx.channel().close();
+                } finally {
+                    runningRead = false;
+                }
+            }
+
+            @Override
+            public void handlerRemoved(ChannelHandlerContext ctx) {
+                if (runningRead) {
+                    throw new IllegalStateException("Reentrant handlerRemoved");
+                }
+            }
+        });
+        channel.writeInbound("foo");
+        channel.checkException();
+    }
+
     private static void release(ByteBuf... buffers) {
         for (ByteBuf buffer : buffers) {
             if (buffer.refCnt() > 0) {


### PR DESCRIPTION
Motivation:

This is another case like #13730 where a close operation in channelRead can lead to a reentrant call to handlerRemoved. In this case, it's a direct Channel#close call that bypasses the reentrancy guard introduced in #13730, and calls the close logic immediately.

ChannelHandlerContext#close is not affected, but Channel#close is called e.g. by ChannelFutureListener#CLOSE so using the context is not always viable.

Discovered by fuzzing.

Modification:

Instead of cancelling scheduled tasks immediately, make the cancellation part of the maybeRunPendingTasks logic.

Result:

Reentrancy is controlled and the test passes.