### PR TITLE
Fix SSLEngineTest.testBufferUnderflowPacketSizeDependency(...)

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -4797,7 +4797,7 @@ public abstract class SSLEngineTest {
 
             handshake(param.type(), param.delegate(), clientEngine, serverEngine);
             fail();
-        } catch (SSLHandshakeException expected) {
+        } catch (SSLException expected) {
             // Expected
         } finally {
             cleanupClientSslEngine(clientEngine);


### PR DESCRIPTION
Motivation:

Seems like the test does not really work on all OS'es / JDKs the same way. Sometimes we observe a SSLHandshakeException and sometimes a SSLException.

Modifications:

Just catch SSLException (SSLHandshakeException is a sub-type)

Result:

Testsuite pass again on all combinations