### PR TITLE
Reduce pipeline stack depth

### DIFF
--- a/microbench/src/main/java/io/netty5/microbench/channel/DefaultChannelPipelineBenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/channel/DefaultChannelPipelineBenchmark.java
@@ -23,8 +23,6 @@ import io.netty5.channel.ReadBufferAllocator;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.microbench.util.AbstractMicrobenchmark;
 import io.netty5.util.concurrent.Future;
-import io.netty5.util.concurrent.GlobalEventExecutor;
-import io.netty5.util.concurrent.Promise;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.CompilerControl;
 import org.openjdk.jmh.annotations.Fork;
@@ -47,7 +45,6 @@ import java.util.SplittableRandom;
 @State(Scope.Thread)
 public class DefaultChannelPipelineBenchmark extends AbstractMicrobenchmark {
     private static final Object MESSAGE = new Object();
-    private static final Future<Void> FUTURE = GlobalEventExecutor.INSTANCE.newSucceededFuture();
 
     private abstract static class SharableHandlerAdapter implements ChannelHandler {
         @Override
@@ -87,10 +84,14 @@ public class DefaultChannelPipelineBenchmark extends AbstractMicrobenchmark {
             // NOOP
         }
 
+        private Future<Void> writeFuture;
         @Override
         public Future<Void> write(ChannelHandlerContext ctx, Object msg) {
+            if (writeFuture == null) {
+                writeFuture = ctx.newSucceededFuture();
+            }
             // NOOP
-            return FUTURE;
+            return writeFuture;
         }
 
         @Override

--- a/microbench/src/main/java/io/netty5/microbench/channel/DefaultChannelPipelineBenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/channel/DefaultChannelPipelineBenchmark.java
@@ -43,7 +43,7 @@ import java.util.SplittableRandom;
 
 @Warmup(iterations = 10)
 @Measurement(iterations = 10)
-@Fork(0)
+@Fork(5)
 @State(Scope.Thread)
 public class DefaultChannelPipelineBenchmark extends AbstractMicrobenchmark {
     private static final Object MESSAGE = new Object();

--- a/transport/src/main/java/io/netty5/channel/DefaultChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty5/channel/DefaultChannelHandlerContext.java
@@ -88,6 +88,7 @@ final class DefaultChannelHandlerContext implements ChannelHandlerContext, Resou
 
     // Is null if the ChannelHandler not implements pendingOutboundBytes(...).
     private final DefaultChannelHandlerContextAwareEventExecutor executor;
+    private final EventExecutor pipelineExecutor;
     private long currentPendingBytes;
 
     // Lazily instantiated tasks used to trigger events to a handler with different executor.
@@ -111,6 +112,7 @@ final class DefaultChannelHandlerContext implements ChannelHandlerContext, Resou
         // wrapping and so can save some work (which is true most of the time).
         executor = handlesPendingOutboundBytes(executionMask) ?
                 new DefaultChannelHandlerContextAwareEventExecutor(pipeline.executor(), this) : null;
+        pipelineExecutor = pipeline.executor();
     }
 
     private static boolean handlesPendingOutboundBytes(int mask) {
@@ -162,7 +164,7 @@ final class DefaultChannelHandlerContext implements ChannelHandlerContext, Resou
     }
 
     private EventExecutor originalExecutor() {
-        return executor == null ? pipeline().executor() : executor.wrappedExecutor();
+        return pipelineExecutor;
     }
 
     @Override
@@ -1246,10 +1248,6 @@ final class DefaultChannelHandlerContext implements ChannelHandlerContext, Resou
         DefaultChannelHandlerContextAwareEventExecutor(EventExecutor executor, DefaultChannelHandlerContext ctx) {
             this.executor = executor;
             this.ctx = ctx;
-        }
-
-        EventExecutor wrappedExecutor() {
-            return executor;
         }
 
         @Override

--- a/transport/src/main/java/io/netty5/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty5/channel/DefaultChannelPipeline.java
@@ -793,31 +793,91 @@ public abstract class DefaultChannelPipeline implements ChannelPipeline {
 
     @Override
     public final ChannelPipeline fireChannelRegistered() {
-        head.invokeChannelRegistered();
+        if (head.executor().inEventLoop()) {
+            if (head.saveCurrentPendingBytesIfNeededInbound()) {
+                try {
+                    head.handler().channelRegistered(head);
+                } catch (Throwable t) {
+                    head.invokeChannelExceptionCaught(t);
+                } finally {
+                    head.updatePendingBytesIfNeeded();
+                }
+            }
+        } else {
+            head.executor().execute(this::fireChannelRegistered);
+        }
         return this;
     }
 
     @Override
     public final ChannelPipeline fireChannelUnregistered() {
-        head.invokeChannelUnregistered();
+        if (head.executor().inEventLoop()) {
+            if (head.saveCurrentPendingBytesIfNeededInbound()) {
+                try {
+                    head.handler().channelUnregistered(head);
+                } catch (Throwable t) {
+                    head.invokeChannelExceptionCaught(t);
+                } finally {
+                    head.updatePendingBytesIfNeeded();
+                }
+            }
+        } else {
+            head.executor().execute(this::fireChannelUnregistered);
+        }
         return this;
     }
 
     @Override
     public final ChannelPipeline fireChannelActive() {
-        head.invokeChannelActive();
+        if (head.executor().inEventLoop()) {
+            if (head.saveCurrentPendingBytesIfNeededInbound()) {
+                try {
+                    head.handler().channelActive(head);
+                } catch (Throwable t) {
+                    head.invokeChannelExceptionCaught(t);
+                } finally {
+                    head.updatePendingBytesIfNeeded();
+                }
+            }
+        } else {
+            head.executor().execute(this::fireChannelActive);
+        }
         return this;
     }
 
     @Override
     public final ChannelPipeline fireChannelInactive() {
-        head.invokeChannelInactive();
+        if (head.executor().inEventLoop()) {
+            if (head.saveCurrentPendingBytesIfNeededInbound()) {
+                try {
+                    head.handler().channelInactive(head);
+                } catch (Throwable t) {
+                    head.invokeChannelExceptionCaught(t);
+                } finally {
+                    head.updatePendingBytesIfNeeded();
+                }
+            }
+        } else {
+            head.executor().execute(this::fireChannelInactive);
+        }
         return this;
     }
 
     @Override
     public final ChannelPipeline fireChannelShutdown(ChannelShutdownDirection direction) {
-        head.invokeChannelShutdown(direction);
+        if (head.executor().inEventLoop()) {
+            if (head.saveCurrentPendingBytesIfNeededInbound()) {
+                try {
+                    head.handler().channelShutdown(head, direction);
+                } catch (Throwable t) {
+                    head.invokeChannelExceptionCaught(t);
+                } finally {
+                    head.updatePendingBytesIfNeeded();
+                }
+            }
+        } else {
+            head.executor().execute(() -> fireChannelShutdown(direction));
+        }
         return this;
     }
 
@@ -829,25 +889,77 @@ public abstract class DefaultChannelPipeline implements ChannelPipeline {
 
     @Override
     public final ChannelPipeline fireChannelInboundEvent(Object event) {
-        head.invokeChannelInboundEvent(event);
+        if (head.executor().inEventLoop()) {
+            if (head.saveCurrentPendingBytesIfNeededInbound()) {
+                try {
+                    head.handler().channelInboundEvent(head, event);
+                } catch (Throwable t) {
+                    head.invokeChannelExceptionCaught(t);
+                } finally {
+                    head.updatePendingBytesIfNeeded();
+                }
+            } else {
+                Resource.dispose(event);
+            }
+        } else {
+            head.executor().execute(() -> fireChannelInboundEvent(event));
+        }
         return this;
     }
 
     @Override
     public final ChannelPipeline fireChannelRead(Object msg) {
-        head.invokeChannelRead(msg);
+        if (head.executor().inEventLoop()) {
+            if (head.saveCurrentPendingBytesIfNeededInbound()) {
+                try {
+                    head.handler().channelRead(head, msg);
+                } catch (Throwable t) {
+                    head.invokeChannelExceptionCaught(t);
+                } finally {
+                    head.updatePendingBytesIfNeeded();
+                }
+            } else {
+                Resource.dispose(msg);
+            }
+        } else {
+            head.executor().execute(() -> fireChannelRead(msg));
+        }
         return this;
     }
 
     @Override
     public final ChannelPipeline fireChannelReadComplete() {
-        head.invokeChannelReadComplete();
+        if (head.executor().inEventLoop()) {
+            if (head.saveCurrentPendingBytesIfNeededInbound()) {
+                try {
+                    head.handler().channelReadComplete(head);
+                } catch (Throwable t) {
+                    head.invokeChannelExceptionCaught(t);
+                } finally {
+                    head.updatePendingBytesIfNeeded();
+                }
+            }
+        } else {
+            head.executor().execute(this::fireChannelReadComplete);
+        }
         return this;
     }
 
     @Override
     public final ChannelPipeline fireChannelWritabilityChanged() {
-        head.invokeChannelWritabilityChanged();
+        if (head.executor().inEventLoop()) {
+            if (head.saveCurrentPendingBytesIfNeededInbound()) {
+                try {
+                    head.handler().channelWritabilityChanged(head);
+                } catch (Throwable t) {
+                    head.invokeChannelExceptionCaught(t);
+                } finally {
+                    head.updatePendingBytesIfNeeded();
+                }
+            }
+        } else {
+            head.executor().execute(this::fireChannelWritabilityChanged);
+        }
         return this;
     }
 


### PR DESCRIPTION
Motivation:

This is a forward port of the pipeline stack flattening of #14705.

Modification:

Manual inlining of inbound handler context methods and pipeline methods.

Result:

Flatter stack traces.

There is not much difference in performance. 5.x is already quite a bit faster than 4.x due to not supporting "child executors".

Some of the difference between 4.x and 5.x also comes down to implementation differences in `EmbeddedChannel` and it's pipeline.