### PR TITLE
IoUring: Fix IoBufferRing implementation

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -325,8 +325,7 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
             if (IoUring.isRegisterBufferRingSupported() && channelConfig.getUseIoUringBufferGroup()) {
                 IoUringBufferRing ioUringBufferRing = ioUringIoHandler.findBufferRing(
                         AbstractIoUringStreamChannel.this, recvBufAllocHandle().guess());
-                if (ioUringBufferRing != null) {
-                    ioUringBufferRing.refillIfNecessary();
+                if (ioUringBufferRing != null && !ioUringBufferRing.isExhausted()) {
                     return scheduleReadProviderBuffer(ioUringBufferRing, first, socketIsEmpty);
                 }
             }


### PR DESCRIPTION
Motivation:

Our implementation made wrong assumptions and so could lead to data corruption. The problem is that if a ring is exhausted we can't assume that all our buffers are used already. We need to keep track of what was used and only refill these when the ring was exhausted.

Motification:

- Fix ring implementation to only refill what was actually used and not what might be still pending to be used

Result:

Fix buffer ring implementation