### PR TITLE
SslHandler: Fix possible NPE when executor is used for delegating

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -1501,7 +1501,10 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
                 if (handshakeStatus == HandshakeStatus.FINISHED || handshakeStatus == HandshakeStatus.NOT_HANDSHAKING) {
                     wrapLater |= (decodeOut.isReadable() ?
                             setHandshakeSuccessUnwrapMarkReentry() : setHandshakeSuccess()) ||
-                            handshakeStatus == HandshakeStatus.FINISHED || !pendingUnencryptedWrites.isEmpty();
+                            handshakeStatus == HandshakeStatus.FINISHED ||
+                            // We need to check if pendingUnecryptedWrites is null as the SslHandler
+                            // might have been removed in the meantime.
+                            (pendingUnencryptedWrites != null  && !pendingUnencryptedWrites.isEmpty());
                 }
 
                 // Dispatch decoded data after we have notified of handshake success. If this method has been invoked


### PR DESCRIPTION
Motivation:

We need to check if pendingUnencryptedWrites is null before accessing it as the SslHandler might have been removed in the meantime.

```
io.netty.handler.codec.DecoderException: java.lang.NullPointerException: Cannot invoke "io.netty.handler.ssl.SslHandlerCoalescingBufferQueue.isEmpty()" because "this.pendingUnencryptedWrites" is null
	at io.netty.handler.ssl.SslHandler$SslTasksRunner.wrapIfNeeded(SslHandler.java:1798)
	at io.netty.handler.ssl.SslHandler$SslTasksRunner.safeExceptionCaught(SslHandler.java:1785)
	at io.netty.handler.ssl.SslHandler$SslTasksRunner.resumeOnEventExecutor(SslHandler.java:1896)
	at io.netty.handler.ssl.SslHandler$SslTasksRunner.access$2000(SslHandler.java:1751)
	at io.netty.handler.ssl.SslHandler$SslTasksRunner$2.run(SslHandler.java:1912)
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472)
	at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:405)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:998)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.lang.NullPointerException: Cannot invoke "io.netty.handler.ssl.SslHandlerCoalescingBufferQueue.isEmpty()" because "this.pendingUnencryptedWrites" is null
	at io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1503)
	at io.netty.handler.ssl.SslHandler.unwrapNonAppData(SslHandler.java:1469)
	at io.netty.handler.ssl.SslHandler.access$1800(SslHandler.java:170)
	at io.netty.handler.ssl.SslHandler$SslTasksRunner.resumeOnEventExecutor(SslHandler.java:1847)
	... 9 more
```

Modifications:

Add null check

Result:

Fix NPE