### PR TITLE
io_uring native transport also works on riscv64

### DIFF
--- a/transport-native-io_uring/README.md
+++ b/transport-native-io_uring/README.md
@@ -4,8 +4,8 @@ The new io_uring interface added to the Linux Kernel 5.1 is a high I/O performan
 
 ## Requirements:
 
-- x86-64 / aarch64 processor
-- at least 5.14.
+- x86-64 / aarch64 / riscv64 processor
+- at least Kernel 5.14, compiled with `CONFIG_IO_URING=y`
 - to run the tests, you have to increase memlock(default 64K)
 
 


### PR DESCRIPTION
- See https://github.com/netty/netty/pull/14968#issuecomment-2757832666