### PR TITLE
Update FastThreadLocal.java

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/FastThreadLocal.java
+++ b/common/src/main/java/io/netty/util/concurrent/FastThreadLocal.java
@@ -62,7 +62,7 @@ public class FastThreadLocal<V> {
                 @SuppressWarnings("unchecked")
                 Set<FastThreadLocal<?>> variablesToRemove = (Set<FastThreadLocal<?>>) v;
                 FastThreadLocal<?>[] variablesToRemoveArray =
-                        variablesToRemove.toArray(new FastThreadLocal[0]);
+                        variablesToRemove.toArray(new FastThreadLocal[variablesToRemove.size()]);
                 for (FastThreadLocal<?> tlv: variablesToRemoveArray) {
                     tlv.remove(threadLocalMap);
                 }


### PR DESCRIPTION


Motivation:

Cannot specify the length of the array as 0,Otherwise, when executing the toArray method, a new array will also be created.See details in IdentityHashMap#toArray(T[] a).


Modification:

Change “new FastThreadLocal[0] ” to “new FastThreadLocal[variablesToRemove.size()] ” in the method named “removeAll”.


