### PR TITLE
Optionally depend on bctls-jdk15on, take 2

### DIFF
--- a/handler/pom.xml
+++ b/handler/pom.xml
@@ -88,6 +88,11 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bctls-jdk18on</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>${conscrypt.groupId}</groupId>
       <artifactId>${conscrypt.artifactId}</artifactId>
       <classifier>${conscrypt.classifier}</classifier>

--- a/pom.xml
+++ b/pom.xml
@@ -864,7 +864,28 @@
       </dependency>
 
       <!--
-        Completely optional integration with Bouncy Castle TLS.
+        Completely optional integration of netty-handler with Bouncy Castle.
+
+        In particular, BouncyCastleAlpnSslUtils is using
+        org.bouncycastle.jsse.{BCApplicationProtocolSelector,BCSSLEngine}
+        via reflection, loading them via Class.forName(String).
+
+        This method of use leads to zero bytecode-level traces of this
+        dependency and works for plain Java without any further reference to
+        bctls.
+
+        maven-bundle-plugin recognizes the invocation of Class.forName() parses
+        its argument to recognize the call requires the org.bouncycastle.jsse
+        to succeed. It generates an Import-Package stanza for it, resulting in
+        a bundle which does not resolve without bctls.
+
+        This declaration, along with its corresponding dependency declaration
+        in netty-handler, provides the additional information about our use.
+        Its presence allows maven-bundle-plugin to observe
+        'org.bouncycastle.jsse' to live in an optional dependency, which is
+        enough for it to also add ';resolution=optional' and thus netty-handler
+        will resolve successfully even when bctls is not present, matching our
+        intent.
       -->
       <dependency>
         <groupId>org.bouncycastle</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -863,6 +863,17 @@
         <optional>true</optional>
       </dependency>
 
+      <!--
+        Completely optional integration with Bouncy Castle TLS.
+      -->
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bctls-jdk18on</artifactId>
+        <version>${bouncycastle.version}</version>
+        <scope>compile</scope>
+        <optional>true</optional>
+      </dependency>
+
       <dependency>
         <groupId>com.fasterxml</groupId>
         <artifactId>aalto-xml</artifactId>


### PR DESCRIPTION
Motivation:

maven-bundle-plugin still detects classes passed to Class.forName(String) and generates Import-Package requirements.

This means Netty-4.2.0.Final's io.netty.handler now requires org.bouncycastle.jsse in OSGi environments.

Modifications:

Add an optional dependency on bctls-jdk18on, properly documenting why it is needed.

Result:

MANIFEST.MF lists org.bouncycastle.jsse with ;resolution:=optional, Fixes #14997.