### PR TITLE
IoUring: Correctly handle pollIn notifications if there is no read pe…

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -819,7 +819,12 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
             if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
                 return;
             }
-
+            if (!readPending) {
+                // We received the POLLIN but the user is not interested yet in reading, just mark socketHasMoreData
+                // as true so we will trigger a read directly once the user calls read()
+                socketHasMoreData = true;
+                return;
+            }
             scheduleFirstReadIfNeeded();
         }
 


### PR DESCRIPTION
…nding

Motivation:

It is possible that while a pollIn notification is received we don't have a read pending yet. This is especially true when multishot polladd is used.

Modification:

Only try to schedule a read if a read is pending and if not set the correct internal state that once read() is triggered we know that there is something to read.

Result:

Correctly handle pollIn notifications in all cases