### PR TITLE
Allow delayed set of owningThread in ManualIoEventLoop

### DIFF
--- a/transport/src/main/java/io/netty/channel/ManualIoEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/ManualIoEventLoop.java
@@ -75,7 +75,7 @@ public final class ManualIoEventLoop extends AbstractScheduledEventExecutor impl
     };
     private final BlockingIoHandlerContext blockingContext = new BlockingIoHandlerContext();
     private final IoEventLoopGroup parent;
-    private Thread owningThread;
+    private volatile Thread owningThread;
     private final IoHandler handler;
 
     private volatile long gracefulShutdownQuietPeriod;

--- a/transport/src/test/java/io/netty/channel/ManualIoEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/ManualIoEventLoopTest.java
@@ -261,6 +261,16 @@ public class ManualIoEventLoopTest {
         eventLoop.shutdownGracefully();
     }
 
+    @Test
+    public void testSetOwnerMultipleTimes() {
+        ManualIoEventLoop eventLoop = new ManualIoEventLoop(null, executor ->
+                new TestIoHandler(new Semaphore(0)));
+        eventLoop.setOwningThread(Thread.currentThread());
+        assertThrows(IllegalStateException.class, () -> eventLoop.setOwningThread(Thread.currentThread()));
+
+        eventLoop.shutdownGracefully();
+    }
+
     private static final class TestRunnable implements Runnable {
         private boolean done;
         @Override

--- a/transport/src/test/java/io/netty/channel/ManualIoEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/ManualIoEventLoopTest.java
@@ -243,6 +243,22 @@ public class ManualIoEventLoopTest {
         cf.get();
 
         eventLoop.shutdownGracefully();
+        thread.join();
+    }
+
+    @Test
+    public void testRunWithoutOwner() throws ExecutionException, InterruptedException {
+        ManualIoEventLoop eventLoop = new ManualIoEventLoop(null, executor ->
+                new TestIoHandler(new Semaphore(0)));
+
+        // prior to setOwningThread, runNow is forbidden
+        assertThrows(IllegalStateException.class, eventLoop::runNow);
+
+        eventLoop.setOwningThread(Thread.currentThread());
+
+        eventLoop.runNow(); // runs fine
+
+        eventLoop.shutdownGracefully();
     }
 
     private static final class TestRunnable implements Runnable {

--- a/transport/src/test/java/io/netty/channel/ManualIoEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/ManualIoEventLoopTest.java
@@ -240,9 +240,9 @@ public class ManualIoEventLoopTest {
         });
 
         thread.start();
-        eventLoop.shutdownGracefully();
-
         cf.get();
+
+        eventLoop.shutdownGracefully();
     }
 
     private static final class TestRunnable implements Runnable {


### PR DESCRIPTION
Motivation:

In some scenarios, it is desirable to immediately create a ManualIoEventLoop, without knowing which thread it is assigned to. In particular, to implement `MultiThreadIoEventLoopGroup.newChild` properly, the owning thread is assigned through an `Executor` call, so we don't see it until the `Executor` actually invokes the `Runnable` it receives, but we need to return the `ManualIoEventLoop` from `newChild` immediately.

Modification:

Allow passing `null` for the `owningThread` constructor parameter, and add a `setOwningThread` setter that can be called at most once.

Result:

`newChild` can be implemented without hacks.

The only use of the `owningThread` field is in `inEventLoop`. That means that the only difference compared to the old constructor approach is that there is a period of time when the future owning thread is running, but inEventLoop still returns `false`. I'm struggling to imagine scenarios where this matters, but @franz1981 had some thoughts, so I'm open to concerns and alternative solutions.