### PR TITLE
Fix channel de-registering executor cache clear bug

### DIFF
--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -335,6 +335,13 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
 
             AbstractChannel.this.eventLoop = eventLoop;
 
+            // Clear any cached executors from prior event loop registrations.
+            AbstractChannelHandlerContext context = pipeline.tail;
+            do {
+                context.contextExecutor = null;
+                context = context.prev;
+            } while (context != null);
+
             if (eventLoop.inEventLoop()) {
                 register0(promise);
             } else {

--- a/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
@@ -1404,15 +1404,7 @@ public class DefaultChannelPipeline implements ChannelPipeline {
 
         @Override
         public void channelUnregistered(ChannelHandlerContext ctx) {
-            try {
-                ctx.fireChannelUnregistered();
-            } finally {
-                AbstractChannelHandlerContext context = tail;
-                do {
-                    context.contextExecutor = null; // Clear cached executors in case channel gets re-registered.
-                    context = context.prev;
-                } while (context != null);
-            }
+            ctx.fireChannelUnregistered();
 
             // Remove all handlers sequentially if channel is closed and unregistered.
             if (!channel.isOpen()) {

--- a/transport/src/test/java/io/netty/channel/AbstractEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/AbstractEventLoopTest.java
@@ -77,7 +77,7 @@ public abstract class AbstractEventLoopTest {
      */
     @ParameterizedTest
     @EnumSource(DeregisterMethod.class)
-    void tesrReregisterOnChannelHandlerContext(DeregisterMethod method) throws Exception {
+    void testReregisterOnChannelHandlerContext(DeregisterMethod method) throws Exception {
         EventLoopGroup bossGroup = newEventLoopGroup();
         EventLoopGroup workerGroup = newEventLoopGroup();
         AtomicReference<Throwable> throwable = new AtomicReference<>();

--- a/transport/src/test/java/io/netty/channel/AbstractEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/AbstractEventLoopTest.java
@@ -170,7 +170,7 @@ public abstract class AbstractEventLoopTest {
         private final DeregisterMethod method;
         private final AtomicReference<Throwable> throwable;
 
-        public ReRegisterHandler(EventLoopGroup eventLoopGroup,
+        ReRegisterHandler(EventLoopGroup eventLoopGroup,
                                  DeregisterMethod method,
                                  AtomicReference<Throwable> throwable) {
             this.eventLoopGroup = eventLoopGroup;

--- a/transport/src/test/java/io/netty/channel/nio/NioEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/nio/NioEventLoopTest.java
@@ -29,6 +29,7 @@ import io.netty.channel.SingleThreadEventLoop;
 import io.netty.channel.SingleThreadIoEventLoop;
 import io.netty.channel.socket.ServerSocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.util.IntSupplier;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.concurrent.Future;
@@ -65,6 +66,11 @@ public class NioEventLoopTest extends AbstractEventLoopTest {
     @Override
     protected Class<? extends ServerSocketChannel> newChannel() {
         return NioServerSocketChannel.class;
+    }
+
+    @Override
+    protected Class<? extends io.netty.channel.socket.SocketChannel> newSocketChannel() {
+        return NioSocketChannel.class;
     }
 
     @Test


### PR DESCRIPTION
Motivation:
Our channel handler contexts are caching their executors. This cache must be cleared when a channel is deregistered, as the contexts would otherwise assume they should run on an incorrect event loop after reregistering.

Modification:
Move the cache clearing away from Channel.deregister, into the correct place that is the pipeline head.channelUnregistered method. This method is called at the end of channel deregistering rather than the beginning, which means other pipeline events that happen as part of deregistering will not repopulate the caches.

Result:
Fixes https://github.com/netty/netty/issues/14923
