### PR TITLE
Adaptive: Correctly enforce leak detection when using AdaptiveByteBuf…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptiveByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptiveByteBufAllocator.java
@@ -62,12 +62,12 @@ public final class AdaptiveByteBufAllocator extends AbstractByteBufAllocator
 
     @Override
     protected ByteBuf newHeapBuffer(int initialCapacity, int maxCapacity) {
-        return heap.allocate(initialCapacity, maxCapacity);
+        return toLeakAwareBuffer(heap.allocate(initialCapacity, maxCapacity));
     }
 
     @Override
     protected ByteBuf newDirectBuffer(int initialCapacity, int maxCapacity) {
-        return direct.allocate(initialCapacity, maxCapacity);
+        return toLeakAwareBuffer(direct.allocate(initialCapacity, maxCapacity));
     }
 
     @Override

--- a/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
@@ -91,21 +91,24 @@ public class AdaptiveByteBufAllocatorTest extends AbstractByteBufAllocatorTest<A
         assertInstanceOf(buffer, AdaptivePoolingAllocator.AdaptiveByteBuf.class);
         // Unwrap if this is wrapped by a leak aware buffer.
         if (buffer instanceof SimpleLeakAwareByteBuf) {
-            buffer = buffer.unwrap();
+            assertNull(buffer.unwrap().unwrap());
+        } else {
+            assertNull(buffer.unwrap());
         }
-        assertNull(buffer.unwrap());
 
         ByteBuf derived = slice ? buffer.slice(0, 4) : buffer.duplicate();
         // When we unwrap the derived buffer we should get our original buffer of type AdaptiveByteBuf back.
-        ByteBuf unwrapped = derived.unwrap();
+        ByteBuf unwrapped = derived instanceof SimpleLeakAwareByteBuf ?
+                derived.unwrap().unwrap() : derived.unwrap();
         assertInstanceOf(unwrapped, AdaptivePoolingAllocator.AdaptiveByteBuf.class);
-        assertSameBuffer(buffer, unwrapped);
+        assertSameBuffer(buffer instanceof SimpleLeakAwareByteBuf ? buffer.unwrap() : buffer, unwrapped);
 
         ByteBuf retainedDerived = slice ? buffer.retainedSlice(0, 4) : buffer.retainedDuplicate();
         // When we unwrap the derived buffer we should get our original buffer of type AdaptiveByteBuf back.
-        ByteBuf unwrappedRetained = retainedDerived.unwrap();
+        ByteBuf unwrappedRetained = retainedDerived instanceof SimpleLeakAwareByteBuf ?
+                retainedDerived.unwrap().unwrap() :  retainedDerived.unwrap();
         assertInstanceOf(unwrappedRetained, AdaptivePoolingAllocator.AdaptiveByteBuf.class);
-        assertSameBuffer(buffer, unwrappedRetained);
+        assertSameBuffer(buffer instanceof SimpleLeakAwareByteBuf ? buffer.unwrap() : buffer, unwrappedRetained);
         retainedDerived.release();
 
         assertTrue(buffer.release());

--- a/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
@@ -89,6 +89,10 @@ public class AdaptiveByteBufAllocatorTest extends AbstractByteBufAllocatorTest<A
         AdaptiveByteBufAllocator allocator = newAllocator(false);
         ByteBuf buffer = allocator.buffer(8);
         assertInstanceOf(buffer, AdaptivePoolingAllocator.AdaptiveByteBuf.class);
+        // Unwrap if this is wrapped by a leak aware buffer.
+        if (buffer instanceof SimpleLeakAwareByteBuf) {
+            buffer = buffer.unwrap();
+        }
         assertNull(buffer.unwrap());
 
         ByteBuf derived = slice ? buffer.slice(0, 4) : buffer.duplicate();


### PR DESCRIPTION
…Allocator

Motivation:

We meesed to call toLeakAwareBuffer(...) in AdaptiveByteBufAllocator which basically means that there was no leak detection at all enabled.

Modifications:

Correctly call toLeakAwareBuffer(...)

Result:

Leak detection also works with AdaptiveByteBufAllocator
