### PR TITLE
HTTP/2: Add newHttp2UnknownFrame to Http2FrameCodec (#14720)

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
@@ -137,7 +137,7 @@ import static io.netty.util.internal.logging.InternalLogLevel.DEBUG;
  * reference counted objects (e.g. {@link ByteBuf}s). The frame codec will call {@link ReferenceCounted#retain()} before
  * propagating a reference counted object through the pipeline, and thus an application handler needs to release such
  * an object after having consumed it. For more information on reference counting take a look at
- * https://netty.io/wiki/reference-counted-objects.html
+ * <a href="https://netty.io/wiki/reference-counted-objects.html">Reference counted objects</a>
  *
  * <h3>HTTP Upgrade</h3>
  * <p>
@@ -604,8 +604,8 @@ public class Http2FrameCodec extends Http2ConnectionHandler {
                 // Ignore unknown frames on connection stream, for example: HTTP/2 GREASE testing
                 return;
             }
-            onHttp2Frame(ctx, new DefaultHttp2UnknownFrame(frameType, flags, payload)
-                    .stream(requireStream(streamId)).retain());
+            onHttp2Frame(ctx, newHttp2UnknownFrame(frameType, streamId, flags, payload.retain())
+                .stream(requireStream(streamId)));
         }
 
         @Override
@@ -716,6 +716,13 @@ public class Http2FrameCodec extends Http2ConnectionHandler {
 
     void onHttp2Frame(ChannelHandlerContext ctx, Http2Frame frame) {
         ctx.fireChannelRead(frame);
+    }
+
+    /**
+     * Create a Http2UnknownFrame. The ownership of the {@link ByteBuf} is transferred.
+     * */
+    protected Http2StreamFrame newHttp2UnknownFrame(byte frameType, int streamId, Http2Flags flags, ByteBuf payload) {
+        return new DefaultHttp2UnknownFrame(frameType, flags, payload);
     }
 
     void onHttp2FrameStreamException(ChannelHandlerContext ctx, Http2FrameStreamException cause) {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
@@ -230,6 +230,22 @@ public class Http2FrameCodecTest {
     }
 
     @Test
+    public void canCreateCustomUnknownFrame() {
+        Http2Connection conn = new DefaultHttp2Connection(true);
+        Http2ConnectionEncoder enc = new DefaultHttp2ConnectionEncoder(conn, new DefaultHttp2FrameWriter());
+        Http2ConnectionDecoder dec = new DefaultHttp2ConnectionDecoder(conn, enc, new DefaultHttp2FrameReader());
+        new Http2FrameCodec(enc, dec, new Http2Settings(), false, true) {
+            @Override
+            protected Http2StreamFrame newHttp2UnknownFrame(byte frameType,
+                                                      int streamId,
+                                                      Http2Flags flags,
+                                                      ByteBuf payload) {
+                return super.newHttp2UnknownFrame(frameType, streamId, flags, payload);
+            }
+        };
+    }
+
+    @Test
     public void entityRequestEntityResponse() throws Exception {
         frameInboundWriter.writeInboundHeaders(1, request, 0, false);
 


### PR DESCRIPTION
Motivation:

When our Frame is an unknown frame of HTTP/2 spec, we want to use Http2FrameCodec but avoid an allocation of the `UnknownHttp2Frame`, meaning I will decode it to my frame type.

Modification:

Add newHttp2UnknownFrame method to Http2FrameCodec

Result:

I can now create my custFrame instead.
