### PR TITLE
IoUring: Only execute write related completion inline (#14704)

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -322,13 +322,13 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
         if (scheduleWrite(in) > 0) {
             ioState |= WRITE_SCHEDULED;
             if (submitAndRunNow && !isWritable() && !((IOUringChannelConfig) config()).getIoseqAsync()) {
-                // Force a submit and processing of the completions to ensure we drain the outbound buffer and
-                // send the data to the remote peer.
-                // We only do this if IOSEQ_ASYNC is not used as if its used it's impossible that the
-                // write is executed inline.
-                registration().submit(IoUringIoHandler.SUBMIT_AND_RUN_ALL);
+                submitAndRunNow();
             }
         }
+    }
+
+    protected void submitAndRunNow() {
+        // NOOP
     }
 
     private int scheduleWrite(ChannelOutboundBuffer in) {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -497,4 +497,14 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
     protected boolean socketIsEmpty(int flags) {
         return IoUring.isIOUringCqeFSockNonEmptySupported() && (flags & Native.IORING_CQE_F_SOCK_NONEMPTY) == 0;
     }
+
+    @Override
+    protected void submitAndRunNow() {
+        if (writeId != 0) {
+            // Force a submit and processing of the completions to ensure we drain the outbound buffer and
+            // send the data to the remote peer.
+            ((IoUringIoHandler) registration().ioHandler()).submitAndRunNow(writeId);
+        }
+        super.submitAndRunNow();
+    }
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionBuffer.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionBuffer.java
@@ -97,6 +97,27 @@ final class CompletionBuffer {
         return i;
     }
 
+    boolean processOneNow(CompletionCallback callback, long udata) {
+        // We basically just scan over the whole array, if this turns out to be a performance problem
+        // (we actually don't expect too many outstanding completions) it's possible to be a bit smarter.
+        //
+        // We could make the udata generation shared across channels and always increase it. Then we could use
+        // a binarySearch to find the right completion to handle. This only downside would be that this will not
+        // work once we overflow so we would need to handle this somehow.
+        int idx = head;
+        for (int i = 0; i < size; i++, idx += 2) {
+            int udataIdx = udataIdx(idx);
+            long data = array[udataIdx];
+            if (udata != data) {
+                continue;
+            }
+            long combined = array[combinedIdx(idx)];
+            array[udataIdx] = tombstone;
+            return handle(callback, combined, udata);
+        }
+        return false;
+    }
+
     private int combinedIdx(int idx) {
         return idx & mask;
     }


### PR DESCRIPTION
Motivation:

4d868a6da3aeb0b222ac24c8bf5f63a416f74ecf added a change which will case the completion queue to be drained and run after a Channel becomes unwritable. Doing so might produce a very deeÃp callstack if some completions will trigger an unwritable state for a different Channel. We should better only run the completion that belongs to the WRITE / WRITEV itself.

Modifications:

- Only run the specific completion that will affect the writability of the Channel itself.
- Drain completion queue and submit in a loop until there is nothing more to do before returning to the caller

Result:

Guard against super deep callstack
