### PR TITLE
Add suppressed exception to original cause when calling Future.sync*

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
+++ b/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
@@ -681,8 +681,8 @@ public class DefaultPromise<V> extends AbstractFuture<V> implements Promise<V> {
             return;
         }
 
-        if (!(cause instanceof CancellationException) && cause.getSuppressed().length == 0) {
-            cause.addSuppressed(new CompletionException("Rethrowing promise failure cause", null));
+        if (!(cause instanceof CancellationException) && ThrowableUtil.getSuppressed(cause).length == 0) {
+            ThrowableUtil.addSuppressed(cause, new RuntimeException("Rethrowing promise failure cause"));
         }
         PlatformDependent.throwException(cause);
     }

--- a/common/src/main/java/io/netty/util/concurrent/Future.java
+++ b/common/src/main/java/io/netty/util/concurrent/Future.java
@@ -153,7 +153,7 @@ public interface Future<V> extends java.util.concurrent.Future<V> {
 
     /**
      * Return the result without blocking. If the future is not done yet this will return {@code null}.
-     *
+     * <p>
      * As it is possible that a {@code null} value is used to mark the future as successful you also need to check
      * if the future is really done with {@link #isDone()} and not rely on the returned {@code null} value.
      */


### PR DESCRIPTION
Motivation:
The `Promise.sync` and `syncUninterruptibly` methods will rethrow any exception that cause the promise to fail. This gives the stack trace of the original failure, but people loose the stack trace telling which specific sync call propagated the exception. This can make debugging confusing and more difficult that necessary. We have to keep this behavior by default for compatibility, but we can add the extra details as suppressed exception and so help with debugging.

Modification:
Add`CompletionException` when `sync` or `syncUninterruptibly` is called as suppressed exception to the original cause.

Result:
Easier to debug.

This is a. back port of https://github.com/netty/netty/pull/14898