### PR TITLE
ThreadExecutorMap must restore old EventExecutor

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/FastThreadLocal.java
+++ b/common/src/main/java/io/netty/util/concurrent/FastThreadLocal.java
@@ -205,7 +205,7 @@ public class FastThreadLocal<V> {
     /**
      * Set the value for the current thread and returns the old value.
      */
-    public final V getAndSet(V value) {
+    public V getAndSet(V value) {
         if (value != InternalThreadLocalMap.UNSET) {
             InternalThreadLocalMap threadLocalMap = InternalThreadLocalMap.get();
             return setKnownNotUnset(threadLocalMap, value);
@@ -216,7 +216,7 @@ public class FastThreadLocal<V> {
     /**
      * Set the value for the specified thread local map. The specified thread local map must be for the current thread.
      */
-    public final V getAndSet(InternalThreadLocalMap threadLocalMap, V value) {
+    public V getAndSet(InternalThreadLocalMap threadLocalMap, V value) {
         if (value != InternalThreadLocalMap.UNSET) {
             return setKnownNotUnset(threadLocalMap, value);
         }

--- a/common/src/main/java/io/netty/util/internal/InternalThreadLocalMap.java
+++ b/common/src/main/java/io/netty/util/internal/InternalThreadLocalMap.java
@@ -331,15 +331,21 @@ public final class InternalThreadLocalMap extends UnpaddedInternalThreadLocalMap
      * @return {@code true} if and only if a new thread-local variable has been created
      */
     public boolean setIndexedVariable(int index, Object value) {
+        return getAndSetIndexedVariable(index, value) == UNSET;
+    }
+
+    /**
+     * @return {@link InternalThreadLocalMap#UNSET} if and only if a new thread-local variable has been created.
+     */
+    public Object getAndSetIndexedVariable(int index, Object value) {
         Object[] lookup = indexedVariables;
         if (index < lookup.length) {
             Object oldValue = lookup[index];
             lookup[index] = value;
-            return oldValue == UNSET;
-        } else {
-            expandIndexedVariableTableAndSet(index, value);
-            return true;
+            return oldValue;
         }
+        expandIndexedVariableTableAndSet(index, value);
+        return UNSET;
     }
 
     private void expandIndexedVariableTableAndSet(int index, Object value) {

--- a/common/src/main/java/io/netty/util/internal/ThreadExecutorMap.java
+++ b/common/src/main/java/io/netty/util/internal/ThreadExecutorMap.java
@@ -40,8 +40,8 @@ public final class ThreadExecutorMap {
     /**
      * Set the current {@link EventExecutor} that is used by the {@link Thread}.
      */
-    public static void setCurrentExecutor(EventExecutor executor) {
-        mappings.set(executor);
+    public static EventExecutor setCurrentExecutor(EventExecutor executor) {
+        return mappings.getAndSet(executor);
     }
 
     /**
@@ -69,11 +69,11 @@ public final class ThreadExecutorMap {
         return new Runnable() {
             @Override
             public void run() {
-                setCurrentExecutor(eventExecutor);
+                EventExecutor old = setCurrentExecutor(eventExecutor);
                 try {
                     command.run();
                 } finally {
-                    setCurrentExecutor(null);
+                    setCurrentExecutor(old);
                 }
             }
         };

--- a/common/src/test/java/io/netty/util/concurrent/FastThreadLocalTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/FastThreadLocalTest.java
@@ -47,6 +47,20 @@ public class FastThreadLocalTest {
     }
 
     @Test
+    public void testGetAndSetReturnsOldValue() {
+        FastThreadLocal<Boolean> threadLocal = new FastThreadLocal<Boolean>() {
+            @Override
+            protected Boolean initialValue() {
+                return Boolean.TRUE;
+            }
+        };
+
+        assertNull(threadLocal.getAndSet(Boolean.FALSE));
+        assertEquals(Boolean.FALSE, threadLocal.get());
+        threadLocal.remove();
+    }
+
+    @Test
     public void testGetIfExists() {
         FastThreadLocal<Boolean> threadLocal = new FastThreadLocal<Boolean>() {
             @Override

--- a/common/src/test/java/io/netty/util/concurrent/FastThreadLocalTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/FastThreadLocalTest.java
@@ -57,6 +57,8 @@ public class FastThreadLocalTest {
 
         assertNull(threadLocal.getAndSet(Boolean.FALSE));
         assertEquals(Boolean.FALSE, threadLocal.get());
+        assertEquals(Boolean.FALSE, threadLocal.getAndSet(Boolean.TRUE));
+        assertEquals(Boolean.TRUE, threadLocal.get());
         threadLocal.remove();
     }
 

--- a/common/src/test/java/io/netty/util/internal/ThreadExecutorMapTest.java
+++ b/common/src/test/java/io/netty/util/internal/ThreadExecutorMapTest.java
@@ -15,17 +15,86 @@
  */
 package io.netty.util.internal;
 
+import io.netty.util.concurrent.AbstractEventExecutor;
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.ImmediateExecutor;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class ThreadExecutorMapTest {
+    private static final EventExecutor EVENT_EXECUTOR = new AbstractEventExecutor() {
+        @Override
+        public void shutdown() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean inEventLoop(Thread thread) {
+            return false;
+        }
+
+        @Override
+        public boolean isShuttingDown() {
+            return false;
+        }
+
+        @Override
+        public Future<?> shutdownGracefully(long quietPeriod, long timeout, TimeUnit unit) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Future<?> terminationFuture() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isShutdown() {
+            return false;
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return false;
+        }
+
+        @Override
+        public boolean awaitTermination(long timeout, @NotNull TimeUnit unit) {
+            return false;
+        }
+
+        @Override
+        public void execute(@NotNull Runnable command) {
+            throw new UnsupportedOperationException();
+        }
+    };
+
+    @Test
+    public void testOldExecutorIsRestored() {
+        Executor executor = ThreadExecutorMap.apply(ImmediateExecutor.INSTANCE, ImmediateEventExecutor.INSTANCE);
+        Executor executor2 = ThreadExecutorMap.apply(ImmediateExecutor.INSTANCE, EVENT_EXECUTOR);
+        executor.execute(new Runnable() {
+            @Override
+            public void run() {
+                executor2.execute(new Runnable() {
+                    @Override
+                    public void run() {
+                        assertSame(EVENT_EXECUTOR, ThreadExecutorMap.currentExecutor());
+                    }
+                });
+                assertSame(ImmediateEventExecutor.INSTANCE, ThreadExecutorMap.currentExecutor());
+            }
+        });
+    }
 
     @Test
     public void testDecorateExecutor() {

--- a/transport/src/main/java/io/netty/channel/ManualIoEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/ManualIoEventLoop.java
@@ -17,6 +17,7 @@ package io.netty.channel;
 
 import io.netty.util.concurrent.AbstractScheduledEventExecutor;
 import io.netty.util.concurrent.DefaultPromise;
+import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GlobalEventExecutor;
 import io.netty.util.concurrent.Promise;
@@ -143,7 +144,7 @@ public final class ManualIoEventLoop extends AbstractScheduledEventExecutor impl
             initialized = true;
             handler.initialize();
         }
-        ThreadExecutorMap.setCurrentExecutor(this);
+        EventExecutor old = ThreadExecutorMap.setCurrentExecutor(this);
         try {
             if (isShuttingDown()) {
                 if (terminationFuture.isDone()) {
@@ -175,7 +176,7 @@ public final class ManualIoEventLoop extends AbstractScheduledEventExecutor impl
             // Now run all tasks.
             return run + runAllTasks();
         } finally {
-            ThreadExecutorMap.setCurrentExecutor(null);
+            ThreadExecutorMap.setCurrentExecutor(old);
         }
     }
 


### PR DESCRIPTION
Motivation:

ThreadExecutorMap did just set the stored EventExecutor to null once done in its wrapping methods. This is not correct as this might result in losing the current EventExecutor. Beside this the same problem existed in ManualIoEventLoop.

Modifications:

 - Add FastThreadLocal.getAndSet(...) that return the old stored value
- Keep track of the old value in ThreadExecutorMap / ManualIoEventLoop and restore it
- Add unit test

Result:

Correctly restore old value