### PR TITLE
Add SETTINGS_ENABLE_CONNECT_PROTOCOL to the default HTTP/2 settings

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
@@ -84,7 +84,8 @@ public final class Http2CodecUtil {
     public static final char SETTINGS_INITIAL_WINDOW_SIZE = 4;
     public static final char SETTINGS_MAX_FRAME_SIZE = 5;
     public static final char SETTINGS_MAX_HEADER_LIST_SIZE = 6;
-    public static final int NUM_STANDARD_SETTINGS = 6;
+    public static final char SETTINGS_ENABLE_CONNECT_PROTOCOL = 8;
+    public static final int NUM_STANDARD_SETTINGS = 7;
 
     public static final long MAX_HEADER_TABLE_SIZE = MAX_UNSIGNED_INT;
     public static final long MAX_CONCURRENT_STREAMS = MAX_UNSIGNED_INT;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Settings.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Settings.java
@@ -30,6 +30,7 @@ import static io.netty.handler.codec.http2.Http2CodecUtil.MIN_HEADER_LIST_SIZE;
 import static io.netty.handler.codec.http2.Http2CodecUtil.MIN_HEADER_TABLE_SIZE;
 import static io.netty.handler.codec.http2.Http2CodecUtil.MIN_INITIAL_WINDOW_SIZE;
 import static io.netty.handler.codec.http2.Http2CodecUtil.NUM_STANDARD_SETTINGS;
+import static io.netty.handler.codec.http2.Http2CodecUtil.SETTINGS_ENABLE_CONNECT_PROTOCOL;
 import static io.netty.handler.codec.http2.Http2CodecUtil.SETTINGS_ENABLE_PUSH;
 import static io.netty.handler.codec.http2.Http2CodecUtil.SETTINGS_HEADER_TABLE_SIZE;
 import static io.netty.handler.codec.http2.Http2CodecUtil.SETTINGS_INITIAL_WINDOW_SIZE;
@@ -183,6 +184,25 @@ public final class Http2Settings extends CharObjectHashMap<Long> {
     }
 
     /**
+     * Gets the {@code SETTINGS_ENABLE_CONNECT_PROTOCOL} value. If unavailable, returns {@code null}.
+     */
+    public Boolean connectProtocolEnabled() {
+        Long value = get(SETTINGS_ENABLE_CONNECT_PROTOCOL);
+        if (value == null) {
+            return null;
+        }
+        return TRUE.equals(value);
+    }
+
+    /**
+     * Sets the {@code SETTINGS_ENABLE_CONNECT_PROTOCOL} value.
+     */
+    public Http2Settings connectProtocolEnabled(boolean enabled) {
+        put(SETTINGS_ENABLE_CONNECT_PROTOCOL, enabled ? TRUE : FALSE);
+        return this;
+    }
+
+    /**
      * Clears and then copies the given settings into this object.
      */
     public Http2Settings copyFrom(Http2Settings settings) {
@@ -243,6 +263,12 @@ public final class Http2Settings extends CharObjectHashMap<Long> {
                             ", expected [" + MIN_HEADER_LIST_SIZE + ", " + MAX_HEADER_LIST_SIZE + ']');
                 }
                 break;
+            case SETTINGS_ENABLE_CONNECT_PROTOCOL:
+                if (value != 0L && value != 1L) {
+                    throw new IllegalArgumentException("Setting ENABLE_CONNECT_PROTOCOL is invalid: " + value +
+                            ", expected [0, 1]");
+                }
+                break;
             default:
                 // Non-standard HTTP/2 setting
                 if (value < 0 || value > MAX_UNSIGNED_INT) {
@@ -268,6 +294,8 @@ public final class Http2Settings extends CharObjectHashMap<Long> {
                 return "MAX_FRAME_SIZE";
             case SETTINGS_MAX_HEADER_LIST_SIZE:
                 return "MAX_HEADER_LIST_SIZE";
+            case SETTINGS_ENABLE_CONNECT_PROTOCOL:
+                return "ENABLE_CONNECT_PROTOCOL";
             default:
                 // Unknown keys.
                 return "0x" + toHexString(key);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2SettingsTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2SettingsTest.java
@@ -61,6 +61,7 @@ public class Http2SettingsTest {
         assertNull(settings.pushEnabled());
         assertNull(settings.maxFrameSize());
         assertNull(settings.maxHeaderListSize());
+        assertNull(settings.connectProtocolEnabled());
     }
 
     @Test
@@ -71,12 +72,14 @@ public class Http2SettingsTest {
         settings.headerTableSize(3);
         settings.maxFrameSize(MAX_FRAME_SIZE_UPPER_BOUND);
         settings.maxHeaderListSize(4);
+        settings.connectProtocolEnabled(true);
         assertEquals(1, (int) settings.initialWindowSize());
         assertEquals(2L, (long) settings.maxConcurrentStreams());
         assertTrue(settings.pushEnabled());
         assertEquals(3L, (long) settings.headerTableSize());
         assertEquals(MAX_FRAME_SIZE_UPPER_BOUND, (int) settings.maxFrameSize());
         assertEquals(4L, (long) settings.maxHeaderListSize());
+        assertTrue(settings.connectProtocolEnabled());
     }
 
     @Test
@@ -227,6 +230,32 @@ public class Http2SettingsTest {
             @Override
             public void execute() {
                 settings.put(Http2CodecUtil.SETTINGS_MAX_FRAME_SIZE, (Long) value);
+            }
+        });
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] value={0}")
+    @ValueSource(booleans = {false, true})
+    public void connectProtocolEnabled(final boolean value) {
+        settings.connectProtocolEnabled(value);
+        assertEquals(value, settings.connectProtocolEnabled());
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] value={0}")
+    @ValueSource(longs = {0, 1})
+    public void enableConnectProtocol(final long value) {
+        settings.put(Http2CodecUtil.SETTINGS_ENABLE_CONNECT_PROTOCOL, (Long) value);
+        assertEquals(value, (long) settings.get(Http2CodecUtil.SETTINGS_ENABLE_CONNECT_PROTOCOL));
+        assertEquals(value == 1, settings.connectProtocolEnabled());
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] value={0}")
+    @ValueSource(longs = {MIN_VALUE, -1, 2, MAX_VALUE})
+    public void enableConnectProtocolBoundCheck(final long value) {
+        assertThrows(IllegalArgumentException.class, new Executable() {
+            @Override
+            public void execute() {
+                settings.put(Http2CodecUtil.SETTINGS_ENABLE_CONNECT_PROTOCOL, (Long) value);
             }
         });
     }


### PR DESCRIPTION
Motivation:
https://datatracker.ietf.org/doc/html/rfc8441#section-9.1 specifies SETTINGS_ENABLE_CONNECT_PROTOCOL as the default setting for enabling the Extended CONNECT. This setting is used for enabling websocket support.

Modification:
- Add SETTINGS_ENABLE_CONNECT_PROTOCOL to the default HTTP/2 settings
- Add junit tests

Result:
SETTINGS_ENABLE_CONNECT_PROTOCOL is part of the default HTTP/2 settings
