### PR TITLE
IoUring: Close ring fd when mmap fails during setup

### DIFF
--- a/transport-native-io_uring/src/main/c/netty_io_uring_native.c
+++ b/transport-native-io_uring/src/main/c/netty_io_uring_native.c
@@ -324,6 +324,8 @@ static jlongArray netty_io_uring_setup(JNIEnv *env, jclass clazz, jint entries, 
     int ret = setup_io_uring(ring_fd, &io_uring_ring, &p);
 
     if (ret != 0) {
+        // Close ring fd before return.
+        close(ring_fd);
         netty_unix_errors_throwRuntimeExceptionErrorNo(env, "failed to mmap io_uring ring buffer: ", ret);
         return NULL;
     }


### PR DESCRIPTION
Motivation:

When we fail to mmap we should close the ring fd as well as otherwise it will leak.

Modifications:

Close fd before return

Result:

Don't leak the ring fd on mmap failure