### PR TITLE
ThreadExecutorMap.currentExecutor() should work when using a ManualIo…

### DIFF
--- a/common/src/main/java/io/netty/util/internal/ThreadExecutorMap.java
+++ b/common/src/main/java/io/netty/util/internal/ThreadExecutorMap.java
@@ -40,7 +40,7 @@ public final class ThreadExecutorMap {
     /**
      * Set the current {@link EventExecutor} that is used by the {@link Thread}.
      */
-    private static void setCurrentEventExecutor(EventExecutor executor) {
+    public static void setCurrentExecutor(EventExecutor executor) {
         mappings.set(executor);
     }
 
@@ -69,11 +69,11 @@ public final class ThreadExecutorMap {
         return new Runnable() {
             @Override
             public void run() {
-                setCurrentEventExecutor(eventExecutor);
+                setCurrentExecutor(eventExecutor);
                 try {
                     command.run();
                 } finally {
-                    setCurrentEventExecutor(null);
+                    setCurrentExecutor(null);
                 }
             }
         };

--- a/transport/src/test/java/io/netty/channel/ManualIoEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/ManualIoEventLoopTest.java
@@ -15,14 +15,18 @@
  */
 package io.netty.channel;
 
+import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Promise;
+import io.netty.util.internal.ThreadExecutorMap;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.function.Executable;
 
 import java.util.Collections;
 import java.util.Set;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
@@ -31,6 +35,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -110,6 +116,24 @@ public class ManualIoEventLoopTest {
 
         assertThrows(IllegalStateException.class, eventLoop::runNow);
         assertThrows(IllegalStateException.class, () -> eventLoop.run(10));
+    }
+
+    @Test
+    public void testThreadEventExecutorMap() throws Exception {
+        final BlockingQueue<EventExecutor> queue = new LinkedBlockingQueue<>();
+        Semaphore semaphore = new Semaphore(0);
+        ManualIoEventLoop eventLoop = new ManualIoEventLoop(Thread.currentThread(), executor ->
+                new TestIoHandler(semaphore));
+        assertNull(ThreadExecutorMap.currentExecutor());
+        eventLoop.execute(() -> queue.offer(ThreadExecutorMap.currentExecutor()));
+        assertEquals(1, eventLoop.runNow());
+        assertSame(eventLoop, queue.take());
+        eventLoop.shutdown();
+
+        while (!eventLoop.isTerminated()) {
+            eventLoop.runNow();
+        }
+        eventLoop.terminationFuture().sync();
     }
 
     @Test


### PR DESCRIPTION
…EventLoop

Motivation:

ThreadExecutorMap.currentExecutor() should return the correct method when ManualIoEventLoop is used.

Modifications:

- Expose ThreadExecutorMap.setCurrentExecutor(...)
- Correct set and reset the executor
- Add test case

Result:

Be able to access current Executor when using ManualIoEventLoop
