### PR TITLE
Use ubuntu-latest for github workflow run (#14886)

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -106,7 +106,7 @@ jobs:
 
   build-pr-cross:
     # The host should always be Linux
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Motivation:

We had ubuntu-20.04 hardcoded in one place which failed the build now as these are deprecated. Just use ubuntu-latest

Modifications:

Use ubuntu-latest

Result:

CI build works again
