### PR TITLE
IoUring: IoUringBufferRingAllocator needs to also know about the atte…

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRing.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRing.java
@@ -109,8 +109,8 @@ final class IoUringBufferRing {
      * @return              the buffer.
      */
     ByteBuf useBuffer(short bid, int readableBytes, boolean more) {
-        allocator.lastBytesRead(readableBytes);
         ByteBuf byteBuf = buffers[bid];
+        allocator.lastBytesRead(byteBuf.readableBytes(), readableBytes);
         if (incremental && more) {
             // The buffer will be used later again, just slice out what we did read so far.
             return byteBuf.readRetainedSlice(readableBytes);

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRingAllocator.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRingAllocator.java
@@ -29,7 +29,8 @@ public interface IoUringBufferRingAllocator {
     /**
      * Set the bytes that have been read for the last read operation that was full-filled out of the buffer ring.
      *
-     * @param bytes The number of bytes from the previous read operation.
+     * @param attempted  the attempted bytes to read.
+     * @param actual     the number of bytes that could be read.
      */
-    void lastBytesRead(int bytes);
+    void lastBytesRead(int attempted, int actual);
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringFixedBufferRingRecvAllocator.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringFixedBufferRingRecvAllocator.java
@@ -55,7 +55,7 @@ public final class IoUringFixedBufferRingRecvAllocator implements IoUringBufferR
     }
 
     @Override
-    public void lastBytesRead(int bytes) {
+    public void lastBytesRead(int attempted, int actual) {
         // NOOP.
     }
 }


### PR DESCRIPTION
…mpted bytes read

Motiviation:

To write some more advanced IoUringBufferRingAllocator implementations we also need to to know about the bytes that were attempted to read. This allows to implement something like the AdaptiveRecvBufAllocator.

Modification:

Adjust lastBytesRead(...) method to also take the attempted bytes as parameter.

Result:

Enhance interface and so open up more possibilites