### PR TITLE
IoUring: Share IovArray to reduce jitter and allocations

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -225,15 +225,13 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
     private final class IoUringStreamUnsafe extends AbstractUringUnsafe {
 
         private ByteBuf readBuffer;
-        private IovArray iovArray;
 
         @Override
         protected int scheduleWriteMultiple(ChannelOutboundBuffer in) {
-            assert iovArray == null;
             assert writeId == 0;
             int numElements = Math.min(in.size(), Limits.IOV_MAX);
-            ByteBuf iovArrayBuffer = alloc().directBuffer(numElements * IovArray.IOV_SIZE);
-            iovArray = new IovArray(iovArrayBuffer);
+            IoUringIoHandler handler = registration().attachment();
+            IovArray iovArray = handler.iovArray();
             try {
                 int offset = iovArray.count();
                 in.forEachFlushedMessage(iovArray);
@@ -246,14 +244,9 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
                 writeId = registration.submit(ops);
                 writeOpCode = opCode;
                 if (writeId == 0) {
-                    iovArray.release();
-                    iovArray = null;
                     return 0;
                 }
             } catch (Exception e) {
-                iovArray.release();
-                iovArray = null;
-
                 // This should never happen, anyway fallback to single write.
                 scheduleWriteSingle(in.current());
             }
@@ -262,7 +255,6 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
 
         @Override
         protected int scheduleWriteSingle(Object msg) {
-            assert iovArray == null;
             assert writeId == 0;
 
             int fd = fd().intValue();
@@ -593,11 +585,6 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
                 return true;
             }
 
-            IovArray iovArray = this.iovArray;
-            if (iovArray != null) {
-                this.iovArray = null;
-                iovArray.release();
-            }
             if (res >= 0) {
                 channelOutboundBuffer.removeBytes(res);
             } else if (res == Native.ERRNO_ECANCELED_NEGATIVE) {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -227,7 +227,9 @@ final class Native {
     static final short IORING_ACCEPT_DONTWAIT = 1 << 1;
     static final short IORING_ACCEPT_POLL_FIRST = 1 << 2;
 
+    static final int IORING_FEAT_SUBMIT_STABLE = 1 << 2;
     static final int IORING_FEAT_RECVSEND_BUNDLE = 1 << 14;
+
     static final int SPLICE_F_MOVE = 1;
 
     static final int IOU_PBUF_RING_INC = 2;

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/IovArray.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/IovArray.java
@@ -128,6 +128,15 @@ public final class IovArray implements MessageProcessor {
         }
     }
 
+    /**
+     * Return {@code true} if there is no more space left in the {@link IovArray}.
+     *
+     * @return full or not.
+     */
+    public boolean isFull() {
+        return memory.capacity() < (count + 1) * IOV_SIZE || size >= maxBytes;
+    }
+
     private boolean add(long memoryAddress, long addr, int len) {
         assert addr != 0;
 


### PR DESCRIPTION
Motivation:

We can easily share the IovArray for Channels that are using the same IoUringIoHandler. This will remove jitter and allocations in general.

Modifications:

- Share IovArray by allocating it up-front
- Submit once there is no space left in the IovArray so we can re-use it

Result:

Less jitter and allocations.
