### PR TITLE
Remove IoUringChannelOption.IOSQE_ASYNC

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -244,9 +244,6 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
     }
 
     protected byte flags(byte flags) {
-        if (((IOUringChannelConfig) config()).getIoseqAsync()) {
-            return (byte) (flags | Native.IOSQE_ASYNC);
-        }
         return flags;
     }
 
@@ -321,7 +318,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
         }
         if (scheduleWrite(in) > 0) {
             ioState |= WRITE_SCHEDULED;
-            if (submitAndRunNow && !isWritable() && !((IOUringChannelConfig) config()).getIoseqAsync()) {
+            if (submitAndRunNow && !isWritable()) {
                 submitAndRunNow();
             }
         }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IOUringChannelConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IOUringChannelConfig.java
@@ -27,7 +27,6 @@ import java.util.Map;
 
 abstract class IOUringChannelConfig extends DefaultChannelConfig {
     private volatile boolean pollInFirst = true;
-    private volatile boolean ioseqAsync;
 
     IOUringChannelConfig(Channel channel) {
         super(channel);
@@ -39,7 +38,7 @@ abstract class IOUringChannelConfig extends DefaultChannelConfig {
 
     @Override
     public Map<ChannelOption<?>, Object> getOptions() {
-        return getOptions(super.getOptions(), IoUringChannelOption.POLLIN_FIRST, IoUringChannelOption.IOSQE_ASYNC);
+        return getOptions(super.getOptions(), IoUringChannelOption.POLLIN_FIRST);
     }
 
     @SuppressWarnings("unchecked")
@@ -47,9 +46,6 @@ abstract class IOUringChannelConfig extends DefaultChannelConfig {
     public <T> T getOption(ChannelOption<T> option) {
         if (option == IoUringChannelOption.POLLIN_FIRST) {
             return (T) Boolean.valueOf(pollInFirst);
-        }
-        if (option == IoUringChannelOption.IOSQE_ASYNC) {
-            return (T) Boolean.valueOf(ioseqAsync);
         }
         return super.getOption(option);
     }
@@ -60,8 +56,6 @@ abstract class IOUringChannelConfig extends DefaultChannelConfig {
 
         if (option == IoUringChannelOption.POLLIN_FIRST) {
             setPollInFirst((Boolean) value);
-        } else if (option == IoUringChannelOption.IOSQE_ASYNC) {
-            setIoseqAsync((Boolean) value);
         } else {
             return super.setOption(option, value);
         }
@@ -75,14 +69,6 @@ abstract class IOUringChannelConfig extends DefaultChannelConfig {
 
     void setPollInFirst(boolean pollInFirst) {
         this.pollInFirst = pollInFirst;
-    }
-
-    boolean getIoseqAsync() {
-        return ioseqAsync;
-    }
-
-    void setIoseqAsync(boolean ioseqAsync) {
-        this.ioseqAsync = ioseqAsync;
     }
 
     @Override

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringChannelOption.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringChannelOption.java
@@ -55,11 +55,6 @@ public final class IoUringChannelOption<T> extends UnixChannelOption<T> {
     public static final ChannelOption<Boolean> POLLIN_FIRST = valueOf("POLLIN_FIRST");
 
     /**
-     * Use {@code IOSQE_ASYNC} when submitting {@link IoUringIoOps}.
-     */
-    public static final ChannelOption<Boolean> IOSQE_ASYNC = valueOf("IOSQE_ASYNC");
-
-    /**
      * The buffer group id to use when submitting recv / read / readv {@link IoUringIoOps}.
      * If it is set to {@code 0}, then this function will be disabled.
      * <p>


### PR DESCRIPTION
Motivation:

There is no advantages by using IOSQE_ASYNC for our use case, as shown in latest benchmarks. Let's remove the ChannelOption to simplify things.

Modifications:

Remove IoUringChannelOption.IOSQE_ASYNC

Result:

Cleanup / Simplify
