### PR TITLE
IoUring: Fill buffer rings from IO thread

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRing.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRing.java
@@ -47,10 +47,9 @@ final class IoUringBufferRing {
         this.source = ioUringIoHandler;
         this.allocator = allocator;
         this.exhaustedEvent = new IoUringBufferRingExhaustedEvent(bufferGroupId);
-        fill();
     }
 
-    private void fill() {
+    void fill() {
         for (short i = 0; i < entries; i++) {
             addBuffer(i);
         }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -150,6 +150,10 @@ public final class IoUringIoHandler implements IoHandler {
     @Override
     public void initialize() {
         ringBuffer.enable();
+        // Fill all buffer rings now.
+        for (IoUringBufferRing bufferRing : registeredIoUringBufferRing.values()) {
+            bufferRing.fill();
+        }
     }
 
     @Override


### PR DESCRIPTION
Motivation:

We should better fill the buffer rings from the thread that will actual use it as the used ByteBufAllocator might return buffers that are cheaper to release on the allocation thread.

Modification:

- Make fill method package-private and call it from the initialize() method.

Result:

Possibility of allocating buffers that will be cheaper to release on the IO thread.