### PR TITLE
IoUring: Ensure io_uring testsuite can also be run if register a buff…

### DIFF
--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingCompositeBufferGatheringWriteTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingCompositeBufferGatheringWriteTest.java
@@ -31,6 +31,7 @@ public class IoUringBufferRingCompositeBufferGatheringWriteTest extends Composit
     @BeforeAll
     public static void loadJNI() {
         assumeTrue(IoUring.isAvailable());
+        assumeTrue(IoUring.isRegisterBufferRingSupported());
     }
 
     @Override

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketChannelNotYetConnectedTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketChannelNotYetConnectedTest.java
@@ -30,6 +30,7 @@ public class IoUringBufferRingSocketChannelNotYetConnectedTest extends SocketCha
     @BeforeAll
     public static void loadJNI() {
         assumeTrue(IoUring.isAvailable());
+        assumeTrue(IoUring.isRegisterBufferRingSupported());
     }
 
     @Override

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketConditionalWritabilityTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketConditionalWritabilityTest.java
@@ -31,6 +31,7 @@ public class IoUringBufferRingSocketConditionalWritabilityTest extends SocketCon
     @BeforeAll
     public static void loadJNI() {
         assumeTrue(IoUring.isAvailable());
+        assumeTrue(IoUring.isRegisterBufferRingSupported());
     }
 
     @Override

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketConnectTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketConnectTest.java
@@ -31,6 +31,7 @@ public class IoUringBufferRingSocketConnectTest extends SocketConnectTest {
     @BeforeAll
     public static void loadJNI() {
         assumeTrue(IoUring.isAvailable());
+        assumeTrue(IoUring.isRegisterBufferRingSupported());
     }
 
     @Override

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketConnectionAttemptTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketConnectionAttemptTest.java
@@ -30,6 +30,7 @@ public class IoUringBufferRingSocketConnectionAttemptTest extends SocketConnecti
     @BeforeAll
     public static void loadJNI() {
         assumeTrue(IoUring.isAvailable());
+        assumeTrue(IoUring.isRegisterBufferRingSupported());
     }
 
     @Override

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketDataReadInitialStateTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketDataReadInitialStateTest.java
@@ -31,6 +31,7 @@ public class IoUringBufferRingSocketDataReadInitialStateTest extends SocketDataR
     @BeforeAll
     public static void loadJNI() {
         assumeTrue(IoUring.isAvailable());
+        assumeTrue(IoUring.isRegisterBufferRingSupported());
     }
 
     @Override

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketEchoTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketEchoTest.java
@@ -31,6 +31,7 @@ public class IoUringBufferRingSocketEchoTest extends SocketEchoTest {
     @BeforeAll
     public static void loadJNI() {
         assumeTrue(IoUring.isAvailable());
+        assumeTrue(IoUring.isRegisterBufferRingSupported());
     }
 
     @Override

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketExceptionHandlingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketExceptionHandlingTest.java
@@ -31,6 +31,7 @@ public class IoUringBufferRingSocketExceptionHandlingTest extends SocketExceptio
     @BeforeAll
     public static void loadJNI() {
         assumeTrue(IoUring.isAvailable());
+        assumeTrue(IoUring.isRegisterBufferRingSupported());
     }
 
     @Override

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketFileRegionTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketFileRegionTest.java
@@ -33,6 +33,7 @@ public class IoUringBufferRingSocketFileRegionTest extends SocketFileRegionTest 
     @BeforeAll
     public static void loadJNI() {
         assumeTrue(IoUring.isAvailable());
+        assumeTrue(IoUring.isRegisterBufferRingSupported());
     }
 
     @Override

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketFixedLengthEchoTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketFixedLengthEchoTest.java
@@ -31,6 +31,7 @@ public class IoUringBufferRingSocketFixedLengthEchoTest extends SocketFixedLengt
     @BeforeAll
     public static void loadJNI() {
         assumeTrue(IoUring.isAvailable());
+        assumeTrue(IoUring.isRegisterBufferRingSupported());
     }
 
     @Override

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketGatheringWriteTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketGatheringWriteTest.java
@@ -31,6 +31,7 @@ public class IoUringBufferRingSocketGatheringWriteTest extends SocketGatheringWr
     @BeforeAll
     public static void loadJNI() {
         assumeTrue(IoUring.isAvailable());
+        assumeTrue(IoUring.isRegisterBufferRingSupported());
     }
 
     @Override

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketHalfClosedTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketHalfClosedTest.java
@@ -36,6 +36,7 @@ public class IoUringBufferRingSocketHalfClosedTest extends SocketHalfClosedTest 
     @BeforeAll
     public static void loadJNI() {
         assumeTrue(IoUring.isAvailable());
+        assumeTrue(IoUring.isRegisterBufferRingSupported());
     }
 
     @Override

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketMultipleConnectTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketMultipleConnectTest.java
@@ -35,6 +35,7 @@ public class IoUringBufferRingSocketMultipleConnectTest extends SocketMultipleCo
     @BeforeAll
     public static void loadJNI() {
         assumeTrue(IoUring.isAvailable());
+        assumeTrue(IoUring.isRegisterBufferRingSupported());
     }
 
     @Override

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketRstTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketRstTest.java
@@ -36,6 +36,7 @@ public class IoUringBufferRingSocketRstTest extends SocketRstTest {
     @BeforeAll
     public static void loadJNI() {
         assumeTrue(IoUring.isAvailable());
+        assumeTrue(IoUring.isRegisterBufferRingSupported());
     }
 
     @Override

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketShutdownOutputByPeerTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketShutdownOutputByPeerTest.java
@@ -30,6 +30,7 @@ public class IoUringBufferRingSocketShutdownOutputByPeerTest extends SocketShutd
     @BeforeAll
     public static void loadJNI() {
         assumeTrue(IoUring.isAvailable());
+        assumeTrue(IoUring.isRegisterBufferRingSupported());
     }
 
     @Override

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketShutdownOutputBySelfTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketShutdownOutputBySelfTest.java
@@ -30,6 +30,7 @@ public class IoUringBufferRingSocketShutdownOutputBySelfTest extends SocketShutd
     @BeforeAll
     public static void loadJNI() {
         assumeTrue(IoUring.isAvailable());
+        assumeTrue(IoUring.isRegisterBufferRingSupported());
     }
 
     @Override

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketSslClientRenegotiateTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketSslClientRenegotiateTest.java
@@ -31,6 +31,7 @@ public class IoUringBufferRingSocketSslClientRenegotiateTest extends SocketSslCl
     @BeforeAll
     public static void loadJNI() {
         assumeTrue(IoUring.isAvailable());
+        assumeTrue(IoUring.isRegisterBufferRingSupported());
     }
 
     @Override

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketSslEchoTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketSslEchoTest.java
@@ -31,6 +31,7 @@ public class IoUringBufferRingSocketSslEchoTest extends SocketSslEchoTest {
     @BeforeAll
     public static void loadJNI() {
         assumeTrue(IoUring.isAvailable());
+        assumeTrue(IoUring.isRegisterBufferRingSupported());
     }
 
     @Override

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketSslGreetingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketSslGreetingTest.java
@@ -31,6 +31,7 @@ public class IoUringBufferRingSocketSslGreetingTest extends SocketSslGreetingTes
     @BeforeAll
     public static void loadJNI() {
         assumeTrue(IoUring.isAvailable());
+        assumeTrue(IoUring.isRegisterBufferRingSupported());
     }
 
     @Override

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketSslSessionReuseTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketSslSessionReuseTest.java
@@ -31,6 +31,7 @@ public class IoUringBufferRingSocketSslSessionReuseTest extends SocketSslSession
     @BeforeAll
     public static void loadJNI() {
         assumeTrue(IoUring.isAvailable());
+        assumeTrue(IoUring.isRegisterBufferRingSupported());
     }
 
     @Override

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketStartTlsTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketStartTlsTest.java
@@ -31,6 +31,7 @@ public class IoUringBufferRingSocketStartTlsTest extends SocketStartTlsTest {
     @BeforeAll
     public static void loadJNI() {
         assumeTrue(IoUring.isAvailable());
+        assumeTrue(IoUring.isRegisterBufferRingSupported());
     }
 
     @Override

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketStringEchoTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketStringEchoTest.java
@@ -31,6 +31,7 @@ public class IoUringBufferRingSocketStringEchoTest extends SocketStringEchoTest 
     @BeforeAll
     public static void loadJNI() {
         assumeTrue(IoUring.isAvailable());
+        assumeTrue(IoUring.isRegisterBufferRingSupported());
     }
 
     @Override

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
@@ -48,6 +48,7 @@ public class IoUringBufferRingTest {
     @BeforeAll
     public static void loadJNI() {
         assumeTrue(IoUring.isAvailable());
+        assumeTrue(IoUring.isRegisterBufferRingSupported());
     }
 
     @Test

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingWriteBeforeRegisteredTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingWriteBeforeRegisteredTest.java
@@ -30,6 +30,7 @@ public class IoUringBufferRingWriteBeforeRegisteredTest extends WriteBeforeRegis
     @BeforeAll
     public static void loadJNI() {
         assumeTrue(IoUring.isAvailable());
+        assumeTrue(IoUring.isRegisterBufferRingSupported());
     }
 
     @Override

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketTestPermutation.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketTestPermutation.java
@@ -44,10 +44,18 @@ public class IoUringSocketTestPermutation extends SocketTestPermutation {
             BOSSES, new DefaultThreadFactory("testsuite-io_uring-boss", true), IoUringIoHandler.newFactory());
     static final EventLoopGroup IO_URING_WORKER_GROUP = new MultiThreadIoEventLoopGroup(
             WORKERS, new DefaultThreadFactory("testsuite-io_uring-worker", true),
-            IoUringIoHandler.newFactory(new IoUringIoHandlerConfig()
-                    .setBufferRingConfig(
-                            new IoUringBufferRingConfig(BGID, (short) 16, 16 * 16,
-                                    new IoUringFixedBufferRingAllocator(1024)))));
+            IoUringIoHandler.newFactory(buildConfig()));
+
+    static IoUringIoHandlerConfig buildConfig() {
+        IoUringIoHandlerConfig config = new IoUringIoHandlerConfig();
+        if (IoUring.isRegisterBufferRingSupported()) {
+            config.setBufferRingConfig(
+                    new IoUringBufferRingConfig(BGID, (short) 16, 16 * 16,
+                            new IoUringFixedBufferRingAllocator(1024)));
+        }
+        return config;
+    }
+
     @Override
     public List<BootstrapComboFactory<ServerBootstrap, Bootstrap>> socket() {
 


### PR DESCRIPTION
…er ring is not supported.

Motivation:

It might not be supported to use a buffer ring, we should just skip these tests then and run the rest.

Modifications:

Only try to use buffer ring if supported

Result:

Be able to run on more distributions