### PR TITLE
AdaptivePoolingAllocator: Round chunk sizes up to MIN_CHUNK_SIZE units and reduce chunk release frequency

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -750,7 +750,10 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
             int size = Math.max(promptingSize * BUFS_PER_CHUNK, preferredChunkSize());
             int minChunks = size / MIN_CHUNK_SIZE;
             if (MIN_CHUNK_SIZE * minChunks < size) {
-                // Round up to nearest whole MIN_CHUNK_SIZE unit.
+                // Round up to nearest whole MIN_CHUNK_SIZE unit. The MIN_CHUNK_SIZE is an even multiple of many
+                // popular small page sizes, like 4k, 16k, and 64k, which makes it easier for the system allocator
+                // to manage the memory in terms of whole pages. This reduces memory fragmentation,
+                // but without the potentially high overhead that power-of-2 chunk sizes would bring.
                 size = MIN_CHUNK_SIZE * (1 + minChunks);
             }
             ChunkAllocator chunkAllocator = parent.chunkAllocator;

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -573,10 +573,10 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
                     allocationLock.unlockWrite(writeLock);
                 }
             }
-            return allocateWithoutLock(size, sizeBucket, maxCapacity, buf);
+            return allocateWithoutLock(size, maxCapacity, buf);
         }
 
-        private boolean allocateWithoutLock(int size, int sizeBucket, int maxCapacity, AdaptiveByteBuf buf) {
+        private boolean allocateWithoutLock(int size, int maxCapacity, AdaptiveByteBuf buf) {
             Chunk curr = NEXT_IN_LINE.getAndSet(this, null);
             if (curr == MAGAZINE_FREED) {
                 // Allocation raced with a stripe-resize that freed this magazine.

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -748,6 +748,11 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
 
         private Chunk newChunkAllocation(int promptingSize) {
             int size = Math.max(promptingSize * BUFS_PER_CHUNK, preferredChunkSize());
+            int minChunks = size / MIN_CHUNK_SIZE;
+            if (MIN_CHUNK_SIZE * minChunks < size) {
+                // Round up to nearest whole MIN_CHUNK_SIZE unit.
+                size = MIN_CHUNK_SIZE * (1 + minChunks);
+            }
             ChunkAllocator chunkAllocator = parent.chunkAllocator;
             return new Chunk(chunkAllocator.allocate(size, size), this, true);
         }

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -87,10 +87,17 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
         None
     }
 
+    /**
+     * The 128 KiB minimum chunk size is chosen to encourage the system allocator to delegate to mmap for chunk
+     * allocations. For instance, glibc will do this.
+     * This pushes any fragmentation from chunk size deviations off physical memory, onto virtual memory,
+     * which is a much, much larger space. Chunks are also allocated in whole multiples of the minimum
+     * chunk size, which itself is a whole multiple of popular page sizes like 4 KiB, 16 KiB, and 64 KiB.
+     */
+    private static final int MIN_CHUNK_SIZE = 128 * 1024;
     private static final int EXPANSION_ATTEMPTS = 3;
     private static final int INITIAL_MAGAZINES = 4;
     private static final int RETIRE_CAPACITY = 4 * 1024;
-    private static final int MIN_CHUNK_SIZE = 128 * 1024;
     private static final int MAX_STRIPES = NettyRuntime.availableProcessors() * 2;
     private static final int BUFS_PER_CHUNK = 10; // For large buffers, aim to have about this many buffers per chunk.
 


### PR DESCRIPTION
Motivation:
As the AdaptivePoolingAllocator adjusts it's preferred chunk size, it may end up causing fragmentation with the system allocator if chunks are allocated and released frequently.

Modification:
The chunk size is now rounded up to the nearest whole multiple of the MIN_CHUNK_SIZE. The MIN_CHUNK_SIZE is itself already an even multiple of many popular small page sizes, like 4k, 16k, and 64k, which makes it easier for the system allocator to manage the memory in terms of whole pages.

To further reduce chunk release frequency, chunks are now probabilistically released if their size differs from the preferred chunk size.
The probability of a chunk being released depends on how many MIN_CHUNK_SIZE units they deviate from the preferred chunk size. The probability is computed as 0.5% per unit of deviation, so chunks that are off by 2.6 MiB or more are guaranteed to be released.

Result:
Reduced memory fragmentation tendency of the adaptive allocator.