### PR TITLE
Faster openCursor in NioBuffer

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/bytebuffer/NioBuffer.java
@@ -33,12 +33,10 @@ import io.netty5.util.internal.SWARUtil;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
-import java.util.Arrays;
 
 import static io.netty5.buffer.internal.InternalBufferUtils.MAX_BUFFER_SIZE;
 import static io.netty5.buffer.internal.InternalBufferUtils.bbput;
@@ -286,7 +284,7 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
         if (hasWritableArray()) {
             System.arraycopy(source, srcPos, writableArray(), writableArrayOffset(), length);
         } else {
-            InternalBufferUtils.bbput(wmem, woff, source, srcPos, length);
+            bbput(wmem, woff, source, srcPos, length);
         }
 
         skipWritableBytes(length);
@@ -303,7 +301,7 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
         if (hasWritableArray()) {
             source.get(writableArray(), writableArrayOffset(), length);
         } else {
-            InternalBufferUtils.bbput(wmem, woff, source, source.position(), length);
+            bbput(wmem, woff, source, source.position(), length);
             source.position(source.position() + length);
         }
 
@@ -1275,7 +1273,7 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
         byte byteValue;
 
         ForwardNioByteCursor(ByteBuffer rmem, int fromOffset, int length) {
-            buffer = rmem.duplicate().order(ByteOrder.BIG_ENDIAN);
+            buffer = rmem;
             index = fromOffset;
             end = index + length;
             byteValue = -1;
@@ -1314,7 +1312,7 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
         byte byteValue;
 
         ReverseNioByteCursor(ByteBuffer rmem, int fromOffset, int length) {
-            buffer = rmem.duplicate().order(ByteOrder.LITTLE_ENDIAN);
+            buffer = rmem;
             index = fromOffset;
             end = index - length;
             byteValue = -1;


### PR DESCRIPTION
Motivation:
When ByteCursor permitted accessing and processing whole longs of data at a time, and when it was possible to change the byte-order of a Netty buffer, the byte order of the ByteCursors underlying ByteBuffer mattered, and as such we had to duplicate the buffer and enforce correct byte order.

These flexibilities have since been removed, so there's no longer a need for us to duplicate ByteBuffers for the ByteCursors.

Modification:
Remove ByteBuffer::duplicate calls in NioBuffer.ForwardNioByteCursor and NioBuffer.ReverseNioByteCursor.

Result:
It's now much faster to open a cursor, and it's more likely for the cursor object to be scalarized.