### PR TITLE
IoUring: Remove IOUring prefix from static method names.

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringServerChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringServerChannel.java
@@ -77,7 +77,7 @@ abstract class AbstractIoUringServerChannel extends AbstractIoUringChannel imple
         //       time to process a past connection. If the application knows that a
         //       new connection cannot come in before a previous one has been
         //       processed, it may be used as expected.
-        if (IoUring.isIOUringAcceptMultishotSupported()) {
+        if (IoUring.isAcceptMultishotSupported()) {
             acceptedAddressMemory = null;
         } else {
             acceptedAddressMemory = new AcceptedAddressMemory();
@@ -164,7 +164,7 @@ abstract class AbstractIoUringServerChannel extends AbstractIoUringChannel imple
 
             // IORING_ACCEPT_POLL_FIRST and IORING_ACCEPT_DONTWAIT were added in the same release.
             // We need to check if its supported as otherwise providing these would result in an -EINVAL.
-            if (IoUring.isIOUringAcceptNoWaitSupported()) {
+            if (IoUring.isAcceptNoWaitSupported()) {
                 if (first) {
                     ioPrio = socketIsEmpty ? Native.IORING_ACCEPT_POLL_FIRST : 0;
                 } else {
@@ -176,7 +176,7 @@ abstract class AbstractIoUringServerChannel extends AbstractIoUringChannel imple
 
             final long acceptedAddressMemoryAddress;
             final long acceptedAddressLengthMemoryAddress;
-            if (IoUring.isIOUringAcceptMultishotSupported()) {
+            if (IoUring.isAcceptMultishotSupported()) {
                 // Let's use multi-shot accept to reduce overhead.
                 ioPrio |= Native.IORING_ACCEPT_MULTISHOT;
                 acceptedAddressMemoryAddress = 0;
@@ -287,8 +287,8 @@ abstract class AbstractIoUringServerChannel extends AbstractIoUringChannel imple
     protected boolean socketIsEmpty(int flags) {
         // IORING_CQE_F_SOCK_NONEMPTY is used for accept since IORING_ACCEPT_DONTWAIT was added.
         // See https://github.com/axboe/liburing/wiki/What's-new-with-io_uring-in-6.10
-        return IoUring.isIOUringAcceptNoWaitSupported() &&
-                IoUring.isIOUringCqeFSockNonEmptySupported() && (flags & Native.IORING_CQE_F_SOCK_NONEMPTY) == 0;
+        return IoUring.isAcceptNoWaitSupported() &&
+                IoUring.isCqeFSockNonEmptySupported() && (flags & Native.IORING_CQE_F_SOCK_NONEMPTY) == 0;
     }
 
     @Override

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -208,7 +208,7 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
     protected Object filterOutboundMessage(Object msg) {
         // Since we cannot use synchronous sendfile,
         // the channel can only support DefaultFileRegion instead of FileRegion.
-        if (IoUring.isIOUringSpliceSupported() && msg instanceof DefaultFileRegion) {
+        if (IoUring.isSpliceSupported() && msg instanceof DefaultFileRegion) {
             return new IoUringFileRegion((DefaultFileRegion) msg);
         }
 
@@ -306,7 +306,7 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
             if (first) {
                 // IORING_RECVSEND_POLL_FIRST and IORING_CQE_F_SOCK_NONEMPTY were added in the same release (5.19).
                 // We need to check if it's supported as otherwise providing these would result in an -EINVAL.
-                return socketIsEmpty && IoUring.isIOUringCqeFSockNonEmptySupported() ?
+                return socketIsEmpty && IoUring.isCqeFSockNonEmptySupported() ?
                         Native.IORING_RECVSEND_POLL_FIRST : 0;
             }
             return 0;
@@ -358,7 +358,7 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
         private int scheduleReadProviderBuffer(IoUringBufferRing bufferRing, boolean first, boolean socketIsEmpty) {
             short bgId = bufferRing.bufferGroupId();
             try {
-                boolean multishot = IoUring.isIOUringRecvMultishotSupported();
+                boolean multishot = IoUring.isRecvMultishotSupported();
                 byte flags = flags((byte) Native.IOSQE_BUFFER_SELECT);
                 short ioPrio = calculateRecvIoPrio(first, socketIsEmpty);
                 int recvFlags = calculateRecvFlags(first);
@@ -607,7 +607,7 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
 
     @Override
     protected boolean socketIsEmpty(int flags) {
-        return IoUring.isIOUringCqeFSockNonEmptySupported() && (flags & Native.IORING_CQE_F_SOCK_NONEMPTY) == 0;
+        return IoUring.isCqeFSockNonEmptySupported() && (flags & Native.IORING_CQE_F_SOCK_NONEMPTY) == 0;
     }
 
     @Override

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUring.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUring.java
@@ -110,17 +110,17 @@ public final class IoUring {
         } else {
             if (logger.isDebugEnabled()) {
                 logger.debug("IoUring support is available (" +
-                        "IORING_CQE_F_SOCK_NONEMPTY_SUPPORTED={}, " +
-                        "IORING_SPLICE_SUPPORTED={}, " +
-                        "IORING_ACCEPT_NO_WAIT_SUPPORTED={}, " +
-                        "IORING_ACCEPT_MULTISHOT_SUPPORTED={}, " +
-                        "IORING_RECV_MULTISHOT_SUPPORTED={}, " +
-                        "IORING_REGISTER_IOWQ_MAX_WORKERS_SUPPORTED={}, " +
-                        "IORING_SETUP_SUBMIT_ALL_SUPPORTED={}, " +
-                        "IORING_SETUP_SINGLE_ISSUER_SUPPORTED={}, " +
-                        "IORING_SETUP_DEFER_TASKRUN_SUPPORTED={}, " +
-                        "IORING_REGISTER_BUFFER_RING_SUPPORTED={}, " +
-                        "IOU_PBUF_RING_INC_SUPPORTED={}" +
+                        "CQE_F_SOCK_NONEMPTY_SUPPORTED={}, " +
+                        "SPLICE_SUPPORTED={}, " +
+                        "ACCEPT_NO_WAIT_SUPPORTED={}, " +
+                        "ACCEPT_MULTISHOT_SUPPORTED={}, " +
+                        "RECV_MULTISHOT_SUPPORTED={}, " +
+                        "REGISTER_IOWQ_MAX_WORKERS_SUPPORTED={}, " +
+                        "SETUP_SUBMIT_ALL_SUPPORTED={}, " +
+                        "SETUP_SINGLE_ISSUER_SUPPORTED={}, " +
+                        "SETUP_DEFER_TASKRUN_SUPPORTED={}, " +
+                        "REGISTER_BUFFER_RING_SUPPORTED={}, " +
+                        "REGISTER_BUFFER_RING_INC_SUPPORTED={}" +
                         ")", socketNonEmptySupported, spliceSupported, acceptSupportNoWait, acceptMultishotSupported,
                         recvMultishotSupported, registerIowqWorkersSupported, submitAllSupported, singleIssuerSupported,
                         deferTaskrunSupported, registerBufferRingSupported, registerBufferRingIncSupported);
@@ -165,23 +165,23 @@ public final class IoUring {
         return isAvailable() && Native.IS_SUPPORTING_TCP_FASTOPEN_SERVER;
     }
 
-    static boolean isIOUringCqeFSockNonEmptySupported() {
+    static boolean isCqeFSockNonEmptySupported() {
         return IORING_CQE_F_SOCK_NONEMPTY_SUPPORTED;
     }
 
-    static boolean isIOUringSpliceSupported() {
+    static boolean isSpliceSupported() {
         return IORING_SPLICE_SUPPORTED;
     }
 
-    static boolean isIOUringAcceptNoWaitSupported() {
+    static boolean isAcceptNoWaitSupported() {
         return IORING_ACCEPT_NO_WAIT_SUPPORTED;
     }
 
-    static boolean isIOUringAcceptMultishotSupported() {
+    static boolean isAcceptMultishotSupported() {
         return IORING_ACCEPT_MULTISHOT_SUPPORTED;
     }
 
-    static boolean isIOUringRecvMultishotSupported() {
+    static boolean isRecvMultishotSupported() {
         return IORING_RECV_MULTISHOT_SUPPORTED;
     }
 
@@ -189,19 +189,19 @@ public final class IoUring {
         return IORING_REGISTER_IOWQ_MAX_WORKERS_SUPPORTED;
     }
 
-    static boolean isIOUringSetupCqeSizeSupported() {
+    static boolean isSetupCqeSizeSupported() {
         return IORING_SETUP_CQ_SIZE_SUPPORTED;
     }
 
-    static boolean isIOUringSetupSubmitAllSupported() {
+    static boolean isSetupSubmitAllSupported() {
         return IORING_SETUP_SUBMIT_ALL_SUPPORTED;
     }
 
-    static boolean isIOUringSetupSingleIssuerSupported() {
+    static boolean isSetupSingleIssuerSupported() {
         return IORING_SETUP_SINGLE_ISSUER_SUPPORTED;
     }
 
-    static boolean isIOUringSetupDeferTaskrunSupported() {
+    static boolean isSetupDeferTaskrunSupported() {
         return IORING_SETUP_DEFER_TASKRUN_SUPPORTED;
     }
 

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
@@ -435,7 +435,7 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
                             // trying to schedule a read. If it's supported and not part of the flags we know for sure
                             // that the next read (which would be using Native.MSG_DONTWAIT) will complete without
                             // be able to read any data. This is useless work and we can skip it.
-                            (!IoUring.isIOUringCqeFSockNonEmptySupported() ||
+                            (!IoUring.isCqeFSockNonEmptySupported() ||
                                     (flags & Native.IORING_CQE_F_SOCK_NONEMPTY) != 0)) {
                         // Let's schedule another read.
                         scheduleRead(false);
@@ -679,7 +679,7 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
 
     @Override
     protected boolean socketIsEmpty(int flags) {
-        return IoUring.isIOUringCqeFSockNonEmptySupported() && (flags & Native.IORING_CQE_F_SOCK_NONEMPTY) == 0;
+        return IoUring.isCqeFSockNonEmptySupported() && (flags & Native.IORING_CQE_F_SOCK_NONEMPTY) == 0;
     }
 
     @Override

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -95,7 +95,7 @@ public final class IoUringIoHandler implements IoHandler {
         // It only makes sense when the user actually specifies the cq ring size.
         int cqSize = 2 * config.getRingSize();
         if (config.needSetupCqeSize()) {
-            if (!IoUring.isIOUringSetupCqeSizeSupported()) {
+            if (!IoUring.isSetupCqeSizeSupported()) {
                 throw new UnsupportedOperationException("IORING_SETUP_CQSIZE is not supported");
             }
             setupFlags |= Native.IORING_SETUP_CQSIZE;

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -316,15 +316,15 @@ final class Native {
 
     static int setupFlags() {
         int flags = Native.IORING_SETUP_R_DISABLED;
-        if (IoUring.isIOUringSetupSubmitAllSupported()) {
+        if (IoUring.isSetupSubmitAllSupported()) {
             flags |= Native.IORING_SETUP_SUBMIT_ALL;
         }
 
         // See https://github.com/axboe/liburing/wiki/io_uring-and-networking-in-2023#task-work
-        if (IoUring.isIOUringSetupSingleIssuerSupported()) {
+        if (IoUring.isSetupSingleIssuerSupported()) {
             flags |= Native.IORING_SETUP_SINGLE_ISSUER;
         }
-        if (IoUring.isIOUringSetupDeferTaskrunSupported()) {
+        if (IoUring.isSetupDeferTaskrunSupported()) {
             flags |= Native.IORING_SETUP_DEFER_TASKRUN;
         }
         return flags;

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/SubmissionQueue.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/SubmissionQueue.java
@@ -246,7 +246,7 @@ final class SubmissionQueue {
     private int ioUringEnter(int toSubmit, int minComplete, int flags) {
         int f = enterFlags | flags;
 
-        if (IoUring.isIOUringSetupSubmitAllSupported()) {
+        if (IoUring.isSetupSubmitAllSupported()) {
             return ioUringEnter0(toSubmit, minComplete, f);
         }
         // If IORING_SETUP_SUBMIT_ALL is not supported we need to loop until we submitted everything as

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringIoHandlerTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringIoHandlerTest.java
@@ -21,7 +21,6 @@ import io.netty.util.concurrent.ThreadAwareExecutor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
-import org.junit.jupiter.api.condition.EnabledIf;
 
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -82,6 +81,6 @@ public class IoUringIoHandlerTest {
     }
 
     private static boolean setUpCQSizeUnavailable() {
-        return !IoUring.isIOUringSetupCqeSizeSupported();
+        return !IoUring.isSetupCqeSizeSupported();
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/SubmissionQueueTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/SubmissionQueueTest.java
@@ -87,6 +87,6 @@ public class SubmissionQueueTest {
     }
 
     private static boolean setUpCQSizeUnavailable() {
-        return !IoUring.isIOUringSetupCqeSizeSupported();
+        return !IoUring.isSetupCqeSizeSupported();
     }
 }


### PR DESCRIPTION
Motivation:

There is no need to have IOUring prefixes on the method names as these are part of the IoUring class.

Modifications:

- Rename prefix from method names
- Rename prefix when logging

Result:

Cleanup