### PR TITLE
IoUring: Only execute write related completion inline

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -322,13 +322,13 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
         if (scheduleWrite(in) > 0) {
             ioState |= WRITE_SCHEDULED;
             if (submitAndRunNow && !isWritable() && !((IOUringChannelConfig) config()).getIoseqAsync()) {
-                // Force a submit and processing of the completions to ensure we drain the outbound buffer and
-                // send the data to the remote peer.
-                // We only do this if IOSEQ_ASYNC is not used as if its used it's impossible that the
-                // write is executed inline.
-                registration().submit(IoUringIoHandler.SUBMIT_AND_RUN_ALL);
+                submitAndRunNow();
             }
         }
+    }
+
+    protected void submitAndRunNow() {
+        // NOOP
     }
 
     private int scheduleWrite(ChannelOutboundBuffer in) {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -499,4 +499,14 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
     protected boolean socketIsEmpty(int flags) {
         return IoUring.isIOUringCqeFSockNonEmptySupported() && (flags & Native.IORING_CQE_F_SOCK_NONEMPTY) == 0;
     }
+
+    @Override
+    protected void submitAndRunNow() {
+        if (writeId != 0) {
+            // Force a submit and processing of the completions to ensure we drain the outbound buffer and
+            // send the data to the remote peer.
+            ((IoUringIoHandler) registration().ioHandler()).submitAndRunNow(writeId);
+        }
+        super.submitAndRunNow();
+    }
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionBuffer.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionBuffer.java
@@ -97,6 +97,27 @@ final class CompletionBuffer {
         return i;
     }
 
+    boolean processOneNow(CompletionCallback callback, long udata) {
+        // We basically just scan over the whole array, if this turns out to be a performance problem
+        // (we actually don't expect too many outstanding completions) it's possible to be a bit smarter.
+        //
+        // We could make the udata generation shared across channels and always increase it. Then we could use
+        // a binarySearch to find the right completion to handle. This only downside would be that this will not
+        // work once we overflow so we would need to handle this somehow.
+        int idx = head;
+        for (int i = 0; i < size; i++, idx += 2) {
+            int udataIdx = udataIdx(idx);
+            long data = array[udataIdx];
+            if (udata != data) {
+                continue;
+            }
+            long combined = array[combinedIdx(idx)];
+            array[udataIdx] = tombstone;
+            return handle(callback, combined, udata);
+        }
+        return false;
+    }
+
     private int combinedIdx(int idx) {
         return idx & mask;
     }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -48,11 +48,6 @@ import static java.util.Objects.requireNonNull;
  * {@link IoHandler} which is implemented in terms of the Linux-specific {@code io_uring} API.
  */
 public final class IoUringIoHandler implements IoHandler {
-
-    // Special IoUringIoOps that will cause a submission and running of all completions.
-    static final IoUringIoOps SUBMIT_AND_RUN_ALL = new IoUringIoOps(
-            (byte) -1, (byte) -1, (short) -1, -1, -1, -1, -1, -1, (short) -1, (short) -1, (short) -1, -1, -1);
-
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(IoUringIoHandler.class);
     private static final short RING_CLOSE = 1;
 
@@ -135,6 +130,15 @@ public final class IoUringIoHandler implements IoHandler {
         CompletionQueue completionQueue = ringBuffer.ioUringCompletionQueue();
         if (submissionQueue.submit() > 0) {
             processedPerRun += drainAndProcessAll(completionQueue, this::handle);
+        }
+    }
+
+    void submitAndRunNow(long udata) {
+        SubmissionQueue submissionQueue = ringBuffer.ioUringSubmissionQueue();
+        CompletionQueue completionQueue = ringBuffer.ioUringCompletionQueue();
+        if (submissionQueue.submit() > 0) {
+            completionBuffer.drain(completionQueue);
+            completionBuffer.processOneNow(this::handle, udata);
         }
     }
 
@@ -396,15 +400,11 @@ public final class IoUringIoHandler implements IoHandler {
         }
 
         private void submit0(IoUringIoOps ioOps, long udata) {
-            if (ioOps == SUBMIT_AND_RUN_ALL) {
-                submitAndRunNow();
-            } else {
-                ringBuffer.ioUringSubmissionQueue().enqueueSqe(ioOps.opcode(), ioOps.flags(), ioOps.ioPrio(),
-                        ioOps.fd(), ioOps.union1(), ioOps.union2(), ioOps.len(), ioOps.union3(), udata,
-                        ioOps.union4(), ioOps.personality(), ioOps.union5(), ioOps.union6()
-                );
-                outstandingCompletions++;
-            }
+            ringBuffer.ioUringSubmissionQueue().enqueueSqe(ioOps.opcode(), ioOps.flags(), ioOps.ioPrio(),
+                    ioOps.fd(), ioOps.union1(), ioOps.union2(), ioOps.len(), ioOps.union3(), udata,
+                    ioOps.union4(), ioOps.personality(), ioOps.union5(), ioOps.union6()
+            );
+            outstandingCompletions++;
         }
 
         @Override


### PR DESCRIPTION
Motivation:

4d868a6da3aeb0b222ac24c8bf5f63a416f74ecf added a change which will case the completion queue to be drained and run after a Channel becomes unwritable. Doing so might produce a very deeÃp callstack if some completions will trigger an unwritable state for a different Channel. We should better only run the completion that belongs to the WRITE / WRITEV itself.

Modifications:

Only run the specific completion that will affect the writability of the Channel itself.

Result:

Guard against super deep callstack