### PR TITLE
Rename IoExecutor to ThreadAwareExecutor and move to concurrent package

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/EventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/EventExecutor.java
@@ -24,12 +24,17 @@ import java.util.concurrent.TimeUnit;
  * Besides this, it also extends the {@link EventExecutorGroup} to allow for a generic
  * way to access methods.
  */
-public interface EventExecutor extends EventExecutorGroup {
+public interface EventExecutor extends EventExecutorGroup, ThreadAwareExecutor {
 
     /**
      * Return the {@link EventExecutorGroup} which is the parent of this {@link EventExecutor},
      */
     EventExecutorGroup parent();
+
+    @Override
+    default boolean isExecutorThread(Thread thread) {
+        return inEventLoop(thread);
+    }
 
     /**
      * Calls {@link #inEventLoop(Thread)} with {@link Thread#currentThread()} as argument

--- a/common/src/main/java/io/netty/util/concurrent/ThreadAwareExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/ThreadAwareExecutor.java
@@ -13,16 +13,17 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package io.netty.channel;
+package io.netty.util.concurrent;
 
 import java.util.concurrent.Executor;
 
 /**
- * An {@link Executor} that is used to drive IO of an {@link IoHandler}.
+ * Executor that is aware its execution thread.
  */
-public interface IoExecutor extends Executor {
+public interface ThreadAwareExecutor extends Executor {
     /**
-     * Return {@code true} if the given {@link Thread} is used by this {@link IoExecutor}.
+     * Return {@code true} if the given {@link Thread} is used by this {@link ThreadAwareExecutor} to execute
+     * work.
      */
-    boolean inExecutorThread(Thread thread);
+    boolean isExecutorThread(Thread thread);
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringIoHandlerTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringIoHandlerTest.java
@@ -15,10 +15,9 @@
  */
 package io.netty.channel.uring;
 
-import io.netty.channel.IoExecutor;
 import io.netty.channel.IoHandler;
 import io.netty.channel.IoHandlerFactory;
-import io.netty.util.concurrent.ImmediateEventExecutor;
+import io.netty.util.concurrent.ThreadAwareExecutor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -38,15 +37,16 @@ public class IoUringIoHandlerTest {
         config.setMaxBoundedWorker(2)
                 .setMaxUnboundedWorker(2);
         IoHandlerFactory ioHandlerFactory = IoUringIoHandler.newFactory(config);
-        IoHandler handler = ioHandlerFactory.newHandler(new IoExecutor() {
+        IoHandler handler = ioHandlerFactory.newHandler(new ThreadAwareExecutor() {
+
             @Override
-            public boolean inExecutorThread(Thread thread) {
-                return ImmediateEventExecutor.INSTANCE.inEventLoop(thread);
+            public boolean isExecutorThread(Thread thread) {
+                return false;
             }
 
             @Override
             public void execute(Runnable command) {
-                ImmediateEventExecutor.INSTANCE.execute(command);
+                command.run();
             }
         });
         handler.initialize();

--- a/transport/src/main/java/io/netty/channel/IoHandle.java
+++ b/transport/src/main/java/io/netty/channel/IoHandle.java
@@ -15,10 +15,11 @@
  */
 package io.netty.channel;
 
+import io.netty.util.concurrent.ThreadAwareExecutor;
 /**
  * A handle that can be registered to a {@link IoHandler}.
- * All methods must be called from the {@link IoExecutor} threa (which means
- * {@link IoExecutor#inExecutorThread(Thread)} must return {@code true})
+ * All methods must be called from the {@link ThreadAwareExecutor} thread (which means
+ * {@link ThreadAwareExecutor#isExecutorThread(Thread)} must return {@code true})
  */
 public interface IoHandle extends AutoCloseable {
 

--- a/transport/src/main/java/io/netty/channel/IoHandler.java
+++ b/transport/src/main/java/io/netty/channel/IoHandler.java
@@ -15,10 +15,12 @@
  */
 package io.netty.channel;
 
+import io.netty.util.concurrent.ThreadAwareExecutor;
+
 /**
- * Handles IO dispatching for an {@link IoExecutor}.
+ * Handles IO dispatching for an {@link ThreadAwareExecutor}.
  * All operations except {@link #wakeup()} and {@link #isCompatible(Class)} <strong>MUST</strong> be executed
- * on the {@link IoExecutor} thread (which means {@link IoExecutor#inExecutorThread(Thread)} must
+ * on the {@link ThreadAwareExecutor} thread (which means {@link ThreadAwareExecutor#isExecutorThread(Thread)} must
  * return {@code true}) and should never be called from the user-directly.
  * <p>
  * Once a {@link IoHandle} is registered via the {@link #register(IoHandle)} method it's possible
@@ -36,15 +38,15 @@ public interface IoHandler {
     default void initialize() { }
 
     /**
-     * Run the IO handled by this {@link IoHandler}. The {@link IoExecutorContext} should be used
+     * Run the IO handled by this {@link IoHandler}. The {@link IoHandlerContext} should be used
      * to ensure we not execute too long and so block the processing of other task that are
-     * scheduled on the {@link IoExecutor}. This is done by taking {@link IoExecutorContext#delayNanos(long)}
-     * or {@link IoExecutorContext#deadlineNanos()} into account.
+     * scheduled on the {@link ThreadAwareExecutor}. This is done by taking {@link IoHandlerContext#delayNanos(long)}
+     * or {@link IoHandlerContext#deadlineNanos()} into account.
      *
-     * @param  context  the {@link IoExecutorContext}.
+     * @param  context  the {@link IoHandlerContext}.
      * @return          the number of {@link IoHandle} for which I/O was handled.
      */
-    int run(IoExecutorContext context);
+    int run(IoHandlerContext context);
 
     /**
      * Prepare to destroy this {@link IoHandler}. This method will be called before {@link #destroy()} and may be

--- a/transport/src/main/java/io/netty/channel/IoHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/IoHandlerContext.java
@@ -15,12 +15,14 @@
  */
 package io.netty.channel;
 
+import io.netty.util.concurrent.ThreadAwareExecutor;
+
 /**
- * The execution context for an {@link IoExecutor}.
- * All methods  <strong>MUST</strong> be executed on the {@link IoExecutor} thread
- * (which means {@link IoExecutor#inExecutorThread(Thread)} must return {@code true}).
+ * The context for an {@link IoHandler} that is run by an {@link ThreadAwareExecutor}.
+ * All methods  <strong>MUST</strong> be executed on the {@link ThreadAwareExecutor} thread
+ * (which means {@link ThreadAwareExecutor#isExecutorThread(Thread)} (Thread)} must return {@code true}).
  */
-public interface IoExecutorContext {
+public interface IoHandlerContext {
     /**
      * Returns {@code true} if blocking for IO is allowed or if we should try to do a non-blocking request for IO to be
      * ready.

--- a/transport/src/main/java/io/netty/channel/IoHandlerFactory.java
+++ b/transport/src/main/java/io/netty/channel/IoHandlerFactory.java
@@ -15,6 +15,8 @@
  */
 package io.netty.channel;
 
+import io.netty.util.concurrent.ThreadAwareExecutor;
+
 /**
  * Factory for {@link IoHandler} instances.
  */
@@ -23,8 +25,8 @@ public interface IoHandlerFactory {
     /**
      * Creates a new {@link IoHandler} instance.
      *
-     * @param ioExecutor        the {@link IoExecutor} for the {@link IoHandler}.
+     * @param ioExecutor        the {@link ThreadAwareExecutor} for the {@link IoHandler}.
      * @return                  a new {@link IoHandler} instance.
      */
-    IoHandler newHandler(IoExecutor ioExecutor);
+    IoHandler newHandler(ThreadAwareExecutor ioExecutor);
 }

--- a/transport/src/main/java/io/netty/channel/SingleThreadIoEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/SingleThreadIoEventLoop.java
@@ -39,7 +39,7 @@ public class SingleThreadIoEventLoop extends SingleThreadEventLoop implements Io
             SystemPropertyUtil.getInt("io.netty.eventLoop.maxTaskProcessingQuantumMs", 1000)));
 
     private final long maxTaskProcessingQuantumNs;
-    private final IoExecutorContext context = new IoExecutorContext() {
+    private final IoHandlerContext context = new IoHandlerContext() {
         @Override
         public boolean canBlock() {
             assert inEventLoop();
@@ -59,19 +59,6 @@ public class SingleThreadIoEventLoop extends SingleThreadEventLoop implements Io
         }
     };
 
-    private final IoExecutor ioExecutor = new IoExecutor() {
-
-        @Override
-        public boolean inExecutorThread(Thread currentThread) {
-            return SingleThreadIoEventLoop.this.inEventLoop(currentThread);
-        }
-
-        @Override
-        public void execute(Runnable command) {
-            SingleThreadIoEventLoop.this.execute(command);
-        }
-    };
-
     private final IoHandler ioHandler;
 
     private final AtomicInteger numRegistrations = new AtomicInteger();
@@ -88,7 +75,7 @@ public class SingleThreadIoEventLoop extends SingleThreadEventLoop implements Io
                                    IoHandlerFactory ioHandlerFactory) {
         super(parent, threadFactory, false, true);
         this.maxTaskProcessingQuantumNs = DEFAULT_MAX_TASK_PROCESSING_QUANTUM_NS;
-        this.ioHandler = ObjectUtil.checkNotNull(ioHandlerFactory, "ioHandlerFactory").newHandler(ioExecutor);
+        this.ioHandler = ObjectUtil.checkNotNull(ioHandlerFactory, "ioHandlerFactory").newHandler(this);
     }
 
     /**
@@ -102,7 +89,7 @@ public class SingleThreadIoEventLoop extends SingleThreadEventLoop implements Io
     public SingleThreadIoEventLoop(IoEventLoopGroup parent, Executor executor, IoHandlerFactory ioHandlerFactory) {
         super(parent, executor, false, true);
         this.maxTaskProcessingQuantumNs = DEFAULT_MAX_TASK_PROCESSING_QUANTUM_NS;
-        this.ioHandler = ObjectUtil.checkNotNull(ioHandlerFactory, "ioHandlerFactory").newHandler(ioExecutor);
+        this.ioHandler = ObjectUtil.checkNotNull(ioHandlerFactory, "ioHandlerFactory").newHandler(this);
     }
 
     /**
@@ -129,7 +116,7 @@ public class SingleThreadIoEventLoop extends SingleThreadEventLoop implements Io
         this.maxTaskProcessingQuantumNs =
                 ObjectUtil.checkPositiveOrZero(maxTaskProcessingQuantumMs, "maxTaskProcessingQuantumMs") == 0 ?
                         DEFAULT_MAX_TASK_PROCESSING_QUANTUM_NS : maxTaskProcessingQuantumMs;
-        this.ioHandler = ObjectUtil.checkNotNull(ioHandlerFactory, "ioHandlerFactory").newHandler(ioExecutor);
+        this.ioHandler = ObjectUtil.checkNotNull(ioHandlerFactory, "ioHandlerFactory").newHandler(this);
     }
 
     /**
@@ -155,7 +142,7 @@ public class SingleThreadIoEventLoop extends SingleThreadEventLoop implements Io
         this.maxTaskProcessingQuantumNs =
                 ObjectUtil.checkPositiveOrZero(maxTaskProcessingQuantumMs, "maxTaskProcessingQuantumMs") == 0 ?
                         DEFAULT_MAX_TASK_PROCESSING_QUANTUM_NS : maxTaskProcessingQuantumMs;
-        this.ioHandler = ObjectUtil.checkNotNull(ioHandlerFactory, "ioHandlerFactory").newHandler(ioExecutor);
+        this.ioHandler = ObjectUtil.checkNotNull(ioHandlerFactory, "ioHandlerFactory").newHandler(this);
     }
 
     /**
@@ -177,7 +164,7 @@ public class SingleThreadIoEventLoop extends SingleThreadEventLoop implements Io
                                       RejectedExecutionHandler rejectedExecutionHandler) {
         super(parent, executor, false, true, taskQueue, tailTaskQueue, rejectedExecutionHandler);
         this.maxTaskProcessingQuantumNs = DEFAULT_MAX_TASK_PROCESSING_QUANTUM_NS;
-        this.ioHandler = ObjectUtil.checkNotNull(ioHandlerFactory, "ioHandlerFactory").newHandler(ioExecutor);
+        this.ioHandler = ObjectUtil.checkNotNull(ioHandlerFactory, "ioHandlerFactory").newHandler(this);
     }
 
     @Override

--- a/transport/src/test/java/io/netty/channel/SingleThreadIoEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/SingleThreadIoEventLoopTest.java
@@ -14,6 +14,7 @@
  * under the License.
  */
 package io.netty.channel;
+import io.netty.util.concurrent.ThreadAwareExecutor;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.Executors;
@@ -30,7 +31,7 @@ public class SingleThreadIoEventLoopTest {
     @Test
     void testIsIoType() {
         class TestIoHandler2 extends TestIoHandler {
-            TestIoHandler2(IoExecutor executor) {
+            TestIoHandler2(ThreadAwareExecutor executor) {
                 super(executor);
             }
         }
@@ -43,7 +44,7 @@ public class SingleThreadIoEventLoopTest {
     }
 
     static final class CompatibleTestIoHandler extends TestIoHandler {
-        CompatibleTestIoHandler(IoExecutor executor) {
+        CompatibleTestIoHandler(ThreadAwareExecutor executor) {
             super(executor);
         }
 
@@ -105,9 +106,9 @@ public class SingleThreadIoEventLoopTest {
 
     private static class TestIoHandler implements IoHandler {
         private final Semaphore semaphore = new Semaphore(0);
-        private final IoExecutor executor;
+        private final ThreadAwareExecutor executor;
 
-        TestIoHandler(IoExecutor executor) {
+        TestIoHandler(ThreadAwareExecutor executor) {
             this.executor = executor;
         }
 
@@ -154,7 +155,7 @@ public class SingleThreadIoEventLoopTest {
         }
 
         @Override
-        public int run(IoExecutorContext context) {
+        public int run(IoHandlerContext context) {
             try {
                 semaphore.acquire();
             } catch (InterruptedException e) {

--- a/transport/src/test/java/io/netty/channel/nio/NioIoHandlerTest.java
+++ b/transport/src/test/java/io/netty/channel/nio/NioIoHandlerTest.java
@@ -15,13 +15,11 @@
  */
 package io.netty.channel.nio;
 
-import io.netty.channel.IoExecutor;
-import io.netty.channel.IoExecutorContext;
+import io.netty.channel.IoHandlerContext;
 import io.netty.channel.IoHandler;
 import io.netty.channel.IoHandlerFactory;
 import io.netty.channel.IoRegistration;
-import io.netty.util.concurrent.DefaultPromise;
-import io.netty.util.concurrent.Promise;
+import io.netty.util.concurrent.ThreadAwareExecutor;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -44,9 +42,9 @@ public class NioIoHandlerTest {
         final Thread current = Thread.currentThread();
         final Queue<Runnable> tasks = new ConcurrentLinkedQueue<>();
         // Create our own IoExecutor that is driven by the main thread
-        final IoExecutor executor = new IoExecutor() {
+        final ThreadAwareExecutor executor = new ThreadAwareExecutor() {
             @Override
-            public boolean inExecutorThread(Thread thread) {
+            public boolean isExecutorThread(Thread thread) {
                 return current == thread;
             }
 
@@ -55,7 +53,7 @@ public class NioIoHandlerTest {
                 tasks.add(command);
             }
         };
-        IoExecutorContext context = new IoExecutorContext() {
+        IoHandlerContext context = new IoHandlerContext() {
             @Override
             public boolean canBlock() {
                 // Just busy spin.


### PR DESCRIPTION
Motivation:

ThreadAwareExecutor is a much better name

Modifications:

- Rename to ThreadAwareExecutor
- Let EventExecutor extend ThreadAwareExecutor

Result:

Cleanup
