### PR TITLE
Java 8 cleanups

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/ByteBufStreamTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufStreamTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.function.Executable;
 import java.io.EOFException;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import static io.netty.util.internal.EmptyArrays.EMPTY_BYTES;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -122,7 +123,7 @@ public class ByteBufStreamTest {
 
             byte[] tmp = new byte[13];
             in.readFully(tmp);
-            assertEquals("Hello, World!", new String(tmp, "ISO-8859-1"));
+            assertEquals("Hello, World!", new String(tmp, StandardCharsets.ISO_8859_1));
 
             assertEquals('H', in.readChar());
             assertEquals('e', in.readChar());
@@ -191,7 +192,7 @@ public class ByteBufStreamTest {
 
     @Test
     public void testReadLine() throws Exception {
-        Charset utf8 = Charset.forName("UTF-8");
+        Charset utf8 = StandardCharsets.UTF_8;
         ByteBuf buf = Unpooled.buffer();
         ByteBufInputStream in = new ByteBufInputStream(buf, true);
 

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/SnappyTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/SnappyTest.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.CharBuffer;
+import java.nio.charset.StandardCharsets;
 
 public class SnappyTest {
     private final Snappy snappy = new Snappy();
@@ -173,7 +174,7 @@ public class SnappyTest {
                    "earned from the implementation of a lot of protocols " +
                    "such as FTP, SMTP, HTTP, and various binary and " +
                    "text-based legacy protocols";
-        ByteBuf in = Unpooled.wrappedBuffer(srcStr.getBytes("US-ASCII"));
+        ByteBuf in = Unpooled.wrappedBuffer(srcStr.getBytes(StandardCharsets.US_ASCII));
         ByteBuf out = Unpooled.buffer(180);
         snappy.encode(in, out, in.readableBytes());
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
@@ -358,10 +358,10 @@ public abstract class AbstractDiskHttpData extends AbstractHttpData {
         }
         if (encoding == null) {
             byte[] array = readFrom(file);
-            return new String(array, HttpConstants.DEFAULT_CHARSET.name());
+            return new String(array, HttpConstants.DEFAULT_CHARSET);
         }
         byte[] array = readFrom(file);
-        return new String(array, encoding.name());
+        return new String(array, encoding);
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHeaderBlockRawDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHeaderBlockRawDecoder.java
@@ -19,6 +19,8 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.internal.ObjectUtil;
 
+import java.nio.charset.StandardCharsets;
+
 import static io.netty.handler.codec.spdy.SpdyCodecUtil.getSignedInt;
 
 public class SpdyHeaderBlockRawDecoder extends SpdyHeaderBlockDecoder {
@@ -131,7 +133,7 @@ public class SpdyHeaderBlockRawDecoder extends SpdyHeaderBlockDecoder {
 
                     byte[] nameBytes = new byte[length];
                     headerBlock.readBytes(nameBytes);
-                    name = new String(nameBytes, "UTF-8");
+                    name = new String(nameBytes, StandardCharsets.UTF_8);
 
                     // Check for identically named headers
                     if (frame.headers().contains(name)) {
@@ -221,7 +223,7 @@ public class SpdyHeaderBlockRawDecoder extends SpdyHeaderBlockDecoder {
                                 break;
                             }
                         }
-                        String value = new String(valueBytes, offset, index - offset, "UTF-8");
+                        String value = new String(valueBytes, offset, index - offset, StandardCharsets.UTF_8);
 
                         try {
                             frame.headers().add(name, value);

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestEncoderTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.function.Executable;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ExecutionException;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
@@ -59,7 +59,7 @@ public class HttpRequestEncoderTest {
             HttpRequestEncoder encoder = new HttpRequestEncoder();
             encoder.encodeInitialLine(buffer, new DefaultHttpRequest(HttpVersion.HTTP_1_1,
                     HttpMethod.GET, "http://localhost"));
-            String req = buffer.toString(Charset.forName("US-ASCII"));
+            String req = buffer.toString(StandardCharsets.US_ASCII);
             assertEquals("GET http://localhost/ HTTP/1.1\r\n", req);
             buffer.release();
         }
@@ -71,7 +71,7 @@ public class HttpRequestEncoderTest {
             HttpRequestEncoder encoder = new HttpRequestEncoder();
             encoder.encodeInitialLine(buffer, new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET,
                     "http://localhost:9999?p1=v1"));
-            String req = buffer.toString(Charset.forName("US-ASCII"));
+            String req = buffer.toString(StandardCharsets.US_ASCII);
             assertEquals("GET http://localhost:9999/?p1=v1 HTTP/1.1\r\n", req);
             buffer.release();
         }
@@ -83,7 +83,7 @@ public class HttpRequestEncoderTest {
             HttpRequestEncoder encoder = new HttpRequestEncoder();
             encoder.encodeInitialLine(buffer, new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET,
                     "http://localhost:9999/?p1=v1"));
-            String req = buffer.toString(Charset.forName("US-ASCII"));
+            String req = buffer.toString(StandardCharsets.US_ASCII);
             assertEquals("GET http://localhost:9999/?p1=v1 HTTP/1.1\r\n", req);
             buffer.release();
         }
@@ -95,7 +95,7 @@ public class HttpRequestEncoderTest {
             HttpRequestEncoder encoder = new HttpRequestEncoder();
             encoder.encodeInitialLine(buffer, new DefaultHttpRequest(HttpVersion.HTTP_1_1,
                     HttpMethod.GET, "http://localhost/"));
-            String req = buffer.toString(Charset.forName("US-ASCII"));
+            String req = buffer.toString(StandardCharsets.US_ASCII);
             assertEquals("GET http://localhost/ HTTP/1.1\r\n", req);
             buffer.release();
         }
@@ -107,7 +107,7 @@ public class HttpRequestEncoderTest {
             HttpRequestEncoder encoder = new HttpRequestEncoder();
             encoder.encodeInitialLine(buffer, new DefaultHttpRequest(HttpVersion.HTTP_1_1,
                     HttpMethod.GET, "/"));
-            String req = buffer.toString(Charset.forName("US-ASCII"));
+            String req = buffer.toString(StandardCharsets.US_ASCII);
             assertEquals("GET / HTTP/1.1\r\n", req);
             buffer.release();
         }
@@ -119,7 +119,7 @@ public class HttpRequestEncoderTest {
             HttpRequestEncoder encoder = new HttpRequestEncoder();
             encoder.encodeInitialLine(buffer, new DefaultHttpRequest(HttpVersion.HTTP_1_1,
                     HttpMethod.GET, ""));
-            String req = buffer.toString(Charset.forName("US-ASCII"));
+            String req = buffer.toString(StandardCharsets.US_ASCII);
             assertEquals("GET / HTTP/1.1\r\n", req);
             buffer.release();
         }
@@ -131,7 +131,7 @@ public class HttpRequestEncoderTest {
             HttpRequestEncoder encoder = new HttpRequestEncoder();
             encoder.encodeInitialLine(buffer, new DefaultHttpRequest(HttpVersion.HTTP_1_1,
                     HttpMethod.GET, "/?url=http://example.com"));
-            String req = buffer.toString(Charset.forName("US-ASCII"));
+            String req = buffer.toString(StandardCharsets.US_ASCII);
             assertEquals("GET /?url=http://example.com HTTP/1.1\r\n", req);
             buffer.release();
         }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/QueryStringDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/QueryStringDecoderTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -208,7 +209,7 @@ public class QueryStringDecoderTest {
                 // source file, we directly use the UTF-8 encoding so as to
                 // not rely on the platform's default encoding (not portable).
                 new byte[] {'C', 'a', 'f', 'f', (byte) 0xC3, (byte) 0xA9},
-                "UTF-8");
+                StandardCharsets.UTF_8);
         final String[] tests = {
             // Encoded   ->   Decoded or error message substring
             "",               "",

--- a/codec-http/src/test/java/io/netty/handler/codec/http/QueryStringEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/QueryStringEncoderTest.java
@@ -18,7 +18,7 @@ package io.netty.handler.codec.http;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -65,7 +65,7 @@ public class QueryStringEncoderTest {
 
     @Test
     public void testNonDefaultEncoding() throws Exception {
-        QueryStringEncoder e = new QueryStringEncoder("/foo/\u00A5", Charset.forName("UTF-16"));
+        QueryStringEncoder e = new QueryStringEncoder("/foo/\u00A5", StandardCharsets.UTF_16);
         e.addParam("a", "\u00A5");
         assertEquals("/foo/\u00A5?a=%FE%FF%00%A5", e.toString());
         assertEquals(new URI("/foo/\u00A5?a=%FE%FF%00%A5"), e.toUri());

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
@@ -380,7 +380,7 @@ public class HttpPostRequestDecoderTest {
                         data + "\r\n" +
                         "--" + boundary + "--\r\n";
 
-        req.content().writeBytes(body.getBytes(CharsetUtil.UTF_8.name()));
+        req.content().writeBytes(body.getBytes(CharsetUtil.UTF_8));
         // Create decoder instance to test.
         final HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(inMemoryFactory, req);
         assertFalse(decoder.getBodyHttpDatas().isEmpty());
@@ -406,7 +406,7 @@ public class HttpPostRequestDecoderTest {
                         data + "\r\n" +
                         "--" + boundary + "--\r\n";
 
-        req.content().writeBytes(body.getBytes(CharsetUtil.UTF_8.name()));
+        req.content().writeBytes(body.getBytes(CharsetUtil.UTF_8));
         // Create decoder instance to test.
         final HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(inMemoryFactory, req);
         assertFalse(decoder.getBodyHttpDatas().isEmpty());
@@ -715,7 +715,7 @@ public class HttpPostRequestDecoderTest {
                         data + "\r\n" +
                         "--" + boundary + "--\r\n";
 
-        req.content().writeBytes(body.getBytes(CharsetUtil.UTF_8.name()));
+        req.content().writeBytes(body.getBytes(CharsetUtil.UTF_8));
         // Create decoder instance to test.
         final HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(inMemoryFactory, req);
         assertFalse(decoder.getBodyHttpDatas().isEmpty());

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
@@ -270,7 +270,7 @@ public class DataCompressionHttp2Test {
     @Test
     public void brotliEncodingSingleMessage() throws Exception {
         final String text = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbccccccccccccccccccccccc";
-        final ByteBuf data = Unpooled.copiedBuffer(text.getBytes(CharsetUtil.UTF_8.name()));
+        final ByteBuf data = Unpooled.copiedBuffer(text.getBytes(CharsetUtil.UTF_8));
         bootstrapEnv(data.readableBytes());
         try {
             final Http2Headers headers = new DefaultHttp2Headers().method(POST).path(PATH)
@@ -318,7 +318,7 @@ public class DataCompressionHttp2Test {
     @Test
     public void zstdEncodingSingleMessage() throws Exception {
         final String text = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbccccccccccccccccccccccc";
-        final ByteBuf data = Unpooled.copiedBuffer(text.getBytes(CharsetUtil.UTF_8.name()));
+        final ByteBuf data = Unpooled.copiedBuffer(text.getBytes(CharsetUtil.UTF_8));
         bootstrapEnv(data.readableBytes());
         try {
             final Http2Headers headers = new DefaultHttp2Headers().method(POST).path(PATH)

--- a/common/src/main/java/io/netty/util/CharsetUtil.java
+++ b/common/src/main/java/io/netty/util/CharsetUtil.java
@@ -22,6 +22,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 /**
@@ -34,33 +35,33 @@ public final class CharsetUtil {
      * 16-bit UTF (UCS Transformation Format) whose byte order is identified by
      * an optional byte-order mark
      */
-    public static final Charset UTF_16 = Charset.forName("UTF-16");
+    public static final Charset UTF_16 = StandardCharsets.UTF_16;
 
     /**
      * 16-bit UTF (UCS Transformation Format) whose byte order is big-endian
      */
-    public static final Charset UTF_16BE = Charset.forName("UTF-16BE");
+    public static final Charset UTF_16BE = StandardCharsets.UTF_16BE;
 
     /**
      * 16-bit UTF (UCS Transformation Format) whose byte order is little-endian
      */
-    public static final Charset UTF_16LE = Charset.forName("UTF-16LE");
+    public static final Charset UTF_16LE = StandardCharsets.UTF_16LE;
 
     /**
      * 8-bit UTF (UCS Transformation Format)
      */
-    public static final Charset UTF_8 = Charset.forName("UTF-8");
+    public static final Charset UTF_8 = StandardCharsets.UTF_8;
 
     /**
      * ISO Latin Alphabet No. 1, as known as <tt>ISO-LATIN-1</tt>
      */
-    public static final Charset ISO_8859_1 = Charset.forName("ISO-8859-1");
+    public static final Charset ISO_8859_1 = StandardCharsets.ISO_8859_1;
 
     /**
      * 7-bit ASCII, as known as ISO646-US or the Basic Latin block of the
      * Unicode character set
      */
-    public static final Charset US_ASCII = Charset.forName("US-ASCII");
+    public static final Charset US_ASCII = StandardCharsets.US_ASCII;
 
     private static final Charset[] CHARSETS = new Charset[]
             { UTF_16, UTF_16BE, UTF_16LE, UTF_8, ISO_8859_1, US_ASCII };

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -565,18 +565,6 @@ public final class PlatformDependent {
     }
 
     private static int toIntExact(long value) {
-        if (javaVersion() >= 8) {
-            return toIntExact8(value);
-        }
-        int result = (int) value;
-        if (result != value) {
-            throw new ArithmeticException("Cannot convert to exact int: " + value);
-        }
-        return result;
-    }
-
-    @SuppressJava6Requirement(reason = "version checked")
-    private static int toIntExact8(long value) {
         return Math.toIntExact(value);
     }
 
@@ -968,9 +956,6 @@ public final class PlatformDependent {
 
     private static final class Mpsc {
         private static final boolean USE_MPSC_CHUNKED_ARRAY_QUEUE;
-
-        private Mpsc() {
-        }
 
         static {
             Object unsafe = null;
@@ -1586,34 +1571,6 @@ public final class PlatformDependent {
         }
 
         return "unknown";
-    }
-
-    private static final class AtomicLongCounter extends AtomicLong implements LongCounter {
-        private static final long serialVersionUID = 4074772784610639305L;
-
-        @Override
-        public void add(long delta) {
-            addAndGet(delta);
-        }
-
-        @Override
-        public void increment() {
-            incrementAndGet();
-        }
-
-        @Override
-        public void decrement() {
-            decrementAndGet();
-        }
-
-        @Override
-        public long value() {
-            return get();
-        }
-    }
-
-    private interface ThreadLocalRandomProvider {
-        Random current();
     }
 
     private PlatformDependent() {

--- a/handler/src/main/java/io/netty/handler/ssl/ResumptionController.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ResumptionController.java
@@ -15,9 +15,6 @@
  */
 package io.netty.handler.ssl;
 
-import io.netty.util.internal.PlatformDependent;
-import io.netty.util.internal.SuppressJava6Requirement;
-
 import java.net.Socket;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
@@ -42,10 +39,9 @@ final class ResumptionController {
         resumableTm = new AtomicReference<ResumableX509ExtendedTrustManager>();
     }
 
-    @SuppressJava6Requirement(reason = "Guarded by version check")
     public TrustManager wrapIfNeeded(TrustManager tm) {
         if (tm instanceof ResumableX509ExtendedTrustManager) {
-            if (PlatformDependent.javaVersion() < 7 || !(tm instanceof X509ExtendedTrustManager)) {
+            if (!(tm instanceof X509ExtendedTrustManager)) {
                 throw new IllegalStateException("ResumableX509ExtendedTrustManager implementation must be a " +
                         "subclass of X509ExtendedTrustManager, found: " + (tm == null ? null : tm.getClass()));
             }
@@ -133,7 +129,6 @@ final class ResumptionController {
         return chain;
     }
 
-    @SuppressJava6Requirement(reason = "Guarded by version check")
     private static final class X509ExtendedWrapTrustManager extends X509ExtendedTrustManager {
         private final X509ExtendedTrustManager trustManager;
         private final Set<SSLEngine> confirmedValidations;

--- a/handler/src/test/java/io/netty/handler/ssl/util/LazyJavaxX509CertificateTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/util/LazyJavaxX509CertificateTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import javax.security.cert.CertificateException;
 import javax.security.cert.X509Certificate;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class LazyJavaxX509CertificateTest {
@@ -73,6 +74,6 @@ public class LazyJavaxX509CertificateTest {
         assertEquals(x509Certificate.getNotAfter(), lazyX509Certificate.getNotAfter());
         assertEquals(x509Certificate.getSigAlgName(), lazyX509Certificate.getSigAlgName());
         assertEquals(x509Certificate.getSigAlgOID(), lazyX509Certificate.getSigAlgOID());
-        assertEquals(x509Certificate.getSigAlgParams(), lazyX509Certificate.getSigAlgParams());
+        assertArrayEquals(x509Certificate.getSigAlgParams(), lazyX509Certificate.getSigAlgParams());
     }
 }

--- a/handler/src/test/java/io/netty/handler/ssl/util/LazyX509CertificateTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/util/LazyX509CertificateTest.java
@@ -73,7 +73,7 @@ public class LazyX509CertificateTest {
         assertArrayEquals(x509Certificate.getSignature(), lazyX509Certificate.getSignature());
         assertEquals(x509Certificate.getSigAlgName(), lazyX509Certificate.getSigAlgName());
         assertEquals(x509Certificate.getSigAlgOID(), lazyX509Certificate.getSigAlgOID());
-        assertEquals(x509Certificate.getSigAlgParams(), lazyX509Certificate.getSigAlgParams());
+        assertArrayEquals(x509Certificate.getSigAlgParams(), lazyX509Certificate.getSigAlgParams());
         assertArrayEquals(x509Certificate.getIssuerUniqueID(), lazyX509Certificate.getIssuerUniqueID());
         assertArrayEquals(x509Certificate.getSubjectUniqueID(), lazyX509Certificate.getSubjectUniqueID());
         assertArrayEquals(x509Certificate.getKeyUsage(), lazyX509Certificate.getKeyUsage());

--- a/pom.xml
+++ b/pom.xml
@@ -1950,6 +1950,46 @@
                   <annotation>@io.netty.util.internal.SuppressJava6Requirement(reason = "guarded by version check")</annotation>
                   <justification>Java baseline version changed.</justification>
                 </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.annotation.removed</code>
+                  <old>method java.net.SocketAddress io.netty.channel.socket.nio.NioDomainSocketChannel::localAddress0()</old>
+                  <new>method java.net.SocketAddress io.netty.channel.socket.nio.NioDomainSocketChannel::localAddress0()</new>
+                  <annotation>@io.netty.util.internal.SuppressJava6Requirement(reason = "Usage guarded by java version check")</annotation>
+                  <justification>Java baseline version changed.</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.annotation.removed</code>
+                  <old>method java.net.SocketAddress io.netty.channel.socket.nio.NioDomainSocketChannel::remoteAddress0()</old>
+                  <new>method java.net.SocketAddress io.netty.channel.socket.nio.NioDomainSocketChannel::remoteAddress0()</new>
+                  <annotation>@io.netty.util.internal.SuppressJava6Requirement(reason = "Usage guarded by java version check")</annotation>
+                  <justification>Java baseline version changed.</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.annotation.removed</code>
+                  <old>method void io.netty.channel.socket.nio.NioServerDomainSocketChannel::&lt;init&gt;(java.nio.channels.ServerSocketChannel)</old>
+                  <new>method void io.netty.channel.socket.nio.NioServerDomainSocketChannel::&lt;init&gt;(java.nio.channels.ServerSocketChannel)</new>
+                  <annotation>@io.netty.util.internal.SuppressJava6Requirement(reason = "Usage guarded by java version check")</annotation>
+                  <justification>Java baseline version changed.</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.annotation.removed</code>
+                  <old>method void io.netty.channel.socket.nio.NioServerDomainSocketChannel::doBind(java.net.SocketAddress) throws java.lang.Exception</old>
+                  <new>method void io.netty.channel.socket.nio.NioServerDomainSocketChannel::doBind(java.net.SocketAddress) throws java.lang.Exception</new>
+                  <annotation>@io.netty.util.internal.SuppressJava6Requirement(reason = "Usage guarded by java version check")</annotation>
+                  <justification>Java baseline version changed.</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.annotation.removed</code>
+                  <old>method java.net.SocketAddress io.netty.channel.socket.nio.NioServerDomainSocketChannel::localAddress0()</old>
+                  <new>method java.net.SocketAddress io.netty.channel.socket.nio.NioServerDomainSocketChannel::localAddress0()</new>
+                  <annotation>@io.netty.util.internal.SuppressJava6Requirement(reason = "Usage guarded by java version check")</annotation>
+                  <justification>Java baseline version changed.</justification>
+                </item>
                 <!-- Changes necessary for upgrading com.google.protobuf:protobuf-java from 2.x to 3.x -->
                 <item>
                   <ignore>true</ignore>

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslSessionReuseTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslSessionReuseTest.java
@@ -35,7 +35,6 @@ import io.netty.handler.ssl.SslHandshakeCompletionEvent;
 import io.netty.handler.ssl.SslProvider;
 import io.netty.pkitesting.CertificateBuilder;
 import io.netty.pkitesting.X509Bundle;
-import io.netty.util.internal.SuppressJava6Requirement;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -324,7 +323,6 @@ public class SocketSslSessionReuseTest extends AbstractSocketTest {
         }
     }
 
-    @SuppressJava6Requirement(reason = "Test only")
     private static final class SessionSettingTrustManager extends X509ExtendedTrustManager
             implements ResumableX509ExtendedTrustManager {
         @Override
@@ -332,7 +330,6 @@ public class SocketSslSessionReuseTest extends AbstractSocketTest {
             engine.getSession().putValue("key", "value");
         }
 
-        @SuppressJava6Requirement(reason = "Test only")
         @Override
         public void checkServerTrusted(X509Certificate[] chain, String authType, SSLEngine engine)
                 throws CertificateException {

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioDomainSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioDomainSocketChannel.java
@@ -37,7 +37,6 @@ import io.netty.channel.socket.DuplexChannel;
 import io.netty.channel.socket.DuplexChannelConfig;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SocketUtils;
-import io.netty.util.internal.SuppressJava6Requirement;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -274,13 +273,11 @@ public final class NioDomainSocketChannel extends AbstractNioByteChannel
         }
     }
 
-    @SuppressJava6Requirement(reason = "Usage guarded by java version check")
     private void shutdownInput0() throws Exception {
         javaChannel().shutdownInput();
         isInputShutdown = true;
     }
 
-    @SuppressJava6Requirement(reason = "Usage guarded by java version check")
     @Override
     protected SocketAddress localAddress0() {
         try {
@@ -291,7 +288,6 @@ public final class NioDomainSocketChannel extends AbstractNioByteChannel
         return null;
     }
 
-    @SuppressJava6Requirement(reason = "Usage guarded by java version check")
     @Override
     protected SocketAddress remoteAddress0() {
         try {
@@ -518,7 +514,6 @@ public final class NioDomainSocketChannel extends AbstractNioByteChannel
             return true;
         }
 
-        @SuppressJava6Requirement(reason = "Usage guarded by java version check")
         private int getReceiveBufferSize() {
             try {
                 return javaChannel.getOption(StandardSocketOptions.SO_RCVBUF);
@@ -527,17 +522,15 @@ public final class NioDomainSocketChannel extends AbstractNioByteChannel
             }
         }
 
-        @SuppressJava6Requirement(reason = "Usage guarded by java version check")
         private NioDomainSocketChannelConfig setReceiveBufferSize(int receiveBufferSize) {
             try {
-                javaChannel.<Integer>setOption(StandardSocketOptions.SO_RCVBUF, receiveBufferSize);
+                javaChannel.setOption(StandardSocketOptions.SO_RCVBUF, receiveBufferSize);
             } catch (IOException e) {
                 throw new ChannelException(e);
             }
             return this;
         }
 
-        @SuppressJava6Requirement(reason = "Usage guarded by java version check")
         private int getSendBufferSize() {
             try {
                 return javaChannel.getOption(StandardSocketOptions.SO_SNDBUF);
@@ -545,10 +538,9 @@ public final class NioDomainSocketChannel extends AbstractNioByteChannel
                 throw new ChannelException(e);
             }
         }
-        @SuppressJava6Requirement(reason = "Usage guarded by java version check")
         private NioDomainSocketChannelConfig setSendBufferSize(int sendBufferSize) {
             try {
-                javaChannel.<Integer>setOption(StandardSocketOptions.SO_SNDBUF, sendBufferSize);
+                javaChannel.setOption(StandardSocketOptions.SO_SNDBUF, sendBufferSize);
             } catch (IOException e) {
                 throw new ChannelException(e);
             }

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioDomainSocketUtil.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioDomainSocketUtil.java
@@ -15,8 +15,6 @@
  */
 package io.netty.channel.socket.nio;
 
-import io.netty.util.internal.SuppressJava6Requirement;
-
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.SocketAddress;
@@ -56,7 +54,6 @@ final class NioDomainSocketUtil {
         }
     }
 
-    @SuppressJava6Requirement(reason = "Guarded by version check")
     static void deleteSocketFile(SocketAddress address) {
         if (GET_PATH_METHOD == null) {
             throw new IllegalStateException();

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioServerDomainSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioServerDomainSocketChannel.java
@@ -27,7 +27,6 @@ import io.netty.channel.nio.AbstractNioMessageChannel;
 import io.netty.util.NetUtil;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SocketUtils;
-import io.netty.util.internal.SuppressJava6Requirement;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -100,7 +99,6 @@ public final class NioServerDomainSocketChannel extends AbstractNioMessageChanne
     /**
      * Create a new instance using the given {@link ServerSocketChannel}.
      */
-    @SuppressJava6Requirement(reason = "Usage guarded by java version check")
     public NioServerDomainSocketChannel(ServerSocketChannel channel) {
         super(null, channel, SelectionKey.OP_ACCEPT);
         if (PlatformDependent.javaVersion() < 16) {
@@ -132,7 +130,6 @@ public final class NioServerDomainSocketChannel extends AbstractNioMessageChanne
         return isOpen() && bound;
     }
 
-    @SuppressJava6Requirement(reason = "Usage guarded by java version check")
     @Override
     protected void doBind(SocketAddress localAddress) throws Exception {
         javaChannel().bind(localAddress, config.getBacklog());
@@ -185,7 +182,6 @@ public final class NioServerDomainSocketChannel extends AbstractNioMessageChanne
         }
     }
 
-    @SuppressJava6Requirement(reason = "Usage guarded by java version check")
     @Override
     protected SocketAddress localAddress0() {
         // do not use unsafe which uses native transport (epoll or kqueue)


### PR DESCRIPTION
Motivation:

Let's sweep some dust, remove dead code, and make use of some Java 8 APIs.

Modification:

- Removed unused classes.
- Removed JDK version checks for versions older than Java 8.
- Use StandardCharset constants.

Result:

Cleaner code.