### PR TITLE
Disable flaky test for now

### DIFF
--- a/transport/src/test/java/io/netty/channel/SingleThreadIoEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/SingleThreadIoEventLoopTest.java
@@ -15,6 +15,7 @@
  */
 package io.netty.channel;
 import io.netty.util.concurrent.ThreadAwareExecutor;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.Executors;
@@ -75,6 +76,7 @@ public class SingleThreadIoEventLoopTest {
         }
     }
 
+    @Disabled("This test is flaky and will often stall the build")
     @Test
     void testSuspendingWhileRegistrationActive() throws Exception {
         TestThreadFactory threadFactory = new TestThreadFactory();


### PR DESCRIPTION
Motivation:
The SignleThreadIoEventLoopTest.testSuspendingWhileRegistrationActive is flaky.

The event loop and the trySuspend calls are racing, so occasionally a wakeup call is ignored (due to the internal state), or occasionally the run(IoHandlerContext) gets to run twice in a row with only one wakeup call.

When this happens, the event loop misses the suspension signal because it's waiting on the semaphore, and in turn the currentThread.join() will not complete.

Modification:
Disable the test for now.

Result:
Build no longer gets stuck on this test.