### PR TITLE
IoUring: Refactor timeout submissions to be less error prone

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -42,6 +42,8 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static java.lang.Math.max;
+import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -65,6 +67,7 @@ public final class IoUringIoHandler implements IoHandler {
     private final AtomicBoolean eventfdAsyncNotify = new AtomicBoolean();
     private final FileDescriptor eventfd;
     private final long eventfdReadBuf;
+    private final long timeoutMemoryAddress;
 
     private long eventfdReadSubmitted;
     private boolean eventFdClosing;
@@ -77,6 +80,11 @@ public final class IoUringIoHandler implements IoHandler {
     private static final int EVENTFD_ID = Integer.MAX_VALUE;
     private static final int RINGFD_ID = EVENTFD_ID - 1;
     private static final int INVALID_ID = 0;
+
+    private static final int KERNEL_TIMESPEC_SIZE = 16; //__kernel_timespec
+
+    private static final int KERNEL_TIMESPEC_TV_SEC_FIELD = 0;
+    private static final int KERNEL_TIMESPEC_TV_NSEC_FIELD = 8;
 
     private final CompletionBuffer completionBuffer;
     private final IoExecutor executor;
@@ -100,6 +108,7 @@ public final class IoUringIoHandler implements IoHandler {
         registrations = new IntObjectHashMap<>();
         eventfd = Native.newBlockingEventFd();
         eventfdReadBuf = PlatformDependent.allocateMemory(8);
+        this.timeoutMemoryAddress = PlatformDependent.allocateMemory(KERNEL_TIMESPEC_SIZE);
 
         // We buffer a maximum of 2 * CompletionQueue.ringSize completions before we drain them in batches.
         // Also as we never submit an udata which is 0L we use this as the tombstone marker.
@@ -121,10 +130,8 @@ public final class IoUringIoHandler implements IoHandler {
             if (eventfdReadSubmitted == 0) {
                 submitEventFdRead();
             }
-            if (context.deadlineNanos() != -1) {
-                submitTimeout(context);
-            }
-            submissionQueue.submitAndWait();
+            long timeoutNanos = context.deadlineNanos() == -1 ? -1 : context.delayNanos(System.nanoTime());
+            submitAndWaitWithTimeout(submissionQueue, false, timeoutNanos);
         } else {
             submissionQueue.submit();
         }
@@ -222,11 +229,32 @@ public final class IoUringIoHandler implements IoHandler {
                 eventfd.intValue(), eventfdReadBuf, 0, 8, udata);
     }
 
-    private void submitTimeout(IoExecutorContext context) {
-        long delayNanos = context.delayNanos(System.nanoTime());
-        long udata = UserData.encode(RINGFD_ID, Native.IORING_OP_TIMEOUT, (short) 0);
+    private int submitAndWaitWithTimeout(SubmissionQueue submissionQueue,
+                                         boolean linkTimeout, long timeoutNanoSeconds) {
+        if (timeoutNanoSeconds != -1) {
+            long udata = UserData.encode(RINGFD_ID,
+                    linkTimeout ? Native.IORING_OP_LINK_TIMEOUT : Native.IORING_OP_TIMEOUT, (short) 0);
+            // We use the same timespec pointer for all add*Timeout operations. This only works because we call
+            // submit directly after it. This ensures the submitted timeout is considered "stable" and so can be reused.
+            long seconds, nanoSeconds;
+            if (timeoutNanoSeconds == 0) {
+                seconds = 0;
+                nanoSeconds = 0;
+            } else {
+                seconds = (int) min(timeoutNanoSeconds / 1000000000L, Integer.MAX_VALUE);
+                nanoSeconds = (int) max(timeoutNanoSeconds - seconds * 1000000000L, 0);
+            }
 
-        ringBuffer.ioUringSubmissionQueue().addTimeout(delayNanos, udata);
+            PlatformDependent.putLong(timeoutMemoryAddress + KERNEL_TIMESPEC_TV_SEC_FIELD, seconds);
+            PlatformDependent.putLong(timeoutMemoryAddress + KERNEL_TIMESPEC_TV_NSEC_FIELD, nanoSeconds);
+
+            if (linkTimeout) {
+                submissionQueue.addLinkTimeout(timeoutMemoryAddress, udata);
+            } else {
+                submissionQueue.addTimeout(timeoutMemoryAddress, udata);
+            }
+        }
+        return submissionQueue.submitAndWait();
     }
 
     @Override
@@ -268,9 +296,7 @@ public final class IoUringIoHandler implements IoHandler {
         long udata = UserData.encode(RINGFD_ID, Native.IORING_OP_NOP, (short) 0);
         submissionQueue.addNop((byte) Native.IOSQE_IO_DRAIN, udata);
         // ... but only wait for 200 milliseconds on this
-        udata = UserData.encode(RINGFD_ID, Native.IORING_OP_LINK_TIMEOUT, (short) 0);
-        submissionQueue.addLinkTimeout(TimeUnit.MILLISECONDS.toNanos(200), udata);
-        submissionQueue.submitAndWait();
+        submitAndWaitWithTimeout(submissionQueue, true, TimeUnit.MILLISECONDS.toNanos(200));
         completionQueue.process(this::handle);
         completeRingClose();
     }
@@ -336,6 +362,7 @@ public final class IoUringIoHandler implements IoHandler {
             logger.warn("Failed to close eventfd", e);
         }
         PlatformDependent.freeMemory(eventfdReadBuf);
+        PlatformDependent.freeMemory(timeoutMemoryAddress);
     }
 
     @Override

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/RingBuffer.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/RingBuffer.java
@@ -43,7 +43,6 @@ final class RingBuffer {
     }
 
     void close() {
-        ioUringSubmissionQueue.release();
         Native.ioUringExit(
                 ioUringSubmissionQueue.submissionQueueArrayAddress,
                 ioUringSubmissionQueue.ringEntries,

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/SubmissionQueue.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/SubmissionQueue.java
@@ -21,15 +21,11 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.util.StringJoiner;
 
-import static java.lang.Math.max;
-import static java.lang.Math.min;
-
 final class SubmissionQueue {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(SubmissionQueue.class);
 
     private static final long SQE_SIZE = 64;
     private static final int INT_SIZE = Integer.BYTES; //no 32 Bit support?
-    private static final int KERNEL_TIMESPEC_SIZE = 16; //__kernel_timespec
 
     //these offsets are used to access specific properties
     //SQE https://github.com/axboe/liburing/blob/liburing-2.6/src/include/liburing/io_uring.h#L30
@@ -47,9 +43,6 @@ final class SubmissionQueue {
     private static final int SQE_UNION5_FIELD = 44;
     private static final int SQE_UNION6_FIELD = 48;
 
-    private static final int KERNEL_TIMESPEC_TV_SEC_FIELD = 0;
-    private static final int KERNEL_TIMESPEC_TV_NSEC_FIELD = 8;
-
     //these unsigned integer pointers(shared with the kernel) will be changed by the kernel
     private final long kHeadAddress;
     private final long kTailAddress;
@@ -64,7 +57,6 @@ final class SubmissionQueue {
     final int ringSize;
     final long ringAddress;
     final int ringFd;
-    private final long timeoutMemoryAddress;
     private int head;
     private int tail;
 
@@ -84,8 +76,6 @@ final class SubmissionQueue {
         this.ringMask = PlatformDependent.getIntVolatile(kRingMaskAddress);
         this.head = PlatformDependent.getIntVolatile(kHeadAddress);
         this.tail = PlatformDependent.getIntVolatile(kTailAddress);
-
-        this.timeoutMemoryAddress = PlatformDependent.allocateMemory(KERNEL_TIMESPEC_SIZE);
 
         // Zero the whole SQE array first
         PlatformDependent.setMemory(submissionQueueArrayAddress, ringEntries * SQE_SIZE, (byte) 0);
@@ -175,16 +165,14 @@ final class SubmissionQueue {
                 (short) 0, (short) 0, 0, 0);
     }
 
-    long addTimeout(long nanoSeconds, long udata) {
-        setTimeout(nanoSeconds);
+    long addTimeout(long timeoutMemoryAddress, long udata) {
         // Mimic what liburing does. We want to use a count of 1:
         // https://github.com/axboe/liburing/blob/liburing-2.8/src/include/liburing.h#L599
         return enqueueSqe0(Native.IORING_OP_TIMEOUT, (byte) 0, (short) 0, -1, 1, timeoutMemoryAddress, 1,
                 0, udata, (short) 0, (short) 0, 0, 0);
     }
 
-    long addLinkTimeout(long nanoSeconds, long extraData) {
-        setTimeout(nanoSeconds);
+    long addLinkTimeout(long timeoutMemoryAddress, long extraData) {
         // Mimic what liburing does:
         // https://github.com/axboe/liburing/blob/liburing-2.8/src/include/liburing.h#L687
         return enqueueSqe0(Native.IORING_OP_LINK_TIMEOUT, (byte) 0, (short) 0, -1, 1, timeoutMemoryAddress, 1,
@@ -236,31 +224,11 @@ final class SubmissionQueue {
         return ret;
     }
 
-    private void setTimeout(long timeoutNanoSeconds) {
-        long seconds, nanoSeconds;
-
-        if (timeoutNanoSeconds == 0) {
-            seconds = 0;
-            nanoSeconds = 0;
-        } else {
-            seconds = (int) min(timeoutNanoSeconds / 1000000000L, Integer.MAX_VALUE);
-            nanoSeconds = (int) max(timeoutNanoSeconds - seconds * 1000000000L, 0);
-        }
-
-        PlatformDependent.putLong(timeoutMemoryAddress + KERNEL_TIMESPEC_TV_SEC_FIELD, seconds);
-        PlatformDependent.putLong(timeoutMemoryAddress + KERNEL_TIMESPEC_TV_NSEC_FIELD, nanoSeconds);
-    }
-
     public int count() {
         return tail - head;
     }
 
     public int remaining() {
         return ringEntries - count();
-    }
-
-    //delete memory
-    public void release() {
-        PlatformDependent.freeMemory(timeoutMemoryAddress);
     }
 }


### PR DESCRIPTION
Motivation:

We use the same timespec pointer for all IORING_OP_TIMEOUT and IORING_OP_LINK_TIMEOUT per RingBuffer and so per IoUringHandler. This only works as we ensure we submit the timeout (via io_uring_enter(...)) and so these an be considered stable. Let's move the code to IoUringIoHandler and ensure we will always follow it with a io_uring_enter(...).

Modifications:

Move code to make it less error-prone in the future.

Result:

Cleanup / More robust code