### PR TITLE
IoUring: Allow to use io_uring without sun.misc.Unsafe

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -36,9 +36,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - setup: linux-x86_64-java8
-            docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.18.yaml build"
-            docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.18.yaml run stage-snapshot"
+          - setup: linux-x86_64-java11
+            docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.111.yaml build"
+            docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.111.yaml run stage-snapshot"
           - setup: linux-aarch64
             docker-compose-build: "-f docker/docker-compose.centos-7.yaml build"
             docker-compose-run: "-f docker/docker-compose.centos-7.yaml run cross-compile-aarch64-stage-snapshot"
@@ -85,11 +85,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up JDK 8
+      - name: Set up JDK 11
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: '8'
+          java-version: '11'
 
       # Cache .m2/repository
       - name: Cache local Maven repository
@@ -121,17 +121,17 @@ jobs:
           name: linux-riscv64-local-staging
           path: ~/linux-riscv64-local-staging
 
-      - name: Download linux-x86_64-java8 staging directory
+      - name: Download linux-x86_64-java11 staging directory
         uses: actions/download-artifact@v4
         with:
-          name: linux-x86_64-java8-local-staging
-          path: ~/linux-x86_64-java8-local-staging
+          name: linux-x86_64-java11-local-staging
+          path: ~/linux-x86_64-java11-local-staging
 
       - name: Copy previous build artifacts to local maven repository
         run: |
           cp -r ~/linux-aarch64-local-staging/deferred/* ~/.m2/repository/
           cp -r ~/linux-riscv64-local-staging/deferred/* ~/.m2/repository/
-          cp -r ~/linux-x86_64-java8-local-staging/deferred/* ~/.m2/repository/
+          cp -r ~/linux-x86_64-java11-local-staging/deferred/* ~/.m2/repository/
 
       - name: Generate netty-all and deploy to local staging.
         run: |
@@ -145,8 +145,8 @@ jobs:
           cp -r ~/linux-aarch64-local-staging/deferred/* ~/local-staging/deferred/
           cat ~/linux-riscv64-local-staging/deferred/.index >>  ~/local-staging/deferred/.index
           cp -r ~/linux-riscv64-local-staging/deferred/* ~/local-staging/deferred/
-          cat ~/linux-x86_64-java8-local-staging/deferred/.index >>  ~/local-staging/deferred/.index
-          cp -r ~/linux-x86_64-java8-local-staging/deferred/* ~/local-staging/deferred/
+          cat ~/linux-x86_64-java11-local-staging/deferred/.index >>  ~/local-staging/deferred/.index
+          cp -r ~/linux-x86_64-java11-local-staging/deferred/* ~/local-staging/deferred/
           cat ~/all-local-staging/deferred/.index >>  ~/local-staging/deferred/.index
           cp -r ~/all-local-staging/deferred/io/netty/netty-all/* ~/local-staging/deferred/io/netty/netty-all/
 

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: '8'
+          java-version: '11'
 
       # Cache .m2/repository
       - name: Cache local Maven repository
@@ -167,9 +167,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - setup: linux-x86_64-java8
-            docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.18.yaml build"
-            docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.18.yaml run build"
           - setup: linux-x86_64-java11
             docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.111.yaml build"
             docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.111.yaml run build"

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 8
+      - name: Set up JDK 11
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'

--- a/.github/workflows/ci-release-4.2.yml
+++ b/.github/workflows/ci-release-4.2.yml
@@ -33,11 +33,11 @@ jobs:
         with:
           ref: 4.2
 
-      - name: Set up JDK 8
+      - name: Set up JDK 11
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: '8'
+          java-version: '11'
 
       - name: Setup git configuration
         run: |
@@ -82,9 +82,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - setup: linux-x86_64-java8
-            docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.18.yaml build"
-            docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.18.yaml run stage-release"
+          - setup: linux-x86_64-java11
+            docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.111.yaml build"
+            docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.111.yaml run stage-release"
           - setup: linux-aarch64
             docker-compose-build: "-f docker/docker-compose.centos-7.yaml build"
             docker-compose-run: "-f docker/docker-compose.centos-7.yaml run cross-compile-aarch64-stage-release"
@@ -104,11 +104,11 @@ jobs:
       - name: Adjust mvnw permissions
         run: chmod 755 ./prepare-release-workspace/mvnw
 
-      - name: Set up JDK 8
+      - name: Set up JDK 11
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: '8'
+          java-version: '11'
 
       - name: Setup git configuration
         run: |
@@ -184,11 +184,11 @@ jobs:
       - name: Adjust mvnw permissions
         run: chmod 755 ./prepare-release-workspace/mvnw
 
-      - name: Set up JDK 8
+      - name: Set up JDK 11
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: '8'
+          java-version: '11'
 
       - name: Setup git configuration
         run: |
@@ -215,17 +215,17 @@ jobs:
           name: linux-riscv64-local-staging
           path: ~/linux-riscv64-local-staging
 
-      - name: Download linux-x86_64-java8 staging directory
+      - name: Download linux-x86_64-java11 staging directory
         uses: actions/download-artifact@v4
         with:
-          name: linux-x86_64-java8-local-staging
-          path: ~/linux-x86_64-java8-local-staging
+          name: linux-x86_64-java11-local-staging
+          path: ~/linux-x86_64-java11-local-staging
 
       # This step takes care of merging all the previous staged repositories in a way that will allow us to deploy
       # all together with one maven command.
       - name: Merge staging repositories
         working-directory: ./prepare-release-workspace/
-        run: bash ./.github/scripts/merge_local_staging.sh /home/runner/local-staging/staging ~/linux-aarch64-local-staging/staging ~/linux-riscv64-local-staging/staging ~/linux-x86_64-java8-local-staging/staging
+        run: bash ./.github/scripts/merge_local_staging.sh /home/runner/local-staging/staging ~/linux-aarch64-local-staging/staging ~/linux-riscv64-local-staging/staging ~/linux-x86_64-java11-local-staging/staging
 
       - uses: s4u/maven-settings-action@v3.0.0
         with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -92,7 +92,7 @@ jobs:
     - uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
-        java-version: '8' # The JDK version to make available on the path.
+        java-version: '11' # The JDK version to make available on the path.
 
     - name: Compile project
       run: ./mvnw -B -ntp clean package -DskipTests=true

--- a/transport-classes-io_uring/pom.xml
+++ b/transport-classes-io_uring/pom.xml
@@ -28,6 +28,9 @@
 
   <properties>
     <javaModuleName>io.netty.transport.classes.io_uring</javaModuleName>
+    <maven.compiler.source>1.9</maven.compiler.source>
+    <maven.compiler.target>1.9</maven.compiler.target>
+    <maven.compiler.release>9</maven.compiler.release>
   </properties>
 
   <dependencies>
@@ -55,6 +58,63 @@
 
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.13.0</version>
+        <!--
+          We need to compile everything except the IoUring class with Java9+
+          The reason for this is that we want still be able to use IoUring.ensureAvaibility() on Java8.
+        -->
+        <executions>
+          <execution>
+            <id>default-compile</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <compilerVersion>1.8</compilerVersion>
+              <fork>true</fork>
+              <source>${maven.compiler.source}</source>
+              <target>${maven.compiler.target}</target>
+              <release>${maven.compiler.release}</release>
+              <debug>true</debug>
+              <optimize>true</optimize>
+              <showDeprecation>true</showDeprecation>
+              <showWarnings>true</showWarnings>
+              <compilerArgument>-Xlint:-options</compilerArgument>
+              <meminitial>256m</meminitial>
+              <maxmem>1024m</maxmem>
+              <excludes>
+                <exclude>**/package-info.java</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>compile-jdk8</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <compilerVersion>1.8</compilerVersion>
+              <fork>true</fork>
+              <source>1.8</source>
+              <target>1.8</target>
+              <release>8</release>
+              <debug>true</debug>
+              <optimize>true</optimize>
+              <showDeprecation>true</showDeprecation>
+              <showWarnings>true</showWarnings>
+              <compilerArgument>-Xlint:-options</compilerArgument>
+              <meminitial>256m</meminitial>
+              <maxmem>1024m</maxmem>
+              <includes>
+                <include>**/IoUring.java</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
+
+      </plugin>
       <plugin>
         <groupId>io.github.dmlloyd.module-info</groupId>
         <artifactId>module-info</artifactId>

