### PR TITLE
IoUring: Remove flags(...) method

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -280,10 +280,6 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
     protected void doDisconnect() throws Exception {
     }
 
-    protected byte flags(byte flags) {
-        return flags;
-    }
-
     private void freeRemoteAddressMemory() {
         if (remoteAddressMemory != null) {
             Buffer.free(remoteAddressMemory);
@@ -305,7 +301,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
         if (registration != null) {
             if (socket.markClosed()) {
                 int fd = fd().intValue();
-                IoUringIoOps ops = IoUringIoOps.newClose(fd, flags((byte) 0), nextOpsId());
+                IoUringIoOps ops = IoUringIoOps.newClose(fd, (byte) 0, nextOpsId());
                 registration.submit(ops);
             }
         } else {
@@ -418,7 +414,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
         int fd = fd().intValue();
         IoRegistration registration = registration();
         IoUringIoOps ops = IoUringIoOps.newPollAdd(
-                fd, flags((byte) 0), mask, multishot ? Native.IORING_POLL_ADD_MULTI : 0, nextOpsId());
+                fd, (byte) 0, mask, multishot ? Native.IORING_POLL_ADD_MULTI : 0, nextOpsId());
         long id = registration.submit(ops);
         if (id != 0) {
             ioState |= (byte) ioMask;
@@ -591,7 +587,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
             if (registration == null || !registration.isValid()) {
                 return;
             }
-            byte flags = flags((byte) 0);
+            byte flags = (byte) 0;
             if ((ioState & POLL_RDHUP_SCHEDULED) != 0) {
                 assert pollRdhupId != 0;
                 long id = registration.submit(
@@ -1114,7 +1110,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
 
                     int fd = fd().intValue();
                     IoRegistration registration = registration();
-                    IoUringIoOps ops = IoUringIoOps.newSendmsg(fd, flags((byte) 0), Native.MSG_FASTOPEN,
+                    IoUringIoOps ops = IoUringIoOps.newSendmsg(fd, (byte) 0, Native.MSG_FASTOPEN,
                             hdr.address(), hdr.idx());
                     connectId = registration.submit(ops);
                     if (connectId == 0) {
@@ -1174,7 +1170,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
         int fd = fd().intValue();
         IoRegistration registration = registration();
         IoUringIoOps ops = IoUringIoOps.newConnect(
-                fd, flags((byte) 0), remoteAddressMemoryAddress, nextOpsId());
+                fd, (byte) 0, remoteAddressMemoryAddress, nextOpsId());
         connectId = registration.submit(ops);
         if (connectId == 0) {
             // Directly release the memory if submitting failed.

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringServerChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringServerChannel.java
@@ -108,7 +108,7 @@ abstract class AbstractIoUringServerChannel extends AbstractIoUringChannel imple
     protected final void cancelOutstandingReads(IoRegistration registration, int numOutstandingReads) {
         if (acceptId != 0) {
             assert numOutstandingReads == 1 || numOutstandingReads == -1;
-            IoUringIoOps ops = IoUringIoOps.newAsyncCancel(flags((byte) 0), acceptId, Native.IORING_OP_ACCEPT);
+            IoUringIoOps ops = IoUringIoOps.newAsyncCancel((byte) 0, acceptId, Native.IORING_OP_ACCEPT);
             registration.submit(ops);
             acceptId = 0;
         } else {
@@ -188,7 +188,7 @@ abstract class AbstractIoUringServerChannel extends AbstractIoUringChannel imple
             }
 
             // See https://github.com/axboe/liburing/wiki/What's-new-with-io_uring-in-6.10#improvements-for-accept
-            IoUringIoOps ops = IoUringIoOps.newAccept(fd, flags((byte) 0), 0, ioPrio,
+            IoUringIoOps ops = IoUringIoOps.newAccept(fd, (byte) 0, 0, ioPrio,
                     acceptedAddressMemoryAddress, acceptedAddressLengthMemoryAddress, nextOpsId());
             acceptId = registration.submit(ops);
             if (acceptId == 0) {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -240,7 +240,7 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
 
                 int fd = fd().intValue();
                 IoRegistration registration = registration();
-                IoUringIoOps ops = IoUringIoOps.newWritev(fd, flags((byte) 0), 0, iovArray.memoryAddress(offset),
+                IoUringIoOps ops = IoUringIoOps.newWritev(fd, (byte) 0, 0, iovArray.memoryAddress(offset),
                         iovArray.count() - offset, nextOpsId());
                 byte opCode = ops.opcode();
                 writeId = registration.submit(ops);
@@ -279,7 +279,7 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
                 ops = fileRegion.splice(fd);
             } else {
                 ByteBuf buf = (ByteBuf) msg;
-                ops = IoUringIoOps.newWrite(fd, flags((byte) 0), 0,
+                ops = IoUringIoOps.newWrite(fd, (byte) 0, 0,
                         buf.memoryAddress() + buf.readerIndex(), buf.readableBytes(), nextOpsId());
             }
 
@@ -336,7 +336,7 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
                 short ioPrio = calculateRecvIoPrio(first, socketIsEmpty);
                 int recvFlags = calculateRecvFlags(first);
 
-                IoUringIoOps ops = IoUringIoOps.newRecv(fd, flags((byte) 0), ioPrio, recvFlags,
+                IoUringIoOps ops = IoUringIoOps.newRecv(fd, (byte) 0, ioPrio, recvFlags,
                         byteBuf.memoryAddress() + byteBuf.writerIndex(), byteBuf.writableBytes(), nextOpsId());
                 readId = registration.submit(ops);
                 if (readId == 0) {
@@ -356,7 +356,7 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
             short bgId = bufferRing.bufferGroupId();
             try {
                 boolean multishot = IoUring.isRecvMultishotSupported();
-                byte flags = flags((byte) Native.IOSQE_BUFFER_SELECT);
+                byte flags = (byte) Native.IOSQE_BUFFER_SELECT;
                 short ioPrio;
                 final int recvFlags;
                 if (multishot) {
@@ -625,7 +625,7 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
         if (readId != 0) {
             // Let's try to cancel outstanding reads as these might be submitted and waiting for data (via fastpoll).
             assert numOutstandingReads == 1 || numOutstandingReads == -1;
-            IoUringIoOps ops = IoUringIoOps.newAsyncCancel(flags((byte) 0), readId, Native.IORING_OP_RECV);
+            IoUringIoOps ops = IoUringIoOps.newAsyncCancel((byte) 0, readId, Native.IORING_OP_RECV);
             long id = registration.submit(ops);
             assert id != 0;
         } else {
@@ -640,7 +640,7 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
             // (via fastpoll).
             assert numOutstandingWrites == 1;
             assert writeOpCode != 0;
-            long id = registration.submit(IoUringIoOps.newAsyncCancel(flags((byte) 0), writeId, writeOpCode));
+            long id = registration.submit(IoUringIoOps.newAsyncCancel((byte) 0, writeId, writeOpCode));
             assert id != 0;
         } else {
             assert numOutstandingWrites == 0;

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
@@ -503,7 +503,7 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
             // We always use idx here so we can detect if no idx was used by checking if data < 0 in
             // readComplete0(...)
             IoUringIoOps ops = IoUringIoOps.newRecvmsg(
-                    fd, flags((byte) 0), msgFlags, msgHdrMemory.address(), msgHdrMemory.idx());
+                    fd, (byte) 0, msgFlags, msgHdrMemory.address(), msgHdrMemory.idx());
             long id = registration.submit(ops);
             if (id == 0) {
                 // Submission failed we don't used the MsgHdrMemory and so should give it back.
@@ -607,7 +607,7 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
             int fd = fd().intValue();
             int msgFlags = first ? 0 : Native.MSG_DONTWAIT;
             IoRegistration registration = registration();
-            IoUringIoOps ops = IoUringIoOps.newSendmsg(fd, flags((byte) 0), msgFlags, hdr.address(), hdr.idx());
+            IoUringIoOps ops = IoUringIoOps.newSendmsg(fd, (byte) 0, msgFlags, hdr.address(), hdr.idx());
             long id = registration.submit(ops);
             if (id == 0) {
                 // Submission failed we don't used the MsgHdrMemory and so should give it back.
@@ -670,7 +670,7 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
             }
             // Let's try to cancel outstanding op as these might be submitted and waiting for data
             // (via fastpoll).
-            IoUringIoOps ops = IoUringIoOps.newAsyncCancel(flags((byte) 0), id, op);
+            IoUringIoOps ops = IoUringIoOps.newAsyncCancel((byte) 0, id, op);
             registration.submit(ops);
             cancelled++;
         }


### PR DESCRIPTION
Motivation:

The flags(...) method is a left-over that is not needed anymore.

Modivations:

- Remove the method and its usage

Result:

Cleanup
