### PR TITLE
Add "unpadded" support to Base64 encoder/decoder

### DIFF
--- a/codec-base/src/test/java/io/netty/handler/codec/base64/Base64Test.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/base64/Base64Test.java
@@ -19,11 +19,14 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
+import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.nio.ByteOrder;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
@@ -123,42 +126,115 @@ public class Base64Test {
     }
 
     @Test
-    public void testEncodeDecodeBE() {
+    public void testEncodeDecodeBE() throws IOException {
         testEncodeDecode(ByteOrder.BIG_ENDIAN);
     }
 
     @Test
-    public void testEncodeDecodeLE() {
+    public void testEncodeDecodeLE() throws IOException {
         testEncodeDecode(ByteOrder.LITTLE_ENDIAN);
     }
 
-    private static void testEncodeDecode(ByteOrder order) {
-        testEncodeDecode(64, order);
-        testEncodeDecode(128, order);
-        testEncodeDecode(512, order);
-        testEncodeDecode(1024, order);
-        testEncodeDecode(4096, order);
-        testEncodeDecode(8192, order);
-        testEncodeDecode(16384, order);
+    private static void testEncodeDecode(ByteOrder order) throws IOException {
+        testEncodeDecode(order, Base64Dialect.STANDARD);
+        testEncodeDecode(order, Base64Dialect.URL_SAFE);
     }
 
-    private static void testEncodeDecode(int size, ByteOrder order) {
+    private static void testEncodeDecode(ByteOrder order, Base64Dialect dialect) throws IOException {
+        testEncodeDecode(order, dialect, true, true);
+        testEncodeDecode(order, dialect, true, false);
+        testEncodeDecode(order, dialect, false, true);
+        testEncodeDecode(order, dialect, false, false);
+    }
+
+    private static void testEncodeDecode(ByteOrder order, Base64Dialect dialect, boolean breakLines, boolean padded)
+            throws IOException {
+        testEncodeDecode(64, order, dialect, breakLines, padded);
+        testEncodeDecode(128, order, dialect, breakLines, padded);
+        testEncodeDecode(512, order, dialect, breakLines, padded);
+        testEncodeDecode(1024, order, dialect, breakLines, padded);
+        testEncodeDecode(4096, order, dialect, breakLines, padded);
+        testEncodeDecode(8192, order, dialect, breakLines, padded);
+        testEncodeDecode(16384, order, dialect, breakLines, padded);
+    }
+
+    private static void testEncodeDecode(
+            int size, ByteOrder order, Base64Dialect dialect, boolean breakLines, boolean padded) throws IOException {
         byte[] bytes = new byte[size];
         PlatformDependent.threadLocalRandom().nextBytes(bytes);
 
-        ByteBuf src = Unpooled.wrappedBuffer(bytes).order(order);
-        ByteBuf encoded = Base64.encode(src);
-        ByteBuf decoded = Base64.decode(encoded);
-        ByteBuf expectedBuf = Unpooled.wrappedBuffer(bytes);
+        // JDK encoder / decoder
+        java.util.Base64.Encoder jdkEncoder =
+                dialect == Base64Dialect.STANDARD ? java.util.Base64.getEncoder() : java.util.Base64.getUrlEncoder();
+        jdkEncoder = padded ? jdkEncoder : jdkEncoder.withoutPadding();
+        java.util.Base64.Decoder jdkDecoder =
+                dialect == Base64Dialect.STANDARD ? java.util.Base64.getDecoder() : java.util.Base64.getUrlDecoder();
+
+        ByteBuf src = null;
+        ByteBuf encoded = null;
+        ByteBuf decoded = null;
+        ByteBuf expectedBuf = null;
+        byte[] jdKEncoded;
+        byte[] jdkDecoded;
         try {
+            jdKEncoded = breakLines ? insertNewLines(jdkEncoder.encode(bytes)) : jdkEncoder.encode(bytes);
+            src = Unpooled.wrappedBuffer(bytes).order(order);
+            encoded = Base64.encode(src, breakLines, dialect, padded);
+
+            // Assert JDK encoded equals netty encoded
+            assertEquals(Unpooled.wrappedBuffer(jdKEncoded), encoded,
+                    StringUtil.NEWLINE + "expected: " + ByteBufUtil.hexDump(jdKEncoded) +
+                    StringUtil.NEWLINE + "actual--: " +  ByteBufUtil.hexDump(encoded));
+
+            jdkDecoded = jdkDecoder.decode(stripNewLines(ByteBufUtil.getBytes(encoded)));
+            decoded = Base64.decode(encoded, dialect);
+            expectedBuf = Unpooled.wrappedBuffer(bytes);
+
+            // Assert JDK decoded equals netty decoded
+            assertEquals(Unpooled.wrappedBuffer(jdkDecoded) , decoded,
+                    StringUtil.NEWLINE + "expected: " + ByteBufUtil.hexDump(jdkDecoded) +
+                    StringUtil.NEWLINE + "actual--: " + ByteBufUtil.hexDump(decoded));
+
+            // Assert netty decoded equals expected
             assertEquals(expectedBuf, decoded,
-                        StringUtil.NEWLINE + "expected: " + ByteBufUtil.hexDump(expectedBuf) +
-                         StringUtil.NEWLINE + "actual--: " + ByteBufUtil.hexDump(decoded));
+                    StringUtil.NEWLINE + "expected: " + ByteBufUtil.hexDump(expectedBuf) +
+                    StringUtil.NEWLINE + "actual--: " + ByteBufUtil.hexDump(decoded));
         } finally {
-            src.release();
-            encoded.release();
-            decoded.release();
-            expectedBuf.release();
+            ReferenceCountUtil.safeRelease(src);
+            ReferenceCountUtil.safeRelease(encoded);
+            ReferenceCountUtil.safeRelease(decoded);
+            ReferenceCountUtil.safeRelease(expectedBuf);
+        }
+    }
+
+    private static byte[] insertNewLines(byte[] src) throws IOException {
+        if (src == null || src.length == 0) {
+            return src;
+        }
+
+        try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+            for (int i = 0; i < src.length; i++) {
+                os.write(src[i]);
+                if (i + 1 < src.length && (i + 1) % 76 == 0) {
+                    os.write('\n');
+                }
+            }
+            return os.toByteArray();
+        }
+    }
+
+    private static byte[] stripNewLines(byte[] src) throws IOException {
+        if (src == null || src.length == 0) {
+            return src;
+        }
+
+        try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+            for (byte b : src) {
+                if (b != '\n') {
+                    os.write(b);
+                }
+            }
+            return os.toByteArray();
         }
     }
 


### PR DESCRIPTION
Add "unpadded" support to Base64 encoder/decoder

**Motivation:**

This patch aims to improve the flexibility of the base64 encoder to allow it to be used more broadly as a general purpose base64 encoder by supporting output with no padding. While RFC 4648 suggests that base64 is always padded, Base64 URL does not require padding in all circumstances, especially when length is known ahead of time. The implementation in Netty assumes the length is always the size of the buffer. In this case the decoder can produce correct output regardless of whether padding is added for either Base64 or Base64 URL encoding.

When the encoder receives an unpadded Base64 URL string today it is possible that one or two bytes are omitted from the resulting buffer. By detecting if these bytes were not processed we can infer the necessary padding and produce the full length decoded source text. Similarly on the encoding side we can omit the padding if the user elects to do so.

**Modifications:**

Decode:
The `ByteProcessor` on the decode loop processes 4 bytes at a time, calling `decode4to3` using a byte[] buffer of size 4. When the `ByteProcessor` completes and there is no padding, the final call to `decode4to3` will not have been made. We can infer based on the index into the 4 byte buffer how much padding is necessary and we can make the final call to `decode4to3` with appropriate padding added.

Encode:
If no padding is necessary, we can simply omit the padding bytes at the end of our processing rounds instead of appending them.

**Result:**

The base64 encoder will support encoding and decoding Base64 without padding. The decoder will handle both modes gracefully, and the encoder will by default add padding, as is suggested by the RFC, but will allow the user to elect not to in the event they want padding omitted.
