### PR TITLE
chore: Sync the id when DefaultHttp2FrameStream's stream is updated. …

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
@@ -771,6 +771,7 @@ public class Http2FrameCodec extends Http2ConnectionHandler {
         DefaultHttp2FrameStream setStreamAndProperty(PropertyKey streamKey, Http2Stream stream) {
             assert id == -1 || stream.id() == id;
             this.stream = stream;
+            this.id = stream.id();
             stream.setProperty(streamKey, this);
             return this;
         }


### PR DESCRIPTION
…(#14803)

Motivation:

Keep the id in sync

Modification:

update the id when stream is updated.

Result:

Fixes https://github.com/netty/netty/issues/14801