### PR TITLE
IoUring: Correctly handle submissions if the kernel does not support …

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/SubmissionQueue.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/SubmissionQueue.java
@@ -273,9 +273,10 @@ final class SubmissionQueue {
             if (ret == toSubmit) {
                 return submitted;
             }
-            // some submission might fail if these are done inline and failed.
-            logger.trace("Not all submissions succeeded. Only {} of {} SQEs were submitted.", ret, toSubmit);
-
+            if (logger.isTraceEnabled()) {
+                // some submission might fail if these are done inline and failed.
+                logger.trace("Not all submissions succeeded. Only {} of {} SQEs were submitted.", ret, toSubmit);
+            }
             toSubmit -= ret;
         }
     }


### PR DESCRIPTION
…IORING_SETUP_SUBMIT_ALL

Motivation:

If we cant use IORING_SETUP_SUBMIT_ALL we need to ensure we loop until we were able to submit everything as io_uring_enter(...) will stop submitting on the first error.

See https://man7.org/linux/man-pages/man2/io_uring_setup.2.html

Modifications:

Loop until we were able to submit everything when IORING_SETUP_SUBMIT_ALL is not used.

Result:

Consistent handle submissions.
