### PR TITLE
fix: Crash early on custom native workdir failure

### DIFF
--- a/common/src/main/java/io/netty/util/internal/NativeLibraryLoader.java
+++ b/common/src/main/java/io/netty/util/internal/NativeLibraryLoader.java
@@ -66,7 +66,8 @@ public final class NativeLibraryLoader {
         if (workdir != null) {
             File f = new File(workdir);
             if (!f.exists() && !f.mkdirs()) {
-             throw new ExceptionInInitializerError(new IOException("Custom native workdir mkdirs failed: " + workdir));
+                throw new ExceptionInInitializerError(
+                    new IOException("Custom native workdir mkdirs failed: " + workdir));
             }
 
             try {

--- a/common/src/main/java/io/netty/util/internal/NativeLibraryLoader.java
+++ b/common/src/main/java/io/netty/util/internal/NativeLibraryLoader.java
@@ -65,7 +65,9 @@ public final class NativeLibraryLoader {
         String workdir = SystemPropertyUtil.get("io.netty.native.workdir");
         if (workdir != null) {
             File f = new File(workdir);
-            f.mkdirs();
+            if (!f.exists() && !f.mkdirs()) {
+             throw new ExceptionInInitializerError(new IOException("Custom native workdir mkdirs failed: " + workdir));
+            }
 
             try {
                 f = f.getAbsoluteFile();


### PR DESCRIPTION
Motivation:

Currently, when a user sets the `io.netty.native.workdir` system property to define a custom working directory for native libraries, it calls `mkdirs` without checking the boolean results.

If creating the workdir fails, typically for permissions reasons, Netty will only fail later when trying to extract the native libraries with an unclear `FileNotFoundException` which actually means that the parent directory was not found.

Modification:

Make NativeLibraryLoader crash on `mkdirs` failure. This is a behavior change but IMHO it's the expected one. If the user has explicitly provided a workdir for native libraries, he's expecting it to work. In particular, depending on how the application is implemented, he's not expecting it to fallback to another implementation.

Result:

Early crash on faulty user-defined native workdir.