### PR TITLE
Use correct dependencies on non linux / macOS systems for the testsuite

### DIFF
--- a/testsuite-native/pom.xml
+++ b/testsuite-native/pom.xml
@@ -66,19 +66,19 @@
       <dependencies>
         <dependency>
           <groupId>${project.groupId}</groupId>
-          <artifactId>netty-transport-native-epoll</artifactId>
+          <artifactId>netty-transport-classes-epoll</artifactId>
           <version>${project.version}</version>
           <scope>compile</scope>
         </dependency>
         <dependency>
           <groupId>${project.groupId}</groupId>
-          <artifactId>netty-transport-native-kqueue</artifactId>
+          <artifactId>netty-transport-classes-kqueue</artifactId>
           <version>${project.version}</version>
           <scope>compile</scope>
         </dependency>
         <dependency>
           <groupId>${project.groupId}</groupId>
-          <artifactId>netty-resolver-dns-native-macos</artifactId>
+          <artifactId>netty-resolver-dns-classes-macos</artifactId>
           <version>${project.version}</version>
           <scope>compile</scope>
         </dependency>


### PR DESCRIPTION
Motivation:

When running on platforms that does not support these native transports we should better depend on the classes artifacts directly.

Modifications:

Change dependencies.

Result:

No more complication error on windows