### PR TITLE
Add build profile for oss-fuzz compilation (#14759)

### DIFF
--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -80,6 +80,12 @@
 
   <profiles>
     <profile>
+      <id>oss-fuzz</id>
+      <properties>
+        <cflags>-std=c99 ${env.CFLAGS} -I${quicheHomeIncludeDir} -I${boringsslHomeIncludeDir}</cflags>
+      </properties>
+    </profile>
+    <profile>
       <id>windows</id>
       <activation>
         <os>

--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -533,6 +533,12 @@
         </dependency>
       </dependencies>
     </profile>
+    <profile>
+      <id>oss-fuzz</id>
+      <properties>
+        <jni.compiler.args.cflags>CFLAGS=${env.CFLAGS} -I${unix.common.include.unpacked.dir}</jni.compiler.args.cflags>
+      </properties>
+    </profile>
   </profiles>
 
   <dependencies>

--- a/transport-native-io_uring/pom.xml
+++ b/transport-native-io_uring/pom.xml
@@ -295,6 +295,12 @@
         <test.argLine>-Dio.netty.leakDetection.level=paranoid -Dio.netty.leakDetection.targetRecords=32</test.argLine>
       </properties>
     </profile>
+    <profile>
+      <id>oss-fuzz</id>
+      <properties>
+        <jni.compiler.args.cflags>CFLAGS=${env.CFLAGS} -I${unix.common.include.unpacked.dir}</jni.compiler.args.cflags>
+      </properties>
+    </profile>
   </profiles>
 
   <dependencies>


### PR DESCRIPTION
Motivation:

On OSS-Fuzz, the CFLAGS env variable contains special build flags that are necessary to give coverage information and sanitization to the fuzzer.

Modification:

Add an 'oss-fuzz' build profile that, instead of using fixed compilation flags, inherits those of the environment.

Result:

https://github.com/yawkat/netty-fuzz-tests can run with instrumentation of epoll native code.