### PR TITLE
IOUring: Add supported for provided buffers

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
@@ -1455,7 +1455,7 @@ public abstract class AbstractByteBuf extends ByteBuf {
         }
     }
 
-    protected final void setIndex0(int readerIndex, int writerIndex) {
+    final void setIndex0(int readerIndex, int writerIndex) {
         this.readerIndex = readerIndex;
         this.writerIndex = writerIndex;
     }

--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
@@ -1455,7 +1455,7 @@ public abstract class AbstractByteBuf extends ByteBuf {
         }
     }
 
-    final void setIndex0(int readerIndex, int writerIndex) {
+    protected final void setIndex0(int readerIndex, int writerIndex) {
         this.readerIndex = readerIndex;
         this.writerIndex = writerIndex;
     }

--- a/common/src/main/java/io/netty/util/internal/ObjectUtil.java
+++ b/common/src/main/java/io/netty/util/internal/ObjectUtil.java
@@ -26,6 +26,7 @@ public final class ObjectUtil {
     private static final double DOUBLE_ZERO = 0.0D;
     private static final long LONG_ZERO = 0L;
     private static final int INT_ZERO = 0;
+    private static final short SHORT_ZERO = 0;
 
     private ObjectUtil() {
     }
@@ -133,6 +134,17 @@ public final class ObjectUtil {
             throw new IllegalArgumentException(name + " : " + f + " (expected: > 0)");
         }
         return f;
+    }
+
+    /**
+     * Checks that the given argument is positive or zero. If it is not , throws {@link IllegalArgumentException}.
+     * Otherwise, returns the argument.
+     */
+    public static short checkPositive(short s, String name) {
+        if (s <= SHORT_ZERO) {
+            throw new IllegalArgumentException(name + " : " + s + " (expected: > 0)");
+        }
+        return s;
     }
 
     /**

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -508,8 +508,8 @@ public final class PlatformDependent {
         PlatformDependent0.safeConstructPutInt(object, fieldOffset, value);
     }
 
-    public static void putShortVolatile(long adddress, short newValue) {
-        PlatformDependent0.putShortVolatile(adddress, newValue);
+    public static void putShortOrdered(long adddress, short newValue) {
+        PlatformDependent0.putShortOrdered(adddress, newValue);
     }
 
     public static int getIntVolatile(long address) {

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -508,6 +508,10 @@ public final class PlatformDependent {
         PlatformDependent0.safeConstructPutInt(object, fieldOffset, value);
     }
 
+    public static void putShortVolatile(long adddress, short newValue) {
+        PlatformDependent0.putShortVolatile(adddress, newValue);
+    }
+
     public static int getIntVolatile(long address) {
         return PlatformDependent0.getIntVolatile(address);
     }

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -722,8 +722,8 @@ final class PlatformDependent0 {
     }
 
     static void putShortOrdered(long adddress, short newValue) {
-        UNSAFE.putShort(null, adddress, newValue);
         UNSAFE.storeFence();
+        UNSAFE.putShort(null, adddress, newValue);
     }
 
     static void putInt(long address, int value) {

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -722,6 +722,10 @@ final class PlatformDependent0 {
         UNSAFE.putShort(address, value);
     }
 
+    static void putShortVolatile(long adddress, short newValue) {
+        UNSAFE.putShortVolatile(null, adddress, newValue);
+    }
+
     static void putInt(long address, int value) {
         UNSAFE.putInt(address, value);
     }

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -31,7 +31,6 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import static java.lang.invoke.MethodType.methodType;
 
 /**
@@ -722,8 +721,9 @@ final class PlatformDependent0 {
         UNSAFE.putShort(address, value);
     }
 
-    static void putShortVolatile(long adddress, short newValue) {
-        UNSAFE.putShortVolatile(null, adddress, newValue);
+    static void putShortOrdered(long adddress, short newValue) {
+        UNSAFE.putShort(null, adddress, newValue);
+        UNSAFE.storeFence();
     }
 
     static void putInt(long address, int value) {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -430,9 +430,12 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
                     allocHandle.lastBytesRead(-1);
                 }
                 if (allocHandle.lastBytesRead() <= 0) {
-                    // nothing was read, release the buffer.
-                    byteBuf.release();
-                    byteBuf = null;
+                    // byteBuf might be null if we used a buffer ring.
+                    if (byteBuf != null) {
+                        // nothing was read, release the buffer.
+                        byteBuf.release();
+                        byteBuf = null;
+                    }
                     allDataRead = allocHandle.lastBytesRead() < 0;
                     if (allDataRead) {
                         // There is nothing left to read as we received an EOF.

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -16,7 +16,6 @@
 package io.netty.channel.uring;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
@@ -298,11 +297,14 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
             // we still check it again here.
             // When the kernel does not support this feature, it helps the JIT to delete this branch.
             // only `first` value is true, we will recv with the buffer ring;
-            if (IoUring.isRegisterBufferRingSupported() && first && channelConfig.isEnableBufferSelectRead()) {
+            if (IoUring.isRegisterBufferRingSupported() && first) {
+
                 short bgId = channelConfig.getBufferRingConfig();
-                IoUringBufferRing ioUringBufferRing = ioUringIoHandler.findBufferRing(bgId);
-                if (ioUringBufferRing.hasSpareBuffer() || !ioUringBufferRing.isFull()) {
-                    return scheduleReadProviderBuffer(ioUringBufferRing);
+                if (bgId != IOUringStreamChannelConfig.DISABLE_BUFFER_SELECT_READ) {
+                    IoUringBufferRing ioUringBufferRing = ioUringIoHandler.findBufferRing(bgId);
+                    if (ioUringBufferRing.hasSpareBuffer() || !ioUringBufferRing.isFull()) {
+                        return scheduleReadProviderBuffer(ioUringBufferRing);
+                    }
                 }
             }
 

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -422,10 +422,8 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
                 } else if (res > 0) {
                     if (bufferRing != null) {
                         byteBuf = bufferRing.borrowBuffer(flags >> Native.IORING_CQE_BUFFER_SHIFT, res);
-                        byteBuf.writerIndex(res);
-                    } else {
-                        byteBuf.writerIndex(byteBuf.writerIndex() + res);
                     }
+                    byteBuf.writerIndex(byteBuf.writerIndex() + res);
                     allocHandle.lastBytesRead(res);
                 } else {
                     // EOF which we signal with -1.

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -295,13 +295,12 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
             final IoUringIoHandler ioUringIoHandler = (IoUringIoHandler) registration().ioHandler();
             // Although we checked whether the current kernel supports `register_buffer_ring`
             // during the initialization of IoUringIoHandler
-            // we still perform this check again here.
+            // we still check it again here.
             // When the kernel does not support this feature, it helps the JIT to delete this branch.
             if (IoUring.isRegisterBufferRingSupported() && channelConfig.isEnableBufferSelectRead()) {
-                short bgId = channelConfig.getBufferRingConfig().bufferGroupId();
+                short bgId = channelConfig.getBufferRingConfig();
                 IoUringBufferRing ioUringBufferRing = ioUringIoHandler.findBufferRing(bgId);
                 if (ioUringBufferRing.hasSpareBuffer() || !ioUringBufferRing.isFull()) {
-                    lastUsedBufferRing = ioUringBufferRing;
                     return scheduleReadProviderBuffer(alloc(), ioUringBufferRing);
                 }
             }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -297,7 +297,8 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
             // during the initialization of IoUringIoHandler
             // we still check it again here.
             // When the kernel does not support this feature, it helps the JIT to delete this branch.
-            if (IoUring.isRegisterBufferRingSupported() && channelConfig.isEnableBufferSelectRead()) {
+            // only `first` value is true,we will recv with the buffer ring;
+            if (IoUring.isRegisterBufferRingSupported() && first && channelConfig.isEnableBufferSelectRead()) {
                 short bgId = channelConfig.getBufferRingConfig();
                 IoUringBufferRing ioUringBufferRing = ioUringIoHandler.findBufferRing(bgId);
                 if (ioUringBufferRing.hasSpareBuffer() || !ioUringBufferRing.isFull()) {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -297,7 +297,7 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
             // during the initialization of IoUringIoHandler
             // we still check it again here.
             // When the kernel does not support this feature, it helps the JIT to delete this branch.
-            // only `first` value is true,we will recv with the buffer ring;
+            // only `first` value is true, we will recv with the buffer ring;
             if (IoUring.isRegisterBufferRingSupported() && first && channelConfig.isEnableBufferSelectRead()) {
                 short bgId = channelConfig.getBufferRingConfig();
                 IoUringBufferRing ioUringBufferRing = ioUringIoHandler.findBufferRing(bgId);

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/BufferRingConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/BufferRingConfig.java
@@ -15,6 +15,8 @@
  */
 package io.netty.channel.uring;
 
+import io.netty.util.internal.ObjectUtil;
+
 public class BufferRingConfig {
     public static final BufferRingConfig DEFAULT_BUFFER_RING_CONFIG = defaultConfig();
 
@@ -23,7 +25,7 @@ public class BufferRingConfig {
     private final int chunkSize;
 
     public BufferRingConfig(short bgId, short bufferRingSize, int chunkSize) {
-        this.bgId = bgId;
+        this.bgId = ObjectUtil.checkPositive(bgId, "bgId");
         this.bufferRingSize = checkBufferRingSize(bufferRingSize);
         this.chunkSize = chunkSize;
     }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/BufferRingConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/BufferRingConfig.java
@@ -75,7 +75,7 @@ public final class BufferRingConfig {
     }
 
     private static int checkInitSize(int initSize, short bufferRingSize) {
-        initSize = ObjectUtil.checkPositiveOrZero(initSize, "initSize");
+        ObjectUtil.checkPositiveOrZero(initSize, "initSize");
         if (initSize > bufferRingSize) {
             throw new IllegalArgumentException(
                     "initSize: " + initSize + " (expected: <= bufferRingSize: " + bufferRingSize + ')'

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/BufferRingConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/BufferRingConfig.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+public class BufferRingConfig {
+    public static final BufferRingConfig DEFAULT_BUFFER_RING_CONFIG = defaultConfig();
+
+    private final short bgId;
+    private final short bufferRingSize;
+    private final int chunkSize;
+
+    public BufferRingConfig(short bgId, short bufferRingSize, int chunkSize) {
+        this.bgId = bgId;
+        this.bufferRingSize = checkBufferRingSize(bufferRingSize);
+        this.chunkSize = chunkSize;
+    }
+
+    private static BufferRingConfig defaultConfig() {
+        return new BufferRingConfig(
+                (short) 1, (short) 16, Native.PAGE_SIZE
+        );
+    }
+
+    public short bufferGroupId() {
+        return bgId;
+    }
+
+    public short bufferRingSize() {
+        return bufferRingSize;
+    }
+
+    public int chunkSize() {
+        return chunkSize;
+    }
+
+    private static short checkBufferRingSize(short bufferRingSize) {
+        if (bufferRingSize < 1) {
+            throw new IllegalArgumentException("bufferRingSize: " + bufferRingSize + " (expected: > 0)");
+        }
+
+        boolean isPowerOfTwo = (bufferRingSize & (bufferRingSize - 1)) == 0;
+        if (!isPowerOfTwo) {
+            throw new IllegalArgumentException("bufferRingSize: " + bufferRingSize + " (expected: power of 2)");
+        }
+        return bufferRingSize;
+    }
+}

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/BufferRingConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/BufferRingConfig.java
@@ -15,6 +15,7 @@
  */
 package io.netty.channel.uring;
 
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.internal.ObjectUtil;
 
 /**
@@ -22,22 +23,17 @@ import io.netty.util.internal.ObjectUtil;
  * It will configure the buffer ring size, buffer group id and the chunk size.
  */
 public final class BufferRingConfig {
-    public static final BufferRingConfig DEFAULT_BUFFER_RING_CONFIG = defaultConfig();
 
     private final short bgId;
     private final short bufferRingSize;
     private final int chunkSize;
+    private final ByteBufAllocator allocator;
 
-    public BufferRingConfig(short bgId, short bufferRingSize, int chunkSize) {
+    public BufferRingConfig(short bgId, short bufferRingSize, int chunkSize, ByteBufAllocator allocator) {
         this.bgId = ObjectUtil.checkPositive(bgId, "bgId");
         this.bufferRingSize = checkBufferRingSize(bufferRingSize);
         this.chunkSize = ObjectUtil.checkPositive(chunkSize, "chunkSize");
-    }
-
-    private static BufferRingConfig defaultConfig() {
-        return new BufferRingConfig(
-                (short) 1, (short) 16, Native.PAGE_SIZE
-        );
+        this.allocator = ObjectUtil.checkNotNull(allocator, "allocator");
     }
 
     public short bufferGroupId() {
@@ -50,6 +46,10 @@ public final class BufferRingConfig {
 
     public int chunkSize() {
         return chunkSize;
+    }
+
+    public ByteBufAllocator allocator() {
+        return allocator;
     }
 
     private static short checkBufferRingSize(short bufferRingSize) {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/BufferRingConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/BufferRingConfig.java
@@ -28,12 +28,18 @@ public final class BufferRingConfig {
     private final short bufferRingSize;
     private final int chunkSize;
     private final ByteBufAllocator allocator;
+    private final int initSize;
 
     public BufferRingConfig(short bgId, short bufferRingSize, int chunkSize, ByteBufAllocator allocator) {
+        this(bgId, bufferRingSize, chunkSize, allocator, 0);
+    }
+
+    public BufferRingConfig(short bgId, short bufferRingSize, int chunkSize, ByteBufAllocator allocator, int initSize) {
         this.bgId = ObjectUtil.checkPositive(bgId, "bgId");
         this.bufferRingSize = checkBufferRingSize(bufferRingSize);
         this.chunkSize = ObjectUtil.checkPositive(chunkSize, "chunkSize");
         this.allocator = ObjectUtil.checkNotNull(allocator, "allocator");
+        this.initSize = checkInitSize(initSize, bufferRingSize);
     }
 
     public short bufferGroupId() {
@@ -52,6 +58,10 @@ public final class BufferRingConfig {
         return allocator;
     }
 
+    public int initSize() {
+        return initSize;
+    }
+
     private static short checkBufferRingSize(short bufferRingSize) {
         if (bufferRingSize < 1) {
             throw new IllegalArgumentException("bufferRingSize: " + bufferRingSize + " (expected: > 0)");
@@ -62,5 +72,15 @@ public final class BufferRingConfig {
             throw new IllegalArgumentException("bufferRingSize: " + bufferRingSize + " (expected: power of 2)");
         }
         return bufferRingSize;
+    }
+
+    private static int checkInitSize(int initSize, short bufferRingSize) {
+        initSize = ObjectUtil.checkPositiveOrZero(initSize, "initSize");
+        if (initSize > bufferRingSize) {
+            throw new IllegalArgumentException(
+                    "initSize: " + initSize + " (expected: <= bufferRingSize: " + bufferRingSize + ')'
+            );
+        }
+        return initSize;
     }
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/BufferRingConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/BufferRingConfig.java
@@ -17,7 +17,11 @@ package io.netty.channel.uring;
 
 import io.netty.util.internal.ObjectUtil;
 
-public class BufferRingConfig {
+/**
+ * Configuration class for an {@link IoUringBufferRing}.
+ * It will configure the buffer ring size, buffer group id and the chunk size.
+ */
+public final class BufferRingConfig {
     public static final BufferRingConfig DEFAULT_BUFFER_RING_CONFIG = defaultConfig();
 
     private final short bgId;
@@ -27,7 +31,7 @@ public class BufferRingConfig {
     public BufferRingConfig(short bgId, short bufferRingSize, int chunkSize) {
         this.bgId = ObjectUtil.checkPositive(bgId, "bgId");
         this.bufferRingSize = checkBufferRingSize(bufferRingSize);
-        this.chunkSize = chunkSize;
+        this.chunkSize = ObjectUtil.checkPositive(chunkSize, "chunkSize");
     }
 
     private static BufferRingConfig defaultConfig() {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/BufferRingExhaustedEvent.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/BufferRingExhaustedEvent.java
@@ -21,12 +21,19 @@ package io.netty.channel.uring;
 public final class BufferRingExhaustedEvent {
     private short bufferGroupId;
 
-    public BufferRingExhaustedEvent(short bufferGroupId) {
+    BufferRingExhaustedEvent(short bufferGroupId) {
         this.bufferGroupId = bufferGroupId;
     }
 
     public short bufferGroupId() {
         return bufferGroupId;
+    }
+
+    @Override
+    public String toString() {
+        return "BufferRingExhaustedEvent{" +
+               "bufferGroupId=" + bufferGroupId +
+               '}';
     }
 
     @Override

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/BufferRingExhaustedEvent.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/BufferRingExhaustedEvent.java
@@ -18,7 +18,7 @@ package io.netty.channel.uring;
 /**
  * Event that is fired when a cqe`s res is NO_BUFFER
  */
-public class BufferRingExhaustedEvent {
+public final class BufferRingExhaustedEvent {
     private short bufferGroupId;
 
     public BufferRingExhaustedEvent(short bufferGroupId) {
@@ -27,5 +27,18 @@ public class BufferRingExhaustedEvent {
 
     public short bufferGroupId() {
         return bufferGroupId;
+    }
+
+    @Override
+    public int hashCode() {
+        return Short.hashCode(bufferGroupId);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof BufferRingExhaustedEvent) {
+            return bufferGroupId == ((BufferRingExhaustedEvent) obj).bufferGroupId;
+        }
+        return false;
     }
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/BufferRingExhaustedEvent.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/BufferRingExhaustedEvent.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+/**
+ * Event that is fired when a cqe`s res is NO_BUFFER
+ */
+public class BufferRingExhaustedEvent {
+    private short bufferGroupId;
+
+    public BufferRingExhaustedEvent(short bufferGroupId) {
+        this.bufferGroupId = bufferGroupId;
+    }
+
+    public short bufferGroupId() {
+        return bufferGroupId;
+    }
+}

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/BufferRingExhaustedEvent.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/BufferRingExhaustedEvent.java
@@ -19,7 +19,7 @@ package io.netty.channel.uring;
  * Event that is fired when a cqe`s res is NO_BUFFER
  */
 public final class BufferRingExhaustedEvent {
-    private short bufferGroupId;
+    private final short bufferGroupId;
 
     BufferRingExhaustedEvent(short bufferGroupId) {
         this.bufferGroupId = bufferGroupId;

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IOUringSocketChannelConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IOUringSocketChannelConfig.java
@@ -626,15 +626,4 @@ final class IOUringSocketChannelConfig extends IOUringStreamChannelConfig implem
         return this;
     }
 
-    @Override
-    public IOUringSocketChannelConfig disableBufferSelectRead() {
-        super.disableBufferSelectRead();
-        return this;
-    }
-
-    @Override
-    public IOUringStreamChannelConfig setBufferGroupId(short bufferGroupId) {
-        super.setBufferGroupId(bufferGroupId);
-        return this;
-    }
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IOUringSocketChannelConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IOUringSocketChannelConfig.java
@@ -31,7 +31,7 @@ import java.util.Map;
 import static io.netty.channel.ChannelOption.*;
 
 
-final class IOUringSocketChannelConfig extends IOUringChannelConfig implements SocketChannelConfig {
+final class IOUringSocketChannelConfig extends IOUringStreamChannelConfig implements SocketChannelConfig {
     private volatile boolean allowHalfClosure;
     private volatile boolean tcpFastopen;
 
@@ -623,6 +623,18 @@ final class IOUringSocketChannelConfig extends IOUringChannelConfig implements S
     @Override
     public IOUringSocketChannelConfig setMessageSizeEstimator(MessageSizeEstimator estimator) {
         super.setMessageSizeEstimator(estimator);
+        return this;
+    }
+
+    @Override
+    public IOUringSocketChannelConfig setEnableBufferSelectRead(boolean enableBufferSelectRead) {
+        super.setEnableBufferSelectRead(enableBufferSelectRead);
+        return this;
+    }
+
+    @Override
+    public IOUringStreamChannelConfig setBufferRingConfig(BufferRingConfig bufferRingConfig) {
+        super.setBufferRingConfig(bufferRingConfig);
         return this;
     }
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IOUringSocketChannelConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IOUringSocketChannelConfig.java
@@ -633,8 +633,8 @@ final class IOUringSocketChannelConfig extends IOUringStreamChannelConfig implem
     }
 
     @Override
-    public IOUringStreamChannelConfig setBufferRingConfig(BufferRingConfig bufferRingConfig) {
-        super.setBufferRingConfig(bufferRingConfig);
+    public IOUringStreamChannelConfig setBufferGroupId(short bufferGroupId) {
+        super.setBufferGroupId(bufferGroupId);
         return this;
     }
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IOUringSocketChannelConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IOUringSocketChannelConfig.java
@@ -627,8 +627,8 @@ final class IOUringSocketChannelConfig extends IOUringStreamChannelConfig implem
     }
 
     @Override
-    public IOUringSocketChannelConfig setEnableBufferSelectRead(boolean enableBufferSelectRead) {
-        super.setEnableBufferSelectRead(enableBufferSelectRead);
+    public IOUringSocketChannelConfig disableBufferSelectRead() {
+        super.disableBufferSelectRead();
         return this;
     }
 

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IOUringStreamChannelConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IOUringStreamChannelConfig.java
@@ -18,12 +18,13 @@ package io.netty.channel.uring;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.RecvByteBufAllocator;
+import io.netty.util.internal.ObjectUtil;
 
 import java.util.Map;
 
 abstract class IOUringStreamChannelConfig extends IOUringChannelConfig {
 
-    private static final short DISABLE_BUFFER_SELECT_READ = -1;
+    static final short DISABLE_BUFFER_SELECT_READ = 0;
 
     private volatile short bufferGroupId = DISABLE_BUFFER_SELECT_READ;
 
@@ -57,24 +58,6 @@ abstract class IOUringStreamChannelConfig extends IOUringChannelConfig {
     }
 
     /**
-     * Returns {@code true}
-     * if <a href="https://man7.org/linux/man-pages/man3/io_uring_setup_buf_ring.3.html">Provider Buffer Read</a>
-     * is enabled, {@code false}
-     * otherwise.
-     */
-    boolean isEnableBufferSelectRead() {
-        return bufferGroupId != DISABLE_BUFFER_SELECT_READ;
-    }
-
-    /**
-     * enable provider buffer, See this <a href="https://lwn.net/Articles/815491/">LWN article</a> for more info
-     */
-    IOUringStreamChannelConfig disableBufferSelectRead() {
-        setBufferGroupId(DISABLE_BUFFER_SELECT_READ);
-        return this;
-    }
-
-    /**
      * Returns the buffer ring config.
      *
      * @return the buffer ring config.
@@ -84,13 +67,14 @@ abstract class IOUringStreamChannelConfig extends IOUringChannelConfig {
     }
 
     /**
-     * Set the buffer ring config.
+     * Set the buffer group id that will be used to select the correct ring buffer. This must have been configured
+     * via {@link BufferRingConfig}.
      *
      * @param bufferGroupId the buffer group id.
-     * @return
+     * @return              itself.
      */
     IOUringStreamChannelConfig setBufferGroupId(short bufferGroupId) {
-        this.bufferGroupId = bufferGroupId;
+        this.bufferGroupId = (short) ObjectUtil.checkPositiveOrZero(bufferGroupId, "bufferGroupId");
         return this;
     }
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IOUringStreamChannelConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IOUringStreamChannelConfig.java
@@ -19,6 +19,8 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.RecvByteBufAllocator;
 
+import java.util.Map;
+
 abstract class IOUringStreamChannelConfig extends IOUringChannelConfig {
 
     private static final short DISABLE_BUFFER_SELECT_READ = -1;
@@ -49,13 +51,18 @@ abstract class IOUringStreamChannelConfig extends IOUringChannelConfig {
         return super.setOption(option, value);
     }
 
+    @Override
+    public Map<ChannelOption<?>, Object> getOptions() {
+        return getOptions(super.getOptions(), IoUringChannelOption.IO_URING_BUFFER_GROUP_ID);
+    }
+
     /**
      * Returns {@code true}
      * if <a href="https://man7.org/linux/man-pages/man3/io_uring_setup_buf_ring.3.html">Provider Buffer Read</a>
      * is enabled, {@code false}
      * otherwise.
      */
-    public boolean isEnableBufferSelectRead() {
+    boolean isEnableBufferSelectRead() {
         return bufferGroupId != DISABLE_BUFFER_SELECT_READ;
     }
 

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IOUringStreamChannelConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IOUringStreamChannelConfig.java
@@ -21,9 +21,9 @@ import io.netty.channel.RecvByteBufAllocator;
 
 abstract class IOUringStreamChannelConfig extends IOUringChannelConfig {
 
-    private volatile short bufferGroupId;
+    private static final short DISABLE_BUFFER_SELECT_READ = -1;
 
-    private volatile boolean enableBufferSelectRead;
+    private volatile short bufferGroupId;
 
     IOUringStreamChannelConfig(Channel channel) {
         super(channel);
@@ -35,9 +35,7 @@ abstract class IOUringStreamChannelConfig extends IOUringChannelConfig {
 
     @Override
     public <T> T getOption(ChannelOption<T> option) {
-        if (option == IoUringChannelOption.ENABLE_BUFFER_SELECT_READ) {
-            return (T) Boolean.valueOf(isEnableBufferSelectRead());
-        } else if (option == IoUringChannelOption.IO_URING_BUFFER_GROUP_ID) {
+        if (option == IoUringChannelOption.IO_URING_BUFFER_GROUP_ID) {
             return (T) Short.valueOf(getBufferRingConfig());
         }
         return super.getOption(option);
@@ -45,9 +43,7 @@ abstract class IOUringStreamChannelConfig extends IOUringChannelConfig {
 
     @Override
     public <T> boolean setOption(ChannelOption<T> option, T value) {
-        if (option == IoUringChannelOption.ENABLE_BUFFER_SELECT_READ) {
-            setEnableBufferSelectRead((Boolean) value);
-        } else if (option == IoUringChannelOption.IO_URING_BUFFER_GROUP_ID) {
+        if (option == IoUringChannelOption.IO_URING_BUFFER_GROUP_ID) {
             setBufferGroupId((Short) value);
         }
         return super.setOption(option, value);
@@ -60,14 +56,14 @@ abstract class IOUringStreamChannelConfig extends IOUringChannelConfig {
      * otherwise.
      */
     public boolean isEnableBufferSelectRead() {
-        return enableBufferSelectRead;
+        return bufferGroupId != DISABLE_BUFFER_SELECT_READ;
     }
 
     /**
      * enable provider buffer, See this <a href="https://lwn.net/Articles/815491/">LWN article</a> for more info
      */
-    public IOUringStreamChannelConfig setEnableBufferSelectRead(boolean enableBufferSelectRead) {
-        this.enableBufferSelectRead = enableBufferSelectRead;
+    public IOUringStreamChannelConfig disableBufferSelectRead() {
+        setBufferGroupId(DISABLE_BUFFER_SELECT_READ);
         return this;
     }
 

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IOUringStreamChannelConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IOUringStreamChannelConfig.java
@@ -69,7 +69,7 @@ abstract class IOUringStreamChannelConfig extends IOUringChannelConfig {
     /**
      * enable provider buffer, See this <a href="https://lwn.net/Articles/815491/">LWN article</a> for more info
      */
-    public IOUringStreamChannelConfig disableBufferSelectRead() {
+    IOUringStreamChannelConfig disableBufferSelectRead() {
         setBufferGroupId(DISABLE_BUFFER_SELECT_READ);
         return this;
     }
@@ -79,7 +79,7 @@ abstract class IOUringStreamChannelConfig extends IOUringChannelConfig {
      *
      * @return the buffer ring config.
      */
-    public short getBufferRingConfig() {
+    short getBufferRingConfig() {
         return bufferGroupId;
     }
 
@@ -89,7 +89,7 @@ abstract class IOUringStreamChannelConfig extends IOUringChannelConfig {
      * @param bufferGroupId the buffer group id.
      * @return
      */
-    public IOUringStreamChannelConfig setBufferGroupId(short bufferGroupId) {
+    IOUringStreamChannelConfig setBufferGroupId(short bufferGroupId) {
         this.bufferGroupId = bufferGroupId;
         return this;
     }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IOUringStreamChannelConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IOUringStreamChannelConfig.java
@@ -68,7 +68,7 @@ abstract class IOUringStreamChannelConfig extends IOUringChannelConfig {
 
     /**
      * Set the buffer group id that will be used to select the correct ring buffer. This must have been configured
-     * via {@link BufferRingConfig}.
+     * via {@link IoUringBufferRingConfig}.
      *
      * @param bufferGroupId the buffer group id.
      * @return              itself.

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IOUringStreamChannelConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IOUringStreamChannelConfig.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.RecvByteBufAllocator;
+
+abstract class IOUringStreamChannelConfig extends IOUringChannelConfig {
+
+    private volatile BufferRingConfig bufferRingConfig;
+
+    private volatile boolean enableBufferSelectRead;
+
+    IOUringStreamChannelConfig(Channel channel) {
+        super(channel);
+    }
+
+    IOUringStreamChannelConfig(Channel channel, RecvByteBufAllocator allocator) {
+        super(channel, allocator);
+    }
+
+    @Override
+    public <T> T getOption(ChannelOption<T> option) {
+        if (option == IoUringChannelOption.ENABLE_BUFFER_SELECT_READ) {
+            return (T) Boolean.valueOf(isEnableBufferSelectRead());
+        } else if (option == IoUringChannelOption.IOURING_BUFFER_RING_CONFIG) {
+            return (T) getBufferRingConfig();
+        }
+        return super.getOption(option);
+    }
+
+    @Override
+    public <T> boolean setOption(ChannelOption<T> option, T value) {
+        if (option == IoUringChannelOption.ENABLE_BUFFER_SELECT_READ) {
+            setEnableBufferSelectRead((Boolean) value);
+        } else if (option == IoUringChannelOption.IOURING_BUFFER_RING_CONFIG) {
+            setBufferRingConfig((BufferRingConfig) value);
+        }
+        return super.setOption(option, value);
+    }
+
+    /**
+     * Returns {@code true}
+     * if <a href="https://man7.org/linux/man-pages/man3/io_uring_setup_buf_ring.3.html">Provider Buffer Read</a>
+     * is enabled, {@code false}
+     * otherwise.
+     */
+    public boolean isEnableBufferSelectRead() {
+        return enableBufferSelectRead;
+    }
+
+    /**
+     * enable provider buffer, See this <a href="https://lwn.net/Articles/815491/">LWN article</a> for more info
+     */
+    public IOUringStreamChannelConfig setEnableBufferSelectRead(boolean enableBufferSelectRead) {
+        this.enableBufferSelectRead = enableBufferSelectRead;
+        return this;
+    }
+
+    /**
+     * Returns the buffer ring config.
+     *
+     * @return the buffer ring config.
+     */
+    public BufferRingConfig getBufferRingConfig() {
+        return bufferRingConfig;
+    }
+
+    /**
+     * Set the buffer ring config.
+     *
+     * @param bufferRingConfig
+     * @return
+     */
+    public IOUringStreamChannelConfig setBufferRingConfig(BufferRingConfig bufferRingConfig) {
+        this.bufferRingConfig = bufferRingConfig;
+        return this;
+    }
+}

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IOUringStreamChannelConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IOUringStreamChannelConfig.java
@@ -21,7 +21,7 @@ import io.netty.channel.RecvByteBufAllocator;
 
 abstract class IOUringStreamChannelConfig extends IOUringChannelConfig {
 
-    private volatile BufferRingConfig bufferRingConfig;
+    private volatile short bufferGroupId;
 
     private volatile boolean enableBufferSelectRead;
 
@@ -37,8 +37,8 @@ abstract class IOUringStreamChannelConfig extends IOUringChannelConfig {
     public <T> T getOption(ChannelOption<T> option) {
         if (option == IoUringChannelOption.ENABLE_BUFFER_SELECT_READ) {
             return (T) Boolean.valueOf(isEnableBufferSelectRead());
-        } else if (option == IoUringChannelOption.IOURING_BUFFER_RING_CONFIG) {
-            return (T) getBufferRingConfig();
+        } else if (option == IoUringChannelOption.IO_URING_BUFFER_GROUP_ID) {
+            return (T) Short.valueOf(getBufferRingConfig());
         }
         return super.getOption(option);
     }
@@ -47,8 +47,8 @@ abstract class IOUringStreamChannelConfig extends IOUringChannelConfig {
     public <T> boolean setOption(ChannelOption<T> option, T value) {
         if (option == IoUringChannelOption.ENABLE_BUFFER_SELECT_READ) {
             setEnableBufferSelectRead((Boolean) value);
-        } else if (option == IoUringChannelOption.IOURING_BUFFER_RING_CONFIG) {
-            setBufferRingConfig((BufferRingConfig) value);
+        } else if (option == IoUringChannelOption.IO_URING_BUFFER_GROUP_ID) {
+            setBufferGroupId((Short) value);
         }
         return super.setOption(option, value);
     }
@@ -76,18 +76,18 @@ abstract class IOUringStreamChannelConfig extends IOUringChannelConfig {
      *
      * @return the buffer ring config.
      */
-    public BufferRingConfig getBufferRingConfig() {
-        return bufferRingConfig;
+    public short getBufferRingConfig() {
+        return bufferGroupId;
     }
 
     /**
      * Set the buffer ring config.
      *
-     * @param bufferRingConfig
+     * @param bufferGroupId the buffer group id.
      * @return
      */
-    public IOUringStreamChannelConfig setBufferRingConfig(BufferRingConfig bufferRingConfig) {
-        this.bufferRingConfig = bufferRingConfig;
+    public IOUringStreamChannelConfig setBufferGroupId(short bufferGroupId) {
+        this.bufferGroupId = bufferGroupId;
         return this;
     }
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IOUringStreamChannelConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IOUringStreamChannelConfig.java
@@ -48,6 +48,7 @@ abstract class IOUringStreamChannelConfig extends IOUringChannelConfig {
     public <T> boolean setOption(ChannelOption<T> option, T value) {
         if (option == IoUringChannelOption.IO_URING_BUFFER_GROUP_ID) {
             setBufferGroupId((Short) value);
+            return true;
         }
         return super.setOption(option, value);
     }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IOUringStreamChannelConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IOUringStreamChannelConfig.java
@@ -25,7 +25,7 @@ abstract class IOUringStreamChannelConfig extends IOUringChannelConfig {
 
     private static final short DISABLE_BUFFER_SELECT_READ = -1;
 
-    private volatile short bufferGroupId;
+    private volatile short bufferGroupId = DISABLE_BUFFER_SELECT_READ;
 
     IOUringStreamChannelConfig(Channel channel) {
         super(channel);

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUring.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUring.java
@@ -31,6 +31,8 @@ public final class IoUring {
     private static final boolean IORING_SETUP_SUBMIT_ALL_SUPPORTED;
     private static final boolean IORING_SETUP_SINGLE_ISSUER_SUPPORTED;
     private static final boolean IORING_SETUP_DEFER_TASKRUN_SUPPORTED;
+    private static final boolean IO_URING_REGISTER_BUFFER_RING_SUPPORTED;
+
     private static final InternalLogger logger;
 
     static {
@@ -43,6 +45,7 @@ public final class IoUring {
         boolean submitAllSupported = false;
         boolean singleIssuerSupported = false;
         boolean deferTaskrunSupported = false;
+        boolean registerBufferRingSupported = false;
         try {
             if (SystemPropertyUtil.getBoolean("io.netty.transport.noNative", false)) {
                 cause = new UnsupportedOperationException(
@@ -67,6 +70,7 @@ public final class IoUring {
                         // See https://manpages.debian.org/unstable/liburing-dev/io_uring_setup.2.en.html
                         deferTaskrunSupported = Native.ioUringSetupSupportsFlags(
                                 Native.IORING_SETUP_SINGLE_ISSUER | Native.IORING_SETUP_DEFER_TASKRUN);
+                        registerBufferRingSupported = Native.isRegisterBufferRingSupported(ringBuffer.fd());
                     } finally {
                         if (ringBuffer != null) {
                             try {
@@ -98,9 +102,11 @@ public final class IoUring {
                         "IORING_REGISTER_IOWQ_MAX_WORKERS_SUPPORTED={}, " +
                         "IORING_SETUP_SUBMIT_ALL_SUPPORTED={}, " +
                         "IORING_SETUP_SINGLE_ISSUER_SUPPORTED={}, " +
-                        "IORING_SETUP_DEFER_TASKRUN_SUPPORTED={}" +
+                        "IORING_SETUP_DEFER_TASKRUN_SUPPORTED={}, " +
+                        "IO_URING_REGISTER_BUFFER_RING_SUPPORTED={}" +
                         ")", socketNonEmptySupported, spliceSupported, acceptSupportNoWait,
-                        registerIowqWorkersSupported, submitAllSupported, singleIssuerSupported, deferTaskrunSupported);
+                        registerIowqWorkersSupported, submitAllSupported, singleIssuerSupported,
+                        deferTaskrunSupported, registerBufferRingSupported);
             }
         }
         UNAVAILABILITY_CAUSE = cause;
@@ -111,6 +117,7 @@ public final class IoUring {
         IORING_SETUP_SUBMIT_ALL_SUPPORTED = submitAllSupported;
         IORING_SETUP_SINGLE_ISSUER_SUPPORTED = singleIssuerSupported;
         IORING_SETUP_DEFER_TASKRUN_SUPPORTED = deferTaskrunSupported;
+        IO_URING_REGISTER_BUFFER_RING_SUPPORTED = registerBufferRingSupported;
     }
 
     public static boolean isAvailable() {
@@ -163,6 +170,10 @@ public final class IoUring {
 
     static boolean isIOUringSetupDeferTaskrunSupported() {
         return IORING_SETUP_DEFER_TASKRUN_SUPPORTED;
+    }
+
+    public static boolean isRegisterBufferRingSupported() {
+        return IO_URING_REGISTER_BUFFER_RING_SUPPORTED;
     }
 
     public static void ensureAvailability() {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRing.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRing.java
@@ -321,7 +321,7 @@ final class IoUringBufferRing {
         public ByteBuf capacity(int newCapacity) {
             if (newCapacity <= maxCapacity()) {
                 this.maxCapacity(newCapacity);
-                setIndex0(Math.min(readerIndex(), newCapacity), Math.min(writerIndex(), newCapacity));
+                setIndex(Math.min(readerIndex(), newCapacity), Math.min(writerIndex(), newCapacity));
                 return this;
             }
 

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRing.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRing.java
@@ -48,7 +48,7 @@ final class IoUringBufferRing {
     private final int chunkSize;
     private final IoUringIoHandler source;
     private final ByteBufAllocator byteBufAllocator;
-    private final BufferRingExhaustedEvent exhaustedEvent;
+    private final IoUringBufferRingExhaustedEvent exhaustedEvent;
 
     private short nextIndex;
     private boolean hasSpareBuffer;
@@ -67,7 +67,7 @@ final class IoUringBufferRing {
         this.chunkSize = chunkSize;
         this.source = ioUringIoHandler;
         this.byteBufAllocator = byteBufAllocator;
-        this.exhaustedEvent = new BufferRingExhaustedEvent(bufferGroupId);
+        this.exhaustedEvent = new IoUringBufferRingExhaustedEvent(bufferGroupId);
     }
 
     void markReadFail() {
@@ -81,7 +81,7 @@ final class IoUringBufferRing {
     /**
      * @return a BufferRingExhaustedEvent Instance
      */
-    BufferRingExhaustedEvent getExhaustedEvent() {
+    IoUringBufferRingExhaustedEvent getExhaustedEvent() {
         return exhaustedEvent;
     }
 

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRing.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRing.java
@@ -1,0 +1,413 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.buffer.AbstractReferenceCountedByteBuf;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.internal.PlatformDependent;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
+import java.nio.channels.GatheringByteChannel;
+import java.nio.channels.ScatteringByteChannel;
+
+public final class IoUringBufferRing {
+
+    private final long ioUringBufRingAddr;
+
+    private final short entries;
+
+    private final short bufferGroupId;
+
+    private final int ringFd;
+
+    private final ByteBuf[] userspaceBufferHolder;
+    private final int chunkSize;
+    private short nextIndex;
+    private boolean hasSpareBuffer;
+    private IoUringIoHandler source;
+
+    IoUringBufferRing(int ringFd, long ioUringBufRingAddr,
+                      short entries, short bufferGroupId,
+                      int chunkSize, IoUringIoHandler ioUringIoHandler
+    ) {
+        this.ioUringBufRingAddr = ioUringBufRingAddr;
+        this.entries = entries;
+        this.bufferGroupId = bufferGroupId;
+        this.ringFd = ringFd;
+        this.userspaceBufferHolder = new ByteBuf[entries];
+        this.nextIndex = 0;
+        this.chunkSize = chunkSize;
+        this.hasSpareBuffer = false;
+        this.source = ioUringIoHandler;
+    }
+
+    public void markReadFail() {
+        hasSpareBuffer = false;
+    }
+
+    public boolean hasSpareBuffer() {
+        return hasSpareBuffer;
+    }
+
+    void recycleBuffer(short bid) {
+        source.submitBeforeIO(new Runnable() {
+            @Override
+            public void run() {
+                addToRing(bid, true);
+            }
+        });
+    }
+
+    void addToRing(short bid, boolean needAdvance) {
+        ByteBuf byteBuf = userspaceBufferHolder[bid];
+        int mask = entries - 1;
+        long tailFieldAddress = ioUringBufRingAddr + Native.IO_URING_BUFFER_RING_TAIL;
+        short oldTail = PlatformDependent.getShort(tailFieldAddress);
+        int ringIndex = oldTail & mask;
+        long ioUringBufAddress = ioUringBufRingAddr + (long) Native.SIZEOF_IOURING_BUF * ringIndex;
+        PlatformDependent.putLong(ioUringBufAddress + Native.IOURING_BUFFER_OFFSETOF_ADDR, byteBuf.memoryAddress());
+        PlatformDependent.putInt(ioUringBufAddress + Native.IOURING_BUFFER_OFFSETOF_LEN, (short) byteBuf.capacity());
+        PlatformDependent.putShort(ioUringBufAddress + Native.IOURING_BUFFER_OFFSETOF_BID, bid);
+        if (needAdvance) {
+            advanceTail(1);
+        }
+    }
+
+    void appendBuffer(ByteBufAllocator byteBufAllocator, int count) {
+        int expectedIndex = nextIndex + count;
+        if (expectedIndex > entries) {
+            throw new IllegalStateException("Buffer ring is full");
+        }
+
+        for (int i = 0; i < count; i++) {
+            ByteBuf buffer = byteBufAllocator.ioBuffer(chunkSize);
+            userspaceBufferHolder[nextIndex] = buffer;
+            addToRing(nextIndex, false);
+            nextIndex++;
+        }
+        advanceTail(count);
+    }
+
+    ByteBuf borrowBuffer(int bid, int maxCap) {
+        ByteBuf byteBuf = userspaceBufferHolder[bid];
+        ByteBuf slice = byteBuf.slice(0, maxCap);
+        return new UserspaceIoUringBuffer(maxCap, (short) bid, slice);
+    }
+
+    private void advanceTail(int count) {
+        long tailFieldAddress = ioUringBufRingAddr + Native.IO_URING_BUFFER_RING_TAIL;
+        short oldTail = PlatformDependent.getShort(tailFieldAddress);
+        short newTail = (short) (oldTail + count);
+        PlatformDependent.putShortVolatile(tailFieldAddress, newTail);
+        hasSpareBuffer = true;
+    }
+
+    public int entries() {
+        return entries;
+    }
+
+    public short bufferGroupId() {
+        return bufferGroupId;
+    }
+
+    public int chunkSize() {
+        return chunkSize;
+    }
+
+    public boolean isFull() {
+        return nextIndex == entries;
+    }
+
+    public long address() {
+        return ioUringBufRingAddr;
+    }
+
+    public void close() {
+        Native.ioUringUnRegisterBufRing(ringFd, ioUringBufRingAddr, 4, 1);
+        for (ByteBuf byteBuf : userspaceBufferHolder) {
+            if (byteBuf != null) {
+                byteBuf.release();
+            }
+        }
+    }
+
+    public class UserspaceIoUringBuffer extends AbstractReferenceCountedByteBuf {
+
+        private final short bid;
+
+        private final ByteBuf userspaceBuffer;
+
+        protected UserspaceIoUringBuffer(int maxCapacity, short bid, ByteBuf userspaceBuffer) {
+            super(maxCapacity);
+            this.bid = bid;
+            this.userspaceBuffer = userspaceBuffer;
+        }
+
+        @Override
+        protected void deallocate() {
+            recycleBuffer(bid);
+        }
+
+        @Override
+        protected byte _getByte(int index) {
+            return userspaceBuffer.getByte(index);
+        }
+
+        @Override
+        protected short _getShort(int index) {
+            return userspaceBuffer.getShort(index);
+        }
+
+        @Override
+        protected short _getShortLE(int index) {
+            return userspaceBuffer.getShortLE(index);
+        }
+
+        @Override
+        protected int _getUnsignedMedium(int index) {
+            return userspaceBuffer.getUnsignedMedium(index);
+        }
+
+        @Override
+        protected int _getUnsignedMediumLE(int index) {
+            return userspaceBuffer.getUnsignedMediumLE(index);
+        }
+
+        @Override
+        protected int _getInt(int index) {
+            return userspaceBuffer.getInt(index);
+        }
+
+        @Override
+        protected int _getIntLE(int index) {
+            return userspaceBuffer.getIntLE(index);
+        }
+
+        @Override
+        protected long _getLong(int index) {
+            return userspaceBuffer.getLong(index);
+        }
+
+        @Override
+        protected long _getLongLE(int index) {
+            return userspaceBuffer.getLongLE(index);
+        }
+
+        @Override
+        protected void _setByte(int index, int value) {
+            userspaceBuffer.setByte(index, value);
+        }
+
+        @Override
+        protected void _setShort(int index, int value) {
+            userspaceBuffer.setShort(index, value);
+        }
+
+        @Override
+        protected void _setShortLE(int index, int value) {
+            userspaceBuffer.setShortLE(index, value);
+        }
+
+        @Override
+        protected void _setMedium(int index, int value) {
+            userspaceBuffer.setMedium(index, value);
+        }
+
+        @Override
+        protected void _setMediumLE(int index, int value) {
+            userspaceBuffer.setMediumLE(index, value);
+        }
+
+        @Override
+        protected void _setInt(int index, int value) {
+            userspaceBuffer.setInt(index, value);
+        }
+
+        @Override
+        protected void _setIntLE(int index, int value) {
+            userspaceBuffer.setIntLE(index, value);
+        }
+
+        @Override
+        protected void _setLong(int index, long value) {
+            userspaceBuffer.setLong(index, value);
+        }
+
+        @Override
+        protected void _setLongLE(int index, long value) {
+            userspaceBuffer.setLongLE(index, value);
+        }
+
+        @Override
+        public int capacity() {
+            return maxCapacity();
+        }
+
+        @Override
+        public ByteBuf capacity(int newCapacity) {
+            return this;
+        }
+
+        @Override
+        public ByteBufAllocator alloc() {
+            return userspaceBuffer.alloc();
+        }
+
+        @Override
+        public ByteOrder order() {
+            return userspaceBuffer.order();
+        }
+
+        @Override
+        public ByteBuf unwrap() {
+            return null;
+        }
+
+        @Override
+        public boolean isDirect() {
+            return true;
+        }
+
+        @Override
+        public ByteBuf getBytes(int index, ByteBuf dst, int dstIndex, int length) {
+            checkIndex(index, length);
+            userspaceBuffer.getBytes(index, dst, dstIndex, length);
+            return this;
+        }
+
+        @Override
+        public ByteBuf getBytes(int index, byte[] dst, int dstIndex, int length) {
+            checkIndex(index, length);
+            userspaceBuffer.getBytes(index, dst, dstIndex, length);
+            return this;
+        }
+
+        @Override
+        public ByteBuf getBytes(int index, ByteBuffer dst) {
+            checkIndex(index, dst.remaining());
+            userspaceBuffer.getBytes(index, dst);
+            return this;
+        }
+
+        @Override
+        public ByteBuf getBytes(int index, OutputStream out, int length)
+                throws IOException {
+            checkIndex(index, length);
+            userspaceBuffer.getBytes(index, out, length);
+            return this;
+        }
+
+        @Override
+        public int getBytes(int index, GatheringByteChannel out, int length) throws IOException {
+            return userspaceBuffer.getBytes(index, out, length);
+        }
+
+        @Override
+        public int getBytes(int index, FileChannel out, long position, int length) throws IOException {
+            return userspaceBuffer.getBytes(index, out, position, length);
+        }
+
+        @Override
+        public ByteBuf setBytes(int index, ByteBuf src, int srcIndex, int length) {
+            userspaceBuffer.setBytes(index, src, srcIndex, length);
+            return this;
+        }
+
+        @Override
+        public ByteBuf setBytes(int index, byte[] src, int srcIndex, int length) {
+            userspaceBuffer.setBytes(index, src, srcIndex, length);
+            return this;
+        }
+
+        @Override
+        public ByteBuf setBytes(int index, ByteBuffer src) {
+            userspaceBuffer.setBytes(index, src);
+            return this;
+        }
+
+        @Override
+        public int setBytes(int index, InputStream in, int length) throws IOException {
+            return userspaceBuffer.setBytes(index, in, length);
+        }
+
+        @Override
+        public int setBytes(int index, ScatteringByteChannel in, int length) throws IOException {
+            return userspaceBuffer.setBytes(index, in, length);
+        }
+
+        @Override
+        public int setBytes(int index, FileChannel in, long position, int length) throws IOException {
+            return userspaceBuffer.setBytes(index, in, position, length);
+        }
+
+        @Override
+        public ByteBuf copy(int index, int length) {
+            return userspaceBuffer.copy(index, length);
+        }
+
+        @Override
+        public int nioBufferCount() {
+            return userspaceBuffer.nioBufferCount();
+        }
+
+        @Override
+        public ByteBuffer nioBuffer(int index, int length) {
+            return userspaceBuffer.nioBuffer(index, length);
+        }
+
+        @Override
+        public ByteBuffer internalNioBuffer(int index, int length) {
+            return userspaceBuffer.internalNioBuffer(index, length);
+        }
+
+        @Override
+        public ByteBuffer[] nioBuffers(int index, int length) {
+            return userspaceBuffer.nioBuffers(index, length);
+        }
+
+        @Override
+        public boolean hasArray() {
+            return userspaceBuffer.hasArray();
+        }
+
+        @Override
+        public byte[] array() {
+            return userspaceBuffer.array();
+        }
+
+        @Override
+        public int arrayOffset() {
+            return userspaceBuffer.arrayOffset();
+        }
+
+        @Override
+        public boolean hasMemoryAddress() {
+            return userspaceBuffer.hasMemoryAddress();
+        }
+
+        @Override
+        public long memoryAddress() {
+            return userspaceBuffer.memoryAddress();
+        }
+    }
+
+}

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRing.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRing.java
@@ -323,6 +323,7 @@ final class IoUringBufferRing {
         public ByteBuf capacity(int newCapacity) {
             if (newCapacity <= maxCapacity()) {
                 this.maxCapacity(newCapacity);
+                setIndex0(Math.min(readerIndex(), newCapacity), Math.min(writerIndex(), newCapacity));
                 return this;
             }
 

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRing.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRing.java
@@ -29,7 +29,7 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.GatheringByteChannel;
 import java.nio.channels.ScatteringByteChannel;
 
-public final class IoUringBufferRing {
+final class IoUringBufferRing {
 
     private final long ioUringBufRingAddr;
 

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRingConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRingConfig.java
@@ -30,10 +30,29 @@ public final class IoUringBufferRingConfig {
     private final ByteBufAllocator allocator;
     private final int initSize;
 
+    /**
+     * Create a new configuration.
+     *
+     * @param bgId              the buffer group id to use.
+     * @param bufferRingSize    the size of the ring
+     * @param chunkSize         the chunk size of each {@link io.netty.buffer.ByteBuf} that is allocated out of the
+     *                          {@link ByteBufAllocator} to fill the ring.
+     * @param allocator         the {@link ByteBufAllocator} to use to allocate {@link io.netty.buffer.ByteBuf}s.
+     */
     public IoUringBufferRingConfig(short bgId, short bufferRingSize, int chunkSize, ByteBufAllocator allocator) {
         this(bgId, bufferRingSize, chunkSize, allocator, 0);
     }
 
+    /**
+     * Create a new configuration.
+     *
+     * @param bgId              the buffer group id to use.
+     * @param bufferRingSize    the size of the ring
+     * @param chunkSize         the chunk size of each {@link io.netty.buffer.ByteBuf} that is allocated out of the
+     *                          {@link ByteBufAllocator} to fill the ring.
+     * @param allocator         the {@link ByteBufAllocator} to use to allocate {@link io.netty.buffer.ByteBuf}s.
+     * @param initSize          the number of buffers that are created during initialization.
+     */
     public IoUringBufferRingConfig(short bgId, short bufferRingSize, int chunkSize,
                                    ByteBufAllocator allocator, int initSize) {
         this.bgId = ObjectUtil.checkPositive(bgId, "bgId");
@@ -43,22 +62,48 @@ public final class IoUringBufferRingConfig {
         this.initSize = checkInitSize(initSize, bufferRingSize);
     }
 
+    /**
+     * Returns the buffer group id to use.
+     *
+     * @return the buffer group id to use.
+     */
     public short bufferGroupId() {
         return bgId;
     }
 
+    /**
+     * Returns the size of the ring.
+     *
+     * @return the size of the ring.
+     */
     public short bufferRingSize() {
         return bufferRingSize;
     }
 
+    /**
+     * Returns the chunk size of each {@link io.netty.buffer.ByteBuf} that is allocated out of the
+     * {@link ByteBufAllocator} to fill the ring.
+     *
+     * @return  the chunksize.
+     */
     public int chunkSize() {
         return chunkSize;
     }
 
+    /**
+     * Returns the {@link ByteBufAllocator} to use to allocate {@link io.netty.buffer.ByteBuf}s.
+     *
+     * @return  the allocator.
+     */
     public ByteBufAllocator allocator() {
         return allocator;
     }
 
+    /**
+     * Returns the number of buffers that are created during initialization.
+     *
+     * @return  init size.
+     */
     public int initSize() {
         return initSize;
     }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRingConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRingConfig.java
@@ -22,7 +22,7 @@ import io.netty.util.internal.ObjectUtil;
  * Configuration class for an {@link IoUringBufferRing}.
  * It will configure the buffer ring size, buffer group id and the chunk size.
  */
-public final class BufferRingConfig {
+public final class IoUringBufferRingConfig {
 
     private final short bgId;
     private final short bufferRingSize;
@@ -30,11 +30,12 @@ public final class BufferRingConfig {
     private final ByteBufAllocator allocator;
     private final int initSize;
 
-    public BufferRingConfig(short bgId, short bufferRingSize, int chunkSize, ByteBufAllocator allocator) {
+    public IoUringBufferRingConfig(short bgId, short bufferRingSize, int chunkSize, ByteBufAllocator allocator) {
         this(bgId, bufferRingSize, chunkSize, allocator, 0);
     }
 
-    public BufferRingConfig(short bgId, short bufferRingSize, int chunkSize, ByteBufAllocator allocator, int initSize) {
+    public IoUringBufferRingConfig(short bgId, short bufferRingSize, int chunkSize,
+                                   ByteBufAllocator allocator, int initSize) {
         this.bgId = ObjectUtil.checkPositive(bgId, "bgId");
         this.bufferRingSize = checkBufferRingSize(bufferRingSize);
         this.chunkSize = ObjectUtil.checkPositive(chunkSize, "chunkSize");

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRingExhaustedEvent.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRingExhaustedEvent.java
@@ -18,10 +18,10 @@ package io.netty.channel.uring;
 /**
  * Event that is fired when a cqe`s res is NO_BUFFER
  */
-public final class BufferRingExhaustedEvent {
+public final class IoUringBufferRingExhaustedEvent {
     private final short bufferGroupId;
 
-    BufferRingExhaustedEvent(short bufferGroupId) {
+    IoUringBufferRingExhaustedEvent(short bufferGroupId) {
         this.bufferGroupId = bufferGroupId;
     }
 
@@ -43,8 +43,8 @@ public final class BufferRingExhaustedEvent {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj instanceof BufferRingExhaustedEvent) {
-            return bufferGroupId == ((BufferRingExhaustedEvent) obj).bufferGroupId;
+        if (obj instanceof IoUringBufferRingExhaustedEvent) {
+            return bufferGroupId == ((IoUringBufferRingExhaustedEvent) obj).bufferGroupId;
         }
         return false;
     }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringChannelOption.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringChannelOption.java
@@ -59,6 +59,10 @@ public final class IoUringChannelOption<T> extends UnixChannelOption<T> {
      */
     public static final ChannelOption<Boolean> IOSQE_ASYNC = valueOf("IOSQE_ASYNC");
 
+    /**
+     * The buffer group id to use when submitting recv {@link IoUringIoOps}.
+     * If it is set to -1, then this function will be disabled.
+     */
     public static final ChannelOption<Short> IO_URING_BUFFER_GROUP_ID =
             ChannelOption.valueOf(IoUringChannelOption.class, "IOURING_BUFFER_GROUP_ID");
 

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringChannelOption.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringChannelOption.java
@@ -59,8 +59,6 @@ public final class IoUringChannelOption<T> extends UnixChannelOption<T> {
      */
     public static final ChannelOption<Boolean> IOSQE_ASYNC = valueOf("IOSQE_ASYNC");
 
-    public static final ChannelOption<Boolean> ENABLE_BUFFER_SELECT_READ = valueOf("ENABLE_BUFFER_SELECT_READ");
-
     public static final ChannelOption<Short> IO_URING_BUFFER_GROUP_ID =
             ChannelOption.valueOf(IoUringChannelOption.class, "IOURING_BUFFER_GROUP_ID");
 

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringChannelOption.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringChannelOption.java
@@ -61,7 +61,7 @@ public final class IoUringChannelOption<T> extends UnixChannelOption<T> {
 
     public static final ChannelOption<Boolean> ENABLE_BUFFER_SELECT_READ = valueOf("ENABLE_BUFFER_SELECT_READ");
 
-    public static final ChannelOption<BufferRingConfig> IOURING_BUFFER_RING_CONFIG =
-            ChannelOption.valueOf(IoUringChannelOption.class, "IOURING_BUFFER_GROUP_CONFIG");
+    public static final ChannelOption<Short> IO_URING_BUFFER_GROUP_ID =
+            ChannelOption.valueOf(IoUringChannelOption.class, "IOURING_BUFFER_GROUP_ID");
 
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringChannelOption.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringChannelOption.java
@@ -58,4 +58,10 @@ public final class IoUringChannelOption<T> extends UnixChannelOption<T> {
      * Use {@code IOSQE_ASYNC} when submitting {@link IoUringIoOps}.
      */
     public static final ChannelOption<Boolean> IOSQE_ASYNC = valueOf("IOSQE_ASYNC");
+
+    public static final ChannelOption<Boolean> ENABLE_BUFFER_SELECT_READ = valueOf("ENABLE_BUFFER_SELECT_READ");
+
+    public static final ChannelOption<BufferRingConfig> IOURING_BUFFER_RING_CONFIG =
+            ChannelOption.valueOf(IoUringChannelOption.class, "IOURING_BUFFER_GROUP_CONFIG");
+
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringChannelOption.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringChannelOption.java
@@ -60,8 +60,12 @@ public final class IoUringChannelOption<T> extends UnixChannelOption<T> {
     public static final ChannelOption<Boolean> IOSQE_ASYNC = valueOf("IOSQE_ASYNC");
 
     /**
-     * The buffer group id to use when submitting recv {@link IoUringIoOps}.
-     * If it is set to -1, then this function will be disabled.
+     * The buffer group id to use when submitting recv / read / readv {@link IoUringIoOps}.
+     * If it is set to {@code 0}, then this function will be disabled.
+     * <p>
+     * Check
+     * <a href="https://man7.org/linux/man-pages/man3/io_uring_setup_buf_ring.3.html"> man io_uring_setup_buf_ring</a>
+     * an this <a href="https://lwn.net/Articles/815491/">LWN article</a> for more details.
      */
     public static final ChannelOption<Short> IO_URING_BUFFER_GROUP_ID =
             ChannelOption.valueOf(IoUringChannelOption.class, "IOURING_BUFFER_GROUP_ID");

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -211,6 +211,11 @@ public final class IoUringIoHandler implements IoHandler {
                 bufferRingSize, bufferGroupId, chunkSize,
                 this, bufferRingConfig.allocator()
         );
+
+        if (bufferRingConfig.initSize() != 0) {
+            ioUringBufferRing.appendBuffer(bufferRingConfig.initSize());
+        }
+
         registeredIoUringBufferRing.put(bufferGroupId, ioUringBufferRing);
         return ioUringBufferRing;
     }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -201,7 +201,7 @@ public final class IoUringIoHandler implements IoHandler {
         IoUringBufferRing ioUringBufferRing = new IoUringBufferRing(
                 ringFd, ioUringBufRingAddr,
                 bufferRingSize, bufferGroupId, chunkSize,
-                this
+                this, bufferRingConfig.allocator()
         );
         registeredIoUringBufferRing.put(bufferGroupId, ioUringBufferRing);
         return ioUringBufferRing;

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -108,14 +108,14 @@ public final class IoUringIoHandler implements IoHandler {
         }
 
         registeredIoUringBufferRing = new IntObjectHashMap<>();
-        List<BufferRingConfig> bufferRingConfigs = config.getInternBufferRingConfigs();
+        List<IoUringBufferRingConfig> bufferRingConfigs = config.getInternBufferRingConfigs();
         if (!bufferRingConfigs.isEmpty()) {
             if (!IoUring.isRegisterBufferRingSupported()) {
                 // Close ringBuffer before throwing to ensure we release all memory on failure.
                 ringBuffer.close();
                 throw new UnsupportedOperationException("io_uring_register_buffer_ring is not supported");
             }
-            for (BufferRingConfig bufferRingConfig : bufferRingConfigs) {
+            for (IoUringBufferRingConfig bufferRingConfig : bufferRingConfigs) {
                 try {
                     registerBufferRing(bufferRingConfig);
                 } catch (Errors.NativeIoException e) {
@@ -132,7 +132,6 @@ public final class IoUringIoHandler implements IoHandler {
         registrations = new IntObjectHashMap<>();
         eventfd = Native.newBlockingEventFd();
         eventfdReadBuf = PlatformDependent.allocateMemory(8);
-        beforeIOHook = PlatformDependent.newMpscQueue();
         this.timeoutMemoryAddress = PlatformDependent.allocateMemory(KERNEL_TIMESPEC_SIZE);
 
         // We buffer a maximum of 2 * CompletionQueue.ringSize completions before we drain them in batches.
@@ -188,7 +187,7 @@ public final class IoUringIoHandler implements IoHandler {
         }
     }
 
-    IoUringBufferRing registerBufferRing(BufferRingConfig bufferRingConfig) throws Errors.NativeIoException {
+    IoUringBufferRing registerBufferRing(IoUringBufferRingConfig bufferRingConfig) throws Errors.NativeIoException {
         int ringFd = ringBuffer.fd();
         short bufferRingSize = bufferRingConfig.bufferRingSize();
         short bufferGroupId = bufferRingConfig.bufferGroupId();

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandlerConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandlerConfig.java
@@ -64,7 +64,7 @@ public final class IoUringIoHandlerConfig {
 
     private int maxUnboundedWorker;
 
-    private List<BufferRingConfig> bufferRingConfigs = new ArrayList<>(0);
+    private final List<BufferRingConfig> bufferRingConfigs = new ArrayList<>(0);
 
     /**
      * Return the ring size of the io_uring instance.

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandlerConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandlerConfig.java
@@ -54,7 +54,7 @@ import java.util.List;
  *       <td>Defines the maximum number of unbounded io_uring worker threads.</td>
  *     </tr>
  *     <tr>
- *       <td>{@link IoUringIoHandlerConfig#appendBufferRingConfig}</td>
+ *       <td>{@link IoUringIoHandlerConfig#addBufferRingConfig}</td>
  *       <td>
  *         Adds a buffer ring configuration to the list of buffer ring configurations.
  *         It will be used to register the buffer ring for the io_uring instance.
@@ -136,7 +136,7 @@ public final class IoUringIoHandlerConfig {
      * @param ringConfig the buffer ring configuration to append.
      * @return reference to this, so the API can be used fluently
      */
-    public IoUringIoHandlerConfig appendBufferRingConfig(IoUringBufferRingConfig ringConfig) {
+    public IoUringIoHandlerConfig addBufferRingConfig(IoUringBufferRingConfig ringConfig) {
         for (IoUringBufferRingConfig bufferRingConfig : bufferRingConfigs) {
             if (bufferRingConfig.bufferGroupId() == ringConfig.bufferGroupId()) {
                 throw new IllegalArgumentException("Duplicated buffer group id: " + ringConfig.bufferGroupId());

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandlerConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandlerConfig.java
@@ -54,7 +54,7 @@ import java.util.List;
  *       <td>Defines the maximum number of unbounded io_uring worker threads.</td>
  *     </tr>
  *     <tr>
- *         <td>{@link IoUringIoHandlerConfiguration#appendBufferRingConfig}</td>
+ *         <td>{@link IoUringIoHandlerConfig#appendBufferRingConfig}</td>
  *         <td>
  *             Adds a buffer ring configuration to the list of buffer ring configurations.
  *             It will be used to register the buffer ring for the io_uring instance.
@@ -71,7 +71,7 @@ public final class IoUringIoHandlerConfig {
 
     private int maxUnboundedWorker;
 
-    private final List<BufferRingConfig> bufferRingConfigs = new ArrayList<>(0);
+    private final List<IoUringBufferRingConfig> bufferRingConfigs = new ArrayList<>(0);
 
     /**
      * Return the ring size of the io_uring instance.
@@ -134,8 +134,8 @@ public final class IoUringIoHandlerConfig {
      * @param ringConfig the buffer ring configuration to append.
      * @return reference to this, so the API can be used fluently
      */
-    public IoUringIoHandlerConfig appendBufferRingConfig(BufferRingConfig ringConfig) {
-        for (BufferRingConfig bufferRingConfig : bufferRingConfigs) {
+    public IoUringIoHandlerConfig appendBufferRingConfig(IoUringBufferRingConfig ringConfig) {
+        for (IoUringBufferRingConfig bufferRingConfig : bufferRingConfigs) {
             if (bufferRingConfig.bufferGroupId() == ringConfig.bufferGroupId()) {
                 throw new IllegalArgumentException("Duplicated buffer group id: " + ringConfig.bufferGroupId());
             }
@@ -148,7 +148,7 @@ public final class IoUringIoHandlerConfig {
      * Get the list of buffer ring configurations.
      * @return the copy of buffer ring configurations.
      */
-    public List<BufferRingConfig> getBufferRingConfigs() {
+    public List<IoUringBufferRingConfig> getBufferRingConfigs() {
         return new ArrayList<>(bufferRingConfigs);
     }
 
@@ -156,7 +156,7 @@ public final class IoUringIoHandlerConfig {
         return maxBoundedWorker > 0 || maxUnboundedWorker > 0;
     }
 
-    List<BufferRingConfig> getInternBufferRingConfigs() {
+    List<IoUringBufferRingConfig> getInternBufferRingConfigs() {
         return bufferRingConfigs;
     }
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandlerConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandlerConfig.java
@@ -54,11 +54,11 @@ import java.util.List;
  *       <td>Defines the maximum number of unbounded io_uring worker threads.</td>
  *     </tr>
  *     <tr>
- *         <td>{@link IoUringIoHandlerConfig#appendBufferRingConfig}</td>
- *         <td>
- *             Adds a buffer ring configuration to the list of buffer ring configurations.
- *             It will be used to register the buffer ring for the io_uring instance.
- *         </td>
+ *       <td>{@link IoUringIoHandlerConfig#appendBufferRingConfig}</td>
+ *       <td>
+ *         Adds a buffer ring configuration to the list of buffer ring configurations.
+ *         It will be used to register the buffer ring for the io_uring instance.
+ *       </td>
  *     </tr>
  *   </tbody>
  * </table>
@@ -130,7 +130,9 @@ public final class IoUringIoHandlerConfig {
     }
 
     /**
-     * Append a buffer ring configuration to the list of buffer ring configurations.
+     * Add a buffer ring configuration to the list of buffer ring configurations.
+     * Each {@link IoUringBufferRingConfig} must have a different {@link IoUringBufferRingConfig#bufferGroupId()}.
+     *
      * @param ringConfig the buffer ring configuration to append.
      * @return reference to this, so the API can be used fluently
      */

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandlerConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandlerConfig.java
@@ -17,6 +17,9 @@ package io.netty.channel.uring;
 
 import io.netty.util.internal.ObjectUtil;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Configuration class for an {@link IoUringIoHandler},
  * managing the settings for a {@link RingBuffer} and its io_uring file descriptor.
@@ -60,6 +63,8 @@ public final class IoUringIoHandlerConfig {
     private int maxBoundedWorker;
 
     private int maxUnboundedWorker;
+
+    private List<BufferRingConfig> bufferRingConfigs = new ArrayList<>(0);
 
     /**
      * Return the ring size of the io_uring instance.
@@ -117,7 +122,34 @@ public final class IoUringIoHandlerConfig {
         return this;
     }
 
+    /**
+     * Append a buffer ring configuration to the list of buffer ring configurations.
+     * @param ringConfig the buffer ring configuration to append.
+     * @return reference to this, so the API can be used fluently
+     */
+    public IoUringIoHandlerConfig appendBufferRingConfig(BufferRingConfig ringConfig) {
+        for (BufferRingConfig bufferRingConfig : bufferRingConfigs) {
+            if (bufferRingConfig.bufferGroupId() == ringConfig.bufferGroupId()) {
+                throw new IllegalArgumentException("Duplicated buffer group id: " + ringConfig.bufferGroupId());
+            }
+        }
+        bufferRingConfigs.add(ringConfig);
+        return this;
+    }
+
+    /**
+     * Get the list of buffer ring configurations.
+     * @return the copy of buffer ring configurations.
+     */
+    public List<BufferRingConfig> getBufferRingConfigs() {
+        return new ArrayList<>(bufferRingConfigs);
+    }
+
     boolean needRegisterIowqMaxWorker() {
         return maxBoundedWorker > 0 || maxUnboundedWorker > 0;
+    }
+
+    List<BufferRingConfig> getInternBufferRingConfigs() {
+        return bufferRingConfigs;
     }
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandlerConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandlerConfig.java
@@ -53,6 +53,13 @@ import java.util.List;
  *       <td>{@link IoUringIoHandlerConfig#setMaxUnboundedWorker}</td>
  *       <td>Defines the maximum number of unbounded io_uring worker threads.</td>
  *     </tr>
+ *     <tr>
+ *         <td>{@link IoUringIoHandlerConfiguration#appendBufferRingConfig}</td>
+ *         <td>
+ *             Adds a buffer ring configuration to the list of buffer ring configurations.
+ *             It will be used to register the buffer ring for the io_uring instance.
+ *         </td>
+ *     </tr>
  *   </tbody>
  * </table>
  */

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoOps.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoOps.java
@@ -379,9 +379,14 @@ public final class IoUringIoOps implements IoOps {
      */
     static IoUringIoOps newRecv(
             int fd, byte flags, short ioPrio, int recvFlags, long memoryAddress, int length, short data) {
+        return newRecv(fd, flags, ioPrio, recvFlags, memoryAddress, length, data, (short) 0);
+    }
+
+    static IoUringIoOps newRecv(
+            int fd, byte flags, short ioPrio, int recvFlags, long memoryAddress, int length, short data, short bid) {
         // See https://github.com/axboe/liburing/blob/liburing-2.8/src/include/liburing.h#L898
         return new IoUringIoOps(Native.IORING_OP_RECV, flags, ioPrio, fd,
-                0, memoryAddress, length, recvFlags, data, (short) 0, (short) 0, 0, 0);
+                0, memoryAddress, length, recvFlags, data, bid, (short) 0, 0, 0);
     }
 
     /**

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/NativeStaticallyReferencedJniMethods.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/NativeStaticallyReferencedJniMethods.java
@@ -36,6 +36,7 @@ final class NativeStaticallyReferencedJniMethods {
     static native int afInet6();
     static native int sizeofSockaddrIn();
     static native int sizeofSockaddrIn6();
+    static native int pageSize();
     static native int sockaddrInOffsetofSinFamily();
     static native int sockaddrInOffsetofSinPort();
     static native int sockaddrInOffsetofSinAddr();
@@ -61,6 +62,7 @@ final class NativeStaticallyReferencedJniMethods {
     static native int msghdrOffsetofMsgFlags();
     static native int etime();
     static native int ecanceled();
+    static native int enobufs();
     static native int pollin();
     static native int pollout();
     static native int pollrdhup();
@@ -69,6 +71,7 @@ final class NativeStaticallyReferencedJniMethods {
     static native int iosqeLink();
     static native int iosqeDrain();
     static native int msgDontwait();
+    static native int iosqeBufferSelect();
     static native int msgFastopen();
     static native int cmsgSpace();
     static native int cmsgLen();
@@ -77,5 +80,10 @@ final class NativeStaticallyReferencedJniMethods {
     static native int cmsghdrOffsetofCmsgLen();
     static native int cmsghdrOffsetofCmsgLevel();
     static native int cmsghdrOffsetofCmsgType();
+    static native int ioUringBufferRingOffsetTail();
+    static native int ioUringBufferOffsetAddr();
+    static native int ioUringBufferOffsetLen();
+    static native int ioUringBufferOffsetBid();
+    static native int sizeofIoUringBuf();
     static native int tcpFastopenMode();
 }

--- a/transport-native-io_uring/src/main/c/io_uring.h
+++ b/transport-native-io_uring/src/main/c/io_uring.h
@@ -340,6 +340,10 @@ enum {
 	IORING_REGISTER_RING_FDS		= 20,
 	IORING_UNREGISTER_RING_FDS		= 21,
 
+	/* register ring based provide buffer group */
+	IORING_REGISTER_PBUF_RING		= 22,
+	IORING_UNREGISTER_PBUF_RING		= 23,
+
 	/* this goes last */
 	IORING_REGISTER_LAST
 };

--- a/transport-native-io_uring/src/main/c/netty_io_uring.h
+++ b/transport-native-io_uring/src/main/c/netty_io_uring.h
@@ -62,4 +62,35 @@ struct io_uring {
     int ring_fd;
 };
 
+struct io_uring_buf {
+	__u64	addr;
+	__u32	len;
+	__u16	bid;
+	__u16	resv;
+};
+
+struct io_uring_buf_reg {
+	__u64	ring_addr;
+	__u32	ring_entries;
+	__u16	bgid;
+	__u16	flags;
+	__u64	resv[3];
+};
+
+struct io_uring_buf_ring {
+	union {
+		/*
+		 * To avoid spilling into more pages than we need to, the
+		 * ring tail is overlaid with the io_uring_buf->resv field.
+		 */
+		struct {
+			__u64	resv1;
+			__u32	resv2;
+			__u16	resv3;
+			__u16	tail;
+		};
+		struct io_uring_buf	bufs[0];
+	};
+};
+
 #endif

--- a/transport-native-io_uring/src/main/c/netty_io_uring_native.c
+++ b/transport-native-io_uring/src/main/c/netty_io_uring_native.c
@@ -376,10 +376,11 @@ static jlong netty_io_uring_register_buf_ring(JNIEnv* env, jclass clazz,
 
     memset(&reg, 0, sizeof(reg));
     ring_size = nentries * sizeof(struct io_uring_buf);
-    br = mmap(NULL, ring_size, PROT_READ | PROT_WRITE,MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+    br = mmap(NULL, ring_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
     if (br == MAP_FAILED) {
         return -errno;
     }
+    memset(&reg, 0, sizeof(struct io_uring_buf_reg));
     reg.ring_addr = (__u64)br;
     reg.ring_entries = nentries;
     reg.bgid = bgid;
@@ -574,7 +575,6 @@ static jint netty_io_uring_ioUringBufOffsetofbid(JNIEnv* env, jclass clazz) {
 static jint netty_io_uring_sizeofIoUringBuf(JNIEnv* env, jclass clazz) {
     return sizeof(struct io_uring_buf);
 }
-
 
 static int getSysctlValue(const char * property, int* returnValue) {
     int rc = -1;

--- a/transport-native-io_uring/src/main/c/netty_io_uring_native.c
+++ b/transport-native-io_uring/src/main/c/netty_io_uring_native.c
@@ -380,7 +380,7 @@ static jlong netty_io_uring_register_buf_ring(JNIEnv* env, jclass clazz,
     if (br == MAP_FAILED) {
         return -errno;
     }
-    memset(&reg, 0, sizeof(struct io_uring_buf_reg));
+
     reg.ring_addr = (__u64)br;
     reg.ring_entries = nentries;
     reg.bgid = bgid;

--- a/transport-native-io_uring/src/main/c/netty_io_uring_native.c
+++ b/transport-native-io_uring/src/main/c/netty_io_uring_native.c
@@ -367,6 +367,47 @@ static jint netty_io_uring_register_ring_fds(JNIEnv *env, jclass clazz, jint rin
     return -1;
 }
 
+static jlong netty_io_uring_register_buf_ring(JNIEnv* env, jclass clazz,
+                                           int ringFd, unsigned int nentries,
+                                           short bgid, unsigned int flags) {
+    struct io_uring_buf_ring *br;
+    struct io_uring_buf_reg reg;
+    size_t ring_size;
+
+    memset(&reg, 0, sizeof(reg));
+    ring_size = nentries * sizeof(struct io_uring_buf);
+    br = mmap(NULL, ring_size, PROT_READ | PROT_WRITE,MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+    if (br == MAP_FAILED) {
+        return -errno;
+    }
+    reg.ring_addr = (__u64)br;
+    reg.ring_entries = nentries;
+    reg.bgid = bgid;
+    reg.flags |= flags;
+
+    int registerRes = sys_io_uring_register(ringFd, IORING_REGISTER_PBUF_RING, &reg, 1);
+
+    if (registerRes) {
+        munmap(br,ring_size);
+        return registerRes;
+    }
+    br->tail = 0;
+    return (jlong)br;
+}
+
+static jint netty_io_uring_unregister_buf_ring(JNIEnv* env, jclass clazz,
+                                        int ringFd, struct io_uring_buf_ring *br,
+                                        unsigned int nentries, int bgid) {
+    struct io_uring_buf_reg reg = { .bgid = bgid };
+    int registerRes = sys_io_uring_register(ringFd, IORING_UNREGISTER_PBUF_RING, &reg, 1);
+    if (registerRes) {
+        return registerRes;
+    }
+    size_t ring_size = nentries * sizeof(struct io_uring_buf);
+    munmap(br,ring_size);
+    return 0;
+}
+
 static jint netty_create_file(JNIEnv *env, jclass class, jstring filename) {
     const char *file = (*env)->GetStringUTFChars(env, filename, 0);
 
@@ -374,7 +415,6 @@ static jint netty_create_file(JNIEnv *env, jclass class, jstring filename) {
     (*env)->ReleaseStringUTFChars(env, filename, file);
     return fd;
 }
-
 
 static jint netty_io_uring_registerUnix(JNIEnv* env, jclass clazz) {
     register_unix_called = 1;
@@ -387,6 +427,10 @@ static jint netty_io_uring_sockNonblock(JNIEnv* env, jclass clazz) {
 
 static jint netty_io_uring_sockCloexec(JNIEnv* env, jclass clazz) {
     return SOCK_CLOEXEC;
+}
+
+static jint netty_io_uring_pageSize(JNIEnv* env, jclass clazz) {
+    return getpagesize();
 }
 
 static jint netty_io_uring_afInet(JNIEnv* env, jclass clazz) {
@@ -511,6 +555,27 @@ static jlong netty_io_uring_cmsghdrData(JNIEnv* env, jclass clazz, jlong cmsghdr
     return (jlong) CMSG_DATA((struct cmsghdr*) cmsghdrAddr);
 }
 
+static jint netty_io_uring_ioUringBufRingOffsetoftail(JNIEnv* env, jclass clazz) {
+   return offsetof(struct io_uring_buf_ring, tail);
+}
+
+static jint netty_io_uring_ioUringBufOffsetofaddr(JNIEnv* env, jclass clazz) {
+   return offsetof(struct io_uring_buf, addr);
+}
+
+static jint netty_io_uring_ioUringBufOffsetoflen(JNIEnv* env, jclass clazz) {
+    return offsetof(struct io_uring_buf, len);
+}
+
+static jint netty_io_uring_ioUringBufOffsetofbid(JNIEnv* env, jclass clazz) {
+    return offsetof(struct io_uring_buf, bid);
+}
+
+static jint netty_io_uring_sizeofIoUringBuf(JNIEnv* env, jclass clazz) {
+    return sizeof(struct io_uring_buf);
+}
+
+
 static int getSysctlValue(const char * property, int* returnValue) {
     int rc = -1;
     FILE *fd=fopen(property, "r");
@@ -539,6 +604,10 @@ static jint netty_io_uring_ecanceled(JNIEnv* env, jclass clazz) {
     return ECANCELED;
 }
 
+static jint netty_io_uring_enobufs(JNIEnv* env, jclass clazz) {
+    return ENOBUFS;
+}
+
 static jint netty_io_uring_pollin(JNIEnv* env, jclass clazz) {
     return POLLIN;
 }
@@ -565,6 +634,10 @@ static jint netty_io_uring_iosqeLink(JNIEnv* env, jclass clazz) {
 
 static jint netty_io_uring_iosqeDrain(JNIEnv* env, jclass clazz) {
     return IOSQE_IO_DRAIN;
+}
+
+static jint netty_io_uring_BufferSelect(JNIEnv* env, jclass clazz) {
+    return IOSQE_BUFFER_SELECT;
 }
 
 static jint netty_io_uring_msgDontwait(JNIEnv* env, jclass clazz) {
@@ -599,6 +672,7 @@ static const JNINativeMethod statically_referenced_fixed_method_table[] = {
   { "afInet6", "()I", (void *) netty_io_uring_afInet6 },
   { "sizeofSockaddrIn", "()I", (void *) netty_io_uring_sizeofSockaddrIn },
   { "sizeofSockaddrIn6", "()I", (void *) netty_io_uring_sizeofSockaddrIn6 },
+  { "pageSize", "()I", (void*) netty_io_uring_pageSize},
   { "sockaddrInOffsetofSinFamily", "()I", (void *) netty_io_uring_sockaddrInOffsetofSinFamily },
   { "sockaddrInOffsetofSinPort", "()I", (void *) netty_io_uring_sockaddrInOffsetofSinPort },
   { "sockaddrInOffsetofSinAddr", "()I", (void *) netty_io_uring_sockaddrInOffsetofSinAddr },
@@ -626,6 +700,7 @@ static const JNINativeMethod statically_referenced_fixed_method_table[] = {
   { "msghdrOffsetofMsgFlags", "()I", (void *) netty_io_uring_msghdrOffsetofMsgFlags },
   { "etime", "()I", (void *) netty_io_uring_etime },
   { "ecanceled", "()I", (void *) netty_io_uring_ecanceled },
+  { "enobufs", "()I", (void*) netty_io_uring_enobufs},
   { "pollin", "()I", (void *) netty_io_uring_pollin },
   { "pollout", "()I", (void *) netty_io_uring_pollout },
   { "pollrdhup", "()I", (void *) netty_io_uring_pollrdhup },
@@ -633,6 +708,7 @@ static const JNINativeMethod statically_referenced_fixed_method_table[] = {
   { "iosqeAsync", "()I", (void *) netty_io_uring_iosqeAsync },
   { "iosqeLink", "()I", (void *) netty_io_uring_iosqeLink },
   { "iosqeDrain", "()I", (void *) netty_io_uring_iosqeDrain },
+  { "iosqeBufferSelect", "()I", (void *) netty_io_uring_BufferSelect },
   { "msgDontwait", "()I", (void *) netty_io_uring_msgDontwait },
   { "msgFastopen", "()I", (void *) netty_io_uring_msgFastopen },
   { "solUdp", "()I", (void *) netty_io_uring_solUdp },
@@ -640,6 +716,11 @@ static const JNINativeMethod statically_referenced_fixed_method_table[] = {
   { "cmsghdrOffsetofCmsgLen", "()I", (void *) netty_io_uring_cmsghdrOffsetofCmsgLen },
   { "cmsghdrOffsetofCmsgLevel", "()I", (void *) netty_io_uring_cmsghdrOffsetofCmsgLevel },
   { "cmsghdrOffsetofCmsgType", "()I", (void *) netty_io_uring_cmsghdrOffsetofCmsgType },
+  { "ioUringBufferRingOffsetTail", "()I", (void *) netty_io_uring_ioUringBufRingOffsetoftail },
+  { "sizeofIoUringBuf", "()I", (void *) netty_io_uring_sizeofIoUringBuf },
+  { "ioUringBufferOffsetAddr", "()I", (void *) netty_io_uring_ioUringBufOffsetofaddr },
+  { "ioUringBufferOffsetLen", "()I", (void *) netty_io_uring_ioUringBufOffsetoflen },
+  { "ioUringBufferOffsetBid", "()I", (void *) netty_io_uring_ioUringBufOffsetofbid },
   { "tcpFastopenMode", "()I", (void *) netty_io_uring_tcpFastopenMode },
 };
 static const jint statically_referenced_fixed_method_table_size = sizeof(statically_referenced_fixed_method_table) / sizeof(statically_referenced_fixed_method_table[0]);
@@ -659,7 +740,9 @@ static const JNINativeMethod method_table[] = {
     {"registerUnix", "()I", (void *) netty_io_uring_registerUnix },
     {"cmsghdrData", "(J)J", (void *) netty_io_uring_cmsghdrData},
     {"kernelVersion", "()Ljava/lang/String;", (void *) netty_io_uring_kernel_version },
-    {"getFd0", "(Ljava/lang/Object;)I", (void *) netty_io_uring_getFd0 }
+    {"getFd0", "(Ljava/lang/Object;)I", (void *) netty_io_uring_getFd0 },
+    {"ioUringRegisterBuffRing", "(IISI)J", (void *) netty_io_uring_register_buf_ring},
+    {"ioUringUnRegisterBufRing", "(IJII)I", (void *) netty_io_uring_unregister_buf_ring}
 };
 static const jint method_table_size =
     sizeof(method_table) / sizeof(method_table[0]);

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
@@ -49,7 +49,7 @@ public class IoUringBufferRingTest {
 
     @Test
     public void testRegister() {
-        RingBuffer ringBuffer = Native.createRingBuffer();
+        RingBuffer ringBuffer = Native.createRingBuffer(8, 0);
         try {
             int ringFd = ringBuffer.fd();
             long ioUringBufRingAddr = Native.ioUringRegisterBuffRing(ringFd, 4, (short) 1, 0);

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
@@ -74,14 +74,14 @@ public class IoUringBufferRingTest {
         IoUringIoHandlerConfig ioUringIoHandlerConfiguration = new IoUringIoHandlerConfig();
         IoUringBufferRingConfig bufferRingConfig = new IoUringBufferRingConfig(
                 (short) 1, (short) 2, 1024, ByteBufAllocator.DEFAULT);
-        ioUringIoHandlerConfiguration.appendBufferRingConfig(bufferRingConfig);
+        ioUringIoHandlerConfiguration.addBufferRingConfig(bufferRingConfig);
 
         IoUringBufferRingConfig bufferRingConfig1 = new IoUringBufferRingConfig(
                 (short) 2, (short) 16,
                 1024, ByteBufAllocator.DEFAULT,
                 12
         );
-        ioUringIoHandlerConfiguration.appendBufferRingConfig(bufferRingConfig1);
+        ioUringIoHandlerConfiguration.addBufferRingConfig(bufferRingConfig1);
 
         MultiThreadIoEventLoopGroup group = new MultiThreadIoEventLoopGroup(1,
                 IoUringIoHandler.newFactory(ioUringIoHandlerConfiguration)

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
@@ -71,11 +71,12 @@ public class IoUringBufferRingTest {
 
     @Test
     public void testProviderBufferRead() throws InterruptedException {
-        IoUringIoHandlerConfiguration ioUringIoHandlerConfiguration = new IoUringIoHandlerConfiguration();
-        BufferRingConfig bufferRingConfig = new BufferRingConfig((short) 1, (short) 2, 1024, ByteBufAllocator.DEFAULT);
+        IoUringIoHandlerConfig ioUringIoHandlerConfiguration = new IoUringIoHandlerConfig();
+        IoUringBufferRingConfig bufferRingConfig = new IoUringBufferRingConfig(
+                (short) 1, (short) 2, 1024, ByteBufAllocator.DEFAULT);
         ioUringIoHandlerConfiguration.appendBufferRingConfig(bufferRingConfig);
 
-        BufferRingConfig bufferRingConfig1 = new BufferRingConfig(
+        IoUringBufferRingConfig bufferRingConfig1 = new IoUringBufferRingConfig(
                 (short) 2, (short) 16,
                 1024, ByteBufAllocator.DEFAULT,
                 12
@@ -91,7 +92,7 @@ public class IoUringBufferRingTest {
         String randomString = UUID.randomUUID().toString();
         int randomStringLength = randomString.length();
 
-        ArrayBlockingQueue<BufferRingExhaustedEvent> eventSyncer = new ArrayBlockingQueue<>(1);
+        ArrayBlockingQueue<IoUringBufferRingExhaustedEvent> eventSyncer = new ArrayBlockingQueue<>(1);
 
         Channel serverChannel = serverBootstrap.group(group)
                 .childHandler(new ChannelInboundHandlerAdapter() {
@@ -102,8 +103,8 @@ public class IoUringBufferRingTest {
 
                     @Override
                     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
-                        if (evt instanceof BufferRingExhaustedEvent) {
-                            eventSyncer.add((BufferRingExhaustedEvent) evt);
+                        if (evt instanceof IoUringBufferRingExhaustedEvent) {
+                            eventSyncer.add((IoUringBufferRingExhaustedEvent) evt);
                         }
                     }
                 })

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IoUringBufferRingTest {
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IoUring.isAvailable());
+    }
+
+    @Test
+    public void testRegister() {
+        RingBuffer ringBuffer = Native.createRingBuffer();
+        try {
+            int ringFd = ringBuffer.fd();
+            long ioUringBufRingAddr = Native.ioUringRegisterBuffRing(ringFd, 4, (short) 1, 0);
+            assumeTrue(
+                    ioUringBufRingAddr > 0,
+                    "ioUringSetupBufRing result must great than 0, but now result is " + ioUringBufRingAddr);
+            int freeRes = Native.ioUringUnRegisterBufRing(ringFd, ioUringBufRingAddr, 4, 1);
+            assumeTrue(
+                    freeRes == 0,
+                    "ioUringFreeBufRing result must be 0, but now result is " + freeRes
+            );
+        } finally {
+            ringBuffer.close();
+        }
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
@@ -76,6 +76,13 @@ public class IoUringBufferRingTest {
         BufferRingConfig bufferRingConfig = new BufferRingConfig((short) 1, (short) 2, 1024, ByteBufAllocator.DEFAULT);
         ioUringIoHandlerConfiguration.appendBufferRingConfig(bufferRingConfig);
 
+        BufferRingConfig bufferRingConfig1 = new BufferRingConfig(
+                (short) 2, (short) 16,
+                1024, ByteBufAllocator.DEFAULT,
+                12
+        );
+        ioUringIoHandlerConfiguration.appendBufferRingConfig(bufferRingConfig1);
+
         MultiThreadIoEventLoopGroup group = new MultiThreadIoEventLoopGroup(1,
                 IoUringIoHandler.newFactory(ioUringIoHandlerConfiguration)
         );

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
@@ -71,7 +71,6 @@ public class IoUringBufferRingTest {
 
     @Test
     public void testProviderBufferRead() throws InterruptedException {
-
         IoUringIoHandlerConfiguration ioUringIoHandlerConfiguration = new IoUringIoHandlerConfiguration();
         BufferRingConfig bufferRingConfig = new BufferRingConfig((short) 1, (short) 2, 1024, ByteBufAllocator.DEFAULT);
         ioUringIoHandlerConfiguration.appendBufferRingConfig(bufferRingConfig);

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
@@ -141,7 +141,7 @@ public class IoUringBufferRingTest {
         group.shutdownGracefully();
     }
 
-    public ByteBuf sendAndRecvMessage(Channel clientChannel, ByteBuf writeBuffer) throws InterruptedException {
+    private ByteBuf sendAndRecvMessage(Channel clientChannel, ByteBuf writeBuffer) throws InterruptedException {
         //retain the buffer to assert
         writeBuffer.retain();
         clientChannel.writeAndFlush(writeBuffer).sync();

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
@@ -18,6 +18,7 @@ package io.netty.channel.uring;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
@@ -56,8 +57,9 @@ public class IoUringBufferRingTest {
                     ioUringBufRingAddr > 0,
                     "ioUringSetupBufRing result must great than 0, but now result is " + ioUringBufRingAddr);
             int freeRes = Native.ioUringUnRegisterBufRing(ringFd, ioUringBufRingAddr, 4, 1);
-            assumeTrue(
-                    freeRes == 0,
+            assertEquals(
+                    0,
+                    freeRes,
                     "ioUringFreeBufRing result must be 0, but now result is " + freeRes
             );
         } finally {
@@ -65,13 +67,13 @@ public class IoUringBufferRingTest {
         }
     }
 
-    private BlockingQueue<ByteBuf> bufferSyncer = new LinkedBlockingQueue<>();
+    private final BlockingQueue<ByteBuf> bufferSyncer = new LinkedBlockingQueue<>();
 
     @Test
     public void testProviderBufferRead() throws InterruptedException {
 
         IoUringIoHandlerConfiguration ioUringIoHandlerConfiguration = new IoUringIoHandlerConfiguration();
-        BufferRingConfig bufferRingConfig = new BufferRingConfig((short) 1, (short) 2, 1024);
+        BufferRingConfig bufferRingConfig = new BufferRingConfig((short) 1, (short) 2, 1024, ByteBufAllocator.DEFAULT);
         ioUringIoHandlerConfiguration.appendBufferRingConfig(bufferRingConfig);
 
         MultiThreadIoEventLoopGroup group = new MultiThreadIoEventLoopGroup(1,

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
@@ -99,7 +99,6 @@ public class IoUringBufferRingTest {
                         }
                     }
                 })
-                .childOption(IoUringChannelOption.ENABLE_BUFFER_SELECT_READ, true)
                 .childOption(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, bufferRingConfig.bufferGroupId())
                 .bind(NetUtil.LOCALHOST, 0)
                 .syncUninterruptibly().channel();
@@ -128,7 +127,6 @@ public class IoUringBufferRingTest {
         assertFalse(readBuffer instanceof IoUringBufferRing.UserspaceIoUringBuffer);
         assertEquals(1, eventSyncer.size());
         assertEquals(bufferRingConfig.bufferGroupId(), eventSyncer.take().bufferGroupId());
-
 
         //now we release the buffer ring buffer
         userspaceIoUringBufferElement1.release();

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketAutoReadTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketAutoReadTest.java
@@ -42,6 +42,9 @@ public class IoUringSocketAutoReadTest extends SocketAutoReadTest {
     protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
         super.configure(sb, cb, allocator);
         sb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        // This test does not enalbe IoUringChannelOption.IO_URING_BUFFER_GROUP_ID as it will not work because
+        // We want to use a custom RecvBytBufAllocator that limit the number of bytes that we can read per read
+        // operation to 1.
         sb.childOption(IoUringChannelOption.POLLIN_FIRST, false);
         cb.option(IoUringChannelOption.POLLIN_FIRST, false);
     }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketChannelNotYetConnectedTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketChannelNotYetConnectedTest.java
@@ -41,5 +41,6 @@ public class IoUringSocketChannelNotYetConnectedTest extends SocketChannelNotYet
     protected void configure(Bootstrap cb, ByteBufAllocator allocator) {
         super.configure(cb, allocator);
         cb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        cb.option(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, IoUringSocketTestPermutation.BGID);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketConditionalWritabilityTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketConditionalWritabilityTest.java
@@ -43,6 +43,8 @@ public class IoUringSocketConditionalWritabilityTest extends SocketConditionalWr
         super.configure(sb, cb, allocator);
         sb.option(IoUringChannelOption.POLLIN_FIRST, false);
         sb.childOption(IoUringChannelOption.POLLIN_FIRST, false);
+        sb.childOption(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, IoUringSocketTestPermutation.BGID);
         cb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        cb.option(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, IoUringSocketTestPermutation.BGID);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketConnectTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketConnectTest.java
@@ -43,6 +43,8 @@ public class IoUringSocketConnectTest extends SocketConnectTest {
         super.configure(sb, cb, allocator);
         sb.option(IoUringChannelOption.POLLIN_FIRST, false);
         sb.childOption(IoUringChannelOption.POLLIN_FIRST, false);
+        sb.childOption(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, IoUringSocketTestPermutation.BGID);
         cb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        cb.option(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, IoUringSocketTestPermutation.BGID);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketConnectionAttemptTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketConnectionAttemptTest.java
@@ -42,5 +42,6 @@ public class IoUringSocketConnectionAttemptTest extends SocketConnectionAttemptT
     protected void configure(Bootstrap cb, ByteBufAllocator allocator) {
         super.configure(cb, allocator);
         cb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        cb.option(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, IoUringSocketTestPermutation.BGID);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketDataReadInitialStateTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketDataReadInitialStateTest.java
@@ -43,6 +43,8 @@ public class IoUringSocketDataReadInitialStateTest extends SocketDataReadInitial
         super.configure(sb, cb, allocator);
         sb.option(IoUringChannelOption.POLLIN_FIRST, false);
         sb.childOption(IoUringChannelOption.POLLIN_FIRST, false);
+        sb.childOption(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, IoUringSocketTestPermutation.BGID);
         cb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        cb.option(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, IoUringSocketTestPermutation.BGID);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketEchoTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketEchoTest.java
@@ -43,6 +43,8 @@ public class IoUringSocketEchoTest extends SocketEchoTest {
         super.configure(sb, cb, allocator);
         sb.option(IoUringChannelOption.POLLIN_FIRST, false);
         sb.childOption(IoUringChannelOption.POLLIN_FIRST, false);
+        sb.childOption(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, IoUringSocketTestPermutation.BGID);
         cb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        cb.option(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, IoUringSocketTestPermutation.BGID);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketExceptionHandlingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketExceptionHandlingTest.java
@@ -43,6 +43,8 @@ public class IoUringSocketExceptionHandlingTest extends SocketExceptionHandlingT
         super.configure(sb, cb, allocator);
         sb.option(IoUringChannelOption.POLLIN_FIRST, false);
         sb.childOption(IoUringChannelOption.POLLIN_FIRST, false);
+        sb.childOption(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, IoUringSocketTestPermutation.BGID);
         cb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        cb.option(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, IoUringSocketTestPermutation.BGID);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketFileRegionTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketFileRegionTest.java
@@ -57,6 +57,8 @@ public class IoUringSocketFileRegionTest extends SocketFileRegionTest {
         super.configure(sb, cb, allocator);
         sb.option(IoUringChannelOption.POLLIN_FIRST, false);
         sb.childOption(IoUringChannelOption.POLLIN_FIRST, false);
+        sb.childOption(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, IoUringSocketTestPermutation.BGID);
         cb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        cb.option(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, IoUringSocketTestPermutation.BGID);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketFixedLengthEchoTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketFixedLengthEchoTest.java
@@ -43,6 +43,8 @@ public class IoUringSocketFixedLengthEchoTest extends SocketFixedLengthEchoTest 
         super.configure(sb, cb, allocator);
         sb.option(IoUringChannelOption.POLLIN_FIRST, false);
         sb.childOption(IoUringChannelOption.POLLIN_FIRST, false);
+        sb.childOption(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, IoUringSocketTestPermutation.BGID);
         cb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        cb.option(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, IoUringSocketTestPermutation.BGID);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketGatheringWriteTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketGatheringWriteTest.java
@@ -43,6 +43,8 @@ public class IoUringSocketGatheringWriteTest extends SocketGatheringWriteTest {
         super.configure(sb, cb, allocator);
         sb.option(IoUringChannelOption.POLLIN_FIRST, false);
         sb.childOption(IoUringChannelOption.POLLIN_FIRST, false);
+        sb.childOption(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, IoUringSocketTestPermutation.BGID);
         cb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        cb.option(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, IoUringSocketTestPermutation.BGID);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketHalfClosedTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketHalfClosedTest.java
@@ -60,6 +60,8 @@ public class IoUringSocketHalfClosedTest extends SocketHalfClosedTest {
         super.configure(sb, cb, allocator);
         sb.option(IoUringChannelOption.POLLIN_FIRST, false);
         sb.childOption(IoUringChannelOption.POLLIN_FIRST, false);
+        sb.childOption(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, IoUringSocketTestPermutation.BGID);
         cb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        cb.option(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, IoUringSocketTestPermutation.BGID);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketMultipleConnectTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketMultipleConnectTest.java
@@ -58,6 +58,8 @@ public class IoUringSocketMultipleConnectTest extends SocketMultipleConnectTest 
         super.configure(sb, cb, allocator);
         sb.option(IoUringChannelOption.POLLIN_FIRST, false);
         sb.childOption(IoUringChannelOption.POLLIN_FIRST, false);
+        sb.childOption(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, IoUringSocketTestPermutation.BGID);
         cb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        cb.option(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, IoUringSocketTestPermutation.BGID);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketReadPendingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketReadPendingTest.java
@@ -42,6 +42,7 @@ public class IoUringSocketReadPendingTest extends SocketReadPendingTest {
     protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
         super.configure(sb, cb, allocator);
         sb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        // Don't use buffer group as the test wants to limit the number of bytes we read to 1.
         sb.childOption(IoUringChannelOption.POLLIN_FIRST, false);
         cb.option(IoUringChannelOption.POLLIN_FIRST, false);
     }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketRstTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketRstTest.java
@@ -60,6 +60,8 @@ public class IoUringSocketRstTest extends SocketRstTest {
         super.configure(sb, cb, allocator);
         sb.option(IoUringChannelOption.POLLIN_FIRST, false);
         sb.childOption(IoUringChannelOption.POLLIN_FIRST, false);
+        sb.childOption(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, IoUringSocketTestPermutation.BGID);
         cb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        cb.option(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, IoUringSocketTestPermutation.BGID);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketShutdownOutputByPeerTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketShutdownOutputByPeerTest.java
@@ -42,5 +42,7 @@ public class IoUringSocketShutdownOutputByPeerTest extends SocketShutdownOutputB
     protected void configure(ServerBootstrap bootstrap, ByteBufAllocator allocator) {
         super.configure(bootstrap, allocator);
         bootstrap.option(IoUringChannelOption.POLLIN_FIRST, false);
+        bootstrap.childOption(IoUringChannelOption.POLLIN_FIRST, false);
+        bootstrap.childOption(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, IoUringSocketTestPermutation.BGID);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketShutdownOutputBySelfTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketShutdownOutputBySelfTest.java
@@ -42,5 +42,6 @@ public class IoUringSocketShutdownOutputBySelfTest extends SocketShutdownOutputB
     protected void configure(Bootstrap bootstrap, ByteBufAllocator allocator) {
         super.configure(bootstrap, allocator);
         bootstrap.option(IoUringChannelOption.POLLIN_FIRST, true);
+        bootstrap.option(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, IoUringSocketTestPermutation.BGID);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketSslClientRenegotiateTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketSslClientRenegotiateTest.java
@@ -43,6 +43,8 @@ public class IoUringSocketSslClientRenegotiateTest extends SocketSslClientRenego
         super.configure(sb, cb, allocator);
         sb.option(IoUringChannelOption.POLLIN_FIRST, false);
         sb.childOption(IoUringChannelOption.POLLIN_FIRST, false);
+        sb.childOption(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, IoUringSocketTestPermutation.BGID);
         cb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        cb.option(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, IoUringSocketTestPermutation.BGID);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketSslEchoTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketSslEchoTest.java
@@ -43,6 +43,8 @@ public class IoUringSocketSslEchoTest extends SocketSslEchoTest {
         super.configure(sb, cb, allocator);
         sb.option(IoUringChannelOption.POLLIN_FIRST, false);
         sb.childOption(IoUringChannelOption.POLLIN_FIRST, false);
+        sb.childOption(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, IoUringSocketTestPermutation.BGID);
         cb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        cb.option(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, IoUringSocketTestPermutation.BGID);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketSslGreetingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketSslGreetingTest.java
@@ -43,6 +43,8 @@ public class IoUringSocketSslGreetingTest extends SocketSslGreetingTest {
         super.configure(sb, cb, allocator);
         sb.option(IoUringChannelOption.POLLIN_FIRST, false);
         sb.childOption(IoUringChannelOption.POLLIN_FIRST, false);
+        sb.childOption(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, IoUringSocketTestPermutation.BGID);
         cb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        cb.option(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, IoUringSocketTestPermutation.BGID);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketSslSessionReuseTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketSslSessionReuseTest.java
@@ -43,6 +43,8 @@ public class IoUringSocketSslSessionReuseTest extends SocketSslSessionReuseTest 
         super.configure(sb, cb, allocator);
         sb.option(IoUringChannelOption.POLLIN_FIRST, false);
         sb.childOption(IoUringChannelOption.POLLIN_FIRST, false);
+        sb.childOption(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, IoUringSocketTestPermutation.BGID);
         cb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        cb.option(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, IoUringSocketTestPermutation.BGID);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketStartTlsTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketStartTlsTest.java
@@ -43,6 +43,8 @@ public class IoUringSocketStartTlsTest extends SocketStartTlsTest {
         super.configure(sb, cb, allocator);
         sb.option(IoUringChannelOption.POLLIN_FIRST, false);
         sb.childOption(IoUringChannelOption.POLLIN_FIRST, false);
+        sb.childOption(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, IoUringSocketTestPermutation.BGID);
         cb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        cb.option(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, IoUringSocketTestPermutation.BGID);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketStringEchoTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketStringEchoTest.java
@@ -43,6 +43,8 @@ public class IoUringSocketStringEchoTest extends SocketStringEchoTest {
         super.configure(sb, cb, allocator);
         sb.option(IoUringChannelOption.POLLIN_FIRST, false);
         sb.childOption(IoUringChannelOption.POLLIN_FIRST, false);
+        sb.childOption(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, IoUringSocketTestPermutation.BGID);
         cb.option(IoUringChannelOption.POLLIN_FIRST, false);
+        cb.option(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, IoUringSocketTestPermutation.BGID);
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketTestPermutation.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketTestPermutation.java
@@ -17,12 +17,12 @@ package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFactory;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultiThreadIoEventLoopGroup;
-import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.channel.socket.SocketProtocolFamily;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
@@ -40,11 +40,15 @@ import java.util.List;
 public class IoUringSocketTestPermutation extends SocketTestPermutation {
 
     static final IoUringSocketTestPermutation INSTANCE = new IoUringSocketTestPermutation();
-
+    static final short BGID = 1;
     static final EventLoopGroup IO_URING_BOSS_GROUP = new MultiThreadIoEventLoopGroup(
             BOSSES, new DefaultThreadFactory("testsuite-io_uring-boss", true), IoUringIoHandler.newFactory());
     static final EventLoopGroup IO_URING_WORKER_GROUP = new MultiThreadIoEventLoopGroup(
-            WORKERS, new DefaultThreadFactory("testsuite-io_uring-worker", true), IoUringIoHandler.newFactory());
+            WORKERS, new DefaultThreadFactory("testsuite-io_uring-worker", true),
+            IoUringIoHandler.newFactory(new IoUringIoHandlerConfiguration()
+                    // Configure a buffer ring that we can easily enable by setting the correct IoUringChannelOption.
+                    .appendBufferRingConfig(
+                            new BufferRingConfig(BGID, (short) 16, 1024, ByteBufAllocator.DEFAULT))));
 
     @Override
     public List<BootstrapComboFactory<ServerBootstrap, Bootstrap>> socket() {

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketTestPermutation.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketTestPermutation.java
@@ -45,10 +45,10 @@ public class IoUringSocketTestPermutation extends SocketTestPermutation {
             BOSSES, new DefaultThreadFactory("testsuite-io_uring-boss", true), IoUringIoHandler.newFactory());
     static final EventLoopGroup IO_URING_WORKER_GROUP = new MultiThreadIoEventLoopGroup(
             WORKERS, new DefaultThreadFactory("testsuite-io_uring-worker", true),
-            IoUringIoHandler.newFactory(new IoUringIoHandlerConfiguration()
+            IoUringIoHandler.newFactory(new IoUringIoHandlerConfig()
                     // Configure a buffer ring that we can easily enable by setting the correct IoUringChannelOption.
                     .appendBufferRingConfig(
-                            new BufferRingConfig(BGID, (short) 16, 1024, ByteBufAllocator.DEFAULT))));
+                            new IoUringBufferRingConfig(BGID, (short) 16, 1024, ByteBufAllocator.DEFAULT))));
 
     @Override
     public List<BootstrapComboFactory<ServerBootstrap, Bootstrap>> socket() {

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketTestPermutation.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketTestPermutation.java
@@ -47,7 +47,7 @@ public class IoUringSocketTestPermutation extends SocketTestPermutation {
             WORKERS, new DefaultThreadFactory("testsuite-io_uring-worker", true),
             IoUringIoHandler.newFactory(new IoUringIoHandlerConfig()
                     // Configure a buffer ring that we can easily enable by setting the correct IoUringChannelOption.
-                    .appendBufferRingConfig(
+                    .addBufferRingConfig(
                             new IoUringBufferRingConfig(BGID, (short) 16, 1024, ByteBufAllocator.DEFAULT))));
 
     @Override

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringWriteBeforeRegisteredTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringWriteBeforeRegisteredTest.java
@@ -41,5 +41,6 @@ public class IoUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest 
     protected void configure(Bootstrap bootstrap, ByteBufAllocator allocator) {
         super.configure(bootstrap, allocator);
         bootstrap.option(IoUringChannelOption.POLLIN_FIRST, false);
+        bootstrap.option(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, IoUringSocketTestPermutation.BGID);
     }
 }


### PR DESCRIPTION
Motivation:

In scenarios with a large number of inactive connections, reduce memory usage and improve performance.

see https://lwn.net/Articles/815491/

Modification:

Implement IoUringBufferRing and IOSQE_BUFFER_SELECT flag for socket recv:

- Enable the use of IOSQE_BUFFER_SELECT in the socket recv when IoUringBufferRing is supported by the current Linux kernel version and IOUringSocketChannelConfig is configured to enable the feature
- IoUringBufferRing elements are not populated immediately; only when submitting recv ops, if there is available space in the current BufferRing, the allocator will be used to allocate a buffer.
- If the res in the recv CQE is -ERRNO_NO_BUFFER, mark the bufferRing as temporarily unavailable. The current and subsequent recv operations will fall back to the old recv path.
- When a ByteBuf allocated from IoUringBufferRing is released by the user, it will be returned to the IoUringBufferRing, and the buffer will be marked as available for reuse.

Result:

Fixes #14614


