### PR TITLE
IoUring: Use IORING_ENTER_GETEVENTS if we want to fill the completion…

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/SubmissionQueue.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/SubmissionQueue.java
@@ -209,20 +209,44 @@ final class SubmissionQueue {
                 udata, (short) 0, (short) 0, 0, 0);
     }
 
+    /**
+     * Submit entries.
+     *
+     * @return  the number of submitted entries.
+     */
     int submit() {
         checkClosed();
         int submit = tail - head;
         return submit > 0 ? submit(submit, 0, 0) : 0;
     }
 
-    int submitAndWait() {
+    /**
+     * Submit entries and fetch completions. This method will block until there is at least one completion ready to be
+     * processed.
+     *
+     * @return  the number of submitted entries.
+     */
+    int submitAndGet() {
+        return submitAndGet0(1);
+    }
+
+    /**
+     * Submit entries and fetch completions.
+     *
+     * @return  the number of submitted entries.
+     */
+    int submitAndGetNow() {
+        return submitAndGet0(0);
+    }
+
+    private int submitAndGet0(int minComplete) {
         checkClosed();
         int submit = tail - head;
         if (submit > 0) {
-            return submit(submit, 1, Native.IORING_ENTER_GETEVENTS);
+            return submit(submit, minComplete, Native.IORING_ENTER_GETEVENTS);
         }
         assert submit == 0;
-        int ret = ioUringEnter(0, 1, Native.IORING_ENTER_GETEVENTS);
+        int ret = ioUringEnter(0, minComplete, Native.IORING_ENTER_GETEVENTS);
         if (ret < 0) {
             throw new RuntimeException("ioUringEnter syscall returned " + ret);
         }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/SubmissionQueueTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/SubmissionQueueTest.java
@@ -51,7 +51,7 @@ public class SubmissionQueueTest {
             assertEquals(8, submissionQueue.count());
             assertThat(submissionQueue.addNop((byte) 0, 1)).isNotZero();
             assertEquals(1, submissionQueue.count());
-            submissionQueue.submitAndWait();
+            submissionQueue.submitAndGet();
             assertEquals(9, completionQueue.count());
         } finally {
             ringBuffer.close();
@@ -74,7 +74,7 @@ public class SubmissionQueueTest {
         assertThrows(IllegalStateException.class, () -> submissionQueue.addNop((byte) 0, 1));
         assertThrows(IllegalStateException.class, submissionQueue::tryRegisterRingFd);
         assertThrows(IllegalStateException.class, submissionQueue::submit);
-        assertThrows(IllegalStateException.class, submissionQueue::submitAndWait);
+        assertThrows(IllegalStateException.class, submissionQueue::submitAndGet);
 
         assertEquals(0, completionQueue.count());
         assertFalse(completionQueue.hasCompletions());
@@ -104,7 +104,7 @@ public class SubmissionQueueTest {
                 assertThat(ringBuffer.ioUringSubmissionQueue().addNop((byte) 0, 1)).isNotZero();
                 count--;
                 if (ringBuffer.ioUringSubmissionQueue().remaining() == 0) {
-                    ringBuffer.ioUringSubmissionQueue().submitAndWait();
+                    ringBuffer.ioUringSubmissionQueue().submitAndGet();
                 }
             }
 


### PR DESCRIPTION
… queue.

Motivation:

If we want to have completion events show up in the completion queue we need to use IORING_ENTER_GETEVENTS.

Modifications:

- Use IORING_ENTER_GETEVENTS when we want to also fetch completion events to process
- Rename submitAndWait() to submitAndGet()
- Add submitAndGetNow() which is a non-blocking variant that correctly use IORING_ENTER_GETEVENTS.
- Replace submit() calls with submitAndGetNow() when we also want to fetch completion events.

Result:

Correctly fetch completion events