### PR TITLE
IoUring: Improve our implementation of the IoUringBufferRing

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -301,8 +301,7 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
             if (channelConfig.getUseIoUringBufferGroup() && IoUring.isRegisterBufferRingSupported() && first) {
                 IoUringBufferRing ioUringBufferRing = ioUringIoHandler.findBufferRing(
                         AbstractIoUringStreamChannel.this, recvBufAllocHandle().guess());
-                if (ioUringBufferRing != null &&
-                        (ioUringBufferRing.hasSpareBuffer() || !ioUringBufferRing.isFull())) {
+                if (ioUringBufferRing != null && ioUringBufferRing.hasSpareBuffer()) {
                     return scheduleReadProviderBuffer(ioUringBufferRing, socketIsEmpty);
                 }
             }
@@ -358,10 +357,6 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
             try {
                 int chunkSize = bufferRing.chunkSize();
                 IoRegistration registration = registration();
-
-                if (!bufferRing.isFull()) {
-                    bufferRing.appendBuffer(1);
-                }
 
                 int fd = fd().intValue();
 
@@ -437,9 +432,10 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
                     if (bufferRing != null) {
                         short bid = (short) (flags >> Native.IORING_CQE_BUFFER_SHIFT);
                         boolean more = (flags & Native.IORING_CQE_F_BUF_MORE) != 0;
-                        byteBuf = bufferRing.borrowBuffer(bid, res, more);
+                        byteBuf = bufferRing.useBuffer(bid, res, more);
+                    } else {
+                        byteBuf.writerIndex(byteBuf.writerIndex() + res);
                     }
-                    byteBuf.writerIndex(byteBuf.writerIndex() + res);
                     allocHandle.lastBytesRead(res);
                 } else {
                     // EOF which we signal with -1.

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRing.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRing.java
@@ -15,43 +15,31 @@
  */
 package io.netty.channel.uring;
 
-import io.netty.buffer.AbstractReferenceCountedByteBuf;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.internal.PlatformDependent;
-import io.netty.util.internal.SystemPropertyUtil;
-import io.netty.util.internal.logging.InternalLogger;
-import io.netty.util.internal.logging.InternalLoggerFactory;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.nio.channels.FileChannel;
-import java.nio.channels.GatheringByteChannel;
-import java.nio.channels.ScatteringByteChannel;
+import java.util.Arrays;
 
 final class IoUringBufferRing {
-    private static final InternalLogger logger = InternalLoggerFactory.getInstance(IoUringBufferRing.class);
-    // todo 8 doesn't have any particular meaning. It's just my intuition.
-    // Maybe we can find a more appropriate value.
-    private static final int BATCH_ALLOCATE_SIZE =
-            SystemPropertyUtil.getInt("io.netty.iouring.bufferRing.allocate.batch.size", 8);
-
     private final long ioUringBufRingAddr;
     private final short entries;
     private final short mask;
     private final short bufferGroupId;
     private final int ringFd;
+    // At the moment we are just always refill everything when there is nothing left.
+    // We could be smarter here as buffers[] is used as a ring buffer. So it would be possible to refill in between
+    // as well.
     private final ByteBuf[] buffers;
     private final int chunkSize;
     private final IoUringIoHandler source;
     private final ByteBufAllocator byteBufAllocator;
     private final IoUringBufferRingExhaustedEvent exhaustedEvent;
     private final boolean incremental;
-    private short nextIndex;
     private boolean hasSpareBuffer;
+
+    private short tail;
+    private int numBuffers;
 
     IoUringBufferRing(int ringFd, long ioUringBufRingAddr,
                       short entries, short bufferGroupId,
@@ -69,6 +57,7 @@ final class IoUringBufferRing {
         this.source = ioUringIoHandler;
         this.byteBufAllocator = byteBufAllocator;
         this.exhaustedEvent = new IoUringBufferRingExhaustedEvent(bufferGroupId);
+        refill();
     }
 
     /**
@@ -78,6 +67,7 @@ final class IoUringBufferRing {
     void markExhausted() {
         hasSpareBuffer = false;
         source.idHandler.notifyAllBuffersUsed(bufferGroupId);
+        refill();
     }
 
     /**
@@ -97,92 +87,59 @@ final class IoUringBufferRing {
         return exhaustedEvent;
     }
 
-    private void addToRing(short bid, boolean needAdvance) {
-        ByteBuf byteBuf = buffers[bid];
-        byteBuf.setIndex(0, byteBuf.capacity());
+    private short idx(short idx) {
+        return (short) (idx & mask);
+    }
 
+    /**
+     * Refill the buffer ring with buffers allocated via our allocator.
+     */
+    private void refill() {
         long tailFieldAddress = ioUringBufRingAddr + Native.IO_URING_BUFFER_RING_TAIL;
         short oldTail = PlatformDependent.getShort(tailFieldAddress);
-        int ringIndex = oldTail & mask;
-        //  see:
-        //  https://github.com/axboe/liburing/blob/19134a8fffd406b22595a5813a3e319c19630ac9/src/include/liburing.h#L1561
-        long ioUringBufAddress = ioUringBufRingAddr + (long) Native.SIZEOF_IOURING_BUF * ringIndex;
-        PlatformDependent.putLong(ioUringBufAddress + Native.IOURING_BUFFER_OFFSETOF_ADDR, byteBuf.memoryAddress());
-        PlatformDependent.putInt(ioUringBufAddress + Native.IOURING_BUFFER_OFFSETOF_LEN, (short) byteBuf.capacity());
-        PlatformDependent.putShort(ioUringBufAddress + Native.IOURING_BUFFER_OFFSETOF_BID, bid);
-        if (needAdvance) {
-            advanceTail(1);
-        }
-    }
 
-    /**
-     * Append more buffers to the ring.
-     *
-     * @param count the number of buffers to add.
-     */
-    void appendBuffer(int count) {
-        int expectedIndex = nextIndex + count;
-        if (expectedIndex > entries) {
-            throw new IllegalStateException(
-                    String.format(
-                            "We want append %d buffer, but buffer ring is full. The ring hold %s buffers",
-                            count, entries)
-            );
-        }
-
-        int batchAllocateCount = count / BATCH_ALLOCATE_SIZE;
-        initBuffers(batchAllocateCount, BATCH_ALLOCATE_SIZE);
-        int countRemain = count % BATCH_ALLOCATE_SIZE;
-        if (countRemain != 0) {
-            initBuffers(countRemain, countRemain);
-        }
-
-        advanceTail(count);
-    }
-
-    private void initBuffers(int numBuffers, int multiplier) {
-        ByteBuf bigChunk = byteBufAllocator.directBuffer(multiplier * chunkSize);
-        for (int j = 0; j < numBuffers; j++) {
-            ByteBuf byteBuf = bigChunk.retainedSlice(j * chunkSize, chunkSize);
-            short bid = nextIndex;
+        int num = entries - numBuffers;
+        for (short i = 0; i < num; i++) {
+            short bid = idx(tail++);
+            assert buffers[bid] == null : "buffer[" + bid + "] is already used";
+            ByteBuf byteBuf = byteBufAllocator.directBuffer(chunkSize);
+            byteBuf.writerIndex(byteBuf.capacity());
             buffers[bid] = byteBuf;
-            addToRing(bid, false);
-            nextIndex++;
+            int ringIndex = (oldTail + i) & mask;
+
+            //  see:
+            //  https://github.com/axboe/liburing/
+            //      blob/19134a8fffd406b22595a5813a3e319c19630ac9/src/include/liburing.h#L1561
+            long ioUringBufAddress = ioUringBufRingAddr + (long) Native.SIZEOF_IOURING_BUF * ringIndex;
+            PlatformDependent.putLong(ioUringBufAddress + Native.IOURING_BUFFER_OFFSETOF_ADDR,
+                    byteBuf.memoryAddress() + byteBuf.readerIndex());
+            PlatformDependent.putInt(ioUringBufAddress + Native.IOURING_BUFFER_OFFSETOF_LEN, byteBuf.capacity());
+            PlatformDependent.putShort(ioUringBufAddress + Native.IOURING_BUFFER_OFFSETOF_BID, bid);
+            numBuffers++;
         }
-        bigChunk.release();
+        // Now advanced the tail by the number of buffers that we just added.
+        PlatformDependent.putShortOrdered(tailFieldAddress, (short) (oldTail + entries));
+        hasSpareBuffer = true;
+        source.idHandler.notifyMoreBuffersReady(bufferGroupId);
     }
 
     /**
-     * Borrow the buffer for the given buffer id. The returned {@link ByteBuf} must be released once not used anymore.
+     * Use the buffer for the given buffer id. The returned {@link ByteBuf} must be released once not used anymore.
      *
      * @param bid           the id of the buffer
      * @param readableBytes the number of bytes that could be read.
      * @return              the buffer.
      */
-    ByteBuf borrowBuffer(short bid, int readableBytes, boolean more) {
+    ByteBuf useBuffer(short bid, int readableBytes, boolean more) {
         ByteBuf byteBuf = buffers[bid];
-        if (incremental) {
-            if (byteBuf.readerIndex() == 0) {
-                if (more) {
-                    byteBuf.retain();
-                }
-            } else if (!more) {
-                byteBuf.release();
-            }
+        if (incremental && more) {
+            // The buffer will be used later again, just slice out what we did read so far.
+            return byteBuf.readRetainedSlice(readableBytes);
         }
-        ByteBuf slice = byteBuf.readRetainedSlice(readableBytes);
-        return new IoUringBufferRingByteBuf(this, bid, slice);
-    }
-
-    private void advanceTail(int count) {
-        long tailFieldAddress = ioUringBufRingAddr + Native.IO_URING_BUFFER_RING_TAIL;
-        short oldTail = PlatformDependent.getShort(tailFieldAddress);
-        short newTail = (short) (oldTail + count);
-        PlatformDependent.putShortOrdered(tailFieldAddress, newTail);
-        if (!hasSpareBuffer) {
-            hasSpareBuffer = true;
-            source.idHandler.notifyMoreBuffersReady(bufferGroupId);
-        }
+        // Buffer is completely used. Remove it from the backing store, adjust writerIndex and return it.
+        buffers[bid] = null;
+        numBuffers--;
+        return byteBuf.writerIndex(byteBuf.readerIndex() + readableBytes);
     }
 
     /**
@@ -204,16 +161,6 @@ final class IoUringBufferRing {
     }
 
     /**
-     * Returns {@code true} if the {@link IoUringBufferRing} is completely filled. This means there
-     * can't be any more new buffers allocated for use.
-     *
-     * @return is full.
-     */
-    boolean isFull() {
-        return nextIndex == entries;
-    }
-
-    /**
      * Close this {@link IoUringBufferRing}, using it after this method is called will lead to undefined behaviour.
      */
     void close() {
@@ -223,291 +170,6 @@ final class IoUringBufferRing {
                 byteBuf.release();
             }
         }
-    }
-
-    static final class IoUringBufferRingByteBuf extends AbstractReferenceCountedByteBuf implements Runnable {
-        private final IoUringBufferRing ring;
-        private final short bid;
-        private final ByteBuf wrapped;
-
-        IoUringBufferRingByteBuf(IoUringBufferRing ring, short bid, ByteBuf wrapped) {
-            super(wrapped.capacity());
-            this.ring = ring;
-            this.bid = bid;
-            this.wrapped = wrapped;
-        }
-
-        @Override
-        protected void deallocate() {
-            // Hand of to the IoExecutorThread to release and recycle.
-            // As we already need to schedule it to the IoExecutorThread we will also just call release there
-            // to reduce overhead. We can't reuse the buffer anyway till it was added back to the ring.
-            ring.source.runInExecutorThread(this);
-        }
-
-        @Override
-        public void run() {
-            try {
-                wrapped.release();
-                if (wrapped.refCnt() == 1) {
-                    ring.addToRing(bid, true);
-                }
-            } catch (Throwable t) {
-                logger.error("Failed to recycle buffer for bid " + bid, t);
-            }
-        }
-
-        @Override
-        protected byte _getByte(int index) {
-            return wrapped.getByte(index);
-        }
-
-        @Override
-        protected short _getShort(int index) {
-            return wrapped.getShort(index);
-        }
-
-        @Override
-        protected short _getShortLE(int index) {
-            return wrapped.getShortLE(index);
-        }
-
-        @Override
-        protected int _getUnsignedMedium(int index) {
-            return wrapped.getUnsignedMedium(index);
-        }
-
-        @Override
-        protected int _getUnsignedMediumLE(int index) {
-            return wrapped.getUnsignedMediumLE(index);
-        }
-
-        @Override
-        protected int _getInt(int index) {
-            return wrapped.getInt(index);
-        }
-
-        @Override
-        protected int _getIntLE(int index) {
-            return wrapped.getIntLE(index);
-        }
-
-        @Override
-        protected long _getLong(int index) {
-            return wrapped.getLong(index);
-        }
-
-        @Override
-        protected long _getLongLE(int index) {
-            return wrapped.getLongLE(index);
-        }
-
-        @Override
-        protected void _setByte(int index, int value) {
-            wrapped.setByte(index, value);
-        }
-
-        @Override
-        protected void _setShort(int index, int value) {
-            wrapped.setShort(index, value);
-        }
-
-        @Override
-        protected void _setShortLE(int index, int value) {
-            wrapped.setShortLE(index, value);
-        }
-
-        @Override
-        protected void _setMedium(int index, int value) {
-            wrapped.setMedium(index, value);
-        }
-
-        @Override
-        protected void _setMediumLE(int index, int value) {
-            wrapped.setMediumLE(index, value);
-        }
-
-        @Override
-        protected void _setInt(int index, int value) {
-            wrapped.setInt(index, value);
-        }
-
-        @Override
-        protected void _setIntLE(int index, int value) {
-            wrapped.setIntLE(index, value);
-        }
-
-        @Override
-        protected void _setLong(int index, long value) {
-            wrapped.setLong(index, value);
-        }
-
-        @Override
-        protected void _setLongLE(int index, long value) {
-            wrapped.setLongLE(index, value);
-        }
-
-        @Override
-        public int capacity() {
-            return maxCapacity();
-        }
-
-        @Override
-        public ByteBuf capacity(int newCapacity) {
-            if (newCapacity <= maxCapacity()) {
-                this.maxCapacity(newCapacity);
-                setIndex(Math.min(readerIndex(), newCapacity), Math.min(writerIndex(), newCapacity));
-                return this;
-            }
-
-            throw new IllegalArgumentException(
-                    String.format(
-                        "minNewCapacity: %d (expected: not greater than maxCapacity(%d)",
-                        newCapacity, maxCapacity()
-                    )
-            );
-        }
-
-        @Override
-        public ByteBufAllocator alloc() {
-            return wrapped.alloc();
-        }
-
-        @Override
-        public ByteOrder order() {
-            return wrapped.order();
-        }
-
-        @Override
-        public ByteBuf unwrap() {
-            return null;
-        }
-
-        @Override
-        public boolean isDirect() {
-            return wrapped.isDirect();
-        }
-
-        @Override
-        public ByteBuf getBytes(int index, ByteBuf dst, int dstIndex, int length) {
-            checkIndex(index, length);
-            wrapped.getBytes(index, dst, dstIndex, length);
-            return this;
-        }
-
-        @Override
-        public ByteBuf getBytes(int index, byte[] dst, int dstIndex, int length) {
-            checkIndex(index, length);
-            wrapped.getBytes(index, dst, dstIndex, length);
-            return this;
-        }
-
-        @Override
-        public ByteBuf getBytes(int index, ByteBuffer dst) {
-            checkIndex(index, dst.remaining());
-            wrapped.getBytes(index, dst);
-            return this;
-        }
-
-        @Override
-        public ByteBuf getBytes(int index, OutputStream out, int length)
-                throws IOException {
-            checkIndex(index, length);
-            wrapped.getBytes(index, out, length);
-            return this;
-        }
-
-        @Override
-        public int getBytes(int index, GatheringByteChannel out, int length) throws IOException {
-            return wrapped.getBytes(index, out, length);
-        }
-
-        @Override
-        public int getBytes(int index, FileChannel out, long position, int length) throws IOException {
-            return wrapped.getBytes(index, out, position, length);
-        }
-
-        @Override
-        public ByteBuf setBytes(int index, ByteBuf src, int srcIndex, int length) {
-            wrapped.setBytes(index, src, srcIndex, length);
-            return this;
-        }
-
-        @Override
-        public ByteBuf setBytes(int index, byte[] src, int srcIndex, int length) {
-            wrapped.setBytes(index, src, srcIndex, length);
-            return this;
-        }
-
-        @Override
-        public ByteBuf setBytes(int index, ByteBuffer src) {
-            wrapped.setBytes(index, src);
-            return this;
-        }
-
-        @Override
-        public int setBytes(int index, InputStream in, int length) throws IOException {
-            return wrapped.setBytes(index, in, length);
-        }
-
-        @Override
-        public int setBytes(int index, ScatteringByteChannel in, int length) throws IOException {
-            return wrapped.setBytes(index, in, length);
-        }
-
-        @Override
-        public int setBytes(int index, FileChannel in, long position, int length) throws IOException {
-            return wrapped.setBytes(index, in, position, length);
-        }
-
-        @Override
-        public ByteBuf copy(int index, int length) {
-            return wrapped.copy(index, length);
-        }
-
-        @Override
-        public int nioBufferCount() {
-            return wrapped.nioBufferCount();
-        }
-
-        @Override
-        public ByteBuffer nioBuffer(int index, int length) {
-            return wrapped.nioBuffer(index, length);
-        }
-
-        @Override
-        public ByteBuffer internalNioBuffer(int index, int length) {
-            return wrapped.internalNioBuffer(index, length);
-        }
-
-        @Override
-        public ByteBuffer[] nioBuffers(int index, int length) {
-            return wrapped.nioBuffers(index, length);
-        }
-
-        @Override
-        public boolean hasArray() {
-            return wrapped.hasArray();
-        }
-
-        @Override
-        public byte[] array() {
-            return wrapped.array();
-        }
-
-        @Override
-        public int arrayOffset() {
-            return wrapped.arrayOffset();
-        }
-
-        @Override
-        public boolean hasMemoryAddress() {
-            return wrapped.hasMemoryAddress();
-        }
-
-        @Override
-        public long memoryAddress() {
-            return wrapped.memoryAddress();
-        }
+        Arrays.fill(buffers, null);
     }
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -180,17 +180,6 @@ public final class IoUringIoHandler implements IoHandler {
         }
     }
 
-    void runInExecutorThread(Runnable runnable) {
-        //if we are in the executor thread we can run the runnable directly
-        if (executor.isExecutorThread(Thread.currentThread())) {
-            // Just directly run.
-            runnable.run();
-        } else {
-            // This will also wakeup the blocked run(...) method if needed.
-            executor.execute(runnable);
-        }
-    }
-
     IoUringBufferRing newBufferRing(IoUringBufferRingConfig bufferRingConfig) throws Errors.NativeIoException {
         int ringFd = ringBuffer.fd();
         short bufferRingSize = bufferRingConfig.bufferRingSize();
@@ -201,17 +190,11 @@ public final class IoUringIoHandler implements IoHandler {
         if (ioUringBufRingAddr < 0) {
             throw Errors.newIOException("ioUringRegisterBuffRing", (int) ioUringBufRingAddr);
         }
-        IoUringBufferRing ioUringBufferRing = new IoUringBufferRing(
+        return new IoUringBufferRing(
                 ringFd, ioUringBufRingAddr,
                 bufferRingSize, bufferGroupId, chunkSize, bufferRingConfig.isIncremental(),
                 this, bufferRingConfig.allocator()
         );
-
-        if (bufferRingConfig.initSize() != 0) {
-            ioUringBufferRing.appendBuffer(bufferRingConfig.initSize());
-        }
-
-        return ioUringBufferRing;
     }
 
     IoUringBufferRing findBufferRing(Channel channel, int guessedSize) {


### PR DESCRIPTION
Motivation:

We already pool buffers anyway so we can simplify the IoUringBufferRing a lot by just allocating buffers once we used everything. There is no need to keep track a of buffers that were borrowed out of the ring as we can just return them to our own pool once these are released and then refill the buffer ring if needed.

Modifications:

- Remove all the complex house-keeping of buffers in the IoUringBufferRing and just refill it out of our pool once there is no buffer left.

Result:

Simplify and less overhead
