### PR TITLE
Add a property to control default endpoint verification

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
@@ -215,7 +215,7 @@ public final class SslContextBuilder {
     private SslContextBuilder(boolean forServer) {
         this.forServer = forServer;
         if (!forServer) {
-            endpointIdentificationAlgorithm = "HTTPS";
+            endpointIdentificationAlgorithm = SslUtils.defaultEndpointVerificationAlgorithm;
         }
     }
 


### PR DESCRIPTION
Motivation:
In Netty 4.2 we enable SSL endpoint verification by default. This is a sane default, but it deviates from Netty 4.1 behavior, and can thus be a roadblock for people to upgrade. To help people with upgrading, we should have a way to opt into the Netty 4.1 behavior.

Modification:
Add a `io.netty.handler.ssl.defaultEndpointVerificationAlgorithm` system property to control the behavior. Make it possible to specify `NONE` to disable default endpoint verification and get back the Netty 4.1 behavior.

Result:
Easier upgrades, and a possibility to add a quick work-around if newly-upgraded systems gets into trouble with endpoint verification.