### PR TITLE
IoHandler: Introduce IoHandler.initialize(IoEventLoop) and remove IoE…

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoHandler.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoHandler.java
@@ -228,7 +228,7 @@ public class EpollIoHandler implements IoHandler {
 
     @Override
     public void wakeup() {
-        if (!eventLoop.inEventLoop() && nextWakeupNanos.getAndSet(AWAKE) != AWAKE) {
+        if ((eventLoop == null || !eventLoop.inEventLoop()) && nextWakeupNanos.getAndSet(AWAKE) != AWAKE) {
             // write to the evfd which will then wake-up epoll_wait(...)
             Native.eventFdWrite(eventFd.intValue(), 1L);
         }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -482,7 +482,7 @@ public final class IoUringIoHandler implements IoHandler {
 
     @Override
     public void wakeup() {
-        if (!eventLoop.inEventLoop() && !eventfdAsyncNotify.getAndSet(true)) {
+        if ((eventLoop == null || !eventLoop.inEventLoop()) && !eventfdAsyncNotify.getAndSet(true)) {
             // write to the eventfd which will then trigger an eventfd read completion.
             Native.eventFdWrite(eventfd.intValue(), 1L);
         }

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoHandler.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoHandler.java
@@ -137,7 +137,7 @@ public final class KQueueIoHandler implements IoHandler {
 
     @Override
     public void wakeup() {
-        if (!eventLoop.inEventLoop() && WAKEN_UP_UPDATER.compareAndSet(this, 0, 1)) {
+        if ((eventLoop == null || !eventLoop.inEventLoop()) && WAKEN_UP_UPDATER.compareAndSet(this, 0, 1)) {
             wakeup();
         }
     }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringIoHandlerTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringIoHandlerTest.java
@@ -36,6 +36,7 @@ public class IoUringIoHandlerTest {
                 .setMaxUnboundedWorker(2);
         IoHandlerFactory ioHandlerFactory = IoUringIoHandler.newFactory(config);
         IoHandler handler = ioHandlerFactory.newHandler();
+        handler.initalize(null);
         handler.destroy();
     }
 }

--- a/transport/src/main/java/io/netty/channel/IoHandler.java
+++ b/transport/src/main/java/io/netty/channel/IoHandler.java
@@ -17,10 +17,10 @@ package io.netty.channel;
 
 /**
  * Handles IO dispatching for an {@link IoEventLoop}
- * All operations except {@link #wakeup(IoEventLoop)} and {@link #isCompatible(Class)} <strong>MUST</strong> be executed
+ * All operations except {@link #wakeup()} and {@link #isCompatible(Class)} <strong>MUST</strong> be executed
  * on the {@link IoEventLoop} thread and should never be called from the user-directly.
  * <p>
- * Once a {@link IoHandle} is registered via the {@link #register(IoEventLoop, IoHandle)} method it's possible
+ * Once a {@link IoHandle} is registered via the {@link #register(IoHandle)} method it's possible
  * to submit {@link IoOps} related to the {@link IoHandle} via {@link IoRegistration#submit(IoOps)}.
  * These submitted {@link IoOps} are the "source" of {@link IoEvent}s that are dispatched to the registered
  * {@link IoHandle} via the {@link IoHandle#handle(IoRegistration, IoEvent)} method.
@@ -28,6 +28,15 @@ package io.netty.channel;
  *
  */
 public interface IoHandler {
+
+    /**
+     * Will be called as part of the initialization of the {@link IoHandler} by the {@link EventLoop}
+     * that uses this {@link IoHandler}.
+     *
+     * @param eventLoop     the {@link IoEventLoop} that will use this {@link IoHandler}.
+     */
+    void initalize(IoEventLoop eventLoop);
+
     /**
      * Run the IO handled by this {@link IoHandler}. The {@link IoExecutionContext} should be used
      * to ensure we not execute too long and so block the processing of other task that are
@@ -53,17 +62,16 @@ public interface IoHandler {
     /**
      * Register a {@link IoHandle} for IO.
      *
-     * @param eventLoop     the {@link IoEventLoop} that did issue the registration.
      * @param handle        the {@link IoHandle} to register.
      * @throws Exception    thrown if an error happens during registration.
      */
-    IoRegistration register(IoEventLoop eventLoop, IoHandle handle) throws Exception;
+    IoRegistration register(IoHandle handle) throws Exception;
 
     /**
      * Wakeup the {@link IoHandler}, which means if any operation blocks it should be unblocked and
      * return as soon as possible.
      */
-    void wakeup(IoEventLoop eventLoop);
+    void wakeup();
 
     /**
      * Returns {@code true} if the given type is compatible with this {@link IoHandler} and so can be registered,

--- a/transport/src/main/java/io/netty/channel/SingleThreadIoEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/SingleThreadIoEventLoop.java
@@ -170,6 +170,7 @@ public class SingleThreadIoEventLoop extends SingleThreadEventLoop implements Io
     @Override
     protected void run() {
         assert inEventLoop();
+        ioHandler.initalize(this);
         do {
             runIo();
             if (isShuttingDown()) {
@@ -224,7 +225,7 @@ public class SingleThreadIoEventLoop extends SingleThreadEventLoop implements Io
         assert inEventLoop();
         final IoRegistration registration;
         try {
-            registration = ioHandler.register(this, handle);
+            registration = ioHandler.register(handle);
         } catch (Exception e) {
             promise.setFailure(e);
             return;
@@ -236,7 +237,7 @@ public class SingleThreadIoEventLoop extends SingleThreadEventLoop implements Io
 
     @Override
     protected final void wakeup(boolean inEventLoop) {
-        ioHandler.wakeup(this);
+        ioHandler.wakeup();
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/local/LocalIoHandler.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalIoHandler.java
@@ -75,7 +75,7 @@ public final class LocalIoHandler implements IoHandler {
 
     @Override
     public void wakeup() {
-        if (!eventLoop.inEventLoop()) {
+        if (eventLoop == null || !eventLoop.inEventLoop()) {
             Thread thread = executionThread;
             if (thread != null) {
                 // Wakeup if we block at the moment.

--- a/transport/src/main/java/io/netty/channel/local/LocalIoHandler.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalIoHandler.java
@@ -32,6 +32,7 @@ import java.util.concurrent.locks.LockSupport;
 
 public final class LocalIoHandler implements IoHandler {
     private final Set<LocalIoHandle> registeredChannels = new HashSet<LocalIoHandle>(64);
+    private IoEventLoop eventLoop;
     private volatile Thread executionThread;
 
     private LocalIoHandler() { }
@@ -68,7 +69,12 @@ public final class LocalIoHandler implements IoHandler {
     }
 
     @Override
-    public void wakeup(IoEventLoop eventLoop) {
+    public void initalize(IoEventLoop eventLoop) {
+        this.eventLoop = eventLoop;
+    }
+
+    @Override
+    public void wakeup() {
         if (!eventLoop.inEventLoop()) {
             Thread thread = executionThread;
             if (thread != null) {
@@ -91,7 +97,7 @@ public final class LocalIoHandler implements IoHandler {
     }
 
     @Override
-    public IoRegistration register(IoEventLoop eventLoop, IoHandle handle) {
+    public IoRegistration register(IoHandle handle) {
         LocalIoHandle localHandle = cast(handle);
         if (registeredChannels.add(localHandle)) {
             LocalIoRegistration registration = new LocalIoRegistration(eventLoop, localHandle);

--- a/transport/src/main/java/io/netty/channel/nio/NioIoHandler.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioIoHandler.java
@@ -608,7 +608,7 @@ public final class NioIoHandler implements IoHandler {
 
     @Override
     public void wakeup() {
-        if (!eventLoop.inEventLoop() && wakenUp.compareAndSet(false, true)) {
+        if ((eventLoop == null || !eventLoop.inEventLoop()) && wakenUp.compareAndSet(false, true)) {
             selector.wakeup();
         }
     }

--- a/transport/src/main/java/io/netty/channel/nio/NioIoHandler.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioIoHandler.java
@@ -114,6 +114,7 @@ public final class NioIoHandler implements IoHandler {
     private final SelectStrategy selectStrategy;
     private int cancelledKeys;
     private boolean needsToSelectAgain;
+    private IoEventLoop eventLoop;
 
     private NioIoHandler(SelectorProvider selectorProvider,
                          SelectStrategy strategy) {
@@ -393,7 +394,12 @@ public final class NioIoHandler implements IoHandler {
     }
 
     @Override
-    public NioIoRegistration register(IoEventLoop eventLoop, IoHandle handle)
+    public void initalize(IoEventLoop eventLoop) {
+        this.eventLoop = eventLoop;
+    }
+
+    @Override
+    public NioIoRegistration register(IoHandle handle)
             throws Exception {
         NioIoHandle nioHandle = nioHandle(handle);
         NioIoOps ops = NioIoOps.NONE;
@@ -601,7 +607,7 @@ public final class NioIoHandler implements IoHandler {
     }
 
     @Override
-    public void wakeup(IoEventLoop eventLoop) {
+    public void wakeup() {
         if (!eventLoop.inEventLoop() && wakenUp.compareAndSet(false, true)) {
             selector.wakeup();
         }

--- a/transport/src/test/java/io/netty/channel/SingleThreadIoEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/SingleThreadIoEventLoopTest.java
@@ -96,6 +96,8 @@ public class SingleThreadIoEventLoopTest {
 
     private static class TestIoHandler implements IoHandler {
         private final Semaphore semaphore = new Semaphore(0);
+        private IoEventLoop eventLoop;
+
         @Override
         public void prepareToDestroy() {
             // NOOP
@@ -107,7 +109,12 @@ public class SingleThreadIoEventLoopTest {
         }
 
         @Override
-        public IoRegistration register(final IoEventLoop eventLoop, final IoHandle handle) {
+        public void initalize(IoEventLoop eventLoop) {
+            this.eventLoop = eventLoop;
+        }
+
+        @Override
+        public IoRegistration register(final IoHandle handle) {
             return new IoRegistration() {
                 private final Promise<?> cancellationPromise = eventLoop.newPromise();
                 @Override
@@ -133,7 +140,7 @@ public class SingleThreadIoEventLoopTest {
         }
 
         @Override
-        public void wakeup(IoEventLoop eventLoop) {
+        public void wakeup() {
             semaphore.release();
         }
 


### PR DESCRIPTION
…ventLoop from the other methods

Motivation:

For some IoHandler implementations it is useful to be able to do initialization work before any work is driven by the IoEventLoop. One of such an example would be https://github.com/netty/netty/pull/14699.

Modifications:

- Add new IoHandler.initialize(IoEventLoop) method and remove IoEventLoop parameter from other methods.

Result:

Be able to do initialization work on an IoHandler
