### PR TITLE
Make `Recycler` virtual thread friendly for main

### DIFF
--- a/common/src/main/java/io/netty5/util/Recycler.java
+++ b/common/src/main/java/io/netty5/util/Recycler.java
@@ -142,7 +142,7 @@ public abstract class Recycler<T> {
 
     @SuppressWarnings("unchecked")
     public final T get() {
-        if (maxCapacityPerThread == 0) {
+        if (maxCapacityPerThread == 0 || Thread.currentThread().isVirtual()) {
             return newObject((Handle<T>) NOOP_HANDLE);
         }
         LocalPool<T> localPool = threadLocal.get();
@@ -165,6 +165,9 @@ public abstract class Recycler<T> {
 
     @VisibleForTesting
     final int threadLocalSize() {
+        if (Thread.currentThread().isVirtual()) {
+            return 0;
+        }
         LocalPool<T> localPool = threadLocal.getIfExists();
         return localPool == null ? 0 : localPool.pooledHandles.size() + localPool.batch.size();
     }


### PR DESCRIPTION
Motivation:

Make `Recycler` virtual thread friendly.

Modification:

If the current thread is a virtual thread, then do not use thread-local in `Recycler`.

Result:

Fixes #14884. 
