### PR TITLE
Remove pkitesting from netty-all

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -451,11 +451,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-pkitesting</artifactId>
-      <version>${project.version}</version>
-    </dependency>
     <!--
       The native dependencies with the classifier are added by the native-dependencies profile.
       -->


### PR DESCRIPTION
Motivation:
Although netty-all is supposed to contain all user-facing modules, we can argue that the test-fixture subproject, pkitesting, should not be included. The pkitesting subproject brings in some hard dependencies on BouncyCastle. This is problematic when downstream projects shade netty-all into an uber-jar. BouncyCastle jars are signed, and the shading breaks the signatures, which means the uber-jar will be rejected by classloaders.

Modification:
Remove netty-pkitesting from netty-all.

Result:
The netty-all subproject now pulls in the same dependencies as it did in 4.1, and specifically does not include the signed BouncyCastle dependencies.