### PR TITLE
Replace SSL assertion with explicit record length check

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
@@ -1700,7 +1700,7 @@ public class SslHandlerTest {
         buf.writeByte(0x2);
         DecoderException e = assertThrows(DecoderException.class, () -> channel.writeInbound(buf));
         assertThat(e.getCause(), instanceOf(NotSslRecordException.class));
-        channel.finishAndReleaseAll();
+        assertTrue(channel.finishAndReleaseAll());
     }
 
     @Test

--- a/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
@@ -1698,7 +1698,12 @@ public class SslHandlerTest {
         buf.writeByte(0xfe);
         buf.writeByte(0x87);
         buf.writeByte(0x2);
-        DecoderException e = assertThrows(DecoderException.class, () -> channel.writeInbound(buf));
+        DecoderException e = assertThrows(DecoderException.class, new Executable() {
+            @Override
+            public void execute() {
+                channel.writeInbound(buf);
+            }
+        });
         assertThat(e.getCause(), instanceOf(NotSslRecordException.class));
         assertTrue(channel.finishAndReleaseAll());
     }

--- a/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
@@ -1685,14 +1685,14 @@ public class SslHandlerTest {
 
     @Test
     public void testIncorrectLength() throws SSLException {
-        SelfSignedCertificate cert = CachedSelfSignedCertificate.getCachedCertificate();
-        EmbeddedChannel channel = new EmbeddedChannel();
+        final SelfSignedCertificate cert = CachedSelfSignedCertificate.getCachedCertificate();
+        final EmbeddedChannel channel = new EmbeddedChannel();
         channel.pipeline().addLast(
                 SslContextBuilder.forServer(cert.key(), cert.cert())
                         .sslProvider(SslProvider.JDK)
                         .build()
                         .newHandler(channel.alloc()));
-        ByteBuf buf = channel.alloc().buffer(5);
+        final ByteBuf buf = channel.alloc().buffer(5);
         buf.writeByte(0x0);
         buf.writeByte(0x1);
         buf.writeByte(0xfe);

--- a/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
@@ -67,6 +67,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.function.Executable;
 
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLProtocolException;
+import javax.net.ssl.X509ExtendedTrustManager;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.nio.channels.ClosedChannelException;
@@ -86,14 +91,12 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLEngine;
-import javax.net.ssl.SSLException;
-import javax.net.ssl.SSLProtocolException;
-import javax.net.ssl.X509ExtendedTrustManager;
-
 import static io.netty.buffer.Unpooled.wrappedBuffer;
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -1678,6 +1681,26 @@ public class SslHandlerTest {
             group.shutdownGracefully();
             ReferenceCountUtil.release(sslClientCtx);
         }
+    }
+
+    @Test
+    public void testIncorrectLength() throws SSLException {
+        SelfSignedCertificate cert = CachedSelfSignedCertificate.getCachedCertificate();
+        EmbeddedChannel channel = new EmbeddedChannel();
+        channel.pipeline().addLast(
+                SslContextBuilder.forServer(cert.key(), cert.cert())
+                        .sslProvider(SslProvider.JDK)
+                        .build()
+                        .newHandler(channel.alloc()));
+        ByteBuf buf = channel.alloc().buffer(5);
+        buf.writeByte(0x0);
+        buf.writeByte(0x1);
+        buf.writeByte(0xfe);
+        buf.writeByte(0x87);
+        buf.writeByte(0x2);
+        DecoderException e = assertThrows(DecoderException.class, () -> channel.writeInbound(buf));
+        assertThat(e.getCause(), instanceOf(NotSslRecordException.class));
+        channel.finishAndReleaseAll();
     }
 
     @Test


### PR DESCRIPTION
Motivation:

This assertion sometimes fails in fuzzing when using the JDK SSL implementation. The reason is that the JDK equivalent of getEncryptedPacketLength (SSLEngineInputRecord#bytesInCompletePacket) remembers when a previous packet was not SSLv2 and will not check for SSLv2 again in that case. getEncryptedPacketLength cannot replicate this behavior and checks for SSLv2 every time. This can lead to a mismatch in the netty and JDK length result, which triggers the assert replaced in this PR.

Modification:

Replace the assert with a normal check and exception. This sort of input should always be a sign of bad data.

Result:

Normal decode failure instead of assertion failure.

From my testing, this only affects the JDK implementation so there's no potential for a crash like CVE-2025-24970. It looks like when assertions are off, the data is just dropped atm.