### PR TITLE
Add build profile for oss-fuzz compilation

### DIFF
--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -534,38 +534,9 @@
     </profile>
     <profile>
       <id>oss-fuzz</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.fusesource.hawtjni</groupId>
-            <artifactId>hawtjni-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>build-native-lib</id>
-                <configuration>
-                  <name>netty_transport_native_epoll_${os.detected.arch}</name>
-                  <nativeSourceDirectory>${nativeSourceDirectory}</nativeSourceDirectory>
-                  <libDirectory>${project.build.outputDirectory}</libDirectory>
-                  <!-- We use Maven's artifact classifier instead.
-                       This hack will make the hawtjni plugin to put the native library
-                       under 'META-INF/native' rather than 'META-INF/native/${platform}'. -->
-                  <platform>.</platform>
-                  <configureArgs>
-                    <arg>${jni.compiler.args.ldflags}</arg>
-                    <arg>${jni.compiler.args.libs}</arg>
-                    <arg>CFLAGS=${env.CFLAGS} -I${unix.common.include.unpacked.dir}</arg>
-                    <configureArg>--libdir=${project.build.directory}/native-build/target/lib</configureArg>
-                  </configureArgs>
-                </configuration>
-                <goals>
-                  <goal>generate</goal>
-                  <goal>build</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
+      <properties>
+        <jni.compiler.args.cflags>CFLAGS=${env.CFLAGS} -I${unix.common.include.unpacked.dir}</jni.compiler.args.cflags>
+      </properties>
     </profile>
   </profiles>
 

--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -532,6 +532,40 @@
         </dependency>
       </dependencies>
     </profile>
+    <profile>
+      <id>oss-fuzz</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.fusesource.hawtjni</groupId>
+            <artifactId>hawtjni-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>build-native-lib</id>
+                <configuration>
+                  <name>netty_transport_native_epoll_${os.detected.arch}</name>
+                  <nativeSourceDirectory>${nativeSourceDirectory}</nativeSourceDirectory>
+                  <libDirectory>${project.build.outputDirectory}</libDirectory>
+                  <!-- We use Maven's artifact classifier instead.
+                       This hack will make the hawtjni plugin to put the native library
+                       under 'META-INF/native' rather than 'META-INF/native/${platform}'. -->
+                  <platform>.</platform>
+                  <configureArgs>
+                    <arg>${jni.compiler.args.ldflags}</arg>
+                    <arg>${jni.compiler.args.libs}</arg>
+                    <configureArg>--libdir=${project.build.directory}/native-build/target/lib</configureArg>
+                  </configureArgs>
+                </configuration>
+                <goals>
+                  <goal>generate</goal>
+                  <goal>build</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
   <dependencies>

--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -553,6 +553,7 @@
                   <configureArgs>
                     <arg>${jni.compiler.args.ldflags}</arg>
                     <arg>${jni.compiler.args.libs}</arg>
+                    <arg>CFLAGS=${env.CFLAGS} -I${unix.common.include.unpacked.dir}</arg>
                     <configureArg>--libdir=${project.build.directory}/native-build/target/lib</configureArg>
                   </configureArgs>
                 </configuration>


### PR DESCRIPTION
Motivation:

On OSS-Fuzz, the CFLAGS env variable contains special build flags that are necessary to give coverage information and sanitization to the fuzzer.

Modification:

Add an 'oss-fuzz' build profile that, instead of using fixed compilation flags, inherits those of the environment.

Result:

https://github.com/yawkat/netty-fuzz-tests can run with instrumentation of epoll native code.