### PR TITLE
IoUring: Guard against reading to fast when using a buffer ring

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/WrappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/WrappedByteBuf.java
@@ -37,7 +37,7 @@ import java.nio.charset.Charset;
  * indices on the fly because of internal optimizations made by {@link ByteBufUtil#writeAscii(ByteBuf, CharSequence)}
  * and {@link ByteBufUtil#writeUtf8(ByteBuf, CharSequence)}.
  */
-class WrappedByteBuf extends ByteBuf {
+public class WrappedByteBuf extends ByteBuf {
 
     protected final ByteBuf buf;
 

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRingConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRingConfig.java
@@ -26,34 +26,44 @@ import java.util.Objects;
 public final class IoUringBufferRingConfig {
     private final short bgId;
     private final short bufferRingSize;
+    private final int maxUnreleasedBuffers;
     private final boolean incremental;
     private final IoUringBufferRingAllocator allocator;
 
     /**
      * Create a new configuration.
      *
-     * @param bgId              the buffer group id to use (must be non-negative).
-     * @param bufferRingSize    the size of the ring
-     * @param allocator         the {@link IoUringBufferRingAllocator} to use to allocate
-     *                          {@link io.netty.buffer.ByteBuf}s.
+     * @param bgId                  the buffer group id to use (must be non-negative).
+     * @param bufferRingSize        the size of the ring
+     * @param maxUnreleasedBuffers  the maximum buffers that were allocated out of this buffer ring and are
+     *                              unreleased yet. Once this threshold is hit the usage of the buffer ring will
+     *                              be temporary disabled.
+     * @param allocator             the {@link IoUringBufferRingAllocator} to use to allocate
+     *                              {@link io.netty.buffer.ByteBuf}s.
      */
-    public IoUringBufferRingConfig(short bgId, short bufferRingSize, IoUringBufferRingAllocator allocator) {
-        this(bgId, bufferRingSize, IoUring.isRegisterBufferRingIncSupported(), allocator);
+    public IoUringBufferRingConfig(short bgId, short bufferRingSize, int maxUnreleasedBuffers,
+                                   IoUringBufferRingAllocator allocator) {
+        this(bgId, bufferRingSize, maxUnreleasedBuffers, IoUring.isRegisterBufferRingIncSupported(), allocator);
     }
 
     /**
      * Create a new configuration.
      *
-     * @param bgId              the buffer group id to use (must be non-negative).
-     * @param bufferRingSize    the size of the ring
-     * @param incremental       {@code true} if the buffer ring is using incremental buffer consumption.
-     * @param allocator         the {@link IoUringBufferRingAllocator} to use to allocate
-     *                          {@link io.netty.buffer.ByteBuf}s.
+     * @param bgId                  the buffer group id to use (must be non-negative).
+     * @param bufferRingSize        the size of the ring
+     * @param maxUnreleasedBuffers  the maximum buffers that can be allocated out of this buffer ring and are
+     *                              unreleased yet. Once this threshold is hit the usage of the buffer ring will
+     *                              be temporarily disabled.
+     * @param incremental           {@code true} if the buffer ring is using incremental buffer consumption.
+     * @param allocator             the {@link IoUringBufferRingAllocator} to use to allocate
+     *                              {@link io.netty.buffer.ByteBuf}s.
      */
-    public IoUringBufferRingConfig(short bgId, short bufferRingSize, boolean incremental,
-                                   IoUringBufferRingAllocator allocator) {
+    public IoUringBufferRingConfig(short bgId, short bufferRingSize, int maxUnreleasedBuffers,
+                                   boolean incremental, IoUringBufferRingAllocator allocator) {
         this.bgId = (short) ObjectUtil.checkPositiveOrZero(bgId, "bgId");
         this.bufferRingSize = checkBufferRingSize(bufferRingSize);
+        this.maxUnreleasedBuffers = ObjectUtil.checkInRange(
+                maxUnreleasedBuffers, bufferRingSize, Integer.MAX_VALUE, "maxUnreleasedBuffers");
         if (incremental && !IoUring.isRegisterBufferRingIncSupported()) {
             throw new IllegalArgumentException("Incremental buffer ring is not supported");
         }
@@ -77,6 +87,16 @@ public final class IoUringBufferRingConfig {
      */
     public short bufferRingSize() {
         return bufferRingSize;
+    }
+
+    /**
+     * Returns the maximum buffers that can be allocated out of this buffer ring and are
+     * unreleased yet
+     *
+     * @return the max unreleased buffers.
+     */
+    public int maxUnreleasedBuffers() {
+        return maxUnreleasedBuffers;
     }
 
     /**

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -202,9 +202,9 @@ public final class IoUringIoHandler implements IoHandler {
         if (ioUringBufRingAddr < 0) {
             throw Errors.newIOException("ioUringRegisterBuffRing", (int) ioUringBufRingAddr);
         }
-        return new IoUringBufferRing(
-                ringFd, ioUringBufRingAddr,
-                bufferRingSize, bufferGroupId, bufferRingConfig.isIncremental(), bufferRingConfig.allocator()
+        return new IoUringBufferRing(ringFd, ioUringBufRingAddr,
+                bufferRingSize, bufferRingConfig.maxUnreleasedBuffers(),
+                bufferGroupId, bufferRingConfig.isIncremental(), bufferRingConfig.allocator()
         );
     }
 

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
@@ -81,10 +81,10 @@ public class IoUringBufferRingTest {
         final BlockingQueue<ByteBuf> bufferSyncer = new LinkedBlockingQueue<>();
         IoUringIoHandlerConfig ioUringIoHandlerConfiguration = new IoUringIoHandlerConfig();
         IoUringBufferRingConfig bufferRingConfig = new IoUringBufferRingConfig(
-                (short) 1, (short) 2, incremental, new IoUringFixedBufferRingAllocator(1024));
+                (short) 1, (short) 2, 2 * 16, incremental, new IoUringFixedBufferRingAllocator(1024));
 
         IoUringBufferRingConfig bufferRingConfig1 = new IoUringBufferRingConfig(
-                (short) 2, (short) 16, incremental, new IoUringFixedBufferRingAllocator(1024)
+                (short) 2, (short) 16, 16 * 16, incremental, new IoUringFixedBufferRingAllocator(1024)
         );
         ioUringIoHandlerConfiguration.setBufferRingConfig(bufferRingConfig, bufferRingConfig1);
 
@@ -170,7 +170,7 @@ public class IoUringBufferRingTest {
         IoUringIoHandlerConfig ioUringIoHandlerConfiguration = new IoUringIoHandlerConfig();
         IoUringBufferRingConfig bufferRingConfig = new IoUringBufferRingConfig(
                 // let's use a small chunkSize so we are sure a recv will span multiple buffers.
-                (short) 1, (short) 16, incremental, new IoUringFixedBufferRingAllocator(bufferRingChunkSize));
+                (short) 1, (short) 16, 16 * 16, incremental, new IoUringFixedBufferRingAllocator(bufferRingChunkSize));
 
         ioUringIoHandlerConfiguration.setBufferRingConfig(bufferRingConfig);
 

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketTestPermutation.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketTestPermutation.java
@@ -46,7 +46,7 @@ public class IoUringSocketTestPermutation extends SocketTestPermutation {
             WORKERS, new DefaultThreadFactory("testsuite-io_uring-worker", true),
             IoUringIoHandler.newFactory(new IoUringIoHandlerConfig()
                     .setBufferRingConfig(
-                            new IoUringBufferRingConfig(BGID, (short) 16,
+                            new IoUringBufferRingConfig(BGID, (short) 16, 16 * 16,
                                     new IoUringFixedBufferRingAllocator(1024)))));
     @Override
     public List<BootstrapComboFactory<ServerBootstrap, Bootstrap>> socket() {


### PR DESCRIPTION
Motivation:

When using a buffer ring combined with multishot recv and recv bundles it's possible that we read so fast that we eventually will run out of memory. We should try to slow down a bit when we have too many buffers used.

Modifications:

- Keep track of how many unreleased buffers we have used out of the ring and only use it when this number did not reach a threshold.

Result:

Guard against OOME.
