### PR TITLE
IoUring: Use same casting as liburing

### DIFF
--- a/transport-native-io_uring/src/main/c/netty_io_uring_native.c
+++ b/transport-native-io_uring/src/main/c/netty_io_uring_native.c
@@ -390,7 +390,7 @@ static jlong netty_io_uring_register_buf_ring(JNIEnv* env, jclass clazz,
         return -errno;
     }
 
-    reg.ring_addr = (__u64) br;
+    reg.ring_addr = (unsigned long) (uintptr_t) br;
     reg.ring_entries = (__u32) nentries;
     reg.bgid = (__u16) bgid;
     reg.flags |= (__u16) flags;


### PR DESCRIPTION
Motivation:

Let's use the same casting as liburing does for buffer rings to keep things consistent

Modification:

Cast to the same types as liburing does

Result:

Cleanup