### PR TITLE
Add ticker to ManualIoEventLoop

### DIFF
--- a/transport/src/main/java/io/netty/channel/ManualIoEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/ManualIoEventLoop.java
@@ -21,6 +21,7 @@ import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GlobalEventExecutor;
 import io.netty.util.concurrent.Promise;
+import io.netty.util.concurrent.Ticker;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.ThreadExecutorMap;
@@ -78,6 +79,7 @@ public final class ManualIoEventLoop extends AbstractScheduledEventExecutor impl
     private final IoEventLoopGroup parent;
     private final AtomicReference<Thread> owningThread;
     private final IoHandler handler;
+    private final Ticker ticker;
 
     private volatile long gracefulShutdownQuietPeriod;
     private volatile long gracefulShutdownTimeout;
@@ -114,10 +116,36 @@ public final class ManualIoEventLoop extends AbstractScheduledEventExecutor impl
      *                          used by this {@link IoEventLoop}.
      */
     public ManualIoEventLoop(IoEventLoopGroup parent, Thread owningThread, IoHandlerFactory factory) {
+        this(parent, owningThread, factory, Ticker.systemTicker());
+    }
+
+    /**
+     * Create a new {@link IoEventLoop} that is owned by the user and so needs to be driven by the user with the given
+     * {@link Thread}. This means that the user is responsible to call either {@link #runNow()} or
+     * {@link #run(long)} to execute IO or tasks that were submitted to this {@link IoEventLoop}.
+     *
+     * @param parent            the parent {@link IoEventLoopGroup} or {@code null} if no parent.
+     * @param owningThread      the {@link Thread} that executes the IO and tasks for this {@link IoEventLoop}. The
+     *                          user will use this {@link Thread} to call {@link #runNow()} or {@link #run(long)} to
+     *                          make progress. If {@code null}, must be set later using
+     *                          {@link #setOwningThread(Thread)}.
+     * @param factory           the {@link IoHandlerFactory} that will be used to create the {@link IoHandler} that is
+     *                          used by this {@link IoEventLoop}.
+     * @param ticker            The {@link #ticker()} to use for this event loop. Note that the {@link IoHandler} does
+     *                          not use the ticker, so if the ticker advances faster than system time, you may have to
+     *                          {@link #wakeup()} this event loop manually.
+     */
+    public ManualIoEventLoop(IoEventLoopGroup parent, Thread owningThread, IoHandlerFactory factory, Ticker ticker) {
         this.parent = parent;
         this.owningThread = new AtomicReference<>(owningThread);
         this.handler = factory.newHandler(this);
+        this.ticker = Objects.requireNonNull(ticker, "ticker");
         state = new AtomicInteger(ST_STARTED);
+    }
+
+    @Override
+    public Ticker ticker() {
+        return ticker;
     }
 
     private int runAllTasks() {
@@ -136,7 +164,7 @@ public final class ManualIoEventLoop extends AbstractScheduledEventExecutor impl
             }
         } while (!fetchedAll); // keep on processing until we fetched all scheduled tasks.
         if (numRun > 0) {
-            lastExecutionTime = getCurrentTimeNanos();
+            lastExecutionTime = ticker.nanoTime();
         }
         return numRun;
     }
@@ -442,7 +470,7 @@ public final class ManualIoEventLoop extends AbstractScheduledEventExecutor impl
         cancelScheduledTasks();
 
         if (gracefulShutdownStartTime == 0) {
-            gracefulShutdownStartTime = getCurrentTimeNanos();
+            gracefulShutdownStartTime = ticker.nanoTime();
         }
 
         if (runAllTasks() > 0) {
@@ -460,7 +488,7 @@ public final class ManualIoEventLoop extends AbstractScheduledEventExecutor impl
             return false;
         }
 
-        final long nanoTime = getCurrentTimeNanos();
+        final long nanoTime = ticker.nanoTime();
 
         if (isShutdown() || nanoTime - gracefulShutdownStartTime > gracefulShutdownTimeout) {
             return true;
@@ -538,7 +566,7 @@ public final class ManualIoEventLoop extends AbstractScheduledEventExecutor impl
         public long deadlineNanos() {
             assert inEventLoop();
             long next = nextScheduledTaskDeadlineNanos();
-            long maxDeadlineNanos = getCurrentTimeNanos() + maxBlockingNanos;
+            long maxDeadlineNanos = ticker.nanoTime() + maxBlockingNanos;
             if (next == -1) {
                 return maxDeadlineNanos;
             }

--- a/transport/src/test/java/io/netty/channel/ManualIoEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/ManualIoEventLoopTest.java
@@ -278,7 +278,8 @@ public class ManualIoEventLoopTest {
     @Test
     public void testTicker() {
         MockTicker ticker = Ticker.newMockTicker();
-        ManualIoEventLoop eventLoop = new ManualIoEventLoop(null, Thread.currentThread(), NioIoHandler.newFactory(), ticker);
+        ManualIoEventLoop eventLoop = new ManualIoEventLoop(
+                null, Thread.currentThread(), NioIoHandler.newFactory(), ticker);
 
         AtomicInteger counter = new AtomicInteger();
         eventLoop.schedule(counter::incrementAndGet, 60, TimeUnit.SECONDS);


### PR DESCRIPTION
Motivation:

ManualIoEventLoop is useful for testing because it matches "normal" event loops more closely than EmbeddedEventLoop. Adding ticker functionality makes testing even easier.

Modification:

Add a ticker parameter.

Note that the IoHandler *does not* use the ticker. A blocking `run` operation may block for the specified real-time duration even if the ticker time flows differently. I don't believe this can be fixed: The IoHandler uses system APIs to block, so the only way to make it adhere to the Ticker would be to wake the IoHandler up when the Ticker time changes, but this would require the Ticker to keep track of the IoHandlers that use it. I don't think this is a good idea.

Since ManualIoEventLoop has a wakeup method, this is easy to work around for users.

Result:

Easy testing of time-dependent code with ManualIoEventLoop.