### PR TITLE
Revert "IoUring: Remove delayed close logic as its not needed (#14540)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1273,6 +1273,16 @@
                 <item>
                   <ignore>true</ignore>
                   <code>java.method.visibilityIncreased</code>
+                  <classQualifiedName>io.netty.channel.AbstractChannel.AbstractUnsafe</classQualifiedName>
+                  <old>method void io.netty.channel.AbstractChannel.AbstractUnsafe::close(io.netty.channel.ChannelPromise, java.lang.Throwable, java.nio.channels.ClosedChannelException, boolean)</old>
+                  <new>method void io.netty.channel.AbstractChannel.AbstractUnsafe::close(io.netty.channel.ChannelPromise, java.lang.Throwable, java.nio.channels.ClosedChannelException)</new>
+                  <oldVisibility>private</oldVisibility>
+                  <newVisibility>protected</newVisibility>
+                  <justification>Was private before and is needed for sub-classes</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.visibilityIncreased</code>
                   <classQualifiedName>io.netty.handler.codec.spdy.SpdyFrameEncoder</classQualifiedName>
                   <old>method void io.netty.handler.codec.spdy.SpdyFrameEncoder::writeControlFrameHeader(io.netty.buffer.ByteBuf, int, byte, int)</old>
                   <new>method void io.netty.handler.codec.spdy.SpdyFrameEncoder::writeControlFrameHeader(io.netty.buffer.ByteBuf, int, byte, int)</new>

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -482,7 +482,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
 
             ClosedChannelException closedChannelException =
                     StacklessClosedChannelException.newInstance(AbstractChannel.class, "close(ChannelPromise)");
-            close(promise, closedChannelException, closedChannelException, false);
+            close(promise, closedChannelException, closedChannelException);
         }
 
         /**
@@ -538,8 +538,8 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             pipeline.fireUserEventTriggered(ChannelOutputShutdownEvent.INSTANCE);
         }
 
-        private void close(final ChannelPromise promise, final Throwable cause,
-                           final ClosedChannelException closeCause, final boolean notify) {
+        protected void close(final ChannelPromise promise, final Throwable cause,
+                           final ClosedChannelException closeCause) {
             if (!promise.setUncancellable()) {
                 return;
             }
@@ -580,7 +580,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                                 public void run() {
                                     if (outboundBuffer != null) {
                                         // Fail all the queued messages
-                                        outboundBuffer.failFlushed(cause, notify);
+                                        outboundBuffer.failFlushed(cause, false);
                                         outboundBuffer.close(closeCause);
                                     }
                                     fireChannelInactiveAndDeregister(wasActive);
@@ -596,7 +596,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                 } finally {
                     if (outboundBuffer != null) {
                         // Fail all the queued messages.
-                        outboundBuffer.failFlushed(cause, notify);
+                        outboundBuffer.failFlushed(cause, false);
                         outboundBuffer.close(closeCause);
                     }
                 }
@@ -811,13 +811,13 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                  * may still return {@code true} even if the channel should be closed as result of the exception.
                  */
                 initialCloseCause = t;
-                close(voidPromise(), t, newClosedChannelException(t, "flush0()"), false);
+                close(voidPromise(), t, newClosedChannelException(t, "flush0()"));
             } else {
                 try {
                     shutdownOutput(voidPromise(), t);
                 } catch (Throwable t2) {
                     initialCloseCause = t;
-                    close(voidPromise(), t2, newClosedChannelException(t, "flush0()"), false);
+                    close(voidPromise(), t2, newClosedChannelException(t, "flush0()"));
                 }
             }
         }


### PR DESCRIPTION
Motivation:

This reverts commit ed3566c69d981567edffc09eda69ce8c6c516ac2 and slightly changes it a bit to ensure write error handlings also take account delayed close

Modifications:

- Revert ed3566c69d981567edffc09eda69ce8c6c516ac2
- Correctly handle delayed close for write errors

Result:

No more problems of tearing down the pipeline before all read / write completions are observed
