### PR TITLE
IoEventLoop*: Move default methods to IoEventLoopGroup

### DIFF
--- a/transport/src/main/java/io/netty/channel/IoEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/IoEventLoop.java
@@ -23,25 +23,10 @@ import io.netty.util.concurrent.Future;
  */
 public interface IoEventLoop extends EventLoop, IoEventLoopGroup {
 
-    // We only not return IoHandleEventLoopGroup here as this could break compat for people
-    // that extend EventLoopGroup implementations that now implement IoHandleEventLoop (for example NioEventLoop).
     @Override
-    default EventLoopGroup parent() {
+    default IoEventLoop next() {
         return this;
     }
-    /**
-     * @deprecated Use {@link #register(IoHandle)}
-     */
-    @Deprecated
-    @Override
-    ChannelFuture register(Channel channel);
-
-    /**
-     * @deprecated Use {@link #register(IoHandle)}
-     */
-    @Deprecated
-    @Override
-    ChannelFuture register(ChannelPromise promise);
 
     /**
      * Register the {@link IoHandle} to the {@link EventLoop} for I/O processing.

--- a/transport/src/main/java/io/netty/channel/IoEventLoopGroup.java
+++ b/transport/src/main/java/io/netty/channel/IoEventLoopGroup.java
@@ -15,6 +15,8 @@
  */
 package io.netty.channel;
 
+import io.netty.util.concurrent.Future;
+
 /**
  * {@link EventLoopGroup} for {@link IoEventLoop}s.
  */
@@ -22,6 +24,34 @@ public interface IoEventLoopGroup extends EventLoopGroup {
 
     @Override
     IoEventLoop next();
+
+    /**
+     * @deprecated Use {@link #register(IoHandle)}
+     */
+    @Deprecated
+    @Override
+    default ChannelFuture register(Channel channel) {
+        return next().register(channel);
+    }
+
+    /**
+     * @deprecated Use {@link #register(IoHandle)}
+     */
+    @Deprecated
+    @Override
+   default ChannelFuture register(ChannelPromise promise) {
+        return next().register(promise);
+    }
+
+    /**
+     * Register the {@link IoHandle} to the {@link EventLoop} for I/O processing.
+     *
+     * @param handle        the {@link IoHandle} to register.
+     * @return              the {@link Future} that is notified once the operations completes.
+     */
+    default Future<IoRegistration> register(IoHandle handle) {
+        return next().register(handle);
+    }
 
     /**
      * Returns {@code true} if the given type is compatible with this {@link IoEventLoopGroup} and so can be registered


### PR DESCRIPTION
Motivation:

The deprecated register(...) methods should be part of `IoEventLoopGroup` and not `IoEventLoop` so they apply to both of them

Modifications:

- Move deprecated methods to IoEventLoopGroup
- Implement the correct methods in IoEventLoop as default method

Result:

Correctly mark methods as deprecated
