### PR TITLE
IoUring: Add code to support multishot in general and use ACCEPT_MULT…

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringServerChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringServerChannel.java
@@ -77,7 +77,7 @@ abstract class AbstractIoUringServerChannel extends AbstractIoUringChannel imple
         //       time to process a past connection. If the application knows that a
         //       new connection cannot come in before a previous one has been
         //       processed, it may be used as expected.
-        if (IoUring.isIOUringAcceptNoWaitSupported()) {
+        if (IoUring.isIOUringAcceptMultishotSupported()) {
             acceptedAddressMemory = null;
         } else {
             acceptedAddressMemory = new AcceptedAddressMemory();
@@ -174,17 +174,15 @@ abstract class AbstractIoUringServerChannel extends AbstractIoUringChannel imple
                 ioPrio = 0;
             }
 
+            final long acceptedAddressMemoryAddress;
+            final long acceptedAddressLengthMemoryAddress;
             if (IoUring.isIOUringAcceptMultishotSupported()) {
                 // Let's use multi-shot accept to reduce overhead.
                 ioPrio |= Native.IORING_ACCEPT_MULTISHOT;
-            }
-
-            final long acceptedAddressMemoryAddress;
-            final long acceptedAddressLengthMemoryAddress;
-            if (acceptedAddressMemory == null) {
                 acceptedAddressMemoryAddress = 0;
                 acceptedAddressLengthMemoryAddress = 0;
             } else {
+                assert acceptedAddressMemory != null;
                 acceptedAddressMemoryAddress = acceptedAddressMemory.acceptedAddressMemoryAddress;
                 acceptedAddressLengthMemoryAddress = acceptedAddressMemory.acceptedAddressLengthMemoryAddress;
             }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -386,6 +386,7 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
         protected void readComplete0(byte op, int res, int flags, short data, int outstanding) {
             assert readId != 0;
             readId = 0;
+            assert outstanding != -1 : "multi-shot not implemented yet";
             boolean allDataRead = false;
 
             final IoUringRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUring.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUring.java
@@ -27,6 +27,7 @@ public final class IoUring {
     private static final boolean IORING_CQE_F_SOCK_NONEMPTY_SUPPORTED;
     private static final boolean IORING_SPLICE_SUPPORTED;
     private static final boolean IORING_ACCEPT_NO_WAIT_SUPPORTED;
+    private static final boolean IORING_ACCEPT_MULTISHOT_SUPPORTED;
     private static final boolean IORING_REGISTER_IOWQ_MAX_WORKERS_SUPPORTED;
     private static final boolean IORING_SETUP_SUBMIT_ALL_SUPPORTED;
     private static final boolean IORING_SETUP_CQ_SIZE_SUPPORTED;
@@ -43,6 +44,7 @@ public final class IoUring {
         boolean socketNonEmptySupported = false;
         boolean spliceSupported = false;
         boolean acceptSupportNoWait = false;
+        boolean acceptMultishotSupported = false;
         boolean registerIowqWorkersSupported = false;
         boolean submitAllSupported = false;
         boolean setUpCqSizeSupported = false;
@@ -68,6 +70,7 @@ public final class IoUring {
                         spliceSupported = Native.isIOUringSupportSplice(ringBuffer.fd());
                         // IORING_FEAT_RECVSEND_BUNDLE was added in the same release.
                         acceptSupportNoWait = (ringBuffer.features() & Native.IORING_FEAT_RECVSEND_BUNDLE) != 0;
+                        acceptMultishotSupported = Native.isIOUringAcceptMultishotSupported(ringBuffer.fd());
                         registerIowqWorkersSupported = Native.isRegisterIOWQWorkerSupported(ringBuffer.fd());
                         submitAllSupported = Native.ioUringSetupSupportsFlags(Native.IORING_SETUP_SUBMIT_ALL);
                         setUpCqSizeSupported = Native.ioUringSetupSupportsFlags(Native.IORING_SETUP_CQSIZE);
@@ -107,13 +110,14 @@ public final class IoUring {
                         "IORING_CQE_F_SOCK_NONEMPTY_SUPPORTED={}, " +
                         "IORING_SPLICE_SUPPORTED={}, " +
                         "IORING_ACCEPT_NO_WAIT_SUPPORTED={}, " +
+                        "IORING_ACCEPT_MULTISHOT_SUPPORTED={}, " +
                         "IORING_REGISTER_IOWQ_MAX_WORKERS_SUPPORTED={}, " +
                         "IORING_SETUP_SUBMIT_ALL_SUPPORTED={}, " +
                         "IORING_SETUP_SINGLE_ISSUER_SUPPORTED={}, " +
                         "IORING_SETUP_DEFER_TASKRUN_SUPPORTED={}, " +
                         "IORING_REGISTER_BUFFER_RING_SUPPORTED={}, " +
                         "IOU_PBUF_RING_INC_SUPPORTED={}" +
-                        ")", socketNonEmptySupported, spliceSupported, acceptSupportNoWait,
+                        ")", socketNonEmptySupported, spliceSupported, acceptSupportNoWait, acceptMultishotSupported,
                         registerIowqWorkersSupported, submitAllSupported, singleIssuerSupported,
                         deferTaskrunSupported, registerBufferRingSupported, registerBufferRingIncSupported);
             }
@@ -122,6 +126,7 @@ public final class IoUring {
         IORING_CQE_F_SOCK_NONEMPTY_SUPPORTED = socketNonEmptySupported;
         IORING_SPLICE_SUPPORTED = spliceSupported;
         IORING_ACCEPT_NO_WAIT_SUPPORTED = acceptSupportNoWait;
+        IORING_ACCEPT_MULTISHOT_SUPPORTED = acceptMultishotSupported;
         IORING_REGISTER_IOWQ_MAX_WORKERS_SUPPORTED = registerIowqWorkersSupported;
         IORING_SETUP_SUBMIT_ALL_SUPPORTED = submitAllSupported;
         IORING_SETUP_CQ_SIZE_SUPPORTED = setUpCqSizeSupported;
@@ -165,6 +170,10 @@ public final class IoUring {
 
     static boolean isIOUringAcceptNoWaitSupported() {
         return IORING_ACCEPT_NO_WAIT_SUPPORTED;
+    }
+
+    static boolean isIOUringAcceptMultishotSupported() {
+        return IORING_ACCEPT_MULTISHOT_SUPPORTED;
     }
 
     static boolean isRegisterIowqMaxWorkersSupported() {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
@@ -383,6 +383,8 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
 
         @Override
         protected void readComplete0(byte op, int res, int flags, short data, int outstanding) {
+            assert outstanding != -1 : "multi-shot not implemented yet";
+
             final IoUringRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
             final ChannelPipeline pipeline = pipeline();
             ByteBuf byteBuf = this.readBuffer;

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
@@ -31,6 +31,11 @@ public final class IoUringSocketChannel extends AbstractIoUringStreamChannel imp
        this.config = new IoUringSocketChannelConfig(this);
     }
 
+    IoUringSocketChannel(Channel parent, LinuxSocket fd) {
+        super(parent, fd, true);
+        this.config = new IoUringSocketChannelConfig(this);
+    }
+
     IoUringSocketChannel(Channel parent, LinuxSocket fd, SocketAddress remote) {
         super(parent, fd, remote);
         this.config = new IoUringSocketChannelConfig(this);

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -202,8 +202,8 @@ final class Native {
     static final byte IORING_OP_FIXED_FD_INSTALL = 54;
     static final byte IORING_OP_FTRUNCATE = 55;
     static final byte IORING_OP_BIND = 56;
+    static final byte IORING_CQE_F_MORE = 1 << 1;
     static final byte IORING_CQE_F_SOCK_NONEMPTY = 1 << 2;
-
     static final int IORING_SETUP_CQSIZE = 1 << 3;
     static final int IORING_SETUP_R_DISABLED = 1 << 6;
     static final int IORING_SETUP_SUBMIT_ALL = 1 << 7;
@@ -213,8 +213,10 @@ final class Native {
     static final int IORING_CQE_F_BUF_MORE = 1 << 4;
 
     static final short IORING_RECVSEND_POLL_FIRST = 1 << 0;
+    static final short IORING_ACCEPT_MULTISHOT = 1 << 0;
     static final short IORING_ACCEPT_DONTWAIT = 1 << 1;
     static final short IORING_ACCEPT_POLL_FIRST = 1 << 2;
+
     static final int IORING_FEAT_RECVSEND_BUNDLE = 1 << 14;
     static final int SPLICE_F_MOVE = 1;
 
@@ -365,6 +367,11 @@ final class Native {
             throw new UnsupportedOperationException("Not all operations are supported: "
                     + Arrays.toString(REQUIRED_IORING_OPS));
         }
+    }
+
+    static boolean isIOUringAcceptMultishotSupported(int ringFd) {
+        // IORING_OP_SOCKET was added in the same release (5.19);
+        return ioUringProbe(ringFd, new int[] { Native.IORING_OP_SOCKET });
     }
 
     static boolean isIOUringCqeFSockNonEmptySupported(int ringFd) {


### PR DESCRIPTION
…ISHOT

Motivation:

Using multishot variants is considered the prefered way to use io_uring to reduce overhead. This change adds the needed changes to support it for "inbound" operations and implement it for accept so far.

Modifications:

- Add code to support multishot for inbound operations in general
- Use ACCEPT_MULTISHOT if possible

Result:

Less overhead for acception connections and preparations to also be able to use multishot for other ops.
