### PR TITLE
Make PooledByteBufAllocator friendly with virtual threads

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolThreadCache.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolThreadCache.java
@@ -64,6 +64,8 @@ final class PoolThreadCache {
     private int allocations;
     // A special `PoolThreadCache` that is not stored in thread-local.
     static final PoolThreadCache THREAD_CACHE_WITHOUT_THREAD_LOCAL = new PoolThreadCache();
+    final int smallCacheSize;
+    final int normalCacheSize;
 
     // TODO: Test if adding padding helps under contention
     //private long pad0, pad1, pad2, pad3, pad4, pad5, pad6, pad7;
@@ -75,6 +77,8 @@ final class PoolThreadCache {
         this.freeSweepAllocationThreshold = freeSweepAllocationThreshold;
         this.heapArena = heapArena;
         this.directArena = directArena;
+        this.smallCacheSize = smallCacheSize;
+        this.normalCacheSize = normalCacheSize;
         if (directArena != null) {
             smallSubPageDirectCaches = createSubPageCaches(smallCacheSize, directArena.sizeClass.nSubpages);
             normalDirectCaches = createNormalCaches(normalCacheSize, maxCachedBufferCapacity, directArena);
@@ -115,6 +119,8 @@ final class PoolThreadCache {
         this.smallSubPageHeapCaches = null;
         this.normalHeapCaches = null;
         this.freeOnFinalize = null;
+        this.smallCacheSize = 0;
+        this.normalCacheSize = 0;
     }
 
     private static <T> MemoryRegionCache<T>[] createSubPageCaches(

--- a/buffer/src/main/java/io/netty/buffer/PoolThreadCache.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolThreadCache.java
@@ -62,6 +62,8 @@ final class PoolThreadCache {
     private final FreeOnFinalize freeOnFinalize;
 
     private int allocations;
+    // A special `PoolThreadCache` that is not stored in thread-local.
+    static final PoolThreadCache THREAD_CACHE_WITHOUT_THREAD_LOCAL = new PoolThreadCache();
 
     // TODO: Test if adding padding helps under contention
     //private long pad0, pad1, pad2, pad3, pad4, pad5, pad6, pad7;
@@ -101,6 +103,18 @@ final class PoolThreadCache {
                     + freeSweepAllocationThreshold + " (expected: > 0)");
         }
         freeOnFinalize = useFinalizer ? new FreeOnFinalize(this) : null;
+    }
+
+    /** Creates a special `PoolThreadCache` that is not stored in thread-local. */
+    PoolThreadCache() {
+        this.freeSweepAllocationThreshold = 0;
+        this.heapArena = null;
+        this.directArena = null;
+        this.smallSubPageDirectCaches = null;
+        this.normalDirectCaches = null;
+        this.smallSubPageHeapCaches = null;
+        this.normalHeapCaches = null;
+        this.freeOnFinalize = null;
     }
 
     private static <T> MemoryRegionCache<T>[] createSubPageCaches(
@@ -167,6 +181,10 @@ final class PoolThreadCache {
             trim();
         }
         return allocated;
+    }
+
+    boolean useThreadLocal() {
+        return this != THREAD_CACHE_WITHOUT_THREAD_LOCAL;
     }
 
     /**

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -538,8 +538,8 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
                     if (useCacheForAllThreads ||
                             // If the current thread is a FastThreadLocalThread we will always use the cache
                             current instanceof FastThreadLocalThread ||
-                            // The Thread is used by an EventExecutor, let's use the cache as the chances are good that we
-                            // will allocate a lot!
+                            // The Thread is used by an EventExecutor,
+                            // let's use the cache as the chances are good that we will allocate a lot!
                             executor != null) {
                         final PoolThreadCache cache = new PoolThreadCache(
                                 heapArena, directArena, smallCacheSize, normalCacheSize,

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -574,7 +574,6 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
             }
         }
 
-
         private PoolArena<byte[]> selectHeapArena() {
             if (heapArenas == null || heapArenas.length == 0) {
                 return null;

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -57,6 +57,7 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
     private static final int MAX_CHUNK_SIZE = (int) (((long) Integer.MAX_VALUE + 1) / 2);
 
     private static final int CACHE_NOT_USED = 0;
+
     private final Runnable trimTask = new Runnable() {
         @Override
         public void run() {
@@ -531,10 +532,12 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
                 @Override
                 protected synchronized PoolThreadCache initialValue() {
                     // Virtual thread should NEVER reach here, which guarded by method `PoolThreadLocalCache.get()`.
-                    final Thread current = Thread.currentThread();
-                    final EventExecutor executor = ThreadExecutorMap.currentExecutor();
                     final PoolArena<byte[]> heapArena = leastUsedArena(heapArenas);
                     final PoolArena<ByteBuffer> directArena = leastUsedArena(directArenas);
+
+                    final Thread current = Thread.currentThread();
+                    final EventExecutor executor = ThreadExecutorMap.currentExecutor();
+
                     if (useCacheForAllThreads ||
                             // If the current thread is a FastThreadLocalThread we will always use the cache
                             current instanceof FastThreadLocalThread ||

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -574,9 +574,6 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
             }
         }
 
-        private boolean feasibleToUseThreadLocal(Thread thread) {
-            return PlatformDependent.checkVirtualThread(thread) == 1;
-        }
 
         private PoolArena<byte[]> selectHeapArena() {
             if (heapArenas == null || heapArenas.length == 0) {
@@ -620,6 +617,10 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
 
             return minArena;
         }
+    }
+
+    private static boolean feasibleToUseThreadLocal(Thread thread) {
+        return PlatformDependent.checkVirtualThread(thread) == 1;
     }
 
     private static boolean useCacheFinalizers(Thread current) {

--- a/buffer/src/main/java/io/netty/buffer/PooledDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledDirectByteBuf.java
@@ -41,7 +41,11 @@ final class PooledDirectByteBuf extends PooledByteBuf<ByteBuffer> {
         return buf;
     }
 
-    private PooledDirectByteBuf(Handle<PooledDirectByteBuf> recyclerHandle, int maxCapacity) {
+    static PooledDirectByteBuf newInstanceNoThreadLocal(Handle<PooledByteBuf<ByteBuffer>> handle) {
+        return new PooledDirectByteBuf(handle, 0);
+    }
+
+    private PooledDirectByteBuf(Handle<? extends PooledByteBuf<ByteBuffer>> recyclerHandle, int maxCapacity) {
         super(recyclerHandle, maxCapacity);
     }
 

--- a/buffer/src/main/java/io/netty/buffer/PooledHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledHeapByteBuf.java
@@ -40,6 +40,10 @@ class PooledHeapByteBuf extends PooledByteBuf<byte[]> {
         return buf;
     }
 
+    static PooledHeapByteBuf newInstanceNoThreadLocal(Handle<PooledHeapByteBuf> handle) {
+        return new PooledHeapByteBuf(handle, 0);
+    }
+
     PooledHeapByteBuf(Handle<? extends PooledHeapByteBuf> recyclerHandle, int maxCapacity) {
         super(recyclerHandle, maxCapacity);
     }

--- a/buffer/src/main/java/io/netty/buffer/PooledUnsafeDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledUnsafeDirectByteBuf.java
@@ -41,9 +41,13 @@ final class PooledUnsafeDirectByteBuf extends PooledByteBuf<ByteBuffer> {
         return buf;
     }
 
+    static PooledUnsafeDirectByteBuf newInstanceNoThreadLocal(Handle<PooledByteBuf<ByteBuffer>> handle) {
+        return new PooledUnsafeDirectByteBuf(handle, 0);
+    }
+
     private long memoryAddress;
 
-    private PooledUnsafeDirectByteBuf(Handle<PooledUnsafeDirectByteBuf> recyclerHandle, int maxCapacity) {
+    private PooledUnsafeDirectByteBuf(Handle<? extends PooledByteBuf<ByteBuffer>> recyclerHandle, int maxCapacity) {
         super(recyclerHandle, maxCapacity);
     }
 

--- a/buffer/src/main/java/io/netty/buffer/PooledUnsafeHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledUnsafeHeapByteBuf.java
@@ -36,7 +36,11 @@ final class PooledUnsafeHeapByteBuf extends PooledHeapByteBuf {
         return buf;
     }
 
-    private PooledUnsafeHeapByteBuf(Handle<PooledUnsafeHeapByteBuf> recyclerHandle, int maxCapacity) {
+    static PooledUnsafeHeapByteBuf newInstanceNoThreadLocal(Handle<PooledHeapByteBuf> handle) {
+        return new PooledUnsafeHeapByteBuf(handle, 0);
+    }
+
+    private PooledUnsafeHeapByteBuf(Handle<? extends PooledHeapByteBuf> recyclerHandle, int maxCapacity) {
         super(recyclerHandle, maxCapacity);
     }
 


### PR DESCRIPTION
Motivation:

In short, this PR makes `PooledByteBufAllocator.DEFAULT` friendly with virtual threads.

It's better to make `PooledByteBufAllocator` friendly with virtual threads, there was another PR https://github.com/netty/netty/pull/14607 done similar thing, but it made a global decision on the constructor to instruct the allocator, this PR instruct the allocator whether to use thread-local based on the thread type, as @franz1981 suggested via https://github.com/netty/netty/pull/14607#discussion_r1894581153.

In this PR, the `PooledByteBufAllocator` use thread-local when the thread type is event-loop(`FastThreadLocalThread`), otherwise, if virtual threads or normal platform threads, the allocator does not use thread-local.

It might be better to let normal platform threads use thread-local too, but it requires a method handler(call `isVirtual()`), I will add this handler if needed in the future. 

Following are some benchmarking results, the benchmark code: [ByteBufAllocatorConcurrentBenchmark](https://github.com/laosijikaichele/netty/blob/tmp/microbench/0301/ByteBufAllocatorConcurrentBenchmark.java), which benchmark on the default `PooledByteBufAllocator.DEFAULT` and `AdaptiveByteBufAllocator`(for comparation), with JDK-21, M1 chip, 8 cores, 16G RAM:

**Use event-loop(`FastThreadLocalThread`) threads(8 threads):**
Before PR:
```
Benchmark                                                    (size)   Mode  Cnt         Score          Error  Units
ByteBufAllocatorConcurrentBenchmark.allocateReleaseAdaptive   00064  thrpt   20  88330081.136 ±  5037031.882  ops/s
ByteBufAllocatorConcurrentBenchmark.allocateReleaseAdaptive   00256  thrpt   20  89871472.042 ± 21346695.226  ops/s
ByteBufAllocatorConcurrentBenchmark.allocateReleaseAdaptive   01024  thrpt   20  78504680.692 ± 21982671.256  ops/s
ByteBufAllocatorConcurrentBenchmark.allocateReleaseAdaptive   04096  thrpt   20  72127653.154 ±  1417842.181  ops/s
ByteBufAllocatorConcurrentBenchmark.allocateReleasePooled     00064  thrpt   20  91054515.118 ±   419255.100  ops/s
ByteBufAllocatorConcurrentBenchmark.allocateReleasePooled     00256  thrpt   20  83165530.913 ±  6702270.137  ops/s
ByteBufAllocatorConcurrentBenchmark.allocateReleasePooled     01024  thrpt   20  88603270.902 ±   666014.029  ops/s
ByteBufAllocatorConcurrentBenchmark.allocateReleasePooled     04096  thrpt   20  79977401.394 ±  8353521.171  ops/s
```
After PR:
```
Benchmark                                                    (size)   Mode  Cnt         Score         Error  Units
ByteBufAllocatorConcurrentBenchmark.allocateReleaseAdaptive   00064  thrpt   20  73216063.559 ± 2040971.965  ops/s
ByteBufAllocatorConcurrentBenchmark.allocateReleaseAdaptive   00256  thrpt   20  76767063.513 ± 1730893.726  ops/s
ByteBufAllocatorConcurrentBenchmark.allocateReleaseAdaptive   01024  thrpt   20  99035714.952 ± 8729132.519  ops/s
ByteBufAllocatorConcurrentBenchmark.allocateReleaseAdaptive   04096  thrpt   20  66960699.666 ± 7575289.284  ops/s
ByteBufAllocatorConcurrentBenchmark.allocateReleasePooled     00064  thrpt   20  87781083.219 ±  363728.822  ops/s
ByteBufAllocatorConcurrentBenchmark.allocateReleasePooled     00256  thrpt   20  90460389.702 ±  360119.721  ops/s
ByteBufAllocatorConcurrentBenchmark.allocateReleasePooled     01024  thrpt   20  89990609.228 ± 1368144.074  ops/s
ByteBufAllocatorConcurrentBenchmark.allocateReleasePooled     04096  thrpt   20  91623220.419 ± 1618839.974  ops/s
```


**Use normal platform threads(8 threads):**
Before PR:
```
Benchmark                                                    (size)   Mode  Cnt         Score         Error  Units
ByteBufAllocatorConcurrentBenchmark.allocateReleaseAdaptive   00064  thrpt   20  69719960.924 ± 3544372.539  ops/s
ByteBufAllocatorConcurrentBenchmark.allocateReleaseAdaptive   00256  thrpt   20  61882436.213 ± 1334615.684  ops/s
ByteBufAllocatorConcurrentBenchmark.allocateReleaseAdaptive   01024  thrpt   20  60091641.208 ±  727157.051  ops/s
ByteBufAllocatorConcurrentBenchmark.allocateReleaseAdaptive   04096  thrpt   20  60916323.123 ± 3760421.873  ops/s
ByteBufAllocatorConcurrentBenchmark.allocateReleasePooled     00064  thrpt   20  71549724.503 ±  831271.688  ops/s
ByteBufAllocatorConcurrentBenchmark.allocateReleasePooled     00256  thrpt   20  71959285.223 ±  530098.030  ops/s
ByteBufAllocatorConcurrentBenchmark.allocateReleasePooled     01024  thrpt   20  70358120.108 ±  359661.461  ops/s
ByteBufAllocatorConcurrentBenchmark.allocateReleasePooled     04096  thrpt   20  68924374.063 ±  889450.468  ops/s
```
After PR:
```
Benchmark                                                    (size)   Mode  Cnt         Score          Error  Units
ByteBufAllocatorConcurrentBenchmark.allocateReleaseAdaptive   00064  thrpt   20  77024154.725 ±  6860884.114  ops/s
ByteBufAllocatorConcurrentBenchmark.allocateReleaseAdaptive   00256  thrpt   20  75523953.520 ±  2820518.874  ops/s
ByteBufAllocatorConcurrentBenchmark.allocateReleaseAdaptive   01024  thrpt   20  70797135.674 ±  3150582.623  ops/s
ByteBufAllocatorConcurrentBenchmark.allocateReleaseAdaptive   04096  thrpt   20  57482330.057 ± 10720046.853  ops/s
ByteBufAllocatorConcurrentBenchmark.allocateReleasePooled     00064  thrpt   20  64865343.834 ±   681320.296  ops/s
ByteBufAllocatorConcurrentBenchmark.allocateReleasePooled     00256  thrpt   20  62511783.012 ±  1381261.696  ops/s
ByteBufAllocatorConcurrentBenchmark.allocateReleasePooled     01024  thrpt   20  62956876.888 ±  1077958.872  ops/s
ByteBufAllocatorConcurrentBenchmark.allocateReleasePooled     04096  thrpt   20  63649065.328 ±  1715389.715  ops/s
```

Now let's benchmark with virtual threads, because JMH does not work well with virtual threads, so I use the custom test code: [PooledByteBufVirtualThreadBenchMark](https://github.com/laosijikaichele/netty/blob/tmp/microbench/0301/PooledByteBufVirtualThreadBenchMark.java).

**Use virtual threads(1000000 threads):**
**(NOTE: The less duration, the better performance)**
Before PR:
```
Adaptive alloc avg duration: 1231
Default alloc avg duration: 1325
---------------------------------------
Adaptive alloc avg duration: 1089
Default alloc avg duration: 1128
---------------------------------------
Adaptive alloc avg duration: 1184
Default alloc avg duration: 1169
---------------------------------------
Adaptive alloc avg duration: 1391
Default alloc avg duration: 1173
---------------------------------------
Adaptive alloc avg duration: 1555
Default alloc avg duration: 1222
---------------------------------------
```
After PR:
```
Adaptive alloc avg duration: 1103
Default alloc avg duration: 892
---------------------------------------
Adaptive alloc avg duration: 1291
Default alloc avg duration: 834
---------------------------------------
Adaptive alloc avg duration: 1199
Default alloc avg duration: 796
---------------------------------------
Adaptive alloc avg duration: 1303
Default alloc avg duration: 946
---------------------------------------
Adaptive alloc avg duration: 1167
Default alloc avg duration: 879
---------------------------------------
```

Analyse:
(The adaptive alloc is mainly used for reference, let's focus on the default alloc)

**When the thread type is event-loop: 
The default alloc performance has no obvious change after PR.**

**When the thread type is normal platform thread: 
The default alloc performance shows degradation after PR: degraded -8% ~ -14%.**
(which makes sense, because it does not use thread-local).

**When the thread type is virtual thread: 
The default alloc performance shows obvious improvement after PR: improved 24+% ~ +48%**

Currently this PR is in draft stage, will update if needed...
