### PR TITLE
IoUring: Correctly updated attemptedBytesRead(...) also when a buffer…

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRing.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRing.java
@@ -82,6 +82,17 @@ final class IoUringBufferRing {
     }
 
     /**
+     * Return the amount of bytes that we attempted to read for the given id.
+     * This method must be called before {@link #useBuffer(short, int, boolean)}.
+     *
+     * @param bid   the id of the buffer.
+     * @return      the attempted bytes.
+     */
+    int attemptedBytesRead(short bid) {
+        return buffers[bid].readableBytes();
+    }
+
+    /**
      * Use the buffer for the given buffer id. The returned {@link ByteBuf} must be released once not used anymore.
      *
      * @param bid           the id of the buffer


### PR DESCRIPTION
… ring is used.

Motivation:

We should always correctly update attemptedBytesRead as it might influence continueReading().

Modifications:

Always update attemptedBytesRead

Result:

More consistent and correct behaviour
