### PR TITLE
Consistently add channel info in HTTP/2 logs (#14829)

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
@@ -790,7 +790,7 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
             //
             // See:
             // https://github.com/netty/netty/issues/4435
-            invokeLater(new Runnable() {
+            invokeLater(promise.channel(), new Runnable() {
                 @Override
                 public void run() {
                     if (fireChannelInactive) {
@@ -809,11 +809,12 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
 
         private void safeSetSuccess(ChannelPromise promise) {
             if (!(promise instanceof VoidChannelPromise) && !promise.trySuccess()) {
-                logger.warn("Failed to mark a promise as success because it is done already: {}", promise);
+                logger.warn("{} Failed to mark a promise as success because it is done already: {}",
+                        promise.channel(), promise);
             }
         }
 
-        private void invokeLater(Runnable task) {
+        private void invokeLater(Channel channel, Runnable task) {
             try {
                 // This method is used by outbound operation implementations to trigger an inbound event later.
                 // They do not trigger an inbound event immediately because an outbound operation might have been
@@ -828,7 +829,7 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
                 // which means the execution of two inbound handler methods of the same handler overlap undesirably.
                 eventLoop().execute(task);
             } catch (RejectedExecutionException e) {
-                logger.warn("Can't invoke task later as EventLoop rejected it", e);
+                logger.warn("{} Can't invoke task later as EventLoop rejected it", channel, e);
             }
         }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
@@ -613,6 +613,15 @@ public class DefaultHttp2Connection implements Http2Connection {
             }
             return (int) (value ^ (value >>> 32));
         }
+
+        @Override
+        public String toString() {
+            return getClass().getSimpleName() +
+                    "{id=" + id +
+                    ", state=" + state +
+                    ", metaState=" + metaState +
+                    '}';
+        }
     }
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
@@ -744,7 +744,8 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
             try {
                 listener.writabilityChanged(state.stream);
             } catch (Throwable cause) {
-                logger.error("Caught Throwable from listener.writabilityChanged", cause);
+                logger.error("{} Caught Throwable from listener.writabilityChanged for {}",
+                        ctx.channel(), state.stream, cause);
             }
         }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ControlFrameLimitEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ControlFrameLimitEncoder.java
@@ -95,8 +95,8 @@ final class Http2ControlFrameLimitEncoder extends DecoratingHttp2ConnectionEncod
                 limitReached = true;
                 Http2Exception exception = Http2Exception.connectionError(Http2Error.ENHANCE_YOUR_CALM,
                         "Maximum number %d of outstanding control frames reached", maxOutstandingControlFrames);
-                logger.info("Maximum number {} of outstanding control frames reached. Closing channel {}",
-                        maxOutstandingControlFrames, ctx.channel(), exception);
+                logger.info("{} Maximum number {} of outstanding control frames reached, closing channel.",
+                        ctx.channel(), maxOutstandingControlFrames, exception);
 
                 // First notify the Http2LifecycleManager and then close the connection.
                 lifecycleManager.onError(ctx, true, exception);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
@@ -568,7 +568,7 @@ public class Http2FrameCodec extends Http2ConnectionHandler {
 
         Http2FrameStream stream = connectionStream.getProperty(streamKey);
         if (stream == null) {
-            LOG.warn("Stream exception thrown without stream object attached.", cause);
+            LOG.warn("{} Stream exception thrown without stream object attached.", ctx.channel(), cause);
             // Write a RST_STREAM
             super.onStreamError(ctx, outbound, cause, streamException);
             return;
@@ -587,7 +587,8 @@ public class Http2FrameCodec extends Http2ConnectionHandler {
         // - fireUserEventTriggered(Http2ResetFrame), see Http2MultiplexHandler#channelRead(...)
         // - by failing write promise
         // Receiver of the error is responsible for correct handling of this exception.
-        LOG.log(DEBUG, "Stream exception thrown for unknown stream {}.", streamException.streamId(), cause);
+        LOG.log(DEBUG, "{} Stream exception thrown for unknown stream {}.",
+                ctx.channel(), streamException.streamId(), cause);
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ServerUpgradeCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ServerUpgradeCodec.java
@@ -134,7 +134,7 @@ public class Http2ServerUpgradeCodec implements HttpServerUpgradeHandler.Upgrade
             // Everything looks good.
             return true;
         } catch (Throwable cause) {
-            logger.info("Error during upgrade to HTTP/2", cause);
+            logger.info("{} Error during upgrade to HTTP/2", ctx.channel(), cause);
             return false;
         }
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamChannelBootstrap.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamChannelBootstrap.java
@@ -235,11 +235,10 @@ public final class Http2StreamChannelBootstrap {
             @SuppressWarnings("unchecked")
             ChannelOption<Object> opt = (ChannelOption<Object>) option;
             if (!channel.config().setOption(opt, value)) {
-                logger.warn("Unknown channel option '{}' for channel '{}'", option, channel);
+                logger.warn("{} Unknown channel option '{}'", channel, option);
             }
         } catch (Throwable t) {
-            logger.warn(
-                    "Failed to set channel option '{}' with value '{}' for channel '{}'", option, value, channel, t);
+            logger.warn("{} Failed to set channel option '{}' with value '{}'", channel, option, value, t);
         }
     }
 


### PR DESCRIPTION
Motivation:

Some HTTP/2 log messages do not contain channel information, making it hard to debug when it's not possible to relate these events to others.

Modifications:

- Add channel info at the beginning of all log messages in `netty-codec-http2` module;

Result:

HTTP/2 logs consistently start with channel info.
