### PR TITLE
IoUring: Directly read ringMask and ringEntries in JNI and so reduce …

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionQueue.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionQueue.java
@@ -48,7 +48,7 @@ final class CompletionQueue {
     private int ringHead;
     private boolean closed;
 
-    CompletionQueue(long kHeadAddress, long kTailAddress, long kRingMaskAddress, long kRingEntriesAddress,
+    CompletionQueue(long kHeadAddress, long kTailAddress, int ringMask, int ringEntries,
                     long kOverflowAddress, long completionQueueArrayAddress, int ringSize, long ringAddress,
                     int ringFd, int ringCapacity) {
         this.kHeadAddress = kHeadAddress;
@@ -59,8 +59,8 @@ final class CompletionQueue {
         this.ringFd = ringFd;
         this.ringCapacity = ringCapacity;
 
-        ringEntries = PlatformDependent.getIntVolatile(kRingEntriesAddress);
-        ringMask = PlatformDependent.getIntVolatile(kRingMaskAddress);
+        this.ringEntries = ringEntries;
+        this.ringMask = ringMask;
         ringHead = PlatformDependent.getIntVolatile(kHeadAddress);
     }
 

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -350,8 +350,8 @@ final class Native {
         CompletionQueue completionQueue = new CompletionQueue(
                 values[0],
                 values[1],
-                values[2],
-                values[3],
+                (int) values[2],
+                (int) values[3],
                 values[4],
                 values[5],
                 (int) values[6],
@@ -361,8 +361,8 @@ final class Native {
         SubmissionQueue submissionQueue = new SubmissionQueue(
                 values[10],
                 values[11],
-                values[12],
-                values[13],
+                (int) values[12],
+                (int) values[13],
                 values[14],
                 values[15],
                 values[16],

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/SubmissionQueue.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/SubmissionQueue.java
@@ -64,7 +64,7 @@ final class SubmissionQueue {
 
     private boolean closed;
 
-    SubmissionQueue(long kHeadAddress, long kTailAddress, long kRingMaskAddress, long kRingEntriesAddress,
+    SubmissionQueue(long kHeadAddress, long kTailAddress, int ringMask, int ringEntries,
                     long kFlagsAddress, long kDroppedAddress, long kArrayAddress,
                     long submissionQueueArrayAddress, int ringSize, long ringAddress,
                     int ringFd) {
@@ -78,8 +78,8 @@ final class SubmissionQueue {
         this.ringAddress = ringAddress;
         this.ringFd = ringFd;
         this.enterRingFd = ringFd;
-        this.ringEntries = PlatformDependent.getIntVolatile(kRingEntriesAddress);
-        this.ringMask = PlatformDependent.getIntVolatile(kRingMaskAddress);
+        this.ringEntries = ringEntries;
+        this.ringMask = ringMask;
         this.head = PlatformDependent.getIntVolatile(kHeadAddress);
         this.tail = PlatformDependent.getIntVolatile(kTailAddress);
 

--- a/transport-native-io_uring/src/main/c/netty_io_uring_native.c
+++ b/transport-native-io_uring/src/main/c/netty_io_uring_native.c
@@ -333,8 +333,10 @@ static jlongArray netty_io_uring_setup(JNIEnv *env, jclass clazz, jint entries, 
     jlong completionArrayElements[] = {
         (jlong)io_uring_ring.cq.khead,
         (jlong)io_uring_ring.cq.ktail,
-        (jlong)io_uring_ring.cq.kring_mask,
-        (jlong)io_uring_ring.cq.kring_entries,
+        // Should be replaced by ring_mask when we depend on later kernel versions
+        (jlong)*io_uring_ring.cq.kring_mask,
+        // Should be replaced by ring_entries when we depend on later kernel versions
+        (jlong)*io_uring_ring.cq.kring_entries,
         (jlong)io_uring_ring.cq.koverflow,
         (jlong)io_uring_ring.cq.cqes,
         (jlong)io_uring_ring.cq.ring_sz,
@@ -347,8 +349,10 @@ static jlongArray netty_io_uring_setup(JNIEnv *env, jclass clazz, jint entries, 
     jlong submissionArrayElements[] = {
         (jlong)io_uring_ring.sq.khead,
         (jlong)io_uring_ring.sq.ktail,
-        (jlong)io_uring_ring.sq.kring_mask,
-        (jlong)io_uring_ring.sq.kring_entries,
+        // Should be replaced by ring_mask when we depend on later kernel versions
+        (jlong)*io_uring_ring.sq.kring_mask,
+        // Should be replaced by ring_entries when we depend on later kernel versions
+        (jlong)*io_uring_ring.sq.kring_entries,
         (jlong)io_uring_ring.sq.kflags,
         (jlong)io_uring_ring.sq.kdropped,
         (jlong)io_uring_ring.sq.array,


### PR DESCRIPTION
…the need of reading native memory via java.

Motivation:

We can read ringMask and ringEntries directly when setup the ring and pass it back to the java layer as these values will never change.

Modifications:

Directly read the values

Result:

Cleanup