### PR TITLE
Decoupling channel processing order from channel pool

### DIFF
--- a/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
@@ -19,6 +19,9 @@ import static io.netty.util.internal.ObjectUtil.checkPositive;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
+import io.netty.channel.pool.processingorder.FifoChannelProcessingOrder;
+import io.netty.channel.pool.processingorder.LifoChannelProcessingOrder;
+import io.netty.channel.pool.processingorder.ChannelProcessingOrder;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
@@ -149,6 +152,10 @@ public class FixedChannelPool extends SimpleChannelPool {
     }
 
     /**
+     * @deprecated Use {@link #FixedChannelPool(Bootstrap, ChannelPoolHandler, ChannelHealthChecker,
+     * AcquireTimeoutAction, long, int, int, boolean, ChannelProcessingOrder)} instead. The {@code lastRecentUsed}
+     * parameter is replaced by {@link ChannelProcessingOrder}.
+     *
      * Creates a new instance.
      *
      * @param bootstrap             the {@link Bootstrap} that is used for connections
@@ -168,13 +175,45 @@ public class FixedChannelPool extends SimpleChannelPool {
      *                              {@code true}.
      * @param lastRecentUsed        {@code true} {@link Channel} selection will be LIFO, if {@code false} FIFO.
      */
+    @Deprecated
     public FixedChannelPool(Bootstrap bootstrap,
                             ChannelPoolHandler handler,
                             ChannelHealthChecker healthCheck, AcquireTimeoutAction action,
                             final long acquireTimeoutMillis,
                             int maxConnections, int maxPendingAcquires,
                             boolean releaseHealthCheck, boolean lastRecentUsed) {
-        super(bootstrap, handler, healthCheck, releaseHealthCheck, lastRecentUsed);
+        this(bootstrap, handler, healthCheck, action, acquireTimeoutMillis, maxConnections, maxPendingAcquires,
+                releaseHealthCheck,
+                lastRecentUsed ? new LifoChannelProcessingOrder() : new FifoChannelProcessingOrder());
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param bootstrap             the {@link Bootstrap} that is used for connections
+     * @param handler               the {@link ChannelPoolHandler} that will be notified for the different pool actions
+     * @param healthCheck           the {@link ChannelHealthChecker} that will be used to check if a {@link Channel} is
+     *                              still healthy when obtain from the {@link ChannelPool}
+     * @param action                the {@link AcquireTimeoutAction} to use or {@code null} if non should be used.
+     *                              In this case {@param acquireTimeoutMillis} must be {@code -1}.
+     * @param acquireTimeoutMillis  the time (in milliseconds) after which an pending acquire must complete or
+     *                              the {@link AcquireTimeoutAction} takes place.
+     * @param maxConnections        the number of maximal active connections, once this is reached new tries to
+     *                              acquire a {@link Channel} will be delayed until a connection is returned to the
+     *                              pool again.
+     * @param maxPendingAcquires    the maximum number of pending acquires. Once this is exceed acquire tries will
+     *                              be failed.
+     * @param releaseHealthCheck    will check channel health before offering back if this parameter set to
+     *                              {@code true}.
+     * @param processingOrder       the {@link ChannelProcessingOrder} that is used to retrieve {@link Channel}
+     */
+    public FixedChannelPool(Bootstrap bootstrap,
+                            ChannelPoolHandler handler,
+                            ChannelHealthChecker healthCheck, AcquireTimeoutAction action,
+                            final long acquireTimeoutMillis,
+                            int maxConnections, int maxPendingAcquires,
+                            boolean releaseHealthCheck, ChannelProcessingOrder processingOrder) {
+        super(bootstrap, handler, healthCheck, releaseHealthCheck, processingOrder);
         checkPositive(maxConnections, "maxConnections");
         checkPositive(maxPendingAcquires, "maxPendingAcquires");
         if (action == null && acquireTimeoutMillis == -1) {

--- a/transport/src/main/java/io/netty/channel/pool/processingorder/ChannelProcessingOrder.java
+++ b/transport/src/main/java/io/netty/channel/pool/processingorder/ChannelProcessingOrder.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.pool.processingorder;
+
+import io.netty.channel.Channel;
+
+/**
+ * Beyond FIFO (First In, First Out) and LIFO (Last In, First Out), there are other types of order types commonly
+ * used in programming and data structures.
+ */
+public interface ChannelProcessingOrder {
+
+    /**
+     * Poll a {@link Channel} out of the internal storage to reuse it. This will return {@code null} if no
+     * {@link Channel} is ready to be reused. Be aware that implementations of these methods needs to be thread-safe!
+     */
+    Channel pollChannel();
+
+    /**
+     * Offer a {@link Channel} back to the internal storage. This will return {@code true} if the {@link Channel}
+     * could be added, {@code false} otherwise. Be aware that implementations of these methods needs to be thread-safe!
+     */
+    boolean offerChannel(Channel channel);
+}

--- a/transport/src/main/java/io/netty/channel/pool/processingorder/FifoChannelProcessingOrder.java
+++ b/transport/src/main/java/io/netty/channel/pool/processingorder/FifoChannelProcessingOrder.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.pool.processingorder;
+
+import io.netty.channel.Channel;
+import io.netty.util.internal.PlatformDependent;
+
+import java.util.Deque;
+
+/**
+ * FIFO (First In, First Out)
+ */
+public class FifoChannelProcessingOrder implements ChannelProcessingOrder {
+
+    private final Deque<Channel> deque = PlatformDependent.newConcurrentDeque();
+
+    @Override
+    public Channel pollChannel() {
+        return this.deque.pollFirst();
+    }
+
+    @Override
+    public boolean offerChannel(Channel channel) {
+        return this.deque.offer(channel);
+    }
+}

--- a/transport/src/main/java/io/netty/channel/pool/processingorder/LifoChannelProcessingOrder.java
+++ b/transport/src/main/java/io/netty/channel/pool/processingorder/LifoChannelProcessingOrder.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.pool.processingorder;
+
+import io.netty.channel.Channel;
+import io.netty.util.internal.PlatformDependent;
+
+import java.util.Deque;
+
+/**
+ * LIFO (Last In, First Out)
+ */
+public class LifoChannelProcessingOrder implements ChannelProcessingOrder {
+
+    private final Deque<Channel> deque = PlatformDependent.newConcurrentDeque();
+
+    @Override
+    public Channel pollChannel() {
+        return this.deque.pollLast();
+    }
+
+    @Override
+    public boolean offerChannel(Channel channel) {
+        return this.deque.offer(channel);
+    }
+}

--- a/transport/src/main/java/io/netty/channel/pool/processingorder/package-info.java
+++ b/transport/src/main/java/io/netty/channel/pool/processingorder/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Implementations and API for {@link io.netty.channel.pool.processingorder.ChannelProcessingOrder}.
+ */
+package io.netty.channel.pool.processingorder;


### PR DESCRIPTION
Motivation:
* Decoupling channel processing order from the channel pool is a good design pattern because we separate the responsibilities.
* There are some scenarios where using FIFO and changing to LIFO during high load can improve the latency. Of course, this scenario depends a lot, but with the interface `ChannelProcessingOrder`, we can now create a different project with those algorithms and testing scenarios.

Modification:
* Deprecate the constructor that uses `boolean::lastRecentUsed`;
* Create a new constructor that accepts the `processingOrder` instance.
* `FifoChannelProcessingOrder` and `LifoChannelProcessingOrder` are currently presented in the project.
* Tests created in https://github.com/netty/netty/pull/15298
* Test changed in order to use the new classes and avoid using the deprecated constructor

Result:

I can create custom implementations of `ChannelProcessingOrder`
