### PR TITLE
IoUring: Rename IoUringIoHandlerConfiguration to IoUringIoHandlerConfig

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -89,7 +89,7 @@ public final class IoUringIoHandler implements IoHandler {
     private final CompletionBuffer completionBuffer;
     private final IoExecutor executor;
 
-    IoUringIoHandler(IoExecutor executor, IoUringIoHandlerConfiguration config) {
+    IoUringIoHandler(IoExecutor executor, IoUringIoHandlerConfig config) {
         // Ensure that we load all native bits as otherwise it may fail when try to use native methods in IovArray
         IoUring.ensureAvailability();
         this.executor = requireNonNull(executor, "executor");
@@ -547,7 +547,7 @@ public final class IoUringIoHandler implements IoHandler {
      * @return factory
      */
     public static IoHandlerFactory newFactory() {
-        return newFactory(new IoUringIoHandlerConfiguration());
+        return newFactory(new IoUringIoHandlerConfig());
     }
 
     /**
@@ -558,7 +558,7 @@ public final class IoUringIoHandler implements IoHandler {
      * @return              factory
      */
     public static IoHandlerFactory newFactory(int ringSize) {
-        IoUringIoHandlerConfiguration configuration = new IoUringIoHandlerConfiguration();
+        IoUringIoHandlerConfig configuration = new IoUringIoHandlerConfig();
         configuration.setRingSize(ringSize);
         return eventLoop -> new IoUringIoHandler(eventLoop, configuration);
     }
@@ -569,7 +569,7 @@ public final class IoUringIoHandler implements IoHandler {
      * @param config the io_uring configuration
      * @return factory
      */
-    public static IoHandlerFactory newFactory(IoUringIoHandlerConfiguration config) {
+    public static IoHandlerFactory newFactory(IoUringIoHandlerConfig config) {
         IoUring.ensureAvailability();
         ObjectUtil.checkNotNull(config, "config");
         return eventLoop -> new IoUringIoHandler(eventLoop, config);

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandlerConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandlerConfig.java
@@ -26,7 +26,7 @@ import io.netty.util.internal.ObjectUtil;
  * to configure the associated io_uring instance.
  *
  * <p>
- * The {@link IoUringIoHandlerConfiguration} class provides the following configurable options:
+ * The {@link IoUringIoHandlerConfig} class provides the following configurable options:
  * </p>
  *
  * <table border="1" cellspacing="0" cellpadding="6">
@@ -39,22 +39,22 @@ import io.netty.util.internal.ObjectUtil;
  *   </thead>
  *   <tbody>
  *     <tr>
- *       <td>{@link IoUringIoHandlerConfiguration#setRingSize}</td>
+ *       <td>{@link IoUringIoHandlerConfig#setRingSize}</td>
  *       <td>Sets the size of the submission queue for the io_uring instance.</td>
  *     </tr>
  *     <tr>
- *       <td>{@link IoUringIoHandlerConfiguration#setMaxBoundedWorker}</td>
+ *       <td>{@link IoUringIoHandlerConfig#setMaxBoundedWorker}</td>
  *       <td>Defines the maximum number of bounded io_uring worker threads.</td>
  *     </tr>
  *     <tr>
- *       <td>{@link IoUringIoHandlerConfiguration#setMaxUnboundedWorker}</td>
+ *       <td>{@link IoUringIoHandlerConfig#setMaxUnboundedWorker}</td>
  *       <td>Defines the maximum number of unbounded io_uring worker threads.</td>
  *     </tr>
  *   </tbody>
  * </table>
  */
 
-public final class IoUringIoHandlerConfiguration {
+public final class IoUringIoHandlerConfig {
     private int ringSize = Native.DEFAULT_RING_SIZE;
 
     private int maxBoundedWorker;
@@ -90,7 +90,7 @@ public final class IoUringIoHandlerConfiguration {
      * @param ringSize the ring size of the io_uring instance.
      * @return reference to this, so the API can be used fluently
      */
-    public IoUringIoHandlerConfiguration setRingSize(int ringSize) {
+    public IoUringIoHandlerConfig setRingSize(int ringSize) {
         this.ringSize = ObjectUtil.checkPositive(ringSize, "ringSize");
         return this;
     }
@@ -101,7 +101,7 @@ public final class IoUringIoHandlerConfiguration {
      *                         or 0 for the Linux kernel default
      * @return reference to this, so the API can be used fluently
      */
-    public IoUringIoHandlerConfiguration setMaxBoundedWorker(int maxBoundedWorker) {
+    public IoUringIoHandlerConfig setMaxBoundedWorker(int maxBoundedWorker) {
         this.maxBoundedWorker = ObjectUtil.checkPositiveOrZero(maxBoundedWorker, "maxBoundedWorker");
         return this;
     }
@@ -112,7 +112,7 @@ public final class IoUringIoHandlerConfiguration {
      *                           of 0 for the Linux kernel default
      * @return reference to this, so the API can be used fluently
      */
-    public IoUringIoHandlerConfiguration setMaxUnboundedWorker(int maxUnboundedWorker) {
+    public IoUringIoHandlerConfig setMaxUnboundedWorker(int maxUnboundedWorker) {
         this.maxUnboundedWorker = ObjectUtil.checkPositiveOrZero(maxUnboundedWorker, "maxUnboundedWorker");
         return this;
     }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringIoHandlerTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringIoHandlerTest.java
@@ -35,7 +35,7 @@ public class IoUringIoHandlerTest {
 
     @Test
     public void testOptions() {
-        IoUringIoHandlerConfiguration config = new IoUringIoHandlerConfiguration();
+        IoUringIoHandlerConfig config = new IoUringIoHandlerConfig();
         config.setMaxBoundedWorker(2)
                 .setMaxUnboundedWorker(2);
         IoHandlerFactory ioHandlerFactory = IoUringIoHandler.newFactory(config);


### PR DESCRIPTION
Motivation:

We should use consistent naming across our classes. So we should better use Config and not Configuration as we use Config everyhwere else

Modification:

Rename IoUringIoHandlerConfiguration to IoUringIoHandlerConfig

Result:

Cleanup and consistent naming