### PR TITLE
IoUring: Expand buffer ring on the fly

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -433,6 +433,9 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
                         // buffer ring size.
                         pipeline.fireUserEventTriggered(bufferRing.getExhaustedEvent());
 
+                        // try to expand the buffer ring by adding more buffers to it if there is any space left.
+                        bufferRing.expand();
+
                         // Let's trigger a read again without consulting the RecvByteBufAllocator.Handle as
                         // we can't count this as a "real" read operation.
                         // Because of how our BufferRing works we should have it filled again.
@@ -473,7 +476,7 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
                                 // Fill a new buffer for the bid after we fired the buffer through the pipeline.
                                 // We do it only after we called fireChannelRead(...) as there is a good chance
                                 // that the user will have released the buffer. In this case we reduce memory usage.
-                                bufferRing.fillBuffer(bid);
+                                bufferRing.fillBuffer();
                                 bid = bufferRing.nextBid(bid);
                                 if (!allocHandle.continueReading()) {
                                     // We should call fireChannelReadComplete() to mimic a normal read loop.
@@ -522,7 +525,7 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
                     // Fill a new buffer for the bid after we fired the buffer through the pipeline.
                     // We do it only after we called fireChannelRead(...) as there is a good chance
                     // that the user will have released the buffer. In this case we reduce memory usage.
-                    bufferRing.fillBuffer(bid);
+                    bufferRing.fillBuffer();
                 }
                 scheduleNextRead(pipeline, allocHandle, rearm, empty);
             } catch (Throwable t) {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRing.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRing.java
@@ -30,6 +30,7 @@ final class IoUringBufferRing {
     private final long ioUringBufRingAddr;
     private final long tailFieldAddress;
     private final short entries;
+    private final int batchSize;
     private final int maxUnreleasedBuffers;
     private final short mask;
     private final short bufferGroupId;
@@ -42,13 +43,17 @@ final class IoUringBufferRing {
     private volatile boolean usable;
     private boolean corrupted;
     private boolean closed;
+    private int numBuffers;
+    private boolean expanded;
+
     IoUringBufferRing(int ringFd, long ioUringBufRingAddr,
-                      short entries, int maxUnreleasedBuffers, short bufferGroupId, boolean incremental,
+                      short entries, int batchSize, int maxUnreleasedBuffers, short bufferGroupId, boolean incremental,
                       IoUringBufferRingAllocator allocator) {
         assert entries % 2 == 0;
         this.ioUringBufRingAddr = ioUringBufRingAddr;
         this.tailFieldAddress = ioUringBufRingAddr + Native.IO_URING_BUFFER_RING_TAIL;
         this.entries = entries;
+        this.batchSize = batchSize;
         this.maxUnreleasedBuffers = maxUnreleasedBuffers;
         this.mask = (short) (entries - 1);
         this.bufferGroupId = bufferGroupId;
@@ -63,11 +68,30 @@ final class IoUringBufferRing {
         return !corrupted && usable;
     }
 
-    void fill() {
-        for (short i = 0; i < entries; i++) {
-            fillBuffer(i);
-        }
+    void initialize() {
+        fillBuffers();
         usable = true;
+    }
+
+    /**
+     * Try to expand by adding more buffers to the ring if there is any space left.
+     * This method might be called multiple times before we call {@link #fillBuffer()} again.
+     */
+    void expand() {
+        // TODO: We could also shrink the number of elements again if we find out we not use all of it frequently.
+        if (!expanded) {
+            // Only expand once before we reset expanded in fillBuffer() which is called once a buffer was completely
+            // used and moved out of the buffer ring.
+            fillBuffers();
+            expanded = true;
+        }
+    }
+
+    private void fillBuffers() {
+        int num = Math.min(batchSize, entries - numBuffers);
+        for (short i = 0; i < num; i++) {
+            fillBuffer();
+        }
     }
 
     /**
@@ -78,14 +102,13 @@ final class IoUringBufferRing {
         return exhaustedEvent;
     }
 
-    void fillBuffer(short bid) {
+    void fillBuffer() {
         if (corrupted || closed) {
             return;
         }
         short oldTail = PlatformDependent.getShort(tailFieldAddress);
-        int ringIndex = oldTail & mask;
-        assert ringIndex == bid;
-        assert buffers[bid] == null;
+        short ringIndex = (short) (oldTail & mask);
+        assert buffers[ringIndex] == null;
         final ByteBuf byteBuf;
         try {
             byteBuf = allocator.allocate();
@@ -97,7 +120,7 @@ final class IoUringBufferRing {
             throw e;
         }
         byteBuf.writerIndex(byteBuf.capacity());
-        buffers[bid] = new IoUringBufferRingByteBuf(byteBuf);
+        buffers[ringIndex] = new IoUringBufferRingByteBuf(byteBuf);
 
         //  see:
         //  https://github.com/axboe/liburing/
@@ -106,9 +129,13 @@ final class IoUringBufferRing {
         PlatformDependent.putLong(ioUringBufAddress + Native.IOURING_BUFFER_OFFSETOF_ADDR,
                 byteBuf.memoryAddress() + byteBuf.readerIndex());
         PlatformDependent.putInt(ioUringBufAddress + Native.IOURING_BUFFER_OFFSETOF_LEN, byteBuf.capacity());
-        PlatformDependent.putShort(ioUringBufAddress + Native.IOURING_BUFFER_OFFSETOF_BID, bid);
+        PlatformDependent.putShort(ioUringBufAddress + Native.IOURING_BUFFER_OFFSETOF_BID, ringIndex);
         // Now advanced the tail by the number of buffers that we just added.
         PlatformDependent.putShortOrdered(tailFieldAddress, (short) (oldTail + 1));
+        numBuffers++;
+        // We added a buffer to the ring, let's reset the expanded variable so we can expand it if we receive
+        // ENOBUFS.
+        expanded = false;
     }
 
     /**
@@ -144,6 +171,7 @@ final class IoUringBufferRing {
 
         // The buffer is considered to be used, null out the slot.
         buffers[bid] = null;
+        numBuffers--;
         byteBuf.markUsed();
         return byteBuf.writerIndex(byteBuf.readerIndex() +
                 Math.min(readableBytes, byteBuf.readableBytes()));

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRingConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRingConfig.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 public final class IoUringBufferRingConfig {
     private final short bgId;
     private final short bufferRingSize;
+    private final int batchSize;
     private final int maxUnreleasedBuffers;
     private final boolean incremental;
     private final IoUringBufferRingAllocator allocator;
@@ -43,7 +44,7 @@ public final class IoUringBufferRingConfig {
      */
     public IoUringBufferRingConfig(short bgId, short bufferRingSize, int maxUnreleasedBuffers,
                                    IoUringBufferRingAllocator allocator) {
-        this(bgId, bufferRingSize, maxUnreleasedBuffers, IoUring.isRegisterBufferRingIncSupported(), allocator);
+        this(bgId, bufferRingSize, bufferRingSize / 2, maxUnreleasedBuffers, IoUring.isRegisterBufferRingIncSupported(), allocator);
     }
 
     /**
@@ -58,10 +59,11 @@ public final class IoUringBufferRingConfig {
      * @param allocator             the {@link IoUringBufferRingAllocator} to use to allocate
      *                              {@link io.netty.buffer.ByteBuf}s.
      */
-    public IoUringBufferRingConfig(short bgId, short bufferRingSize, int maxUnreleasedBuffers,
+    public IoUringBufferRingConfig(short bgId, short bufferRingSize, int batchSize, int maxUnreleasedBuffers,
                                    boolean incremental, IoUringBufferRingAllocator allocator) {
         this.bgId = (short) ObjectUtil.checkPositiveOrZero(bgId, "bgId");
         this.bufferRingSize = checkBufferRingSize(bufferRingSize);
+        this.batchSize = ObjectUtil.checkInRange(batchSize, 1, bufferRingSize, "batchSize");
         this.maxUnreleasedBuffers = ObjectUtil.checkInRange(
                 maxUnreleasedBuffers, bufferRingSize, Integer.MAX_VALUE, "maxUnreleasedBuffers");
         if (incremental && !IoUring.isRegisterBufferRingIncSupported()) {
@@ -87,6 +89,15 @@ public final class IoUringBufferRingConfig {
      */
     public short bufferRingSize() {
         return bufferRingSize;
+    }
+
+    /**
+     * Returns the size of the batch on how many buffers are added everytime we need to expand the buffer ring.
+     *
+     * @return batch size.
+     */
+    public int batchSize() {
+        return batchSize;
     }
 
     /**

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRingConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRingConfig.java
@@ -44,7 +44,8 @@ public final class IoUringBufferRingConfig {
      */
     public IoUringBufferRingConfig(short bgId, short bufferRingSize, int maxUnreleasedBuffers,
                                    IoUringBufferRingAllocator allocator) {
-        this(bgId, bufferRingSize, bufferRingSize / 2, maxUnreleasedBuffers, IoUring.isRegisterBufferRingIncSupported(), allocator);
+        this(bgId, bufferRingSize, bufferRingSize / 2, maxUnreleasedBuffers,
+                IoUring.isRegisterBufferRingIncSupported(), allocator);
     }
 
     /**
@@ -52,6 +53,8 @@ public final class IoUringBufferRingConfig {
      *
      * @param bgId                  the buffer group id to use (must be non-negative).
      * @param bufferRingSize        the size of the ring
+     * @param batchSize             the size of the batch on how many buffers are added everytime we need to expand the
+     *                              buffer ring.
      * @param maxUnreleasedBuffers  the maximum buffers that can be allocated out of this buffer ring and are
      *                              unreleased yet. Once this threshold is hit the usage of the buffer ring will
      *                              be temporarily disabled.

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -148,7 +148,7 @@ public final class IoUringIoHandler implements IoHandler {
         ringBuffer.enable();
         // Fill all buffer rings now.
         for (IoUringBufferRing bufferRing : registeredIoUringBufferRing.values()) {
-            bufferRing.fill();
+            bufferRing.initialize();
         }
     }
 
@@ -202,7 +202,7 @@ public final class IoUringIoHandler implements IoHandler {
             throw Errors.newIOException("ioUringRegisterBufRing", (int) ioUringBufRingAddr);
         }
         return new IoUringBufferRing(ringFd, ioUringBufRingAddr,
-                bufferRingSize, bufferRingConfig.maxUnreleasedBuffers(),
+                bufferRingSize, bufferRingConfig.batchSize(), bufferRingConfig.maxUnreleasedBuffers(),
                 bufferGroupId, bufferRingConfig.isIncremental(), bufferRingConfig.allocator()
         );
     }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
@@ -82,10 +82,10 @@ public class IoUringBufferRingTest {
         final BlockingQueue<ByteBuf> bufferSyncer = new LinkedBlockingQueue<>();
         IoUringIoHandlerConfig ioUringIoHandlerConfiguration = new IoUringIoHandlerConfig();
         IoUringBufferRingConfig bufferRingConfig = new IoUringBufferRingConfig(
-                (short) 1, (short) 2, 2 * 16, incremental, new IoUringFixedBufferRingAllocator(1024));
+                (short) 1, (short) 2, 2, 2 * 16, incremental, new IoUringFixedBufferRingAllocator(1024));
 
         IoUringBufferRingConfig bufferRingConfig1 = new IoUringBufferRingConfig(
-                (short) 2, (short) 16, 16 * 16, incremental, new IoUringFixedBufferRingAllocator(1024)
+                (short) 2, (short) 16, 8, 16 * 16, incremental, new IoUringFixedBufferRingAllocator(1024)
         );
         ioUringIoHandlerConfiguration.setBufferRingConfig(bufferRingConfig, bufferRingConfig1);
 
@@ -182,7 +182,7 @@ public class IoUringBufferRingTest {
         IoUringIoHandlerConfig ioUringIoHandlerConfiguration = new IoUringIoHandlerConfig();
         IoUringBufferRingConfig bufferRingConfig = new IoUringBufferRingConfig(
                 // let's use a small chunkSize so we are sure a recv will span multiple buffers.
-                (short) 1, (short) 16, 16 * 16, incremental, new IoUringFixedBufferRingAllocator(bufferRingChunkSize));
+                (short) 1, (short) 16, 8, 16 * 16, incremental, new IoUringFixedBufferRingAllocator(bufferRingChunkSize));
 
         ioUringIoHandlerConfiguration.setBufferRingConfig(bufferRingConfig);
 

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
@@ -182,7 +182,8 @@ public class IoUringBufferRingTest {
         IoUringIoHandlerConfig ioUringIoHandlerConfiguration = new IoUringIoHandlerConfig();
         IoUringBufferRingConfig bufferRingConfig = new IoUringBufferRingConfig(
                 // let's use a small chunkSize so we are sure a recv will span multiple buffers.
-                (short) 1, (short) 16, 8, 16 * 16, incremental, new IoUringFixedBufferRingAllocator(bufferRingChunkSize));
+                (short) 1, (short) 16, 8, 16 * 16,
+                incremental, new IoUringFixedBufferRingAllocator(bufferRingChunkSize));
 
         ioUringIoHandlerConfiguration.setBufferRingConfig(bufferRingConfig);
 


### PR DESCRIPTION
Motivation:

At the moment we always try to fill the whole buffer ring from the start. This can be very wasteful especially if we allocated a bigger buffer ring as we acutally need. We should better allocate the ring and then increase the number of usable buffers if needed. This way we might be able to waste less memory.

Modification:

Start with a small number of buffers and then increase the number on the flight until we reached the maximum capacity

Result:

Easier to size the buffer ring without wasting memory