### PR TITLE
IoUring: Use IORING_SETUP_CLAMP when setup the ring

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -208,6 +208,8 @@ final class Native {
     static final byte IORING_CQE_F_BUF_MORE = 1 << 4;
 
     static final int IORING_SETUP_CQSIZE = 1 << 3;
+    static final int IORING_SETUP_CLAMP = 1 << 4;
+
     static final int IORING_SETUP_R_DISABLED = 1 << 6;
     static final int IORING_SETUP_SUBMIT_ALL = 1 << 7;
     static final int IORING_SETUP_SINGLE_ISSUER = 1 << 12;
@@ -320,7 +322,7 @@ final class Native {
     };
 
     static int setupFlags() {
-        int flags = Native.IORING_SETUP_R_DISABLED;
+        int flags = Native.IORING_SETUP_R_DISABLED | Native.IORING_SETUP_CLAMP;
         if (IoUring.isSetupSubmitAllSupported()) {
             flags |= Native.IORING_SETUP_SUBMIT_ALL;
         }


### PR DESCRIPTION
Motivation:

There is no way to know what the maximum size is that is supported by the kernel. Let's use IORING_SETUP_CLAMP to allow the kernel to clamp it if needed.

Modification:

Use IORING_SETUP_CLAMP (which is supported till kernel 5.6)

Result:

Don't fail if a ring size is used that is not supported by the kernel
