### PR TITLE
IoHandler: Introduce IoExecutor and pass it to IoHandlerFactory.newHandler(...)

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
@@ -18,7 +18,7 @@ package io.netty.channel.epoll;
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoopTaskQueueFactory;
 import io.netty.channel.IoEventLoopGroup;
-import io.netty.channel.IoHandler;
+import io.netty.channel.IoHandlerFactory;
 import io.netty.channel.SingleThreadIoEventLoop;
 import io.netty.util.concurrent.RejectedExecutionHandler;
 import io.netty.util.internal.PlatformDependent;
@@ -38,19 +38,19 @@ public class EpollEventLoop extends SingleThreadIoEventLoop {
 
     private static final InternalLogger LOGGER = InternalLoggerFactory.getInstance(EpollEventLoop.class);
 
-    EpollEventLoop(IoEventLoopGroup parent, ThreadFactory threadFactory, IoHandler ioHandler) {
-        super(parent, threadFactory, ioHandler);
+    EpollEventLoop(IoEventLoopGroup parent, ThreadFactory threadFactory, IoHandlerFactory ioHandlerFactory) {
+        super(parent, threadFactory, ioHandlerFactory);
     }
 
-    EpollEventLoop(IoEventLoopGroup parent, Executor executor, IoHandler ioHandler) {
-        super(parent, executor, ioHandler);
+    EpollEventLoop(IoEventLoopGroup parent, Executor executor, IoHandlerFactory ioHandlerFactory) {
+        super(parent, executor, ioHandlerFactory);
     }
 
-    EpollEventLoop(IoEventLoopGroup parent, Executor executor, IoHandler ioHandler,
+    EpollEventLoop(IoEventLoopGroup parent, Executor executor, IoHandlerFactory ioHandlerFactory,
                    EventLoopTaskQueueFactory taskQueueFactory,
                    EventLoopTaskQueueFactory tailTaskQueueFactory,
                    RejectedExecutionHandler rejectedExecutionHandler) {
-        super(parent, executor, ioHandler, newTaskQueue(taskQueueFactory), newTaskQueue(tailTaskQueueFactory),
+        super(parent, executor, ioHandlerFactory, newTaskQueue(taskQueueFactory), newTaskQueue(tailTaskQueueFactory),
                 rejectedExecutionHandler);
     }
 

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoopGroup.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoopGroup.java
@@ -19,7 +19,7 @@ import io.netty.channel.DefaultSelectStrategyFactory;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.EventLoopTaskQueueFactory;
 import io.netty.channel.IoEventLoop;
-import io.netty.channel.IoHandler;
+import io.netty.channel.IoHandlerFactory;
 import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.SelectStrategyFactory;
 import io.netty.channel.SingleThreadEventLoop;
@@ -183,7 +183,7 @@ public final class EpollEventLoopGroup extends MultiThreadIoEventLoopGroup {
     }
 
     @Override
-    protected IoEventLoop newChild(Executor executor, IoHandler handler, Object... args) {
+    protected IoEventLoop newChild(Executor executor, IoHandlerFactory ioHandlerFactory, Object... args) {
         RejectedExecutionHandler rejectedExecutionHandler = (RejectedExecutionHandler) args[0];
         EventLoopTaskQueueFactory taskQueueFactory = null;
         EventLoopTaskQueueFactory tailTaskQueueFactory = null;
@@ -195,7 +195,7 @@ public final class EpollEventLoopGroup extends MultiThreadIoEventLoopGroup {
         if (argsLength > 2) {
             tailTaskQueueFactory = (EventLoopTaskQueueFactory) args[2];
         }
-        return new EpollEventLoop(this, executor, handler, taskQueueFactory, tailTaskQueueFactory,
+        return new EpollEventLoop(this, executor, ioHandlerFactory, taskQueueFactory, tailTaskQueueFactory,
                 rejectedExecutionHandler);
     }
 }

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoopGroup.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoopGroup.java
@@ -20,7 +20,7 @@ import io.netty.channel.DefaultSelectStrategyFactory;
 import io.netty.channel.EventLoopTaskQueueFactory;
 import io.netty.channel.IoEventLoopGroup;
 import io.netty.channel.IoEventLoop;
-import io.netty.channel.IoHandler;
+import io.netty.channel.IoHandlerFactory;
 import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.SelectStrategyFactory;
 import io.netty.channel.SingleThreadEventLoop;
@@ -188,7 +188,7 @@ public final class KQueueEventLoopGroup extends MultiThreadIoEventLoopGroup {
     }
 
     @Override
-    protected IoEventLoop newChild(Executor executor, IoHandler handler, Object... args) {
+    protected IoEventLoop newChild(Executor executor, IoHandlerFactory ioHandlerFactory, Object... args) {
         RejectedExecutionHandler rejectedExecutionHandler = null;
         EventLoopTaskQueueFactory taskQueueFactory = null;
         EventLoopTaskQueueFactory tailTaskQueueFactory = null;
@@ -202,17 +202,17 @@ public final class KQueueEventLoopGroup extends MultiThreadIoEventLoopGroup {
         if (argsLength > 2) {
             tailTaskQueueFactory = (EventLoopTaskQueueFactory) args[1];
         }
-        return new KQueueEventLoop(this, executor, handler,
+        return new KQueueEventLoop(this, executor, ioHandlerFactory,
                 KQueueEventLoop.newTaskQueue(taskQueueFactory),
                 KQueueEventLoop.newTaskQueue(tailTaskQueueFactory),
                 rejectedExecutionHandler);
     }
 
     private static final class KQueueEventLoop extends SingleThreadIoEventLoop {
-        KQueueEventLoop(IoEventLoopGroup parent, Executor executor, IoHandler ioHandler,
+        KQueueEventLoop(IoEventLoopGroup parent, Executor executor, IoHandlerFactory ioHandlerFactory,
                         Queue<Runnable> taskQueue, Queue<Runnable> tailTaskQueue,
                         RejectedExecutionHandler rejectedExecutionHandler) {
-            super(parent, executor, ioHandler, taskQueue, tailTaskQueue, rejectedExecutionHandler);
+            super(parent, executor, ioHandlerFactory, taskQueue, tailTaskQueue, rejectedExecutionHandler);
         }
 
         static Queue<Runnable> newTaskQueue(

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollEventLoopTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollEventLoopTest.java
@@ -64,8 +64,8 @@ public class EpollEventLoopTest extends AbstractSingleThreadEventLoopTest {
         final AtomicReference<Throwable> capture = new AtomicReference<Throwable>();
 
         final EventLoopGroup group = new EpollEventLoop(null,
-                new ThreadPerTaskExecutor(new DefaultThreadFactory(getClass())), new EpollIoHandler(0,
-                DefaultSelectStrategyFactory.INSTANCE.newSelectStrategy()) {
+                new ThreadPerTaskExecutor(new DefaultThreadFactory(getClass())), eventLoop -> new EpollIoHandler(
+                        eventLoop, 0, DefaultSelectStrategyFactory.INSTANCE.newSelectStrategy()) {
             @Override
             void handleLoopException(Throwable t) {
                 capture.set(t);

--- a/transport/src/main/java/io/netty/channel/IoExecutor.java
+++ b/transport/src/main/java/io/netty/channel/IoExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Netty Project
+ * Copyright 2025 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -15,16 +15,21 @@
  */
 package io.netty.channel;
 
+import io.netty.util.concurrent.Promise;
+
+import java.util.concurrent.Executor;
+
 /**
- * Factory for {@link IoHandler} instances.
+ * An {@link Executor} that is used to drive IO of an {@link IoHandler}.
  */
-public interface IoHandlerFactory {
+public interface IoExecutor extends Executor {
+    /**
+     * Return {@code true} if the given {@link Thread} is used by this {@link IoExecutor}.
+     */
+    boolean inExecutorThread(Thread thread);
 
     /**
-     * Creates a new {@link IoHandler} instance.
-     *
-     * @param ioExecutor        the {@link IoExecutor} for the {@link IoHandler}.
-     * @return                  a new {@link IoHandler} instance.
+     * Return a new {@link Promise}.
      */
-    IoHandler newHandler(IoExecutor ioExecutor);
+    <V> Promise<V> newPromise();
 }

--- a/transport/src/main/java/io/netty/channel/IoExecutorContext.java
+++ b/transport/src/main/java/io/netty/channel/IoExecutorContext.java
@@ -16,10 +16,11 @@
 package io.netty.channel;
 
 /**
- * The execution context for an {@link IoHandler}.
- * All methods must be called from the {@link IoEventLoop} thread.
+ * The execution context for an {@link IoExecutor}.
+ * All methods  <strong>MUST</strong> be executed on the {@link IoExecutor} thread
+ * (which means {@link IoExecutor#inExecutorThread(Thread)} must return {@code true}).
  */
-public interface IoExecutionContext {
+public interface IoExecutorContext {
     /**
      * Returns {@code true} if blocking for IO is allowed or if we should try to do a non-blocking request for IO to be
      * ready.

--- a/transport/src/main/java/io/netty/channel/IoHandle.java
+++ b/transport/src/main/java/io/netty/channel/IoHandle.java
@@ -16,8 +16,9 @@
 package io.netty.channel;
 
 /**
- * A handle that can be registered to a {@link IoEventLoop}.
- * All methods must be called from the {@link IoEventLoop} thread.
+ * A handle that can be registered to a {@link IoHandler}.
+ * All methods must be called from the {@link IoExecutor} threa (which means
+ * {@link IoExecutor#inExecutorThread(Thread)} must return {@code true})
  */
 public interface IoHandle extends AutoCloseable {
 

--- a/transport/src/main/java/io/netty/channel/MultiThreadIoEventLoopGroup.java
+++ b/transport/src/main/java/io/netty/channel/MultiThreadIoEventLoopGroup.java
@@ -190,20 +190,21 @@ public class MultiThreadIoEventLoopGroup extends MultithreadEventLoopGroup imple
         } else {
             argsCopy = EmptyArrays.EMPTY_OBJECTS;
         }
-        return newChild(executor, handlerFactory.newHandler(), argsCopy);
+        return newChild(executor, handlerFactory, argsCopy);
     }
 
     /**
      * Creates a new {@link IoEventLoop} to use with the given {@link Executor} and {@link IoHandler}.
      *
-     * @param executor      the {@link Executor} that should be used to handle execution of tasks and IO.
-     * @param ioHandler     the {@link IoHandler} that should be used to handle IO.
-     * @param args          extra arguments that are based by the constructor.
-     * @return              the created {@link IoEventLoop}.
+     * @param executor              the {@link Executor} that should be used to handle execution of tasks and IO.
+     * @param ioHandlerFactory      the {@link IoHandlerFactory} that should be used to obtain {@link IoHandler} to
+     *                              handle IO.
+     * @param args                  extra arguments that are based by the constructor.
+     * @return                      the created {@link IoEventLoop}.
      */
-    protected IoEventLoop newChild(Executor executor, IoHandler ioHandler,
+    protected IoEventLoop newChild(Executor executor, IoHandlerFactory ioHandlerFactory,
                                    @SuppressWarnings("unused") Object... args) {
-        return new SingleThreadIoEventLoop(this, executor, ioHandler);
+        return new SingleThreadIoEventLoop(this, executor, ioHandlerFactory);
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
@@ -18,6 +18,7 @@ package io.netty.channel.nio;
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoopTaskQueueFactory;
 import io.netty.channel.IoHandler;
+import io.netty.channel.IoHandlerFactory;
 import io.netty.channel.SingleThreadIoEventLoop;
 import io.netty.util.concurrent.RejectedExecutionHandler;
 import io.netty.util.internal.ObjectUtil;
@@ -46,10 +47,10 @@ public final class NioEventLoop extends SingleThreadIoEventLoop {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(NioEventLoop.class);
 
-    NioEventLoop(NioEventLoopGroup parent, Executor executor, IoHandler ioHandler,
+    NioEventLoop(NioEventLoopGroup parent, Executor executor, IoHandlerFactory ioHandlerFactory,
                  EventLoopTaskQueueFactory taskQueueFactory,
                  EventLoopTaskQueueFactory tailTaskQueueFactory, RejectedExecutionHandler rejectedExecutionHandler) {
-        super(parent, executor, ioHandler, newTaskQueue(taskQueueFactory), newTaskQueue(tailTaskQueueFactory),
+        super(parent, executor, ioHandlerFactory, newTaskQueue(taskQueueFactory), newTaskQueue(tailTaskQueueFactory),
                 rejectedExecutionHandler);
     }
 

--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoopGroup.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoopGroup.java
@@ -20,7 +20,7 @@ import io.netty.channel.DefaultSelectStrategyFactory;
 import io.netty.channel.EventLoopTaskQueueFactory;
 import io.netty.channel.IoEventLoop;
 import io.netty.channel.IoEventLoopGroup;
-import io.netty.channel.IoHandler;
+import io.netty.channel.IoHandlerFactory;
 import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.SelectStrategyFactory;
 import io.netty.channel.SingleThreadEventLoop;
@@ -177,7 +177,7 @@ public class NioEventLoopGroup extends MultiThreadIoEventLoopGroup implements Io
     }
 
     @Override
-    protected IoEventLoop newChild(Executor executor, IoHandler ioHandler, Object... args) {
+    protected IoEventLoop newChild(Executor executor, IoHandlerFactory ioHandlerFactory, Object... args) {
         RejectedExecutionHandler rejectedExecutionHandler = (RejectedExecutionHandler) args[0];
         EventLoopTaskQueueFactory taskQueueFactory = null;
         EventLoopTaskQueueFactory tailTaskQueueFactory = null;
@@ -190,6 +190,6 @@ public class NioEventLoopGroup extends MultiThreadIoEventLoopGroup implements Io
             tailTaskQueueFactory = (EventLoopTaskQueueFactory) args[2];
         }
         return new NioEventLoop(
-                this, executor, ioHandler, taskQueueFactory, tailTaskQueueFactory, rejectedExecutionHandler);
+                this, executor, ioHandlerFactory, taskQueueFactory, tailTaskQueueFactory, rejectedExecutionHandler);
     }
 }


### PR DESCRIPTION
Motivation:

The IoHandler is currently tightly coupled with the IoEventLoop while a much simplier interface can do the job.

This has various pros:
 - IoHandler can be driven without implementing a while IoEventLoop
 - IoHandler implementations can now check if a Thread is the same as the one that will be used for IoExecutors.
 - IoHandler implementations can submit work that will be executed by the sme Thread as the IoExecutor use

Modifications:

- Add IoExecutor interfance and rename IoExecutionContext to IoExecutorContext
- Remove IoEventLoop from method signatures of IoExectuorContext
- Change IoHandlerFactory.newHandler(...) to take IoExecutor as parameter
- Fix usage and tests

Result:

More flexible IoHandler implementations and more flexible way to drive IO.