--- a/transport-classes-io_uring/pom.xml
+++ b/transport-classes-io_uring/pom.xml
@@ -72,7 +72,7 @@
               <goal>compile</goal>
             </goals>
             <configuration>
-              <compilerVersion>1.8</compilerVersion>
+              <compilerVersion>1.9</compilerVersion>
               <fork>true</fork>
               <source>${maven.compiler.source}</source>
               <target>${maven.compiler.target}</target>

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringServerChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringServerChannel.java
@@ -122,7 +122,7 @@ abstract class AbstractIoUringServerChannel extends AbstractIoUringChannel imple
     }
 
     abstract Channel newChildChannel(
-            int fd, long acceptedAddressMemoryAddress, long acceptedAddressLengthMemoryAddress) throws Exception;
+            int fd, ByteBuffer acceptedAddressMemory) throws Exception;
 
     private final class UringServerChannelUnsafe extends AbstractIoUringChannel.AbstractUringUnsafe {
 
@@ -221,18 +221,15 @@ abstract class AbstractIoUringServerChannel extends AbstractIoUringChannel imple
 
             if (res >= 0) {
                 allocHandle.incMessagesRead(1);
-                final long acceptedAddressMemoryAddress;
+                final ByteBuffer acceptedAddressBuffer;
                 final long acceptedAddressLengthMemoryAddress;
                 if (acceptedAddressMemory == null) {
-                    acceptedAddressMemoryAddress = 0;
-                    acceptedAddressLengthMemoryAddress = 0;
+                    acceptedAddressBuffer = null;
                 } else {
-                    acceptedAddressMemoryAddress = acceptedAddressMemory.acceptedAddressMemoryAddress;
-                    acceptedAddressLengthMemoryAddress = acceptedAddressMemory.acceptedAddressLengthMemoryAddress;
+                    acceptedAddressBuffer = acceptedAddressMemory.acceptedAddressMemory;
                 }
                 try {
-                    Channel channel = newChildChannel(
-                            res, acceptedAddressMemoryAddress, acceptedAddressLengthMemoryAddress);
+                    Channel channel = newChildChannel(res, acceptedAddressBuffer);
                     pipeline.fireChannelRead(channel);
 
                     if (allocHandle.continueReading() &&

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -280,7 +280,7 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
             } else {
                 ByteBuf buf = (ByteBuf) msg;
                 ops = IoUringIoOps.newWrite(fd, (byte) 0, 0,
-                        buf.memoryAddress() + buf.readerIndex(), buf.readableBytes(), nextOpsId());
+                        IoUring.memoryAddress(buf) + buf.readerIndex(), buf.readableBytes(), nextOpsId());
             }
 
             byte opCode = ops.opcode();
@@ -337,7 +337,7 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
                 int recvFlags = calculateRecvFlags(first);
 
                 IoUringIoOps ops = IoUringIoOps.newRecv(fd, (byte) 0, ioPrio, recvFlags,
-                        byteBuf.memoryAddress() + byteBuf.writerIndex(), byteBuf.writableBytes(), nextOpsId());
+                        IoUring.memoryAddress(byteBuf) + byteBuf.writerIndex(), byteBuf.writableBytes(), nextOpsId());
                 readId = registration.submit(ops);
                 if (readId == 0) {
                     return 0;

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CmsgHdr.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CmsgHdr.java
@@ -15,7 +15,7 @@
  */
 package io.netty.channel.uring;
 
-import io.netty.util.internal.PlatformDependent;
+import java.nio.ByteBuffer;
 
 /**
  * <pre>{@code
@@ -31,16 +31,17 @@ final class CmsgHdr {
 
     private CmsgHdr() { }
 
-    static void write(long cmsghdrAddress, long cmsgHdrDataAddress,
+    static void write(ByteBuffer cmsghdr, int cmsgHdrDataOffset,
                       int cmsgLen, int cmsgLevel, int cmsgType, short segmentSize) {
+        int cmsghdrPosition = cmsghdr.position();
         if (Native.SIZEOF_SIZE_T == 4) {
-            PlatformDependent.putInt(cmsghdrAddress + Native.CMSG_OFFSETOF_CMSG_LEN, cmsgLen);
+            cmsghdr.putInt(cmsghdrPosition + Native.CMSG_OFFSETOF_CMSG_LEN, cmsgLen);
         } else {
             assert Native.SIZEOF_SIZE_T == 8;
-            PlatformDependent.putLong(cmsghdrAddress + Native.CMSG_OFFSETOF_CMSG_LEN, cmsgLen);
+            cmsghdr.putLong(cmsghdrPosition + Native.CMSG_OFFSETOF_CMSG_LEN, cmsgLen);
         }
-        PlatformDependent.putInt(cmsghdrAddress + Native.CMSG_OFFSETOF_CMSG_LEVEL, cmsgLevel);
-        PlatformDependent.putInt(cmsghdrAddress + Native.CMSG_OFFSETOF_CMSG_TYPE, cmsgType);
-        PlatformDependent.putShort(cmsgHdrDataAddress, segmentSize);
+        cmsghdr.putInt(cmsghdrPosition + Native.CMSG_OFFSETOF_CMSG_LEVEL, cmsgLevel);
+        cmsghdr.putInt(cmsghdrPosition + Native.CMSG_OFFSETOF_CMSG_TYPE, cmsgType);
+        cmsghdr.putShort(cmsghdrPosition + cmsgHdrDataOffset, segmentSize);
     }
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionQueue.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionQueue.java
@@ -15,8 +15,10 @@
  */
 package io.netty.channel.uring;
 
-import io.netty.util.internal.PlatformDependent;
-
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.StringJoiner;
 
 /**
@@ -30,14 +32,14 @@ final class CompletionQueue {
     private static final int CQE_RES_FIELD = 8;
     private static final int CQE_FLAGS_FIELD = 12;
 
-    private static final long CQE_SIZE = 16;
+    static final int CQE_SIZE = 16;
 
-    //these unsigned integer pointers(shared with the kernel) will be changed by the kernel
-    private final long kHeadAddress;
-    private final long kTailAddress;
-
-    private final long completionQueueArrayAddress;
-
+    //these unsigned integer pointers(shared with the kernel) will be changed by the kernel and us
+    // using a VarHandle.
+    private final ByteBuffer khead;
+    private final ByteBuffer ktail;
+    private final ByteBuffer completionQueueArray;
+    private final VarHandle intHandle;
     final int ringSize;
     final long ringAddress;
     final int ringFd;
@@ -48,12 +50,13 @@ final class CompletionQueue {
     private int ringHead;
     private boolean closed;
 
-    CompletionQueue(long kHeadAddress, long kTailAddress, int ringMask, int ringEntries,
-                    long completionQueueArrayAddress, int ringSize, long ringAddress,
+    CompletionQueue(ByteBuffer kHead, ByteBuffer kTail, int ringMask, int ringEntries,
+                    ByteBuffer completionQueueArray, int ringSize, long ringAddress,
                     int ringFd, int ringCapacity) {
-        this.kHeadAddress = kHeadAddress;
-        this.kTailAddress = kTailAddress;
-        this.completionQueueArrayAddress = completionQueueArrayAddress;
+        intHandle = MethodHandles.byteBufferViewVarHandle(int[].class, ByteOrder.nativeOrder());
+        this.khead = kHead;
+        this.ktail = kTail;
+        this.completionQueueArray = completionQueueArray;
         this.ringSize = ringSize;
         this.ringAddress = ringAddress;
         this.ringFd = ringFd;
@@ -61,7 +64,7 @@ final class CompletionQueue {
 
         this.ringEntries = ringEntries;
         this.ringMask = ringMask;
-        ringHead = PlatformDependent.getIntVolatile(kHeadAddress);
+        ringHead = (int) intHandle.getVolatile(kHead, 0);
     }
 
     void close() {
@@ -73,14 +76,14 @@ final class CompletionQueue {
      * {@link #process(CompletionCallback)}, {@code false} otherwise.
      */
     boolean hasCompletions() {
-        return !closed && ringHead != PlatformDependent.getIntVolatile(kTailAddress);
+        return !closed && ringHead != (int) intHandle.getVolatile(ktail, 0);
     }
 
     int count() {
         if (closed) {
             return 0;
         }
-        return PlatformDependent.getIntVolatile(kTailAddress) - ringHead;
+        return (int) intHandle.getVolatile(ktail, 0) - ringHead;
     }
 
     /**
@@ -91,15 +94,15 @@ final class CompletionQueue {
         if (closed) {
             return 0;
         }
-        int tail = PlatformDependent.getIntVolatile(kTailAddress);
+        int tail = (int) intHandle.getVolatile(ktail, 0);
         try {
             int i = 0;
             while (ringHead != tail) {
-                long cqeAddress = completionQueueArrayAddress + (ringHead & ringMask) * CQE_SIZE;
+                int cqePosition = cqeIdx(ringHead, ringMask);
 
-                long udata = PlatformDependent.getLong(cqeAddress + CQE_USER_DATA_FIELD);
-                int res = PlatformDependent.getInt(cqeAddress + CQE_RES_FIELD);
-                int flags = PlatformDependent.getInt(cqeAddress + CQE_FLAGS_FIELD);
+                long udata = completionQueueArray.getLong(cqePosition + CQE_USER_DATA_FIELD);
+                int res = completionQueueArray.getInt(cqePosition + CQE_RES_FIELD);
+                int flags = completionQueueArray.getInt(cqePosition + CQE_FLAGS_FIELD);
 
                 ringHead++;
 
@@ -112,7 +115,7 @@ final class CompletionQueue {
             return i;
         } finally {
             // Ensure that the kernel only sees the new value of the head index after the CQEs have been read.
-            PlatformDependent.putIntOrdered(kHeadAddress, ringHead);
+            intHandle.setRelease(khead, 0, ringHead);
         }
     }
 
@@ -122,18 +125,21 @@ final class CompletionQueue {
         if (closed) {
             sb.add("closed");
         } else {
-            int tail = PlatformDependent.getIntVolatile(kTailAddress);
+            int tail = (int) intHandle.getVolatile(ktail, 0);
             int head = ringHead;
             while (head != tail) {
-                long cqeAddress = completionQueueArrayAddress + (ringHead & ringMask) * CQE_SIZE;
-                long udata = PlatformDependent.getLong(cqeAddress + CQE_USER_DATA_FIELD);
-                int res = PlatformDependent.getInt(cqeAddress + CQE_RES_FIELD);
-                int flags = PlatformDependent.getInt(cqeAddress + CQE_FLAGS_FIELD);
+                int cqePosition = cqeIdx(head++, ringMask);
+                long udata = completionQueueArray.getLong(cqePosition + CQE_USER_DATA_FIELD);
+                int res = completionQueueArray.getInt(cqePosition + CQE_RES_FIELD);
+                int flags = completionQueueArray.getInt(cqePosition + CQE_FLAGS_FIELD);
 
                 sb.add("(res=" + res).add(", flags=" + flags).add(", udata=" + udata).add(")");
-                head++;
             }
         }
         return sb.toString();
+    }
+
+    private static int cqeIdx(int ringHead, int ringMask) {
+        return (ringHead & ringMask) * CQE_SIZE;
     }
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRing.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRing.java
@@ -20,15 +20,19 @@ import io.netty.buffer.DuplicatedByteBuf;
 import io.netty.buffer.SlicedByteBuf;
 import io.netty.buffer.SwappedByteBuf;
 import io.netty.buffer.WrappedByteBuf;
-import io.netty.util.internal.PlatformDependent;
+import io.netty.channel.unix.Buffer;
 
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
 
 final class IoUringBufferRing {
-    private final long ioUringBufRingAddr;
-    private final long tailFieldAddress;
+    private final VarHandle shortHandle;
+    private final ByteBuffer ioUringBufRing;
+    private final int tailFieldPosition;
     private final short entries;
     private final int batchSize;
     private final int maxUnreleasedBuffers;
@@ -46,12 +50,13 @@ final class IoUringBufferRing {
     private int numBuffers;
     private boolean expanded;
 
-    IoUringBufferRing(int ringFd, long ioUringBufRingAddr,
+    IoUringBufferRing(int ringFd, ByteBuffer ioUringBufRing,
                       short entries, int batchSize, int maxUnreleasedBuffers, short bufferGroupId, boolean incremental,
                       IoUringBufferRingAllocator allocator) {
         assert entries % 2 == 0;
-        this.ioUringBufRingAddr = ioUringBufRingAddr;
-        this.tailFieldAddress = ioUringBufRingAddr + Native.IO_URING_BUFFER_RING_TAIL;
+        shortHandle = MethodHandles.byteBufferViewVarHandle(short[].class, ByteOrder.nativeOrder());
+        this.ioUringBufRing = ioUringBufRing;
+        this.tailFieldPosition = Native.IO_URING_BUFFER_RING_TAIL;
         this.entries = entries;
         this.batchSize = batchSize;
         this.maxUnreleasedBuffers = maxUnreleasedBuffers;
@@ -106,7 +111,7 @@ final class IoUringBufferRing {
         if (corrupted || closed) {
             return;
         }
-        short oldTail = PlatformDependent.getShort(tailFieldAddress);
+        short oldTail = (short) shortHandle.get(ioUringBufRing, tailFieldPosition);
         short ringIndex = (short) (oldTail & mask);
         assert buffers[ringIndex] == null;
         final ByteBuf byteBuf;
@@ -125,13 +130,14 @@ final class IoUringBufferRing {
         //  see:
         //  https://github.com/axboe/liburing/
         //      blob/19134a8fffd406b22595a5813a3e319c19630ac9/src/include/liburing.h#L1561
-        long ioUringBufAddress = ioUringBufRingAddr + (long) Native.SIZEOF_IOURING_BUF * ringIndex;
-        PlatformDependent.putLong(ioUringBufAddress + Native.IOURING_BUFFER_OFFSETOF_ADDR,
-                byteBuf.memoryAddress() + byteBuf.readerIndex());
-        PlatformDependent.putInt(ioUringBufAddress + Native.IOURING_BUFFER_OFFSETOF_LEN, byteBuf.capacity());
-        PlatformDependent.putShort(ioUringBufAddress + Native.IOURING_BUFFER_OFFSETOF_BID, ringIndex);
+        int  position = Native.SIZEOF_IOURING_BUF * ringIndex;
+        ioUringBufRing.putLong(position + Native.IOURING_BUFFER_OFFSETOF_ADDR,
+                IoUring.memoryAddress(byteBuf) + byteBuf.readerIndex());
+        ioUringBufRing.putInt(position + Native.IOURING_BUFFER_OFFSETOF_LEN, byteBuf.capacity());
+        ioUringBufRing.putShort(position + Native.IOURING_BUFFER_OFFSETOF_BID, ringIndex);
+
         // Now advanced the tail by the number of buffers that we just added.
-        PlatformDependent.putShortOrdered(tailFieldAddress, (short) (oldTail + 1));
+        shortHandle.setRelease(ioUringBufRing, tailFieldPosition, (short) (oldTail + 1));
         numBuffers++;
         // We added a buffer to the ring, let's reset the expanded variable so we can expand it if we receive
         // ENOBUFS.
@@ -198,7 +204,7 @@ final class IoUringBufferRing {
             return;
         }
         closed = true;
-        Native.ioUringUnRegisterBufRing(ringFd, ioUringBufRingAddr, entries, bufferGroupId);
+        Native.ioUringUnRegisterBufRing(ringFd, Buffer.memoryAddress(ioUringBufRing), entries, bufferGroupId);
         for (ByteBuf byteBuf : buffers) {
             if (byteBuf != null) {
                 byteBuf.release();

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -21,19 +21,20 @@ import io.netty.channel.IoHandler;
 import io.netty.channel.IoHandlerFactory;
 import io.netty.channel.IoOps;
 import io.netty.channel.IoRegistration;
+import io.netty.channel.unix.Buffer;
 import io.netty.channel.unix.Errors;
 import io.netty.channel.unix.FileDescriptor;
 import io.netty.util.collection.IntObjectHashMap;
 import io.netty.util.collection.IntObjectMap;
 import io.netty.util.concurrent.ThreadAwareExecutor;
 import io.netty.util.internal.ObjectUtil;
-import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -59,7 +60,9 @@ public final class IoUringIoHandler implements IoHandler {
 
     private final AtomicBoolean eventfdAsyncNotify = new AtomicBoolean();
     private final FileDescriptor eventfd;
-    private final long eventfdReadBuf;
+    private final ByteBuffer eventfdReadBuf;
+    private final long eventfdReadBufAddress;
+    private final ByteBuffer timeoutMemory;
     private final long timeoutMemoryAddress;
 
     private long eventfdReadSubmitted;
@@ -135,9 +138,10 @@ public final class IoUringIoHandler implements IoHandler {
 
         registrations = new IntObjectHashMap<>();
         eventfd = Native.newBlockingEventFd();
-        eventfdReadBuf = PlatformDependent.allocateMemory(8);
-        this.timeoutMemoryAddress = PlatformDependent.allocateMemory(KERNEL_TIMESPEC_SIZE);
-
+        eventfdReadBuf = Buffer.allocateDirectWithNativeOrder(Long.BYTES);
+        eventfdReadBufAddress = Buffer.memoryAddress(eventfdReadBuf);
+        this.timeoutMemory = Buffer.allocateDirectWithNativeOrder(KERNEL_TIMESPEC_SIZE);
+        this.timeoutMemoryAddress = Buffer.memoryAddress(timeoutMemory);
         // We buffer a maximum of 2 * CompletionQueue.ringCapacity completions before we drain them in batches.
         // Also as we never submit an udata which is 0L we use this as the tombstone marker.
         completionBuffer = new CompletionBuffer(ringBuffer.ioUringCompletionQueue().ringCapacity * 2, 0);
@@ -207,7 +211,8 @@ public final class IoUringIoHandler implements IoHandler {
         if (ioUringBufRingAddr < 0) {
             throw Errors.newIOException("ioUringRegisterBufRing", (int) ioUringBufRingAddr);
         }
-        return new IoUringBufferRing(ringFd, ioUringBufRingAddr,
+        return new IoUringBufferRing(ringFd,
+                Buffer.wrapMemoryAddressWithNativeOrder(ioUringBufRingAddr, Native.ioUringBufRingSize(bufferRingSize)),
                 bufferRingSize, bufferRingConfig.batchSize(), bufferRingConfig.maxUnreleasedBuffers(),
                 bufferGroupId, bufferRingConfig.isIncremental(), bufferRingConfig.allocator()
         );
@@ -294,7 +299,7 @@ public final class IoUringIoHandler implements IoHandler {
         long udata = UserData.encode(EVENTFD_ID, Native.IORING_OP_READ, (short) 0);
 
         eventfdReadSubmitted = submissionQueue.addEventFdRead(
-                eventfd.intValue(), eventfdReadBuf, 0, 8, udata);
+                eventfd.intValue(), eventfdReadBufAddress, 0, 8, udata);
     }
 
     private int submitAndWaitWithTimeout(SubmissionQueue submissionQueue,
@@ -313,9 +318,8 @@ public final class IoUringIoHandler implements IoHandler {
                 nanoSeconds = (int) max(timeoutNanoSeconds - seconds * 1000000000L, 0);
             }
 
-            PlatformDependent.putLong(timeoutMemoryAddress + KERNEL_TIMESPEC_TV_SEC_FIELD, seconds);
-            PlatformDependent.putLong(timeoutMemoryAddress + KERNEL_TIMESPEC_TV_NSEC_FIELD, nanoSeconds);
-
+            timeoutMemory.putLong(KERNEL_TIMESPEC_TV_SEC_FIELD, seconds);
+            timeoutMemory.putLong(KERNEL_TIMESPEC_TV_NSEC_FIELD, nanoSeconds);
             if (linkTimeout) {
                 submissionQueue.addLinkTimeout(timeoutMemoryAddress, udata);
             } else {
@@ -442,8 +446,8 @@ public final class IoUringIoHandler implements IoHandler {
         } catch (IOException e) {
             logger.warn("Failed to close eventfd", e);
         }
-        PlatformDependent.freeMemory(eventfdReadBuf);
-        PlatformDependent.freeMemory(timeoutMemoryAddress);
+        Buffer.free(eventfdReadBuf);
+        Buffer.free(timeoutMemory);
     }
 
     @Override

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Iov.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Iov.java
@@ -15,7 +15,7 @@
  */
 package io.netty.channel.uring;
 
-import io.netty.util.internal.PlatformDependent;
+import java.nio.ByteBuffer;
 
 /**
  * <pre>{@code
@@ -29,39 +29,30 @@ final class Iov {
 
     private Iov() { }
 
-    static void write(long iovAddress, long bufferAddress, int length) {
+    static void set(ByteBuffer buffer, long bufferAddress, int length) {
         if (Native.SIZEOF_SIZE_T == 4) {
-            PlatformDependent.putInt(iovAddress + Native.IOVEC_OFFSETOF_IOV_BASE, (int) bufferAddress);
-            PlatformDependent.putInt(iovAddress + Native.IOVEC_OFFSETOF_IOV_LEN, length);
+            buffer.putInt(buffer.position() + Native.IOVEC_OFFSETOF_IOV_BASE, (int) bufferAddress);
+            buffer.putInt(buffer.position() + Native.IOVEC_OFFSETOF_IOV_LEN, length);
         } else {
             assert Native.SIZEOF_SIZE_T == 8;
-            PlatformDependent.putLong(iovAddress + Native.IOVEC_OFFSETOF_IOV_BASE, bufferAddress);
-            PlatformDependent.putLong(iovAddress + Native.IOVEC_OFFSETOF_IOV_LEN, length);
+            buffer.putLong(buffer.position() + Native.IOVEC_OFFSETOF_IOV_BASE, bufferAddress);
+            buffer.putLong(buffer.position() + Native.IOVEC_OFFSETOF_IOV_LEN, length);
         }
     }
 
-    static long readBufferAddress(long iovAddress) {
+    static long getBufferAddress(ByteBuffer iov) {
         if (Native.SIZEOF_SIZE_T == 4) {
-            return PlatformDependent.getInt(iovAddress + Native.IOVEC_OFFSETOF_IOV_BASE);
+            return iov.getInt(iov.position() + Native.IOVEC_OFFSETOF_IOV_BASE);
         }
         assert Native.SIZEOF_SIZE_T == 8;
-        return PlatformDependent.getLong(iovAddress + Native.IOVEC_OFFSETOF_IOV_BASE);
+        return iov.getLong(iov.position() + Native.IOVEC_OFFSETOF_IOV_BASE);
     }
 
-    static int readBufferLength(long iovAddress) {
+    static int getBufferLength(ByteBuffer iov) {
         if (Native.SIZEOF_SIZE_T == 4) {
-            return PlatformDependent.getInt(iovAddress + Native.IOVEC_OFFSETOF_IOV_LEN);
+            return iov.getInt(iov.position() + Native.IOVEC_OFFSETOF_IOV_LEN);
         }
         assert Native.SIZEOF_SIZE_T == 8;
-        return (int) PlatformDependent.getLong(iovAddress + Native.IOVEC_OFFSETOF_IOV_LEN);
-    }
-
-    static long sumSize(long iovAddress, int length) {
-        long sum = 0;
-        for (int i = 0; i < length; i++) {
-            sum += readBufferLength(iovAddress);
-            iovAddress += 2L * Native.SIZEOF_SIZE_T;
-        }
-        return sum;
+        return (int) iov.getLong(iov.position() + Native.IOVEC_OFFSETOF_IOV_LEN);
     }
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Iov.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Iov.java
@@ -30,13 +30,14 @@ final class Iov {
     private Iov() { }
 
     static void set(ByteBuffer buffer, long bufferAddress, int length) {
+        int position = buffer.position();
         if (Native.SIZEOF_SIZE_T == 4) {
-            buffer.putInt(buffer.position() + Native.IOVEC_OFFSETOF_IOV_BASE, (int) bufferAddress);
-            buffer.putInt(buffer.position() + Native.IOVEC_OFFSETOF_IOV_LEN, length);
+            buffer.putInt(position + Native.IOVEC_OFFSETOF_IOV_BASE, (int) bufferAddress);
+            buffer.putInt(position + Native.IOVEC_OFFSETOF_IOV_LEN, length);
         } else {
             assert Native.SIZEOF_SIZE_T == 8;
-            buffer.putLong(buffer.position() + Native.IOVEC_OFFSETOF_IOV_BASE, bufferAddress);
-            buffer.putLong(buffer.position() + Native.IOVEC_OFFSETOF_IOV_LEN, length);
+            buffer.putLong(position + Native.IOVEC_OFFSETOF_IOV_BASE, bufferAddress);
+            buffer.putLong(position + Native.IOVEC_OFFSETOF_IOV_LEN, length);
         }
     }
 

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/MsgHdrMemory.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/MsgHdrMemory.java
@@ -41,7 +41,6 @@ final class MsgHdrMemory {
         iovMemory = Buffer.allocateDirectWithNativeOrder(Native.SIZEOF_IOVEC);
         cmsgDataMemory = Buffer.allocateDirectWithNativeOrder(Native.CMSG_SPACE);
 
-        // We retrieve the address of the data once so we can just be JNI free after construction.
         long cmsgDataMemoryAddr = Buffer.memoryAddress(cmsgDataMemory);
         long cmsgDataAddr = Native.cmsghdrData(cmsgDataMemoryAddr);
         cmsgDataOffset = (int) (cmsgDataAddr + cmsgDataMemoryAddr);
@@ -51,11 +50,11 @@ final class MsgHdrMemory {
         int addressLength;
         if (address == null) {
             addressLength = socket.isIpv6() ? Native.SIZEOF_SOCKADDR_IN6 : Native.SIZEOF_SOCKADDR_IN;
-            int socketAddrMemoryPosition = socketAddrMemory.position();
+            socketAddrMemory.mark();
             try {
                 socketAddrMemory.put(EMPTY_SOCKADDR_STORAGE);
             } finally {
-                socketAddrMemory.position(socketAddrMemoryPosition);
+                socketAddrMemory.reset();
             }
         } else {
             addressLength = SockaddrIn.set(socket.isIpv6(), socketAddrMemory, address);

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/RingBuffer.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/RingBuffer.java
@@ -65,7 +65,7 @@ final class RingBuffer {
         ioUringSubmissionQueue.close();
         ioUringCompletionQueue.close();
         Native.ioUringExit(
-                ioUringSubmissionQueue.submissionQueueArrayAddress,
+                ioUringSubmissionQueue.submissionQueueArrayAddress(),
                 ioUringSubmissionQueue.ringEntries,
                 ioUringSubmissionQueue.ringAddress,
                 ioUringSubmissionQueue.ringSize,

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/SockaddrIn.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/SockaddrIn.java
@@ -38,9 +38,8 @@ final class SockaddrIn {
     static int set(boolean ipv6, ByteBuffer memory, InetSocketAddress address) {
         if (ipv6) {
             return setIPv6(memory, address.getAddress(), address.getPort());
-        } else {
-            return setIPv4(memory, address.getAddress(), address.getPort());
         }
+        return setIPv4(memory, address.getAddress(), address.getPort());
     }
 
     /**
@@ -59,6 +58,7 @@ final class SockaddrIn {
      */
     static int setIPv4(ByteBuffer memory, InetAddress address, int port) {
         int position = memory.position();
+        memory.mark();
         try {
             // memset
             memory.put(SOCKADDR_IN_EMPTY_ARRAY);
@@ -79,7 +79,7 @@ final class SockaddrIn {
             return Native.SIZEOF_SOCKADDR_IN;
         } finally {
             // Restore position as we did change it via memory.put(byte[]...).
-            memory.position(position);
+            memory.reset();
         }
     }
 
@@ -100,6 +100,7 @@ final class SockaddrIn {
      */
     static int setIPv6(ByteBuffer memory, InetAddress address, int port) {
         int position = memory.position();
+        memory.mark();
         try {
             // memset
             memory.put(SOCKADDR_IN6_EMPTY_ARRAY);
@@ -112,8 +113,6 @@ final class SockaddrIn {
             if (bytes.length == IPV4_ADDRESS_LENGTH) {
                 memory.position(position + offset);
                 memory.put(IPV4_MAPPED_IPV6_PREFIX);
-
-                memory.position(position + offset + IPV4_MAPPED_IPV6_PREFIX.length);
                 memory.put(bytes, 0, IPV4_ADDRESS_LENGTH);
 
                 // Skip sin6_scope_id as we did memset before
@@ -126,14 +125,14 @@ final class SockaddrIn {
             }
             return Native.SIZEOF_SOCKADDR_IN6;
         } finally {
-            memory.position(position);
+            memory.reset();
         }
     }
 
     static InetSocketAddress getIPv4(ByteBuffer memory, byte[] tmpArray) {
         assert tmpArray.length == IPV4_ADDRESS_LENGTH;
         int position = memory.position();
-
+        memory.mark();
         try {
             int port = handleNetworkOrder(memory.order(),
                     memory.getShort(position + Native.SOCKADDR_IN_OFFSETOF_SIN_PORT)) & 0xFFFF;
@@ -145,7 +144,7 @@ final class SockaddrIn {
                 return null;
             }
         } finally {
-            memory.position(position);
+            memory.reset();
         }
     }
 
@@ -153,7 +152,7 @@ final class SockaddrIn {
         assert ipv6Array.length == IPV6_ADDRESS_LENGTH;
         assert ipv4Array.length == IPV4_ADDRESS_LENGTH;
         int position = memory.position();
-
+        memory.mark();
         try {
             int port = handleNetworkOrder(memory.order(), memory.getShort(
                     position + Native.SOCKADDR_IN6_OFFSETOF_SIN6_PORT)) & 0xFFFF;
@@ -176,7 +175,7 @@ final class SockaddrIn {
                 }
             }
         } finally {
-            memory.position(position);
+            memory.reset();
         }
     }
 

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/SubmissionQueue.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/SubmissionQueue.java
@@ -15,16 +15,20 @@
  */
 package io.netty.channel.uring;
 
-import io.netty.util.internal.PlatformDependent;
+import io.netty.channel.unix.Buffer;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.StringJoiner;
 
 final class SubmissionQueue {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(SubmissionQueue.class);
 
-    private static final long SQE_SIZE = 64;
+    static final int SQE_SIZE = 64;
 
     //these offsets are used to access specific properties
     //SQE https://github.com/axboe/liburing/blob/liburing-2.6/src/include/liburing/io_uring.h#L30
@@ -42,10 +46,12 @@ final class SubmissionQueue {
     private static final int SQE_UNION5_FIELD = 44;
     private static final int SQE_UNION6_FIELD = 48;
 
-    //these unsigned integer pointers(shared with the kernel) will be changed by the kernel
-    private final long kHeadAddress;
-    private final long kTailAddress;
-    final long submissionQueueArrayAddress;
+    // These unsigned integer pointers(shared with the kernel) will be changed by the kernel and us
+    // using a VarHandle.
+    private final VarHandle intHandle;
+    private final ByteBuffer kHead;
+    private final ByteBuffer kTail;
+    private final ByteBuffer submissionQueueArray;
 
     final int ringEntries;
     private final int ringMask; // = ringEntries - 1
@@ -60,20 +66,25 @@ final class SubmissionQueue {
 
     private boolean closed;
 
-    SubmissionQueue(long kHeadAddress, long kTailAddress, int ringMask, int ringEntries,
-                    long submissionQueueArrayAddress, int ringSize, long ringAddress,
+    SubmissionQueue(ByteBuffer khead, ByteBuffer ktail, int ringMask, int ringEntries, ByteBuffer submissionQueueArray,
+                    int ringSize, long ringAddress,
                     int ringFd) {
-        this.kHeadAddress = kHeadAddress;
-        this.kTailAddress = kTailAddress;
-        this.submissionQueueArrayAddress = submissionQueueArrayAddress;
+        intHandle = MethodHandles.byteBufferViewVarHandle(int[].class, ByteOrder.nativeOrder());
+        this.kHead = khead;
+        this.kTail = ktail;
+        this.submissionQueueArray = submissionQueueArray;
         this.ringSize = ringSize;
         this.ringAddress = ringAddress;
         this.ringFd = ringFd;
         this.enterRingFd = ringFd;
         this.ringEntries = ringEntries;
         this.ringMask = ringMask;
-        this.head = PlatformDependent.getIntVolatile(kHeadAddress);
-        this.tail = PlatformDependent.getIntVolatile(kTailAddress);
+        this.head = (int) intHandle.getVolatile(khead, 0);
+        this.tail = (int) intHandle.getVolatile(ktail, 0);
+    }
+
+    long submissionQueueArrayAddress() {
+        return Buffer.memoryAddress(submissionQueueArray);
     }
 
     void close() {
@@ -114,29 +125,28 @@ final class SubmissionQueue {
                 throw new RuntimeException("SQ ring full and no submissions accepted");
             }
         }
-        long sqe = submissionQueueArrayAddress + (tail++ & ringMask) * SQE_SIZE;
+        int sqe = sqeIndex(tail++, ringMask);
 
         //set sqe(submission queue) properties
-
-        PlatformDependent.putByte(sqe + SQE_OP_CODE_FIELD, opcode);
-        PlatformDependent.putByte(sqe + SQE_FLAGS_FIELD, flags);
+        submissionQueueArray.put(sqe + SQE_OP_CODE_FIELD, opcode);
+        submissionQueueArray.put(sqe + SQE_FLAGS_FIELD, flags);
         // This constant is set up-front
-        PlatformDependent.putShort(sqe + SQE_IOPRIO_FIELD, ioPrio);
-        PlatformDependent.putInt(sqe + SQE_FD_FIELD, fd);
-        PlatformDependent.putLong(sqe + SQE_UNION1_FIELD, union1);
-        PlatformDependent.putLong(sqe + SQE_UNION2_FIELD, union2);
-        PlatformDependent.putInt(sqe + SQE_LEN_FIELD, len);
-        PlatformDependent.putInt(sqe + SQE_UNION3_FIELD, union3);
-        PlatformDependent.putLong(sqe + SQE_USER_DATA_FIELD, udata);
-        PlatformDependent.putShort(sqe + SQE_UNION4_FIELD, union4);
-        PlatformDependent.putShort(sqe + SQE_PERSONALITY_FIELD, personality);
-        PlatformDependent.putInt(sqe + SQE_UNION5_FIELD, union5);
-        PlatformDependent.putLong(sqe + SQE_UNION6_FIELD, union6);
+        submissionQueueArray.putShort(sqe + SQE_IOPRIO_FIELD, ioPrio);
+        submissionQueueArray.putInt(sqe + SQE_FD_FIELD, fd);
+        submissionQueueArray.putLong(sqe + SQE_UNION1_FIELD, union1);
+        submissionQueueArray.putLong(sqe + SQE_UNION2_FIELD, union2);
+        submissionQueueArray.putInt(sqe + SQE_LEN_FIELD, len);
+        submissionQueueArray.putInt(sqe + SQE_UNION3_FIELD, union3);
+        submissionQueueArray.putLong(sqe + SQE_USER_DATA_FIELD, udata);
+        submissionQueueArray.putShort(sqe + SQE_UNION4_FIELD, union4);
+        submissionQueueArray.putShort(sqe + SQE_PERSONALITY_FIELD, personality);
+        submissionQueueArray.putInt(sqe + SQE_UNION5_FIELD, union5);
+        submissionQueueArray.putLong(sqe + SQE_UNION6_FIELD, union6);
 
         if (logger.isTraceEnabled()) {
             if (opcode == Native.IORING_OP_WRITEV || opcode == Native.IORING_OP_READV) {
-                logger.trace("add(ring={}, enterRing:{} ): {}(fd={}, len={} ({} bytes), off={}, data={})",
-                        ringFd, enterRingFd, Native.opToStr(opcode), fd, len, Iov.sumSize(union2, len), union1, udata);
+                logger.trace("add(ring={}, enterRing:{} ): {}(fd={}, len={}, off={}, data={})",
+                        ringFd, enterRingFd, Native.opToStr(opcode), fd, len, union1, udata);
             } else {
                 logger.trace("add(ring={}, enterRing:{}): {}(fd={}, len={}, off={}, data={})",
                         ringFd, enterRingFd, Native.opToStr(opcode), fd, len, union1, udata);
@@ -152,13 +162,18 @@ final class SubmissionQueue {
             sb.add("closed");
         } else {
             int pending = tail - head;
+            int idx = tail;
             for (int i = 0; i < pending; i++) {
-                long sqe = submissionQueueArrayAddress + (head + i & ringMask) * SQE_SIZE;
-                sb.add(Native.opToStr(PlatformDependent.getByte(sqe + SQE_OP_CODE_FIELD)) +
-                        "(fd=" + PlatformDependent.getInt(sqe + SQE_FD_FIELD) + ')');
+                int sqe = sqeIndex(idx++, ringMask);
+                sb.add(Native.opToStr(submissionQueueArray.get(sqe + SQE_OP_CODE_FIELD)) +
+                        "(fd=" + submissionQueueArray.getInt(sqe + SQE_FD_FIELD) + ')');
             }
         }
         return sb.toString();
+    }
+
+    private static int sqeIndex(int tail, int ringMask) {
+        return (tail & ringMask) * SQE_SIZE;
     }
 
     long addNop(byte flags, long udata) {
@@ -215,9 +230,9 @@ final class SubmissionQueue {
     }
 
     private int submit(int toSubmit, int minComplete, int flags) {
-        PlatformDependent.putIntOrdered(kTailAddress, tail); // release memory barrier
+        intHandle.setRelease(kTail, 0, tail);
         int ret = ioUringEnter(toSubmit, minComplete, flags);
-        head = PlatformDependent.getIntVolatile(kHeadAddress); // acquire memory barrier
+        head = (int) intHandle.getVolatile(kHead, 0); // acquire memory barrier
         if (ret != toSubmit) {
             if (ret < 0) {
                 throw new RuntimeException("ioUringEnter syscall returned " + ret);

--- a/transport-native-io_uring/src/main/c/netty_io_uring_native.c
+++ b/transport-native-io_uring/src/main/c/netty_io_uring_native.c
@@ -130,7 +130,6 @@ static int io_uring_mmap(int fd, struct io_uring_params *p, struct io_uring_sq *
     sq->kflags = sq->ring_ptr + p->sq_off.flags;
     sq->kdropped = sq->ring_ptr + p->sq_off.dropped;
     sq->array = sq->ring_ptr + p->sq_off.array;
-
     size = p->sq_entries * sizeof(struct io_uring_sqe);
     sq->sqes = mmap(0, size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_POPULATE, fd, IORING_OFF_SQES);
     if (sq->sqes == MAP_FAILED) {
@@ -150,6 +149,7 @@ static int io_uring_mmap(int fd, struct io_uring_params *p, struct io_uring_sq *
             sq->array[index] = index;
         }
     }
+
     return 0;
 err:
     io_uring_unmap_rings(sq, cq);
@@ -417,6 +417,10 @@ static jlong netty_io_uring_register_buf_ring(JNIEnv* env, jclass clazz,
     }
     br->tail = 0;
     return (jlong) br;
+}
+
+static jint netty_io_uring_buf_ring_size(JNIEnv* env, jclass clazz, jint nentries) {
+    return (jint) nentries * sizeof(struct io_uring_buf);
 }
 
 static jint netty_io_uring_unregister_buf_ring(JNIEnv* env, jclass clazz,
@@ -768,8 +772,9 @@ static const JNINativeMethod method_table[] = {
     {"cmsghdrData", "(J)J", (void *) netty_io_uring_cmsghdrData},
     {"kernelVersion", "()Ljava/lang/String;", (void *) netty_io_uring_kernel_version },
     {"getFd0", "(Ljava/lang/Object;)I", (void *) netty_io_uring_getFd0 },
-    {"ioUringRegisterBufRing", "(IISI)J", (void *) netty_io_uring_register_buf_ring},
-    {"ioUringUnRegisterBufRing", "(IJIS)I", (void *) netty_io_uring_unregister_buf_ring}
+    {"ioUringRegisterBufRing", "(IISI)J", (void *) netty_io_uring_register_buf_ring },
+    {"ioUringUnRegisterBufRing", "(IJIS)I", (void *) netty_io_uring_unregister_buf_ring },
+    {"ioUringBufRingSize", "(I)I", (void *) netty_io_uring_buf_ring_size }
 };
 static const jint method_table_size =
     sizeof(method_table) / sizeof(method_table[0]);

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/SockaddrInTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/SockaddrInTest.java
@@ -15,7 +15,6 @@
  */
 package io.netty.channel.uring;
 
-import io.netty.channel.unix.Buffer;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -42,12 +41,11 @@ public class SockaddrInTest {
     public void testIp4() throws Exception {
         ByteBuffer buffer = allocateDirectWithNativeOrder(64);
         try {
-            long memoryAddress = Buffer.memoryAddress(buffer);
             InetAddress address = InetAddress.getByAddress(new byte[] { 10, 10, 10, 10 });
             int port = 45678;
-            assertEquals(Native.SIZEOF_SOCKADDR_IN, SockaddrIn.writeIPv4(memoryAddress, address, port));
+            assertEquals(Native.SIZEOF_SOCKADDR_IN, SockaddrIn.setIPv4(buffer, address, port));
             byte[] bytes = new byte[4];
-            InetSocketAddress sockAddr = SockaddrIn.readIPv4(memoryAddress, bytes);
+            InetSocketAddress sockAddr = SockaddrIn.getIPv4(buffer, bytes);
             assertArrayEquals(address.getAddress(), sockAddr.getAddress().getAddress());
             assertEquals(port, sockAddr.getPort());
         } finally {
@@ -59,15 +57,14 @@ public class SockaddrInTest {
     public void testIp6() throws Exception {
         ByteBuffer buffer = allocateDirectWithNativeOrder(64);
         try {
-            long memoryAddress = Buffer.memoryAddress(buffer);
             Inet6Address address = Inet6Address.getByAddress(
                     null, new byte[] { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 }, 12345);
             int port = 45678;
-            assertEquals(Native.SIZEOF_SOCKADDR_IN6, SockaddrIn.writeIPv6(memoryAddress, address, port));
+            assertEquals(Native.SIZEOF_SOCKADDR_IN6, SockaddrIn.setIPv6(buffer, address, port));
             byte[] ipv6Bytes = new byte[16];
             byte[] ipv4Bytes = new byte[4];
 
-            InetSocketAddress sockAddr = SockaddrIn.readIPv6(memoryAddress, ipv6Bytes, ipv4Bytes);
+            InetSocketAddress sockAddr = SockaddrIn.getIPv6(buffer, ipv6Bytes, ipv4Bytes);
             Inet6Address inet6Address = (Inet6Address) sockAddr.getAddress();
             assertArrayEquals(address.getAddress(), inet6Address.getAddress());
             assertEquals(address.getScopeId(), inet6Address.getScopeId());
@@ -81,14 +78,13 @@ public class SockaddrInTest {
     public void testWriteIp4ReadIpv6Mapped() throws Exception {
         ByteBuffer buffer = allocateDirectWithNativeOrder(64);
         try {
-            long memoryAddress = Buffer.memoryAddress(buffer);
             InetAddress address = InetAddress.getByAddress(new byte[] { 10, 10, 10, 10 });
             int port = 45678;
-            assertEquals(Native.SIZEOF_SOCKADDR_IN6, SockaddrIn.writeIPv6(memoryAddress, address, port));
+            assertEquals(Native.SIZEOF_SOCKADDR_IN6, SockaddrIn.setIPv6(buffer, address, port));
             byte[] ipv6Bytes = new byte[16];
             byte[] ipv4Bytes = new byte[4];
 
-            InetSocketAddress sockAddr = SockaddrIn.readIPv6(memoryAddress, ipv6Bytes, ipv4Bytes);
+            InetSocketAddress sockAddr = SockaddrIn.getIPv6(buffer, ipv6Bytes, ipv4Bytes);
             Inet4Address ipv4Address = (Inet4Address) sockAddr.getAddress();
 
             System.arraycopy(SockaddrIn.IPV4_MAPPED_IPV6_PREFIX, 0, ipv6Bytes, 0,

--- a/transport-native-unix-common/src/main/c/netty_unix_buffer.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_buffer.c
@@ -29,7 +29,6 @@ static jint netty_unix_buffer_addressSize0(JNIEnv* env, jclass clazz) {
    return (jint) sizeof(int*);
 }
 
-// JNI Registered Methods Begin
 static jobject netty_unix_buffer_wrapMemoryAddress(JNIEnv* env, jclass clazz, jlong address, jint capacity) {
     return (*env)->NewDirectByteBuffer(env, (void*) address, capacity);
 }

--- a/transport-native-unix-common/src/main/c/netty_unix_buffer.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_buffer.c
@@ -29,12 +29,17 @@ static jint netty_unix_buffer_addressSize0(JNIEnv* env, jclass clazz) {
    return (jint) sizeof(int*);
 }
 
+// JNI Registered Methods Begin
+static jobject netty_unix_buffer_wrapMemoryAddress(JNIEnv* env, jclass clazz, jlong address, jint capacity) {
+    return (*env)->NewDirectByteBuffer(env, (void*) address, capacity);
+}
 // JNI Registered Methods End
 
 // JNI Method Registration Table Begin
 static const JNINativeMethod statically_referenced_fixed_method_table[] = {
   { "memoryAddress0", "(Ljava/nio/ByteBuffer;)J", (void *) netty_unix_buffer_memoryAddress0 },
-  { "addressSize0", "()I", (void *) netty_unix_buffer_addressSize0 }
+  { "addressSize0", "()I", (void *) netty_unix_buffer_addressSize0 },
+  { "wrapMemoryAddress","(JI)Ljava/nio/ByteBuffer;", (void *) netty_unix_buffer_wrapMemoryAddress },
 };
 static const jint statically_referenced_fixed_method_table_size = sizeof(statically_referenced_fixed_method_table) / sizeof(statically_referenced_fixed_method_table[0]);
 // JNI Method Registration Table End

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/Buffer.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/Buffer.java
@@ -65,4 +65,10 @@ public final class Buffer {
     // If Unsafe can not be used we will need to do JNI calls.
     private static native int addressSize0();
     private static native long memoryAddress0(ByteBuffer buffer);
+
+    public static ByteBuffer wrapMemoryAddressWithNativeOrder(long memoryAddress, int capacity) {
+        return wrapMemoryAddress(memoryAddress, capacity).order(ByteOrder.nativeOrder());
+    }
+
+    public static native ByteBuffer wrapMemoryAddress(long memoryAddress, int capacity);
 }


### PR DESCRIPTION
Motivation:

Using sun.misc.Unsafe becomes more challenging as it needs to be abled by some flags on java24+. There is no reason we really need it for io_uring, so lets ensure we can use sun.misc.Unsafe even without it.

Modifications:

- Use VarHandles and ByteBuffer as replacement for Unsafe.
- Require Java9+ for io_uring

Result:

Be able to use io_uring without sun.misc.Unsafe. Fixes https://github.com/netty/netty/issues/14944 and https://github.com/netty/netty/issues/14522