### PR TITLE
[bugfix]: Fix the issue where pendingTimeouts may be incorrect in the…

### DIFF
--- a/common/src/test/java/io/netty/util/HashedWheelTimerTest.java
+++ b/common/src/test/java/io/netty/util/HashedWheelTimerTest.java
@@ -17,6 +17,8 @@ package io.netty.util;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
@@ -298,7 +300,6 @@ public class HashedWheelTimerTest {
         }
     }
 
-    @Test
     @org.junit.jupiter.api.Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
     public void cancelWillCallCallback() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
@@ -318,7 +319,32 @@ public class HashedWheelTimerTest {
         assertEquals(1, timer.pendingTimeouts());
         t1.cancel();
         latch.await();
+    }
 
+    @Test
+    public void testPendingTimeoutsShouldBeCountedCorrectlyWhenTimeoutCancelledWithinGoalTick()
+        throws InterruptedException {
+        final HashedWheelTimer timer = new HashedWheelTimer();
+        final CountDownLatch barrier = new CountDownLatch(1);
+        // A total of 11 timeouts with the same delay are submitted, and they will be processed in the same tick.
+        timer.newTimeout(new TimerTask() {
+            @Override
+            public void run(Timeout timeout) throws Exception {
+                barrier.countDown();
+                Thread.sleep(1000);
+            }
+        }, 200, TimeUnit.MILLISECONDS);
+        List<Timeout> timeouts = new ArrayList<Timeout>();
+        for (int i = 0; i < 10; i++) {
+            timeouts.add(timer.newTimeout(createNoOpTimerTask(), 200, TimeUnit.MILLISECONDS));
+        }
+        barrier.await();
+        // The simulation here is that the timeout has been transferred to a bucket and is canceled before it is
+        // actually expired in the goal tick.
+        for (Timeout timeout : timeouts) {
+            timeout.cancel();
+        }
+        Thread.sleep(2000);
         assertEquals(0, timer.pendingTimeouts());
         timer.stop();
     }


### PR DESCRIPTION
… HashedWheelTimer. (#14959) (#14960)

Motivation:

If the user sets a positive `maxPendingTimeouts` of `HashedWheelTimer,` this bug means that the maximum number of tasks can be potentially increased.

Modification:

When the worker thread expires the tasks of the current tick, `pendingTimeouts` decremented only when the status of `HashedWheelTimeout` is successfully changed from `ST_INIT` to `ST_EXPIRED.` For other cases, `pendingTimeouts` will be decremented in `processCancelledTasks()` when the next tick is reached.

Result:

Fixes #14959.