### PR TITLE
Preserve optionality of dependencies in netty-all

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -367,11 +367,27 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-codec-protobuf</artifactId>
       <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.protobuf</groupId>
+          <artifactId>protobuf-java</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.protobuf.nano</groupId>
+          <artifactId>protobuf-javanano</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-codec-marshalling</artifactId>
       <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.marshalling</groupId>
+          <artifactId>jboss-marshalling</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
Motivation:
We split the netty-codec module into multiple modules in 4.2, and made sure that when people depend on netty-codec, the behavior of the optional jboss-marshalling and protobuf-nano dependencies would be the same. However, we forgot to apply the same trick for netty-all. This means that people upgrading a netty-all dependency from Netty 4.1.117 to 4.2.0.RC2 will see that they suddenly include jboss-marshalling and protobuf-nano, where they previously didn't.

Modification:
Make netty-all exclude the protobuf and jboss-marshalling dependencies when including the relevant netty-codec subprojects.

Result:
Transitive dependencies off netty-all behave the same for 4.1 and 4.2.
