### PR TITLE
IoUring: Use IORING_POLL_ADD_MULTI when possible

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUring.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUring.java
@@ -29,6 +29,7 @@ public final class IoUring {
     private static final boolean IORING_ACCEPT_NO_WAIT_SUPPORTED;
     private static final boolean IORING_ACCEPT_MULTISHOT_SUPPORTED;
     private static final boolean IORING_RECV_MULTISHOT_SUPPORTED;
+    private static final boolean IORING_POLL_ADD_MULTISHOT_SUPPORTED;
     private static final boolean IORING_REGISTER_IOWQ_MAX_WORKERS_SUPPORTED;
     private static final boolean IORING_SETUP_SUBMIT_ALL_SUPPORTED;
     private static final boolean IORING_SETUP_CQ_SIZE_SUPPORTED;
@@ -47,6 +48,7 @@ public final class IoUring {
         boolean acceptSupportNoWait = false;
         boolean acceptMultishotSupported = false;
         boolean recvMultishotSupported = false;
+        boolean pollAddMultishotSupported = false;
         boolean registerIowqWorkersSupported = false;
         boolean submitAllSupported = false;
         boolean setUpCqSizeSupported = false;
@@ -74,6 +76,7 @@ public final class IoUring {
                         acceptSupportNoWait = (ringBuffer.features() & Native.IORING_FEAT_RECVSEND_BUNDLE) != 0;
                         acceptMultishotSupported = Native.isAcceptMultishotSupported(ringBuffer.fd());
                         recvMultishotSupported = Native.isRecvMultishotSupported();
+                        pollAddMultishotSupported = Native.isPollAddMultiShotSupported(ringBuffer.fd());
                         registerIowqWorkersSupported = Native.isRegisterIoWqWorkerSupported(ringBuffer.fd());
                         submitAllSupported = Native.ioUringSetupSupportsFlags(Native.IORING_SETUP_SUBMIT_ALL);
                         setUpCqSizeSupported = Native.ioUringSetupSupportsFlags(Native.IORING_SETUP_CQSIZE);
@@ -114,6 +117,7 @@ public final class IoUring {
                         "SPLICE_SUPPORTED={}, " +
                         "ACCEPT_NO_WAIT_SUPPORTED={}, " +
                         "ACCEPT_MULTISHOT_SUPPORTED={}, " +
+                        "POLL_ADD_MULTISHOT_SUPPORTED={} " +
                         "RECV_MULTISHOT_SUPPORTED={}, " +
                         "REGISTER_IOWQ_MAX_WORKERS_SUPPORTED={}, " +
                         "SETUP_SUBMIT_ALL_SUPPORTED={}, " +
@@ -122,8 +126,9 @@ public final class IoUring {
                         "REGISTER_BUFFER_RING_SUPPORTED={}, " +
                         "REGISTER_BUFFER_RING_INC_SUPPORTED={}" +
                         ")", socketNonEmptySupported, spliceSupported, acceptSupportNoWait, acceptMultishotSupported,
-                        recvMultishotSupported, registerIowqWorkersSupported, submitAllSupported, singleIssuerSupported,
-                        deferTaskrunSupported, registerBufferRingSupported, registerBufferRingIncSupported);
+                        pollAddMultishotSupported, recvMultishotSupported, registerIowqWorkersSupported,
+                        submitAllSupported, singleIssuerSupported, deferTaskrunSupported, registerBufferRingSupported,
+                        registerBufferRingIncSupported);
             }
         }
         UNAVAILABILITY_CAUSE = cause;
@@ -132,6 +137,7 @@ public final class IoUring {
         IORING_ACCEPT_NO_WAIT_SUPPORTED = acceptSupportNoWait;
         IORING_ACCEPT_MULTISHOT_SUPPORTED = acceptMultishotSupported;
         IORING_RECV_MULTISHOT_SUPPORTED = recvMultishotSupported;
+        IORING_POLL_ADD_MULTISHOT_SUPPORTED = pollAddMultishotSupported;
         IORING_REGISTER_IOWQ_MAX_WORKERS_SUPPORTED = registerIowqWorkersSupported;
         IORING_SETUP_SUBMIT_ALL_SUPPORTED = submitAllSupported;
         IORING_SETUP_CQ_SIZE_SUPPORTED = setUpCqSizeSupported;
@@ -183,6 +189,10 @@ public final class IoUring {
 
     static boolean isRecvMultishotSupported() {
         return IORING_RECV_MULTISHOT_SUPPORTED;
+    }
+
+    static boolean isPollAddMultishotSupported() {
+        return IORING_POLL_ADD_MULTISHOT_SUPPORTED;
     }
 
     static boolean isRegisterIowqMaxWorkersSupported() {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoOps.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoOps.java
@@ -255,12 +255,13 @@ public final class IoUringIoOps implements IoOps {
      * @param fd        the filedescriptor
      * @param flags     the flags.
      * @param mask      the mask.
-     * @param data      the data
+     * @param len       the len.
+     * @param data      the data.
      * @return          ops.
      */
-    static IoUringIoOps newPollAdd(int fd, byte flags, int mask, short data) {
+    static IoUringIoOps newPollAdd(int fd, byte flags, int mask, int len, short data) {
         // See https://github.com/axboe/liburing/blob/liburing-2.8/src/include/liburing.h#L554
-        return new IoUringIoOps(Native.IORING_OP_POLL_ADD, flags, (short) 0, fd, 0L, 0L, 0, mask, data,
+        return new IoUringIoOps(Native.IORING_OP_POLL_ADD, flags, (short) 0, fd, 0L, 0L, len, mask, data,
                 (short) 0, (short) 0, 0, 0);
     }
 

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -213,6 +213,9 @@ final class Native {
     static final int IORING_SETUP_SINGLE_ISSUER = 1 << 12;
     static final int IORING_SETUP_DEFER_TASKRUN = 1 << 13;
     static final int IORING_CQE_BUFFER_SHIFT = 16;
+
+    static final short IORING_POLL_ADD_MULTI = 1 << 0;
+
     static final short IORING_RECVSEND_POLL_FIRST = 1 << 0;
     static final short IORING_RECV_MULTISHOT = 1 << 1;
 
@@ -390,6 +393,11 @@ final class Native {
     static boolean isSpliceSupported(int ringFd) {
         // IORING_OP_SPLICE Available since 5.7
         return ioUringProbe(ringFd, new int[] { Native.IORING_OP_SPLICE });
+    }
+
+    static boolean isPollAddMultiShotSupported(int ringfd) {
+        // Was added in the same release and we also need this feature to correctly handle edge-triggered mode.
+        return isCqeFSockNonEmptySupported(ringfd);
     }
 
     /**


### PR DESCRIPTION
Motivation:

If we need to use POLLIN (no buffer ring configured) we should at least try to use IORING_POLL_ADD_MULTI to reduce overhead

Modifications:

Use IORING_POLL_ADD_MULTI if possible

Result:

Less overhead if we cant use a buffer ring
