### PR TITLE
IoUring: Guard against possible crash when resources are accessed aft…

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -49,7 +49,6 @@ import static java.util.Objects.requireNonNull;
  */
 public final class IoUringIoHandler implements IoHandler {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(IoUringIoHandler.class);
-    private static final short RING_CLOSE = 1;
 
     private final RingBuffer ringBuffer;
     private final IntObjectMap<IoUringBufferRing> registeredIoUringBufferRing;
@@ -257,9 +256,7 @@ public final class IoUringIoHandler implements IoHandler {
                 return true;
             }
             if (id == RINGFD_ID) {
-                if (op == Native.IORING_OP_NOP && data == RING_CLOSE) {
-                    completeRingClose();
-                }
+                // Just return
                 return true;
             }
             DefaultIoUringIoRegistration registration = registrations.get(id);

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/RingBuffer.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/RingBuffer.java
@@ -20,6 +20,7 @@ final class RingBuffer {
     private final SubmissionQueue ioUringSubmissionQueue;
     private final CompletionQueue ioUringCompletionQueue;
     private final int features;
+    private boolean closed;
 
     RingBuffer(SubmissionQueue ioUringSubmissionQueue,
                CompletionQueue ioUringCompletionQueue, int features) {
@@ -57,6 +58,12 @@ final class RingBuffer {
     }
 
     void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        ioUringSubmissionQueue.close();
+        ioUringCompletionQueue.close();
         Native.ioUringExit(
                 ioUringSubmissionQueue.submissionQueueArrayAddress,
                 ioUringSubmissionQueue.ringEntries,

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/SubmissionQueue.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/SubmissionQueue.java
@@ -62,6 +62,8 @@ final class SubmissionQueue {
     private int head;
     private int tail;
 
+    private boolean closed;
+
     SubmissionQueue(long kHeadAddress, long kTailAddress, long kRingMaskAddress, long kRingEntriesAddress,
                     long kFlagsAddress, long kDroppedAddress, long kArrayAddress,
                     long submissionQueueArrayAddress, int ringSize, long ringAddress,
@@ -91,7 +93,18 @@ final class SubmissionQueue {
         }
     }
 
+    void close() {
+        closed = true;
+    }
+
+    private void checkClosed() {
+        if (closed) {
+            throw new IllegalStateException();
+        }
+    }
+
     void tryRegisterRingFd() {
+        checkClosed();
         // Try to use IORING_REGISTER_RING_FDS.
         // See https://manpages.debian.org/unstable/liburing-dev/io_uring_register.2.en.html#IORING_REGISTER_RING_FDS
         int enterRingFd = Native.ioUringRegisterRingFds(ringFd);
@@ -107,8 +120,9 @@ final class SubmissionQueue {
         this.enterFlags = enterFlags;
     }
 
-    private long enqueueSqe0(byte opcode, byte flags, short ioPrio, int fd, long union1, long union2, int len,
+    long enqueueSqe(byte opcode, byte flags, short ioPrio, int fd, long union1, long union2, int len,
                              int union3, long udata, short union4, short personality, int union5, long union6) {
+        checkClosed();
         int pending = tail - head;
         if (pending == ringEntries) {
             int submitted = submit();
@@ -118,28 +132,7 @@ final class SubmissionQueue {
             }
         }
         long sqe = submissionQueueArrayAddress + (tail++ & ringMask) * SQE_SIZE;
-        setData(sqe, opcode, flags, ioPrio, fd, union1, union2, len,
-                union3, udata, union4, personality, union5, union6);
-        return udata;
-    }
 
-    void enqueueSqe(byte opcode, byte flags, short ioPrio, int fd, long union1, long union2, int len, int union3,
-                    long udata, short union4, short personality, int union5, long union6) {
-        int pending = tail - head;
-        if (pending == ringEntries) {
-            int submitted = submit();
-            if (submitted == 0) {
-                // We have a problem, could not submit to make more room in the ring
-                throw new RuntimeException("SQ ring full and no submissions accepted");
-            }
-        }
-        long sqe = submissionQueueArrayAddress + (tail++ & ringMask) * SQE_SIZE;
-        setData(sqe, opcode, flags, ioPrio, fd, union1, union2, len,
-                union3, udata, union4, personality, union5, union6);
-    }
-
-    private void setData(long sqe, byte opcode, byte flags, short ioPrio, int fd, long union1, long union2, int len,
-                         int union3, long udata, short union4, short personality, int union5, long union6) {
         //set sqe(submission queue) properties
 
         PlatformDependent.putByte(sqe + SQE_OP_CODE_FIELD, opcode);
@@ -166,6 +159,7 @@ final class SubmissionQueue {
                         ringFd, enterRingFd, Native.opToStr(opcode), fd, len, union1, udata);
             }
         }
+        return udata;
     }
 
     @Override
@@ -183,42 +177,44 @@ final class SubmissionQueue {
     long addNop(byte flags, long udata) {
         // Mimic what liburing does:
         // https://github.com/axboe/liburing/blob/liburing-2.8/src/include/liburing.h#L592
-        return enqueueSqe0(Native.IORING_OP_NOP, flags, (short) 0, -1, 0, 0, 0, 0, udata,
+        return enqueueSqe(Native.IORING_OP_NOP, flags, (short) 0, -1, 0, 0, 0, 0, udata,
                 (short) 0, (short) 0, 0, 0);
     }
 
     long addTimeout(long timeoutMemoryAddress, long udata) {
         // Mimic what liburing does. We want to use a count of 1:
         // https://github.com/axboe/liburing/blob/liburing-2.8/src/include/liburing.h#L599
-        return enqueueSqe0(Native.IORING_OP_TIMEOUT, (byte) 0, (short) 0, -1, 1, timeoutMemoryAddress, 1,
+        return enqueueSqe(Native.IORING_OP_TIMEOUT, (byte) 0, (short) 0, -1, 1, timeoutMemoryAddress, 1,
                 0, udata, (short) 0, (short) 0, 0, 0);
     }
 
     long addLinkTimeout(long timeoutMemoryAddress, long extraData) {
         // Mimic what liburing does:
         // https://github.com/axboe/liburing/blob/liburing-2.8/src/include/liburing.h#L687
-        return enqueueSqe0(Native.IORING_OP_LINK_TIMEOUT, (byte) 0, (short) 0, -1, 1, timeoutMemoryAddress, 1,
+        return enqueueSqe(Native.IORING_OP_LINK_TIMEOUT, (byte) 0, (short) 0, -1, 1, timeoutMemoryAddress, 1,
                 0, extraData, (short) 0, (short) 0, 0, 0);
     }
 
     long addEventFdRead(int fd, long bufferAddress, int pos, int limit, long udata) {
-        return enqueueSqe0(Native.IORING_OP_READ, (byte) 0, (short) 0, fd, 0, bufferAddress + pos, limit - pos,
+        return enqueueSqe(Native.IORING_OP_READ, (byte) 0, (short) 0, fd, 0, bufferAddress + pos, limit - pos,
                 0, udata, (short) 0, (short) 0, 0, 0);
     }
 
     // Mimic what liburing does:
     // https://github.com/axboe/liburing/blob/liburing-2.8/src/include/liburing.h#L673
     long addCancel(long sqeToCancel, long udata) {
-        return enqueueSqe0(Native.IORING_OP_ASYNC_CANCEL, (byte) 0, (short) 0, -1, 0, sqeToCancel, 0, 0,
+        return enqueueSqe(Native.IORING_OP_ASYNC_CANCEL, (byte) 0, (short) 0, -1, 0, sqeToCancel, 0, 0,
                 udata, (short) 0, (short) 0, 0, 0);
     }
 
     int submit() {
+        checkClosed();
         int submit = tail - head;
         return submit > 0 ? submit(submit, 0, 0) : 0;
     }
 
     int submitAndWait() {
+        checkClosed();
         int submit = tail - head;
         if (submit > 0) {
             return submit(submit, 1, Native.IORING_ENTER_GETEVENTS);


### PR DESCRIPTION
…er closure

Motivation:

We need to ensure we not use the native resources anymore afte we closed / released these. Failing to do so might result in a crash.

Modifications:

- Add guards
- Remove some duplicated code
- Add testcase

Result:

Guard against possible crash