### PR TITLE
IoUring: Pass correct value to scheduleRead(...) when recv fails beca…

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -420,10 +420,7 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
                         // This will do the correct thing, taking into account if
                         // there is again room in the ring or not and so either use the buffer ring or not for the
                         // read.
-                        //
-                        // As we only use the buffer ring for the first read we can call schedule(...) with true as
-                        // parameter.
-                        scheduleRead(true);
+                        scheduleRead(allocHandle.isFirstRead());
                         return;
                     }
 

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringRecvByteAllocatorHandle.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringRecvByteAllocatorHandle.java
@@ -43,7 +43,7 @@ final class IoUringRecvByteAllocatorHandle extends RecvByteBufAllocator.Delegati
     public void reset(ChannelConfig config) {
         super.reset(config);
         readComplete = false;
-        firstRead = false;
+        firstRead = true;
     }
 
     void rdHupReceived() {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringRecvByteAllocatorHandle.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringRecvByteAllocatorHandle.java
@@ -35,6 +35,7 @@ final class IoUringRecvByteAllocatorHandle extends RecvByteBufAllocator.Delegati
         super(handle);
     }
 
+    private boolean firstRead;
     private boolean rdHupReceived;
     private boolean readComplete;
 
@@ -42,6 +43,7 @@ final class IoUringRecvByteAllocatorHandle extends RecvByteBufAllocator.Delegati
     public void reset(ChannelConfig config) {
         super.reset(config);
         readComplete = false;
+        firstRead = false;
     }
 
     void rdHupReceived() {
@@ -68,6 +70,10 @@ final class IoUringRecvByteAllocatorHandle extends RecvByteBufAllocator.Delegati
                 || rdHupReceived;
     }
 
+    public boolean isFirstRead() {
+        return firstRead;
+    }
+
     @Override
     public void readComplete() {
         super.readComplete();
@@ -76,5 +82,17 @@ final class IoUringRecvByteAllocatorHandle extends RecvByteBufAllocator.Delegati
 
     boolean isReadComplete() {
         return readComplete;
+    }
+
+    @Override
+    public void lastBytesRead(int bytes) {
+        firstRead = false;
+        super.lastBytesRead(bytes);
+    }
+
+    @Override
+    public void incMessagesRead(int numMessages) {
+        firstRead = false;
+        super.incMessagesRead(numMessages);
     }
 }


### PR DESCRIPTION
…use there is no buffer left in the buffer ring.

Motivation:

d1b63585a695426b0ab5aab75d6499ee9269fd55 introduced the usage of the buffer ring for all reads so we need to ensure we call scheduleRead(...) with the right param depending on if its the first read or not.

Modifications:

Keep track if its the first read or not and use this information to call scheduleRead(...)

Result:

Pick the optimial values for ioPro and flags when doing a recv because of no buffer left in the ring