### PR TITLE
IoUring: Correctly handle submission failures when using MsgHdrMemory…

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
@@ -503,6 +503,8 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
                     fd, flags((byte) 0), msgFlags, msgHdrMemory.address(), msgHdrMemory.idx());
             long id = registration.submit(ops);
             if (id == 0) {
+                // Submission failed we don't used the MsgHdrMemory and so should give it back.
+                recvmsgHdrs.restoreNextHdr(msgHdrMemory);
                 return false;
             }
             recvmsgHdrs.setId(msgHdrMemory.idx(), id);
@@ -605,6 +607,8 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
             IoUringIoOps ops = IoUringIoOps.newSendmsg(fd, flags((byte) 0), msgFlags, hdr.address(), hdr.idx());
             long id = registration.submit(ops);
             if (id == 0) {
+                // Submission failed we don't used the MsgHdrMemory and so should give it back.
+                sendmsgHdrs.restoreNextHdr(hdr);
                 return false;
             }
             sendmsgHdrs.setId(hdr.idx(), id);

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/MsgHdrMemoryArray.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/MsgHdrMemoryArray.java
@@ -44,6 +44,11 @@ final class MsgHdrMemoryArray {
         return hdrs[idx++];
     }
 
+    void restoreNextHdr(MsgHdrMemory hdr) {
+        assert hdr.idx() == idx - 1;
+        idx--;
+    }
+
     MsgHdrMemory hdr(int idx) {
         return hdrs[idx];
     }


### PR DESCRIPTION
…Array

Motivation:

When submission of the IoUriingIoOps fails we also need to ensure we can restore the previously reserved MsgHdrMemory as we will never receive a completion event for it.

Modification:

Restore MsgHdrMemory when submission fails

Result:

Correctly handle submission failures
