### PR TITLE
Add support for generating ML-DSA certs with CertificateBuilder

### DIFF
--- a/pkitesting/src/main/java/io/netty/pkitesting/Algorithms.java
+++ b/pkitesting/src/main/java/io/netty/pkitesting/Algorithms.java
@@ -48,6 +48,12 @@ final class Algorithms {
                 return "1.3.101.112";
             case "ed448":
                 return "1.3.101.113";
+            case "ml-dsa-44":
+                return "2.16.840.1.101.3.4.3.17";
+            case "ml-dsa-65":
+                return "2.16.840.1.101.3.4.3.18";
+            case "ml-dsa-87":
+                return "2.16.840.1.101.3.4.3.19";
             default:
                 throw new UnsupportedOperationException("Algorithm not supported: " + algorithmIdentifier);
         }

--- a/pkitesting/src/main/java/io/netty/pkitesting/CertificateBuilder.java
+++ b/pkitesting/src/main/java/io/netty/pkitesting/CertificateBuilder.java
@@ -114,6 +114,8 @@ public final class CertificateBuilder {
     static final String OID_MICROSOFT_SMARTCARD_LOGIN = "1.3.6.1.4.1.311.20.2.2";
     private static final GeneralName[] EMPTY_GENERAL_NAMES = new GeneralName[0];
     private static final DistributionPoint[] EMPTY_DIST_POINTS = new DistributionPoint[0];
+    private static final AlgorithmParameterSpec UNSUPPORTED_SPEC = new AlgorithmParameterSpec() {
+    };
 
     SecureRandom random;
     Algorithm algorithm = Algorithm.ecp256;
@@ -399,7 +401,7 @@ public final class CertificateBuilder {
      */
     public CertificateBuilder algorithm(Algorithm algorithm) {
         requireNonNull(algorithm, "algorithm");
-        if (algorithm.parameterSpec == Algorithm.UNSUPPORTED) {
+        if (algorithm.parameterSpec == UNSUPPORTED_SPEC) {
             throw new UnsupportedOperationException("This algorithm is not supported: " + algorithm);
         }
         this.algorithm = algorithm;
@@ -900,16 +902,40 @@ public final class CertificateBuilder {
          * The Ed25519 algorithm offer fast key generation, signing, and verification,
          * with very small keys and signatures, at 128-bits of security strength.
          * <p>
-         * This algorithm is relatively new, require Java 15 or newer, and may not be supported everywhere.
+         * This algorithm was added in Java 15, and may not be supported everywhere.
          */
         ed25519("Ed25519", namedParameterSpec("Ed25519"), "Ed25519"),
         /**
          * The Ed448 algorithm offer fast key generation, signing, and verification,
          * with small keys and signatures, at 224-bits of security strength.
          * <p>
-         * This algorithm is relatively new, require Java 15 or newer, and may not be supported everywhere.
+         * This algorithm was added in Java 15, and may not be supported everywhere.
          */
-        ed448("Ed448", namedParameterSpec("Ed448"), "Ed448");
+        ed448("Ed448", namedParameterSpec("Ed448"), "Ed448"),
+        /**
+         * The ML-DSA-44 algorithm is the NIST FIPS 204 version of the post-quantum Dilithium algorithm.
+         * It has 128-bits of classical security strength, and is claimed to meet NIST Level 2
+         * quantum security strength (equivalent to finding a SHA-256 collision).
+         * <p>
+         * This algorithm was added in Java 24, and may not be supported everywhere.
+         */
+        mlDsa44("ML-DSA", namedParameterSpec("ML-DSA-44"), "ML-DSA-44"),
+        /**
+         * The ML-DSA-65 algorithm is the NIST FIPS 204 version of the post-quantum Dilithium algorithm.
+         * It has 192-bits of classical security strength, and is claimed to meet NIST Level 3
+         * quantum security strength (equivalent to finding the key for an AES-192 block).
+         * <p>
+         * This algorithm was added in Java 24, and may not be supported everywhere.
+         */
+        mlDsa65("ML-DSA", namedParameterSpec("ML-DSA-65"), "ML-DSA-65"),
+        /**
+         * The ML-DSA-87 algorithm is the NIST FIPS 204 version of the post-quantum Dilithium algorithm.
+         * It has 256-bits of classical security strength, and is claimed to meet NIST Level 5
+         * quantum security strength (equivalent to finding the key for an AES-256 block).
+         * <p>
+         * This algorithm was added in Java 24, and may not be supported everywhere.
+         */
+        mlDsa87("ML-DSA", namedParameterSpec("ML-DSA-87"), "ML-DSA-87");
 
         final String keyType;
         final AlgorithmParameterSpec parameterSpec;
@@ -920,9 +946,6 @@ public final class CertificateBuilder {
             this.parameterSpec = parameterSpec;
             this.signatureType = signatureType;
         }
-
-        static final AlgorithmParameterSpec UNSUPPORTED = new AlgorithmParameterSpec() {
-        };
 
         private static AlgorithmParameterSpec namedParameterSpec(String name) {
             try {
@@ -935,19 +958,34 @@ public final class CertificateBuilder {
                 if ("Ed448".equals(name)) {
                     return new EdDSAParameterSpec(EdDSAParameterSpec.Ed448);
                 }
-                return UNSUPPORTED;
+                return UNSUPPORTED_SPEC;
             }
         }
 
+        /**
+         * Generate a new {@link KeyPair} using this algorithm, and the given {@link SecureRandom} generator.
+         * @param secureRandom The {@link SecureRandom} generator to use, not {@code null}.
+         * @return The generated {@link KeyPair}.
+         * @throws GeneralSecurityException if the key pair cannot be generated using this algorithm for some reason.
+         * @throws UnsupportedOperationException if this algorithm is not support in the current JVM.
+         */
         public KeyPair generateKeyPair(SecureRandom secureRandom)
                 throws GeneralSecurityException {
             requireNonNull(secureRandom, "secureRandom");
 
-            if (parameterSpec == UNSUPPORTED) {
+            if (parameterSpec == UNSUPPORTED_SPEC) {
                 throw new UnsupportedOperationException("This algorithm is not supported: " + this);
             }
             KeyPairGenerator keyGen = Algorithms.keyPairGenerator(keyType, parameterSpec, secureRandom);
             return keyGen.generateKeyPair();
+        }
+
+        /**
+         * Tell whether this algorithm is supported in the current JVM.
+         * @return {@code true} if this algorithm is supported.
+         */
+        public boolean isSupported() {
+            return parameterSpec != UNSUPPORTED_SPEC;
         }
     }
 

--- a/pkitesting/src/main/java/io/netty/pkitesting/CertificateBuilder.java
+++ b/pkitesting/src/main/java/io/netty/pkitesting/CertificateBuilder.java
@@ -976,6 +976,26 @@ public final class CertificateBuilder {
             if (parameterSpec == UNSUPPORTED_SPEC) {
                 throw new UnsupportedOperationException("This algorithm is not supported: " + this);
             }
+            if (this == mlDsa44 || this == mlDsa65 || this == mlDsa87) {
+                return genMlDsaKeyPair(secureRandom);
+            }
+            return genKeyPair(secureRandom);
+        }
+
+        private KeyPair genMlDsaKeyPair(SecureRandom secureRandom) throws GeneralSecurityException {
+            final byte[] seed = new byte[32];
+            KeyPair keyPair = genKeyPair(new SecureRandom() {
+                @Override
+                public void nextBytes(byte[] bytes) {
+                    assert bytes.length == 32;
+                    secureRandom.nextBytes(bytes);
+                    System.arraycopy(bytes, 0, seed, 0, seed.length);
+                }
+            });
+            return new KeyPair(keyPair.getPublic(), new MLDSASeedPrivateKey(keyPair.getPrivate(), this, seed));
+        }
+
+        private KeyPair genKeyPair(SecureRandom secureRandom) throws GeneralSecurityException {
             KeyPairGenerator keyGen = Algorithms.keyPairGenerator(keyType, parameterSpec, secureRandom);
             return keyGen.generateKeyPair();
         }

--- a/pkitesting/src/main/java/io/netty/pkitesting/MLDSASeedPrivateKey.java
+++ b/pkitesting/src/main/java/io/netty/pkitesting/MLDSASeedPrivateKey.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.pkitesting;
+
+import org.bouncycastle.asn1.ASN1Encodable;
+import org.bouncycastle.asn1.ASN1Integer;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.DEROctetString;
+import org.bouncycastle.asn1.DERSequence;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.security.PrivateKey;
+import java.security.spec.AlgorithmParameterSpec;
+import java.util.Arrays;
+import javax.security.auth.DestroyFailedException;
+
+/**
+ * ML-DSA needs to be represented in a seed-form when serialized, but the current encoding the JDK is using
+ * the expanded form, and throws away the seed during the key generation.
+ * <p>
+ * This class preserves the seed, and keeps a seed-form encoding of the key, which we can use when creating PEM files.
+ * It is important to unwrap the key to its inner representation, before interacting with the JDK and 3rd-party
+ * libraries, like BouncyCastle, since they may have expectations around the concrete class used.
+ */
+final class MLDSASeedPrivateKey implements PrivateKey {
+    private static final long serialVersionUID = 4206741400099880395L;
+    private final PrivateKey key;
+    private final byte[] seedFormat;
+
+    MLDSASeedPrivateKey(PrivateKey key, CertificateBuilder.Algorithm algorithm, byte[] seed) {
+        this.key = key;
+        // See https://www.ietf.org/archive/id/draft-ietf-lamps-dilithium-certificates-06.html#name-private-key-format
+        try {
+            seedFormat = new DERSequence(new ASN1Encodable[]{
+                    new ASN1Integer(0),
+                    new DERSequence(new ASN1ObjectIdentifier(Algorithms.oidForAlgorithmName(algorithm.signatureType))),
+                    new DEROctetString(seed)
+            }).getEncoded("DER");
+        } catch (IOException e) {
+            throw new UncheckedIOException("Unexpected problem encoding private key DER", e);
+        }
+    }
+
+    @Override
+    public AlgorithmParameterSpec getParams() {
+        return key.getParams();
+    }
+
+    @Override
+    public String getAlgorithm() {
+        return key.getAlgorithm();
+    }
+
+    @Override
+    public String getFormat() {
+        return key.getFormat();
+    }
+
+    @Override
+    public byte[] getEncoded() {
+        return seedFormat.clone();
+    }
+
+    @Override
+    public void destroy() throws DestroyFailedException {
+        key.destroy();
+        Arrays.fill(seedFormat, (byte) 0);
+    }
+
+    @Override
+    public boolean isDestroyed() {
+        return key.isDestroyed();
+    }
+
+    static byte[] getEncoded(PrivateKey key) {
+        if (key instanceof MLDSASeedPrivateKey) {
+            return ((MLDSASeedPrivateKey) key).seedFormat.clone();
+        }
+        return key.getEncoded();
+    }
+
+    static PrivateKey unwrap(PrivateKey key) {
+        if (key instanceof MLDSASeedPrivateKey) {
+            return ((MLDSASeedPrivateKey) key).key;
+        }
+        return key;
+    }
+}

--- a/pkitesting/src/main/java/io/netty/pkitesting/MLDSASeedPrivateKey.java
+++ b/pkitesting/src/main/java/io/netty/pkitesting/MLDSASeedPrivateKey.java
@@ -23,6 +23,7 @@ import org.bouncycastle.asn1.DERSequence;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.lang.reflect.InvocationTargetException;
 import java.security.PrivateKey;
 import java.security.spec.AlgorithmParameterSpec;
 import java.util.Arrays;
@@ -55,9 +56,12 @@ final class MLDSASeedPrivateKey implements PrivateKey {
         }
     }
 
-    @Override
     public AlgorithmParameterSpec getParams() {
-        return key.getParams();
+        try {
+            return (AlgorithmParameterSpec) key.getClass().getMethod("getParams").invoke(key);
+        } catch (Exception e) {
+            throw new UnsupportedOperationException(e);
+        }
     }
 
     @Override

--- a/pkitesting/src/main/java/io/netty/pkitesting/Signed.java
+++ b/pkitesting/src/main/java/io/netty/pkitesting/Signed.java
@@ -50,7 +50,7 @@ final class Signed {
 
     byte[] getEncoded() throws NoSuchAlgorithmException, InvalidKeyException, SignatureException {
         Signature signature = Algorithms.signature(algorithmIdentifier);
-        signature.initSign(privateKey);
+        signature.initSign(MLDSASeedPrivateKey.unwrap(privateKey));
         signature.update(toBeSigned);
         byte[] signatureBytes = signature.sign();
         try {

--- a/pkitesting/src/main/java/io/netty/pkitesting/X509Bundle.java
+++ b/pkitesting/src/main/java/io/netty/pkitesting/X509Bundle.java
@@ -28,6 +28,7 @@ import java.security.KeyPair;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
@@ -197,7 +198,8 @@ public final class X509Bundle {
         Base64.Encoder encoder = getMimeEncoder();
         StringBuilder sb = new StringBuilder();
         sb.append("-----BEGIN PRIVATE KEY-----\r\n");
-        sb.append(encoder.encodeToString(keyPair.getPrivate().getEncoded()));
+        PrivateKey privateKey = keyPair.getPrivate();
+        sb.append(encoder.encodeToString(MLDSASeedPrivateKey.getEncoded(privateKey)));
         sb.append("\r\n-----END PRIVATE KEY-----\r\n");
         return sb.toString();
     }
@@ -312,7 +314,7 @@ public final class X509Bundle {
         }
         keyStore.setCertificateEntry("1", root);
         if (keyPair.getPrivate() != null) {
-            keyStore.setKeyEntry("2", keyPair.getPrivate(), keyEntryPassword, certPath);
+            keyStore.setKeyEntry("2", MLDSASeedPrivateKey.unwrap(keyPair.getPrivate()), keyEntryPassword, certPath);
         }
         return keyStore;
     }

--- a/pkitesting/src/test/java/io/netty/pkitesting/CertificateBuilderTest.java
+++ b/pkitesting/src/test/java/io/netty/pkitesting/CertificateBuilderTest.java
@@ -67,6 +67,7 @@ class CertificateBuilderTest {
         // Assume that RSA 4096 and RSA 8192 work if the other RSA bit-widths work.
         // These big keys just take too long to test with.
         assumeTrue(algorithm != Algorithm.rsa4096 && algorithm != Algorithm.rsa8192);
+        assumeTrue(algorithm.isSupported());
 
         X509Bundle bundle = BASE.copy()
                 .algorithm(algorithm)

--- a/pom.xml
+++ b/pom.xml
@@ -645,7 +645,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <netty.build.version>31</netty.build.version>
     <jboss.marshalling.version>1.4.11.Final</jboss.marshalling.version>
-    <bouncycastle.version>1.79</bouncycastle.version>
+    <bouncycastle.version>1.80</bouncycastle.version>
     <argLine.common>
       -server
       -dsa -da -ea:io.netty...


### PR DESCRIPTION
Motivation:
Post-quantum encryption algorithms are fast becoming relevant to a lot of people. NIST finalized CRYSTALS-Dilithium as ML-DSA with 3 parameter sets (44, 65, 87) in FIPS 204. Let's make it possible to create test certificates using these algorithms.

Java 24 natively adds support, see: https://openjdk.org/jeps/497

For Java 11 to 23, we can support ML-DSA certificate generation with BouncyCastle.

On older Java releases, we throw an exception if people try to use these algorithms.

Modification:
Add ML-DSA-44, ML-DSA-65, ML-DSA-87 algorithms to CertificateBuilder.Algorithm. Upgrade BouncyCastle to version 1.80, where support for these algorithms is finalized.

Result:
It's now possible to generate post-quantum certificates with the ML-DSA algorithms.