### PR TITLE
Fix flaky tests

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/internal/CleanerPool.java
+++ b/buffer/src/main/java/io/netty5/buffer/internal/CleanerPool.java
@@ -113,18 +113,11 @@ final class CleanerPool {
         protected Cleaner initialValue() {
             if (!EVENT_LOOP_USE_POOL && Thread.currentThread() instanceof FastThreadLocalThread) {
                 // Allocate one dedicated cleaner for the caller event-loop thread
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Creating new cleaner instance.");
-                }
                 return Cleaner.create();
             }
 
             // Return one of the shared cleaners from the shared cleaner pool.
-            Cleaner cleaner = CleanersPool.cleaners[(counter.getAndIncrement() & 0x7F_FF_FF_FF) % POOL_SIZE];
-            if (logger.isDebugEnabled()) {
-                logger.debug("Reusing cleaner {} from the shared pool.", System.identityHashCode(cleaner));
-            }
-            return cleaner;
+            return CleanersPool.cleaners[(counter.getAndIncrement() & 0x7F_FF_FF_FF) % POOL_SIZE];
         }
     }
 

--- a/buffer/src/main/java/io/netty5/buffer/internal/LeakDetection.java
+++ b/buffer/src/main/java/io/netty5/buffer/internal/LeakDetection.java
@@ -96,7 +96,7 @@ public final class LeakDetection {
      * Called when a leak is detected. This method will inform all registered
      * {@linkplain MemoryManager#onLeakDetected(Consumer) on-leak-detected} callbacks.
      *
-     * @param tracer The life-cycle trace of the leaked object.
+     * @param tracer The life-cycle tracer of the leaked object.
      * @param leakedObjectDescription A human-readable description of the leaked object, that can be used for logging.
      */
     public static void reportLeak(LifecycleTracer tracer, String leakedObjectDescription) {

--- a/buffer/src/test/java/io/netty5/buffer/tests/BufferLeakDetectionTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/tests/BufferLeakDetectionTest.java
@@ -336,9 +336,6 @@ public class BufferLeakDetectionTest extends BufferTestSupport {
 
             boolean gotInterrupted = false;
             do {
-                if (trigger.get() >= 1 && isNotNull(ref)) {
-                    System.out.println("hmmm.");
-                }
                 try (AutoCloseable ignore = installGcEventListener(gcCallback)) {
                     for (int i = 0; i < N_THREADS; i++) {
                         executor.execute(gcProducer);

--- a/buffer/src/test/java/io/netty5/buffer/tests/BufferLeakDetectionTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/tests/BufferLeakDetectionTest.java
@@ -68,7 +68,7 @@ public class BufferLeakDetectionTest extends BufferTestSupport {
             var runnable = new CreateAndUseBuffers(allocator, hint, closeBuffer);
             var thread = new Thread(runnable);
             thread.start();
-            gcEvents.acquire(); // Wait for a GC event to happen.
+            acquire(gcEvents); // Wait for a GC event to happen.
             thread.interrupt();
             thread.join();
             assertThat(counter.get()).as("Unexpected leak in " + testInfo.getDisplayName()).isZero();
@@ -116,7 +116,7 @@ public class BufferLeakDetectionTest extends BufferTestSupport {
             var runnable = new CreateAndUseBuffers(allocator, hint, sendThenClose);
             var thread = new Thread(runnable);
             thread.start();
-            gcEvents.acquire(); // Wait for a GC event to happen.
+            acquire(gcEvents); // Wait for a GC event to happen.
             thread.interrupt();
             thread.join();
             assertThat(counter.get()).as("Unexpected leak in " + testInfo.getDisplayName()).isZero();
@@ -238,6 +238,12 @@ public class BufferLeakDetectionTest extends BufferTestSupport {
             System.gc();
         }
         return info;
+    }
+
+    private static void acquire(Semaphore gcEvents) throws InterruptedException {
+        while (!gcEvents.tryAcquire(1, TimeUnit.SECONDS)) {
+            System.gc();
+        }
     }
 
     private static class CreateAndUseBuffers implements Runnable {

--- a/buffer/src/test/java/io/netty5/buffer/tests/BufferLeakDetectionTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/tests/BufferLeakDetectionTest.java
@@ -19,8 +19,12 @@ import io.netty5.buffer.Buffer;
 import io.netty5.buffer.BufferAllocator;
 import io.netty5.buffer.LeakInfo;
 import io.netty5.buffer.MemoryManager;
+import io.netty5.buffer.internal.LeakDetection;
+import io.netty5.util.SafeCloseable;
 import io.netty5.util.Send;
 import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -28,6 +32,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.management.ListenerNotFoundException;
 import javax.management.Notification;
 import javax.management.NotificationBroadcaster;
 import javax.management.NotificationListener;
@@ -37,10 +42,12 @@ import java.lang.ref.WeakReference;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -54,6 +61,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SuppressWarnings("StringOperationCanBeSimplified")
 @Isolated
 public class BufferLeakDetectionTest extends BufferTestSupport {
+
+    private static SafeCloseable enforcedLeakTracing;
+
+    @BeforeAll
+    public static void forceAllLeaksToHaveTracebacks() {
+        enforcedLeakTracing = LeakDetection.onLeakDetected(info -> {
+        });
+    }
+
+    @AfterAll
+    public static void stopTracingAllLeaks() {
+        enforcedLeakTracing.close();
+    }
+
     @ParameterizedTest
     @MethodSource("allocators")
     public void bufferMustNotLeakWhenClosedProperly(Fixture fixture, TestInfo testInfo) throws Exception {
@@ -71,7 +92,7 @@ public class BufferLeakDetectionTest extends BufferTestSupport {
             acquire(gcEvents); // Wait for a GC event to happen.
             thread.interrupt();
             thread.join();
-            assertThat(counter.get()).as("Unexpected leak in " + testInfo.getDisplayName()).isZero();
+            assertThat(counter.get()).as("Unexpected leak " + hint).isZero();
         }
     }
 
@@ -94,9 +115,7 @@ public class BufferLeakDetectionTest extends BufferTestSupport {
             thread.interrupt();
             thread.join();
         }
-        assertThat(leakInfo)
-                .as("No leak detected in 20 seconds for \"" + testInfo.getDisplayName() + "\".")
-                .isNotNull();
+        assertThat(leakInfo).isNotNull();
     }
 
     @ParameterizedTest
@@ -148,9 +167,7 @@ public class BufferLeakDetectionTest extends BufferTestSupport {
             thread.interrupt();
             thread.join();
         }
-        assertThat(leakInfo)
-                .as("No leak detected in 20 seconds for \"" + testInfo.getDisplayName() + "\".")
-                .isNotNull();
+        assertThat(leakInfo).isNotNull();
         if (nonLeakAsserts.get() != null) {
             LeakInfo info = nonLeakAsserts.get();
             AssertionError error = new AssertionError(
@@ -181,9 +198,7 @@ public class BufferLeakDetectionTest extends BufferTestSupport {
             thread.interrupt();
             thread.join();
         }
-        assertThat(leakInfo)
-                .as("No leak detected in 20 seconds for \"" + testInfo.getDisplayName() + "\".")
-                .isNotNull();
+        assertThat(leakInfo).isNotNull();
     }
 
     private static String makeHint(TestInfo testInfo) {
@@ -221,9 +236,14 @@ public class BufferLeakDetectionTest extends BufferTestSupport {
             if (foundIntendedLeak) {
                 consumer.accept(leak);
             } else if (warnOnUnrecognized) {
+                Throwable traceback = new Throwable("Trace back", null, true, false) {
+                };
+                leak.stream().forEachOrdered(tracePoint -> {
+                    traceback.addSuppressed(tracePoint.traceback());
+                });
                 Logger logger = LoggerFactory.getLogger(BufferLeakDetectionTest.class);
                 logger.warn("Found leaked object \"{}\" that did not match hint \"{}\".",
-                            leak.objectDescription(), hint);
+                            leak.objectDescription(), hint, traceback);
             }
         };
     }
@@ -240,8 +260,12 @@ public class BufferLeakDetectionTest extends BufferTestSupport {
         return info;
     }
 
-    private static void acquire(Semaphore gcEvents) throws InterruptedException {
+    private static void acquire(Semaphore gcEvents) throws Exception {
+        int seconds = 0;
         while (!gcEvents.tryAcquire(1, TimeUnit.SECONDS)) {
+            if (seconds++ > 30) {
+                throw new TimeoutException();
+            }
             System.gc();
         }
     }
@@ -252,7 +276,6 @@ public class BufferLeakDetectionTest extends BufferTestSupport {
         private final BufferAllocator allocator;
         private final Object hint;
         private final Consumer<Buffer> consumer;
-        private final ExecutorService executor;
 
         CreateAndUseBuffers(BufferAllocator allocator, Object hint, Consumer<Buffer> consumer) {
             requireNonNull(allocator, "allocator");
@@ -261,21 +284,32 @@ public class BufferLeakDetectionTest extends BufferTestSupport {
             this.allocator = allocator;
             this.hint = hint;
             this.consumer = consumer;
-            executor = Executors.newFixedThreadPool(N_THREADS);
         }
 
         @Override
         public void run() {
             allocateAndProcessBuffer();
-            while (!Thread.interrupted()) {
-                produceGarbage();
-            }
-            executor.shutdown();
+
+            Thread ownerThread = Thread.currentThread();
+            ExecutorService executor = Executors.newFixedThreadPool(N_THREADS, new ThreadFactory() {
+                private final AtomicInteger childNumber = new AtomicInteger();
+
+                @Override
+                public Thread newThread(Runnable r) {
+                    return new Thread(r, ownerThread.getName() + "-poolThread-" + childNumber.incrementAndGet());
+                }
+            });
             try {
-                //noinspection ResultOfMethodCallIgnored
-                executor.awaitTermination(10, TimeUnit.SECONDS);
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
+                while (!Thread.interrupted()) {
+                    produceGarbage(executor);
+                }
+            } finally {
+                executor.shutdown();
+                try {
+                    //noinspection ResultOfMethodCallIgnored
+                    executor.awaitTermination(10, TimeUnit.SECONDS);
+                } catch (InterruptedException ignore) {
+                }
             }
         }
 
@@ -283,14 +317,15 @@ public class BufferLeakDetectionTest extends BufferTestSupport {
             Buffer buffer = allocator.allocate(128);
             buffer.touch(hint);
             consumer.accept(buffer);
+            buffer = null;
         }
 
-        private void produceGarbage() {
-            Semaphore semaphore = new Semaphore(0);
-            AtomicInteger trigger = new AtomicInteger();
+        private static void produceGarbage(ExecutorService executor) {
+            final CountDownLatch latch = new CountDownLatch(1);
+            final AtomicInteger trigger = new AtomicInteger();
             Runnable gcCallback = () -> {
+                latch.countDown();
                 trigger.incrementAndGet();
-                semaphore.release();
             };
             Runnable gcProducer = () -> {
                 while (trigger.get() < 1) {
@@ -299,20 +334,44 @@ public class BufferLeakDetectionTest extends BufferTestSupport {
             };
             WeakReference<Object> ref = createWeakReference();
 
+            boolean gotInterrupted = false;
             do {
+                if (trigger.get() >= 1 && isNotNull(ref)) {
+                    System.out.println("hmmm.");
+                }
                 try (AutoCloseable ignore = installGcEventListener(gcCallback)) {
                     for (int i = 0; i < N_THREADS; i++) {
                         executor.execute(gcProducer);
                     }
-                    semaphore.acquireUninterruptibly();
+                    boolean cont = true;
+                    do {
+                        try {
+                            cont = !latch.await(100, TimeUnit.MILLISECONDS);
+                        } catch (InterruptedException e) {
+                            gotInterrupted = true;
+                        }
+                    } while (cont && trigger.get() == 0);
                 } catch (Exception e) {
                     throw new RuntimeException(e);
                 }
-            } while (ref.get() != null);
+            } while (isNotNull(ref));
+            if (gotInterrupted) {
+                Thread.currentThread().interrupt();
+            }
         }
 
         private static @NotNull WeakReference<Object> createWeakReference() {
-            return new WeakReference<>(new Object());
+            Object object = new Object();
+            WeakReference<Object> ref = new WeakReference<>(object);
+            object = null;
+            return ref;
+        }
+
+        private static boolean isNotNull(WeakReference<Object> ref) {
+            Object object = ref.get();
+            boolean result = object != null;
+            object = null;
+            return result;
         }
     }
 
@@ -338,7 +397,10 @@ public class BufferLeakDetectionTest extends BufferTestSupport {
         @Override
         public void close() throws Exception {
             for (NotificationBroadcaster broadcaster : installedBroadcasters) {
-                broadcaster.removeNotificationListener(this);
+                try {
+                    broadcaster.removeNotificationListener(this);
+                } catch (ListenerNotFoundException ignore) {
+                }
             }
         }
     }

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
@@ -489,6 +489,7 @@ abstract class AbstractEpollChannel<P extends UnixChannel>
     /**
      * Connect to the remote peer
      */
+    @Override
     protected boolean doConnect(SocketAddress remoteAddress, SocketAddress localAddress, Buffer initialData)
             throws Exception {
         if (localAddress instanceof InetSocketAddress) {

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueChannel.java
@@ -214,6 +214,7 @@ abstract class AbstractKQueueChannel<P extends UnixChannel>
         }
     }
 
+    @Override
     protected final KQueueIoRegistration registration() {
         return (KQueueIoRegistration) super.registration();
     }
@@ -518,6 +519,7 @@ abstract class AbstractKQueueChannel<P extends UnixChannel>
     /**
      * Connect to the remote peer
      */
+    @Override
     protected boolean doConnect(SocketAddress remoteAddress, SocketAddress localAddress, Buffer initialData)
             throws Exception {
         if (localAddress instanceof InetSocketAddress) {

--- a/transport/src/test/java/io/netty5/bootstrap/BootstrapTest.java
+++ b/transport/src/test/java/io/netty5/bootstrap/BootstrapTest.java
@@ -54,8 +54,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -200,7 +199,6 @@ public class BootstrapTest {
             bootstrap.childHandler(new DummyHandler());
             bootstrap.localAddress(new LocalAddress(getClass()));
             Future<Channel> future = bootstrap.bind();
-            assertFalse(future.isDone());
             registerHandler.registerPromise().setSuccess(null);
             final BlockingQueue<Boolean> queue = new LinkedBlockingQueue<>();
             future.addListener(fut -> {
@@ -236,7 +234,6 @@ public class BootstrapTest {
             bootstrap.handler(registerHandler);
             bootstrap.localAddress(new LocalAddress(getClass()));
             Future<Channel> future = bootstrap.bind();
-            assertFalse(future.isDone());
             registerHandler.registerPromise().setSuccess(null);
             final BlockingQueue<Boolean> queue = new LinkedBlockingQueue<>();
             future.addListener(fut -> {
@@ -262,10 +259,9 @@ public class BootstrapTest {
             bootstrapA.channel(LocalChannel.class);
             bootstrapA.handler(registerHandler);
             Future<Channel> future = bootstrapA.connect(LocalAddress.ANY);
-            assertFalse(future.isDone());
             registerHandler.registerPromise().setSuccess(null);
             CompletionException cause = assertThrows(CompletionException.class, future.asStage()::sync);
-            assertThat(cause.getCause(), instanceOf(ConnectException.class));
+            assertThat(cause).hasCauseInstanceOf(ConnectException.class);
         } finally {
             group.shutdownGracefully();
         }
@@ -303,7 +299,7 @@ public class BootstrapTest {
         bootstrapB.childHandler(dummyHandler);
 
         assertTrue(bootstrapA.config().toString().contains("resolver:"));
-        assertThat(bootstrapA.resolver(), instanceOf(TestAddressResolverGroup.class));
+        assertThat(bootstrapA.resolver()).isInstanceOf(TestAddressResolverGroup.class);
 
         SocketAddress localAddress = bootstrapB.bind(LocalAddress.ANY).asStage().get().localAddress();
 
@@ -328,7 +324,7 @@ public class BootstrapTest {
             registerFuture.asStage().sync();
             CompletionException exception =
                     assertThrows(CompletionException.class, connectFuture.asStage()::sync);
-            assertTrue(exception.getCause() instanceof ConnectException);
+            assertThat(exception).hasCauseInstanceOf(ConnectException.class);
         } finally {
             group.shutdownGracefully();
         }
@@ -353,7 +349,7 @@ public class BootstrapTest {
 
         // Should fail with the UnknownHostException.
         assertTrue(connectFuture.asStage().await(10000, TimeUnit.MILLISECONDS));
-        assertThat(connectFuture.cause(), instanceOf(UnknownHostException.class));
+        assertThat(connectFuture.cause()).isInstanceOf(UnknownHostException.class);
     }
 
     @Test


### PR DESCRIPTION
Motivation:
These tests regularly fail the build.

Modification:
- It's entirely possible that the future returned from `Bootstrap.bind` has completed, because the `LateRegisterHandler` does not block registration.
- The DefaultChannelPipelineTailTest now uses the LocalChannel machinery, instead of the ad-hoc one it had before, which appeared prone to deadlocks.

Result:
More stable builds.
