### PR TITLE
Fix UBI9 build using the wrong docker image

### DIFF
--- a/docker/docker-compose.ubi9.21.yaml
+++ b/docker/docker-compose.ubi9.21.yaml
@@ -8,7 +8,7 @@ services:
       args:
         java_version : "21.0.5-zulu"
       context: .
-      dockerfile: Dockerfile.centos6
+      dockerfile: Dockerfile.ubi9
 
   build:
     image: netty:ubi9-21


### PR DESCRIPTION
Motivation:
The UBI9 build should use the UBI9 docker file.
This was probably a copy-paste mistake when originally implementing this.

Modification:
Change the UBI9 docker compose file to use the UBI9 docker image.

Result:
Build now runs with correct image.
