### PR TITLE
Fix a `Bytebuf` leak in `TcpDnsQueryDecoder`

### DIFF
--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/TcpDnsQueryDecoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/TcpDnsQueryDecoder.java
@@ -45,11 +45,15 @@ public final class TcpDnsQueryDecoder extends LengthFieldBasedFrameDecoder {
             return null;
         }
 
-        return DnsMessageUtil.decodeDnsQuery(decoder, frame.slice(), new DnsMessageUtil.DnsQueryFactory() {
-            @Override
-            public DnsQuery newQuery(int id, DnsOpCode dnsOpCode) {
-                return new DefaultDnsQuery(id, dnsOpCode);
-            }
-        });
+        try {
+            return DnsMessageUtil.decodeDnsQuery(decoder, frame.slice(), new DnsMessageUtil.DnsQueryFactory() {
+                @Override
+                public DnsQuery newQuery(int id, DnsOpCode dnsOpCode) {
+                    return new DefaultDnsQuery(id, dnsOpCode);
+                }
+            });
+        } finally {
+            frame.release();
+        }
     }
 }

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/TcpDnsTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/TcpDnsTest.java
@@ -15,6 +15,7 @@
  */
 package io.netty.handler.codec.dns;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.ReferenceCountUtil;
@@ -46,6 +47,25 @@ public class TcpDnsTest {
         assertThat(readQuery.recordAt(DnsSection.QUESTION).name(), is(query.recordAt(DnsSection.QUESTION).name()));
         readQuery.release();
         assertFalse(channel.finish());
+    }
+
+    @Test
+    public void testDecoderLeak() {
+        EmbeddedChannel decoder = new EmbeddedChannel(new TcpDnsQueryDecoder());
+        EmbeddedChannel encoder = new EmbeddedChannel(new TcpDnsQueryEncoder());
+        int randomID = new Random().nextInt(60000 - 1000) + 1000;
+        DnsQuery query = new DefaultDnsQuery(randomID, DnsOpCode.QUERY)
+                .setRecord(DnsSection.QUESTION, new DefaultDnsQuestion(QUERY_DOMAIN, DnsRecordType.A));
+        assertTrue(encoder.writeOutbound(query));
+        final ByteBuf encoded = encoder.readOutbound();
+        assertTrue(decoder.writeInbound(encoded));
+        final DnsQuery decoded = decoder.readInbound();
+        assertThat(decoded, is(query));
+        // Make sure the ByteBuf is released by TcpDnsQueryDecoder
+        assertTrue(encoded.refCnt() == 0);
+
+        assertFalse(encoder.finish());
+        assertFalse(decoder.finish());
     }
 
     @Test


### PR DESCRIPTION
Motivation:

A memory leak was detected during the implementation of a DNS over TCP server.
```
15:49:44.002 [armeria-common-worker-kqueue-2-6] ERROR io.netty.util.ResourceLeakDetector - LEAK: ByteBuf.release() was not called before it's garbage-collected. See https://netty.io/wiki/reference-counted-objects.html for more information.
Recent access records:
  io.netty.buffer.AdvancedLeakAwareByteBuf.readUnsignedShort(AdvancedLeakAwareByteBuf.java:419)
  io.netty.handler.codec.dns.DefaultDnsRecordDecoder.decodeQuestion(DefaultDnsRecordDecoder.java:38)
  io.netty.handler.codec.dns.DnsMessageUtil.decodeQuestions(DnsMessageUtil.java:221)
  io.netty.handler.codec.dns.DnsMessageUtil.decodeDnsQuery(DnsMessageUtil.java:192)
  io.netty.handler.codec.dns.TcpDnsQueryDecoder.decode(TcpDnsQueryDecoder.java:48)
  io.netty.handler.codec.LengthFieldBasedFrameDecoder.decode(LengthFieldBasedFrameDecoder.java:333)
  io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:530)
  io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:469)
  io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:290)
  io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
```

It seems that the `frame` generated by `LengthFieldBasedFrameDecoder.decode()` `TcpDnsQueryDecoder` is not released after being decoded by `TcpDnsQueryDecoder`. https://github.com/netty/netty/blob/d639d876aa577eea21acebaa970c8cc60644a851/codec-dns/src/main/java/io/netty/handler/codec/dns/TcpDnsQueryDecoder.java#L42-L53

Motifications:

- Release `frame` after use.

Result:

Resolved a memory leak in `TcpDnsQueryEncoder`