### PR TITLE
Update the pipeline benchmark to make it more realistic (#14724)

### DIFF
--- a/microbench/src/main/java/io/netty5/microbench/channel/DefaultChannelPipelineBenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/channel/DefaultChannelPipelineBenchmark.java
@@ -17,12 +17,20 @@ package io.netty5.microbench.channel;
 
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
+import io.netty5.channel.ChannelOption;
 import io.netty5.channel.ChannelPipeline;
+import io.netty5.channel.ReadBufferAllocator;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.microbench.util.AbstractMicrobenchmark;
+import io.netty5.util.concurrent.Future;
+import io.netty5.util.concurrent.GlobalEventExecutor;
+import io.netty5.util.concurrent.Promise;
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
@@ -31,53 +39,319 @@ import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
-@Warmup(iterations = 5)
-@Measurement(iterations = 5)
-@State(Scope.Benchmark)
-public class DefaultChannelPipelineBenchmark extends AbstractMicrobenchmark {
+import java.util.SplittableRandom;
 
-    private static final ChannelHandler NOOP_HANDLER = new ChannelHandler() {
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@Fork(0)
+@State(Scope.Thread)
+public class DefaultChannelPipelineBenchmark extends AbstractMicrobenchmark {
+    private static final Object MESSAGE = new Object();
+    private static final Future<Void> FUTURE = GlobalEventExecutor.INSTANCE.newSucceededFuture();
+
+    private abstract static class SharableHandlerAdapter implements ChannelHandler {
         @Override
-        public boolean isSharable() {
+        public final boolean isSharable() {
             return true;
         }
-    };
+    }
 
-    private static final ChannelHandler CONSUMING_HANDLER = new ChannelHandler() {
+    private static final ChannelHandler CONSUMING_HANDLER = new SharableHandlerAdapter() {
         @Override
-        public boolean isSharable() {
-            return true;
+        public void channelActive(ChannelHandlerContext ctx) throws Exception {
+            // NOOP
+        }
+
+        @Override
+        public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+            // NOOP
+        }
+
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+            // NOOP
+        }
+
+        @Override
+        public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
+            // NOOP
         }
 
         @Override
         public void channelReadComplete(ChannelHandlerContext ctx) {
             // NOOP
         }
+
+        @Override
+        public void read(ChannelHandlerContext ctx, ReadBufferAllocator readBufferAllocator) {
+            // NOOP
+        }
+
+        @Override
+        public Future<Void> write(ChannelHandlerContext ctx, Object msg) {
+            // NOOP
+            return FUTURE;
+        }
+
+        @Override
+        public void flush(ChannelHandlerContext ctx) {
+            // NOOP
+        }
     };
 
-    @Param({ "4" })
+    private static final ChannelHandler[] HANDLERS = {
+            new SharableHandlerAdapter() {
+                @Override
+                public void channelActive(ChannelHandlerContext ctx) throws Exception {
+                    ctx.fireChannelActive();
+                }
+            },
+            new SharableHandlerAdapter() {
+                @Override
+                public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+                    ctx.fireChannelInactive();
+                }
+            },
+            new SharableHandlerAdapter() {
+                @Override
+                public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+                    ctx.fireChannelRead(msg);
+                }
+            },
+            new SharableHandlerAdapter() {
+                @Override
+                public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
+                    ctx.fireChannelInboundEvent(evt);
+                }
+            },
+            new SharableHandlerAdapter() {
+                @Override
+                public void channelReadComplete(ChannelHandlerContext ctx) {
+                    ctx.fireChannelReadComplete();
+                }
+            },
+            new SharableHandlerAdapter() {
+                @Override
+                public void channelActive(ChannelHandlerContext ctx) throws Exception {
+                    ctx.fireChannelActive();
+                }
+
+                @Override
+                public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+                    ctx.fireChannelInactive();
+                }
+            },
+            new SharableHandlerAdapter() {
+                @Override
+                public void channelActive(ChannelHandlerContext ctx) throws Exception {
+                    ctx.fireChannelActive();
+                }
+
+                @Override
+                public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+                    ctx.fireChannelRead(msg);
+                }
+            },
+            new SharableHandlerAdapter() {
+                @Override
+                public void channelActive(ChannelHandlerContext ctx) throws Exception {
+                    ctx.fireChannelActive();
+                }
+
+                @Override
+                public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
+                    ctx.fireChannelInboundEvent(evt);
+                }
+            },
+            new SharableHandlerAdapter() {
+                @Override
+                public void channelActive(ChannelHandlerContext ctx) throws Exception {
+                    ctx.fireChannelActive();
+                }
+
+                @Override
+                public void channelReadComplete(ChannelHandlerContext ctx) {
+                    ctx.fireChannelReadComplete();
+                }
+            },
+            new SharableHandlerAdapter() {
+                @Override
+                public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+                    ctx.fireChannelInactive();
+                }
+
+                @Override
+                public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+                    ctx.fireChannelRead(msg);
+                }
+            },
+            new SharableHandlerAdapter() {
+                @Override
+                public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+                    ctx.fireChannelInactive();
+                }
+
+                @Override
+                public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
+                    ctx.fireChannelInboundEvent(evt);
+                }
+            },
+            new SharableHandlerAdapter() {
+                @Override
+                public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+                    ctx.fireChannelInactive();
+                }
+
+                @Override
+                public void channelReadComplete(ChannelHandlerContext ctx) {
+                    ctx.fireChannelReadComplete();
+                }
+            },
+            new SharableHandlerAdapter() {
+                @Override
+                public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+                    ctx.fireChannelRead(msg);
+                }
+
+                @Override
+                public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
+                    ctx.fireChannelInboundEvent(evt);
+                }
+            },
+            new SharableHandlerAdapter() {
+                @Override
+                public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+                    ctx.fireChannelRead(msg);
+                }
+
+                @Override
+                public void channelReadComplete(ChannelHandlerContext ctx) {
+                    ctx.fireChannelReadComplete();
+                }
+            },
+            new SharableHandlerAdapter() {
+                @Override
+                public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
+                    ctx.fireChannelInboundEvent(evt);
+                }
+
+                @Override
+                public void channelReadComplete(ChannelHandlerContext ctx) {
+                    ctx.fireChannelReadComplete();
+                }
+            },
+            new SharableHandlerAdapter() {
+                @Override
+                public void read(ChannelHandlerContext ctx, ReadBufferAllocator readBufferAllocator) {
+                    ctx.read();
+                }
+            },
+            new SharableHandlerAdapter() {
+                @Override
+                public Future<Void> write(ChannelHandlerContext ctx, Object msg) {
+                    return ctx.write(msg);
+                }
+            },
+            new SharableHandlerAdapter() {
+                @Override
+                public void flush(ChannelHandlerContext ctx) {
+                    ctx.flush();
+                }
+            },
+            new SharableHandlerAdapter() {
+                @Override
+                public void read(ChannelHandlerContext ctx, ReadBufferAllocator readBufferAllocator) {
+                    ctx.read();
+                }
+
+                @Override
+                public Future<Void> write(ChannelHandlerContext ctx, Object msg) {
+                    return ctx.write(msg);
+                }
+            },
+            new SharableHandlerAdapter() {
+                @Override
+                public void read(ChannelHandlerContext ctx, ReadBufferAllocator readBufferAllocator) {
+                    ctx.read();
+                }
+
+                @Override
+                public void flush(ChannelHandlerContext ctx) {
+                    ctx.flush();
+                }
+            },
+            new SharableHandlerAdapter() {
+                @Override
+                public Future<Void> write(ChannelHandlerContext ctx, Object msg) {
+                    return ctx.write(msg);
+                }
+
+                @Override
+                public void flush(ChannelHandlerContext ctx) {
+                    ctx.flush();
+                }
+            },
+    };
+
+    @Param({ "1024" })
+    private int pipelineArrayLength;
+    private int pipelineArrayMask;
+
+    @Param({ "16" })
     public int extraHandlers;
 
