### PR TITLE
ManualIoEventLoop::shutdown should work outside owning Thread

### DIFF
--- a/transport/src/main/java/io/netty/channel/ManualIoEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/ManualIoEventLoop.java
@@ -44,12 +44,12 @@ import java.util.concurrent.atomic.AtomicInteger;
  * {@link #waitAndRun()}} methods are called in a timely fashion.
  */
 public final class ManualIoEventLoop extends AbstractScheduledEventExecutor implements IoEventLoop {
-    private static final int ST_STARTED = 4;
-    private static final int ST_SHUTTING_DOWN = 5;
-    private static final int ST_SHUTDOWN = 6;
-    private static final int ST_TERMINATED = 7;
+    private static final int ST_STARTED = 0;
+    private static final int ST_SHUTTING_DOWN = 1;
+    private static final int ST_SHUTDOWN = 2;
+    private static final int ST_TERMINATED = 3;
 
-    private final AtomicInteger state = new AtomicInteger();
+    private final AtomicInteger state;
     private final Promise<?> terminationFuture = new DefaultPromise<Void>(GlobalEventExecutor.INSTANCE);
     private final Queue<Runnable> taskQueue = PlatformDependent.newMpscQueue();
     private final IoHandlerContext nonBlockingContext = new IoHandlerContext() {
@@ -95,6 +95,7 @@ public final class ManualIoEventLoop extends AbstractScheduledEventExecutor impl
     public ManualIoEventLoop(Thread owningThread, IoHandlerFactory factory) {
         this.owningThread = Objects.requireNonNull(owningThread, "owningThread");
         this.handler = factory.newHandler(this);
+        state = new AtomicInteger(ST_STARTED);
     }
 
     private int runAllTasks() {


### PR DESCRIPTION
Motivation:
ManualIoEventLoop is not correctly handling shutdown outside of the owner Thread

Modifications:
Correctly initialize the event loop's state to be ST_STARTED

Result:
It's now possible to shutdown the manual event loop outside of the owner Thread
