### PR TITLE
Experimentally optimize `PlatformDependent0.isVirtualThread()`: Replace reflection with interned class name comparison

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -67,6 +67,8 @@ final class PlatformDependent0 {
     // Package-private for testing.
     static final Class<?> BASE_VIRTUAL_THREAD_CLASS = getBaseVirtualThreadClass();
 
+    private static final String BASE_VIRTUAL_CLASS_BINARY_NAME = "java.lang.BaseVirtualThread";
+
     static final Unsafe UNSAFE;
 
     // constants borrowed from murmur3
@@ -593,18 +595,10 @@ final class PlatformDependent0 {
         }
         Class<?> clazz = thread.getClass();
         // Common cases:
-        if (clazz == Thread.class || clazz.getSuperclass() == Thread.class) {
+        if (clazz == Thread.class || (clazz = clazz.getSuperclass()) == Thread.class) {
             return false;
         }
-        try {
-            return (Boolean) IS_VIRTUAL_THREAD_METHOD.invoke(thread);
-        } catch (Throwable t) {
-            // Should not happen.
-            if (t instanceof Error) {
-                throw (Error) t;
-            }
-            throw new Error(t);
-        }
+        return clazz.getName() == BASE_VIRTUAL_CLASS_BINARY_NAME;
     }
 
     private static boolean unsafeStaticFieldOffsetSupported() {

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -65,7 +65,7 @@ final class PlatformDependent0 {
     // Package-private for testing.
     static final Method IS_VIRTUAL_THREAD_METHOD = getIsVirtualThreadMethod();
     // Package-private for testing.
-    static final Class<?> BASE_VIRTUAL_THREAD_CLASS = getBaseVirtualThreadClass();
+    static volatile Class<?> BASE_VIRTUAL_THREAD_CLASS = getBaseVirtualThreadClass();
 
     private static final String BASE_VIRTUAL_CLASS_BINARY_NAME = "java.lang.BaseVirtualThread";
 
@@ -598,7 +598,11 @@ final class PlatformDependent0 {
         if (clazz == Thread.class || (clazz = clazz.getSuperclass()) == Thread.class) {
             return false;
         }
-        return clazz.getName() == BASE_VIRTUAL_CLASS_BINARY_NAME;
+        if (clazz.getName() == BASE_VIRTUAL_CLASS_BINARY_NAME) {
+            BASE_VIRTUAL_THREAD_CLASS = clazz;
+            return true;
+        }
+        return false;
     }
 
     private static boolean unsafeStaticFieldOffsetSupported() {

--- a/common/src/test/java/io/netty/util/internal/VirtualThreadCheckTest.java
+++ b/common/src/test/java/io/netty/util/internal/VirtualThreadCheckTest.java
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static io.netty.util.internal.PlatformDependent0.BASE_VIRTUAL_THREAD_CLASS;
 import static io.netty.util.internal.PlatformDependent0.IS_VIRTUAL_THREAD_METHOD;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -82,19 +83,7 @@ public class VirtualThreadCheckTest {
         if (PlatformDependent.javaVersion() < 19) {
             assertNull(IS_VIRTUAL_THREAD_METHOD);
         } else {
-            assumeTrue(PlatformDependent.javaVersion() >= 21);
-            assumeTrue(IS_VIRTUAL_THREAD_METHOD != null);
-            boolean isVirtual = (Boolean) IS_VIRTUAL_THREAD_METHOD.invoke(Thread.currentThread());
-            assertFalse(isVirtual);
-
-            Method startVirtualThread = getStartVirtualThreadMethod();
-            Thread virtualThread = (Thread) startVirtualThread.invoke(null, new Runnable() {
-                @Override
-                public void run() {
-                }
-            });
-            isVirtual = (Boolean) IS_VIRTUAL_THREAD_METHOD.invoke(virtualThread);
-            assertTrue(isVirtual);
+            assertNotNull(IS_VIRTUAL_THREAD_METHOD);
         }
     }
 


### PR DESCRIPTION
Motivation:

For 4.1-branch, the `PlatformDependent0.isVirtualThread()` use reflection `Method.invoke()` to invoke `Thread.isVirtual()`, which has more overhead than `Method.invokeExact()`, this PR try another approach: replace it with interned class name comparison.

This approach is based on the JLS [When Reference Types Are the Same](https://docs.oracle.com/javase/specs/jls/se21/html/jls-4.html#jls-4.3.4) part(checked from 19-24):
> **Two reference types are the same run-time type if**:
> They are both class or both interface types, are defined by the same class loader, and **have the same binary name**, in which case they are sometimes said to be the same run-time class or the same run-time interface.

The `Class.getName()` returns a 'binary name' of a class(checked from 19-24): 
https://docs.oracle.com/en/java/javase/19/docs/api/java.base/java/lang/Class.html#getName()
https://docs.oracle.com/en/java/javase/20/docs/api/java.base/java/lang/Class.html#getName()
https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/Class.html#getName()
https://docs.oracle.com/en/java/javase/22/docs/api/java.base/java/lang/Class.html#getName()
https://docs.oracle.com/en/java/javase/23/docs/api/java.base/java/lang/Class.html#getName()
https://docs.oracle.com/en/java/javase/24/docs/api/java.base/java/lang/Class.html#getName()

The following quoted from [JLS-21](https://docs.oracle.com/javase/specs/jls/se21/html):

> The **binary name** of a **top level class** or interface is its **canonical name**.

> For every primitive type, named package, **top level class**, and top level interface, the **canonical name** is the same as the **fully qualified name**.

> The **fully qualified name of a named package** that is a subpackage of another named package consists of the fully qualified name of the containing package, followed by ".", followed by the simple (member) name of the subpackage.

> The **fully qualified name of a top level class** or top level interface that is declared in a named package consists of the **fully qualified name of the package**, followed by ".", followed by the simple name of the class or interface.

I checked JLS from 19 to 24, they all have the same definition above.

And the OpenJDK implementation sticked to the JLS(checked from 19-24):
https://github.com/openjdk/jdk/blob/jdk-19-ga/src/hotspot/share/oops/klass.hpp#L581-L585
https://github.com/openjdk/jdk/blob/jdk-20-ga/src/hotspot/share/oops/klass.hpp#L588-L592
https://github.com/openjdk/jdk/blob/jdk-21-ga/src/hotspot/share/oops/klass.hpp#L604-L608
https://github.com/openjdk/jdk/blob/jdk-22-ga/src/hotspot/share/oops/klass.hpp#L603-L607
https://github.com/openjdk/jdk/blob/jdk-23-ga/src/hotspot/share/oops/klass.hpp#L632-L636
https://github.com/openjdk/jdk/blob/jdk-24-ga/src/hotspot/share/oops/klass.hpp#L653-L657

Since the `BaseVirtualThread` is a [top level](https://docs.oracle.com/javase/specs/jls/se21/html/jls-8.html) class, so if the thread is a virtual thread, then `virtualThreadInstance.getClass().getSuperClass().getName()` must return the base class name: "java.lang.BaseVirtualThread".

And the `name`(String) is interned in StringTable(checked from 19-24):
https://github.com/openjdk/jdk/blob/jdk-19-ga/src/hotspot/share/classfile/javaClasses.cpp#L1475
https://github.com/openjdk/jdk/blob/jdk-20-ga/src/hotspot/share/classfile/javaClasses.cpp#L1384
https://github.com/openjdk/jdk/blob/jdk-21-ga/src/hotspot/share/classfile/javaClasses.cpp#L1241
https://github.com/openjdk/jdk/blob/jdk-22-ga/src/hotspot/share/classfile/javaClasses.cpp#L1241
https://github.com/openjdk/jdk/blob/jdk-23-ga/src/hotspot/share/classfile/javaClasses.cpp#L1261
https://github.com/openjdk/jdk/blob/jdk-24-ga/src/hotspot/share/classfile/javaClasses.cpp#L1336

The `name` is also cached in `Class`(checked from 19-24):
https://github.com/openjdk/jdk/blob/jdk-21-ga/src/java.base/share/classes/java/lang/Class.java#L951-L953

So we can use: "java.lang.BaseVirtualThread" == `threadInstance.getClass().getSuperClass().getName()`, to verify the thread is a virtual thread or not, which is faster than using `Method.invoke()`.

Modification:

Replace reflection with interned class name comparison.

Result:

Improve performance.
