### PR TITLE
IoUring: Throw IllegalArgumentException if IOSQE_CQE_SKIP_SUCCESS is …

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -495,6 +495,11 @@ public final class IoUringIoHandler implements IoHandler {
             if (!isValid()) {
                 return INVALID_ID;
             }
+            if ((ioOps.flags() & Native.IOSQE_CQE_SKIP_SUCCESS) != 0) {
+                // Because we expect at least 1 completion per submission we can't support IOSQE_CQE_SKIP_SUCCESS
+                // as it will only produce a completion on failure.
+                throw new IllegalArgumentException("IOSQE_CQE_SKIP_SUCCESS not supported");
+            }
             long udata = UserData.encode(id, ioOps.opcode(), ioOps.data());
             if (executor.isExecutorThread(Thread.currentThread())) {
                 submit0(ioOps, udata);

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -282,6 +282,7 @@ final class Native {
     static final int IOSQE_LINK = NativeStaticallyReferencedJniMethods.iosqeLink();
     static final int IOSQE_IO_DRAIN = NativeStaticallyReferencedJniMethods.iosqeDrain();
     static final int IOSQE_BUFFER_SELECT = NativeStaticallyReferencedJniMethods.iosqeBufferSelect();
+    static final int IOSQE_CQE_SKIP_SUCCESS = 1 << 6;
     static final int MSG_DONTWAIT = NativeStaticallyReferencedJniMethods.msgDontwait();
     static final int MSG_FASTOPEN = NativeStaticallyReferencedJniMethods.msgFastopen();
     static final int SOL_UDP = NativeStaticallyReferencedJniMethods.solUdp();


### PR DESCRIPTION
…used

Motivation:

Because of how we keep track of submissions and completions its impossible to support IOSQE_CQE_SKIP_SUCCESS for now. We should guard against using of it as it would cause problems when we try to keep track on when we can finally remove a registration.

Modifications:

- Check if IOSQE_CQE_SKIP_SUCCESS is used and if so throw an IllegalArgumentException
- Add unit test

Result:

Guard against usage of unsupported flag