### PR TITLE
IoUring: Handle read errors because of no space in the buffer ring as…

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -415,7 +415,16 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
                         // fire the BufferRingExhaustedEvent to notify users.
                         // Users can then switch the ring buffer or do other things as they wish
                         pipeline.fireUserEventTriggered(bufferRing.getExhaustedEvent());
-                        scheduleNextRead(flags);
+
+                        // Let's trigger a read again without consulting the RecvByteBufAllocator.Handle as
+                        // we can't count this as a "real" read operation.
+                        // This will do the correct thing, taking into account if
+                        // there is again room in the ring or not and so either use the buffer ring or not for the
+                        // read.
+                        //
+                        // As we only use the buffer ring for the first read we can call schedule(...) with true as
+                        // parameter.
+                        scheduleRead(true);
                         return;
                     }
 


### PR DESCRIPTION
… no-op

Motivation:

If a read fails because we had no buffer left in the buffer ring we should just schedule another read without consulting the RecvByteBufAllocator.Handle. The next read will then either use the buffer ring (which might have been changed by the user) or do a regular read, depending on if the buffer ring has something to use left.

Modification:

Don't consult the handle