### PR TITLE
[bugfix]: Fix the issue where pendingTimeouts may be incorrect in the HashedWheelTimer. (#14959)

### DIFF
--- a/common/src/main/java/io/netty/util/HashedWheelTimer.java
+++ b/common/src/main/java/io/netty/util/HashedWheelTimer.java
@@ -669,9 +669,8 @@ public class HashedWheelTimer implements Timer {
             HashedWheelBucket bucket = this.bucket;
             if (bucket != null) {
                 bucket.remove(this);
-            } else {
-                timer.pendingTimeouts.decrementAndGet();
             }
+            timer.pendingTimeouts.decrementAndGet();
         }
 
         public boolean compareAndSetState(int expected, int state) {
@@ -698,6 +697,7 @@ public class HashedWheelTimer implements Timer {
             }
 
             try {
+                remove();
                 timer.taskExecutor.execute(this);
             } catch (Throwable t) {
                 if (logger.isWarnEnabled()) {
@@ -783,7 +783,6 @@ public class HashedWheelTimer implements Timer {
             while (timeout != null) {
                 HashedWheelTimeout next = timeout.next;
                 if (timeout.remainingRounds <= 0) {
-                    next = remove(timeout);
                     if (timeout.deadline <= deadline) {
                         timeout.expire();
                     } else {
@@ -791,9 +790,7 @@ public class HashedWheelTimer implements Timer {
                         throw new IllegalStateException(String.format(
                                 "timeout.deadline (%d) > deadline (%d)", timeout.deadline, deadline));
                     }
-                } else if (timeout.isCancelled()) {
-                    next = remove(timeout);
-                } else {
+                } else if (!timeout.isCancelled()) {
                     timeout.remainingRounds --;
                 }
                 timeout = next;
@@ -826,7 +823,6 @@ public class HashedWheelTimer implements Timer {
             timeout.prev = null;
             timeout.next = null;
             timeout.bucket = null;
-            timeout.timer.pendingTimeouts.decrementAndGet();
             return next;
         }
 


### PR DESCRIPTION
Motivation:

If the user sets a positive `maxPendingTimeouts` of `HashedWheelTimer,` this bug means that the maximum number of tasks can be potentially increased.

Modification:

When the worker thread expires the tasks of the current tick, `pendingTimeouts`  decremented only when the status of `HashedWheelTimeout` is successfully changed from `ST_INIT` to `ST_EXPIRED.` For other cases, `pendingTimeouts` will be decremented in `processCancelledTasks()` when the next tick is reached.

Result:

Fixes #14959. 