### PR TITLE
Update java versions

### DIFF
--- a/docker/docker-compose.centos-6.111.yaml
+++ b/docker/docker-compose.centos-6.111.yaml
@@ -6,7 +6,7 @@ services:
     image: netty:centos-6-1.11
     build:
       args:
-        java_version : "11.0.24-zulu"
+        java_version : "11.0.25-zulu"
 
   build:
     image: netty:centos-6-1.11

--- a/docker/docker-compose.centos-6.18.yaml
+++ b/docker/docker-compose.centos-6.18.yaml
@@ -6,7 +6,7 @@ services:
     image: netty:centos-6-1.8
     build:
       args:
-        java_version : "8.0.422-zulu"
+        java_version : "8.0.432-zulu"
 
   build:
     image: netty:centos-6-1.8

--- a/docker/docker-compose.centos-6.21.yaml
+++ b/docker/docker-compose.centos-6.21.yaml
@@ -6,7 +6,7 @@ services:
     image: netty:centos-6-21
     build:
       args:
-        java_version : "21.0.4-zulu"
+        java_version : "21.0.5-zulu"
 
   build:
     image: netty:centos-6-21

--- a/docker/docker-compose.centos-7.117.yaml
+++ b/docker/docker-compose.centos-7.117.yaml
@@ -6,7 +6,7 @@ services:
     image: netty:centos-7-1.17
     build:
       args:
-        java_version : "17.0.12-zulu"
+        java_version : "17.0.13-zulu"
 
   build:
     image: netty:centos-7-1.17


### PR DESCRIPTION
Motivation:

We are not using the latest releases in our docker builds and so not on the CI

Modifications:

Update to latest java releases

Result:

Use latest java releases during build