### PR TITLE
AsciiString::regionMatches is not optimized for AsciiString

### DIFF
--- a/common/src/main/java/io/netty/util/AsciiString.java
+++ b/common/src/main/java/io/netty/util/AsciiString.java
@@ -833,6 +833,11 @@ public final class AsciiString implements CharSequence, Comparable<CharSequence>
             return true;
         }
 
+        if (string instanceof AsciiString) {
+            final AsciiString asciiString = (AsciiString) string;
+            return PlatformDependent.equals(value, thisStart + offset, asciiString.value,
+                                            start + asciiString.offset, length);
+        }
         final int thatEnd = start + length;
         for (int i = start, j = thisStart + arrayOffset(); i < thatEnd; i++, j++) {
             if (b2c(value[j]) != string.charAt(i)) {
@@ -871,6 +876,18 @@ public final class AsciiString implements CharSequence, Comparable<CharSequence>
 
         thisStart += arrayOffset();
         final int thisEnd = thisStart + length;
+        if (string instanceof AsciiString) {
+            final AsciiString asciiString = (AsciiString) string;
+            final byte[] value = this.value;
+            final byte[] otherValue = asciiString.value;
+            start += asciiString.offset;
+            while (thisStart < thisEnd) {
+                if (!equalsIgnoreCase(value[thisStart++], otherValue[start++])) {
+                    return false;
+                }
+            }
+            return true;
+        }
         while (thisStart < thisEnd) {
             if (!equalsIgnoreCase(b2c(value[thisStart++]), string.charAt(start++))) {
                 return false;

--- a/common/src/test/java/io/netty/util/AsciiStringCharacterTest.java
+++ b/common/src/test/java/io/netty/util/AsciiStringCharacterTest.java
@@ -100,7 +100,7 @@ public class AsciiStringCharacterTest {
 
     @Test
     public void subSequenceTest() {
-        byte[] init = {'t', 'h', 'i', 's', ' ', 'i', 's', ' ', 'a', ' ', 't', 'e', 's', 't' };
+        byte[] init = { 't', 'h', 'i', 's', ' ', 'i', 's', ' ', 'a', ' ', 't', 'e', 's', 't' };
         AsciiString ascii = new AsciiString(init);
         final int start = 2;
         final int end = init.length;
@@ -115,8 +115,8 @@ public class AsciiStringCharacterTest {
 
     @Test
     public void testContains() {
-        String[] falseLhs = {null, "a", "aa", "aaa" };
-        String[] falseRhs = {null, "b", "ba", "baa" };
+        String[] falseLhs = { null, "a", "aa", "aaa" };
+        String[] falseRhs = { null, "b", "ba", "baa" };
         for (int i = 0; i < falseLhs.length; ++i) {
             for (int j = 0; j < falseRhs.length; ++j) {
                 assertContains(falseLhs[i], falseRhs[i], false, false);
@@ -364,7 +364,7 @@ public class AsciiStringCharacterTest {
 
     @Test
     public void testLastIndexOfCharSequence() {
-        final byte[] bytes = {'a', 'b', 'c', 'd', 'e'};
+        final byte[] bytes = { 'a', 'b', 'c', 'd', 'e' };
         final AsciiString ascii = new AsciiString(bytes, 2, 3, false);
 
         assertEquals(0, new AsciiString("abcd").lastIndexOf("abcd", 0));
@@ -462,5 +462,94 @@ public class AsciiStringCharacterTest {
     public void testToUpperCaseLong() {
         AsciiString foo = AsciiString.of("This is a test for longer sequences");
         assertEquals("THIS IS A TEST FOR LONGER SEQUENCES", foo.toUpperCase().toString());
+    }
+
+    @Test
+    public void testRegionMatchesReturnsTrueForEqualRegions() {
+        AsciiString str = new AsciiString("Hello, World!");
+        AsciiString hello = new AsciiString("Hello");
+        AsciiString world = new AsciiString("World");
+        assertTrue(AsciiString.regionMatches(str, false, 0, hello, 0, 5));
+        assertTrue(AsciiString.regionMatches(str, false, 7, world, 0, 5));
+    }
+
+    @Test
+    public void testRegionMatchesReturnsFalseForDifferentRegions() {
+        AsciiString str = new AsciiString("Hello, World!");
+        AsciiString world = new AsciiString("world");
+        AsciiString hello = new AsciiString("hello");
+        assertFalse(AsciiString.regionMatches(str, false, 0, world, 0, 5));
+        assertFalse(AsciiString.regionMatches(str, false, 7, hello, 0, 5));
+    }
+
+    @Test
+    public void testRegionMatchesIgnoreCaseReturnsTrueForEqualRegions() {
+        AsciiString str = new AsciiString("Hello, World!");
+        AsciiString hello = new AsciiString("hello");
+        AsciiString world = new AsciiString("world");
+        assertTrue(AsciiString.regionMatches(str, true, 0, hello, 0, 5));
+        assertTrue(AsciiString.regionMatches(str, true, 7, world, 0, 5));
+    }
+
+    @Test
+    public void testRegionMatchesIgnoreCaseReturnsFalseForDifferentRegions() {
+        AsciiString str = new AsciiString("Hello, World!");
+        AsciiString world = new AsciiString("world");
+        AsciiString hello = new AsciiString("hello");
+        assertFalse(AsciiString.regionMatches(str, true, 0, world, 0, 5));
+        assertFalse(AsciiString.regionMatches(str, true, 7, hello, 0, 5));
+    }
+
+    @Test
+    public void testRegionMatchesAsciiReturnsTrueForEqualRegions() {
+        AsciiString str = new AsciiString("Hello, World!");
+        AsciiString hello = new AsciiString("Hello");
+        AsciiString world = new AsciiString("World");
+        assertTrue(AsciiString.regionMatchesAscii(str, false, 0, hello, 0, 5));
+        assertTrue(AsciiString.regionMatchesAscii(str, false, 7, world, 0, 5));
+    }
+
+    @Test
+    public void testRegionMatchesAsciiReturnsFalseForDifferentRegions() {
+        AsciiString str = new AsciiString("Hello, World!");
+        AsciiString world = new AsciiString("world");
+        AsciiString hello = new AsciiString("hello");
+        assertFalse(AsciiString.regionMatchesAscii(str, false, 0, world, 0, 5));
+        assertFalse(AsciiString.regionMatchesAscii(str, false, 7, hello, 0, 5));
+    }
+
+    @Test
+    public void testRegionMatchesAsciiIgnoreCaseReturnsTrueForEqualRegions() {
+        AsciiString str = new AsciiString("Hello, World!");
+        AsciiString hello = new AsciiString("hello");
+        AsciiString world = new AsciiString("world");
+        assertTrue(AsciiString.regionMatchesAscii(str, true, 0, hello, 0, 5));
+        assertTrue(AsciiString.regionMatchesAscii(str, true, 7, world, 0, 5));
+    }
+
+    @Test
+    public void testRegionMatchesAsciiIgnoreCaseReturnsFalseForDifferentRegions() {
+        AsciiString str = new AsciiString("Hello, World!");
+        AsciiString world = new AsciiString("world");
+        AsciiString hello = new AsciiString("hello");
+        assertFalse(AsciiString.regionMatchesAscii(str, true, 0, world, 0, 5));
+        assertFalse(AsciiString.regionMatchesAscii(str, true, 7, hello, 0, 5));
+    }
+
+    @Test
+    public void testRegionMatchesHandlesOutOfBounds() {
+        AsciiString str = new AsciiString("Hello, World!");
+        AsciiString hello = new AsciiString("Hello");
+        assertFalse(AsciiString.regionMatches(str, false, -1, hello, 0, 5));
+        assertFalse(AsciiString.regionMatches(str, false, 0, hello, -1, 5));
+        assertFalse(AsciiString.regionMatches(str, false, 0, hello, 0, 20));
+    }
+
+    @Test
+    public void testRegionMatchesAsciiHandlesOutOfBounds() {
+        AsciiString str = new AsciiString("Hello, World!");
+        AsciiString hello = new AsciiString("Hello");
+        assertFalse(AsciiString.regionMatchesAscii(str, false, -1, hello, 0, 5));
+        assertFalse(AsciiString.regionMatchesAscii(str, false, 0, hello, -1, 5));
     }
 }


### PR DESCRIPTION
Motivation:
AsciiString::regionMatches is not optimized for the case where the other char sequence is an AsciiString, increasing the chance it become bimorphic e.g. String, AsciiString

Modifications:
Create two fast path in case the other char sequence is an AsciiString

Result:
Faster and more stable ascii region matching