### PR TITLE
Disable assertion by default in JMH tests (#14878)

### DIFF
--- a/microbench/src/main/java/io/netty/microbench/buffer/AdaptiveByteBufAllocatorConcurrentNoCacheBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/AdaptiveByteBufAllocatorConcurrentNoCacheBenchmark.java
@@ -44,7 +44,7 @@ public class AdaptiveByteBufAllocatorConcurrentNoCacheBenchmark extends Abstract
     private int size;
 
     public AdaptiveByteBufAllocatorConcurrentNoCacheBenchmark() {
-        super(false, true);
+        super(true, true);
     }
 
     @Benchmark

--- a/microbench/src/main/java/io/netty/microbench/concurrent/FastThreadLocalSlowPathBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/concurrent/FastThreadLocalSlowPathBenchmark.java
@@ -57,7 +57,7 @@ public class FastThreadLocalSlowPathBenchmark extends AbstractMicrobenchmark {
     }
 
     public FastThreadLocalSlowPathBenchmark() {
-        super(false, true);
+        super(true, true);
     }
 
     @Benchmark

--- a/microbench/src/main/java/io/netty/microbench/util/AbstractMicrobenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/util/AbstractMicrobenchmark.java
@@ -106,14 +106,31 @@ public class AbstractMicrobenchmark extends AbstractMicrobenchmarkBase {
 
     private final String[] jvmArgs;
 
+    /**
+     * Default settings:
+     * <br>
+     * Disable assertion in package: {@code io.netty.*}, except {@code io.netty.microbench.*}.
+     * <br>
+     * Use custom {@code HarnessExecutor}.
+     */
     public AbstractMicrobenchmark() {
-        this(false, false);
+        this(true, false);
     }
 
+    /**
+     * @param disableAssertions If true, it will disable assertion in package: {@code io.netty.*},
+     *                          except {@code io.netty.microbench.*},
+     *                          which means package {@code io.netty.microbench.*} always gets assertion enabled.
+     */
     public AbstractMicrobenchmark(boolean disableAssertions) {
         this(disableAssertions, false);
     }
 
+    /**
+     * @param disableAssertions If true, it will disable assertion in package: {@code io.netty.*},
+     *                          except {@code io.netty.microbench.*},
+     *                          which means package {@code io.netty.microbench.*} always gets assertion enabled.
+     */
     public AbstractMicrobenchmark(boolean disableAssertions, boolean disableHarnessExecutor) {
 
         final List<String> jvmArgs = new ArrayList<>(Arrays.asList(BASE_JVM_ARGS));
@@ -129,6 +146,8 @@ public class AbstractMicrobenchmark extends AbstractMicrobenchmarkBase {
         }
         if (disableAssertions) {
             removeAssertions(jvmArgs);
+            // Enable assertion in 'io.netty.microbench.*' package.
+            jvmArgs.add("-ea:io.netty.microbench...");
         }
         this.jvmArgs = jvmArgs.toArray(EmptyArrays.EMPTY_STRINGS);
     }


### PR DESCRIPTION
Motivation:

Disable assertion by default in JMH tests, to exclude the noise introduced by assertion.

Modification:

Disable assertion in default constructor of `AbstractMicrobenchmark`, also make existing tests `FastThreadLocalSlowPathBenchmark` and `AdaptiveByteBufAllocatorConcurrentNoCacheBenchmark` aligned with this.

Assertion will always be enabled in package `io.netty.microbench.*`.

Result:

Fixes #14876.