### PR TITLE
IoUring: Correctly handle late removal of registration for multishot …

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -566,7 +566,9 @@ public final class IoUringIoHandler implements IoHandler {
         void handle(int res, int flags, byte op, short data) {
             event.update(res, flags, op, data);
             handle.handle(this, event);
-            if (--outstandingCompletions == 0 && removeLater) {
+            // Only decrement outstandingCompletions if IORING_CQE_F_MORE is not set as otherwise we know that we will
+            // receive more completions for the intial request.
+            if ((flags & Native.IORING_CQE_F_MORE) == 0 && --outstandingCompletions == 0 && removeLater) {
                 // No more outstanding completions, remove the fd <-> registration mapping now.
                 removeLater = false;
                 remove();


### PR DESCRIPTION
…completions

Motivation:

We keep track of outstanding completions to correctly handle the removal of the registration. The problem was that we assumed that one submission always restults in one completion. This is not always true and so we sometimes removed a registration even tho there were more completions pending.

This resulted in logs like:

```
2025-03-10T02:51:25.6273390Z 02:51:25.614 [testsuite-io_uring-worker-19-3] DEBUG io.netty.channel.uring.IoUringIoHandler -- ignoring POLL_ADD completion for unknown registration (id=-2147483624, res=-125)
```
Modifications.

Before decrementing the outstandingCompletions counter check if the IORING_CQE_F_MORE flag is not set

Result:

Correctly handle  late removal