### PR TITLE
IoUring: Don't mark sockets as blocking as it makes no difference

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringServerChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringServerChannel.java
@@ -43,7 +43,7 @@ abstract class AbstractIoUringServerChannel extends AbstractIoUringChannel imple
     private long acceptId;
 
     protected AbstractIoUringServerChannel(LinuxSocket socket, boolean active) {
-        super(null, IoUring.isIOUringAcceptNoWaitSupported() ? LinuxSocket.makeBlocking(socket) : socket, active);
+        super(null, socket, active);
 
         acceptedAddressMemory = Buffer.allocateDirectWithNativeOrder(Native.SIZEOF_SOCKADDR_STORAGE);
         acceptedAddressMemoryAddress = Buffer.memoryAddress(acceptedAddressMemory);

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -48,13 +48,11 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
     private long readId;
 
     AbstractIoUringStreamChannel(Channel parent, LinuxSocket socket, boolean active) {
-        // Use a blocking fd, we can make use of fastpoll.
-        super(parent, LinuxSocket.makeBlocking(socket), active);
+        super(parent, socket, active);
     }
 
     AbstractIoUringStreamChannel(Channel parent, LinuxSocket socket, SocketAddress remote) {
-        // Use a blocking fd, we can make use of fastpoll.
-        super(parent, LinuxSocket.makeBlocking(socket), remote);
+        super(parent, socket, remote);
     }
 
     @Override

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
@@ -101,7 +101,7 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
 
     private IoUringDatagramChannel(LinuxSocket fd, boolean active) {
         // Always use a blocking fd and so make use of fast-poll.
-        super(null, LinuxSocket.makeBlocking(fd), active);
+        super(null, fd, active);
         config = new IoUringDatagramChannelConfig(this);
     }
 

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/LinuxSocket.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/LinuxSocket.java
@@ -17,7 +17,6 @@ package io.netty.channel.uring;
 
 import io.netty.channel.ChannelException;
 import io.netty.channel.socket.SocketProtocolFamily;
-import io.netty.channel.unix.Errors;
 import io.netty.channel.unix.NativeInetAddress;
 import io.netty.channel.unix.PeerCredentials;
 import io.netty.channel.unix.Socket;
@@ -37,7 +36,6 @@ final class LinuxSocket extends Socket {
     static final InetAddress INET6_ANY = unsafeInetAddrByName("::");
     private static final InetAddress INET_ANY = unsafeInetAddrByName("0.0.0.0");
     private static final long MAX_UINT32_T = 0xFFFFFFFFL;
-    private boolean blocking;
 
     LinuxSocket(int fd) {
         super(fd);
@@ -281,18 +279,6 @@ final class LinuxSocket extends Socket {
 
     void setUdpGro(boolean gro) throws IOException {
         setUdpGro(intValue(), gro ? 1 : 0);
-    }
-
-    void makeBlocking() throws IOException {
-        int result = makeBlocking(intValue());
-        if (result != 0) {
-            throw Errors.newIOException("makeBlocking", result);
-        }
-        blocking = true;
-    }
-
-    boolean isBlocking() {
-        return blocking;
     }
 
     private static InetAddress deriveInetAddress(NetworkInterface netInterface, boolean ipv6) {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/LinuxSocket.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/LinuxSocket.java
@@ -43,15 +43,6 @@ final class LinuxSocket extends Socket {
         super(fd);
     }
 
-    static LinuxSocket makeBlocking(LinuxSocket socket) {
-        try {
-            socket.makeBlocking();
-            return socket;
-        } catch (IOException e) {
-            throw new ChannelException(e);
-        }
-    }
-
     SocketProtocolFamily family() {
         return ipv6 ? SocketProtocolFamily.INET6 : SocketProtocolFamily.INET;
     }


### PR DESCRIPTION
Motivation:

io_uring does not care about if a socket is blocking or non blocking. If you want to do non-blocking operations it needs to be done by io-hint and not file-hint.

Modifications:

Don't mark sockets explicit as blocking

Result:

Cleanup and one less syscall per socket
