### PR TITLE
Fix NPE when upgrade message fails to aggregate (#14816)

### DIFF
--- a/codec-base/src/main/java/io/netty/handler/codec/MessageAggregator.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/MessageAggregator.java
@@ -460,12 +460,12 @@ public abstract class MessageAggregator<I, S, C extends ByteBufHolder, O extends
         }
     }
 
-    private void releaseCurrentMessage() {
+    protected final void releaseCurrentMessage() {
         if (currentMessage != null) {
             currentMessage.release();
             currentMessage = null;
-            handlingOversizedMessage = false;
-            aggregating = false;
         }
+        handlingOversizedMessage = false;
+        aggregating = false;
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerUpgradeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerUpgradeHandler.java
@@ -277,6 +277,12 @@ public class HttpServerUpgradeHandler extends HttpObjectAggregator {
             // Call the base class to handle the aggregation of the full request.
             super.decode(ctx, msg, out);
             if (out.isEmpty()) {
+                if (msg instanceof LastHttpContent) {
+                    // request failed to aggregate, try with the next request
+                    handlingUpgrade = false;
+                    releaseCurrentMessage();
+                }
+
                 // The full request hasn't been created yet, still awaiting more data.
                 return;
             }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerUpgradeHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerUpgradeHandlerTest.java
@@ -229,4 +229,33 @@ public class HttpServerUpgradeHandlerTest {
         assertNull(channel.readOutbound());
         assertFalse(channel.finishAndReleaseAll());
     }
+
+    @Test
+    public void upgradeExpect() {
+        final HttpServerCodec httpServerCodec = new HttpServerCodec();
+        final UpgradeCodecFactory factory = new UpgradeCodecFactory() {
+            @Override
+            public UpgradeCodec newUpgradeCodec(CharSequence protocol) {
+                return new TestUpgradeCodec();
+            }
+        };
+
+        HttpServerUpgradeHandler upgradeHandler = new HttpServerUpgradeHandler(httpServerCodec, factory);
+
+        EmbeddedChannel channel = new EmbeddedChannel(httpServerCodec, upgradeHandler);
+
+        // Build a h2c upgrade request, but without connection header.
+        String upgradeString = "GET / HTTP/1.1\r\n" +
+                "Expect: foo\r\n" +
+                "Upgrade: h2c\r\n" +
+                "\r\n" +
+                "GET / HTTP/1.1\r\n" +
+                "Content-Length: 0\r\n" +
+                "\r\n";
+        ByteBuf upgrade = Unpooled.copiedBuffer(upgradeString, CharsetUtil.US_ASCII);
+
+        assertTrue(channel.writeInbound(upgrade));
+        channel.checkException();
+        assertTrue(channel.finishAndReleaseAll());
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -7345,6 +7345,54 @@
                   <new>method io.netty.channel.ServerChannel io.netty.channel.socket.nio.NioDomainSocketChannel::parent()</new>
                   <justification>Old return type made no sense, the parent channel is a NioServerDomainSocketChannel which does not implement ServerSocketChannel. The method always threw a ClassCastException (except for null).</justification>
                 </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.finalMethodAddedToNonFinalClass</code>
+                  <new>method void io.netty.handler.codec.MessageAggregator&lt;I, S, C extends io.netty.buffer.ByteBufHolder, O extends io.netty.buffer.ByteBufHolder&gt;::releaseCurrentMessage()</new>
+                  <justification>Exposed private method.</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.finalMethodAddedToNonFinalClass</code>
+                  <new>method void io.netty.handler.codec.MessageAggregator&lt;I, S, C extends io.netty.buffer.ByteBufHolder, O extends io.netty.buffer.ByteBufHolder&gt;::releaseCurrentMessage() @ io.netty.handler.codec.http.HttpClientUpgradeHandler</new>
+                  <justification>Exposed private method.</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.finalMethodAddedToNonFinalClass</code>
+                  <new>method void io.netty.handler.codec.MessageAggregator&lt;I, S, C extends io.netty.buffer.ByteBufHolder, O extends io.netty.buffer.ByteBufHolder&gt;::releaseCurrentMessage() @ io.netty.handler.codec.http.HttpObjectAggregator</new>
+                  <justification>Exposed private method.</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.finalMethodAddedToNonFinalClass</code>
+                  <new>method void io.netty.handler.codec.MessageAggregator&lt;I, S, C extends io.netty.buffer.ByteBufHolder, O extends io.netty.buffer.ByteBufHolder&gt;::releaseCurrentMessage() @ io.netty.handler.codec.http.HttpServerUpgradeHandler</new>
+                  <justification>Exposed private method.</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.finalMethodAddedToNonFinalClass</code>
+                  <new>method void io.netty.handler.codec.MessageAggregator&lt;I, S, C extends io.netty.buffer.ByteBufHolder, O extends io.netty.buffer.ByteBufHolder&gt;::releaseCurrentMessage() @ io.netty.handler.codec.http.websocketx.WebSocketFrameAggregator</new>
+                  <justification>Exposed private method.</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.finalMethodAddedToNonFinalClass</code>
+                  <new>method void io.netty.handler.codec.MessageAggregator&lt;I, S, C extends io.netty.buffer.ByteBufHolder, O extends io.netty.buffer.ByteBufHolder&gt;::releaseCurrentMessage() @ io.netty.handler.codec.memcache.binary.BinaryMemcacheObjectAggregator</new>
+                  <justification>Exposed private method.</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.finalMethodAddedToNonFinalClass</code>
+                  <new>method void io.netty.handler.codec.MessageAggregator&lt;I, S, C extends io.netty.buffer.ByteBufHolder, O extends io.netty.buffer.ByteBufHolder&gt;::releaseCurrentMessage() @ io.netty.handler.codec.memcache.AbstractMemcacheObjectAggregator&lt;H extends io.netty.handler.codec.memcache.MemcacheMessage&gt;</new>
+                  <justification>Exposed private method.</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.finalMethodAddedToNonFinalClass</code>
+                  <new>method void io.netty.handler.codec.MessageAggregator&lt;I, S, C extends io.netty.buffer.ByteBufHolder, O extends io.netty.buffer.ByteBufHolder&gt;::releaseCurrentMessage() @ io.netty.handler.codec.stomp.StompSubframeAggregator</new>
+                  <justification>Exposed private method.</justification>
+                </item>
 
                 <!-- Move netty-codec classes to netty-codec-base -->
                 <item>


### PR DESCRIPTION
Motivation:

When an HTTP message fails to aggregate, for example due to an invalid 'Expect' header, MessageAggregator does not produce a FullHttpRequest. HttpServerUpgradeHandler would then continue with the next request, wrongly believing it to be an upgrade request, even though only the previous one was. This produces an NPE:

```
Caused by: java.lang.NullPointerException: Cannot invoke "java.lang.CharSequence.length()" because "header" is null
	at io.netty.handler.codec.http.HttpServerUpgradeHandler.splitHeader(HttpServerUpgradeHandler.java:429)
	at io.netty.handler.codec.http.HttpServerUpgradeHandler.upgrade(HttpServerUpgradeHandler.java:328)
	at io.netty.handler.codec.http.HttpServerUpgradeHandler.decode(HttpServerUpgradeHandler.java:290)
	at io.netty.handler.codec.http.HttpServerUpgradeHandler.decode(HttpServerUpgradeHandler.java:40)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:91)
	... 35 common frames omitted
```

Modification:

When the upgrade handler sees a LastHttpContent, cancel the current upgrade and cancel aggregation.

Result:

No NPE for this input.

Found by fuzzing.