### PR TITLE
AdaptivePoolingAllocator: code clean

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -136,10 +136,6 @@ final class AdaptivePoolingAllocator {
     private volatile boolean freed;
 
     static {
-        if (CENTRAL_QUEUE_CAPACITY < 2) {
-            throw new IllegalArgumentException("CENTRAL_QUEUE_CAPACITY: " + CENTRAL_QUEUE_CAPACITY
-                    + " (expected: >= " + 2 + ')');
-        }
         if (MAGAZINE_BUFFER_QUEUE_CAPACITY < 2) {
             throw new IllegalArgumentException("MAGAZINE_BUFFER_QUEUE_CAPACITY: " + MAGAZINE_BUFFER_QUEUE_CAPACITY
                     + " (expected: >= " + 2 + ')');


### PR DESCRIPTION
Motivation:

In `AdaptivePoolingAllocator`, the `CENTRAL_QUEUE_CAPACITY` is already guarded by `Math.max()`, so no need to check the range in the static block.

Modification:

Remove the range check of  `CENTRAL_QUEUE_CAPACITY` in the static block.

Result:

More clean code.
