### PR TITLE
IoUring: Cleanup method names

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -121,7 +121,7 @@ public final class IoUringIoHandler implements IoHandler {
             }
             for (IoUringBufferRingConfig bufferRingConfig : bufferRingConfigs) {
                 try {
-                    IoUringBufferRing ring = newBufferRing(bufferRingConfig);
+                    IoUringBufferRing ring = newBufferRing(ringBuffer.fd(), bufferRingConfig);
                     registeredIoUringBufferRing.put(bufferRingConfig.bufferGroupId(), ring);
                 } catch (Errors.NativeIoException e) {
                     for (IoUringBufferRing bufferRing : registeredIoUringBufferRing.values()) {
@@ -193,14 +193,14 @@ public final class IoUringIoHandler implements IoHandler {
         }
     }
 
-    IoUringBufferRing newBufferRing(IoUringBufferRingConfig bufferRingConfig) throws Errors.NativeIoException {
-        int ringFd = ringBuffer.fd();
+    IoUringBufferRing newBufferRing(int ringFd, IoUringBufferRingConfig bufferRingConfig)
+            throws Errors.NativeIoException {
         short bufferRingSize = bufferRingConfig.bufferRingSize();
         short bufferGroupId = bufferRingConfig.bufferGroupId();
         int flags = bufferRingConfig.isIncremental() ? Native.IOU_PBUF_RING_INC : 0;
-        long ioUringBufRingAddr = Native.ioUringRegisterBuffRing(ringFd, bufferRingSize, bufferGroupId, flags);
+        long ioUringBufRingAddr = Native.ioUringRegisterBufRing(ringFd, bufferRingSize, bufferGroupId, flags);
         if (ioUringBufRingAddr < 0) {
-            throw Errors.newIOException("ioUringRegisterBuffRing", (int) ioUringBufRingAddr);
+            throw Errors.newIOException("ioUringRegisterBufRing", (int) ioUringBufRingAddr);
         }
         return new IoUringBufferRing(ringFd, ioUringBufRingAddr,
                 bufferRingSize, bufferRingConfig.maxUnreleasedBuffers(),

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -422,7 +422,7 @@ final class Native {
     static boolean isRegisterBufferRingSupported(int ringFd, int flags) {
         int entries = 2;
         short bgid = 1;
-        long result = ioUringRegisterBuffRing(ringFd, entries, bgid, flags);
+        long result = ioUringRegisterBufRing(ringFd, entries, bgid, flags);
         if (result >= 0) {
             ioUringUnRegisterBufRing(ringFd, result, entries, bgid);
             return true;
@@ -484,7 +484,7 @@ final class Native {
     static native int ioUringRegisterEnableRings(int ringFd);
     static native int ioUringRegisterRingFds(int ringFds);
 
-    static native long ioUringRegisterBuffRing(int ringFd, int entries, short bufferGroup, int flags);
+    static native long ioUringRegisterBufRing(int ringFd, int entries, short bufferGroup, int flags);
     static native int ioUringUnRegisterBufRing(int ringFd, long ioUringBufRingAddr, int entries, int bufferGroupId);
 
     static native int ioUringEnter(int ringFd, int toSubmit, int minComplete, int flags);

--- a/transport-native-io_uring/src/main/c/netty_io_uring_native.c
+++ b/transport-native-io_uring/src/main/c/netty_io_uring_native.c
@@ -750,7 +750,7 @@ static const JNINativeMethod method_table[] = {
     {"cmsghdrData", "(J)J", (void *) netty_io_uring_cmsghdrData},
     {"kernelVersion", "()Ljava/lang/String;", (void *) netty_io_uring_kernel_version },
     {"getFd0", "(Ljava/lang/Object;)I", (void *) netty_io_uring_getFd0 },
-    {"ioUringRegisterBuffRing", "(IISI)J", (void *) netty_io_uring_register_buf_ring},
+    {"ioUringRegisterBufRing", "(IISI)J", (void *) netty_io_uring_register_buf_ring},
     {"ioUringUnRegisterBufRing", "(IJII)I", (void *) netty_io_uring_unregister_buf_ring}
 };
 static const jint method_table_size =

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
@@ -56,7 +56,7 @@ public class IoUringBufferRingTest {
         RingBuffer ringBuffer = Native.createRingBuffer(8, 15, 0);
         try {
             int ringFd = ringBuffer.fd();
-            long ioUringBufRingAddr = Native.ioUringRegisterBuffRing(ringFd, 4, (short) 1, 0);
+            long ioUringBufRingAddr = Native.ioUringRegisterBufRing(ringFd, 4, (short) 1, 0);
             assumeTrue(
                     ioUringBufRingAddr > 0,
                     "ioUringSetupBufRing result must great than 0, but now result is " + ioUringBufRingAddr);


### PR DESCRIPTION
Modifications:

There were some typos in method names.

Modifications:

Fix typos

Result:

Cleanup