### PR TITLE
Small pkitesting cleanup for ML-DSA

### DIFF
--- a/pkitesting/src/main/java/io/netty/pkitesting/MLDSASeedPrivateKey.java
+++ b/pkitesting/src/main/java/io/netty/pkitesting/MLDSASeedPrivateKey.java
@@ -90,13 +90,6 @@ final class MLDSASeedPrivateKey implements PrivateKey {
         return key.isDestroyed();
     }
 
-    static byte[] getEncoded(PrivateKey key) {
-        if (key instanceof MLDSASeedPrivateKey) {
-            return ((MLDSASeedPrivateKey) key).seedFormat.clone();
-        }
-        return key.getEncoded();
-    }
-
     static PrivateKey unwrap(PrivateKey key) {
         if (key instanceof MLDSASeedPrivateKey) {
             return ((MLDSASeedPrivateKey) key).key;

--- a/pkitesting/src/main/java/io/netty/pkitesting/X509Bundle.java
+++ b/pkitesting/src/main/java/io/netty/pkitesting/X509Bundle.java
@@ -199,7 +199,7 @@ public final class X509Bundle {
         StringBuilder sb = new StringBuilder();
         sb.append("-----BEGIN PRIVATE KEY-----\r\n");
         PrivateKey privateKey = keyPair.getPrivate();
-        sb.append(encoder.encodeToString(MLDSASeedPrivateKey.getEncoded(privateKey)));
+        sb.append(encoder.encodeToString(privateKey.getEncoded()));
         sb.append("\r\n-----END PRIVATE KEY-----\r\n");
         return sb.toString();
     }


### PR DESCRIPTION
Motivation:
These were leftovers from mid-development changes.

Modification:
MLDSASeedPrivateKey.getEncoded directly returns seed-form encoding. Remove the useless static method.

Result:
Cleaner code.