### PR TITLE
Fix AccessControlException in GlobalEventExecutor

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
@@ -236,7 +236,8 @@ public final class GlobalEventExecutor extends AbstractScheduledEventExecutor im
     private void startThread() {
         if (started.compareAndSet(false, true)) {
             Thread callingThread = Thread.currentThread();
-            ClassLoader parentCCL = callingThread.getContextClassLoader();
+            ClassLoader parentCCL = AccessController.doPrivileged(
+                (PrivilegedAction<ClassLoader>) callingThread::getContextClassLoader);
             // Avoid calling classloader leaking through Thread.inheritedAccessControlContext.
             setContextClassLoader(callingThread, null);
             try {

--- a/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
@@ -235,9 +235,13 @@ public final class GlobalEventExecutor extends AbstractScheduledEventExecutor im
 
     private void startThread() {
         if (started.compareAndSet(false, true)) {
-            Thread callingThread = Thread.currentThread();
-            ClassLoader parentCCL = AccessController.doPrivileged(
-                (PrivilegedAction<ClassLoader>) callingThread::getContextClassLoader);
+            final Thread callingThread = Thread.currentThread();
+            ClassLoader parentCCL = AccessController.doPrivileged(new PrivilegedAction<ClassLoader>() {
+                @Override
+                public ClassLoader run() {
+                    return callingThread.getContextClassLoader();
+                }
+            });
             // Avoid calling classloader leaking through Thread.inheritedAccessControlContext.
             setContextClassLoader(callingThread, null);
             try {


### PR DESCRIPTION
Motivation: fix recently introduced (as part of https://github.com/netty/netty/pull/14623) `java.security.AccessControlException`, here is the relevant stack trace

```
java.security.AccessControlException: access denied ("java.lang.RuntimePermission" "getClassLoader")                                                                       
        at java.base/java.security.AccessControlContext.checkPermission(AccessControlContext.java:488) ~[?:?]                                                              
        at java.base/java.security.AccessController.checkPermission(AccessController.java:1085) ~[?:?]                                                                     
        at java.base/java.lang.SecurityManager.checkPermission(SecurityManager.java:411) ~[?:?]                                                                            
        at java.base/java.lang.ClassLoader.checkClassLoaderPermission(ClassLoader.java:2071) ~[?:?]                                                                        
        at java.base/java.lang.Thread.getContextClassLoader(Thread.java:2284) ~[?:?]
        at io.netty.util.concurrent.GlobalEventExecutor.startThread(GlobalEventExecutor.java:239) ~[netty-common-4.1.117.Final.jar:4.1.117.Final]
        at io.netty.util.concurrent.GlobalEventExecutor.execute0(GlobalEventExecutor.java:232) ~[netty-common-4.1.117.Final.jar:4.1.117.Final]
        at io.netty.util.concurrent.GlobalEventExecutor.execute(GlobalEventExecutor.java:226) ~[netty-common-4.1.117.Final.jar:4.1.117.Final]
        at io.netty.util.concurrent.DefaultPromise.safeExecute(DefaultPromise.java:862) [netty-common-4.1.117.Final.jar:4.1.117.Final]
        at io.netty.util.concurrent.DefaultPromise.notifyListeners(DefaultPromise.java:500) [netty-common-4.1.117.Final.jar:4.1.117.Final]
        at io.netty.util.concurrent.DefaultPromise.setValue0(DefaultPromise.java:636) [netty-common-4.1.117.Final.jar:4.1.117.Final]
        at io.netty.util.concurrent.DefaultPromise.setSuccess0(DefaultPromise.java:625) [netty-common-4.1.117.Final.jar:4.1.117.Final]
        at io.netty.util.concurrent.DefaultPromise.setSuccess(DefaultPromise.java:97) [netty-common-4.1.117.Final.jar:4.1.117.Final]
        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:1059) [netty-common-4.1.117.Final.jar:4.1.117.Final]
        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) [netty-common-4.1.117.Final.jar:4.1.117.Final]
        at java.base/java.lang.Thread.run(Thread.java:1575) [?:?]
```

Modification:

Apply `AccessController.doPrivileged` block

Result:

With the proper security policy, the exception is gone

Affected Version: 4.1.117.Final

