### PR TITLE
IoUring: Ensure we guard against segfaults in all cases

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -154,6 +154,9 @@ public final class IoUringIoHandler implements IoHandler {
 
     @Override
     public int run(IoHandlerContext context) {
+        if (closeCompleted) {
+            return 0;
+        }
         int processedPerRun = 0;
         SubmissionQueue submissionQueue = ringBuffer.ioUringSubmissionQueue();
         CompletionQueue completionQueue = ringBuffer.ioUringCompletionQueue();
@@ -184,6 +187,9 @@ public final class IoUringIoHandler implements IoHandler {
     }
 
     void submitAndRunNow(long udata) {
+        if (closeCompleted) {
+            return;
+        }
         SubmissionQueue submissionQueue = ringBuffer.ioUringSubmissionQueue();
         CompletionQueue completionQueue = ringBuffer.ioUringCompletionQueue();
         if (submissionQueue.submit() > 0) {
@@ -192,7 +198,7 @@ public final class IoUringIoHandler implements IoHandler {
         }
     }
 
-    IoUringBufferRing newBufferRing(int ringFd, IoUringBufferRingConfig bufferRingConfig)
+    private static IoUringBufferRing newBufferRing(int ringFd, IoUringBufferRingConfig bufferRingConfig)
             throws Errors.NativeIoException {
         short bufferRingSize = bufferRingConfig.bufferRingSize();
         short bufferGroupId = bufferRingConfig.bufferGroupId();

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/SubmissionQueue.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/SubmissionQueue.java
@@ -165,11 +165,15 @@ final class SubmissionQueue {
     @Override
     public String toString() {
         StringJoiner sb = new StringJoiner(", ", "SubmissionQueue [", "]");
-        int pending = tail - head;
-        for (int i = 0; i < pending; i++) {
-            long sqe = submissionQueueArrayAddress + (head + i & ringMask) * SQE_SIZE;
-            sb.add(Native.opToStr(PlatformDependent.getByte(sqe + SQE_OP_CODE_FIELD)) +
-                    "(fd=" + PlatformDependent.getInt(sqe + SQE_FD_FIELD) + ')');
+        if (closed) {
+            sb.add("closed");
+        } else {
+            int pending = tail - head;
+            for (int i = 0; i < pending; i++) {
+                long sqe = submissionQueueArrayAddress + (head + i & ringMask) * SQE_SIZE;
+                sb.add(Native.opToStr(PlatformDependent.getByte(sqe + SQE_OP_CODE_FIELD)) +
+                        "(fd=" + PlatformDependent.getInt(sqe + SQE_FD_FIELD) + ')');
+            }
         }
         return sb.toString();
     }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/SubmissionQueueTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/SubmissionQueueTest.java
@@ -82,6 +82,10 @@ public class SubmissionQueueTest {
             fail("Should not be called");
             return false;
         }));
+
+        // Ensure both return not null and also not segfault.
+        assertNotNull(submissionQueue.toString());
+        assertNotNull(completionQueue.toString());
     }
 
     @Test


### PR DESCRIPTION
Motivation:

We had few places where we didnt guard against segfaults caused by freeing native resources.

Modifications:

- Add guards
- Add some more unit tests

Result:

No more segfaults
