### PR TITLE
IoUring: Add support for Incremental provided buffer consumption

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -437,7 +437,9 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
                     allocHandle.lastBytesRead(ioResult("io_uring read", res));
                 } else if (res > 0) {
                     if (bufferRing != null) {
-                        byteBuf = bufferRing.borrowBuffer((short) (flags >> Native.IORING_CQE_BUFFER_SHIFT), res);
+                        short bid = (short) (flags >> Native.IORING_CQE_BUFFER_SHIFT);
+                        boolean more = (flags & Native.IORING_CQE_F_BUF_MORE) != 0;
+                        byteBuf = bufferRing.borrowBuffer(bid, res, more);
                     }
                     byteBuf.writerIndex(byteBuf.writerIndex() + res);
                     allocHandle.lastBytesRead(res);

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUring.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUring.java
@@ -182,6 +182,7 @@ public final class IoUring {
     public static boolean isRegisterBufferRingSupported() {
         return IORING_REGISTER_BUFFER_RING_SUPPORTED;
     }
+
     public static boolean isRegisterBufferRingIncSupported() {
         return IORING_REGISTER_BUFFER_RING_INC_SUPPORTED;
     }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUring.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUring.java
@@ -31,7 +31,8 @@ public final class IoUring {
     private static final boolean IORING_SETUP_SUBMIT_ALL_SUPPORTED;
     private static final boolean IORING_SETUP_SINGLE_ISSUER_SUPPORTED;
     private static final boolean IORING_SETUP_DEFER_TASKRUN_SUPPORTED;
-    private static final boolean IO_URING_REGISTER_BUFFER_RING_SUPPORTED;
+    private static final boolean IORING_REGISTER_BUFFER_RING_SUPPORTED;
+    private static final boolean IORING_REGISTER_BUFFER_RING_INC_SUPPORTED;
 
     private static final InternalLogger logger;
 
@@ -46,6 +47,8 @@ public final class IoUring {
         boolean singleIssuerSupported = false;
         boolean deferTaskrunSupported = false;
         boolean registerBufferRingSupported = false;
+        boolean registerBufferRingIncSupported = false;
+
         try {
             if (SystemPropertyUtil.getBoolean("io.netty.transport.noNative", false)) {
                 cause = new UnsupportedOperationException(
@@ -70,7 +73,9 @@ public final class IoUring {
                         // See https://manpages.debian.org/unstable/liburing-dev/io_uring_setup.2.en.html
                         deferTaskrunSupported = Native.ioUringSetupSupportsFlags(
                                 Native.IORING_SETUP_SINGLE_ISSUER | Native.IORING_SETUP_DEFER_TASKRUN);
-                        registerBufferRingSupported = Native.isRegisterBufferRingSupported(ringBuffer.fd());
+                        registerBufferRingSupported = Native.isRegisterBufferRingSupported(ringBuffer.fd(), 0);
+                        registerBufferRingIncSupported = Native.isRegisterBufferRingSupported(ringBuffer.fd(),
+                                Native.IOU_PBUF_RING_INC);
                     } finally {
                         if (ringBuffer != null) {
                             try {
@@ -103,10 +108,11 @@ public final class IoUring {
                         "IORING_SETUP_SUBMIT_ALL_SUPPORTED={}, " +
                         "IORING_SETUP_SINGLE_ISSUER_SUPPORTED={}, " +
                         "IORING_SETUP_DEFER_TASKRUN_SUPPORTED={}, " +
-                        "IO_URING_REGISTER_BUFFER_RING_SUPPORTED={}" +
+                        "IORING_REGISTER_BUFFER_RING_SUPPORTED={}, " +
+                        "IOU_PBUF_RING_INC_SUPPORTED={}" +
                         ")", socketNonEmptySupported, spliceSupported, acceptSupportNoWait,
                         registerIowqWorkersSupported, submitAllSupported, singleIssuerSupported,
-                        deferTaskrunSupported, registerBufferRingSupported);
+                        deferTaskrunSupported, registerBufferRingSupported, registerBufferRingIncSupported);
             }
         }
         UNAVAILABILITY_CAUSE = cause;
@@ -117,7 +123,8 @@ public final class IoUring {
         IORING_SETUP_SUBMIT_ALL_SUPPORTED = submitAllSupported;
         IORING_SETUP_SINGLE_ISSUER_SUPPORTED = singleIssuerSupported;
         IORING_SETUP_DEFER_TASKRUN_SUPPORTED = deferTaskrunSupported;
-        IO_URING_REGISTER_BUFFER_RING_SUPPORTED = registerBufferRingSupported;
+        IORING_REGISTER_BUFFER_RING_SUPPORTED = registerBufferRingSupported;
+        IORING_REGISTER_BUFFER_RING_INC_SUPPORTED = registerBufferRingIncSupported;
     }
 
     public static boolean isAvailable() {
@@ -173,7 +180,10 @@ public final class IoUring {
     }
 
     public static boolean isRegisterBufferRingSupported() {
-        return IO_URING_REGISTER_BUFFER_RING_SUPPORTED;
+        return IORING_REGISTER_BUFFER_RING_SUPPORTED;
+    }
+    public static boolean isRegisterBufferRingIncSupported() {
+        return IORING_REGISTER_BUFFER_RING_INC_SUPPORTED;
     }
 
     public static void ensureAvailability() {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -192,13 +192,14 @@ public final class IoUringIoHandler implements IoHandler {
         short bufferRingSize = bufferRingConfig.bufferRingSize();
         short bufferGroupId = bufferRingConfig.bufferGroupId();
         int chunkSize = bufferRingConfig.chunkSize();
-        long ioUringBufRingAddr = Native.ioUringRegisterBuffRing(ringFd, bufferRingSize, bufferGroupId, 0);
+        int flags = bufferRingConfig.isIncremental() ? Native.IOU_PBUF_RING_INC : 0;
+        long ioUringBufRingAddr = Native.ioUringRegisterBuffRing(ringFd, bufferRingSize, bufferGroupId, flags);
         if (ioUringBufRingAddr < 0) {
             throw Errors.newIOException("ioUringRegisterBuffRing", (int) ioUringBufRingAddr);
         }
         IoUringBufferRing ioUringBufferRing = new IoUringBufferRing(
                 ringFd, ioUringBufRingAddr,
-                bufferRingSize, bufferGroupId, chunkSize,
+                bufferRingSize, bufferGroupId, chunkSize, bufferRingConfig.isIncremental(),
                 this, bufferRingConfig.allocator()
         );
 

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -209,6 +209,7 @@ final class Native {
     static final int IORING_SETUP_SINGLE_ISSUER = 1 << 12;
     static final int IORING_SETUP_DEFER_TASKRUN = 1 << 13;
     static final int IORING_CQE_BUFFER_SHIFT = 16;
+    static final int IORING_CQE_F_BUF_MORE = 1 << 4;
 
     static final short IORING_RECVSEND_POLL_FIRST = 1 << 0;
     static final short IORING_ACCEPT_DONTWAIT = 1 << 1;
@@ -216,6 +217,7 @@ final class Native {
     static final int IORING_FEAT_RECVSEND_BUNDLE = 1 << 14;
     static final int SPLICE_F_MOVE = 1;
 
+    static final int IOU_PBUF_RING_INC = 2;
     static String opToStr(byte op) {
         switch (op) {
             case IORING_OP_NOP: return "NOP";
@@ -384,10 +386,12 @@ final class Native {
         return false;
     }
 
-    static boolean isRegisterBufferRingSupported(int ringFd) {
-        long result = ioUringRegisterBuffRing(ringFd, 2, (short) 1, 0);
+    static boolean isRegisterBufferRingSupported(int ringFd, int flags) {
+        int entries = 2;
+        short bgid = 1;
+        long result = ioUringRegisterBuffRing(ringFd, entries, bgid, flags);
         if (result >= 0) {
-            ioUringUnRegisterBufRing(ringFd, result, 2, 1);
+            ioUringUnRegisterBufRing(ringFd, result, entries, bgid);
             return true;
         }
         // This is not supported and so will return -EINVAL

--- a/transport-native-io_uring/src/main/c/netty_io_uring_native.c
+++ b/transport-native-io_uring/src/main/c/netty_io_uring_native.c
@@ -368,8 +368,8 @@ static jint netty_io_uring_register_ring_fds(JNIEnv *env, jclass clazz, jint rin
 }
 
 static jlong netty_io_uring_register_buf_ring(JNIEnv* env, jclass clazz,
-                                           int ringFd, unsigned int nentries,
-                                           short bgid, unsigned int flags) {
+                                           jint ringFd, jint nentries,
+                                           jshort bgid, jint flags) {
     struct io_uring_buf_ring *br;
     struct io_uring_buf_reg reg;
     size_t ring_size;
@@ -381,15 +381,15 @@ static jlong netty_io_uring_register_buf_ring(JNIEnv* env, jclass clazz,
         return -errno;
     }
 
-    reg.ring_addr = (__u64)br;
-    reg.ring_entries = nentries;
-    reg.bgid = bgid;
-    reg.flags |= flags;
+    reg.ring_addr = (__u64) br;
+    reg.ring_entries = (__u32) nentries;
+    reg.bgid = (__u16) bgid;
+    reg.flags |= (__u16) flags;
 
     int registerRes = sys_io_uring_register(ringFd, IORING_REGISTER_PBUF_RING, &reg, 1);
 
     if (registerRes) {
-        munmap(br,ring_size);
+        munmap(br, ring_size);
         return registerRes;
     }
     br->tail = 0;

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
@@ -29,6 +29,8 @@ import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.util.NetUtil;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.UUID;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -67,17 +69,21 @@ public class IoUringBufferRingTest {
         }
     }
 
-    @Test
-    public void testProviderBufferRead() throws InterruptedException {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testProviderBufferRead(boolean incremental) throws InterruptedException {
+        if (incremental) {
+            assumeTrue(IoUring.isRegisterBufferRingIncSupported());
+        }
         final BlockingQueue<ByteBuf> bufferSyncer = new LinkedBlockingQueue<>();
         IoUringIoHandlerConfig ioUringIoHandlerConfiguration = new IoUringIoHandlerConfig();
         IoUringBufferRingConfig bufferRingConfig = new IoUringBufferRingConfig(
-                (short) 1, (short) 2, 1024, ByteBufAllocator.DEFAULT);
+                (short) 1, (short) 2, 1024, incremental, ByteBufAllocator.DEFAULT);
         ioUringIoHandlerConfiguration.addBufferRingConfig(bufferRingConfig);
 
         IoUringBufferRingConfig bufferRingConfig1 = new IoUringBufferRingConfig(
                 (short) 2, (short) 16,
-                1024, ByteBufAllocator.DEFAULT,
+                1024, incremental, ByteBufAllocator.DEFAULT,
                 12
         );
         ioUringIoHandlerConfiguration.addBufferRingConfig(bufferRingConfig1);
@@ -126,22 +132,34 @@ public class IoUringBufferRingTest {
         assertInstanceOf(IoUringBufferRing.IoUringBufferRingByteBuf.class, userspaceIoUringBufferElement1);
         ByteBuf userspaceIoUringBufferElement2 = sendAndRecvMessage(clientChannel, writeBuffer, bufferSyncer);
         assertInstanceOf(IoUringBufferRing.IoUringBufferRingByteBuf.class, userspaceIoUringBufferElement2);
-        // Directly after the second read we will see the event as it will be triggered inline when doing the submit.
-        assertEquals(bufferRingConfig.bufferGroupId(), eventSyncer.take().bufferGroupId());
+        if (!incremental) {
+            // Directly after the second read we will see the event as it will be triggered inline when
+            // doing the submit.
+            assertEquals(bufferRingConfig.bufferGroupId(), eventSyncer.take().bufferGroupId());
+        }
         assertEquals(0, eventSyncer.size());
 
-        // We ran out of buffers in the buffer ring
         ByteBuf readBuffer = sendAndRecvMessage(clientChannel, writeBuffer, bufferSyncer);
-        assertFalse(readBuffer instanceof IoUringBufferRing.IoUringBufferRingByteBuf);
+        if (incremental) {
+            assertInstanceOf(IoUringBufferRing.IoUringBufferRingByteBuf.class, readBuffer);
+        } else {
+            // We ran out of buffers in the buffer ring
+            assertFalse(readBuffer instanceof IoUringBufferRing.IoUringBufferRingByteBuf);
+        }
         readBuffer.release();
 
         // Now we release the buffer and so put it back into the buffer ring.
         userspaceIoUringBufferElement1.release();
         userspaceIoUringBufferElement2.release();
 
-        // As we already had the next read scheduled we will see one more buffer that was not taken out of the ring
         readBuffer = sendAndRecvMessage(clientChannel, writeBuffer, bufferSyncer);
-        assertFalse(readBuffer instanceof IoUringBufferRing.IoUringBufferRingByteBuf);
+
+        if (incremental) {
+            assertInstanceOf(IoUringBufferRing.IoUringBufferRingByteBuf.class, readBuffer);
+        } else {
+            // As we already had the next read scheduled we will see one more buffer that was not taken out of the ring
+            assertFalse(readBuffer instanceof IoUringBufferRing.IoUringBufferRingByteBuf);
+        }
         readBuffer.release();
 
         // The next buffer is expected to be provided out of the ring again.


### PR DESCRIPTION
Motivation:

To make best use of the configured buffer ring we should use Incremental provided buffer consumption

Modifcation:

Add support for Incremental provided buffer consumption

Result:

Fixes https://github.com/netty/netty/issues/14774