### PR TITLE
IoUring: Correctly handle IORING_CQE_F_SOCK_NONEMPTY for accepts

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -1166,9 +1166,13 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
             ioState &= ~POLL_RDHUP_SCHEDULED;
             pollRdhupId = 0;
         }
-     }
-
-    protected static boolean socketIsEmpty(int flags) {
-        return IoUring.isIOUringCqeFSockNonEmptySupported() && (flags & Native.IORING_CQE_F_SOCK_NONEMPTY) == 0;
     }
+
+    /**
+     * Return if the socket is guaranteed to be empty when the submitted io was executed and the completion event be
+     * created.
+     * @param flags     the flags that were part of the completion
+     * @return          {@code true} if empty.
+     */
+    protected abstract boolean socketIsEmpty(int flags);
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -493,4 +493,9 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
             assert numOutstandingWrites == 0;
         }
     }
+
+    @Override
+    protected boolean socketIsEmpty(int flags) {
+        return IoUring.isIOUringCqeFSockNonEmptySupported() && (flags & Native.IORING_CQE_F_SOCK_NONEMPTY) == 0;
+    }
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
@@ -674,4 +674,9 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
         }
         return cancelled;
     }
+
+    @Override
+    protected boolean socketIsEmpty(int flags) {
+        return IoUring.isIOUringCqeFSockNonEmptySupported() && (flags & Native.IORING_CQE_F_SOCK_NONEMPTY) == 0;
+    }
 }


### PR DESCRIPTION
Motivation:

IORING_CQE_F_SOCK_NONEMPTY usage was only added for accept when IORING_ACCEPT_DONTWAIT was added. We can't assume support before.

Modifications:

Implement the correct socketIsEmpty method for each different channel type

Result:

Correct handling of IORING_CQE_F_SOCK_NONEMPTY for accepts
