### PR TITLE
IoUring: Add support for IORING_RECV_MULTISHOT

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -292,7 +292,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
         readPending = true;
         if (inReadComplete || !isActive()) {
             // We are currently in the readComplete(...) callback which might issue more reads by itself.
-            // If readComplete(...) will not issue more reads itself it will pick up he readPending flag, reset it and
+            // If readComplete(...) will not issue more reads itself it will pick up the readPending flag, reset it and
             // call doBeginReadNow().
             return;
         }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -748,7 +748,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
                         // The readComplete(...) was triggered because the previous read was cancelled.
                         // In this case we we need to check if the user did signal the desire to read again
                         // in the meantime. If this is the case we need to schedule the read to ensure
-                        // we not stale.
+                        // we do not stall.
                         if (pending) {
                             doBeginReadNow();
                         }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -289,11 +289,11 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
             // We already have a read pending.
             return;
         }
+        readPending = true;
         if (inReadComplete || !isActive()) {
-            // We are currently in the readComplete(...) callback which might issue more reads by itself. Just
-            // mark it as a pending read. If readComplete(...) will not issue more reads itself it will pick up
-            // the readPending flag, reset it and call doBeginReadNow().
-            readPending = true;
+            // We are currently in the readComplete(...) callback which might issue more reads by itself.
+            // If readComplete(...) will not issue more reads itself it will pick up he readPending flag, reset it and
+            // call doBeginReadNow().
             return;
         }
         doBeginReadNow();
@@ -667,6 +667,8 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
                     }
                     pipeline().fireUserEventTriggered(ChannelInputShutdownEvent.INSTANCE);
                 } else {
+                    // Handle this same way as if we did read all data so we don't schedule another read.
+                    inputClosedSeenErrorOnRead = true;
                     close(voidPromise());
                     return;
                 }
