### PR TITLE
Backport ticker feature

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/DefaultMockTicker.java
+++ b/common/src/main/java/io/netty/util/concurrent/DefaultMockTicker.java
@@ -15,10 +15,12 @@
  */
 package io.netty.util.concurrent;
 
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Condition;
-import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
@@ -29,9 +31,12 @@ import static java.util.Objects.requireNonNull;
  */
 final class DefaultMockTicker implements MockTicker {
 
-    private final Lock lock = new ReentrantLock();
-    private final Condition cond = lock.newCondition();
+    // The lock is fair, so waiters get to process condition signals in the order they (the waiters) queued up.
+    private final ReentrantLock lock = new ReentrantLock(true);
+    private final Condition tickCondition = lock.newCondition();
+    private final Condition sleeperCondition = lock.newCondition();
     private final AtomicLong nanoTime = new AtomicLong();
+    private final Set<Thread> sleepers = Collections.newSetFromMap(new IdentityHashMap<>());
 
     @Override
     public long nanoTime() {
@@ -47,13 +52,30 @@ final class DefaultMockTicker implements MockTicker {
             return;
         }
 
-        final long startTimeNanos = nanoTime();
         final long delayNanos = unit.toNanos(delay);
         lock.lockInterruptibly();
         try {
+            final long startTimeNanos = nanoTime();
+            sleepers.add(Thread.currentThread());
+            sleeperCondition.signalAll();
             do {
-                cond.await();
+                tickCondition.await();
             } while (nanoTime() - startTimeNanos < delayNanos);
+        } finally {
+            sleepers.remove(Thread.currentThread());
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Wait for the given thread to enter the {@link #sleep(long, TimeUnit)} method, and block.
+     */
+    public void awaitSleepingThread(Thread thread) throws InterruptedException {
+        lock.lockInterruptibly();
+        try {
+            while (!sleepers.contains(thread)) {
+                sleeperCondition.await();
+            }
         } finally {
             lock.unlock();
         }
@@ -72,9 +94,10 @@ final class DefaultMockTicker implements MockTicker {
         lock.lock();
         try {
             nanoTime.addAndGet(amountNanos);
-            cond.signalAll();
+            tickCondition.signalAll();
         } finally {
             lock.unlock();
         }
     }
 }
+

--- a/common/src/main/java/io/netty/util/concurrent/DefaultMockTicker.java
+++ b/common/src/main/java/io/netty/util/concurrent/DefaultMockTicker.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.concurrent;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * The default {@link MockTicker} implementation.
+ */
+final class DefaultMockTicker implements MockTicker {
+
+    private final Lock lock = new ReentrantLock();
+    private final Condition cond = lock.newCondition();
+    private final AtomicLong nanoTime = new AtomicLong();
+
+    @Override
+    public long nanoTime() {
+        return nanoTime.get();
+    }
+
+    @Override
+    public void sleep(long delay, TimeUnit unit) throws InterruptedException {
+        checkPositiveOrZero(delay, "delay");
+        requireNonNull(unit, "unit");
+
+        if (delay == 0) {
+            return;
+        }
+
+        final long startTimeNanos = nanoTime();
+        final long delayNanos = unit.toNanos(delay);
+        lock.lockInterruptibly();
+        try {
+            do {
+                cond.await();
+            } while (nanoTime() - startTimeNanos < delayNanos);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void advance(long amount, TimeUnit unit) {
+        checkPositiveOrZero(amount, "amount");
+        requireNonNull(unit, "unit");
+
+        if (amount == 0) {
+            return;
+        }
+
+        final long amountNanos = unit.toNanos(amount);
+        lock.lock();
+        try {
+            nanoTime.addAndGet(amountNanos);
+            cond.signalAll();
+        } finally {
+            lock.unlock();
+        }
+    }
+}

--- a/common/src/main/java/io/netty/util/concurrent/EventExecutorGroup.java
+++ b/common/src/main/java/io/netty/util/concurrent/EventExecutorGroup.java
@@ -95,6 +95,19 @@ public interface EventExecutorGroup extends ScheduledExecutorService, Iterable<E
     @Override
     <T> Future<T> submit(Callable<T> task);
 
+    /**
+     * The ticker for this executor. Usually the {@link #schedule} methods will follow the
+     * {@link Ticker#systemTicker() system ticker} (i.e. {@link System#nanoTime()}), but especially for testing it is
+     * sometimes useful to have more control over the ticker. In that case, this method will be overridden. Code that
+     * schedules tasks on this executor should use this ticker in order to stay consistent with the executor (e.g. not
+     * be surprised by scheduled tasks running "early").
+     *
+     * @return The ticker for this scheduler
+     */
+    default Ticker ticker() {
+        return Ticker.systemTicker();
+    }
+
     @Override
     ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit);
 

--- a/common/src/main/java/io/netty/util/concurrent/MockTicker.java
+++ b/common/src/main/java/io/netty/util/concurrent/MockTicker.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.concurrent;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A fake {@link Ticker} that allows the caller control the flow of time.
+ * This can be useful when you test time-sensitive logic without waiting for too long
+ * or introducing flakiness due to non-deterministic nature of system clock.
+ */
+public interface MockTicker extends Ticker {
+
+    @Override
+    default long initialNanoTime() {
+        return 0;
+    }
+
+    /**
+     * Advances the current {@link #nanoTime()} by the given amount of time.
+     *
+     * @param amount the amount of time to advance this ticker by.
+     * @param unit the {@link TimeUnit} of {@code amount}.
+     */
+    void advance(long amount, TimeUnit unit);
+
+    /**
+     * Advances the current {@link #nanoTime()} by the given amount of time.
+     *
+     * @param amountMillis the number of milliseconds to advance this ticker by.
+     */
+    default void advanceMillis(long amountMillis) {
+        advance(amountMillis, TimeUnit.MILLISECONDS);
+    }
+}

--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -538,7 +538,7 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
      * Returns the amount of time left until the scheduled task with the closest dead line is executed.
      */
     protected long delayNanos(long currentTimeNanos) {
-        currentTimeNanos -= initialNanoTime();
+        currentTimeNanos -= ticker().initialNanoTime();
 
         ScheduledFutureTask<?> scheduledTask = peekScheduledTask();
         if (scheduledTask == null) {

--- a/common/src/main/java/io/netty/util/concurrent/SystemTicker.java
+++ b/common/src/main/java/io/netty/util/concurrent/SystemTicker.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.concurrent;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+final class SystemTicker implements Ticker {
+    static final SystemTicker INSTANCE = new SystemTicker();
+    private static final long START_TIME = System.nanoTime();
+
+    @Override
+    public long initialNanoTime() {
+        return START_TIME;
+    }
+
+    @Override
+    public long nanoTime() {
+        return System.nanoTime() - START_TIME;
+    }
+
+    @Override
+    public void sleep(long delay, TimeUnit unit) throws InterruptedException {
+        Objects.requireNonNull(unit, "unit");
+        unit.sleep(delay);
+    }
+}

--- a/common/src/main/java/io/netty/util/concurrent/Ticker.java
+++ b/common/src/main/java/io/netty/util/concurrent/Ticker.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.concurrent;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A nanosecond-based time source, e.g. {@link System#nanoTime()}.
+ */
+public interface Ticker {
+    /**
+     * Returns the singleton {@link Ticker} that returns the values from the real system clock source.
+     * However, note that this is not the same as {@link System#nanoTime()} because we apply a fixed offset
+     * to the {@link System#nanoTime() nanoTime}.
+     */
+    static Ticker systemTicker() {
+        return SystemTicker.INSTANCE;
+    }
+
+    /**
+     * Returns a newly created mock {@link Ticker} that allows the caller control the flow of time.
+     * This can be useful when you test time-sensitive logic without waiting for too long or introducing
+     * flakiness due to non-deterministic nature of system clock.
+     */
+    static MockTicker newMockTicker() {
+        return new DefaultMockTicker();
+    }
+
+    /**
+     * The initial value used for delay and computations based upon a monotonic time source.
+     * @return initial value used for delay and computations based upon a monotonic time source.
+     */
+    long initialNanoTime();
+
+    /**
+     * The time elapsed since initialization of this class in nanoseconds. This may return a negative number just like
+     * {@link System#nanoTime()}.
+     */
+    long nanoTime();
+
+    /**
+     * Waits until the given amount of time goes by.
+     *
+     * @param delay the amount of delay.
+     * @param unit the {@link TimeUnit} of {@code delay}.
+     *
+     * @see Thread#sleep(long)
+     */
+    void sleep(long delay, TimeUnit unit) throws InterruptedException;
+
+    /**
+     * Waits until the given amount of time goes by.
+     *
+     * @param delayMillis the number of milliseconds.
+     *
+     * @see Thread#sleep(long)
+     */
+    default void sleepMillis(long delayMillis) throws InterruptedException {
+        sleep(delayMillis, TimeUnit.MILLISECONDS);
+    }
+}

--- a/common/src/test/java/io/netty/util/concurrent/AbstractScheduledEventExecutorTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/AbstractScheduledEventExecutorTest.java
@@ -121,7 +121,7 @@ public class AbstractScheduledEventExecutorTest {
     @Test
     public void testDeadlineNanosNotOverflow() {
         Assertions.assertEquals(Long.MAX_VALUE, AbstractScheduledEventExecutor.deadlineNanos(
-                AbstractScheduledEventExecutor.defaultCurrentTimeNanos(), Long.MAX_VALUE));
+                Ticker.systemTicker().nanoTime(), Long.MAX_VALUE));
     }
 
     private static final class TestScheduledEventExecutor extends AbstractScheduledEventExecutor {

--- a/common/src/test/java/io/netty/util/concurrent/DefaultMockTickerTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/DefaultMockTickerTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.concurrent;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DefaultMockTickerTest {
+
+    @Test
+    void newMockTickerShouldReturnDefaultMockTicker() {
+        assertTrue(Ticker.newMockTicker() instanceof DefaultMockTicker);
+    }
+
+    @Test
+    void defaultValues() {
+        final MockTicker ticker = Ticker.newMockTicker();
+        assertEquals(0, ticker.initialNanoTime());
+        assertEquals(0, ticker.nanoTime());
+    }
+
+    @Test
+    void advanceWithoutWaiters() {
+        final MockTicker ticker = Ticker.newMockTicker();
+        ticker.advance(42, TimeUnit.NANOSECONDS);
+        assertEquals(0, ticker.initialNanoTime());
+        assertEquals(42, ticker.nanoTime());
+
+        ticker.advanceMillis(42);
+        assertEquals(42_000_042, ticker.nanoTime());
+    }
+
+    @Test
+    void advanceWithNegativeAmount() {
+        final MockTicker ticker = Ticker.newMockTicker();
+        assertThrows(IllegalArgumentException.class, () -> {
+            ticker.advance(-1, TimeUnit.SECONDS);
+        });
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            ticker.advanceMillis(-1);
+        });
+    }
+
+    @Test
+    void advanceWithWaiters() throws Exception {
+        final MockTicker ticker = Ticker.newMockTicker();
+        final int numWaiters = 4;
+        final List<CompletableFuture<Void>> futures = new ArrayList<>();
+        for (int i = 0; i < numWaiters; i++) {
+            futures.add(CompletableFuture.runAsync(() -> {
+                try {
+                    ticker.sleep(1, TimeUnit.MILLISECONDS);
+                } catch (InterruptedException e) {
+                    throw new CompletionException(e);
+                }
+            }));
+        }
+
+        // Time did not advance at all, and thus future will not complete.
+        for (int i = 0; i < numWaiters; i++) {
+            final int finalCnt = i;
+            assertThrows(TimeoutException.class, () -> {
+                futures.get(finalCnt).get(1, TimeUnit.SECONDS);
+            });
+        }
+
+        // Advance just one nanosecond before completion.
+        ticker.advance(999_999, TimeUnit.NANOSECONDS);
+
+        // Still needs one more nanosecond.
+        for (int i = 0; i < numWaiters; i++) {
+            final int finalCnt = i;
+            assertThrows(TimeoutException.class, () -> {
+                futures.get(finalCnt).get(1, TimeUnit.SECONDS);
+            });
+        }
+
+        // Reach at the 1 millisecond mark and ensure the future is complete.
+        ticker.advance(1, TimeUnit.NANOSECONDS);
+        for (int i = 0; i < numWaiters; i++) {
+            futures.get(i).get();
+        }
+    }
+
+    @Test
+    void sleepZero() throws InterruptedException {
+        final MockTicker ticker = Ticker.newMockTicker();
+        // All sleep calls with 0 delay should return immediately.
+        ticker.sleep(0, TimeUnit.SECONDS);
+        ticker.sleepMillis(0);
+        assertEquals(0, ticker.nanoTime());
+    }
+}

--- a/common/src/test/java/io/netty/util/concurrent/DefaultMockTickerTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/DefaultMockTickerTest.java
@@ -16,11 +16,12 @@
 package io.netty.util.concurrent;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -65,44 +66,74 @@ class DefaultMockTickerTest {
         });
     }
 
+    @Timeout(60)
     @Test
     void advanceWithWaiters() throws Exception {
-        final MockTicker ticker = Ticker.newMockTicker();
+        final List<Thread> threads = new ArrayList<>();
+        final DefaultMockTicker ticker = (DefaultMockTicker) Ticker.newMockTicker();
         final int numWaiters = 4;
-        final List<CompletableFuture<Void>> futures = new ArrayList<>();
+        final List<FutureTask<Void>> futures = new ArrayList<>();
         for (int i = 0; i < numWaiters; i++) {
-            futures.add(CompletableFuture.runAsync(() -> {
+            FutureTask<Void> task = new FutureTask<>(() -> {
                 try {
                     ticker.sleep(1, TimeUnit.MILLISECONDS);
                 } catch (InterruptedException e) {
                     throw new CompletionException(e);
                 }
-            }));
-        }
-
-        // Time did not advance at all, and thus future will not complete.
-        for (int i = 0; i < numWaiters; i++) {
-            final int finalCnt = i;
-            assertThrows(TimeoutException.class, () -> {
-                futures.get(finalCnt).get(1, TimeUnit.SECONDS);
+                return null;
             });
+            Thread thread = new Thread(task);
+            threads.add(thread);
+            futures.add(task);
+            thread.start();
         }
 
-        // Advance just one nanosecond before completion.
-        ticker.advance(999_999, TimeUnit.NANOSECONDS);
+        try {
+            // Wait for all threads to be sleeping.
+            for (Thread thread : threads) {
+                ticker.awaitSleepingThread(thread);
+            }
 
-        // Still needs one more nanosecond.
-        for (int i = 0; i < numWaiters; i++) {
-            final int finalCnt = i;
-            assertThrows(TimeoutException.class, () -> {
-                futures.get(finalCnt).get(1, TimeUnit.SECONDS);
-            });
-        }
+            // Time did not advance at all, and thus future will not complete.
+            for (int i = 0; i < numWaiters; i++) {
+                final int finalCnt = i;
+                assertThrows(TimeoutException.class, () -> {
+                    futures.get(finalCnt).get(1, TimeUnit.MILLISECONDS);
+                });
+            }
 
-        // Reach at the 1 millisecond mark and ensure the future is complete.
-        ticker.advance(1, TimeUnit.NANOSECONDS);
-        for (int i = 0; i < numWaiters; i++) {
-            futures.get(i).get();
+            // Advance just one nanosecond before completion.
+            ticker.advance(999_999, TimeUnit.NANOSECONDS);
+
+            // All threads should still be sleeping.
+            for (Thread thread : threads) {
+                ticker.awaitSleepingThread(thread);
+            }
+
+            // Still needs one more nanosecond for our futures.
+            for (int i = 0; i < numWaiters; i++) {
+                final int finalCnt = i;
+                assertThrows(TimeoutException.class, () -> {
+                    futures.get(finalCnt).get(1, TimeUnit.MILLISECONDS);
+                });
+            }
+
+            // Reach at the 1 millisecond mark and ensure the future is complete.
+            ticker.advance(1, TimeUnit.NANOSECONDS);
+            for (int i = 0; i < numWaiters; i++) {
+                futures.get(i).get();
+            }
+        } catch (InterruptedException ie) {
+            for (Thread thread : threads) {
+                String name = thread.getName();
+                Thread.State state = thread.getState();
+                StackTraceElement[] stackTrace = thread.getStackTrace();
+                thread.interrupt();
+                InterruptedException threadStackTrace = new InterruptedException(name + ": " + state);
+                threadStackTrace.setStackTrace(stackTrace);
+                ie.addSuppressed(threadStackTrace);
+            }
+            throw ie;
         }
     }
 

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedEventLoop.java
@@ -23,29 +23,19 @@ import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.util.concurrent.AbstractScheduledEventExecutor;
 import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.MockTicker;
+import io.netty.util.concurrent.Ticker;
 import io.netty.util.internal.ObjectUtil;
 
 import java.util.ArrayDeque;
 import java.util.Queue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 final class EmbeddedEventLoop extends AbstractScheduledEventExecutor implements EventLoop {
-    /**
-     * When time is not {@link #timeFrozen frozen}, the base time to subtract from {@link System#nanoTime()}. When time
-     * is frozen, this variable is unused.
-     *
-     * Initialized to {@link #initialNanoTime()} so that until one of the time mutator methods is called,
-     * {@link #getCurrentTimeNanos()} matches the default behavior.
-     */
-    private long startTime = initialNanoTime();
-    /**
-     * When time is frozen, the timestamp returned by {@link #getCurrentTimeNanos()}. When unfrozen, this is unused.
-     */
-    private long frozenTimestamp;
-    /**
-     * Whether time is currently frozen.
-     */
-    private boolean timeFrozen;
+    private final FreezableTicker ticker = new FreezableTicker();
 
     private final Queue<Runnable> tasks = new ArrayDeque<Runnable>(2);
 
@@ -96,37 +86,25 @@ final class EmbeddedEventLoop extends AbstractScheduledEventExecutor implements 
     }
 
     @Override
+    public Ticker ticker() {
+        return ticker;
+    }
+
+    @Override
     protected long getCurrentTimeNanos() {
-        if (timeFrozen) {
-            return frozenTimestamp;
-        }
-        return System.nanoTime() - startTime;
+        return ticker.nanoTime();
     }
 
     void advanceTimeBy(long nanos) {
-        if (timeFrozen) {
-            frozenTimestamp += nanos;
-        } else {
-            // startTime is subtracted from nanoTime, so increasing the startTime will advance getCurrentTimeNanos
-            startTime -= nanos;
-        }
+        ticker.advance(nanos, TimeUnit.NANOSECONDS);
     }
 
     void freezeTime() {
-        if (!timeFrozen) {
-            frozenTimestamp = getCurrentTimeNanos();
-            timeFrozen = true;
-        }
+        ticker.freezeTime();
     }
 
     void unfreezeTime() {
-        if (timeFrozen) {
-            // we want getCurrentTimeNanos to continue right where frozenTimestamp left off:
-            // getCurrentTimeNanos = nanoTime - startTime = frozenTimestamp
-            // then solve for startTime
-            startTime = System.nanoTime() - frozenTimestamp;
-            timeFrozen = false;
-        }
+        ticker.unfreezeTime();
     }
 
     @Override
@@ -197,5 +175,106 @@ final class EmbeddedEventLoop extends AbstractScheduledEventExecutor implements 
     @Override
     public boolean inEventLoop(Thread thread) {
         return true;
+    }
+
+    /**
+     * Ticker that implements the old {@link EmbeddedChannel} time freezing mechanics.
+     */
+    private static final class FreezableTicker implements MockTicker {
+        private final Ticker unfrozen = Ticker.systemTicker();
+        private final Lock lock = new ReentrantLock();
+        private final Condition cond = lock.newCondition();
+        /**
+         * When time is not {@link #timeFrozen frozen}, the base time to subtract from {@link System#nanoTime()}. When
+         * time is frozen, this variable is unused.
+         */
+        private long startTime;
+        /**
+         * When time is frozen, the timestamp returned by {@link #getCurrentTimeNanos()}. When unfrozen, this is unused.
+         */
+        private long frozenTimestamp;
+        /**
+         * Whether time is currently frozen.
+         */
+        private boolean timeFrozen;
+
+        @Override
+        public void advance(long amount, TimeUnit unit) {
+            lock.lock();
+            try {
+                long nanos = unit.toNanos(amount);
+                if (timeFrozen) {
+                    frozenTimestamp += nanos;
+                } else {
+                    // startTime is subtracted from nanoTime, so increasing the startTime will advance
+                    // getCurrentTimeNanos
+                    startTime -= nanos;
+                }
+                cond.signalAll();
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        @Override
+        public long nanoTime() {
+            lock.lock();
+            try {
+                if (timeFrozen) {
+                    return frozenTimestamp;
+                }
+                return unfrozen.nanoTime() - startTime;
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        @Override
+        public void sleep(long delay, TimeUnit unit) throws InterruptedException {
+            long deadline = nanoTime() + unit.toNanos(delay);
+            lock.lockInterruptibly();
+            try {
+                while (true) {
+                    long timeout = deadline - nanoTime();
+                    if (timeout < 0) {
+                        break;
+                    }
+                    if (timeFrozen) {
+                        cond.await();
+                    } else {
+                        cond.awaitNanos(timeout);
+                    }
+                }
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        public void freezeTime() {
+            lock.lock();
+            try {
+                if (!timeFrozen) {
+                    frozenTimestamp = nanoTime();
+                    timeFrozen = true;
+                }
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        public void unfreezeTime() {
+            lock.lock();
+            try {
+                if (timeFrozen) {
+                    // we want getCurrentTimeNanos to continue right where frozenTimestamp left off:
+                    // nanoTime = unfrozen.nanoTime - startTime = frozenTimestamp
+                    // then solve for startTime
+                    startTime = unfrozen.nanoTime() - frozenTimestamp;
+                    timeFrozen = false;
+                }
+            } finally {
+                lock.unlock();
+            }
+        }
     }
 }


### PR DESCRIPTION
Motivation:

I'd like to be able to test IdleStateHandler in netty 4.

Additionally, I want to move some tests from EmbeddedEventLoop to ManualIoEventLoop because it matches actual event loop behavior more closely. That will require a time manipulation feature similar to EmbeddedChannel, which is better realized by backporting the netty 5 Ticker API.

Modification:

- Backport #13169.
- Add a `ticker()` method to EventExecutorGroup.
- Migrate `IdleStateHandler` (and its test) to the ticker from the EventLoop.

Result:

- Future pathway to altering the ticker for event loops other than the EmbeddedEventLoop
- Timeouts become testable
