### PR TITLE
Install Java11 and use it for cross-compiling

### DIFF
--- a/docker/Dockerfile.cross_compile_aarch64
+++ b/docker/Dockerfile.cross_compile_aarch64
@@ -12,7 +12,7 @@ RUN sed -i -e 's/^mirrorlist/#mirrorlist/g' -e 's/^#baseurl=http:\/\/mirror.cent
 RUN yum install -y wget tar git make redhat-lsb-core autoconf automake libtool glibc-devel libaio-devel openssl-devel apr-devel lksctp-tools unzip zip
 
 # Install Java
-RUN yum install -y java-1.8.0-openjdk-devel
+RUN yum install -y java-11-openjdk-devel
 
 RUN mkdir $SOURCE_DIR
 WORKDIR $SOURCE_DIR
@@ -22,7 +22,7 @@ RUN wget https://developer.arm.com/-/media/Files/downloads/gnu-a/$GCC_VERSION/bi
    tar xvf gcc-arm-$GCC_VERSION-x86_64-aarch64-none-linux-gnu.tar.xz && mv gcc-arm-$GCC_VERSION-x86_64-aarch64-none-linux-gnu /opt/
 ENV PATH="/opt/gcc-arm-$GCC_VERSION-x86_64-aarch64-none-linux-gnu/bin:${PATH}"
 
-ENV JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk/"
+ENV JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64/"
 
 # Cleanup
 RUN rm -rf $SOURCE_DIR

--- a/docker/Dockerfile.cross_compile_riscv64
+++ b/docker/Dockerfile.cross_compile_riscv64
@@ -16,10 +16,10 @@ RUN apt-get update -qq \
         libssl-dev \
         libtool \
         make \
-        openjdk-8-jdk-headless \
+        openjdk-11-jdk-headless \
         tar \
         unzip \
         zip \
  && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
+ENV JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64"


### PR DESCRIPTION
Motivation:

We need java9+ now when compiling io_uring.

Modifications:

Install java11 and use it

Result:

No more failures during cross compile