### PR TITLE
SSL: Clear native error if named group is not supported

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
@@ -187,6 +187,9 @@ public final class OpenSsl {
                         // fips and the configure group is not supported when using FIPS.
                         // See https://github.com/netty/netty-tcnative/issues/883
                         defaultGroupsIter.remove();
+
+                        // Clear the error as otherwise we might fail later.
+                        SSL.clearError();
                     }
                 }
                 namedGroups = defaultConvertedNamedGroups.toArray(EmptyArrays.EMPTY_STRINGS);
@@ -318,6 +321,9 @@ public final class OpenSsl {
                                 supportedNamedGroups.add(namedGroup);
                             } else {
                                 unsupportedNamedGroups.add(namedGroup);
+
+                                // Clear the error as otherwise we might fail later.
+                                SSL.clearError();
                             }
                         }
 

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
@@ -221,6 +221,7 @@ public final class OpenSsl {
 
                         } catch (Exception ignore) {
                             tlsv13Supported = false;
+                            SSL.clearError();
                         }
                     }
 
@@ -288,6 +289,7 @@ public final class OpenSsl {
                             }
                         } catch (Exception e) {
                             logger.debug("KeyManagerFactory not supported", e);
+                            SSL.clearError();
                         } finally {
                             privateKey.release();
                         }
@@ -342,7 +344,7 @@ public final class OpenSsl {
                                         Arrays.toString(groupArray),
                                         Arrays.toString(unsupportedNamedGroups.toArray(EmptyArrays.EMPTY_STRINGS)));
                             }
-                            namedGroups =  supportedConvertedNamedGroups.toArray(EmptyArrays.EMPTY_STRINGS);
+                            namedGroups = supportedConvertedNamedGroups.toArray(EmptyArrays.EMPTY_STRINGS);
                         }
                     } else {
                         namedGroups = defaultConvertedNamedGroups.toArray(EmptyArrays.EMPTY_STRINGS);


### PR DESCRIPTION
Motivation:

We use SSLContext.setCurvesList(...) to detect if a named group is not supported or not but if its not we don't clear the native error stack atm. This is problematic as if you miss to clear the stack it might produce errors later which might cause the native SSL context creation to fail.

Modifications:

Add SSL.clearError()

Result:

Fixes https://github.com/netty/netty/issues/14991