### PR TITLE
IoUring: Add metric

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionQueue.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionQueue.java
@@ -35,6 +35,7 @@ final class CompletionQueue {
     //these unsigned integer pointers(shared with the kernel) will be changed by the kernel
     private final long kHeadAddress;
     private final long kTailAddress;
+    private final long koverflowAddress;
 
     private final long completionQueueArrayAddress;
 
@@ -51,6 +52,7 @@ final class CompletionQueue {
                     int ringFd) {
         this.kHeadAddress = kHeadAddress;
         this.kTailAddress = kTailAddress;
+        this.koverflowAddress = kOverflowAddress;
         this.completionQueueArrayAddress = completionQueueArrayAddress;
         this.ringSize = ringSize;
         this.ringAddress = ringAddress;
@@ -97,7 +99,13 @@ final class CompletionQueue {
                 break;
             }
         }
+        IoUringMetric.increaseCqeCounter(i);
+        IoUringMetric.recordOverflowCounter(this, getKoverflow());
         return i;
+    }
+
+    int getKoverflow() {
+        return PlatformDependent.getInt(koverflowAddress);
     }
 
     @Override

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUring.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUring.java
@@ -32,6 +32,7 @@ public final class IoUring {
     private static final boolean IORING_SETUP_SINGLE_ISSUER_SUPPORTED;
     private static final boolean IORING_SETUP_DEFER_TASKRUN_SUPPORTED;
     private static final boolean IO_URING_REGISTER_BUFFER_RING_SUPPORTED;
+    private static final boolean IO_URING_NO_DROP_SUPPORTED;
 
     private static final InternalLogger logger;
 
@@ -46,6 +47,7 @@ public final class IoUring {
         boolean singleIssuerSupported = false;
         boolean deferTaskrunSupported = false;
         boolean registerBufferRingSupported = false;
+        boolean noDropSupported = false;
         try {
             if (SystemPropertyUtil.getBoolean("io.netty.transport.noNative", false)) {
                 cause = new UnsupportedOperationException(
@@ -63,6 +65,7 @@ public final class IoUring {
                         spliceSupported = Native.isIOUringSupportSplice(ringBuffer.fd());
                         // IORING_FEAT_RECVSEND_BUNDLE was added in the same release.
                         acceptSupportNoWait = (ringBuffer.features() & Native.IORING_FEAT_RECVSEND_BUNDLE) != 0;
+                        noDropSupported = (ringBuffer.features() & Native.IORING_FEAT_NODROP) != 0;
                         registerIowqWorkersSupported = Native.isRegisterIOWQWorkerSupported(ringBuffer.fd());
                         submitAllSupported = Native.ioUringSetupSupportsFlags(Native.IORING_SETUP_SUBMIT_ALL);
                         singleIssuerSupported = Native.ioUringSetupSupportsFlags(Native.IORING_SETUP_SINGLE_ISSUER);
@@ -118,6 +121,7 @@ public final class IoUring {
         IORING_SETUP_SINGLE_ISSUER_SUPPORTED = singleIssuerSupported;
         IORING_SETUP_DEFER_TASKRUN_SUPPORTED = deferTaskrunSupported;
         IO_URING_REGISTER_BUFFER_RING_SUPPORTED = registerBufferRingSupported;
+        IO_URING_NO_DROP_SUPPORTED = noDropSupported;
     }
 
     public static boolean isAvailable() {
@@ -174,6 +178,10 @@ public final class IoUring {
 
     public static boolean isRegisterBufferRingSupported() {
         return IO_URING_REGISTER_BUFFER_RING_SUPPORTED;
+    }
+
+    static boolean isIoUringNoDropSupported() {
+        return IO_URING_NO_DROP_SUPPORTED;
     }
 
     public static void ensureAvailability() {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRing.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRing.java
@@ -75,6 +75,7 @@ final class IoUringBufferRing {
      * to use.
      */
     void markExhausted() {
+        IoUringMetric.increaseProviderBufferReadFailCounter();
         hasSpareBuffer = false;
     }
 

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringMetric.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringMetric.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.util.internal.LongCounter;
+import io.netty.util.internal.PlatformDependent;
+import io.netty.util.internal.SystemPropertyUtil;
+
+import java.util.Map;
+
+/**
+ * Metric for {@link IoUring}.
+ */
+public final class IoUringMetric {
+
+    private static final boolean ENABLE_METRIC = SystemPropertyUtil.getBoolean("io.netty.iouring.enableMetric", true);
+
+    private static final LongCounter SQE_HANDLE_COUNTER = PlatformDependent.newLongCounter();
+
+    private static final LongCounter CQE_HANDLE_COUNT = PlatformDependent.newLongCounter();
+
+    private static final LongCounter PROVIDER_BUFFER_READ_FAIL_COUNT = PlatformDependent.newLongCounter();
+
+    /**
+     * Use map instead of directly using CompletionQueue to prevent illegal access after ioUring is closed
+     */
+    private static final Map<CompletionQueue, Integer> OVERFLOW_RECORD = PlatformDependent.newConcurrentHashMap();
+
+    private static final LongCounter OVERFLOW_FROM_CLOSED_CQE = PlatformDependent.newLongCounter();
+
+    private IoUringMetric() {
+        // utility
+    }
+
+    static void increaseSqeCounter(int count) {
+        if (ENABLE_METRIC) {
+            SQE_HANDLE_COUNTER.add(count);
+        }
+    }
+
+    static void increaseCqeCounter(int count) {
+        if (ENABLE_METRIC) {
+            CQE_HANDLE_COUNT.add(count);
+        }
+    }
+
+    static void increaseProviderBufferReadFailCounter() {
+        if (ENABLE_METRIC) {
+            PROVIDER_BUFFER_READ_FAIL_COUNT.increment();
+        }
+    }
+
+    static void recordOverflowCounter(CompletionQueue queue, int kflowValue) {
+        if (ENABLE_METRIC) {
+            OVERFLOW_RECORD.put(queue, kflowValue);
+        }
+    }
+
+    static void recordIOUringClose(RingBuffer ringBuffer) {
+        CompletionQueue completionQueue = ringBuffer.ioUringCompletionQueue();
+        OVERFLOW_FROM_CLOSED_CQE.add(completionQueue.getKoverflow());
+    }
+
+    /**
+     * The number of submitted SQEs submitted
+     *
+     * @return the number of SQEs submitted
+     */
+    public static long sqeCounter() {
+        return ENABLE_METRIC ? SQE_HANDLE_COUNTER.value() : 0;
+    }
+
+    /**
+     * The number of handle processed CQEs
+     *
+     * @return The number of handle processed CQEs
+     */
+    public static long cqeCounter() {
+        return ENABLE_METRIC ? CQE_HANDLE_COUNT.value() : 0;
+    }
+
+    /**
+     *  if the kernel supports IORING_FEAT_NODROP the ring enters a CQ ring overflow state.
+     *  Otherwise it drops the CQEs and increments cq.koverflow in struct io_uring with the number of CQEs dropped
+     *
+     * @return The number of overflowed CQEs
+     */
+    public static long overflowCounter() {
+        if (!ENABLE_METRIC || IoUring.isIoUringNoDropSupported()) {
+            return 0;
+        }
+        long count = 0;
+
+        for (Integer value : OVERFLOW_RECORD.values()) {
+            count += value;
+        }
+
+        return count + OVERFLOW_FROM_CLOSED_CQE.value();
+    }
+
+    /**
+     * The number of buffer ring exhaustion occurrences
+     *
+     * @return the number of buffer ring exhaustion occurrences
+     */
+    public static long providerBufferReadFailCounter() {
+        return ENABLE_METRIC && IoUring.isRegisterBufferRingSupported() ? PROVIDER_BUFFER_READ_FAIL_COUNT.value() : 0;
+    }
+}

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -213,6 +213,7 @@ final class Native {
     static final short IORING_RECVSEND_POLL_FIRST = 1 << 0;
     static final short IORING_ACCEPT_DONTWAIT = 1 << 1;
     static final short IORING_ACCEPT_POLL_FIRST = 1 << 2;
+    static final int IORING_FEAT_NODROP = 1 << 1;
     static final int IORING_FEAT_RECVSEND_BUNDLE = 1 << 14;
     static final int SPLICE_F_MOVE = 1;
 

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/RingBuffer.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/RingBuffer.java
@@ -57,6 +57,7 @@ final class RingBuffer {
     }
 
     void close() {
+        IoUringMetric.recordIOUringClose(this);
         Native.ioUringExit(
                 ioUringSubmissionQueue.submissionQueueArrayAddress,
                 ioUringSubmissionQueue.ringEntries,

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/SubmissionQueueTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/SubmissionQueueTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class SubmissionQueueTest {
@@ -53,6 +54,17 @@ public class SubmissionQueueTest {
             assertEquals(1, submissionQueue.count());
             submissionQueue.submitAndWait();
             assertEquals(9, completionQueue.count());
+            assertEquals(9, IoUringMetric.sqeCounter());
+            assertEquals(0, IoUringMetric.cqeCounter());
+
+            completionQueue.process(new CompletionCallback() {
+                @Override
+                public boolean handle(int res, int flags, long udata) {
+                    //just drop
+                    return true;
+                }
+            });
+            assertEquals(9, IoUringMetric.cqeCounter());
         } finally {
             ringBuffer.close();
         }


### PR DESCRIPTION
Motivation:

Provide a set of io_uring metrics to assist users in tuning based on actual conditions

Modification:

Introduce `IoUringMetric` class,it will provide the following types of data and allow the use of command-line arguments to control whether it is enabled or not

- the number of submitted SQEs submitted
- the number of handle processed CQEs
- the number of overflowed CQEs
- the number of buffer ring exhaustion occurrences