### PR TITLE
Correcly handle comments appended to nameserver declarations (#14658)

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/ResolvConf.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/ResolvConf.java
@@ -80,7 +80,15 @@ final class ResolvConf {
             }
 
             if (ln.startsWith("nameserver")) {
-                ln = ln.substring("nameserver".length()).trim();
+                ln = ln.substring("nameserver".length());
+                int cIndex = ln.indexOf('#');
+                if (cIndex != -1) {
+                    ln = ln.substring(0, cIndex);
+                }
+                ln = ln.trim();
+                if (ln.isEmpty()) {
+                    continue;
+                }
                 nameservers.add(new InetSocketAddress(ln, 53));
             }
         }

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/ResolvConfTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/ResolvConfTest.java
@@ -48,13 +48,13 @@ public class ResolvConfTest {
     @MethodSource
     public void scenarios(String resolvConf, List<String> nameservers) throws Exception {
         assertIterableEquals(
-                ResolvConf.fromReader(new BufferedReader(new StringReader(resolvConf))).getNameservers(),
                 nameservers.stream().map(new Function<String, InetSocketAddress>() {
                     @Override
                     public InetSocketAddress apply(String n) {
                         return new InetSocketAddress(n, 53);
                     }
-                }).collect(Collectors.toList()));
+                }).collect(Collectors.toList()),
+                ResolvConf.fromReader(new BufferedReader(new StringReader(resolvConf))).getNameservers());
     }
 
     static List<Arguments> scenarios() {
@@ -72,6 +72,11 @@ public class ResolvConfTest {
                                 + "# nameserver hello\n"
                                 + "\n"
                                 + "nameserver 1.2.3.4\n"
+                                + "nameserver 127.1.2.3",
+                        Arrays.asList("1.2.3.4", "127.1.2.3")),
+                arguments(
+                        "# some comment\n"
+                                + "nameserver 1.2.3.4 # comment\n"
                                 + "nameserver 127.1.2.3",
                         Arrays.asList("1.2.3.4", "127.1.2.3")),
                 arguments(


### PR DESCRIPTION
Motivation:

We need to ensure we correctly filter out appended comments in resolv.conf

Modifications:

- Skip comments
- Add unit test

Result:

Fixes https://github.com/netty/netty/issues/14514