### PR TITLE
Add a RedHat ubi9 based build

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -183,6 +183,9 @@ jobs:
           - setup: linux-x86_64-java11-adaptive
             docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.111.yaml build"
             docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.111.yaml run build-leak-adaptive"
+          - setup: linux-x86_64-ubi9-java21
+            docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.ubi9.21.yaml build"
+            docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.ubi9.21.yaml run build-boringssl-static"
 
     name: ${{ matrix.setup }} build
     needs: verify-pr

--- a/docker/Dockerfile.ubi9
+++ b/docker/Dockerfile.ubi9
@@ -1,0 +1,37 @@
+FROM --platform=linux/amd64 redhat/ubi9-minimal
+
+RUN microdnf install -y \
+ apr-devel \
+ autoconf \
+ automake \
+ git \
+ glibc-devel \
+ libtool \
+ lksctp-tools \
+ make \
+ openssl-devel \
+ tar \
+ unzip \
+ wget \
+ zip
+
+# Downloading and installing SDKMAN!
+RUN curl -s  "https://get.sdkman.io" | bash
+
+ARG java_version=11.0.12-zulu
+ENV JAVA_VERSION $java_version
+
+# Installing Java removing some unnecessary SDKMAN files
+RUN bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && \
+    yes | sdk install java $JAVA_VERSION && \
+    rm -rf $HOME/.sdkman/archives/* && \
+    rm -rf $HOME/.sdkman/tmp/*"
+
+RUN echo 'export JAVA_HOME="/root/.sdkman/candidates/java/current"' >> ~/.bashrc
+RUN echo 'PATH=/jdk/bin:$PATH' >> ~/.bashrc
+
+# Cleanup
+RUN microdnf clean all
+
+# when the JDK is GraalVM install native-image
+RUN if [ -O /root/.sdkman/candidates/java/current/bin/gu ]; then /root/.sdkman/candidates/java/current/bin/gu install native-image; else echo "Not GraalVM, skip installation of native-image" ; fi

--- a/docker/docker-compose.ubi9.21.yaml
+++ b/docker/docker-compose.ubi9.21.yaml
@@ -1,0 +1,29 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: netty:ubi9-21
+    build:
+      args:
+        java_version : "21.0.5-zulu"
+      context: .
+      dockerfile: Dockerfile.centos6
+
+  build:
+    image: netty:ubi9-21
+
+  build-leak:
+    image: netty:ubi9-21
+
+  build-boringssl-static:
+    image: netty:ubi9-21
+
+  build-leak-boringssl-static:
+    image: netty:ubi9-21
+
+  build-boringssl-snapshot:
+    image: netty:ubi9-21
+
+  shell:
+    image: netty:ubi9-21


### PR DESCRIPTION
Motivation:
CentOS 6 is ancient, and the repo mirrors are even starting to disappear. Netty 5 should be based on a much more modern OS environment, so let's explore some alternatives like RedHat ubi9.

Modification:
Add a RedHat ubi9 based PR build.
We only build with the BoringSSL variant of tcnative on ubi9, because tcnative wishes to link to openssl 1.0, and that's not available anymore.

Result:
We get to see if this works, and if it does, we can move the other builds over to this base image.