### PR TITLE
Small SNIServerName fixes

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
@@ -39,7 +39,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
-import javax.net.ssl.SNIHostName;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.TrustManager;


### PR DESCRIPTION
Motivation:
A few edge cases were missed when changing the handling of SSLParameter serverNames.

Modification:
Make the ExtendedSSLSession from ReferenceCountedOpenSslEngine produce an immutable list of names. Make ReferenceCountedOpenSslEngine.setSSLParameters handle null server names.

Result:
Fix a few edge cases.