### PR TITLE
Fix bug in method `AdaptivePoolingAllocator.allocateWithoutLock(...)`

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -594,8 +594,10 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
                 }
                 curr.attachToMagazine(this);
             }
+            boolean allocated = false;
             if (curr.remainingCapacity() >= size) {
                 curr.readInitInto(buf, size, maxCapacity);
+                allocated = true;
             }
             try {
                 if (curr.remainingCapacity() >= RETIRE_CAPACITY) {
@@ -607,7 +609,7 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
                     curr.release();
                 }
             }
-            return true;
+            return allocated;
         }
 
         private boolean allocate(int size, int sizeBucket, int maxCapacity, AdaptiveByteBuf buf) {

--- a/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
@@ -118,7 +118,6 @@ public class AdaptiveByteBufAllocatorTest extends AbstractByteBufAllocatorTest<A
         assertTrue(buffer.release());
     }
 
-    // See https://github.com/netty/netty/issues/15028
     @Test
     public void testAllocateWithoutLock() throws InterruptedException {
         final AdaptiveByteBufAllocator alloc = new AdaptiveByteBufAllocator();

--- a/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
@@ -15,6 +15,7 @@
  */
 package io.netty.buffer;
 
+import io.netty.util.NettyRuntime;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -121,7 +122,8 @@ public class AdaptiveByteBufAllocatorTest extends AbstractByteBufAllocatorTest<A
     @Test
     public void testAllocateWithoutLock() throws InterruptedException {
         final AdaptiveByteBufAllocator alloc = new AdaptiveByteBufAllocator();
-        int threadCount = 32;
+        // Make `threadCount` bigger than `AdaptivePoolingAllocator.MAX_STRIPES`, to let thread collision easily happen.
+        int threadCount = NettyRuntime.availableProcessors() * 4;
         final CountDownLatch countDownLatch = new CountDownLatch(threadCount);
         final AtomicReference<Throwable> throwableAtomicReference = new AtomicReference<Throwable>();
         for (int i = 0; i < threadCount; i++) {
@@ -133,7 +135,7 @@ public class AdaptiveByteBufAllocatorTest extends AbstractByteBufAllocatorTest<A
                             ByteBuf buffer = null;
                             try {
                                 buffer = alloc.heapBuffer(128);
-                                buffer.ensureWritable(ThreadLocalRandom.current().nextInt(512, 32768 + 1));
+                                buffer.ensureWritable(ThreadLocalRandom.current().nextInt(512, 32769));
                             } finally {
                                 if (buffer != null) {
                                     buffer.release();


### PR DESCRIPTION
Motivation:

There is a bug in method `AdaptivePoolingAllocator.allocateWithoutLock(...)`, which should return `false` if `curr.remainingCapacity() < size`.

Modification:

Return `false` if `curr.remainingCapacity() < size`.

Result:

Fixes #15028
