### PR TITLE
IoUring: IoUringBufferRing group ids should allow value of 0

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRingConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRingConfig.java
@@ -33,7 +33,7 @@ public final class IoUringBufferRingConfig {
     /**
      * Create a new configuration.
      *
-     * @param bgId              the buffer group id to use.
+     * @param bgId              the buffer group id to use (must be non-negative).
      * @param bufferRingSize    the size of the ring
      * @param chunkSize         the chunk size of each {@link io.netty.buffer.ByteBuf} that is allocated out of the
      *                          {@link ByteBufAllocator} to fill the ring.
@@ -46,7 +46,7 @@ public final class IoUringBufferRingConfig {
     /**
      * Create a new configuration.
      *
-     * @param bgId              the buffer group id to use.
+     * @param bgId              the buffer group id to use (must be non-negative).
      * @param bufferRingSize    the size of the ring
      * @param chunkSize         the chunk size of each {@link io.netty.buffer.ByteBuf} that is allocated out of the
      *                          {@link ByteBufAllocator} to fill the ring.
@@ -55,7 +55,7 @@ public final class IoUringBufferRingConfig {
      */
     public IoUringBufferRingConfig(short bgId, short bufferRingSize, int chunkSize,
                                    ByteBufAllocator allocator, int initSize) {
-        this.bgId = ObjectUtil.checkPositive(bgId, "bgId");
+        this.bgId = (short) ObjectUtil.checkPositiveOrZero(bgId, "bgId");
         this.bufferRingSize = checkBufferRingSize(bufferRingSize);
         this.chunkSize = ObjectUtil.checkPositive(chunkSize, "chunkSize");
         this.allocator = ObjectUtil.checkNotNull(allocator, "allocator");

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringChannelOption.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringChannelOption.java
@@ -45,7 +45,7 @@ public final class IoUringChannelOption<T> extends UnixChannelOption<T> {
 
     /**
      * The buffer group id to use when submitting recv / read / readv {@link IoUringIoOps}.
-     * If it is set to {@code 0}, then this function will be disabled.
+     * If it is set to {@code -1}, then this function will be disabled.
      * <p>
      * Check
      * <a href="https://man7.org/linux/man-pages/man3/io_uring_setup_buf_ring.3.html"> man io_uring_setup_buf_ring</a>

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringStreamChannelConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringStreamChannelConfig.java
@@ -24,7 +24,7 @@ import java.util.Map;
 
 abstract class IoUringStreamChannelConfig extends IoUringChannelConfig {
 
-    static final short DISABLE_BUFFER_SELECT_READ = 0;
+    static final short DISABLE_BUFFER_SELECT_READ = -1;
 
     private volatile short bufferGroupId = DISABLE_BUFFER_SELECT_READ;
 
@@ -80,7 +80,7 @@ abstract class IoUringStreamChannelConfig extends IoUringChannelConfig {
      * @return              itself.
      */
     IoUringStreamChannelConfig setBufferGroupId(short bufferGroupId) {
-        this.bufferGroupId = (short) ObjectUtil.checkPositiveOrZero(bufferGroupId, "bufferGroupId");
+        this.bufferGroupId = (short) ObjectUtil.checkInRange(bufferGroupId, -1, Short.MAX_VALUE, "bufferGroupId");
         return this;
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketTestPermutation.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketTestPermutation.java
@@ -40,8 +40,8 @@ import java.util.List;
 public class IoUringSocketTestPermutation extends SocketTestPermutation {
 
     static final IoUringSocketTestPermutation INSTANCE = new IoUringSocketTestPermutation();
-    static final short NO_BGID = 0;
-    static final short BGID = 1;
+    static final short NO_BGID = -1;
+    static final short BGID = 0;
     static final EventLoopGroup IO_URING_BOSS_GROUP = new MultiThreadIoEventLoopGroup(
             BOSSES, new DefaultThreadFactory("testsuite-io_uring-boss", true), IoUringIoHandler.newFactory());
     static final EventLoopGroup IO_URING_WORKER_GROUP = new MultiThreadIoEventLoopGroup(


### PR DESCRIPTION
Motiviations:

As stated in the manpages the group id of 0 is valid so we should allow it.

Modifications:

- Change checks to support 0 as group id
- Use -1 as value to disable buffer ring usage

Result:

More inline with the C api