### PR TITLE
Clarify documentation on max HTTP header size

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpDecoderConfig.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpDecoderConfig.java
@@ -77,7 +77,7 @@ public final class HttpDecoderConfig implements Cloneable {
      * Set the maximum line length of header lines.
      * This limits how much memory Netty will use when parsing HTTP header key-value pairs.
      * The limit applies to the sum of all the headers, so it applies equally to many short header-lines,
-     * or fewer bug longer header lines.
+     * or fewer but longer header lines.
      * <p>
      * You would typically set this to the same value as {@link #setMaxInitialLineLength(int)}.
      *

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpDecoderConfig.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpDecoderConfig.java
@@ -76,6 +76,9 @@ public final class HttpDecoderConfig implements Cloneable {
     /**
      * Set the maximum line length of header lines.
      * This limits how much memory Netty will use when parsing HTTP header key-value pairs.
+     * The limit applies to the sum of all the headers, so it applies equally to many short header-lines,
+     * or fewer bug longer header lines.
+     * <p>
      * You would typically set this to the same value as {@link #setMaxInitialLineLength(int)}.
      *
      * @param maxHeaderSize The maximum length, in bytes.

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpRequestDecoder.java
@@ -126,12 +126,22 @@ public class HttpRequestDecoder extends HttpObjectDecoder {
      * Creates a new instance with the default
      * {@code maxInitialLineLength (4096)}, {@code maxHeaderSize (8192)}, and
      * {@code maxChunkSize (8192)}.
+     * @see HttpDecoderConfig HttpDecoderConfig API documentation for detailed descriptions of
+     * the configuration parameters.
      */
     public HttpRequestDecoder() {
     }
 
     /**
      * Creates a new instance with the specified parameters.
+     *
+     * @param maxInitialLineLength the initial size of the temporary buffer used when parsing the lines of the
+     * HTTP headers.
+     * @param maxHeaderSize the maximum permitted combined size of all headers in any one request.
+     * @param maxChunkSize The maximum amount of data that the decoder will buffer
+     * before sending chunks down the pipeline.
+     * @see HttpDecoderConfig HttpDecoderConfig API documentation for detailed descriptions of
+     * the configuration parameters.
      */
     public HttpRequestDecoder(
             int maxInitialLineLength, int maxHeaderSize, int maxChunkSize) {
@@ -144,6 +154,8 @@ public class HttpRequestDecoder extends HttpObjectDecoder {
     /**
      * @deprecated Prefer the {@link #HttpRequestDecoder(HttpDecoderConfig)} constructor,
      * to always have header validation enabled.
+     * @see HttpDecoderConfig HttpDecoderConfig API documentation for detailed descriptions of
+     * the configuration parameters.
      */
     @Deprecated
     public HttpRequestDecoder(
@@ -154,6 +166,8 @@ public class HttpRequestDecoder extends HttpObjectDecoder {
     /**
      * @deprecated Prefer the {@link #HttpRequestDecoder(HttpDecoderConfig)} constructor,
      * to always have header validation enabled.
+     * @see HttpDecoderConfig HttpDecoderConfig API documentation for detailed descriptions of
+     * the configuration parameters.
      */
     @Deprecated
     public HttpRequestDecoder(
@@ -166,6 +180,8 @@ public class HttpRequestDecoder extends HttpObjectDecoder {
     /**
      * @deprecated Prefer the {@link #HttpRequestDecoder(HttpDecoderConfig)} constructor,
      * to always have header validation enabled.
+     * @see HttpDecoderConfig HttpDecoderConfig API documentation for detailed descriptions of
+     * the configuration parameters.
      */
     @Deprecated
     public HttpRequestDecoder(
@@ -178,6 +194,8 @@ public class HttpRequestDecoder extends HttpObjectDecoder {
     /**
      * @deprecated Prefer the {@link #HttpRequestDecoder(HttpDecoderConfig)} constructor,
      * to always have header validation enabled.
+     * @see HttpDecoderConfig HttpDecoderConfig API documentation for detailed descriptions of
+     * the configuration parameters.
      */
     @Deprecated
     public HttpRequestDecoder(
@@ -189,6 +207,8 @@ public class HttpRequestDecoder extends HttpObjectDecoder {
 
     /**
      * Creates a new instance with the specified configuration.
+     * @see HttpDecoderConfig HttpDecoderConfig API documentation for detailed descriptions of
+     * the configuration parameters.
      */
     public HttpRequestDecoder(HttpDecoderConfig config) {
         super(config);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseDecoder.java
@@ -124,12 +124,22 @@ public class HttpResponseDecoder extends HttpObjectDecoder {
      * Creates a new instance with the default
      * {@code maxInitialLineLength (4096)}, {@code maxHeaderSize (8192)}, and
      * {@code maxChunkSize (8192)}.
+     * @see HttpDecoderConfig HttpDecoderConfig API documentation for detailed descriptions of
+     * the configuration parameters.
      */
     public HttpResponseDecoder() {
     }
 
     /**
      * Creates a new instance with the specified parameters.
+     *
+     * @param maxInitialLineLength the initial size of the temporary buffer used when parsing the lines of the
+     * HTTP headers.
+     * @param maxHeaderSize the maximum permitted combined size of all headers in any one response.
+     * @param maxChunkSize The maximum amount of data that the decoder will buffer
+     * before sending chunks down the pipeline.
+     * @see HttpDecoderConfig HttpDecoderConfig API documentation for detailed descriptions of
+     * the configuration parameters.
      */
     public HttpResponseDecoder(
             int maxInitialLineLength, int maxHeaderSize, int maxChunkSize) {
@@ -141,6 +151,8 @@ public class HttpResponseDecoder extends HttpObjectDecoder {
 
     /**
      * @deprecated Prefer the {@link #HttpResponseDecoder(HttpDecoderConfig)} constructor.
+     * @see HttpDecoderConfig HttpDecoderConfig API documentation for detailed descriptions of
+     * the configuration parameters.
      */
     @Deprecated
     public HttpResponseDecoder(
@@ -150,6 +162,8 @@ public class HttpResponseDecoder extends HttpObjectDecoder {
 
     /**
      * @deprecated Prefer the {@link #HttpResponseDecoder(HttpDecoderConfig)} constructor.
+     * @see HttpDecoderConfig HttpDecoderConfig API documentation for detailed descriptions of
+     * the configuration parameters.
      */
     @Deprecated
     public HttpResponseDecoder(
@@ -161,6 +175,8 @@ public class HttpResponseDecoder extends HttpObjectDecoder {
 
     /**
      * @deprecated Prefer the {@link #HttpResponseDecoder(HttpDecoderConfig)} constructor.
+     * @see HttpDecoderConfig HttpDecoderConfig API documentation for detailed descriptions of
+     * the configuration parameters.
      */
     @Deprecated
     public HttpResponseDecoder(
@@ -172,6 +188,8 @@ public class HttpResponseDecoder extends HttpObjectDecoder {
 
     /**
      * @deprecated Prefer the {@link #HttpResponseDecoder(HttpDecoderConfig)} constructor.
+     * @see HttpDecoderConfig HttpDecoderConfig API documentation for detailed descriptions of
+     * the configuration parameters.
      */
     @Deprecated
     public HttpResponseDecoder(
@@ -183,6 +201,8 @@ public class HttpResponseDecoder extends HttpObjectDecoder {
 
     /**
      * Creates a new instance with the specified configuration.
+     * @see HttpDecoderConfig HttpDecoderConfig API documentation for detailed descriptions of
+     * the configuration parameters.
      */
     public HttpResponseDecoder(HttpDecoderConfig config) {
         super(config);

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -382,6 +382,33 @@ public class HttpRequestDecoderTest {
     }
 
     @Test
+    void testTotalHeaderLimit() throws Exception {
+        String requestStr = "GET /some/path HTTP/1.1\r\n" +
+                "Host: a.b\r\n" + // 9 content bytes
+                "a1: b\r\n" +     // + 5 = 14 bytes,
+                "a2: b\r\n\r\n";  // + 5 = 19 bytes
+
+        // Decoding with a max header size of 18 bytes must fail:
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder(1024, 18, 1024));
+        assertTrue(channel.writeInbound(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)));
+        HttpRequest request = channel.readInbound();
+        assertTrue(request.decoderResult().isFailure());
+        assertInstanceOf(TooLongHttpHeaderException.class, request.decoderResult().cause());
+        assertFalse(channel.finish());
+
+        // Decoding with a max header size of 19 must pass:
+        channel = new EmbeddedChannel(new HttpRequestDecoder(1024, 19, 1024));
+        assertTrue(channel.writeInbound(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)));
+        request = channel.readInbound();
+        assertTrue(request.decoderResult().isSuccess());
+        assertEquals("a.b", request.headers().get("Host"));
+        assertEquals("b", request.headers().get("a1"));
+        assertEquals("b", request.headers().get("a2"));
+        assertEquals(LastHttpContent.EMPTY_LAST_CONTENT, channel.readInbound());
+        assertFalse(channel.finish());
+    }
+
+    @Test
     public void testHeaderNameStartsWithControlChar1c() {
         testHeaderNameStartsWithControlChar(0x1c);
     }


### PR DESCRIPTION
Motivation:
Limiting the size of buffers in the HTTP decoders is an important security consideration. The API documentation on the max header size could be more clear, so people can make correct decisions about how to configure it.

Modification:
Updated the API documentation on the HttpDecoderConfig methods, and HttpRequest/ResponseDecoder constructor parameters, to clarify that the limit applies to the sum total size of all the headers in an HTTP message.

Result:
Clearer documentation.
