### PR TITLE
Convenient API for specifying SNI hostname

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/JdkSslClientContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkSslClientContext.java
@@ -20,6 +20,7 @@ import java.security.KeyStore;
 import java.security.Provider;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLSessionContext;
@@ -29,6 +30,7 @@ import java.io.File;
 import java.security.PrivateKey;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
+import java.util.List;
 
 /**
  * A client-side {@link SslContext} which uses JDK's SSL/TLS implementation.
@@ -270,13 +272,13 @@ public final class JdkSslClientContext extends JdkSslContext {
                         KeyManagerFactory keyManagerFactory, Iterable<String> ciphers, CipherSuiteFilter cipherFilter,
                         ApplicationProtocolConfig apn, String[] protocols, long sessionCacheSize, long sessionTimeout,
                         SecureRandom secureRandom, String keyStoreType, String endpointIdentificationAlgorithm,
-                        ResumptionController resumptionController)
+                        List<SNIServerName> serverNames, ResumptionController resumptionController)
             throws SSLException {
         super(newSSLContext(sslContextProvider, trustCertCollection, trustManagerFactory,
                             keyCertChain, key, keyPassword, keyManagerFactory, sessionCacheSize,
                             sessionTimeout, secureRandom, keyStoreType, resumptionController),
                 true, ciphers, cipherFilter, toNegotiator(apn, false), ClientAuth.NONE, protocols, false,
-                endpointIdentificationAlgorithm, resumptionController);
+                endpointIdentificationAlgorithm, serverNames, resumptionController);
     }
 
     private static SSLContext newSSLContext(Provider sslContextProvider,

--- a/handler/src/main/java/io/netty/handler/ssl/JdkSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkSslContext.java
@@ -391,7 +391,9 @@ public class JdkSslContext extends SslContext {
     private void configureSSLParameters(SSLEngine engine) {
         SSLParameters params = engine.getSSLParameters();
         params.setEndpointIdentificationAlgorithm(endpointIdentificationAlgorithm);
-        params.setServerNames(serverNames); // Note: setServerNames also accepts null and empty lists.
+        if (serverNames != null && !serverNames.isEmpty()) {
+            params.setServerNames(serverNames);
+        }
         engine.setSSLParameters(params);
     }
 

--- a/handler/src/main/java/io/netty/handler/ssl/JdkSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkSslContext.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Set;
 import javax.crypto.NoSuchPaddingException;
 import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLParameters;
@@ -191,6 +192,7 @@ public class JdkSslContext extends SslContext {
     private final SSLContext sslContext;
     private final boolean isClient;
     private final String endpointIdentificationAlgorithm;
+    private final List<SNIServerName> serverNames;
 
     /**
      * Creates a new {@link JdkSslContext} from a pre-configured {@link SSLContext}.
@@ -260,18 +262,20 @@ public class JdkSslContext extends SslContext {
     @SuppressWarnings("deprecation")
     JdkSslContext(SSLContext sslContext, boolean isClient, Iterable<String> ciphers, CipherSuiteFilter cipherFilter,
                   JdkApplicationProtocolNegotiator apn, ClientAuth clientAuth, String[] protocols, boolean startTls) {
-        this(sslContext, isClient, ciphers, cipherFilter, apn, clientAuth, protocols, startTls, null, null);
+        this(sslContext, isClient, ciphers, cipherFilter, apn, clientAuth, protocols, startTls, null, null, null);
     }
 
     @SuppressWarnings("deprecation")
     JdkSslContext(SSLContext sslContext, boolean isClient, Iterable<String> ciphers, CipherSuiteFilter cipherFilter,
                   JdkApplicationProtocolNegotiator apn, ClientAuth clientAuth, String[] protocols, boolean startTls,
-                  String endpointIdentificationAlgorithm, ResumptionController resumptionController) {
+                  String endpointIdentificationAlgorithm, List<SNIServerName> serverNames,
+                  ResumptionController resumptionController) {
         super(startTls, resumptionController);
         this.apn = checkNotNull(apn, "apn");
         this.clientAuth = checkNotNull(clientAuth, "clientAuth");
         this.sslContext = checkNotNull(sslContext, "sslContext");
         this.endpointIdentificationAlgorithm = endpointIdentificationAlgorithm;
+        this.serverNames = serverNames;
 
         final List<String> defaultCiphers;
         final Set<String> supportedCiphers;
@@ -375,7 +379,7 @@ public class JdkSslContext extends SslContext {
                     throw new Error("Unknown auth " + clientAuth);
             }
         }
-        configureEndpointVerification(engine);
+        configureSSLParameters(engine);
         JdkApplicationProtocolNegotiator.SslEngineWrapperFactory factory = apn.wrapperFactory();
         if (factory instanceof JdkApplicationProtocolNegotiator.AllocatorAwareSslEngineWrapperFactory) {
             return ((JdkApplicationProtocolNegotiator.AllocatorAwareSslEngineWrapperFactory) factory)
@@ -384,9 +388,10 @@ public class JdkSslContext extends SslContext {
         return factory.wrapSslEngine(engine, apn, isServer());
     }
 
-    private void configureEndpointVerification(SSLEngine engine) {
+    private void configureSSLParameters(SSLEngine engine) {
         SSLParameters params = engine.getSSLParameters();
         params.setEndpointIdentificationAlgorithm(endpointIdentificationAlgorithm);
+        params.setServerNames(serverNames); // Note: setServerNames also accepts null and empty lists.
         engine.setSSLParameters(params);
     }
 

--- a/handler/src/main/java/io/netty/handler/ssl/JdkSslServerContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkSslServerContext.java
@@ -300,7 +300,7 @@ public final class JdkSslServerContext extends JdkSslContext {
                         keyPassword, keyManagerFactory, sessionCacheSize, sessionTimeout, secureRandom, keyStore,
                         resumptionController),
                 false, ciphers, cipherFilter, toNegotiator(apn, true), clientAuth, protocols, startTls, null,
-                resumptionController);
+                null, resumptionController);
     }
 
     private static SSLContext newSSLContext(Provider sslContextProvider, X509Certificate[] trustCertCollection,

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslClientContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslClientContext.java
@@ -21,9 +21,11 @@ import java.io.File;
 import java.security.KeyStore;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
+import java.util.List;
 import java.util.Map;
 
 import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
@@ -178,7 +180,7 @@ public final class OpenSslClientContext extends OpenSslContext {
         this(toX509CertificatesInternal(trustCertCollectionFile), trustManagerFactory,
                 toX509CertificatesInternal(keyCertChainFile), toPrivateKeyInternal(keyFile, keyPassword),
                 keyPassword, keyManagerFactory, ciphers, cipherFilter, apn, null, sessionCacheSize,
-                sessionTimeout, false, KeyStore.getDefaultType(), null, null);
+                sessionTimeout, false, KeyStore.getDefaultType(), null, null, null);
     }
 
     OpenSslClientContext(X509Certificate[] trustCertCollection, TrustManagerFactory trustManagerFactory,
@@ -186,11 +188,12 @@ public final class OpenSslClientContext extends OpenSslContext {
                          KeyManagerFactory keyManagerFactory, Iterable<String> ciphers,
                          CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn, String[] protocols,
                          long sessionCacheSize, long sessionTimeout, boolean enableOcsp, String keyStore,
-                         String endpointIdentificationAlgorithm, ResumptionController resumptionController,
+                         String endpointIdentificationAlgorithm, List<SNIServerName> serverNames,
+                         ResumptionController resumptionController,
                          Map.Entry<SslContextOption<?>, Object>... options)
             throws SSLException {
         super(ciphers, cipherFilter, apn, SSL.SSL_MODE_CLIENT, keyCertChain, ClientAuth.NONE, protocols, false,
-                endpointIdentificationAlgorithm, enableOcsp, resumptionController, options);
+                endpointIdentificationAlgorithm, enableOcsp, serverNames, resumptionController, options);
         boolean success = false;
         try {
             OpenSslKeyMaterialProvider.validateKeyMaterialSupported(keyCertChain, key, keyPassword);

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslContext.java
@@ -18,8 +18,10 @@ package io.netty.handler.ssl;
 import io.netty.buffer.ByteBufAllocator;
 
 import java.security.cert.Certificate;
+import java.util.List;
 import java.util.Map;
 
+import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 
@@ -31,28 +33,28 @@ public abstract class OpenSslContext extends ReferenceCountedOpenSslContext {
     OpenSslContext(Iterable<String> ciphers, CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apnCfg,
                    int mode, Certificate[] keyCertChain,
                    ClientAuth clientAuth, String[] protocols, boolean startTls, String endpointIdentificationAlgorithm,
-                   boolean enableOcsp, ResumptionController resumptionController,
+                   boolean enableOcsp, List<SNIServerName> serverNames, ResumptionController resumptionController,
                    Map.Entry<SslContextOption<?>, Object>... options)
             throws SSLException {
         super(ciphers, cipherFilter, toNegotiator(apnCfg), mode, keyCertChain,
                 clientAuth, protocols, startTls, endpointIdentificationAlgorithm, enableOcsp, false,
-                resumptionController, options);
+                serverNames, resumptionController, options);
     }
 
     OpenSslContext(Iterable<String> ciphers, CipherSuiteFilter cipherFilter, OpenSslApplicationProtocolNegotiator apn,
                    int mode, Certificate[] keyCertChain,
                    ClientAuth clientAuth, String[] protocols, boolean startTls, boolean enableOcsp,
-                   ResumptionController resumptionController,
+                   List<SNIServerName> serverNames, ResumptionController resumptionController,
                    Map.Entry<SslContextOption<?>, Object>... options)
             throws SSLException {
         super(ciphers, cipherFilter, apn, mode, keyCertChain,
-                clientAuth, protocols, startTls, null, enableOcsp, false, resumptionController, options);
+                clientAuth, protocols, startTls, null, enableOcsp, false, serverNames, resumptionController, options);
     }
 
     @Override
     final SSLEngine newEngine0(ByteBufAllocator alloc, String peerHost, int peerPort, boolean jdkCompatibilityMode) {
         return new OpenSslEngine(this, alloc, peerHost, peerPort, jdkCompatibilityMode,
-                endpointIdentificationAlgorithm);
+                endpointIdentificationAlgorithm, serverNames);
     }
 
     @Override

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslEngine.java
@@ -17,6 +17,8 @@ package io.netty.handler.ssl;
 
 import io.netty.buffer.ByteBufAllocator;
 
+import java.util.List;
+import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLEngine;
 
 /**
@@ -28,8 +30,10 @@ import javax.net.ssl.SSLEngine;
  */
 public final class OpenSslEngine extends ReferenceCountedOpenSslEngine {
     OpenSslEngine(OpenSslContext context, ByteBufAllocator alloc, String peerHost, int peerPort,
-                  boolean jdkCompatibilityMode, String endpointIdentificationAlgorithm) {
-        super(context, alloc, peerHost, peerPort, jdkCompatibilityMode, false, endpointIdentificationAlgorithm);
+                  boolean jdkCompatibilityMode, String endpointIdentificationAlgorithm,
+                  List<SNIServerName> serverNames) {
+        super(context, alloc, peerHost, peerPort, jdkCompatibilityMode, false, endpointIdentificationAlgorithm,
+                serverNames);
     }
 
     @Override

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslServerContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslServerContext.java
@@ -350,7 +350,7 @@ public final class OpenSslServerContext extends OpenSslContext {
             Map.Entry<SslContextOption<?>, Object>... options)
             throws SSLException {
         super(ciphers, cipherFilter, apn, SSL.SSL_MODE_SERVER, keyCertChain,
-                clientAuth, protocols, startTls, enableOcsp, resumptionController, options);
+                clientAuth, protocols, startTls, enableOcsp, null, resumptionController, options);
 
         // Create a new SSL_CTX and configure it.
         boolean success = false;

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslClientContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslClientContext.java
@@ -27,9 +27,11 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509ExtendedTrustManager;
@@ -61,11 +63,11 @@ public final class ReferenceCountedOpenSslClientContext extends ReferenceCounted
                                          CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn,
                                          String[] protocols, long sessionCacheSize, long sessionTimeout,
                                          boolean enableOcsp, String keyStore, String endpointIdentificationAlgorithm,
-                                         ResumptionController resumptionController,
+                                         List<SNIServerName> serverNames, ResumptionController resumptionController,
                                          Map.Entry<SslContextOption<?>, Object>... options) throws SSLException {
         super(ciphers, cipherFilter, toNegotiator(apn), SSL.SSL_MODE_CLIENT, keyCertChain,
               ClientAuth.NONE, protocols, false, endpointIdentificationAlgorithm, enableOcsp, true,
-                resumptionController, options);
+                serverNames, resumptionController, options);
         boolean success = false;
         try {
             sessionContext = newSessionContext(this, ctx, engineMap, trustCertCollection, trustManagerFactory,

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -63,6 +63,7 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
@@ -156,6 +157,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
     final ClientAuth clientAuth;
     final String[] protocols;
     final String endpointIdentificationAlgorithm;
+    final List<SNIServerName> serverNames;
     final boolean hasTLSv13Cipher;
 
     final boolean enableOcsp;
@@ -213,7 +215,8 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
                                    OpenSslApplicationProtocolNegotiator apn, int mode, Certificate[] keyCertChain,
                                    ClientAuth clientAuth, String[] protocols, boolean startTls,
                                    String endpointIdentificationAlgorithm, boolean enableOcsp,
-                                   boolean leakDetection, ResumptionController resumptionController,
+                                   boolean leakDetection, List<SNIServerName> serverNames,
+                                   ResumptionController resumptionController,
                                    Map.Entry<SslContextOption<?>, Object>... ctxOptions)
             throws SSLException {
         super(startTls, resumptionController);
@@ -277,6 +280,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
         this.clientAuth = isServer() ? checkNotNull(clientAuth, "clientAuth") : ClientAuth.NONE;
         this.protocols = protocols == null ? OpenSsl.defaultProtocols(mode == SSL.SSL_MODE_CLIENT) : protocols;
         this.endpointIdentificationAlgorithm = endpointIdentificationAlgorithm;
+        this.serverNames = serverNames;
         this.enableOcsp = enableOcsp;
 
         this.keyCertChain = keyCertChain == null ? null : keyCertChain.clone();
@@ -516,7 +520,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
 
     SSLEngine newEngine0(ByteBufAllocator alloc, String peerHost, int peerPort, boolean jdkCompatibilityMode) {
         return new ReferenceCountedOpenSslEngine(this, alloc, peerHost, peerPort, jdkCompatibilityMode, true,
-                endpointIdentificationAlgorithm);
+                endpointIdentificationAlgorithm, serverNames);
     }
 
     /**

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -340,7 +340,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
 
                 // Use SNI if peerHost was specified and a valid hostname
                 // See https://github.com/netty/netty/issues/4746
-                boolean usePeerHost = peerHost != null && SslUtils.isValidHostNameForSNI(peerHost);
+                boolean usePeerHost = SslUtils.isValidHostNameForSNI(peerHost) && isValidHostNameForSNI(peerHost);
                 boolean useServerNames = serverNames != null && !serverNames.isEmpty();
                 if (clientMode && (usePeerHost || useServerNames)) {
                     // We do some extra validation to ensure we can construct the SNIHostName later again.
@@ -413,6 +413,15 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
         // Only create the leak after everything else was executed and so ensure we don't produce a false-positive for
         // the ResourceLeakDetector.
         leak = leakDetection ? leakDetector.track(this) : null;
+    }
+
+    private static boolean isValidHostNameForSNI(String hostname) {
+        try {
+            new SNIHostName(hostname);
+            return true;
+        } catch (IllegalArgumentException illegal) {
+            return false;
+        }
     }
 
     final synchronized String[] authMethods() {

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslServerContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslServerContext.java
@@ -72,7 +72,7 @@ public final class ReferenceCountedOpenSslServerContext extends ReferenceCounted
         super(ciphers, cipherFilter, apn, SSL.SSL_MODE_SERVER, keyCertChain,
                 clientAuth, protocols, startTls,
                 null, // No endpoint validation for servers.
-                enableOcsp, true, resumptionController, options);
+                enableOcsp, true, null, resumptionController, options);
         // Create a new SSL_CTX and configure it.
         boolean success = false;
         try {

--- a/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
@@ -655,7 +655,12 @@ public final class SslContextBuilder {
             throw new UnsupportedOperationException("Cannot add Server Name Indication extension, " +
                     "because this is a server context builder.");
         }
-        serverNames.add(checkNotNull(serverName, "serverName"));
+        checkNotNull(serverName, "serverName");
+        if (!(serverName instanceof SNIHostName)) {
+            throw new IllegalArgumentException("Only SNIHostName is supported. The given SNIServerName type was " +
+                    serverName.getClass().getName());
+        }
+        serverNames.add(serverName);
         return this;
     }
 

--- a/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
@@ -221,7 +221,7 @@ public final class SslContextBuilder {
         if (!forServer) {
             endpointIdentificationAlgorithm = SslUtils.defaultEndpointVerificationAlgorithm;
         }
-        serverNames = forServer ? null : new ArrayList<>(); // Only for clients.
+        serverNames = forServer ? null : new ArrayList<>(2); // Only for clients.
     }
 
     /**

--- a/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
@@ -22,8 +22,11 @@ import io.netty.util.internal.UnstableApi;
 
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SNIHostName;
+import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLParameters;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import java.io.File;
@@ -169,7 +172,7 @@ public final class SslContextBuilder {
 
     /**
      * Creates a builder for new server-side {@link SslContext}.
-     *
+     * <p>
      * If you use {@link SslProvider#OPENSSL} or {@link SslProvider#OPENSSL_REFCNT} consider using
      * {@link OpenSslX509KeyManagerFactory} or {@link OpenSslCachingX509KeyManagerFactory}.
      *
@@ -211,12 +214,14 @@ public final class SslContextBuilder {
     private String keyStoreType = KeyStore.getDefaultType();
     private String endpointIdentificationAlgorithm;
     private final Map<SslContextOption<?>, Object> options = new HashMap<SslContextOption<?>, Object>();
+    private final List<SNIServerName> serverNames;
 
     private SslContextBuilder(boolean forServer) {
         this.forServer = forServer;
         if (!forServer) {
             endpointIdentificationAlgorithm = SslUtils.defaultEndpointVerificationAlgorithm;
         }
+        serverNames = forServer ? null : new ArrayList<>(); // Only for clients.
     }
 
     /**
@@ -272,7 +277,7 @@ public final class SslContextBuilder {
     /**
      * Trusted certificates for verifying the remote endpoint's certificate. The input stream should
      * contain an X.509 certificate collection in PEM format. {@code null} uses the system default.
-     *
+     * <p>
      * The caller is responsible for calling {@link InputStream#close()} after {@link #build()} has been called.
      */
     public SslContextBuilder trustManager(InputStream trustCertCollectionInputStream) {
@@ -317,9 +322,9 @@ public final class SslContextBuilder {
      */
     public SslContextBuilder trustManager(TrustManager trustManager) {
         if (trustManager != null) {
-            this.trustManagerFactory = new TrustManagerFactoryWrapper(trustManager);
+            trustManagerFactory = new TrustManagerFactoryWrapper(trustManager);
         } else {
-            this.trustManagerFactory = null;
+            trustManagerFactory = null;
         }
         trustCertCollection = null;
         return this;
@@ -477,7 +482,7 @@ public final class SslContextBuilder {
      * if the used openssl version is 1.0.1+. You can check if your openssl version supports using a
      * {@link KeyManagerFactory} by calling {@link OpenSsl#supportsKeyManagerFactory()}. If this is not the case
      * you must use {@link #keyManager(File, File)} or {@link #keyManager(File, File, String)}.
-     *
+     * <p>
      * If you use {@link SslProvider#OPENSSL} or {@link SslProvider#OPENSSL_REFCNT} consider using
      * {@link OpenSslX509KeyManagerFactory} or {@link OpenSslCachingX509KeyManagerFactory}.
      */
@@ -504,9 +509,9 @@ public final class SslContextBuilder {
             checkNotNull(keyManager, "keyManager required for servers");
         }
         if (keyManager != null) {
-            this.keyManagerFactory = new KeyManagerFactoryWrapper(keyManager);
+            keyManagerFactory = new KeyManagerFactoryWrapper(keyManager);
         } else {
-            this.keyManagerFactory = null;
+            keyManagerFactory = null;
         }
         keyCertChain = null;
         key = null;
@@ -629,10 +634,28 @@ public final class SslContextBuilder {
      *     Java Security Standard Names</a> for a list of supported algorithms.
      *
      * @param algorithm either {@code "HTTPS"}, {@code "LDAPS"}, or {@code null} (disables hostname verification).
-     * @see javax.net.ssl.SSLParameters#setEndpointIdentificationAlgorithm(String)
+     * @see SSLParameters#setEndpointIdentificationAlgorithm(String)
      */
     public SslContextBuilder endpointIdentificationAlgorithm(String algorithm) {
         endpointIdentificationAlgorithm = algorithm;
+        return this;
+    }
+
+    /**
+     * Add the given server name indication to this client context. This will cause the client to include a
+     * Server Name Indication extension with its {@code ClientHello} message, as per
+     * <a href="https://datatracker.ietf.org/doc/html/rfc6066#section-3">RFC 6066 section 3</a>.
+     * <p>
+     * Note that only one name per name type can be included in the message.
+     * Currently, only the {@link SNIHostName} type is supported.
+     * @param serverName The server name to include in the SNI extension.
+     */
+    public SslContextBuilder serverName(SNIServerName serverName) {
+        if (forServer) {
+            throw new UnsupportedOperationException("Cannot add Server Name Indication extension, " +
+                    "because this is a server context builder.");
+        }
+        serverNames.add(serverName);
         return this;
     }
 
@@ -652,7 +675,7 @@ public final class SslContextBuilder {
                 trustManagerFactory, keyCertChain, key, keyPassword, keyManagerFactory,
                 ciphers, cipherFilter, apn, protocols, sessionCacheSize,
                     sessionTimeout, enableOcsp, secureRandom, keyStoreType, endpointIdentificationAlgorithm,
-                    toArray(options.entrySet(), EMPTY_ENTRIES));
+                    serverNames, toArray(options.entrySet(), EMPTY_ENTRIES));
         }
     }
 

--- a/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
@@ -655,7 +655,7 @@ public final class SslContextBuilder {
             throw new UnsupportedOperationException("Cannot add Server Name Indication extension, " +
                     "because this is a server context builder.");
         }
-        serverNames.add(serverName);
+        serverNames.add(checkNotNull(serverName, "serverName"));
         return this;
     }
 

--- a/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
@@ -39,6 +39,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
+import javax.net.ssl.SNIHostName;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.TrustManager;
@@ -572,14 +573,12 @@ final class SslUtils {
      * Validate that the given hostname can be used in SNI extension.
      */
     static boolean isValidHostNameForSNI(String hostname) {
-        // See  https://datatracker.ietf.org/doc/html/rfc6066#section-3
-        return hostname != null &&
-               // SNI HostName has to be a FQDN according to TLS SNI Extension spec (see [1]),
-               // which means that is has to have at least a host name and a domain part.
-               hostname.indexOf('.') > 0 &&
-               !hostname.endsWith(".") && !hostname.startsWith("/") &&
-               !NetUtil.isValidIpV4Address(hostname) &&
-               !NetUtil.isValidIpV6Address(hostname);
+        try {
+            new SNIHostName(hostname);
+            return true;
+        } catch (IllegalArgumentException illegal) {
+            return false;
+        }
     }
 
     /**

--- a/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
@@ -573,12 +573,14 @@ final class SslUtils {
      * Validate that the given hostname can be used in SNI extension.
      */
     static boolean isValidHostNameForSNI(String hostname) {
-        try {
-            new SNIHostName(hostname);
-            return true;
-        } catch (IllegalArgumentException illegal) {
-            return false;
-        }
+        // See  https://datatracker.ietf.org/doc/html/rfc6066#section-3
+        return hostname != null &&
+                // SNI HostName has to be a FQDN according to TLS SNI Extension spec (see [1]),
+                // which means that is has to have at least a host name and a domain part.
+                hostname.indexOf('.') > 0 &&
+                !hostname.endsWith(".") && !hostname.startsWith("/") &&
+                !NetUtil.isValidIpV4Address(hostname) &&
+                !NetUtil.isValidIpV6Address(hostname);
     }
 
     /**

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -3130,15 +3130,11 @@ public abstract class SSLEngineTest {
                 })
                 .sslContextProvider(clientSslContextProvider())
                 .sslProvider(sslClientProvider())
+                .serverName(new SNIHostName(fqdn))
+                .endpointIdentificationAlgorithm("HTTPS")
                 .build());
 
         SSLEngine client = wrapEngine(clientSslCtx.newEngine(UnpooledByteBufAllocator.DEFAULT, "127.0.0.1", 1234));
-        SSLParameters sslParameters = client.getSSLParameters();
-        sslParameters.setEndpointIdentificationAlgorithm("HTTPS");
-        if (useSNI) {
-            sslParameters.setServerNames(Collections.<SNIServerName>singletonList(new SNIHostName(fqdn)));
-        }
-        client.setSSLParameters(sslParameters);
 
         serverSslCtx = wrapContext(param, SslContextBuilder
                 .forServer(cert.getKeyPair().getPrivate(), cert.getCertificatePath())


### PR DESCRIPTION
Motivation:
As we now depend on Java 8, we can now mention these new types in our API. This allow us to let clients configure their TLS SNI extension through the `SslContextBuilder`.

Modification:
Add a method to the `SslContextBuilder` for adding SNI server names extensions. Funnel the parameters through to the relevant `SSLEngine` implementations and their `SSLParameter` instances. Update the test that was testing the SNI functionality to use the new APIs.

Result:
We now have a more convenient API for specifying SNI server names in the TLS `ClientHello` message.