### PR TITLE
Fix support for DH_anon and ECDH_anon authentication methods

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
@@ -713,7 +713,8 @@ public final class OpenSsl {
 
     static boolean isOptionSupported(SslContextOption<?> option) {
         if (isAvailable()) {
-            if (option == OpenSslContextOption.USE_TASKS) {
+            if (option == OpenSslContextOption.USE_TASKS ||
+                    option == OpenSslContextOption.TMP_DH_KEYLENGTH) {
                 return true;
             }
             // Check for options that are only supported by BoringSSL atm.

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslContextOption.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslContextOption.java
@@ -82,4 +82,15 @@ public final class OpenSslContextOption<T> extends SslContextOption<T> {
      *     SSL_CTX_set1_groups_list</a>.
      */
     public static final OpenSslContextOption<String[]> GROUPS = new OpenSslContextOption<String[]>("GROUPS");
+
+    /**
+     * Set the desired length of the Diffie-Hellman ephemeral session keys.
+     * This will override the key length set with {@code -Djdk.tls.ephemeralDHKeySize}.
+     * <p>
+     * The only supported values are {@code 512}, {@code 1024}, {@code 2048}, and {@code 4096}.
+     * <p>
+     * See <a href="https://docs.openssl.org/1.0.2/man3/SSL_CTX_set_tmp_dh_callback/">SSL_CTX_set_tmp_dh_callback</a>.
+     */
+    public static final OpenSslContextOption<Integer> TMP_DH_KEYLENGTH =
+            new OpenSslContextOption<Integer>("TMP_DH_KEYLENGTH");
 }

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslKeyMaterialManager.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslKeyMaterialManager.java
@@ -60,9 +60,11 @@ final class OpenSslKeyMaterialManager {
     }
 
     private final OpenSslKeyMaterialProvider provider;
+    private final boolean hasTmpDhKeys;
 
-    OpenSslKeyMaterialManager(OpenSslKeyMaterialProvider provider) {
+    OpenSslKeyMaterialManager(OpenSslKeyMaterialProvider provider, boolean hasTmpDhKeys) {
         this.provider = provider;
+        this.hasTmpDhKeys = hasTmpDhKeys;
     }
 
     void setKeyMaterialServerSide(ReferenceCountedOpenSslEngine engine) throws SSLException {
@@ -85,6 +87,10 @@ final class OpenSslKeyMaterialManager {
                     return;
                 }
             }
+        }
+        if (hasTmpDhKeys && authMethods.length == 1 &&
+                ("DH_anon".equals(authMethods[0]) || "ECDH_anon".equals(authMethods[0]))) {
+            return; // These auth methods don't require certificates.
         }
         throw new SSLHandshakeException("Unable to find key material for auth method(s): "
                 + Arrays.toString(authMethods));

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslClientContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslClientContext.java
@@ -129,7 +129,8 @@ public final class ReferenceCountedOpenSslClientContext extends ReferenceCounted
                     }
 
                     if (keyMaterialProvider != null) {
-                        OpenSslKeyMaterialManager materialManager = new OpenSslKeyMaterialManager(keyMaterialProvider);
+                        OpenSslKeyMaterialManager materialManager =
+                                new OpenSslKeyMaterialManager(keyMaterialProvider, thiz.hasTmpDhKeys);
                         SSLContext.setCertificateCallback(ctx, new OpenSslClientCertificateCallback(
                                 engineMap, materialManager));
                     }

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslServerContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslServerContext.java
@@ -135,7 +135,7 @@ public final class ReferenceCountedOpenSslServerContext extends ReferenceCounted
                     keyMaterialProvider = providerFor(keyManagerFactory, keyPassword);
 
                     SSLContext.setCertificateCallback(ctx, new OpenSslServerCertificateCallback(
-                            engineMap, new OpenSslKeyMaterialManager(keyMaterialProvider)));
+                            engineMap, new OpenSslKeyMaterialManager(keyMaterialProvider, thiz.hasTmpDhKeys)));
                 }
             } catch (Exception e) {
                 throw new SSLException("failed to set certificate and key", e);

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
@@ -550,8 +550,9 @@ public class OpenSslEngineTest extends SSLEngineTest {
                                         .build());
         SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         serverSslCtx = wrapContext(param, SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
-                                        .sslProvider(sslServerProvider())
-                                        .build());
+                .sslProvider(sslServerProvider())
+                .option(OpenSslContextOption.TMP_DH_KEYLENGTH, 2048)
+                .build());
 
         testWrapWithDifferentSizes(param, SslProtocols.TLS_v1, "AES128-SHA");
         testWrapWithDifferentSizes(param, SslProtocols.TLS_v1, "ECDHE-RSA-AES128-SHA");
@@ -582,8 +583,9 @@ public class OpenSslEngineTest extends SSLEngineTest {
                                         .build());
         SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         serverSslCtx = wrapContext(param, SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
-                                        .sslProvider(sslServerProvider())
-                                        .build());
+                .sslProvider(sslServerProvider())
+                .option(OpenSslContextOption.TMP_DH_KEYLENGTH, 2048)
+                .build());
 
         testWrapWithDifferentSizes(param, SslProtocols.TLS_v1_1, "ECDHE-RSA-AES256-SHA");
         testWrapWithDifferentSizes(param, SslProtocols.TLS_v1_1, "AES256-SHA");
@@ -612,6 +614,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
         SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         serverSslCtx = wrapContext(param, SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                 .sslProvider(sslServerProvider())
+                .option(OpenSslContextOption.TMP_DH_KEYLENGTH, 2048)
                 .build());
 
         testWrapWithDifferentSizes(param, SslProtocols.TLS_v1_2, "AES128-SHA");
@@ -651,6 +654,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
         SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         serverSslCtx = wrapContext(param, SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                 .sslProvider(sslServerProvider())
+                .option(OpenSslContextOption.TMP_DH_KEYLENGTH, 2048)
                 .build());
 
         testWrapWithDifferentSizes(param, SslProtocols.SSL_v3, "ADH-AES128-SHA");

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslKeyMaterialManagerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslKeyMaterialManagerTest.java
@@ -74,7 +74,7 @@ public class OpenSslKeyMaterialManagerTest {
                 fail("Should not be called when alias is null");
                 return null;
             }
-        });
+        }, false);
         SslContext context = SslContextBuilder.forClient().sslProvider(SslProvider.OPENSSL).build();
         OpenSslEngine engine =
                 (OpenSslEngine) context.newEngine(UnpooledByteBufAllocator.DEFAULT);


### PR DESCRIPTION
Motivation:
We have tests for these methods, and the tests aren't running because the OpenSSL version we test with is too old. However, when we run the tests on CentOS 7, they start running and they fail because our server-side cert callback tries to choose key material for these auth methods, decides it can't, and throws an exception that breaks the handshake.

The DH_anon and ECDH_anon auth methods are only relevant when we hook up a callback in tcnative to provide ephemeral DH key material to openssl, but this is not enabled by default.

Modification:
- Add an `OpenSslContextOption.TMP_DH_KEYLENGTH` so we can set DH key material on a per-test basis.
- Update the relevant tests to enable DH ephemeral keys.
- Update the key material callbacks to allow these authentication methods to go through, when ephemeral DH keys are enabled.

Result:
The DH_anon and ECDH_anon authentication methods are no longer broken. The tests should now pass when running on a new enough OS.

This is a back port of https://github.com/netty/netty/pull/14977
