### PR TITLE
Upgrade netty-tcnative to 2.0.70.Final

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -65,7 +65,7 @@
 
   <properties>
     <!-- Keep in sync with ../pom.xml -->
-    <tcnative.version>2.0.69.Final</tcnative.version>
+    <tcnative.version>2.0.70.Final</tcnative.version>
   </properties>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -606,7 +606,7 @@
       <id>boringssl-snapshot</id>
       <properties>
         <tcnative.artifactId>netty-tcnative-boringssl-static</tcnative.artifactId>
-        <tcnative.version>2.0.70.Final-SNAPSHOT</tcnative.version>
+        <tcnative.version>2.0.71.Final-SNAPSHOT</tcnative.version>
         <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
       </properties>
     </profile>
@@ -739,7 +739,7 @@
     <os.detection.classifierWithLikes>fedora,suse,arch</os.detection.classifierWithLikes>
     <tcnative.artifactId>netty-tcnative</tcnative.artifactId>
     <!-- Keep in sync with bom/pom.xml -->
-    <tcnative.version>2.0.69.Final</tcnative.version>
+    <tcnative.version>2.0.70.Final</tcnative.version>
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
     <conscrypt.groupId>org.conscrypt</conscrypt.groupId>
     <conscrypt.artifactId>conscrypt-openjdk-uber</conscrypt.artifactId>


### PR DESCRIPTION
Motivation:

A new tcnative release is out

Modifications:

Upgrade to latest release

Result:

Use latest netty tcnative version