### PR TITLE
IoUring: Move encoding / decoding logic out of the completion and submission queue

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionCallback.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionCallback.java
@@ -19,5 +19,5 @@ interface CompletionCallback {
     /**
      * Called for a completion event that was put into the {@link CompletionQueue}.
      */
-    void handle(int res, int flags, int id, byte op, short data);
+    void handle(int res, int flags, long udata);
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionQueue.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionQueue.java
@@ -89,7 +89,6 @@ final class CompletionQueue implements IntSupplier {
     int process(CompletionCallback callback) {
         int tail = PlatformDependent.getIntVolatile(kTailAddress);
         int i = 0;
-        boolean isTraceEnabled = logger.isTraceEnabled();
         while (ringHead != tail) {
             long cqeAddress = completionQueueArrayAddress + (ringHead & ringMask) * CQE_SIZE;
 
@@ -103,10 +102,6 @@ final class CompletionQueue implements IntSupplier {
 
             i++;
 
-            if (isTraceEnabled) {
-                logger.trace("completed(ring {}: (res={}, flags={}, udata={})",
-                        ringFd, res, flags, udata);
-            }
             try {
                 callback.handle(res, flags, udata);
             } catch (Error e) {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -115,6 +115,10 @@ public final class IoUringIoHandler implements IoHandler {
         byte op = UserData.decodeOp(udata);
         short data = UserData.decodeData(udata);
 
+        if (logger.isTraceEnabled()) {
+            logger.trace("completed(ring {}): {}(id={}, res={})",
+                    ringBuffer.fd(), Native.opToStr(op), data, res);
+        }
         if (id == EVENTFD_ID) {
             handleEventFdRead();
             return;

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/UserData.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/UserData.java
@@ -31,13 +31,6 @@ final class UserData {
         return ((long) data << 48) | ((op & 0xFFL)  << 32) | id & 0xFFFFFFFFL;
     }
 
-    static void decode(int res, int flags, long udata, CompletionCallback callback) {
-        int id = decodeId(udata);
-        byte op = decodeOp(udata);
-        short data = decodeData(udata);
-        callback.handle(res, flags, id, op, data);
-    }
-
     static int decodeId(long udata) {
         return (int) (udata & 0xFFFFFFFFL);
     }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/SubmissionQueueTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/SubmissionQueueTest.java
@@ -43,12 +43,12 @@ public class SubmissionQueueTest {
 
             int counter = 0;
             while (submissionQueue.remaining() > 0) {
-                assertThat(submissionQueue.addNop(0, (byte) 0, 0, (short) 1)).isNotZero();
+                assertThat(submissionQueue.addNop(0, (byte) 0, 1)).isNotZero();
                 counter++;
             }
             assertEquals(8, counter);
             assertEquals(8, submissionQueue.count());
-            assertThat(submissionQueue.addNop(0, (byte) 0, 0, (short) 1)).isNotZero();
+            assertThat(submissionQueue.addNop(0, (byte) 0, 1)).isNotZero();
             assertEquals(1, submissionQueue.count());
             submissionQueue.submitAndWait();
             assertEquals(9, completionQueue.count());

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/UserDataTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/UserDataTest.java
@@ -26,15 +26,11 @@ public class UserDataTest {
         for (int fd : new int[] { -10, -1, 0, 1, 10, Short.MAX_VALUE, Integer.MAX_VALUE }) {
             for (byte op = 0; op < 20; op++) {
                 for (int data = Short.MIN_VALUE; data <= Short.MAX_VALUE; data++) {
-                    final int expectedFd = fd;
-                    final byte expectedOp = op;
                     final short expectedData = (short) data;
-                    long udata = UserData.encode(expectedFd, expectedOp, expectedData);
-                    UserData.decode(0, 0, udata, (res, flags, actualFd, actualOp, actualData) -> {
-                        assertEquals(expectedFd, actualFd);
-                        assertEquals(expectedOp, actualOp);
-                        assertEquals(expectedData, actualData);
-                    });
+                    long udata = UserData.encode(fd, op, expectedData);
+                    assertEquals(fd, UserData.decodeId(udata));
+                    assertEquals(op, UserData.decodeOp(udata));
+                    assertEquals(expectedData, UserData.decodeData(udata));
                 }
             }
         }


### PR DESCRIPTION
Motivation:

The encoding / decoding of id, opcode and data is not really the responsibility of the SubmissionQueue / CompletionQueue.

Modifications:

Move encoding / decoding to IoUringIoHandler

Result:

Better split of responsibilites
