### PR TITLE
Clearing EPOLL flags can save syscall

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
@@ -124,8 +124,13 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
 
     void clearFlag(int flag) throws IOException {
         IoRegistration registration = registration();
-        ops = ops.without(EpollIoOps.valueOf(flag));
-        registration.submit(ops);
+        EpollIoOps newOps = ops.without(EpollIoOps.valueOf(flag));
+        // we can save a syscall if the ops did not change
+        if (newOps == ops) {
+            return;
+        }
+        ops = newOps;
+        registration.submit(newOps);
     }
 
     protected final IoRegistration registration() {

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoOps.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoOps.java
@@ -83,6 +83,10 @@ public final class EpollIoOps implements IoOps {
         return (value & ops.value) != 0;
     }
 
+    boolean contains(int value) {
+        return (this.value & value) != 0;
+    }
+
     /**
      * Return a {@link EpollIoOps} which is a combination of the current and the given {@link EpollIoOps}.
      *


### PR DESCRIPTION
Motivation:
EPOLL write always clear EPOLLOUT, but sometime is not needed to submit the new ops, if it hasn't changed

Modifications:
Save modifying ops if hasn't changed

Effect:
Faster clear flags


Found while profiling 

![image-4](https://github.com/user-attachments/assets/11e1686a-a3a2-4675-b796-a51dc040eb4f)
