### PR TITLE
Revert new constructor of DefaultPromise

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
+++ b/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
@@ -25,7 +25,6 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
@@ -49,7 +48,7 @@ public class DefaultPromise<V> extends AbstractFuture<V> implements Promise<V> {
     private static final StackTraceElement[] CANCELLATION_STACK = CANCELLATION_CAUSE_HOLDER.cause.getStackTrace();
 
     private volatile Object result;
-    private final Executor executor;
+    private final EventExecutor executor;
     /**
      * One or more listeners. Can be a {@link GenericFutureListener} or a {@link DefaultFutureListeners}.
      * If {@code null}, it means either 1) no listeners were added yet or 2) all listeners were notified.
@@ -82,21 +81,6 @@ public class DefaultPromise<V> extends AbstractFuture<V> implements Promise<V> {
      *
      */
     public DefaultPromise(EventExecutor executor) {
-        this.executor = checkNotNull(executor, "executor");
-    }
-
-    /**
-     * Creates a new instance.
-     *
-     * @param executor
-     *        the {@link Executor} which is used to notify the promise once it is complete.
-     *        It is assumed this executor will protect against {@link StackOverflowError} exceptions.
-     *        The executor may be used to avoid {@link StackOverflowError} by executing a {@link Runnable} if the stack
-     *        depth exceeds a threshold.
-     *
-     */
-    protected DefaultPromise(Executor executor) {
-        // This constructor is protected as we don't encourage people to use it without a special need.
         this.executor = checkNotNull(executor, "executor");
     }
 
@@ -470,11 +454,7 @@ public class DefaultPromise<V> extends AbstractFuture<V> implements Promise<V> {
      * @return The executor used to notify listeners when this promise is complete.
      */
     protected EventExecutor executor() {
-        try {
-            return (EventExecutor) executor;
-        } catch (ClassCastException e) {
-            throw new UnsupportedOperationException(e);
-        }
+        return executor;
     }
 
     protected void checkDeadLock() {


### PR DESCRIPTION
Motivation:

754183b40168219d217c60855edc1432c4b56294 added a new Constructor to DefaultPromise. This was not needed at the end so let's remove it again

Modifications:

Remove unused constructor

Result:

Cleanup