### PR TITLE
Add test to show IoExecutor in action

### DIFF
--- a/transport/src/test/java/io/netty/channel/nio/NioIoHandlerTest.java
+++ b/transport/src/test/java/io/netty/channel/nio/NioIoHandlerTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.nio;
+
+import io.netty.channel.IoExecutor;
+import io.netty.channel.IoExecutorContext;
+import io.netty.channel.IoHandler;
+import io.netty.channel.IoHandlerFactory;
+import io.netty.channel.IoRegistration;
+import io.netty.util.concurrent.DefaultPromise;
+import io.netty.util.concurrent.Promise;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.spi.SelectorProvider;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class NioIoHandlerTest {
+
+    @Test
+    void testNioHandlerCanBeDrivenByMainThread() throws Exception {
+        IoHandlerFactory factory = NioIoHandler.newFactory();
+        final Thread current = Thread.currentThread();
+        final Queue<Runnable> tasks = new ConcurrentLinkedQueue<>();
+        // Create our own IoExecutor that is driven by the main thread
+        final IoExecutor executor = new IoExecutor() {
+            @Override
+            public boolean inExecutorThread(Thread thread) {
+                return current == thread;
+            }
+
+            @Override
+            public <V> Promise<V> newPromise() {
+                return new DefaultPromise<V>(this) { };
+            }
+
+            @Override
+            public void execute(Runnable command) {
+                tasks.add(command);
+            }
+        };
+        IoExecutorContext context = new IoExecutorContext() {
+            @Override
+            public boolean canBlock() {
+                // Just busy spin.
+                return false;
+            }
+
+            @Override
+            public long delayNanos(long currentTimeNanos) {
+                return 0;
+            }
+
+            @Override
+            public long deadlineNanos() {
+                return -1;
+            }
+        };
+        IoHandler handler = factory.newHandler(executor);
+
+        // Open a ServerSocketChannel that we can connect to.
+        ServerSocketChannel channel = SelectorProvider.provider().openServerSocketChannel();
+        channel.configureBlocking(false);
+        channel.bind(new InetSocketAddress(0));
+        // Do the connect in another thread so we don't block our io execution loop.
+        Thread t = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                Socket socket = new Socket();
+                try {
+                    socket.connect(channel.getLocalAddress());
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+        AtomicBoolean acceptedConnection = new AtomicBoolean();
+        IoRegistration registration = handler.register(new NioSelectableChannelIoHandle<ServerSocketChannel>(channel) {
+            @Override
+            protected void handle(ServerSocketChannel channel, SelectionKey key) {
+                if (key.isAcceptable()) {
+                    try {
+                        // Just accept the connection and close it.
+                        java.nio.channels.SocketChannel accepted = channel.accept();
+                        accepted.close();
+                    } catch (Exception e) {
+                        // ignore
+                    } finally {
+                        acceptedConnection.set(true);
+                    }
+                }
+            }
+        });
+        registration.submit(NioIoOps.ACCEPT);
+        t.start();
+
+        // Let's loop until our registration was cancelled.
+        while (registration.isValid()) {
+            handler.run(context);
+            for (;;) {
+                // Execute all tasks that were dispatched.
+                Runnable r = tasks.poll();
+                if (r == null) {
+                    break;
+                }
+                r.run();
+            }
+            if (acceptedConnection.get()) {
+                // We accepted the connection, let's cancel the registration.
+                registration.cancel();
+            }
+        }
+        // Wait until the connect thread is done.
+        t.join();
+        // The future that is tied to the cancellation of the registration should be done as well.
+        registration.cancelFuture().sync();
+
+        // Let's now close the ServerSocketChannel and after that destroy the IoHandler.
+        channel.close();
+        handler.prepareToDestroy();
+        handler.destroy();
+    }
+}


### PR DESCRIPTION
Motivation:

In 9fbd6993c0a61f53756236728267f966c2750b31 we added the concept of the IoExecutor to remove tight coupling to an EventLoop with the IoHandler. We should provide a testcase that shows that its actually possible now drive an IoHandler without an EventExecutor implementation for more advanced use-cases.

Modifications:

- Add constructor for DefaultPromise which makes it possible to implement an own IoExecutor without the need to also implement a full Promise.
- Add unit test

Result:

Show that its possible to use IoExecutor without a full-blown EventLoop