### PR TITLE
Lower the Quiche native logging to TRACE level

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/codec/quic/Quiche.java
+++ b/codec-classes-quic/src/main/java/io/netty/codec/quic/Quiche.java
@@ -32,7 +32,7 @@ import java.nio.ByteOrder;
 
 final class Quiche {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(Quiche.class);
-    private static final boolean DEBUG_LOGGING_ENABLED = logger.isDebugEnabled();
+    private static final boolean TRACE_LOGGING_ENABLED = logger.isTraceEnabled();
     private static final IntObjectHashMap<QuicTransportErrorHolder> ERROR_MAPPINGS = new IntObjectHashMap<>();
 
     static {
@@ -59,8 +59,8 @@ final class Quiche {
             loadNativeLibrary();
         }
 
-        // Let's enable debug logging for quiche if its enabled in our logger.
-        if (DEBUG_LOGGING_ENABLED) {
+        // Let's enable debug logging for quiche if the TRACE level is enabled in our logger.
+        if (TRACE_LOGGING_ENABLED) {
             quiche_enable_debug_logging(new QuicheLogger(logger));
         }
     }

--- a/codec-classes-quic/src/main/java/io/netty/codec/quic/QuicheLogger.java
+++ b/codec-classes-quic/src/main/java/io/netty/codec/quic/QuicheLogger.java
@@ -30,6 +30,6 @@ final class QuicheLogger {
     // Called from JNI.
     @SuppressWarnings("unused")
     void log(String msg) {
-        logger.debug(msg);
+        logger.trace(msg);
     }
 }


### PR DESCRIPTION
Motivation:
Quiche produces an enormous amount of logging output from its debug logging.
It fills our CI logs with roughly 300 MiB of output. This is too much.

Modification:
Change the Quiche log level to TRACE, and only enable debug logging if the logger for the Quiche class has TRACE level enabled.

Result:
Significantly less log output in our build logs.
