### PR TITLE
IoUring: Correctly retrieves the cqe capacity

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionBuffer.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionBuffer.java
@@ -32,7 +32,7 @@ final class CompletionBuffer {
     private int tail = -1;
 
     CompletionBuffer(int numCompletions, long tombstone) {
-        capacity = MathUtil.findNextPositivePowerOfTwo(numCompletions * 2);
+        capacity = MathUtil.findNextPositivePowerOfTwo(numCompletions);
         array = new long[capacity];
         mask = capacity - 1;
         for (int i = 0; i < capacity; i += 2) {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionQueue.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionQueue.java
@@ -42,19 +42,21 @@ final class CompletionQueue {
     final long ringAddress;
     final int ringFd;
     final int ringEntries;
+    final int ringCapacity;
 
     private final int ringMask;
     private int ringHead;
 
     CompletionQueue(long kHeadAddress, long kTailAddress, long kRingMaskAddress, long kRingEntriesAddress,
                     long kOverflowAddress, long completionQueueArrayAddress, int ringSize, long ringAddress,
-                    int ringFd) {
+                    int ringFd, int ringCapacity) {
         this.kHeadAddress = kHeadAddress;
         this.kTailAddress = kTailAddress;
         this.completionQueueArrayAddress = completionQueueArrayAddress;
         this.ringSize = ringSize;
         this.ringAddress = ringAddress;
         this.ringFd = ringFd;
+        this.ringCapacity = ringCapacity;
 
         ringEntries = PlatformDependent.getIntVolatile(kRingEntriesAddress);
         ringMask = PlatformDependent.getIntVolatile(kRingMaskAddress);

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -139,9 +139,9 @@ public final class IoUringIoHandler implements IoHandler {
         eventfdReadBuf = PlatformDependent.allocateMemory(8);
         this.timeoutMemoryAddress = PlatformDependent.allocateMemory(KERNEL_TIMESPEC_SIZE);
 
-        // We buffer a maximum of 2 * CompletionQueue.ringSize completions before we drain them in batches.
+        // We buffer a maximum of 2 * CompletionQueue.ringCapacity completions before we drain them in batches.
         // Also as we never submit an udata which is 0L we use this as the tombstone marker.
-        completionBuffer = new CompletionBuffer(ringBuffer.ioUringCompletionQueue().ringSize * 2, 0);
+        completionBuffer = new CompletionBuffer(ringBuffer.ioUringCompletionQueue().ringCapacity * 2, 0);
     }
 
     @Override

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -343,7 +343,7 @@ final class Native {
         ObjectUtil.checkPositive(ringSize, "ringSize");
         ObjectUtil.checkPositive(cqeSize, "cqeSize");
         long[] values = ioUringSetup(ringSize, cqeSize, setupFlags);
-        assert values.length == 21;
+        assert values.length == 22;
         CompletionQueue completionQueue = new CompletionQueue(
                 values[0],
                 values[1],
@@ -353,9 +353,9 @@ final class Native {
                 values[5],
                 (int) values[6],
                 values[7],
-                (int) values[8]);
+                (int) values[8],
+                (int) values[9]);
         SubmissionQueue submissionQueue = new SubmissionQueue(
-                values[9],
                 values[10],
                 values[11],
                 values[12],
@@ -363,10 +363,11 @@ final class Native {
                 values[14],
                 values[15],
                 values[16],
-                (int) values[17],
-                values[18],
-                (int) values[19]);
-        return new RingBuffer(submissionQueue, completionQueue, (int) values[20]);
+                values[17],
+                (int) values[18],
+                values[19],
+                (int) values[20]);
+        return new RingBuffer(submissionQueue, completionQueue, (int) values[21]);
     }
 
     static void checkAllIOSupported(int ringFd) {

--- a/transport-native-io_uring/src/main/c/netty_io_uring_native.c
+++ b/transport-native-io_uring/src/main/c/netty_io_uring_native.c
@@ -293,7 +293,7 @@ static jlongArray netty_io_uring_setup(JNIEnv *env, jclass clazz, jint entries, 
         p.cq_entries = (__u32) cqSize;
     }
 
-    jlongArray array = (*env)->NewLongArray(env, 21);
+    jlongArray array = (*env)->NewLongArray(env, 22);
     if (array == NULL) {
         // This will put an OOME on the stack
         return NULL;
@@ -328,9 +328,10 @@ static jlongArray netty_io_uring_setup(JNIEnv *env, jclass clazz, jint entries, 
         (jlong)io_uring_ring.cq.cqes,
         (jlong)io_uring_ring.cq.ring_sz,
         (jlong)io_uring_ring.cq.ring_ptr,
-        (jlong)ring_fd
+        (jlong)ring_fd,
+        (jlong)p.cq_entries
     };
-    (*env)->SetLongArrayRegion(env, array, 0, 9, completionArrayElements);
+    (*env)->SetLongArrayRegion(env, array, 0, 10, completionArrayElements);
 
     jlong submissionArrayElements[] = {
         (jlong)io_uring_ring.sq.khead,
@@ -345,10 +346,10 @@ static jlongArray netty_io_uring_setup(JNIEnv *env, jclass clazz, jint entries, 
         (jlong)io_uring_ring.sq.ring_ptr,
         (jlong)ring_fd
     };
-    (*env)->SetLongArrayRegion(env, array, 9, 11, submissionArrayElements);
+    (*env)->SetLongArrayRegion(env, array, 10, 11, submissionArrayElements);
 
     jlong features = (jlong) p.features;
-    (*env)->SetLongArrayRegion(env, array, 20, 1, &features);
+    (*env)->SetLongArrayRegion(env, array, 21, 1, &features);
     return array;
 }
 

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
@@ -51,7 +51,8 @@ public class IoUringBufferRingTest {
 
     @Test
     public void testRegister() {
-        RingBuffer ringBuffer = Native.createRingBuffer(8, 0);
+        // using cqeSize on purpose NOT a power of 2
+        RingBuffer ringBuffer = Native.createRingBuffer(8, 15, 0);
         try {
             int ringFd = ringBuffer.fd();
             long ioUringBufRingAddr = Native.ioUringRegisterBuffRing(ringFd, 4, (short) 1, 0);
@@ -64,6 +65,8 @@ public class IoUringBufferRingTest {
                     freeRes,
                     "ioUringFreeBufRing result must be 0, but now result is " + freeRes
             );
+            // let io_uring to "fix" it
+            assertEquals(16, ringBuffer.ioUringCompletionQueue().ringCapacity);
         } finally {
             ringBuffer.close();
         }


### PR DESCRIPTION
Motivation:

We wrongly use the size in bytes of cqe to size the CompletionQueue: we should use the real capacity in number of entries instead.

Modifications:

Uses the ring buffer configured capacity and expose it as a new property

Result:

Smaller CompletionQueue