### PR TITLE
Fix flawed termination condition check in HttpPostRequestEncoder…

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostRequestEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostRequestEncoder.java
@@ -1009,7 +1009,8 @@ public class HttpPostRequestEncoder implements ChunkedInput<HttpContent> {
         }
 
         // end for current InterfaceHttpData, need more data
-        if (currentBuffer.readableBytes() < HttpPostBodyUtil.chunkSize) {
+        final int delimiterSize = delimiter != null ? delimiter.readableBytes() : 0;
+        if (currentBuffer.readableBytes() - delimiterSize < HttpPostBodyUtil.chunkSize) {
             currentData = null;
             isKey = true;
             return null;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostRequestEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostRequestEncoder.java
@@ -969,11 +969,13 @@ public class HttpPostRequestEncoder implements ChunkedInput<HttpContent> {
         ByteBuf delimiter = null;
         if (buffer.readableBytes() < size) {
             isKey = true;
+            currentData = null;
             delimiter = iterator.hasNext() ? wrappedBuffer("&".getBytes(charset)) : null;
         }
 
         // End for current InterfaceHttpData, need potentially more data
         if (buffer.capacity() == 0) {
+            isKey = true;
             currentData = null;
             if (currentBuffer == null) {
                 if (delimiter == null) {
@@ -1008,16 +1010,10 @@ public class HttpPostRequestEncoder implements ChunkedInput<HttpContent> {
             }
         }
 
-        // end for current InterfaceHttpData, need more data
-        final int delimiterSize = delimiter != null ? delimiter.readableBytes() : 0;
-        if (currentBuffer.readableBytes() - delimiterSize < HttpPostBodyUtil.chunkSize) {
-            currentData = null;
-            isKey = true;
-            return null;
+        if (currentBuffer.readableBytes() >= HttpPostBodyUtil.chunkSize) {
+            return new DefaultHttpContent(fillByteBuf());
         }
-
-        buffer = fillByteBuf();
-        return new DefaultHttpContent(buffer);
+        return null;
     }
 
     @Override

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestEncoderTest.java
@@ -18,8 +18,8 @@ package io.netty.handler.codec.http.multipart;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
-import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.HttpConstants;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpMethod;
@@ -450,15 +450,9 @@ public class HttpPostRequestEncoderTest {
     public void testEncodeChunkedContent() throws Exception {
         HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/");
         HttpPostRequestEncoder encoder = new HttpPostRequestEncoder(req, false);
-
-        int length = 8077 + 8096;
-        char[] array = new char[length];
-        Arrays.fill(array, 'a');
-        String longText = new String(array);
-
-        encoder.addBodyAttribute("data", longText);
+        encoder.addBodyAttribute("data", largeValue("data", 3));
+        encoder.addBodyAttribute("data", largeValue("data", 4));
         encoder.addBodyAttribute("moreData", "abcd");
-
         assertNotNull(encoder.finalizeRequest());
 
         while (!encoder.isEndOfInput()) {
@@ -467,5 +461,12 @@ public class HttpPostRequestEncoderTest {
 
         assertTrue(encoder.isEndOfInput());
         encoder.cleanFiles();
+    }
+
+    private String largeValue(String key, int multipleChunks) {
+        final int length = HttpPostBodyUtil.chunkSize * multipleChunks - key.length() - 2; // 2 is '=' and '&'
+        final char[] array = new char[length];
+        Arrays.fill(array, 'a');
+        return new String(array);
     }
 }


### PR DESCRIPTION
…#encodeNextChunkUrlEncoded(int) for current InterfaceHttpData

Motivation:

I am using `HttpPostRequestEncoder` to encode a few request parameters, but I read **infinite** chunks when the following conditions are met:

1. The number of POST request parameters is greater than or equal to 2.
2. The length of the first request parameter value > `DefaultHttpDataFactory#minSize`.
3. The length of the first request parameter key + the length of the request parameter value + 2 = N * `HttpPostBodyUtil#chunkSize`

This issue can be reproduced by modifying the [length](https://github.com/netty/netty/blob/34011b5f02c52122eccd36ce7cc69502a514d0f1/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestEncoderTest.java#L454) variable in the [HttpPostRequestEncoderTest#testEncodeChunkedContent()](https://github.com/netty/netty/blob/34011b5f02c52122eccd36ce7cc69502a514d0f1/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestEncoderTest.java#L450) method to `HttpPostBodyUtil.chunkSize * 3 - 4 - 2`.  Normally, this test method should complete quickly, but when the length variable is set to `HttpPostBodyUtil.chunkSize * 3 - 4 - 2`, it will never finish.

Modification:

1. Enhance the logic of determining whether the current `InterfaceHttpData` has been fully read.

Result:

Fix flawed termination condition check.