### PR TITLE
Make native image profiles activate on 'native-image' binary

### DIFF
--- a/docker/Dockerfile.centos6
+++ b/docker/Dockerfile.centos6
@@ -41,4 +41,4 @@ RUN yum clean all && \
     rm -rf /var/cache/yum
 
 # when the JDK is GraalVM install native-image
-RUN if [ -O /root/.sdkman/candidates/java/current/bin/gu ]; then /root/.sdkman/candidates/java/current/bin/gu install native-image; else echo "Not GraalVM, skip installation of native-image" ; fi
+RUN if [ -O /root/.sdkman/candidates/java/current/bin/gu ]; then /root/.sdkman/candidates/java/current/bin/gu install native-image; else echo "No Graal Updater, skip installation of native-image" ; fi

--- a/pom.xml
+++ b/pom.xml
@@ -178,8 +178,8 @@
       <id>graal</id>
       <activation>
         <file>
-          <!-- GraalVM Component Updater should exists when using GraalVM-->
-          <exists>${java.home}/bin/gu</exists>
+          <!-- GraalVM 'native-image' should exist when using GraalVM -->
+          <exists>${java.home}/bin/native-image</exists>
         </file>
       </activation>
       <properties>


### PR DESCRIPTION
Motivation:
GraalVM no longer include the `$JAVA_HOME/bin/gu` binary. It is also no longer necessary, because graalvm include the `native-image` binary we actually need, by default.

Modification:
Change the native image maven profile activation to be predicated on the `native-image` binary instead of the `gu` binary.

Result:
The native image test suites should now run as part of our graal builds.

