### PR TITLE
IoUring: Support for IORING_SETUP_CQSIZE

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionQueue.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionQueue.java
@@ -41,8 +41,8 @@ final class CompletionQueue {
     final int ringSize;
     final long ringAddress;
     final int ringFd;
+    final int ringEntries;
 
-    private final int ringEntries;
     private final int ringMask;
     private int ringHead;
 

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUring.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUring.java
@@ -29,6 +29,7 @@ public final class IoUring {
     private static final boolean IORING_ACCEPT_NO_WAIT_SUPPORTED;
     private static final boolean IORING_REGISTER_IOWQ_MAX_WORKERS_SUPPORTED;
     private static final boolean IORING_SETUP_SUBMIT_ALL_SUPPORTED;
+    private static final boolean IORING_SETUP_CQ_SIZE_SUPPORTED;
     private static final boolean IORING_SETUP_SINGLE_ISSUER_SUPPORTED;
     private static final boolean IORING_SETUP_DEFER_TASKRUN_SUPPORTED;
     private static final boolean IORING_REGISTER_BUFFER_RING_SUPPORTED;
@@ -44,6 +45,7 @@ public final class IoUring {
         boolean acceptSupportNoWait = false;
         boolean registerIowqWorkersSupported = false;
         boolean submitAllSupported = false;
+        boolean setUpCqSizeSupported = false;
         boolean singleIssuerSupported = false;
         boolean deferTaskrunSupported = false;
         boolean registerBufferRingSupported = false;
@@ -68,6 +70,7 @@ public final class IoUring {
                         acceptSupportNoWait = (ringBuffer.features() & Native.IORING_FEAT_RECVSEND_BUNDLE) != 0;
                         registerIowqWorkersSupported = Native.isRegisterIOWQWorkerSupported(ringBuffer.fd());
                         submitAllSupported = Native.ioUringSetupSupportsFlags(Native.IORING_SETUP_SUBMIT_ALL);
+                        setUpCqSizeSupported = Native.ioUringSetupSupportsFlags(Native.IORING_SETUP_CQSIZE);
                         singleIssuerSupported = Native.ioUringSetupSupportsFlags(Native.IORING_SETUP_SINGLE_ISSUER);
                         // IORING_SETUP_DEFER_TASKRUN requires to also set IORING_SETUP_SINGLE_ISSUER.
                         // See https://manpages.debian.org/unstable/liburing-dev/io_uring_setup.2.en.html
@@ -121,6 +124,7 @@ public final class IoUring {
         IORING_ACCEPT_NO_WAIT_SUPPORTED = acceptSupportNoWait;
         IORING_REGISTER_IOWQ_MAX_WORKERS_SUPPORTED = registerIowqWorkersSupported;
         IORING_SETUP_SUBMIT_ALL_SUPPORTED = submitAllSupported;
+        IORING_SETUP_CQ_SIZE_SUPPORTED = setUpCqSizeSupported;
         IORING_SETUP_SINGLE_ISSUER_SUPPORTED = singleIssuerSupported;
         IORING_SETUP_DEFER_TASKRUN_SUPPORTED = deferTaskrunSupported;
         IORING_REGISTER_BUFFER_RING_SUPPORTED = registerBufferRingSupported;
@@ -165,6 +169,10 @@ public final class IoUring {
 
     static boolean isRegisterIowqMaxWorkersSupported() {
         return IORING_REGISTER_IOWQ_MAX_WORKERS_SUPPORTED;
+    }
+
+    static boolean isIOUringSetupCqeSizeSupported() {
+        return IORING_SETUP_CQ_SIZE_SUPPORTED;
     }
 
     static boolean isIOUringSetupSubmitAllSupported() {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -91,14 +91,16 @@ public final class IoUringIoHandler implements IoHandler {
         requireNonNull(config, "config");
         int setupFlags = Native.setupFlags();
 
+        //The default cq size is always twice the ringSize.
+        // It only makes sense when the user actually specifies the cq ring size.
+        int cqSize = 2 * config.getRingSize();
         if (config.needSetupCqeSize()) {
             if (!IoUring.isIOUringSetupCqeSizeSupported()) {
                 throw new UnsupportedOperationException("IORING_SETUP_CQSIZE is not supported");
             }
             setupFlags |= Native.IORING_SETUP_CQSIZE;
+            cqSize = config.checkCqSize(config.getCqSize());
         }
-
-        int cqSize = config.checkCqSize(config.getCqSize());
         this.ringBuffer = Native.createRingBuffer(config.getRingSize(), cqSize, setupFlags);
         if (IoUring.isRegisterIowqMaxWorkersSupported() && config.needRegisterIowqMaxWorker()) {
             int maxBoundedWorker = Math.max(config.getMaxBoundedWorker(), 0);

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandlerConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandlerConfig.java
@@ -138,7 +138,8 @@ public final class IoUringIoHandlerConfig {
         if (cqSize < ringSize) {
             throw new IllegalArgumentException("cqSize must be greater than or equal to ringSize");
         }
-        boolean isPowerOfTwo = (cqSize & (cqSize - 1)) == 0;
+
+        boolean isPowerOfTwo = Integer.bitCount(cqSize) == 1;
         if (!isPowerOfTwo) {
             throw new IllegalArgumentException("cqSize: " + cqSize + " (expected: power of 2)");
         }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -204,6 +204,7 @@ final class Native {
     static final byte IORING_OP_BIND = 56;
     static final byte IORING_CQE_F_SOCK_NONEMPTY = 1 << 2;
 
+    static final int IORING_SETUP_CQSIZE = 1 << 3;
     static final int IORING_SETUP_R_DISABLED = 1 << 6;
     static final int IORING_SETUP_SUBMIT_ALL = 1 << 7;
     static final int IORING_SETUP_SINGLE_ISSUER = 1 << 12;
@@ -326,8 +327,13 @@ final class Native {
     }
 
     static RingBuffer createRingBuffer(int ringSize, int setupFlags) {
+        return createRingBuffer(ringSize, ringSize * 2, setupFlags);
+    }
+
+    static RingBuffer createRingBuffer(int ringSize, int cqeSize, int setupFlags) {
         ObjectUtil.checkPositive(ringSize, "ringSize");
-        long[] values = ioUringSetup(ringSize, setupFlags);
+        ObjectUtil.checkPositive(cqeSize, "cqeSize");
+        long[] values = ioUringSetup(ringSize, cqeSize, setupFlags);
         assert values.length == 21;
         CompletionQueue completionQueue = new CompletionQueue(
                 values[0],
@@ -445,7 +451,7 @@ final class Native {
 
     static native boolean ioUringSetupSupportsFlags(int setupFlags);
     private static native boolean ioUringProbe(int ringFd, int[] ios);
-    private static native long[] ioUringSetup(int entries, int setupFlags);
+    private static native long[] ioUringSetup(int entries, int cqeSize, int setupFlags);
 
     static native int ioUringRegisterIoWqMaxWorkers(int ringFd, int maxBoundedValue, int maxUnboundedValue);
     static native int ioUringRegisterEnableRings(int ringFd);

--- a/transport-native-io_uring/src/main/c/netty_io_uring_native.c
+++ b/transport-native-io_uring/src/main/c/netty_io_uring_native.c
@@ -238,6 +238,10 @@ static jboolean netty_io_uring_setup_supports_flags(JNIEnv *env, jclass clazz, j
     memset(&p, 0, sizeof(p));
     p.flags = (__u32) flags;
 
+    if (flags & IORING_SETUP_CQSIZE) {
+        p.cq_entries = (__u32) 4;
+    }
+
     // Just try to create the ring and if it works we know the flags are supported.
     int ring_fd = sys_io_uring_setup((int) 1, &p);
     if (ring_fd < 0) {
@@ -279,11 +283,15 @@ done:
 }
 
 
-static jlongArray netty_io_uring_setup(JNIEnv *env, jclass clazz, jint entries, jint setupFlags) {
+static jlongArray netty_io_uring_setup(JNIEnv *env, jclass clazz, jint entries, jint cqSize, jint setupFlags) {
     struct io_uring_params p;
     memset(&p, 0, sizeof(p));
 
     p.flags = (__u32) setupFlags;
+
+    if (setupFlags & IORING_SETUP_CQSIZE) {
+        p.cq_entries = (__u32) cqSize;
+    }
 
     jlongArray array = (*env)->NewLongArray(env, 21);
     if (array == NULL) {
@@ -727,7 +735,7 @@ static const jint statically_referenced_fixed_method_table_size = sizeof(statica
 
 static const JNINativeMethod method_table[] = {
     {"ioUringSetupSupportsFlags", "(I)Z", (void *) netty_io_uring_setup_supports_flags },
-    {"ioUringSetup", "(II)[J", (void *) netty_io_uring_setup},
+    {"ioUringSetup", "(III)[J", (void *) netty_io_uring_setup},
     {"ioUringRegisterIoWqMaxWorkers","(III)I", (void*) netty_io_uring_register_iowq_max_workers },
     {"ioUringRegisterEnableRings","(I)I", (void*) netty_io_uring_register_enable_rings },
     {"ioUringRegisterRingFds","(I)I", (void*) netty_io_uring_register_ring_fds },

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringIoHandlerTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringIoHandlerTest.java
@@ -35,7 +35,9 @@ public class IoUringIoHandlerTest {
     public void testOptions() {
         IoUringIoHandlerConfig config = new IoUringIoHandlerConfig();
         config.setMaxBoundedWorker(2)
-                .setMaxUnboundedWorker(2);
+                .setMaxUnboundedWorker(2)
+                .setRingSize(4)
+                .setCqSize(32);
         IoHandlerFactory ioHandlerFactory = IoUringIoHandler.newFactory(config);
         IoHandler handler = ioHandlerFactory.newHandler(new ThreadAwareExecutor() {
 

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringIoHandlerTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringIoHandlerTest.java
@@ -56,7 +56,6 @@ public class IoUringIoHandlerTest {
         handler.destroy();
     }
 
-
     @Test
     @DisabledIf("setUpCQSizeUnavailable")
     public void testSetCqSizeOptions() {

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringIoHandlerTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringIoHandlerTest.java
@@ -20,6 +20,8 @@ import io.netty.channel.IoHandlerFactory;
 import io.netty.util.concurrent.ThreadAwareExecutor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
+import org.junit.jupiter.api.condition.EnabledIf;
 
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -33,6 +35,31 @@ public class IoUringIoHandlerTest {
 
     @Test
     public void testOptions() {
+        IoUringIoHandlerConfig config = new IoUringIoHandlerConfig();
+        config.setMaxBoundedWorker(2)
+                .setMaxUnboundedWorker(2)
+                .setRingSize(4);
+        IoHandlerFactory ioHandlerFactory = IoUringIoHandler.newFactory(config);
+        IoHandler handler = ioHandlerFactory.newHandler(new ThreadAwareExecutor() {
+
+            @Override
+            public boolean isExecutorThread(Thread thread) {
+                return false;
+            }
+
+            @Override
+            public void execute(Runnable command) {
+                command.run();
+            }
+        });
+        handler.initialize();
+        handler.destroy();
+    }
+
+
+    @Test
+    @DisabledIf("setUpCQSizeUnavailable")
+    public void testSetCqSizeOptions() {
         IoUringIoHandlerConfig config = new IoUringIoHandlerConfig();
         config.setMaxBoundedWorker(2)
                 .setMaxUnboundedWorker(2)
@@ -53,5 +80,9 @@ public class IoUringIoHandlerTest {
         });
         handler.initialize();
         handler.destroy();
+    }
+
+    private static boolean setUpCQSizeUnavailable() {
+        return !IoUring.isIOUringSetupCqeSizeSupported();
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/SubmissionQueueTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/SubmissionQueueTest.java
@@ -17,6 +17,7 @@ package io.netty.channel.uring;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -59,6 +60,7 @@ public class SubmissionQueueTest {
     }
 
     @Test
+    @DisabledIf("setUpCQSizeUnavailable")
     public void testSetUpCqSize() {
         int cqSize = 8;
         RingBuffer ringBuffer = Native.createRingBuffer(2, cqSize, Native.IORING_SETUP_CQSIZE);
@@ -84,4 +86,7 @@ public class SubmissionQueueTest {
         }
     }
 
+    private static boolean setUpCQSizeUnavailable() {
+        return !IoUring.isIOUringSetupCqeSizeSupported();
+    }
 }


### PR DESCRIPTION
Motivation:

If we introduce support for operations such as IO_UIRING_*_MULTISHOT in the future.We may have a lot of requests pending.

This pr allows us to hold a larger CQ without changing the size of the SQ.

https://lore.kernel.org/linux-block/0188a3ff-6a41-1a95-f444-2ef308a83f7a@kernel.dk/t/

Modification:

Support for IORING_SETUP_CQSIZE
