### PR TITLE
IoUring: Fix crashes caused by IoUringBufferRing

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRingConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRingConfig.java
@@ -27,7 +27,6 @@ public final class IoUringBufferRingConfig {
     private final short bgId;
     private final short bufferRingSize;
     private final int batchSize;
-    private final int maxUnreleasedBuffers;
     private final boolean incremental;
     private final IoUringBufferRingAllocator allocator;
 
@@ -36,15 +35,12 @@ public final class IoUringBufferRingConfig {
      *
      * @param bgId                  the buffer group id to use (must be non-negative).
      * @param bufferRingSize        the size of the ring
-     * @param maxUnreleasedBuffers  the maximum buffers that were allocated out of this buffer ring and are
-     *                              unreleased yet. Once this threshold is hit the usage of the buffer ring will
-     *                              be temporary disabled.
      * @param allocator             the {@link IoUringBufferRingAllocator} to use to allocate
      *                              {@link io.netty.buffer.ByteBuf}s.
      */
-    public IoUringBufferRingConfig(short bgId, short bufferRingSize, int maxUnreleasedBuffers,
+    public IoUringBufferRingConfig(short bgId, short bufferRingSize,
                                    IoUringBufferRingAllocator allocator) {
-        this(bgId, bufferRingSize, bufferRingSize / 2, maxUnreleasedBuffers,
+        this(bgId, bufferRingSize, bufferRingSize / 2,
                 IoUring.isRegisterBufferRingIncSupported(), allocator);
     }
 
@@ -55,20 +51,15 @@ public final class IoUringBufferRingConfig {
      * @param bufferRingSize        the size of the ring
      * @param batchSize             the size of the batch on how many buffers are added everytime we need to expand the
      *                              buffer ring.
-     * @param maxUnreleasedBuffers  the maximum buffers that can be allocated out of this buffer ring and are
-     *                              unreleased yet. Once this threshold is hit the usage of the buffer ring will
-     *                              be temporarily disabled.
      * @param incremental           {@code true} if the buffer ring is using incremental buffer consumption.
      * @param allocator             the {@link IoUringBufferRingAllocator} to use to allocate
      *                              {@link io.netty.buffer.ByteBuf}s.
      */
-    public IoUringBufferRingConfig(short bgId, short bufferRingSize, int batchSize, int maxUnreleasedBuffers,
+    public IoUringBufferRingConfig(short bgId, short bufferRingSize, int batchSize,
                                    boolean incremental, IoUringBufferRingAllocator allocator) {
         this.bgId = (short) ObjectUtil.checkPositiveOrZero(bgId, "bgId");
         this.bufferRingSize = checkBufferRingSize(bufferRingSize);
         this.batchSize = ObjectUtil.checkInRange(batchSize, 1, bufferRingSize, "batchSize");
-        this.maxUnreleasedBuffers = ObjectUtil.checkInRange(
-                maxUnreleasedBuffers, bufferRingSize, Integer.MAX_VALUE, "maxUnreleasedBuffers");
         if (incremental && !IoUring.isRegisterBufferRingIncSupported()) {
             throw new IllegalArgumentException("Incremental buffer ring is not supported");
         }
@@ -101,16 +92,6 @@ public final class IoUringBufferRingConfig {
      */
     public int batchSize() {
         return batchSize;
-    }
-
-    /**
-     * Returns the maximum buffers that can be allocated out of this buffer ring and are
-     * unreleased yet
-     *
-     * @return the max unreleased buffers.
-     */
-    public int maxUnreleasedBuffers() {
-        return maxUnreleasedBuffers;
     }
 
     /**

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -202,7 +202,7 @@ public final class IoUringIoHandler implements IoHandler {
             throw Errors.newIOException("ioUringRegisterBufRing", (int) ioUringBufRingAddr);
         }
         return new IoUringBufferRing(ringFd, ioUringBufRingAddr,
-                bufferRingSize, bufferRingConfig.batchSize(), bufferRingConfig.maxUnreleasedBuffers(),
+                bufferRingSize, bufferRingConfig.batchSize(),
                 bufferGroupId, bufferRingConfig.isIncremental(), bufferRingConfig.allocator()
         );
     }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
@@ -40,7 +40,6 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -82,10 +81,10 @@ public class IoUringBufferRingTest {
         final BlockingQueue<ByteBuf> bufferSyncer = new LinkedBlockingQueue<>();
         IoUringIoHandlerConfig ioUringIoHandlerConfiguration = new IoUringIoHandlerConfig();
         IoUringBufferRingConfig bufferRingConfig = new IoUringBufferRingConfig(
-                (short) 1, (short) 2, 2, 2 * 16, incremental, new IoUringFixedBufferRingAllocator(1024));
+                (short) 1, (short) 2, 2, incremental, new IoUringFixedBufferRingAllocator(1024));
 
         IoUringBufferRingConfig bufferRingConfig1 = new IoUringBufferRingConfig(
-                (short) 2, (short) 16, 8, 16 * 16, incremental, new IoUringFixedBufferRingAllocator(1024)
+                (short) 2, (short) 16, 8, incremental, new IoUringFixedBufferRingAllocator(1024)
         );
         ioUringIoHandlerConfiguration.setBufferRingConfig(bufferRingConfig, bufferRingConfig1);
 
@@ -130,19 +129,19 @@ public class IoUringBufferRingTest {
         ByteBuf writeBuffer = Unpooled.directBuffer(randomStringLength);
         ByteBufUtil.writeAscii(writeBuffer, randomString);
         ByteBuf userspaceIoUringBufferElement1 = sendAndRecvMessage(clientChannel, writeBuffer, bufferSyncer);
-        if (incremental) {
+        /*if (incremental) {
             // Need to unwrap as its a slice.
             assertInstanceOf(IoUringBufferRing.IoUringBufferRingByteBuf.class, userspaceIoUringBufferElement1.unwrap());
         } else {
             assertInstanceOf(IoUringBufferRing.IoUringBufferRingByteBuf.class, userspaceIoUringBufferElement1);
-        }
+        }*/
         ByteBuf userspaceIoUringBufferElement2 = sendAndRecvMessage(clientChannel, writeBuffer, bufferSyncer);
-        if (incremental) {
+        /*if (incremental) {
             // Need to unwrap as its a slice.
             assertInstanceOf(IoUringBufferRing.IoUringBufferRingByteBuf.class, userspaceIoUringBufferElement2.unwrap());
         } else {
             assertInstanceOf(IoUringBufferRing.IoUringBufferRingByteBuf.class, userspaceIoUringBufferElement2);
-        }
+        }*/
         ByteBuf readBuffer = sendAndRecvMessage(clientChannel, writeBuffer, bufferSyncer);
         readBuffer.release();
 
@@ -182,7 +181,7 @@ public class IoUringBufferRingTest {
         IoUringIoHandlerConfig ioUringIoHandlerConfiguration = new IoUringIoHandlerConfig();
         IoUringBufferRingConfig bufferRingConfig = new IoUringBufferRingConfig(
                 // let's use a small chunkSize so we are sure a recv will span multiple buffers.
-                (short) 1, (short) 16, 8, 16 * 16,
+                (short) 1, (short) 16, 8,
                 incremental, new IoUringFixedBufferRingAllocator(bufferRingChunkSize));
 
         ioUringIoHandlerConfiguration.setBufferRingConfig(bufferRingConfig);

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketTestPermutation.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketTestPermutation.java
@@ -46,7 +46,7 @@ public class IoUringSocketTestPermutation extends SocketTestPermutation {
             WORKERS, new DefaultThreadFactory("testsuite-io_uring-worker", true),
             IoUringIoHandler.newFactory(new IoUringIoHandlerConfig()
                     .setBufferRingConfig(
-                            new IoUringBufferRingConfig(BGID, (short) 16, 16 * 16,
+                            new IoUringBufferRingConfig(BGID, (short) 16,
                                     new IoUringFixedBufferRingAllocator(1024)))));
     @Override
     public List<BootstrapComboFactory<ServerBootstrap, Bootstrap>> socket() {


### PR DESCRIPTION
Motivation:

Our current implementation of IoUringBufferRing sometimes cause a crash which seems to be caused by the fact that we use a sub-type of WrappedByteBuf. While we investigate why this happens let's revert the change that did introduce this crash for now.

Modifications:

Remove max unreleasable buffer tracking code for now.

Result:

No more crashes