### PR TITLE
Add QueryStringDecoder option to leave '+' alone

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/QueryStringDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/QueryStringDecoder.java
@@ -68,6 +68,7 @@ public class QueryStringDecoder {
     private final String uri;
     private final int maxParams;
     private final boolean semicolonIsNormalChar;
+    private final boolean htmlQueryDecoding;
     private int pathEndIdx;
     private String path;
     private Map<String, List<String>> params;
@@ -77,7 +78,7 @@ public class QueryStringDecoder {
      * assume that the query string is encoded in UTF-8.
      */
     public QueryStringDecoder(String uri) {
-        this(uri, HttpConstants.DEFAULT_CHARSET);
+        this(builder(), uri);
     }
 
     /**
@@ -85,7 +86,7 @@ public class QueryStringDecoder {
      * specified charset.
      */
     public QueryStringDecoder(String uri, boolean hasPath) {
-        this(uri, HttpConstants.DEFAULT_CHARSET, hasPath);
+        this(builder().hasPath(hasPath), uri);
     }
 
     /**
@@ -93,7 +94,7 @@ public class QueryStringDecoder {
      * specified charset.
      */
     public QueryStringDecoder(String uri, Charset charset) {
-        this(uri, charset, true);
+        this(builder().charset(charset), uri);
     }
 
     /**
@@ -101,7 +102,7 @@ public class QueryStringDecoder {
      * specified charset.
      */
     public QueryStringDecoder(String uri, Charset charset, boolean hasPath) {
-        this(uri, charset, hasPath, DEFAULT_MAX_PARAMS);
+        this(builder().hasPath(hasPath).charset(charset), uri);
     }
 
     /**
@@ -109,7 +110,7 @@ public class QueryStringDecoder {
      * specified charset.
      */
     public QueryStringDecoder(String uri, Charset charset, boolean hasPath, int maxParams) {
-        this(uri, charset, hasPath, maxParams, false);
+        this(builder().hasPath(hasPath).charset(charset).maxParams(maxParams), uri);
     }
 
     /**
@@ -118,13 +119,13 @@ public class QueryStringDecoder {
      */
     public QueryStringDecoder(String uri, Charset charset, boolean hasPath,
                               int maxParams, boolean semicolonIsNormalChar) {
-        this.uri = checkNotNull(uri, "uri");
-        this.charset = checkNotNull(charset, "charset");
-        this.maxParams = checkPositive(maxParams, "maxParams");
-        this.semicolonIsNormalChar = semicolonIsNormalChar;
-
-        // `-1` means that path end index will be initialized lazily
-        pathEndIdx = hasPath ? -1 : 0;
+        this(
+                builder()
+                        .hasPath(hasPath)
+                        .charset(charset)
+                        .maxParams(maxParams)
+                        .semicolonIsNormalChar(semicolonIsNormalChar),
+                uri);
     }
 
     /**
@@ -132,7 +133,7 @@ public class QueryStringDecoder {
      * assume that the query string is encoded in UTF-8.
      */
     public QueryStringDecoder(URI uri) {
-        this(uri, HttpConstants.DEFAULT_CHARSET);
+        this(builder(), uri);
     }
 
     /**
@@ -140,7 +141,7 @@ public class QueryStringDecoder {
      * specified charset.
      */
     public QueryStringDecoder(URI uri, Charset charset) {
-        this(uri, charset, DEFAULT_MAX_PARAMS);
+        this(builder().charset(charset), uri);
     }
 
     /**
@@ -148,7 +149,7 @@ public class QueryStringDecoder {
      * specified charset.
      */
     public QueryStringDecoder(URI uri, Charset charset, int maxParams) {
-        this(uri, charset, maxParams, false);
+        this(builder().charset(charset).maxParams(maxParams), uri);
     }
 
     /**
@@ -156,6 +157,21 @@ public class QueryStringDecoder {
      * specified charset.
      */
     public QueryStringDecoder(URI uri, Charset charset, int maxParams, boolean semicolonIsNormalChar) {
+        this(builder().charset(charset).maxParams(maxParams).semicolonIsNormalChar(semicolonIsNormalChar), uri);
+    }
+
+    private QueryStringDecoder(Builder builder, String uri) {
+        this.uri = checkNotNull(uri, "uri");
+        this.charset = checkNotNull(builder.charset, "charset");
+        this.maxParams = checkPositive(builder.maxParams, "maxParams");
+        this.semicolonIsNormalChar = builder.semicolonIsNormalChar;
+        this.htmlQueryDecoding = builder.htmlQueryDecoding;
+
+        // `-1` means that path end index will be initialized lazily
+        pathEndIdx = builder.hasPath ? -1 : 0;
+    }
+
+    private QueryStringDecoder(Builder builder, URI uri) {
         String rawPath = uri.getRawPath();
         if (rawPath == null) {
             rawPath = EMPTY_STRING;
@@ -163,9 +179,10 @@ public class QueryStringDecoder {
         String rawQuery = uri.getRawQuery();
         // Also take care of cut of things like "http://localhost"
         this.uri = rawQuery == null? rawPath : rawPath + '?' + rawQuery;
-        this.charset = checkNotNull(charset, "charset");
-        this.maxParams = checkPositive(maxParams, "maxParams");
-        this.semicolonIsNormalChar = semicolonIsNormalChar;
+        this.charset = checkNotNull(builder.charset, "charset");
+        this.maxParams = checkPositive(builder.maxParams, "maxParams");
+        this.semicolonIsNormalChar = builder.semicolonIsNormalChar;
+        this.htmlQueryDecoding = builder.htmlQueryDecoding;
         pathEndIdx = rawPath.length();
     }
 
@@ -186,7 +203,7 @@ public class QueryStringDecoder {
      */
     public String path() {
         if (path == null) {
-            path = decodeComponent(uri, 0, pathEndIdx(), charset, true);
+            path = decodeComponent(uri, 0, pathEndIdx(), charset, false);
         }
         return path;
     }
@@ -196,7 +213,7 @@ public class QueryStringDecoder {
      */
     public Map<String, List<String>> parameters() {
         if (params == null) {
-            params = decodeParams(uri, pathEndIdx(), charset, maxParams, semicolonIsNormalChar);
+            params = decodeParams(uri, pathEndIdx(), charset, maxParams);
         }
         return params;
     }
@@ -223,8 +240,7 @@ public class QueryStringDecoder {
         return pathEndIdx;
     }
 
-    private static Map<String, List<String>> decodeParams(String s, int from, Charset charset, int paramsLimit,
-                                                          boolean semicolonIsNormalChar) {
+    private Map<String, List<String>> decodeParams(String s, int from, Charset charset, int paramsLimit) {
         int len = s.length();
         if (from >= len) {
             return Collections.emptyMap();
@@ -270,7 +286,7 @@ public class QueryStringDecoder {
         return params;
     }
 
-    private static boolean addParam(String s, int nameStart, int valueStart, int valueEnd,
+    private boolean addParam(String s, int nameStart, int valueStart, int valueEnd,
                                     Map<String, List<String>> params, Charset charset) {
         if (nameStart >= valueEnd) {
             return false;
@@ -278,8 +294,8 @@ public class QueryStringDecoder {
         if (valueStart <= nameStart) {
             valueStart = valueEnd + 1;
         }
-        String name = decodeComponent(s, nameStart, valueStart - 1, charset, false);
-        String value = decodeComponent(s, valueStart, valueEnd, charset, false);
+        String name = decodeComponent(s, nameStart, valueStart - 1, charset, htmlQueryDecoding);
+        String value = decodeComponent(s, valueStart, valueEnd, charset, htmlQueryDecoding);
         List<String> values = params.get(name);
         if (values == null) {
             values = new ArrayList<String>(1);  // Often there's only 1 value.
@@ -330,10 +346,10 @@ public class QueryStringDecoder {
         if (s == null) {
             return EMPTY_STRING;
         }
-        return decodeComponent(s, 0, s.length(), charset, false);
+        return decodeComponent(s, 0, s.length(), charset, true);
     }
 
-    private static String decodeComponent(String s, int from, int toExcluded, Charset charset, boolean isPath) {
+    private static String decodeComponent(String s, int from, int toExcluded, Charset charset, boolean plusToSpace) {
         int len = toExcluded - from;
         if (len <= 0) {
             return EMPTY_STRING;
@@ -341,7 +357,7 @@ public class QueryStringDecoder {
         int firstEscaped = -1;
         for (int i = from; i < toExcluded; i++) {
             char c = s.charAt(i);
-            if (c == '%' || c == '+' && !isPath) {
+            if (c == '%' || (c == '+' && plusToSpace)) {
                 firstEscaped = i;
                 break;
             }
@@ -361,7 +377,7 @@ public class QueryStringDecoder {
         for (int i = firstEscaped; i < toExcluded; i++) {
             char c = s.charAt(i);
             if (c != '%') {
-                strBuf.append(c != '+' || isPath? c : SPACE);
+                strBuf.append(c != '+' || !plusToSpace ? c : SPACE);
                 continue;
             }
 
@@ -389,5 +405,103 @@ public class QueryStringDecoder {
             }
         }
         return len;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private boolean hasPath = true;
+        private int maxParams = DEFAULT_MAX_PARAMS;
+        private boolean semicolonIsNormalChar;
+        private Charset charset = HttpConstants.DEFAULT_CHARSET;
+        private boolean htmlQueryDecoding = true;
+
+        private Builder() {
+        }
+
+        /**
+         * {@code true} by default. When set to {@code false}, the input string only contains the query component of
+         * the URI.
+         *
+         * @param hasPath Whether the URI contains a path
+         * @return This builder
+         */
+        public Builder hasPath(boolean hasPath) {
+            this.hasPath = hasPath;
+            return this;
+        }
+
+        /**
+         * Maximum number of query parameters allowed, to mitigate HashDOS. {@value DEFAULT_MAX_PARAMS} by default.
+         *
+         * @param maxParams The maximum number of query parameters
+         * @return This builder
+         */
+        public Builder maxParams(int maxParams) {
+            this.maxParams = maxParams;
+            return this;
+        }
+
+        /**
+         * {@code false} by default. If set to {@code true}, instead of allowing query parameters to be separated by
+         * semicolons, treat the semicolon as a normal character in a query value.
+         *
+         * @param semicolonIsNormalChar Whether to treat semicolons as a normal character
+         * @return This builder
+         */
+        public Builder semicolonIsNormalChar(boolean semicolonIsNormalChar) {
+            this.semicolonIsNormalChar = semicolonIsNormalChar;
+            return this;
+        }
+
+        /**
+         * The charset to use for decoding percent escape sequences. {@link HttpConstants#DEFAULT_CHARSET} by default.
+         *
+         * @param charset The charset
+         * @return This builder
+         */
+        public Builder charset(Charset charset) {
+            this.charset = charset;
+            return this;
+        }
+
+        /**
+         * RFC 3986 (the URI standard) makes no mention of using '+' to encode a space in a URI query component. The
+         * whatwg HTML standard, however, defines the query to be encoded with the
+         * {@code application/x-www-form-urlencoded} serializer defined in the whatwg URL standard, which does use '+'
+         * to encode a space instead of {@code %20}.
+         * <p>This flag controls whether the decoding should happen according to HTML rules, which decodes the '+' to a
+         * space. The default is {@code true}.
+         *
+         * @param htmlQueryDecoding Whether to decode '+' to space
+         * @return This builder
+         */
+        public Builder htmlQueryDecoding(boolean htmlQueryDecoding) {
+            this.htmlQueryDecoding = htmlQueryDecoding;
+            return this;
+        }
+
+        /**
+         * Create a decoder that will lazily decode the given URI with the settings configured in this builder.
+         *
+         * @param uri The URI in String form
+         * @return The decoder
+         */
+        public QueryStringDecoder build(String uri) {
+            return new QueryStringDecoder(this, uri);
+        }
+
+        /**
+         * Create a decoder that will lazily decode the given URI with the settings configured in this builder. Note
+         * that {@link #hasPath(boolean)} has no effect when using this method.
+         *
+         * @param uri The already parsed URI
+         * @return The decoder
+         */
+        public QueryStringDecoder build(URI uri) {
+            return new QueryStringDecoder(this, uri);
+        }
     }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/QueryStringDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/QueryStringDecoderTest.java
@@ -111,6 +111,15 @@ public class QueryStringDecoderTest {
     }
 
     @Test
+    public void testNonHtmlQuery() {
+        QueryStringDecoder d = QueryStringDecoder.builder().build("/foo?abc=foo+bar");
+        assertEquals("foo bar", d.parameters().get("abc").get(0));
+
+        d = QueryStringDecoder.builder().htmlQueryDecoding(false).build("/foo?abc=foo+bar");
+        assertEquals("foo+bar", d.parameters().get("abc").get(0));
+    }
+
+    @Test
     public void testExotic() {
         assertQueryString("", "");
         assertQueryString("foo", "foo");

--- a/microbench/src/main/java/io/netty/microbench/util/AbstractMicrobenchmarkBase.java
+++ b/microbench/src/main/java/io/netty/microbench/util/AbstractMicrobenchmarkBase.java
@@ -16,11 +16,10 @@
 package io.netty.microbench.util;
 
 import io.netty.util.ResourceLeakDetector;
-import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.SystemPropertyUtil;
 
 import java.io.File;
-import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -87,17 +86,13 @@ public abstract class AbstractMicrobenchmarkBase {
 
     protected abstract String[] jvmArgs();
 
-    protected static String[] removeAssertions(String[] jvmArgs) {
-        List<String> customArgs = new ArrayList<String>(jvmArgs.length);
-        for (String arg : jvmArgs) {
-            if (!arg.startsWith("-ea")) {
-                customArgs.add(arg);
+    static void removeAssertions(List<String> jvmArgs) {
+        for (Iterator<String> iterator = jvmArgs.iterator(); iterator.hasNext(); ) {
+            String jvmArg = iterator.next();
+            if (jvmArg.startsWith("-ea")) {
+                iterator.remove();
             }
         }
-        if (jvmArgs.length != customArgs.size()) {
-            jvmArgs = customArgs.toArray(EmptyArrays.EMPTY_STRINGS);
-        }
-        return jvmArgs;
     }
 
     @Test


### PR DESCRIPTION
Motivation:

The URI standard RFC 3986 does not specify that query components have their spaces encoded as `+`. It is implied that the encoding is `%20` instead. However, the whatwg HTML standard says explicitly that the query must be encoded using `application/x-www-form-urlencoded` rules, which does use `+` for space. This is also what browsers do.

QueryStringDecoder should offer a way to parse either format.

Modification:

- Modify QueryStringDecoder to use a builder to accommodate the increasing number of flags
- Add a `htmlQueryDecoding` flag, enabled by default, to control the `+` decoding

The default value of `htmlQueryDecoding` is appropriate for most use cases, I don't think it should be changed even in netty 5.

Also fixed the benchmark harness for Java 21.

Result:

Query strings encoded purely according to the URI spec can be decoded properly.

I measured the performance of the new builder, and it didn't look any different.