### PR TITLE
Fix the assignment error of maxQoS parameter in ConnAck Properties (#…

### DIFF
--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttMessageBuilders.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttMessageBuilders.java
@@ -380,7 +380,8 @@ public final class MqttMessageBuilders {
                 props.add(new MqttProperties.IntegerProperty(MqttPropertyType.RECEIVE_MAXIMUM.value(), receiveMaximum));
             }
             if (maximumQos != null) {
-                props.add(new MqttProperties.IntegerProperty(MqttPropertyType.MAXIMUM_QOS.value(), receiveMaximum));
+                props.add(new MqttProperties.IntegerProperty(MqttPropertyType.MAXIMUM_QOS.value(),
+                        maximumQos.intValue()));
             }
             props.add(new MqttProperties.IntegerProperty(MqttPropertyType.RETAIN_AVAILABLE.value(), retain ? 1 : 0));
             if (maximumPacketSize != null) {


### PR DESCRIPTION
…15017)

Motivation:
The wrong value was used for maxQos.

Modifications:

Fix the assignment error of maxQoS parameter in ConnAck Properties Builder.

Result:

Use the correct value for ConnAck.
