### PR TITLE
IoUring: Use IORING_REGISTER_RING_FDS when possible

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -108,8 +108,7 @@ public final class IoUringIoHandler implements IoHandler {
 
     @Override
     public void initialize() {
-        // We create our ring in disabled mode and so need to enable it first.
-        Native.ioUringRegisterEnableRings(ringBuffer.fd());
+        ringBuffer.enable();
     }
 
     @Override

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -252,6 +252,7 @@ final class Native {
     }
 
     static final int IORING_ENTER_GETEVENTS = NativeStaticallyReferencedJniMethods.ioringEnterGetevents();
+    static final int IORING_ENTER_REGISTERED_RING = 1 << 4;
     static final int IOSQE_ASYNC = NativeStaticallyReferencedJniMethods.iosqeAsync();
     static final int IOSQE_LINK = NativeStaticallyReferencedJniMethods.iosqeLink();
     static final int IOSQE_IO_DRAIN = NativeStaticallyReferencedJniMethods.iosqeDrain();
@@ -421,9 +422,8 @@ final class Native {
     private static native long[] ioUringSetup(int entries, int setupFlags);
 
     static native int ioUringRegisterIoWqMaxWorkers(int ringFd, int maxBoundedValue, int maxUnboundedValue);
-
     static native int ioUringRegisterEnableRings(int ringFd);
-
+    static native int ioUringRegisterRingFds(int ringFds);
     static native int ioUringEnter(int ringFd, int toSubmit, int minComplete, int flags);
 
     static native void eventFdWrite(int fd, long value);
@@ -441,7 +441,7 @@ final class Native {
     static native void ioUringExit(long submissionQueueArrayAddress, int submissionQueueRingEntries,
                                           long submissionQueueRingAddress, int submissionQueueRingSize,
                                           long completionQueueRingAddress, int completionQueueRingSize,
-                                          int ringFd);
+                                          int ringFd, int enterRingFd);
 
     private static native int blockingEventFd();
 

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/RingBuffer.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/RingBuffer.java
@@ -20,10 +20,24 @@ final class RingBuffer {
     private final SubmissionQueue ioUringSubmissionQueue;
     private final CompletionQueue ioUringCompletionQueue;
     private final int features;
-    RingBuffer(SubmissionQueue ioUringSubmissionQueue, CompletionQueue ioUringCompletionQueue, int features) {
+
+    RingBuffer(SubmissionQueue ioUringSubmissionQueue,
+               CompletionQueue ioUringCompletionQueue, int features) {
         this.ioUringSubmissionQueue = ioUringSubmissionQueue;
         this.ioUringCompletionQueue = ioUringCompletionQueue;
         this.features = features;
+    }
+
+    /**
+     * Enable ring. This method must be called from the same method that will call {@link SubmissionQueue#submit()} and
+     * {@link SubmissionQueue#submitAndWait()}.
+     */
+    void enable() {
+        // We create our ring in disabled mode and so need to enable it first.
+        Native.ioUringRegisterEnableRings(fd());
+        // Now also register the ring filedescriptor itself. This needs to happen in the same thread
+        // that will also call the io_uring_enter(...)
+        ioUringSubmissionQueue.tryRegisterRingFd();
     }
 
     int fd() {
@@ -51,6 +65,6 @@ final class RingBuffer {
                 ioUringSubmissionQueue.ringSize,
                 ioUringCompletionQueue.ringAddress,
                 ioUringCompletionQueue.ringSize,
-                ioUringCompletionQueue.ringFd);
+                ioUringSubmissionQueue.ringFd, ioUringSubmissionQueue.enterRingFd);
     }
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/RingBuffer.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/RingBuffer.java
@@ -65,6 +65,7 @@ final class RingBuffer {
                 ioUringSubmissionQueue.ringSize,
                 ioUringCompletionQueue.ringAddress,
                 ioUringCompletionQueue.ringSize,
-                ioUringSubmissionQueue.ringFd, ioUringSubmissionQueue.enterRingFd);
+                ioUringSubmissionQueue.ringFd,
+                ioUringSubmissionQueue.enterRingFd);
     }
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/SubmissionQueue.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/SubmissionQueue.java
@@ -64,13 +64,16 @@ final class SubmissionQueue {
     final int ringSize;
     final long ringAddress;
     final int ringFd;
+    int enterRingFd;
+    private int enterFlags;
     private final long timeoutMemoryAddress;
     private int head;
     private int tail;
 
     SubmissionQueue(long kHeadAddress, long kTailAddress, long kRingMaskAddress, long kRingEntriesAddress,
                     long kFlagsAddress, long kDroppedAddress, long kArrayAddress,
-                    long submissionQueueArrayAddress, int ringSize, long ringAddress, int ringFd) {
+                    long submissionQueueArrayAddress, int ringSize, long ringAddress,
+                    int ringFd) {
         this.kHeadAddress = kHeadAddress;
         this.kTailAddress = kTailAddress;
         this.kFlagsAddress = kFlagsAddress;
@@ -80,6 +83,7 @@ final class SubmissionQueue {
         this.ringSize = ringSize;
         this.ringAddress = ringAddress;
         this.ringFd = ringFd;
+        this.enterRingFd = ringFd;
         this.ringEntries = PlatformDependent.getIntVolatile(kRingEntriesAddress);
         this.ringMask = PlatformDependent.getIntVolatile(kRingMaskAddress);
         this.head = PlatformDependent.getIntVolatile(kHeadAddress);
@@ -95,6 +99,22 @@ final class SubmissionQueue {
         for (int i = 0; i < ringEntries; i++, address += INT_SIZE) {
             PlatformDependent.putInt(address, i);
         }
+    }
+
+    void tryRegisterRingFd() {
+        // Try to use IORING_REGISTER_RING_FDS.
+        // See https://manpages.debian.org/unstable/liburing-dev/io_uring_register.2.en.html#IORING_REGISTER_RING_FDS
+        int enterRingFd = Native.ioUringRegisterRingFds(ringFd);
+        final int enterFlags;
+        if (enterRingFd < 0) {
+            // Use of IORING_REGISTER_RING_FDS failed, just use the ring fd directly.
+            enterRingFd = ringFd;
+            enterFlags = 0;
+        } else {
+            enterFlags = Native.IORING_ENTER_REGISTERED_RING;
+        }
+        this.enterRingFd = enterRingFd;
+        this.enterFlags = enterFlags;
     }
 
     private long enqueueSqe0(byte opcode, byte flags, short ioPrio, int fd, long union1, long union2, int len,
@@ -149,11 +169,11 @@ final class SubmissionQueue {
 
         if (logger.isTraceEnabled()) {
             if (opcode == Native.IORING_OP_WRITEV || opcode == Native.IORING_OP_READV) {
-                logger.trace("add(ring {}): {}(fd={}, len={} ({} bytes), off={}, data={})",
-                        ringFd, Native.opToStr(opcode), fd, len, Iov.sumSize(union2, len), union1, udata);
+                logger.trace("add(ring={}, enterRing:{} ): {}(fd={}, len={} ({} bytes), off={}, data={})",
+                        ringFd, enterRingFd, Native.opToStr(opcode), fd, len, Iov.sumSize(union2, len), union1, udata);
             } else {
-                logger.trace("add(ring {}): {}(fd={}, len={}, off={}, data={})",
-                        ringFd, Native.opToStr(opcode), fd, len, union1, udata);
+                logger.trace("add(ring={}, enterRing:{}): {}(fd={}, len={}, off={}, data={})",
+                        ringFd, enterRingFd, Native.opToStr(opcode), fd, len, union1, udata);
             }
         }
     }
@@ -212,7 +232,7 @@ final class SubmissionQueue {
             return submit(submit, 1, Native.IORING_ENTER_GETEVENTS);
         }
         assert submit == 0;
-        int ret = Native.ioUringEnter(ringFd, 0, 1, Native.IORING_ENTER_GETEVENTS);
+        int ret = ioUringEnter(0, 1, Native.IORING_ENTER_GETEVENTS);
         if (ret < 0) {
             throw new RuntimeException("ioUringEnter syscall returned " + ret);
         }
@@ -220,11 +240,8 @@ final class SubmissionQueue {
     }
 
     private int submit(int toSubmit, int minComplete, int flags) {
-        if (logger.isTraceEnabled()) {
-            logger.trace("submit(ring {}): {}", ringFd, toString());
-        }
         PlatformDependent.putIntOrdered(kTailAddress, tail); // release memory barrier
-        int ret = Native.ioUringEnter(ringFd, toSubmit, minComplete, flags);
+        int ret = ioUringEnter(toSubmit, minComplete, flags);
         head = PlatformDependent.getIntVolatile(kHeadAddress); // acquire memory barrier
         if (ret != toSubmit) {
             if (ret < 0) {
@@ -234,6 +251,15 @@ final class SubmissionQueue {
             logger.trace("Not all submissions succeeded. Only {} of {} SQEs were submitted.", ret, toSubmit);
         }
         return ret;
+    }
+
+    private int ioUringEnter(int toSubmit, int minComplete, int flags) {
+        int f = enterFlags | flags;
+        if (logger.isTraceEnabled()) {
+            logger.trace("io_uring_enter(ring={}, enterRing={}, toSubmit={}, minComplete={}, flags={}): {}",
+                    ringFd, enterRingFd, toSubmit, minComplete, f, toString());
+        }
+        return Native.ioUringEnter(enterRingFd, toSubmit, minComplete, f);
     }
 
     private void setTimeout(long timeoutNanoSeconds) {

--- a/transport-native-io_uring/src/main/c/io_uring.h
+++ b/transport-native-io_uring/src/main/c/io_uring.h
@@ -336,6 +336,10 @@ enum {
 	/* set/get max number of io-wq workers */
 	IORING_REGISTER_IOWQ_MAX_WORKERS	= 19,
 
+	/* register/unregister io_uring fd with the ring */
+	IORING_REGISTER_RING_FDS		= 20,
+	IORING_UNREGISTER_RING_FDS		= 21,
+
 	/* this goes last */
 	IORING_REGISTER_LAST
 };
@@ -344,6 +348,12 @@ struct io_uring_files_update {
 	__u32 offset;
 	__u32 resv;
 	__aligned_u64 /* __s32 * */ fds;
+};
+
+struct io_uring_rsrc_update {
+	__u32 offset;
+	__u32 resv;
+	__aligned_u64 data;
 };
 
 #define IO_URING_OP_SUPPORTED	(1U << 0)

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/SubmissionQueueTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/SubmissionQueueTest.java
@@ -33,7 +33,7 @@ public class SubmissionQueueTest {
     @Test
     public void sqeFullTest() {
         RingBuffer ringBuffer = Native.createRingBuffer(8, 0);
-        Native.ioUringRegisterEnableRings(ringBuffer.fd());
+        ringBuffer.enable();
         try {
             SubmissionQueue submissionQueue = ringBuffer.ioUringSubmissionQueue();
             final CompletionQueue completionQueue = ringBuffer.ioUringCompletionQueue();


### PR DESCRIPTION
Motivation:

If IORING_REGISTER_RING_FDS can be used we should do so to reduce overhead on io_uring_enter(...)

Modification:

Make use of IORING_REGISTER_RING_FDS

Result:

Less overhead during io_uring_enter(...)