@@ -692,6 +694,12 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
 
         private void readComplete(byte op, int res, int flags, short data) {
             assert numOutstandingReads > 0 || numOutstandingReads == -1 : numOutstandingReads;
+            // Reset READ_SCHEDULED if there is nothing more to handle and so we need to re-arm. This works for
+            // multi-shot and non multi-shot variants.
+            if ((flags & Native.IORING_CQE_F_MORE) == 0) {
+                ioState &= ~READ_SCHEDULED;
+            }
+            boolean pending = readPending;
             if (numOutstandingReads == -1) {
                 // Reset readPending so we can still keep track if we might need to cancel the multi-shot read or
                 // not.
@@ -706,25 +714,49 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
 
                 readComplete0(op, res, flags, data, numOutstandingReads);
             } finally {
-                socketIsEmpty = false;
-                inReadComplete = false;
-                // There is a pending read and readComplete0(...) also did stop issue read request.
-                // Let's trigger the requested read now.
-                if (recvBufAllocHandle().isReadComplete()) {
-                    if (numOutstandingReads != -1) {
-                        if (readPending) {
+                try {
+                    // Check if we should consider the read loop to be done.
+                    if (recvBufAllocHandle().isReadComplete()) {
+                        // Reset the handle as we are done with the read-loop.
+                        recvBufAllocHandle().reset(config());
+
+                        // Check if this was a readComplete(...) triggered by a read or multi-shot read.
+                        if (numOutstandingReads != -1) {
+                            if (readPending) {
+                                // This was a "normal" read and the user did signal we should continue reading.
+                                // Let's schedule the read now.
+                                doBeginReadNow();
+                            }
+                        } else {
+                            // The readComplete(...) was triggered by a multi-shot read. Because of this the state
+                            // machine is a bit more complicated.
+                            if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
+                                // The readComplete(...) was triggered because the previous read was cancelled.
+                                // In this case we we need to check if the user did signal the desire to read again
+                                // in the meantime. If this is the case we need to schedule the read to ensure
+                                // we not stale.
+                                if (pending) {
+                                    doBeginReadNow();
+                                }
+                            } else if (!readPending) {
+                                // Cancel the multi-shot read now as the user did not signal that we want to keep
+                                // reading while we handle the completion event.
+                                cancelOutstandingReads(registration, numOutstandingReads);
+                            }
+                        }
+                    } else if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
+                        // The readComplete(...) was triggered because the previous read was cancelled.
+                        // In this case we we need to check if the user did signal the desire to read again
+                        // in the meantime. If this is the case we need to schedule the read to ensure
+                        // we not stale.
+                        if (pending) {
                             doBeginReadNow();
                         }
-                    } else if (!readPending) {
-                        // Cancel the multi-shot read now as the user did not signal that we want to keep reading.
-                        cancelOutstandingReads(registration, numOutstandingReads);
-                        ioState &= ~READ_SCHEDULED;
+                        doBeginReadNow();
                     }
-                } else if (res == Native.ERRNO_ECANCELED_NEGATIVE && !readPending) {
-                    // In case of using multi-shot we should ensure we reset READ_SCHEDULED if the original
-                    // read was canceled as otherwise we might not be able to close the channel later on as it
-                    // consider things not completely cleaned up.
-                    ioState &= ~READ_SCHEDULED;
+                } finally {
+                    socketIsEmpty = false;
+                    inReadComplete = false;
                 }
             }
         }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -734,7 +734,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
                                 // The readComplete(...) was triggered because the previous read was cancelled.
                                 // In this case we we need to check if the user did signal the desire to read again
                                 // in the meantime. If this is the case we need to schedule the read to ensure
-                                // we not stale.
+                                // we do not stall.
                                 if (pending) {
                                     doBeginReadNow();
                                 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -315,7 +315,7 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
         @Override
         protected int scheduleRead0(boolean first, boolean socketIsEmpty) {
             assert readBuffer == null;
-            assert readId == 0;
+            assert readId == 0 : readId;
 
             final IoUringStreamChannelConfig channelConfig = (IoUringStreamChannelConfig) config();
             final IoUringIoHandler ioUringIoHandler = registration().attachment();
@@ -359,22 +359,32 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
         private int scheduleReadProviderBuffer(IoUringBufferRing bufferRing, boolean first, boolean socketIsEmpty) {
             short bgId = bufferRing.bufferGroupId();
             try {
-                int chunkSize = bufferRing.chunkSize();
-                IoRegistration registration = registration();
-
-                int fd = fd().intValue();
+                boolean multishot = IoUring.isIOUringRecvMultishotSupported();
+                byte flags = flags((byte) Native.IOSQE_BUFFER_SELECT);
                 short ioPrio = calculateRecvIoPrio(first, socketIsEmpty);
                 int recvFlags = calculateRecvFlags(first);
-
+                final int len;
+                if (multishot) {
+                    ioPrio |= Native.IORING_RECV_MULTISHOT;
+                    len = 0;
+                } else {
+                    len = bufferRing.chunkSize();
+                }
+                IoRegistration registration = registration();
+                int fd = fd().intValue();
                 IoUringIoOps ops = IoUringIoOps.newRecv(
-                        fd, flags((byte) Native.IOSQE_BUFFER_SELECT), ioPrio, recvFlags, 0,
-                        chunkSize, nextOpsId(), bgId
+                        fd, flags, ioPrio, recvFlags, 0,
+                        len, nextOpsId(), bgId
                 );
                 readId = registration.submit(ops);
                 if (readId == 0) {
                     return 0;
                 }
                 lastUsedBufferRing = bufferRing;
+                if (multishot) {
+                    // Return -1 to signal we used multishot and so expect multiple recvComplete(...) calls.
+                    return -1;
+                }
                 return 1;
             } catch (IllegalArgumentException illegalArgumentException) {
                 this.handleReadException(pipeline(), null, illegalArgumentException, false, recvBufAllocHandle());
@@ -384,29 +394,42 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
 
         @Override
         protected void readComplete0(byte op, int res, int flags, short data, int outstanding) {
+            ByteBuf byteBuf = readBuffer;
+            readBuffer = null;
+            if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
+                readId = 0;
+                // In case of cancellation we should reset the last used buffer ring to null as we will select a new one
+                // when calling scheduleRead(..)
+                lastUsedBufferRing = null;
+                if (byteBuf != null) {
+                    //recv without buffer ring
+                    byteBuf.release();
+                }
+                return;
+            }
             assert readId != 0;
-            readId = 0;
-            assert outstanding != -1 : "multi-shot not implemented yet";
+            IoUringBufferRing bufferRing = lastUsedBufferRing;
+            boolean rearm = (flags & Native.IORING_CQE_F_MORE) == 0;
+            boolean empty = socketIsEmpty(flags);
+            if (rearm) {
+                // Only reset if we don't use multi-shot or we need to re-arm because the multi-shot was cancelled.
+                readId = 0;
+                // In case of rearm we should reset the last used buffer ring to null as we will select a new one
+                // when calling scheduleRead(..)
+                lastUsedBufferRing = null;
+            }
+
             boolean allDataRead = false;
 
             final IoUringRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
             final ChannelPipeline pipeline = pipeline();
-            ByteBuf byteBuf = this.readBuffer;
-            IoUringBufferRing bufferRing = lastUsedBufferRing;
-            this.readBuffer = null;
-            this.lastUsedBufferRing = null;
 
             try {
                 if (res < 0) {
-                    if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
-                        if (byteBuf != null) {
-                            //recv without buffer ring
-                            byteBuf.release();
-                        }
-                        return;
-                    }
-
                     if (res == Native.ERRNO_NO_BUFFER_NEGATIVE) {
+                        // Reset the last used buffer ring to null as we will call scheduleRead(...) below which
+                        // will either select a new buffer ring to use or not use a buffer ring at all.
+                        this.lastUsedBufferRing = null;
                         //recv with provider buffer fail!
                         //fallback to normal recv
                         bufferRing.markExhausted();
@@ -463,18 +486,20 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
                 allocHandle.incMessagesRead(1);
                 pipeline.fireChannelRead(byteBuf);
                 byteBuf = null;
-                scheduleNextRead(flags);
+                scheduleNextRead(pipeline, allocHandle, rearm, empty);
             } catch (Throwable t) {
                 handleReadException(pipeline, byteBuf, t, allDataRead, allocHandle);
             }
         }
 
-        private void scheduleNextRead(int cqeFlags) {
-            final IoUringRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
-            final ChannelPipeline pipeline = pipeline();
-            if (allocHandle.continueReading() && !socketIsEmpty(cqeFlags)) {
-                // Let's schedule another read.
-                scheduleRead(false);
+        private void scheduleNextRead(ChannelPipeline pipeline, IoUringRecvByteAllocatorHandle allocHandle,
+                                      boolean rearm, boolean empty) {
+            if (allocHandle.continueReading() && !empty) {
+                if (rearm) {
+                    // We only should schedule another read if we need to rearm.
+                    // See https://github.com/axboe/liburing/wiki/io_uring-and-networking-in-2023#multi-shot
+                    scheduleRead(false);
+                }
             } else {
                 // We did not fill the whole ByteBuf so we should break the "read loop" and try again later.
                 allocHandle.readComplete();
@@ -561,11 +586,12 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
     protected final void cancelOutstandingReads(IoRegistration registration, int numOutstandingReads) {
         if (readId != 0) {
             // Let's try to cancel outstanding reads as these might be submitted and waiting for data (via fastpoll).
-            assert numOutstandingReads == 1;
+            assert numOutstandingReads == 1 || numOutstandingReads == -1;
             IoUringIoOps ops = IoUringIoOps.newAsyncCancel(flags((byte) 0), readId, Native.IORING_OP_RECV);
-            registration.submit(ops);
+            long id = registration.submit(ops);
+            assert id != 0;
         } else {
-            assert numOutstandingReads == 0;
+            assert numOutstandingReads == 0 || numOutstandingReads == -1;
         }
     }
 
@@ -576,7 +602,8 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
             // (via fastpoll).
             assert numOutstandingWrites == 1;
             assert writeOpCode != 0;
-            registration.submit(IoUringIoOps.newAsyncCancel(flags((byte) 0), writeId, writeOpCode));
+            long id = registration.submit(IoUringIoOps.newAsyncCancel(flags((byte) 0), writeId, writeOpCode));
+            assert id != 0;
         } else {
             assert numOutstandingWrites == 0;
         }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUring.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUring.java
@@ -28,6 +28,7 @@ public final class IoUring {
     private static final boolean IORING_SPLICE_SUPPORTED;
     private static final boolean IORING_ACCEPT_NO_WAIT_SUPPORTED;
     private static final boolean IORING_ACCEPT_MULTISHOT_SUPPORTED;
+    private static final boolean IORING_RECV_MULTISHOT_SUPPORTED;
     private static final boolean IORING_REGISTER_IOWQ_MAX_WORKERS_SUPPORTED;
     private static final boolean IORING_SETUP_SUBMIT_ALL_SUPPORTED;
     private static final boolean IORING_SETUP_CQ_SIZE_SUPPORTED;
@@ -45,6 +46,7 @@ public final class IoUring {
         boolean spliceSupported = false;
         boolean acceptSupportNoWait = false;
         boolean acceptMultishotSupported = false;
+        boolean recvMultishotSupported = false;
         boolean registerIowqWorkersSupported = false;
         boolean submitAllSupported = false;
         boolean setUpCqSizeSupported = false;
@@ -71,6 +73,7 @@ public final class IoUring {
                         // IORING_FEAT_RECVSEND_BUNDLE was added in the same release.
                         acceptSupportNoWait = (ringBuffer.features() & Native.IORING_FEAT_RECVSEND_BUNDLE) != 0;
                         acceptMultishotSupported = Native.isIOUringAcceptMultishotSupported(ringBuffer.fd());
+                        recvMultishotSupported = Native.isIOUringRecvMultishotSupported();
                         registerIowqWorkersSupported = Native.isRegisterIOWQWorkerSupported(ringBuffer.fd());
                         submitAllSupported = Native.ioUringSetupSupportsFlags(Native.IORING_SETUP_SUBMIT_ALL);
                         setUpCqSizeSupported = Native.ioUringSetupSupportsFlags(Native.IORING_SETUP_CQSIZE);
@@ -111,6 +114,7 @@ public final class IoUring {
                         "IORING_SPLICE_SUPPORTED={}, " +
                         "IORING_ACCEPT_NO_WAIT_SUPPORTED={}, " +
                         "IORING_ACCEPT_MULTISHOT_SUPPORTED={}, " +
+                        "IORING_RECV_MULTISHOT_SUPPORTED={}, " +
                         "IORING_REGISTER_IOWQ_MAX_WORKERS_SUPPORTED={}, " +
                         "IORING_SETUP_SUBMIT_ALL_SUPPORTED={}, " +
                         "IORING_SETUP_SINGLE_ISSUER_SUPPORTED={}, " +
@@ -118,7 +122,7 @@ public final class IoUring {
                         "IORING_REGISTER_BUFFER_RING_SUPPORTED={}, " +
                         "IOU_PBUF_RING_INC_SUPPORTED={}" +
                         ")", socketNonEmptySupported, spliceSupported, acceptSupportNoWait, acceptMultishotSupported,
-                        registerIowqWorkersSupported, submitAllSupported, singleIssuerSupported,
+                        recvMultishotSupported, registerIowqWorkersSupported, submitAllSupported, singleIssuerSupported,
                         deferTaskrunSupported, registerBufferRingSupported, registerBufferRingIncSupported);
             }
         }
@@ -127,6 +131,7 @@ public final class IoUring {
         IORING_SPLICE_SUPPORTED = spliceSupported;
         IORING_ACCEPT_NO_WAIT_SUPPORTED = acceptSupportNoWait;
         IORING_ACCEPT_MULTISHOT_SUPPORTED = acceptMultishotSupported;
+        IORING_RECV_MULTISHOT_SUPPORTED = recvMultishotSupported;
         IORING_REGISTER_IOWQ_MAX_WORKERS_SUPPORTED = registerIowqWorkersSupported;
         IORING_SETUP_SUBMIT_ALL_SUPPORTED = submitAllSupported;
         IORING_SETUP_CQ_SIZE_SUPPORTED = setUpCqSizeSupported;
@@ -174,6 +179,10 @@ public final class IoUring {
 
     static boolean isIOUringAcceptMultishotSupported() {
         return IORING_ACCEPT_MULTISHOT_SUPPORTED;
+    }
+
+    static boolean isIOUringRecvMultishotSupported() {
+        return IORING_RECV_MULTISHOT_SUPPORTED;
     }
 
     static boolean isRegisterIowqMaxWorkersSupported() {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -213,6 +213,8 @@ final class Native {
     static final int IORING_CQE_F_BUF_MORE = 1 << 4;
 
     static final short IORING_RECVSEND_POLL_FIRST = 1 << 0;
+    static final short IORING_RECV_MULTISHOT = 1 << 1;
+
     static final short IORING_ACCEPT_MULTISHOT = 1 << 0;
     static final short IORING_ACCEPT_DONTWAIT = 1 << 1;
     static final short IORING_ACCEPT_POLL_FIRST = 1 << 2;
@@ -367,6 +369,11 @@ final class Native {
             throw new UnsupportedOperationException("Not all operations are supported: "
                     + Arrays.toString(REQUIRED_IORING_OPS));
         }
+    }
+
+    static boolean isIOUringRecvMultishotSupported() {
+        // Added in the same release as IORING_SETUP_SINGLE_ISSUER.
+        return Native.ioUringSetupSupportsFlags(Native.IORING_SETUP_SINGLE_ISSUER);
     }
 
     static boolean isIOUringAcceptMultishotSupported(int ringFd) {

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
@@ -127,14 +127,14 @@ public class IoUringBufferRingTest {
         ByteBufUtil.writeAscii(writeBuffer, randomString);
         ByteBuf userspaceIoUringBufferElement1 = sendAndRecvMessage(clientChannel, writeBuffer, bufferSyncer);
         ByteBuf userspaceIoUringBufferElement2 = sendAndRecvMessage(clientChannel, writeBuffer, bufferSyncer);
+
+        ByteBuf readBuffer = sendAndRecvMessage(clientChannel, writeBuffer, bufferSyncer);
         if (!incremental) {
             // Directly after the second read we will see the event as it will be triggered inline when
             // doing the submit.
             assertEquals(bufferRingConfig.bufferGroupId(), eventSyncer.take().bufferGroupId());
         }
         assertEquals(0, eventSyncer.size());
-
-        ByteBuf readBuffer = sendAndRecvMessage(clientChannel, writeBuffer, bufferSyncer);
         readBuffer.release();
 
         // Now we release the buffer and so put it back into the buffer ring.


### PR DESCRIPTION
Motivation:

To reduce overhead we should use IORING_RECV_MULTISHOT when possible.

Modifications:

- Add code to use IORING_RECV_MULTISHOT
- Fix bug related to cancellations that are inflight

Result:

Be able to use IORING_RECV_MULTISHOT to reduce overhead if kernel supports it
