### PR TITLE
Change the default AdaptiveRecvByteBufAllocator buffer size values' v…

### DIFF
--- a/transport/src/main/java/io/netty/channel/AdaptiveRecvByteBufAllocator.java
+++ b/transport/src/main/java/io/netty/channel/AdaptiveRecvByteBufAllocator.java
@@ -34,10 +34,10 @@ import static java.lang.Math.min;
  */
 public class AdaptiveRecvByteBufAllocator extends DefaultMaxMessagesRecvByteBufAllocator {
 
-    static final int DEFAULT_MINIMUM = 64;
+    public static final int DEFAULT_MINIMUM = 64;
     // Use an initial value that is bigger than the common MTU of 1500
-    static final int DEFAULT_INITIAL = 2048;
-    static final int DEFAULT_MAXIMUM = 65536;
+    public static final int DEFAULT_INITIAL = 2048;
+    public static final int DEFAULT_MAXIMUM = 65536;
 
     private static final int INDEX_INCREMENT = 4;
     private static final int INDEX_DECREMENT = 1;


### PR DESCRIPTION
…isibility to public (#14758)

Motivation:
Currently, the constants for default values of the buffer are package-private.

Modification:
Introduce the ability to reference and reuse the default values for the buffer size from other classes/projects.

Result:
Changing the three constants for the buffer default value to public visibility.