### PR TITLE
Add property to make Promise.sync wrap exceptions

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/Future.java
+++ b/common/src/main/java/io/netty/util/concurrent/Future.java
@@ -153,7 +153,7 @@ public interface Future<V> extends java.util.concurrent.Future<V> {
 
     /**
      * Return the result without blocking. If the future is not done yet this will return {@code null}.
-     *
+     * <p>
      * As it is possible that a {@code null} value is used to mark the future as successful you also need to check
      * if the future is really done with {@link #isDone()} and not rely on the returned {@code null} value.
      */


### PR DESCRIPTION
Motivation:
The `Promise.sync` and `syncUninterruptibly` methods will rethrow any exception that cause the promise to fail. This gives the stack trace of the original failure, but people loose the stack trace telling which specific sync call propagated the exception. This can make debugging confusing and more difficult that necessary. We have to keep this behavior by default for compatibility, but we can offer and override. This is especially useful for tests, where you often have multiple promises and futures from different places that can potentially fail.

Modification:
Add a `io.netty.defaultPromise.completionExceptionWrap` system property, which can be set to `true` to have promise failures wrapped in `CompletionException` when `sync` or `syncUninterruptibly` is called.

Result:
We have another helpful debugging tool, though we cannot enable it by default.