### PR TITLE
Fix NPE when upgrade message fails to aggregate (#14816)

### DIFF
--- a/codec-http/src/main/java/io/netty5/handler/codec/http/HttpServerUpgradeHandler.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/HttpServerUpgradeHandler.java
@@ -251,11 +251,7 @@ public class HttpServerUpgradeHandler<C extends HttpContent<C>> extends HttpObje
                 public ChannelHandlerContext fireChannelRead(Object msg) {
                     // Finished aggregating the full request, get it from the output list.
                     handlingUpgrade = false;
-                    FullHttpRequest request = (FullHttpRequest) msg;
-                    HttpHeaders headers = request.headers();
-                    if (headers != null && headers.contains(HttpHeaderNames.UPGRADE)) {
-                        tryUpgrade(ctx, request);
-                    }
+                    tryUpgrade(ctx, (FullHttpRequest) msg);
                     return this;
                 }
             }, msg);

--- a/codec/src/main/java/io/netty5/handler/codec/MessageAggregator.java
+++ b/codec/src/main/java/io/netty5/handler/codec/MessageAggregator.java
@@ -388,12 +388,12 @@ public abstract class MessageAggregator<I, S, C extends AutoCloseable, A extends
         }
     }
 
-    private void releaseCurrentMessage() throws Exception {
+    protected final void releaseCurrentMessage() throws Exception {
         if (currentMessage != null) {
             currentMessage.close();
             currentMessage = null;
-            handlingOversizedMessage = false;
-            aggregating = false;
         }
+        handlingOversizedMessage = false;
+        aggregating = false;
     }
 }


### PR DESCRIPTION
Motivation:

When an HTTP message fails to aggregate, for example due to an invalid 'Expect' header, MessageAggregator does not produce a FullHttpRequest. HttpServerUpgradeHandler would then continue with the next request, wrongly believing it to be an upgrade request, even though only the previous one was. This produces an NPE:

```
Caused by: java.lang.NullPointerException: Cannot invoke "java.lang.CharSequence.length()" because "header" is null
    at io.netty.handler.codec.http.HttpServerUpgradeHandler.splitHeader(HttpServerUpgradeHandler.java:429)
    at io.netty.handler.codec.http.HttpServerUpgradeHandler.upgrade(HttpServerUpgradeHandler.java:328)
    at io.netty.handler.codec.http.HttpServerUpgradeHandler.decode(HttpServerUpgradeHandler.java:290)
    at io.netty.handler.codec.http.HttpServerUpgradeHandler.decode(HttpServerUpgradeHandler.java:40)
    at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:91)
    ... 35 common frames omitted
```

Modification:

When the upgrade handler sees a LastHttpContent, cancel the current upgrade and cancel aggregation.

Result:

No NPE for this input.

Found by fuzzing.