### PR TITLE
ChannelPipeline: If ChannelHandlerContext.isRemoved() returns true we…

### DIFF
--- a/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
@@ -673,7 +673,7 @@ public class DefaultChannelPipeline implements ChannelPipeline {
                 return null;
             }
 
-            if (ctx.handler() == handler) {
+            if (ctx.handler() == handler && !ctx.isRemoved()) {
                 return ctx;
             }
 
@@ -690,7 +690,7 @@ public class DefaultChannelPipeline implements ChannelPipeline {
             if (ctx == null) {
                 return null;
             }
-            if (handlerType.isAssignableFrom(ctx.handler().getClass())) {
+            if (handlerType.isAssignableFrom(ctx.handler().getClass()) && !ctx.isRemoved()) {
                 return ctx;
             }
             ctx = ctx.next;
@@ -705,7 +705,9 @@ public class DefaultChannelPipeline implements ChannelPipeline {
             if (ctx == null) {
                 return list;
             }
-            list.add(ctx.name());
+            if (!ctx.isRemoved()) {
+                list.add(ctx.name());
+            }
             ctx = ctx.next;
         }
     }
@@ -718,7 +720,9 @@ public class DefaultChannelPipeline implements ChannelPipeline {
             if (ctx == tail) {
                 return map;
             }
-            map.put(ctx.name(), ctx.handler());
+            if (!ctx.isRemoved()) {
+                map.put(ctx.name(), ctx.handler());
+            }
             ctx = ctx.next;
         }
     }
@@ -742,12 +746,13 @@ public class DefaultChannelPipeline implements ChannelPipeline {
                 break;
             }
 
-            buf.append('(')
-               .append(ctx.name())
-               .append(" = ")
-               .append(ctx.handler().getClass().getName())
-               .append(')');
-
+            if (!ctx.isRemoved()) {
+                buf.append('(')
+                        .append(ctx.name())
+                        .append(" = ")
+                        .append(ctx.handler().getClass().getName())
+                        .append(')');
+            }
             ctx = ctx.next;
             if (ctx == tail) {
                 break;


### PR DESCRIPTION
… also must return null for ChannelPipeline.context(...)

Motivation:

We might end up in a situation where isRemoved() returns true but the ChannelHandlerContext is still not completely removed from the internal datastructure of DefaultChannelPipeline. In this case we need to ensure we skip it when scanning the handlers in the pipeline to make methods like context(...) and get(...) behave consistent.

Modifications:

Check if the context was removed before consider it as "still in the pipeline".

Result:

Fixes https://github.com/netty/netty/issues/14679
