### PR TITLE
Fix flawed termination condition check in HttpPostRequestEncoder… (#1…

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostRequestEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostRequestEncoder.java
@@ -969,11 +969,13 @@ public class HttpPostRequestEncoder implements ChunkedInput<HttpContent> {
         ByteBuf delimiter = null;
         if (buffer.readableBytes() < size) {
             isKey = true;
+            currentData = null;
             delimiter = iterator.hasNext() ? wrappedBuffer("&".getBytes(charset)) : null;
         }
 
         // End for current InterfaceHttpData, need potentially more data
         if (buffer.capacity() == 0) {
+            isKey = true;
             currentData = null;
             if (currentBuffer == null) {
                 if (delimiter == null) {
@@ -1008,15 +1010,10 @@ public class HttpPostRequestEncoder implements ChunkedInput<HttpContent> {
             }
         }
 
-        // end for current InterfaceHttpData, need more data
-        if (currentBuffer.readableBytes() < HttpPostBodyUtil.chunkSize) {
-            currentData = null;
-            isKey = true;
-            return null;
+        if (currentBuffer.readableBytes() >= HttpPostBodyUtil.chunkSize) {
+            return new DefaultHttpContent(fillByteBuf());
         }
-
-        buffer = fillByteBuf();
-        return new DefaultHttpContent(buffer);
+        return null;
     }
 
     @Override


### PR DESCRIPTION
…4799)

…#encodeNextChunkUrlEncoded(int) for current InterfaceHttpData

Motivation:

I am using `HttpPostRequestEncoder` to encode a few request parameters, but I read **infinite** chunks when the following conditions are met:

1. The number of POST request parameters is greater than or equal to 2.
2. The length of the first request parameter value > `DefaultHttpDataFactory#minSize`.
3. The length of the first request parameter key + the length of the request parameter value + 2 = N * `HttpPostBodyUtil#chunkSize`

This issue can be reproduced by modifying the
[length](https://github.com/netty/netty/blob/34011b5f02c52122eccd36ce7cc69502a514d0f1/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestEncoderTest.java#L454) variable in the
[HttpPostRequestEncoderTest#testEncodeChunkedContent()](https://github.com/netty/netty/blob/34011b5f02c52122eccd36ce7cc69502a514d0f1/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestEncoderTest.java#L450) method to `HttpPostBodyUtil.chunkSize * 3 - 4 - 2`. Normally, this test method should complete quickly, but when the length variable is set to `HttpPostBodyUtil.chunkSize * 3 - 4 - 2`, it will never finish.

Modification:

1. Enhance the logic of determining whether the current `InterfaceHttpData` has been fully read.

Result:

Fix flawed termination condition check.