### PR TITLE
IoUring: Make allocations for the buffer ring more flexible

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -362,12 +362,9 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
                 byte flags = flags((byte) Native.IOSQE_BUFFER_SELECT);
                 short ioPrio = calculateRecvIoPrio(first, socketIsEmpty);
                 int recvFlags = calculateRecvFlags(first);
-                final int len;
+                final int len = 0;
                 if (multishot) {
                     ioPrio |= Native.IORING_RECV_MULTISHOT;
-                    len = 0;
-                } else {
-                    len = bufferRing.chunkSize();
                 }
                 IoRegistration registration = registration();
                 int fd = fd().intValue();

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRing.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRing.java
@@ -28,14 +28,14 @@ final class IoUringBufferRing {
     private final int ringFd;
     private final ByteBuf[] buffers;
     private final IoUringIoHandler source;
-    private final IoUringBufferRingRecvAllocator allocator;
+    private final IoUringBufferRingAllocator allocator;
     private final IoUringBufferRingExhaustedEvent exhaustedEvent;
     private final boolean incremental;
     private boolean hasSpareBuffer;
 
     IoUringBufferRing(int ringFd, long ioUringBufRingAddr,
                       short entries, short bufferGroupId, boolean incremental, IoUringIoHandler ioUringIoHandler,
-                      IoUringBufferRingRecvAllocator allocator) {
+                      IoUringBufferRingAllocator allocator) {
         assert entries % 2 == 0;
         this.ioUringBufRingAddr = ioUringBufRingAddr;
         this.entries = entries;

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRingAllocator.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRingAllocator.java
@@ -20,7 +20,7 @@ import io.netty.buffer.ByteBuf;
 /**
  * Allocator that is responsible to allocate buffers for a buffer ring.
  */
-public interface IoUringBufferRingRecvAllocator {
+public interface IoUringBufferRingAllocator {
     /**
      * Creates a new receive buffer to use by the buffer ring. The returned {@link ByteBuf} must be direct.
      */

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRingConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRingConfig.java
@@ -15,7 +15,6 @@
  */
 package io.netty.channel.uring;
 
-import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.internal.ObjectUtil;
 
 import java.util.Objects;
@@ -28,17 +27,17 @@ public final class IoUringBufferRingConfig {
     private final short bgId;
     private final short bufferRingSize;
     private final boolean incremental;
-    private final IoUringBufferRingRecvAllocator allocator;
+    private final IoUringBufferRingAllocator allocator;
 
     /**
      * Create a new configuration.
      *
      * @param bgId              the buffer group id to use (must be non-negative).
      * @param bufferRingSize    the size of the ring
-     * @param allocator         the {@link IoUringBufferRingRecvAllocator} to use to allocate
+     * @param allocator         the {@link IoUringBufferRingAllocator} to use to allocate
      *                          {@link io.netty.buffer.ByteBuf}s.
      */
-    public IoUringBufferRingConfig(short bgId, short bufferRingSize, IoUringBufferRingRecvAllocator allocator) {
+    public IoUringBufferRingConfig(short bgId, short bufferRingSize, IoUringBufferRingAllocator allocator) {
         this(bgId, bufferRingSize, IoUring.isRegisterBufferRingIncSupported(), allocator);
     }
 
@@ -48,11 +47,11 @@ public final class IoUringBufferRingConfig {
      * @param bgId              the buffer group id to use (must be non-negative).
      * @param bufferRingSize    the size of the ring
      * @param incremental       {@code true} if the buffer ring is using incremental buffer consumption.
-     * @param allocator         the {@link IoUringBufferRingRecvAllocator} to use to allocate
+     * @param allocator         the {@link IoUringBufferRingAllocator} to use to allocate
      *                          {@link io.netty.buffer.ByteBuf}s.
      */
     public IoUringBufferRingConfig(short bgId, short bufferRingSize, boolean incremental,
-                                   IoUringBufferRingRecvAllocator allocator) {
+                                   IoUringBufferRingAllocator allocator) {
         this.bgId = (short) ObjectUtil.checkPositiveOrZero(bgId, "bgId");
         this.bufferRingSize = checkBufferRingSize(bufferRingSize);
         if (incremental && !IoUring.isRegisterBufferRingIncSupported()) {
@@ -81,11 +80,11 @@ public final class IoUringBufferRingConfig {
     }
 
     /**
-     * Returns the {@link IoUringBufferRingRecvAllocator} to use to allocate {@link io.netty.buffer.ByteBuf}s.
+     * Returns the {@link IoUringBufferRingAllocator} to use to allocate {@link io.netty.buffer.ByteBuf}s.
      *
      * @return  the allocator.
      */
-    public IoUringBufferRingRecvAllocator allocator() {
+    public IoUringBufferRingAllocator allocator() {
         return allocator;
     }
 

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRingConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRingConfig.java
@@ -25,24 +25,21 @@ import java.util.Objects;
  * It will configure the buffer ring size, buffer group id and the chunk size.
  */
 public final class IoUringBufferRingConfig {
-
     private final short bgId;
     private final short bufferRingSize;
-    private final int chunkSize;
     private final boolean incremental;
-    private final ByteBufAllocator allocator;
+    private final IoUringBufferRingRecvAllocator allocator;
 
     /**
      * Create a new configuration.
      *
      * @param bgId              the buffer group id to use (must be non-negative).
      * @param bufferRingSize    the size of the ring
-     * @param chunkSize         the chunk size of each {@link io.netty.buffer.ByteBuf} that is allocated out of the
-     *                          {@link ByteBufAllocator} to fill the ring.
-     * @param allocator         the {@link ByteBufAllocator} to use to allocate {@link io.netty.buffer.ByteBuf}s.
+     * @param allocator         the {@link IoUringBufferRingRecvAllocator} to use to allocate
+     *                          {@link io.netty.buffer.ByteBuf}s.
      */
-    public IoUringBufferRingConfig(short bgId, short bufferRingSize, int chunkSize, ByteBufAllocator allocator) {
-        this(bgId, bufferRingSize, chunkSize, IoUring.isRegisterBufferRingIncSupported(), allocator);
+    public IoUringBufferRingConfig(short bgId, short bufferRingSize, IoUringBufferRingRecvAllocator allocator) {
+        this(bgId, bufferRingSize, IoUring.isRegisterBufferRingIncSupported(), allocator);
     }
 
     /**
@@ -50,16 +47,14 @@ public final class IoUringBufferRingConfig {
      *
      * @param bgId              the buffer group id to use (must be non-negative).
      * @param bufferRingSize    the size of the ring
-     * @param chunkSize         the chunk size of each {@link io.netty.buffer.ByteBuf} that is allocated out of the
-     *                          {@link ByteBufAllocator} to fill the ring.
      * @param incremental       {@code true} if the buffer ring is using incremental buffer consumption.
-     * @param allocator         the {@link ByteBufAllocator} to use to allocate {@link io.netty.buffer.ByteBuf}s.
+     * @param allocator         the {@link IoUringBufferRingRecvAllocator} to use to allocate
+     *                          {@link io.netty.buffer.ByteBuf}s.
      */
-    public IoUringBufferRingConfig(short bgId, short bufferRingSize, int chunkSize, boolean incremental,
-                                   ByteBufAllocator allocator) {
+    public IoUringBufferRingConfig(short bgId, short bufferRingSize, boolean incremental,
+                                   IoUringBufferRingRecvAllocator allocator) {
         this.bgId = (short) ObjectUtil.checkPositiveOrZero(bgId, "bgId");
         this.bufferRingSize = checkBufferRingSize(bufferRingSize);
-        this.chunkSize = ObjectUtil.checkPositive(chunkSize, "chunkSize");
         if (incremental && !IoUring.isRegisterBufferRingIncSupported()) {
             throw new IllegalArgumentException("Incremental buffer ring is not supported");
         }
@@ -86,24 +81,21 @@ public final class IoUringBufferRingConfig {
     }
 
     /**
-     * Returns the chunk size of each {@link io.netty.buffer.ByteBuf} that is allocated out of the
-     * {@link ByteBufAllocator} to fill the ring.
-     *
-     * @return  the chunksize.
-     */
-    public int chunkSize() {
-        return chunkSize;
-    }
-
-    /**
-     * Returns the {@link ByteBufAllocator} to use to allocate {@link io.netty.buffer.ByteBuf}s.
+     * Returns the {@link IoUringBufferRingRecvAllocator} to use to allocate {@link io.netty.buffer.ByteBuf}s.
      *
      * @return  the allocator.
      */
-    public ByteBufAllocator allocator() {
+    public IoUringBufferRingRecvAllocator allocator() {
         return allocator;
     }
 
+    /**
+     * Returns true if <a href="https://github.com/axboe/liburing/wiki/
+     * What's-new-with-io_uring-in-6.11-and-6.12#incremental-provided-buffer-consumption">incremental mode</a>
+     * should be used for the buffer ring.
+     *
+     * @return {@code true} if incremental mode is used, {@code false} otherwise.
+     */
     public boolean isIncremental() {
         return incremental;
     }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRingRecvAllocator.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRingRecvAllocator.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.buffer.ByteBuf;
+
+/**
+ * Allocator that is responsible to allocate buffers for a buffer ring.
+ */
+public interface IoUringBufferRingRecvAllocator {
+    /**
+     * Creates a new receive buffer to use by the buffer ring. The returned {@link ByteBuf} must be direct.
+     */
+    ByteBuf allocate();
+
+    /**
+     * Set the bytes that have been read for the last read operation that was full-filled out of the buffer ring.
+     *
+     * @param bytes The number of bytes from the previous read operation.
+     */
+    void lastBytesRead(int bytes);
+}

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringFixedBufferRingRecvAllocator.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringFixedBufferRingRecvAllocator.java
@@ -21,15 +21,30 @@ import io.netty.util.internal.ObjectUtil;
 
 import java.util.Objects;
 
-public final class IoUringFixedBufferRingRecvAllocator implements IoUringBufferRingRecvAllocator {
+/**
+ * {@link IoUringBufferRingAllocator} implementation which uses a fixed size for the buffers that are returned by
+ * {@link #allocate()}.
+ */
+public final class IoUringFixedBufferRingRecvAllocator implements IoUringBufferRingAllocator {
     private final ByteBufAllocator allocator;
     private final int bufferSize;
 
+    /**
+     * Create a new instance
+     *
+     * @param allocator     the {@link ByteBufAllocator} to use.
+     * @param bufferSize    the size of the buffers that are allocated.
+     */
     public IoUringFixedBufferRingRecvAllocator(ByteBufAllocator allocator, int bufferSize) {
         this.allocator = Objects.requireNonNull(allocator, "allocator");
         this.bufferSize = ObjectUtil.checkPositive(bufferSize, "bufferSize");
     }
 
+    /**
+     * Create a new instance
+     *
+     * @param bufferSize    the size of the buffers that are allocated.
+     */
     public IoUringFixedBufferRingRecvAllocator(int bufferSize) {
         this(ByteBufAllocator.DEFAULT, bufferSize);
     }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringFixedBufferRingRecvAllocator.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringFixedBufferRingRecvAllocator.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.internal.ObjectUtil;
+
+import java.util.Objects;
+
+public final class IoUringFixedBufferRingRecvAllocator implements IoUringBufferRingRecvAllocator {
+    private final ByteBufAllocator allocator;
+    private final int bufferSize;
+
+    public IoUringFixedBufferRingRecvAllocator(ByteBufAllocator allocator, int bufferSize) {
+        this.allocator = Objects.requireNonNull(allocator, "allocator");
+        this.bufferSize = ObjectUtil.checkPositive(bufferSize, "bufferSize");
+    }
+
+    public IoUringFixedBufferRingRecvAllocator(int bufferSize) {
+        this(ByteBufAllocator.DEFAULT, bufferSize);
+    }
+
+    @Override
+    public ByteBuf allocate() {
+        return allocator.directBuffer(bufferSize);
+    }
+
+    @Override
+    public void lastBytesRead(int bytes) {
+        // NOOP.
+    }
+}

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -196,7 +196,6 @@ public final class IoUringIoHandler implements IoHandler {
         int ringFd = ringBuffer.fd();
         short bufferRingSize = bufferRingConfig.bufferRingSize();
         short bufferGroupId = bufferRingConfig.bufferGroupId();
-        int chunkSize = bufferRingConfig.chunkSize();
         int flags = bufferRingConfig.isIncremental() ? Native.IOU_PBUF_RING_INC : 0;
         long ioUringBufRingAddr = Native.ioUringRegisterBuffRing(ringFd, bufferRingSize, bufferGroupId, flags);
         if (ioUringBufRingAddr < 0) {
@@ -204,7 +203,7 @@ public final class IoUringIoHandler implements IoHandler {
         }
         return new IoUringBufferRing(
                 ringFd, ioUringBufRingAddr,
-                bufferRingSize, bufferGroupId, chunkSize, bufferRingConfig.isIncremental(),
+                bufferRingSize, bufferGroupId, bufferRingConfig.isIncremental(),
                 this, bufferRingConfig.allocator()
         );
     }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
@@ -76,11 +76,10 @@ public class IoUringBufferRingTest {
         final BlockingQueue<ByteBuf> bufferSyncer = new LinkedBlockingQueue<>();
         IoUringIoHandlerConfig ioUringIoHandlerConfiguration = new IoUringIoHandlerConfig();
         IoUringBufferRingConfig bufferRingConfig = new IoUringBufferRingConfig(
-                (short) 1, (short) 2, 1024, incremental, ByteBufAllocator.DEFAULT);
+                (short) 1, (short) 2, incremental, new IoUringFixedBufferRingRecvAllocator(1024));
 
         IoUringBufferRingConfig bufferRingConfig1 = new IoUringBufferRingConfig(
-                (short) 2, (short) 16,
-                1024, incremental, ByteBufAllocator.DEFAULT
+                (short) 2, (short) 16, incremental, new IoUringFixedBufferRingRecvAllocator(1024)
         );
         ioUringIoHandlerConfiguration.setBufferRingConfig(
                 (ch, size) -> bufferRingConfig.bufferGroupId(), bufferRingConfig, bufferRingConfig1);

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketTestPermutation.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketTestPermutation.java
@@ -48,7 +48,8 @@ public class IoUringSocketTestPermutation extends SocketTestPermutation {
             WORKERS, new DefaultThreadFactory("testsuite-io_uring-worker", true),
             IoUringIoHandler.newFactory(new IoUringIoHandlerConfig()
                     .setBufferRingConfig(RING_SELECTOR,
-                            new IoUringBufferRingConfig(BGID, (short) 16, 1024, ByteBufAllocator.DEFAULT))));
+                            new IoUringBufferRingConfig(BGID, (short) 16,
+                                    new IoUringFixedBufferRingRecvAllocator(1024)))));
     @Override
     public List<BootstrapComboFactory<ServerBootstrap, Bootstrap>> socket() {
 


### PR DESCRIPTION
Motivation:

At the moment we configure the size of the buffers we want to allocate to use in buffer ring up front. This is very unflexible as we might want to either increase or decrease these buffers over the life-time of the ring.

Modifications:

- Add IoUringBufferRingRecvAllocator that can be used to customize allocation strategy
- Add IoUringFixedBufferRingRecvAllocator which mimics the old behaviour by always allocate buffers with the same fixed size
- Change IoUringBufferRingConfig to take IoUringFixedBufferRingRecvAllocator as argument and remove chunkSize and allocator

Result:

More flexible when allocating buffers for the buffer ring. Fixes https://github.com/netty/netty/issues/14805