### PR TITLE
Fix allocateUninitializedArray invocation via MH

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -452,7 +452,7 @@ final class PlatformDependent0 {
                         try {
                             MethodHandle m = (MethodHandle) maybeException;
                             m = m.bindTo(finalInternalUnsafe);
-                            byte[] bytes = (byte[]) m.invokeExact(byte.class, 8);
+                            byte[] bytes = (byte[]) (Object) m.invokeExact(byte.class, 8);
                             assert bytes.length == 8;
                             allocateArrayMethod = m;
                         } catch (Throwable e) {
@@ -605,7 +605,7 @@ final class PlatformDependent0 {
 
     static byte[] allocateUninitializedArray(int size) {
         try {
-            return (byte[]) ALLOCATE_ARRAY_METHOD.invokeExact(byte.class, size);
+            return (byte[]) (Object) ALLOCATE_ARRAY_METHOD.invokeExact(byte.class, size);
         } catch (Throwable e) {
             rethrowIfPossible(e);
             throw new LinkageError("Unsafe.allocateUninitializedArray not available", e);


### PR DESCRIPTION
Motivation:

The code that detects the availability of `allocateUninitializedArray` has been failing since #14032, because `MethodHandle::invokeExact` requires exact type matches.

Modification:

Cast the return value to `Object`, matching the exact signature of `allocateUninitializedArray`. The existing cast to `byte[]` remains and happens immediately after the invocation.

Result:

Fixes #14930