-    private ChannelPipeline pipeline;
+    private ChannelPipeline[] pipelines;
+    private int pipelineCounter;
 
     @Setup(Level.Iteration)
     public void setup() {
-        pipeline = new EmbeddedChannel().pipeline();
-        for (int i = 0; i < extraHandlers; i++) {
-            pipeline.addLast(NOOP_HANDLER);
+        SplittableRandom rng = new SplittableRandom();
+        pipelineArrayMask = pipelineArrayLength - 1;
+        pipelines = new ChannelPipeline[pipelineArrayLength];
+        for (int i = 0; i < pipelineArrayLength; i++) {
+            EmbeddedChannel channel = new EmbeddedChannel();
+            channel.setOption(ChannelOption.AUTO_READ, false);
+            ChannelPipeline pipeline = channel.pipeline();
+            pipeline.addLast(CONSUMING_HANDLER);
+            for (int j = 0; j < extraHandlers; j++) {
+                pipeline.addLast(HANDLERS[rng.nextInt(0, HANDLERS.length)]);
+            }
+            pipeline.addLast(CONSUMING_HANDLER);
+            pipelines[i] = pipeline;
         }
-        pipeline.addLast(CONSUMING_HANDLER);
     }
 
     @TearDown
     public void tearDown() {
-        pipeline.channel().close();
+        for (ChannelPipeline pipeline : pipelines) {
+            pipeline.channel().close();
+        }
     }
 
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     @Benchmark
     public void propagateEvent(Blackhole hole) {
-        for (int i = 0; i < 100; i++) {
-            hole.consume(pipeline.fireChannelReadComplete());
-        }
+        ChannelPipeline pipeline = pipelines[pipelineCounter++ & pipelineArrayMask];
+        hole.consume(pipeline.fireChannelReadComplete());
+    }
+
+    @OperationsPerInvocation(12)
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    @Benchmark
+    public void propagateVariety(Blackhole hole) {
+        int index = pipelineCounter++ & pipelineArrayMask;
+        ChannelPipeline pipeline = pipelines[index];
+        hole.consume(pipeline.fireChannelActive());              // 1
+        hole.consume(pipeline.fireChannelRead(MESSAGE));         // 2
+        hole.consume(pipeline.fireChannelRead(MESSAGE));         // 3
+        hole.consume(pipeline.write(MESSAGE));                   // 4
+        hole.consume(pipeline.fireChannelRead(MESSAGE));         // 5
+        hole.consume(pipeline.fireChannelRead(MESSAGE));         // 6
+        hole.consume(pipeline.write(MESSAGE));                   // 7
+        hole.consume(pipeline.fireChannelReadComplete());        // 8
+        hole.consume(pipeline.fireChannelInboundEvent(MESSAGE)); // 9
+        hole.consume(pipeline.fireChannelWritabilityChanged());  // 10
+        hole.consume(pipeline.flush());                          // 11
+        hole.consume(pipeline.fireChannelInactive());            // 12
     }
 }


### PR DESCRIPTION
Motivation:
If we are to make meaningful optimisations to the pipeline machinery, we need a benchmark that is pipeline-focused, but still representative of realistic interaction patterns.

Modification:
Generate a variety of pipelines with many different handlers that implement a mix of methods, so some will be skipped while others will be called.

We then measure both single-method call sequences, and we measure a sequence of different calls.

This puts pressure on the handler-skipping logic.

Result:
We have a more realistic benchmark for message propagation in channel handler pipelines.