### PR TITLE
IoUring: Retry buffer ring based ready directly once we receive a ENO…

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringRecvByteAllocatorHandle.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringRecvByteAllocatorHandle.java
@@ -38,7 +38,6 @@ final class IoUringRecvByteAllocatorHandle extends RecvByteBufAllocator.Delegati
     private boolean firstRead;
     private boolean rdHupReceived;
     private boolean readComplete;
-    private boolean forceNonBufferRing;
 
     @Override
     public void reset(ChannelConfig config) {
@@ -79,8 +78,6 @@ final class IoUringRecvByteAllocatorHandle extends RecvByteBufAllocator.Delegati
     public void readComplete() {
         super.readComplete();
         readComplete = true;
-        // Reset this so we might try again to use the buffer ring.
-        forceNonBufferRing = false;
     }
 
     boolean isReadComplete() {
@@ -97,13 +94,5 @@ final class IoUringRecvByteAllocatorHandle extends RecvByteBufAllocator.Delegati
     public void incMessagesRead(int numMessages) {
         firstRead = false;
         super.incMessagesRead(numMessages);
-    }
-
-    boolean isNonBufferRingForced() {
-        return forceNonBufferRing;
-    }
-
-    void forceNonBufferRing() {
-        forceNonBufferRing = true;
     }
 }


### PR DESCRIPTION
…BUFS.

Motivation:

When we use a buffer ring and receive ENOBUFS we should just let the user know and retry with a buffer ring again. This works as expected as we always refill the buffer ring once we used a buffer out of it. At the moment we will fallback to do a read loop without a buffer ring which slows down things without any benefits.

Modifications:

Just retry directly with a buffer ring.

Result:

Performance improvements when the buffer ring is exhausted in between.

Before:

```
./src/tcpkali -m xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx   -c 50 -T 30 127.0.0.1:8081
Destination: [127.0.0.1]:8081
Interface lo address [127.0.0.1]:0
Using interface lo to connect to [127.0.0.1]:8081
Ramped up to 50 connections.
Total data sent:     130258.4 MiB (136585805824 bytes)
Total data received: 130229.7 MiB (136555722112 bytes)
Bandwidth per channel: 1456.511⇅ Mbps (182063.8 kBps)
Aggregate bandwidth: 36408.753↓, 36416.774↑ Mbps
Packet rate estimate: 3333377.7↓, 3125676.8↑ (12↓, 45↑ TCP MSS/op)
Test duration: 30.005 s.
```

With this change:

```
./src/tcpkali -m xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx   -c 50 -T 30 127.0.0.1:8081
Destination: [127.0.0.1]:8081
Interface lo address [127.0.0.1]:0
Using interface lo to connect to [127.0.0.1]:8081
Ramped up to 50 connections.
Total data sent:     201195.0 MiB (210968248320 bytes)
Total data received: 201185.2 MiB (210958005952 bytes)
Bandwidth per channel: 2249.524⇅ Mbps (281190.5 kBps)
Aggregate bandwidth: 56236.732↓, 56239.462↑ Mbps
Packet rate estimate: 5148636.2↓, 4827071.8↑ (12↓, 45↑ TCP MSS/op)
Test duration: 30.01 s.
```
