### PR TITLE
Notify event loop termination future of unexpected exceptions

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -992,11 +992,13 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
                 }
 
                 boolean success = false;
+                Throwable unexpectedException = null;
                 updateLastExecutionTime();
                 try {
                     SingleThreadEventExecutor.this.run();
                     success = true;
                 } catch (Throwable t) {
+                    unexpectedException = t;
                     logger.warn("Unexpected exception from an event executor: ", t);
                 } finally {
                     for (;;) {
@@ -1056,7 +1058,11 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
                                 logger.warn("An event executor terminated with " +
                                         "non-empty task queue (" + numUserTasks + ')');
                             }
-                            terminationFuture.setSuccess(null);
+                            if (unexpectedException == null) {
+                                terminationFuture.setSuccess(null);
+                            } else {
+                                terminationFuture.setFailure(unexpectedException);
+                            }
                         }
                     }
                 }

--- a/common/src/test/java/io/netty/util/concurrent/SingleThreadEventExecutorTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/SingleThreadEventExecutorTest.java
@@ -38,6 +38,7 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -426,5 +427,30 @@ public class SingleThreadEventExecutorTest {
         public void run() {
             ran.set(true);
         }
+    }
+
+    @Test
+    @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
+    public void testExceptionIsPropagatedToTerminationFuture() throws Exception {
+        final IllegalStateException exception = new IllegalStateException();
+        final SingleThreadEventExecutor executor =
+                new SingleThreadEventExecutor(null, Executors.defaultThreadFactory(), true) {
+                    @Override
+                    protected void run() {
+                        throw exception;
+                    }
+                };
+
+        // Schedule something so we are sure the run() method will be called.
+        executor.execute(new Runnable() {
+            @Override
+            public void run() {
+                // Noop.
+            }
+        });
+
+        executor.terminationFuture().await();
+
+        assertSame(exception, executor.terminationFuture().cause());
     }
 }


### PR DESCRIPTION
Motivations:
These exceptions generally shouldn't happen, but if they do, they break internal invariants and the best a system can do is to somehow restart.

To facilitate systems reacting to this, we should tell the termination future about these exceptions.

Modification:
When an event loop terminates from an unexpected exception, we now shut down the event loop as normal, but mark the termination future as failed.

Result:
It's now possible for applications to listen for event loops displaying improper lifetime behavior.

This helps situations such as the one described in https://github.com/netty/netty/issues/14632