### PR TITLE
Replace SSL assertion with explicit record length check (#14810)

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -63,6 +63,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
+
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLEngineResult;
 import javax.net.ssl.SSLEngineResult.HandshakeStatus;
@@ -1374,9 +1375,11 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
         this.packetLength = 0;
         try {
             final int bytesConsumed = unwrap(ctx, in, packetLength);
-            assert bytesConsumed == packetLength || engine.isInboundDone() :
-                    "we feed the SSLEngine a packets worth of data: " + packetLength + " but it only consumed: " +
-                            bytesConsumed;
+            if (bytesConsumed != packetLength && !engine.isInboundDone()) {
+                // The JDK equivalent of getEncryptedPacketLength has some optimizations and can behave slightly
+                // differently to ours, but this should always be a sign of bad input data.
+                throw new NotSslRecordException();
+            }
         } catch (Throwable cause) {
             handleUnwrapThrowable(ctx, cause);
         }


### PR DESCRIPTION
Motivation:

This assertion sometimes fails in fuzzing when using the JDK SSL implementation. The reason is that the JDK equivalent of getEncryptedPacketLength (SSLEngineInputRecord#bytesInCompletePacket) remembers when a previous packet was not SSLv2 and will not check for SSLv2 again in that case. getEncryptedPacketLength cannot replicate this behavior and checks for SSLv2 every time. This can lead to a mismatch in the netty and JDK length result, which triggers the assert replaced in this PR.

Modification:

Replace the assert with a normal check and exception. This sort of input should always be a sign of bad data.

Result:

Normal decode failure instead of assertion failure.

From my testing, this only affects the JDK implementation so there's no potential for a crash like CVE-2025-24970. It looks like when assertions are off, the data is just dropped atm.