### PR TITLE
Adaptive: Correctly enforce leak detection when using AdaptiveByteBuf…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptiveByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptiveByteBufAllocator.java
@@ -70,12 +70,12 @@ public final class AdaptiveByteBufAllocator extends AbstractByteBufAllocator
 
     @Override
     protected ByteBuf newHeapBuffer(int initialCapacity, int maxCapacity) {
-        return heap.allocate(initialCapacity, maxCapacity);
+        return toLeakAwareBuffer(heap.allocate(initialCapacity, maxCapacity));
     }
 
     @Override
     protected ByteBuf newDirectBuffer(int initialCapacity, int maxCapacity) {
-        return direct.allocate(initialCapacity, maxCapacity);
+        return toLeakAwareBuffer(direct.allocate(initialCapacity, maxCapacity));
     }
 
     @Override


### PR DESCRIPTION
…… (#14946)

…Allocator

Motivation:

We meesed to call toLeakAwareBuffer(...) in AdaptiveByteBufAllocator which basically means that there was no leak detection at all enabled.

Modifications:

Correctly call toLeakAwareBuffer(...)

Result:

Leak detection also works with AdaptiveByteBufAllocator
