### PR TITLE
Fix snapshot deploy for windows

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -31,7 +31,7 @@ env:
   MAVEN_OPTS: -Xmx6g -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryhandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
 
 jobs:
-  stage-snapshot:
+  stage-snapshot-linux:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -135,7 +135,7 @@ jobs:
   deploy-staged-snapshots:
     runs-on: ubuntu-latest
     # Wait until we have staged everything
-    needs: stage-snapshot
+    needs: [ stage-snapshot-linux, stage-snapshot-windows-x86_64 ]
     steps:
       - uses: actions/checkout@v4
 
@@ -189,6 +189,7 @@ jobs:
 
       - name: Copy previous build artifacts to local maven repository
         run: |
+          cp -r ~/windows-x86_64-local-staging/deferred/* ~/.m2/repository/
           cp -r ~/linux-aarch64-local-staging/deferred/* ~/.m2/repository/
           cp -r ~/linux-riscv64-local-staging/deferred/* ~/.m2/repository/
           cp -r ~/linux-x86_64-java11-local-staging/deferred/* ~/.m2/repository/

--- a/testsuite-native/pom.xml
+++ b/testsuite-native/pom.xml
@@ -33,6 +33,8 @@
     <skipNativeTestsuite>false</skipNativeTestsuite>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
+    <jni.classifier.linux/>
+    <jni.classifier.macos/>
   </properties>
 
   <dependencies>
@@ -43,6 +45,27 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-transport-native-epoll</artifactId>
+      <version>${project.version}</version>
+      <classifier>${jni.classifier.linux}</classifier>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-transport-native-kqueue</artifactId>
+      <version>${project.version}</version>
+      <classifier>${jni.classifier.macos}</classifier>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-resolver-dns-native-macos</artifactId>
+      <version>${project.version}</version>
+      <classifier>${jni.classifier.macos}</classifier>
+      <scope>compile</scope>
     </dependency>
   </dependencies>
   <profiles>
@@ -57,34 +80,6 @@
         <skipNativeTestsuite>true</skipNativeTestsuite>
       </properties>
     </profile>
-
-    <profile>
-      <id>default</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>netty-transport-classes-epoll</artifactId>
-          <version>${project.version}</version>
-          <scope>compile</scope>
-        </dependency>
-        <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>netty-transport-classes-kqueue</artifactId>
-          <version>${project.version}</version>
-          <scope>compile</scope>
-        </dependency>
-        <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>netty-resolver-dns-classes-macos</artifactId>
-          <version>${project.version}</version>
-          <scope>compile</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-
     <profile>
       <id>linux</id>
       <activation>
@@ -92,27 +87,9 @@
           <family>linux</family>
         </os>
       </activation>
-      <dependencies>
-        <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>netty-transport-native-epoll</artifactId>
-          <version>${project.version}</version>
-          <classifier>${jni.classifier}</classifier>
-          <scope>compile</scope>
-        </dependency>
-        <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>netty-transport-native-kqueue</artifactId>
-          <version>${project.version}</version>
-          <scope>compile</scope>
-        </dependency>
-        <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>netty-resolver-dns-native-macos</artifactId>
-          <version>${project.version}</version>
-          <scope>compile</scope>
-        </dependency>
-      </dependencies>
+      <properties>
+        <jni.classifier.linux>${jni.classifier}</jni.classifier.linux>
+      </properties>
     </profile>
 
     <profile>
@@ -122,28 +99,9 @@
           <family>mac</family>
         </os>
       </activation>
-      <dependencies>
-        <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>netty-transport-native-kqueue</artifactId>
-          <version>${project.version}</version>
-          <classifier>${jni.classifier}</classifier>
-          <scope>compile</scope>
-        </dependency>
-        <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>netty-resolver-dns-native-macos</artifactId>
-          <version>${project.version}</version>
-          <classifier>${jni.classifier}</classifier>
-          <scope>compile</scope>
-        </dependency>
-        <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>netty-transport-native-epoll</artifactId>
-          <version>${project.version}</version>
-          <scope>compile</scope>
-        </dependency>
-      </dependencies>
+      <properties>
+        <jni.classifier.macos>${jni.classifier}</jni.classifier.macos>
+      </properties>
     </profile>
   </profiles>
 


### PR DESCRIPTION
Motivation:

We needed to ensure we also wait for the staging of the windows artifacts before merge all staging artifacts and also ensure we setup dependencies correctly in our native testsuite when using windows

Modifications:

- Fix workflow
- Correctly setup dependencies

Result:

Snapshot deploys work again
