### PR TITLE
KQueueEventLoop leaks memory on shutdown.

### DIFF
--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoop.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoop.java
@@ -380,6 +380,7 @@ final class KQueueEventLoop extends SingleThreadEventLoop {
             }
         } finally {
             // Cleanup all native memory!
+            iovArray.release();
             changeList.free();
             eventList.free();
         }


### PR DESCRIPTION
Motivation:

We did miss to release the IovArray when shutdown the KQueueEventLoop. This lead to a small native memory leak.

Modifications:

Correctly release the native memory on shutdown

Result:

Fix small memory leak
