### PR TITLE
IoUring: Cleanup SubmissionQueue methods to not include fd if OP don'…

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/SubmissionQueue.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/SubmissionQueue.java
@@ -170,20 +170,20 @@ final class SubmissionQueue {
         return sb.toString();
     }
 
-    long addNop(int fd, byte flags, long udata) {
-        return enqueueSqe0(Native.IORING_OP_NOP, flags, (short) 0, fd, 0, 0, 0, 0, udata,
+    long addNop(byte flags, long udata) {
+        return enqueueSqe0(Native.IORING_OP_NOP, flags, (short) 0, 0, 0, 0, 0, 0, udata,
                 (short) 0, (short) 0, 0, 0);
     }
 
-    long addTimeout(int fd, long nanoSeconds, long udata) {
+    long addTimeout(long nanoSeconds, long udata) {
         setTimeout(nanoSeconds);
-        return enqueueSqe0(Native.IORING_OP_TIMEOUT, (byte) 0, (short) 0, fd, 0, timeoutMemoryAddress, 1,
+        return enqueueSqe0(Native.IORING_OP_TIMEOUT, (byte) 0, (short) 0, 0, 0, timeoutMemoryAddress, 1,
                 0, udata, (short) 0, (short) 0, 0, 0);
     }
 
-    long addLinkTimeout(int fd, long nanoSeconds, long extraData) {
+    long addLinkTimeout(long nanoSeconds, long extraData) {
         setTimeout(nanoSeconds);
-        return enqueueSqe0(Native.IORING_OP_LINK_TIMEOUT, (byte) 0, (short) 0, fd, 0, timeoutMemoryAddress, 1,
+        return enqueueSqe0(Native.IORING_OP_LINK_TIMEOUT, (byte) 0, (short) 0, 0, 0, timeoutMemoryAddress, 1,
                 0, extraData, (short) 0, (short) 0, 0, 0);
     }
 
@@ -192,8 +192,8 @@ final class SubmissionQueue {
                 0, udata, (short) 0, (short) 0, 0, 0);
     }
 
-    long addCancel(int fd, long sqeToCancel, long udata) {
-        return enqueueSqe0(Native.IORING_OP_ASYNC_CANCEL, (byte) 0, (short) 0, fd, 0, sqeToCancel, 0, 0,
+    long addCancel(long sqeToCancel, long udata) {
+        return enqueueSqe0(Native.IORING_OP_ASYNC_CANCEL, (byte) 0, (short) 0, 0, 0, sqeToCancel, 0, 0,
                 udata, (short) 0, (short) 0, 0, 0);
     }
 

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/SubmissionQueueTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/SubmissionQueueTest.java
@@ -43,12 +43,12 @@ public class SubmissionQueueTest {
 
             int counter = 0;
             while (submissionQueue.remaining() > 0) {
-                assertThat(submissionQueue.addNop(0, (byte) 0, 1)).isNotZero();
+                assertThat(submissionQueue.addNop((byte) 0, 1)).isNotZero();
                 counter++;
             }
             assertEquals(8, counter);
             assertEquals(8, submissionQueue.count());
-            assertThat(submissionQueue.addNop(0, (byte) 0, 1)).isNotZero();
+            assertThat(submissionQueue.addNop((byte) 0, 1)).isNotZero();
             assertEquals(1, submissionQueue.count());
             submissionQueue.submitAndWait();
             assertEquals(9, completionQueue.count());


### PR DESCRIPTION
…t use i

Motivation:

We had various methods in SubmissionQueue that did add a fd to the submission queue while the OP itself does not use it. We should just use 0 in this case.

Modifications:

Remove fd from parameters of methods and just use 0

Result:

Cleanup