### PR TITLE
IoUring: Use correct native jni types in function definition

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -485,7 +485,7 @@ final class Native {
     static native int ioUringRegisterRingFds(int ringFds);
 
     static native long ioUringRegisterBufRing(int ringFd, int entries, short bufferGroup, int flags);
-    static native int ioUringUnRegisterBufRing(int ringFd, long ioUringBufRingAddr, int entries, int bufferGroupId);
+    static native int ioUringUnRegisterBufRing(int ringFd, long ioUringBufRingAddr, int entries, short bufferGroupId);
 
     static native int ioUringEnter(int ringFd, int toSubmit, int minComplete, int flags);
 

--- a/transport-native-io_uring/src/main/c/netty_io_uring_native.c
+++ b/transport-native-io_uring/src/main/c/netty_io_uring_native.c
@@ -402,19 +402,19 @@ static jlong netty_io_uring_register_buf_ring(JNIEnv* env, jclass clazz,
         return registerRes;
     }
     br->tail = 0;
-    return (jlong)br;
+    return (jlong) br;
 }
 
 static jint netty_io_uring_unregister_buf_ring(JNIEnv* env, jclass clazz,
-                                        int ringFd, struct io_uring_buf_ring *br,
-                                        unsigned int nentries, int bgid) {
-    struct io_uring_buf_reg reg = { .bgid = bgid };
+                                        jint ringFd, jlong br,
+                                        jint nentries, jshort bgid) {
+    struct io_uring_buf_reg reg = { .bgid = (__u16) bgid };
     int registerRes = sys_io_uring_register(ringFd, IORING_UNREGISTER_PBUF_RING, &reg, 1);
     if (registerRes) {
         return registerRes;
     }
     size_t ring_size = nentries * sizeof(struct io_uring_buf);
-    munmap(br,ring_size);
+    munmap((struct io_uring_buf_ring *) br, ring_size);
     return 0;
 }
 
@@ -751,7 +751,7 @@ static const JNINativeMethod method_table[] = {
     {"kernelVersion", "()Ljava/lang/String;", (void *) netty_io_uring_kernel_version },
     {"getFd0", "(Ljava/lang/Object;)I", (void *) netty_io_uring_getFd0 },
     {"ioUringRegisterBufRing", "(IISI)J", (void *) netty_io_uring_register_buf_ring},
-    {"ioUringUnRegisterBufRing", "(IJII)I", (void *) netty_io_uring_unregister_buf_ring}
+    {"ioUringUnRegisterBufRing", "(IJIS)I", (void *) netty_io_uring_unregister_buf_ring}
 };
 static const jint method_table_size =
     sizeof(method_table) / sizeof(method_table[0]);

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
@@ -60,7 +60,7 @@ public class IoUringBufferRingTest {
             assumeTrue(
                     ioUringBufRingAddr > 0,
                     "ioUringSetupBufRing result must great than 0, but now result is " + ioUringBufRingAddr);
-            int freeRes = Native.ioUringUnRegisterBufRing(ringFd, ioUringBufRingAddr, 4, 1);
+            int freeRes = Native.ioUringUnRegisterBufRing(ringFd, ioUringBufRingAddr, 4, (short) 1);
             assertEquals(
                     0,
                     freeRes,


### PR DESCRIPTION
Motivation:

When define functions that are exposed via JNI we need to ensure we use the types that are provided and supported by JNI. Not doing so might result in undefined behaviour depending on the platform.

Modification:

Fix netty_io_uring_unregister_buf_ring to use the correct supported types.

Result:

No undefined behaviour anymore when unregister buffer ring
