### PR TITLE
IoUring: Rename constant to match name used by io_uring

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringServerChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringServerChannel.java
@@ -136,7 +136,7 @@ abstract class AbstractIoUringServerChannel extends AbstractIoUringChannel imple
             if (first) {
                 ioPrio = socketIsEmpty ? Native.IORING_ACCEPT_POLL_FIRST : 0;
             } else {
-                ioPrio = Native.IORING_ACCEPT_DONT_WAIT;
+                ioPrio = Native.IORING_ACCEPT_DONTWAIT;
             }
             // See https://github.com/axboe/liburing/wiki/What's-new-with-io_uring-in-6.10#improvements-for-accept
             IoUringIoOps ops = IoUringIoOps.newAccept(fd, flags((byte) 0), 0, ioPrio,

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -195,7 +195,7 @@ final class Native {
     static final byte IORING_CQE_F_SOCK_NONEMPTY = 1 << 2;
 
     static final short IORING_RECVSEND_POLL_FIRST = 1 << 0;
-    static final short IORING_ACCEPT_DONT_WAIT = 1 << 1;
+    static final short IORING_ACCEPT_DONTWAIT = 1 << 1;
     static final short IORING_ACCEPT_POLL_FIRST = 1 << 2;
     static final int IORING_FEAT_RECVSEND_BUNDLE = 1 << 14;
     static final int SPLICE_F_MOVE = 1;


### PR DESCRIPTION
Motivation:

We had a typo in the name of the field, we should fix it and use the correct naming.

Modifications:

Rename to IORING_ACCEPT_DONTWAIT

Result:

Cleanup
