### PR TITLE
Update javadocs to better guide user on what to use to replace deprec…

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoopGroup.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoopGroup.java
@@ -36,7 +36,7 @@ import java.util.concurrent.ThreadFactory;
  * {@link EventLoopGroup} which uses epoll under the covers. Because of this
  * it only works on linux.
  *
- * @deprecated Use {@link MultiThreadIoEventLoopGroup} with {@link EpollIoHandler}.
+ * @deprecated Use {@link MultiThreadIoEventLoopGroup} with {@link EpollIoHandler#newFactory()}.
  */
 @Deprecated
 public final class EpollEventLoopGroup extends MultiThreadIoEventLoopGroup {

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoopGroup.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoopGroup.java
@@ -39,7 +39,7 @@ import java.util.concurrent.ThreadFactory;
 
 
 /**
- * @deprecated Use {@link MultiThreadIoEventLoopGroup} with {@link KQueueIoHandler}.
+ * @deprecated Use {@link MultiThreadIoEventLoopGroup} with {@link KQueueIoHandler#newFactory()}.
  */
 @Deprecated
 public final class KQueueEventLoopGroup extends MultiThreadIoEventLoopGroup {

--- a/transport/src/main/java/io/netty/channel/local/LocalEventLoopGroup.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalEventLoopGroup.java
@@ -20,7 +20,7 @@ import io.netty.channel.MultiThreadIoEventLoopGroup;
 import java.util.concurrent.ThreadFactory;
 
 /**
- * @deprecated Use {@link MultiThreadIoEventLoopGroup} with {@link io.netty.channel.local.LocalIoHandler}.
+ * @deprecated Use {@link MultiThreadIoEventLoopGroup} with {@link LocalIoHandler#newFactory()}.
  */
 @Deprecated
 public class LocalEventLoopGroup extends MultiThreadIoEventLoopGroup {

--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoopGroup.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoopGroup.java
@@ -39,7 +39,7 @@ import java.util.concurrent.ThreadFactory;
 /**
  * {@link MultiThreadIoEventLoopGroup} implementation which is used for NIO {@link Selector} based {@link Channel}s.
  *
- * @deprecated Use {@link MultiThreadIoEventLoopGroup} with {@link io.netty.channel.nio.NioIoHandler}.
+ * @deprecated Use {@link MultiThreadIoEventLoopGroup} with {@link NioIoHandler#newFactory()}.
  */
 @Deprecated
 public class NioEventLoopGroup extends MultiThreadIoEventLoopGroup implements IoEventLoopGroup {


### PR DESCRIPTION
…ated code

Motivation:

*EventLoopGroup implementations are deprecated now, let's point the user to the code to use.

Modifications:

Add better docs

Result:

Better documentation