### PR TITLE
IoUring: Remove unused fields / params and fill sqarray when setup ring

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionQueue.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionQueue.java
@@ -49,7 +49,7 @@ final class CompletionQueue {
     private boolean closed;
 
     CompletionQueue(long kHeadAddress, long kTailAddress, int ringMask, int ringEntries,
-                    long kOverflowAddress, long completionQueueArrayAddress, int ringSize, long ringAddress,
+                    long completionQueueArrayAddress, int ringSize, long ringAddress,
                     int ringFd, int ringCapacity) {
         this.kHeadAddress = kHeadAddress;
         this.kTailAddress = kTailAddress;

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -346,31 +346,27 @@ final class Native {
         ObjectUtil.checkPositive(ringSize, "ringSize");
         ObjectUtil.checkPositive(cqeSize, "cqeSize");
         long[] values = ioUringSetup(ringSize, cqeSize, setupFlags);
-        assert values.length == 22;
+        assert values.length == 18;
         CompletionQueue completionQueue = new CompletionQueue(
                 values[0],
                 values[1],
                 (int) values[2],
                 (int) values[3],
                 values[4],
-                values[5],
-                (int) values[6],
-                values[7],
-                (int) values[8],
-                (int) values[9]);
+                (int) values[5],
+                values[6],
+                (int) values[7],
+                (int) values[8]);
         SubmissionQueue submissionQueue = new SubmissionQueue(
+                values[9],
                 values[10],
-                values[11],
+                (int) values[11],
                 (int) values[12],
-                (int) values[13],
-                values[14],
+                values[13],
+                (int) values[14],
                 values[15],
-                values[16],
-                values[17],
-                (int) values[18],
-                values[19],
-                (int) values[20]);
-        return new RingBuffer(submissionQueue, completionQueue, (int) values[21]);
+                (int) values[16]);
+        return new RingBuffer(submissionQueue, completionQueue, (int) values[17]);
     }
 
     static void checkAllIOSupported(int ringFd) {

--- a/transport-native-io_uring/src/main/c/io_uring.h
+++ b/transport-native-io_uring/src/main/c/io_uring.h
@@ -147,6 +147,11 @@ enum {
  */
 #define IORING_SETUP_DEFER_TASKRUN	(1U << 13)
 
+/*
+ * Removes indirection through the SQ index array.
+ */
+#define IORING_SETUP_NO_SQARRAY		(1U << 16)
+
 enum {
 	IORING_OP_NOP,
 	IORING_OP_READV,

--- a/transport-native-io_uring/src/main/c/netty_io_uring_native.c
+++ b/transport-native-io_uring/src/main/c/netty_io_uring_native.c
@@ -96,6 +96,7 @@ static void io_uring_unmap_rings(struct io_uring_sq *sq, struct io_uring_cq *cq)
 static int io_uring_mmap(int fd, struct io_uring_params *p, struct io_uring_sq *sq, struct io_uring_cq *cq) {
     size_t size;
     int ret;
+    int index;
 
     sq->ring_sz = p->sq_off.array + p->sq_entries * sizeof(unsigned);
     cq->ring_sz = p->cq_off.cqes + p->cq_entries * sizeof(struct io_uring_cqe);
@@ -145,7 +146,7 @@ static int io_uring_mmap(int fd, struct io_uring_params *p, struct io_uring_sq *
     cq->cqes = cq->ring_ptr + p->cq_off.cqes;
 
     if (!(p->flags & IORING_SETUP_NO_SQARRAY)) {
-        for (int index = 0; index < p->sq_entries; index++) {
+        for (index = 0; index < p->sq_entries; index++) {
             sq->array[index] = index;
         }
     }


### PR DESCRIPTION
Motivation:

We passed various pointers back that we actually not need. Beside this we also did some initialization of the sqarray in our java layer while we should better move it to the jni layer as its part of the setup.

Modifications:

- Remove unused pointers from returned long[] and also from constructors / fields.
- Fill sq array while setup ring in JNI layer

Result:

Cleanup