### PR TITLE
AdaptivePoolingAllocator: Round chunk sizes up to MIN_CHUNK_SIZE unit…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -28,7 +28,6 @@ import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.ReferenceCountUpdater;
 import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.ThreadExecutorMap;
-import io.netty.util.internal.ThreadLocalRandom;
 import io.netty.util.internal.UnstableApi;
 
 import java.io.IOException;
@@ -45,6 +44,7 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
@@ -939,7 +939,7 @@ final class AdaptivePoolingAllocator {
 
             // Retire chunks with a 0.5% probability per unit of MIN_CHUNK_SIZE deviation from preference.
             return deviation != 0 &&
-                    PlatformDependent.threadLocalRandom().nextDouble() * 200.0 > deviation;
+                    ThreadLocalRandom.current().nextDouble() * 200.0 > deviation;
         }
 
         public void readInitInto(AdaptiveByteBuf buf, int size, int maxCapacity) {

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -28,6 +28,7 @@ import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.ReferenceCountUpdater;
 import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.ThreadExecutorMap;
+import io.netty.util.internal.ThreadLocalRandom;
 import io.netty.util.internal.UnstableApi;
 
 import java.io.IOException;
@@ -84,10 +85,17 @@ final class AdaptivePoolingAllocator {
         None
     }
 
+    /**
+     * The 128 KiB minimum chunk size is chosen to encourage the system allocator to delegate to mmap for chunk
+     * allocations. For instance, glibc will do this.
+     * This pushes any fragmentation from chunk size deviations off physical memory, onto virtual memory,
+     * which is a much, much larger space. Chunks are also allocated in whole multiples of the minimum
+     * chunk size, which itself is a whole multiple of popular page sizes like 4 KiB, 16 KiB, and 64 KiB.
+     */
+    private static final int MIN_CHUNK_SIZE = 128 * 1024;
     private static final int EXPANSION_ATTEMPTS = 3;
     private static final int INITIAL_MAGAZINES = 4;
     private static final int RETIRE_CAPACITY = 4 * 1024;
-    private static final int MIN_CHUNK_SIZE = 128 * 1024;
     private static final int MAX_STRIPES = NettyRuntime.availableProcessors() * 2;
     private static final int BUFS_PER_CHUNK = 10; // For large buffers, aim to have about this many buffers per chunk.
 
@@ -568,10 +576,10 @@ final class AdaptivePoolingAllocator {
                     allocationLock.unlockWrite(writeLock);
                 }
             }
-            return allocateWithoutLock(size, sizeBucket, maxCapacity, buf);
+            return allocateWithoutLock(size, maxCapacity, buf);
         }
 
-        private boolean allocateWithoutLock(int size, int sizeBucket, int maxCapacity, AdaptiveByteBuf buf) {
+        private boolean allocateWithoutLock(int size, int maxCapacity, AdaptiveByteBuf buf) {
             Chunk curr = NEXT_IN_LINE.getAndSet(this, null);
             if (curr == MAGAZINE_FREED) {
                 // Allocation raced with a stripe-resize that freed this magazine.
@@ -743,6 +751,14 @@ final class AdaptivePoolingAllocator {
 
         private Chunk newChunkAllocation(int promptingSize) {
             int size = Math.max(promptingSize * BUFS_PER_CHUNK, preferredChunkSize());
+            int minChunks = size / MIN_CHUNK_SIZE;
+            if (MIN_CHUNK_SIZE * minChunks < size) {
+                // Round up to nearest whole MIN_CHUNK_SIZE unit. The MIN_CHUNK_SIZE is an even multiple of many
+                // popular small page sizes, like 4k, 16k, and 64k, which makes it easier for the system allocator
+                // to manage the memory in terms of whole pages. This reduces memory fragmentation,
+                // but without the potentially high overhead that power-of-2 chunk sizes would bring.
+                size = MIN_CHUNK_SIZE * (1 + minChunks);
+            }
             ChunkAllocator chunkAllocator = parent.chunkAllocator;
             return new Chunk(chunkAllocator.allocate(size, size), this, true);
         }
@@ -893,9 +909,9 @@ final class AdaptivePoolingAllocator {
             AdaptivePoolingAllocator parent = mag.parent;
             int chunkSize = mag.preferredChunkSize();
             int memSize = delegate.capacity();
-            if (!pooled || memSize < chunkSize || memSize > chunkSize + (chunkSize >> 1)) {
-                // Drop the chunk if the parent allocator is closed, or if the chunk is smaller than the
-                // preferred chunk size, or over 50% larger than the preferred chunk size.
+            if (!pooled || shouldReleaseSuboptimalChunkSuze(memSize, chunkSize)) {
+                // Drop the chunk if the parent allocator is closed,
+                // or if the chunk deviates too much from the preferred chunk size.
                 detachFromMagazine();
                 delegate.release();
             } else {
@@ -914,6 +930,16 @@ final class AdaptivePoolingAllocator {
                     }
                 }
             }
+        }
+
+        private static boolean shouldReleaseSuboptimalChunkSuze(int givenSize, int preferredSize) {
+            int givenChunks = givenSize / MIN_CHUNK_SIZE;
+            int preferredChunks = preferredSize / MIN_CHUNK_SIZE;
+            int deviation = Math.abs(givenChunks - preferredChunks);
+
+            // Retire chunks with a 0.5% probability per unit of MIN_CHUNK_SIZE deviation from preference.
+            return deviation != 0 &&
+                    PlatformDependent.threadLocalRandom().nextDouble() * 200.0 > deviation;
         }
 
         public void readInitInto(AdaptiveByteBuf buf, int size, int maxCapacity) {


### PR DESCRIPTION
…s and reduce chunk release frequency (#14768)

Motivation:
As the AdaptivePoolingAllocator adjusts it's preferred chunk size, it may end up causing fragmentation with the system allocator if chunks are allocated and released frequently.

Modification:
The chunk size is now rounded up to the nearest whole multiple of the MIN_CHUNK_SIZE. The MIN_CHUNK_SIZE is itself already an even multiple of many popular small page sizes, like 4k, 16k, and 64k, which makes it easier for the system allocator to manage the memory in terms of whole pages.

To further reduce chunk release frequency, chunks are now probabilistically released if their size differs from the preferred chunk size.
The probability of a chunk being released depends on how many MIN_CHUNK_SIZE units they deviate from the preferred chunk size. The probability is computed as 0.5% per unit of deviation, so chunks that are off by 2.6 MiB or more are guaranteed to be released.

Result:
Reduced memory fragmentation tendency of the adaptive allocator.