### PR TITLE
Convenient API for specifying SNI hostname (#14849)

### DIFF
--- a/handler/src/main/java/io/netty5/handler/ssl/JdkSslClientContext.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/JdkSslClientContext.java
@@ -17,6 +17,7 @@
 package io.netty5.handler.ssl;
 
 import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLSessionContext;
@@ -28,6 +29,7 @@ import java.security.PrivateKey;
 import java.security.Provider;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
+import java.util.List;
 
 /**
  * A client-side {@link SslContext} which uses JDK's SSL/TLS implementation.
@@ -47,7 +49,7 @@ final class JdkSslClientContext extends JdkSslContext {
         super(newSSLContext(provider, toX509CertificatesInternal(trustCertCollectionFile),
           trustManagerFactory, null, null,
           null, null, sessionCacheSize, sessionTimeout, null, KeyStore.getDefaultType(), null), true,
-          ciphers, cipherFilter, apn, ClientAuth.NONE, null, false, null, null);
+          ciphers, cipherFilter, apn, ClientAuth.NONE, null, false, null, null, null);
     }
 
     JdkSslClientContext(Provider sslContextProvider,
@@ -66,13 +68,14 @@ final class JdkSslClientContext extends JdkSslContext {
                         SecureRandom secureRandom,
                         String keyStore,
                         String endpointIdentificationAlgorithm,
+                        List<SNIServerName> serverNames,
                         ResumptionController resumptionController)
       throws Exception {
         super(newSSLContext(sslContextProvider, trustCertCollection, trustManagerFactory,
           keyCertChain, key, keyPassword, keyManagerFactory, sessionCacheSize, sessionTimeout, secureRandom, keyStore,
                         resumptionController),
           true, ciphers, cipherFilter, toNegotiator(apn, false), ClientAuth.NONE, protocols, false,
-                endpointIdentificationAlgorithm, resumptionController);
+                endpointIdentificationAlgorithm, serverNames, resumptionController);
     }
 
     private static SSLContext newSSLContext(Provider sslContextProvider,

--- a/handler/src/main/java/io/netty5/handler/ssl/JdkSslServerContext.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/JdkSslServerContext.java
@@ -93,7 +93,7 @@ final class JdkSslServerContext extends JdkSslContext {
         super(newSSLContext(provider, null, null,
           toX509CertificatesInternal(certChainFile), toPrivateKeyInternal(keyFile, keyPassword),
           keyPassword, null, sessionCacheSize, sessionTimeout, null, KeyStore.getDefaultType(), null),
-          false, ciphers, cipherFilter, apn, ClientAuth.NONE, null, false, null, null);
+          false, ciphers, cipherFilter, apn, ClientAuth.NONE, null, false, null, null, null);
     }
 
     JdkSslServerContext(Provider provider,
@@ -118,7 +118,8 @@ final class JdkSslServerContext extends JdkSslContext {
         super(newSSLContext(provider, trustCertCollection, trustManagerFactory, keyCertChain, key,
           keyPassword, keyManagerFactory, sessionCacheSize, sessionTimeout, secureRandom, keyStore,
                         resumptionController), false,
-          ciphers, cipherFilter, toNegotiator(apn, true), clientAuth, protocols, startTls, null, resumptionController);
+          ciphers, cipherFilter, toNegotiator(apn, true), clientAuth, protocols, startTls, null, null,
+                resumptionController);
     }
 
     private static SSLContext newSSLContext(Provider sslContextProvider, X509Certificate[] trustCertCollection,

--- a/handler/src/main/java/io/netty5/handler/ssl/OpenSslClientContext.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/OpenSslClientContext.java
@@ -18,10 +18,12 @@ package io.netty5.handler.ssl;
 import io.netty.internal.tcnative.SSL;
 
 import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.TrustManagerFactory;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
+import java.util.List;
 import java.util.Map;
 
 import static io.netty5.handler.ssl.ReferenceCountedOpenSslClientContext.newSessionContext;
@@ -36,14 +38,15 @@ final class OpenSslClientContext extends OpenSslContext {
 
     OpenSslClientContext(X509Certificate[] trustCertCollection, TrustManagerFactory trustManagerFactory,
                          X509Certificate[] keyCertChain, PrivateKey key, String keyPassword,
-                                KeyManagerFactory keyManagerFactory, Iterable<String> ciphers,
-                                CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn, String[] protocols,
-                                long sessionCacheSize, long sessionTimeout, boolean enableOcsp, String keyStore,
-                         String endpointIdentificationAlgorithm, ResumptionController resumptionController,
+                         KeyManagerFactory keyManagerFactory, Iterable<String> ciphers,
+                         CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn, String[] protocols,
+                         long sessionCacheSize, long sessionTimeout, boolean enableOcsp, String keyStore,
+                         String endpointIdentificationAlgorithm, List<SNIServerName> serverName,
+                         ResumptionController resumptionController,
                          Map.Entry<SslContextOption<?>, Object>... options)
             throws SSLException {
         super(ciphers, cipherFilter, apn, SSL.SSL_MODE_CLIENT, keyCertChain, ClientAuth.NONE, protocols, false,
-                enableOcsp, endpointIdentificationAlgorithm, resumptionController, options);
+                enableOcsp, endpointIdentificationAlgorithm, serverName, resumptionController, options);
         boolean success = false;
         try {
             OpenSslKeyMaterialProvider.validateKeyMaterialSupported(keyCertChain, key, keyPassword);

--- a/handler/src/main/java/io/netty5/handler/ssl/OpenSslContext.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/OpenSslContext.java
@@ -17,9 +17,11 @@ package io.netty5.handler.ssl;
 
 import io.netty5.buffer.BufferAllocator;
 
+import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 import java.security.cert.Certificate;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -31,29 +33,31 @@ public abstract class OpenSslContext extends ReferenceCountedOpenSslContext {
                    int mode, Certificate[] keyCertChain,
                    ClientAuth clientAuth, String[] protocols, boolean startTls,
                    boolean enableOcsp, String endpointIdentificationAlgorithm,
+                   List<SNIServerName> serverNames,
                    ResumptionController resumptionController,
                    Map.Entry<SslContextOption<?>, Object>... options)
             throws SSLException {
         super(ciphers, cipherFilter, toNegotiator(apnCfg), mode, keyCertChain,
-                clientAuth, protocols, startTls, enableOcsp, false, endpointIdentificationAlgorithm,
+                clientAuth, protocols, startTls, enableOcsp, false, endpointIdentificationAlgorithm, serverNames,
                 resumptionController, options);
     }
 
     OpenSslContext(Iterable<String> ciphers, CipherSuiteFilter cipherFilter, OpenSslApplicationProtocolNegotiator apn,
                    int mode, Certificate[] keyCertChain,
                    ClientAuth clientAuth, String[] protocols, boolean startTls, boolean enableOcsp,
-                   String endpointIdentificationAlgorithm, ResumptionController resumptionController,
+                   String endpointIdentificationAlgorithm, List<SNIServerName> serverNames,
+                   ResumptionController resumptionController,
                    Map.Entry<SslContextOption<?>, Object>... options)
             throws SSLException {
         super(ciphers, cipherFilter, apn, mode, keyCertChain,
-                clientAuth, protocols, startTls, enableOcsp, false, endpointIdentificationAlgorithm,
+                clientAuth, protocols, startTls, enableOcsp, false, endpointIdentificationAlgorithm, serverNames,
                 resumptionController, options);
     }
 
     @Override
     final SSLEngine newEngine0(BufferAllocator alloc, String peerHost, int peerPort, boolean jdkCompatibilityMode) {
         return new OpenSslEngine(this, alloc, peerHost, peerPort, jdkCompatibilityMode,
-                endpointIdentificationAlgorithm);
+                endpointIdentificationAlgorithm, serverNames);
     }
 
     @Override

--- a/handler/src/main/java/io/netty5/handler/ssl/OpenSslEngine.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/OpenSslEngine.java
@@ -17,6 +17,8 @@ package io.netty5.handler.ssl;
 
 import io.netty5.buffer.BufferAllocator;
 
+import java.util.List;
+import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLEngine;
 
 /**
@@ -28,8 +30,10 @@ import javax.net.ssl.SSLEngine;
  */
 public final class OpenSslEngine extends ReferenceCountedOpenSslEngine {
     OpenSslEngine(OpenSslContext context, BufferAllocator alloc, String peerHost, int peerPort,
-                  boolean jdkCompatibilityMode,  String endpointIdentificationAlgorithm) {
-        super(context, alloc, peerHost, peerPort, jdkCompatibilityMode, false, endpointIdentificationAlgorithm);
+                  boolean jdkCompatibilityMode,  String endpointIdentificationAlgorithm,
+                  List<SNIServerName> serverNames) {
+        super(context, alloc, peerHost, peerPort, jdkCompatibilityMode, false, endpointIdentificationAlgorithm,
+                serverNames);
     }
 
     @Override

--- a/handler/src/main/java/io/netty5/handler/ssl/OpenSslServerContext.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/OpenSslServerContext.java
@@ -57,7 +57,7 @@ final class OpenSslServerContext extends OpenSslContext {
             Map.Entry<SslContextOption<?>, Object>... options)
             throws SSLException {
         super(ciphers, cipherFilter, apn, SSL.SSL_MODE_SERVER, keyCertChain,
-                clientAuth, protocols, startTls, enableOcsp, null, resumptionController, options);
+                clientAuth, protocols, startTls, enableOcsp, null, null, resumptionController, options);
         // Create a new SSL_CTX and configure it.
         boolean success = false;
         try {

--- a/handler/src/main/java/io/netty5/handler/ssl/ReferenceCountedOpenSslClientContext.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/ReferenceCountedOpenSslClientContext.java
@@ -21,6 +21,7 @@ import io.netty.internal.tcnative.SSLContext;
 import io.netty5.util.internal.EmptyArrays;
 
 import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509ExtendedTrustManager;
@@ -33,6 +34,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -61,10 +63,11 @@ public final class ReferenceCountedOpenSslClientContext extends ReferenceCounted
                                          CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn,
                                          String[] protocols, long sessionCacheSize, long sessionTimeout,
                                          boolean enableOcsp, String keyStore, String endpointIdentificationAlgorithm,
+                                         List<SNIServerName> serverNames,
                                          ResumptionController resumptionController,
                                          Map.Entry<SslContextOption<?>, Object>... options) throws SSLException {
         super(ciphers, cipherFilter, toNegotiator(apn), SSL.SSL_MODE_CLIENT, keyCertChain,
-                ClientAuth.NONE, protocols, false, enableOcsp, true, endpointIdentificationAlgorithm,
+                ClientAuth.NONE, protocols, false, enableOcsp, true, endpointIdentificationAlgorithm, serverNames,
                 resumptionController, options);
         boolean success = false;
         try {

--- a/handler/src/main/java/io/netty5/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -43,6 +43,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
@@ -156,6 +157,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
     final ClientAuth clientAuth;
     final String[] protocols;
     final String endpointIdentificationAlgorithm;
+    final List<SNIServerName> serverNames;
     final boolean hasTLSv13Cipher;
 
     final boolean enableOcsp;
@@ -213,6 +215,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
                                    OpenSslApplicationProtocolNegotiator apn, int mode, Certificate[] keyCertChain,
                                    ClientAuth clientAuth, String[] protocols, boolean startTls, boolean enableOcsp,
                                    boolean leakDetection, String endpointIdentificationAlgorithm,
+                                   List<SNIServerName> serverNames,
                                    ResumptionController resumptionController,
                                    Map.Entry<SslContextOption<?>, Object>... ctxOptions)
             throws SSLException {
@@ -277,6 +280,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
         this.clientAuth = isServer() ? requireNonNull(clientAuth, "clientAuth") : ClientAuth.NONE;
         this.protocols = protocols == null ? OpenSsl.defaultProtocols(mode == SSL.SSL_MODE_CLIENT) : protocols;
         this.endpointIdentificationAlgorithm = endpointIdentificationAlgorithm;
+        this.serverNames = serverNames;
         this.enableOcsp = enableOcsp;
 
         this.keyCertChain = keyCertChain == null ? null : keyCertChain.clone();
@@ -516,7 +520,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
 
     SSLEngine newEngine0(BufferAllocator alloc, String peerHost, int peerPort, boolean jdkCompatibilityMode) {
         return new ReferenceCountedOpenSslEngine(this, alloc, peerHost, peerPort, jdkCompatibilityMode, true,
-                endpointIdentificationAlgorithm);
+                endpointIdentificationAlgorithm, serverNames);
     }
 
     /**

--- a/handler/src/main/java/io/netty5/handler/ssl/ReferenceCountedOpenSslServerContext.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/ReferenceCountedOpenSslServerContext.java
@@ -72,6 +72,7 @@ public final class ReferenceCountedOpenSslServerContext extends ReferenceCounted
                 clientAuth, protocols, startTls,
                 enableOcsp, true,
                 null, // No endpoint validation for servers.
+                null, // No SNI extensions for servers.
                 resumptionController, options);
         // Create a new SSL_CTX and configure it.
         boolean success = false;

--- a/handler/src/main/java/io/netty5/handler/ssl/SslContext.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslContext.java
@@ -36,6 +36,7 @@ import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.PBEKeySpec;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
@@ -811,7 +812,7 @@ public abstract class SslContext {
                                             toX509Certificates(keyCertChainFile), toPrivateKey(keyFile, keyPassword),
                                             keyPassword, keyManagerFactory, ciphers, cipherFilter,
                                             apn, null, sessionCacheSize, sessionTimeout, false,
-                                            null, KeyStore.getDefaultType(), "HTTPS");
+                                            null, KeyStore.getDefaultType(), "HTTPS", null);
         } catch (Exception e) {
             if (e instanceof SSLException) {
                 throw (SSLException) e;
@@ -828,6 +829,7 @@ public abstract class SslContext {
             Iterable<String> ciphers, CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn, String[] protocols,
             long sessionCacheSize, long sessionTimeout, boolean enableOcsp,
             SecureRandom secureRandom, String keyStoreType, String endpointIdentificationAlgorithm,
+            List<SNIServerName> serverNames,
             Map.Entry<SslContextOption<?>, Object>... options) throws SSLException {
         if (provider == null) {
             provider = defaultClientProvider();
@@ -845,7 +847,7 @@ public abstract class SslContext {
                             trustCert, trustManagerFactory, keyCertChain, key, keyPassword,
                             keyManagerFactory, ciphers, cipherFilter, apn, protocols, sessionCacheSize,
                             sessionTimeout, secureRandom, keyStoreType, endpointIdentificationAlgorithm,
-                            resumptionController);
+                            serverNames, resumptionController);
                 } catch (SSLException e) {
                     throw e;
                 } catch (Exception e) {
@@ -857,14 +859,16 @@ public abstract class SslContext {
                 return new OpenSslClientContext(
                         trustCert, trustManagerFactory, keyCertChain, key, keyPassword,
                         keyManagerFactory, ciphers, cipherFilter, apn, protocols, sessionCacheSize, sessionTimeout,
-                        enableOcsp, keyStoreType, endpointIdentificationAlgorithm, resumptionController, options);
+                        enableOcsp, keyStoreType, endpointIdentificationAlgorithm, serverNames, resumptionController,
+                        options);
             case OPENSSL_REFCNT:
                 verifyNullSslContextProvider(provider, sslContextProvider);
                 OpenSsl.ensureAvailability();
                 return new ReferenceCountedOpenSslClientContext(
                         trustCert, trustManagerFactory, keyCertChain, key, keyPassword,
                         keyManagerFactory, ciphers, cipherFilter, apn, protocols, sessionCacheSize, sessionTimeout,
-                        enableOcsp, keyStoreType, endpointIdentificationAlgorithm, resumptionController, options);
+                        enableOcsp, keyStoreType, endpointIdentificationAlgorithm, serverNames, resumptionController,
+                        options);
             default:
                 throw new Error(provider.toString());
         }


### PR DESCRIPTION
Motivation:
As we now depend on Java 8, we can now mention these new types in our API. This allow us to let clients configure their TLS SNI extension through the `SslContextBuilder`.

Modification:
Add a method to the `SslContextBuilder` for adding SNI server names extensions. Funnel the parameters through to the relevant `SSLEngine` implementations and their `SSLParameter` instances. Update the test that was testing the SNI functionality to use the new APIs.

Result:
We now have a more convenient API for specifying SNI server names in the TLS `ClientHello` message.