### PR TITLE
Add support for ML-KEM in CertificateBuilder (#15012)

### DIFF
--- a/pkitesting/src/main/java/io/netty5/pkitesting/CertificateBuilder.java
+++ b/pkitesting/src/main/java/io/netty5/pkitesting/CertificateBuilder.java
@@ -39,6 +39,7 @@ import org.bouncycastle.jcajce.spec.EdDSAParameterSpec;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.lang.reflect.Method;
 import java.math.BigInteger;
 import java.net.InetAddress;
 import java.net.URI;
@@ -62,6 +63,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.TreeSet;
@@ -116,6 +118,7 @@ public final class CertificateBuilder {
     private static final DistributionPoint[] EMPTY_DIST_POINTS = new DistributionPoint[0];
     private static final AlgorithmParameterSpec UNSUPPORTED_SPEC = new AlgorithmParameterSpec() {
     };
+    private static final String UNSUPPORTED_SIGN = "UNSUPPORTED_SIGN";
 
     SecureRandom random;
     Algorithm algorithm = Algorithm.ecp256;
@@ -658,6 +661,10 @@ public final class CertificateBuilder {
         if (publicKey != null) {
             throw new IllegalStateException("Cannot create a self-signed certificate with a public key from a CSR.");
         }
+        if (!algorithm.supportSigning()) {
+            throw new IllegalStateException("Cannot create a self-signed certificate with a " +
+                    "key algorithm that does not support signing: " + algorithm);
+        }
         KeyPair keyPair = generateKeyPair();
 
         V3TBSCertificateGenerator generator = createCertBuilder(subject, subject, keyPair, algorithm.signatureType);
@@ -736,7 +743,7 @@ public final class CertificateBuilder {
             return "SHA512withECDSA";
         }
         if (key instanceof DSAPublicKey) {
-            throw new IllegalArgumentException("DSA keys are not supported because they are obsolete.");
+            throw new IllegalArgumentException("DSA keys are not supported because they are obsolete");
         }
         String keyAlgorithm = key.getAlgorithm();
         if ("Ed25519".equals(keyAlgorithm) || "1.3.101.112".equals(keyAlgorithm)) {
@@ -753,6 +760,19 @@ public final class CertificateBuilder {
             if (encoded.length <= 69) {
                 return "Ed448";
             }
+        }
+        if ("ML-DSA".equals(keyAlgorithm)) {
+            try {
+                Method getParams = key.getClass().getMethod("getParams");
+                Object params = getParams.invoke(key);
+                Method getName = params.getClass().getMethod("getName");
+                return (String) getName.invoke(params);
+            } catch (Exception e) {
+                throw new IllegalArgumentException("Cannot get algorithm name for ML-DSA key", e);
+            }
+        }
+        if ("ML-KEM".equals(keyAlgorithm)) {
+            throw new IllegalArgumentException("ML-KEM keys cannot be used for signing");
         }
         throw new IllegalArgumentException("Don't know what signature algorithm is best for " + key);
     }
@@ -935,7 +955,31 @@ public final class CertificateBuilder {
          * <p>
          * This algorithm was added in Java 24, and may not be supported everywhere.
          */
-        mlDsa87("ML-DSA", namedParameterSpec("ML-DSA-87"), "ML-DSA-87");
+        mlDsa87("ML-DSA", namedParameterSpec("ML-DSA-87"), "ML-DSA-87"),
+        /**
+         * The ML-KEM-512 algorithm is the NIST FIPS 203 version of the post-quantum Kyber algorithm.
+         * It has 128-bits of classical security strength, and is claimed to meet NIST Level 1
+         * quantum security strength (equivalent to finding the key for an AES-1128 block).
+         * <p>
+         * This algorithm was added in Java 24, and may not be supported everywhere.
+         */
+        mlKem512("ML-KEM", namedParameterSpec("ML-KEM-512"), UNSUPPORTED_SIGN),
+        /**
+         * The ML-KEM-768 algorithm is the NIST FIPS 203 version of the post-quantum Kyber algorithm.
+         * It has 192-bits of classical security strength, and is claimed to meet NIST Level 3
+         * quantum security strength (equivalent to finding the key for an AES-192 block).
+         * <p>
+         * This algorithm was added in Java 24, and may not be supported everywhere.
+         */
+        mlKem768("ML-KEM", namedParameterSpec("ML-KEM-768"), UNSUPPORTED_SIGN),
+        /**
+         * The ML-KEM-1024 algorithm is the NIST FIPS 203 version of the post-quantum Kyber algorithm.
+         * It has 256-bits of classical security strength, and is claimed to meet NIST Level 5
+         * quantum security strength (equivalent to finding the key for an AES-256 block).
+         * <p>
+         * This algorithm was added in Java 24, and may not be supported everywhere.
+         */
+        mlKem1024("ML-KEM", namedParameterSpec("ML-KEM-1024"), UNSUPPORTED_SIGN);
 
         final String keyType;
         final AlgorithmParameterSpec parameterSpec;
@@ -976,18 +1020,7 @@ public final class CertificateBuilder {
             if (parameterSpec == UNSUPPORTED_SPEC) {
                 throw new UnsupportedOperationException("This algorithm is not supported: " + this);
             }
-            if (this == mlDsa44 || this == mlDsa65 || this == mlDsa87) {
-                return genMlDsaKeyPair(secureRandom);
-            }
-            return genKeyPair(secureRandom);
-        }
 
-        private KeyPair genMlDsaKeyPair(SecureRandom secureRandom) throws GeneralSecurityException {
-            KeyPair keyPair = genKeyPair(secureRandom);
-            return new KeyPair(keyPair.getPublic(), keyPair.getPrivate());
-        }
-
-        private KeyPair genKeyPair(SecureRandom secureRandom) throws GeneralSecurityException {
             KeyPairGenerator keyGen = Algorithms.keyPairGenerator(keyType, parameterSpec, secureRandom);
             return keyGen.generateKeyPair();
         }
@@ -998,6 +1031,20 @@ public final class CertificateBuilder {
          */
         public boolean isSupported() {
             return parameterSpec != UNSUPPORTED_SPEC;
+        }
+
+        /**
+         * Discern if this algorithm can be used for signing.
+         * Algorithms need to support signing in order to create self-signed certificates,
+         * or to be used as signing issuers of other certificates.
+         * <p>
+         * Note that this method only inspects a property of the algorithm, and does not check if the algorithm
+         * {@linkplain #isSupported() is supported} in your environment.
+         *
+         * @return {@code true} if this algorithm can be used for signing, otherwise {@code false}.
+         */
+        public boolean supportSigning() {
+            return !Objects.equals(signatureType, UNSUPPORTED_SIGN);
         }
     }
 

--- a/pkitesting/src/test/java/io/netty5/pkitesting/CertificateBuilderTest.java
+++ b/pkitesting/src/test/java/io/netty5/pkitesting/CertificateBuilderTest.java
@@ -19,6 +19,8 @@ import io.netty5.pkitesting.CertificateBuilder.Algorithm;
 import io.netty5.pkitesting.CertificateBuilder.KeyUsage;
 import io.netty5.util.internal.PlatformDependent;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
@@ -49,6 +51,7 @@ import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -60,6 +63,7 @@ class CertificateBuilderTest {
             .notBefore(NOW.minus(1, DAYS))
             .notAfter(NOW.plus(1, DAYS))
             .subject(SUBJECT);
+    private static final SecureRandom RNG = new SecureRandom();
 
     @ParameterizedTest
     @EnumSource
@@ -68,6 +72,7 @@ class CertificateBuilderTest {
         // These big keys just take too long to test with.
         assumeTrue(algorithm != Algorithm.rsa4096 && algorithm != Algorithm.rsa8192);
         assumeTrue(algorithm.isSupported());
+        assumeTrue(algorithm.supportSigning());
 
         X509Bundle bundle = BASE.copy()
                 .algorithm(algorithm)
@@ -77,6 +82,56 @@ class CertificateBuilderTest {
         assertTrue(bundle.isCertificateAuthority());
         assertTrue(bundle.isSelfSigned());
         assertThat(cert.getSubjectX500Principal()).isEqualTo(new X500Principal(SUBJECT));
+    }
+
+    @ParameterizedTest
+    @EnumSource
+    void createKeyPairOfEveryKeyType(Algorithm algorithm) throws Exception {
+        // Assume that RSA 4096 and RSA 8192 work if the other RSA bit-widths work.
+        // These big keys just take too long to test with.
+        assumeTrue(algorithm != Algorithm.rsa4096 && algorithm != Algorithm.rsa8192);
+        assumeTrue(algorithm.isSupported());
+
+        KeyPair keyPair = algorithm.generateKeyPair(RNG);
+        assertNotNull(keyPair);
+        assertNotNull(keyPair.getPrivate());
+        assertNotNull(keyPair.getPublic());
+    }
+
+    @EnabledForJreRange(
+            min = JRE.JAVA_24,
+            disabledReason = "ML-KEM is only supported in Java 24 onwards")
+    @ParameterizedTest
+    @EnumSource(names = {"mlKem512", "mlKem768", "mlKem1024"})
+    void createMlKemCerts(Algorithm algorithm) throws Exception {
+        CertificateBuilder mlKemBuilder = BASE.copy()
+                .algorithm(algorithm);
+
+        // ML-KEM cannot be used to sign itself
+        assertThrows(IllegalStateException.class, () -> {
+            mlKemBuilder.copy().setIsCertificateAuthority(true).buildSelfSigned();
+        });
+
+        CertificateBuilder mlDsaBuilder = BASE.copy()
+                .algorithm(Algorithm.mlDsa44);
+        X509Bundle issuer = mlDsaBuilder
+                .subject("CN=issuer.netty.io, O=Netty")
+                .setIsCertificateAuthority(true)
+                .buildSelfSigned();
+
+        // ML-KEM can be signed by others
+        X509Bundle mlKemBundle = mlKemBuilder.buildIssuedBy(issuer);
+
+        X509Certificate cert = mlKemBundle.getCertificate();
+        assertFalse(mlKemBundle.isCertificateAuthority());
+        assertFalse(mlKemBundle.isSelfSigned());
+        assertThat(cert.getSubjectX500Principal()).isEqualTo(new X500Principal(SUBJECT));
+
+        // ML-KEM cannot sign others
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> {
+            mlDsaBuilder.buildIssuedBy(mlKemBundle);
+        });
+        assertThat(e).hasMessageContaining("cannot be used for signing");
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -445,7 +445,7 @@
     <logging.logLevel>debug</logging.logLevel>
     <log4j2.version>2.17.2</log4j2.version>
     <enforcer.plugin.version>3.0.0</enforcer.plugin.version>
-    <junit.version>5.11.0-M1</junit.version>
+    <junit.version>5.12.1</junit.version>
     <nativebuildtools.version>0.9.13</nativebuildtools.version>
     <skipTests>false</skipTests>
     <testJavaHome>${java.home}</testJavaHome>


### PR DESCRIPTION
Motivation:
Java 24 added support for the ML-DSA and ML-KEM post-quantum algorithms. In a previous PR we added support for self-signed ML-DSA. This completes our support for these algorithms in CertificateBuilder.

Modification:
- Add the FIPS 203 ML-KEM-512, ML-KEM-768, and ML-KEM-1024 algorithms to CertificateBuilder.Algorithm.
- Add checks that these keys are not used for signing.
- Add support for ML-DSA cert bundles to be used as issuers.
- Simplify the Algorithm.generateKeyPair method.

Result:
You can now create certs with ML-KEM keys, and you can now use ML-DSA as issuer keys.