### PR TITLE
Adjust release workflow for 4.2 to include macos and windows artifacts

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -263,7 +263,22 @@ jobs:
           ./mvnw -B --file pom.xml -Pnative-dependencies -am -pl all clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=$HOME/all-local-staging -DskipRemoteStaging=true -DskipTests=true
 
       - name: Merge staging repositories
-        run: bash ./.github/scripts/merge_local_staging.sh ~/local-staging ~/windows-x86_64-local-staging ~/linux-aarch64-local-staging ~/linux-x86_64-java11-local-staging ~/linux-riscv64-local-staging
+        run: |
+          mkdir -p ~/local-staging/deferred
+          cat ~/windows-x86_64-local-staging/deferred/.index >>  ~/local-staging/deferred/.index
+          cp -r ~/windows-x86_64-local-staging/deferred/* ~/local-staging/deferred/
+          cat ~/macos-aarch64-java11-local-staging/deferred/.index >>  ~/local-staging/deferred/.index
+          cp -r ~/macos-aarch64-java11-local-staging/deferred/* ~/local-staging/deferred/
+          cat ~/macos-x86_64-java11-local-staging/deferred/.index >>  ~/local-staging/deferred/.index
+          cp -r ~/macos-x86_64-java11-local-staging/deferred/* ~/local-staging/deferred/
+          cat ~/linux-aarch64-local-staging/deferred/.index >>  ~/local-staging/deferred/.index
+          cp -r ~/linux-aarch64-local-staging/deferred/* ~/local-staging/deferred/
+          cat ~/linux-riscv64-local-staging/deferred/.index >>  ~/local-staging/deferred/.index
+          cp -r ~/linux-riscv64-local-staging/deferred/* ~/local-staging/deferred/
+          cat ~/linux-x86_64-java11-local-staging/deferred/.index >>  ~/local-staging/deferred/.index
+          cp -r ~/linux-x86_64-java11-local-staging/deferred/* ~/local-staging/deferred/
+          cat ~/all-local-staging/deferred/.index >>  ~/local-staging/deferred/.index
+          cp -r ~/all-local-staging/deferred/io/netty/netty-all/* ~/local-staging/deferred/io/netty/netty-all/
 
       - uses: s4u/maven-settings-action@v3.0.0
         with:

--- a/.github/workflows/ci-release-4.2.yml
+++ b/.github/workflows/ci-release-4.2.yml
@@ -170,10 +170,181 @@ jobs:
         # Rollback the release in case of an failure
         run: bash ./.github/scripts/release_rollback.sh release.properties netty/netty 4.2
 
+  stage-release-macos:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - setup: macos-x86_64-java11
+            os: macos-13
+          - setup: macos-aarch64-java11
+            os: macos-15
+
+    runs-on: ${{ matrix.os }}
+    name:  stage-release-${{ matrix.setup }}
+
+    steps:
+      - name: Download release-workspace
+        uses: actions/download-artifact@v4
+        with:
+          name: prepare-release-workspace
+          path: ./prepare-release-workspace/
+
+      - name: Adjust mvnw permissions
+        run: chmod 755 ./prepare-release-workspace/mvnw
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+
+      - name: Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Setup git configuration
+        run: |
+          git config --global user.email "netty-project-bot@users.noreply.github.com"
+          git config --global user.name "Netty Project Bot"
+
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.SSH_PRIVATE_KEY_PEM }}
+          known_hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
+
+      - uses: s4u/maven-settings-action@v3.0.0
+        with:
+          servers: |
+            [{
+              "id": "sonatype-nexus-staging",
+              "username": "${{ secrets.SONATYPE_USERNAME }}",
+              "password": "${{ secrets.SONATYPE_PASSWORD }}"
+            }]
+
+      # Cache .m2/repository
+      # Caching of maven dependencies
+      - uses: actions/cache@v4
+        continue-on-error: true
+        with:
+          path: ~/.m2/repository
+          key: pr-${{ matrix.setup }}-maven-cache-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            pr-${{ matrix.setup }}-maven-cache-
+
+      - name: Install tools via brew
+        run: brew bundle
+
+      - name: Create local staging directory
+        run: mkdir -p ~/local-staging
+
+      - name: Stage release to local staging directory
+        working-directory: ./prepare-release-workspace/
+        run: ./mvnw -B -ntp clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=$HOME/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE }} -Dgpg.keyname=${{ secrets.GPG_KEYNAME }}
+
+      - name: Upload local staging directory
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.setup }}-local-staging
+          path: /local-staging
+          if-no-files-found: error
+          include-hidden-files: true
+
+      - name: Rollback release on failure
+        working-directory: ./prepare-release-workspace/
+        if: ${{ failure() }}
+        # Rollback the release in case of an failure
+        run: bash ./.github/scripts/release_rollback.sh release.properties netty/netty 4.2
+
+  stage-release-windows:
+    runs-on: windows-2019
+    name: stage-release-windows-x86_64
+    env:
+      # Let's limit the amount of ram that is used to unpack rustup as we saw
+      # failures sometimes due the fact that not enough memory could be reserved.
+      RUSTUP_UNPACK_RAM: 134217728  # Use 128 MiB
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Setup git configuration
+        run: |
+          git config --global user.email "netty-project-bot@users.noreply.github.com"
+          git config --global user.name "Netty Project Bot"
+
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.SSH_PRIVATE_KEY_PEM }}
+          known_hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
+
+      - uses: s4u/maven-settings-action@v3.0.0
+        with:
+          servers: |
+            [{
+              "id": "sonatype-nexus-staging",
+              "username": "${{ secrets.SONATYPE_USERNAME }}",
+              "password": "${{ secrets.SONATYPE_PASSWORD }}"
+            }]
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: 11
+
+      - name: Install stable rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Configuring Developer Command Prompt
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x86_amd64
+
+      - name: Install tools
+        uses: crazy-max/ghaction-chocolatey@v3
+        with:
+          args: install ninja nasm
+
+      # Caching of maven dependencies
+      - uses: actions/cache@v4
+        continue-on-error: true
+        with:
+          path: ~/.m2/repository
+          key: stage-release-windows-x86_64-maven-cache-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            stage-release-windows-x86_64-maven-cache-
+
+      - name: Stage snapshots to local staging directory
+        run: ./mvnw.cmd -B -ntp --file pom.xml javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=$HOME/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE }} -Dgpg.keyname=${{ secrets.GPG_KEYNAME }}
+
+      - name: Upload local staging directory
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-x86_64-local-staging
+          path: local-staging
+          if-no-files-found: error
+          include-hidden-files: true
+
   deploy-staged-release:
     runs-on: ubuntu-latest
     # Wait until we have staged everything
-    needs: stage-release-linux
+    needs: [ stage-release-linux, stage-release-macos, stage-release-windows]
     steps:
       - name: Download release-workspace
         uses: actions/download-artifact@v4
@@ -201,32 +372,6 @@ jobs:
           key: ${{ secrets.SSH_PRIVATE_KEY_PEM }}
           known_hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
 
-      # Hardcode the staging artifacts that need to be downloaded.
-      # These must match the matrix setups. There is currently no way to pull this out of the config.
-      - name: Download linux-aarch64 staging directory
-        uses: actions/download-artifact@v4
-        with:
-          name: linux-aarch64-local-staging
-          path: ~/linux-aarch64-local-staging
-
-      - name: Download linux-riscv64 staging directory
-        uses: actions/download-artifact@v4
-        with:
-          name: linux-riscv64-local-staging
-          path: ~/linux-riscv64-local-staging
-
-      - name: Download linux-x86_64-java11 staging directory
-        uses: actions/download-artifact@v4
-        with:
-          name: linux-x86_64-java11-local-staging
-          path: ~/linux-x86_64-java11-local-staging
-
-      # This step takes care of merging all the previous staged repositories in a way that will allow us to deploy
-      # all together with one maven command.
-      - name: Merge staging repositories
-        working-directory: ./prepare-release-workspace/
-        run: bash ./.github/scripts/merge_local_staging.sh /home/runner/local-staging/staging ~/linux-aarch64-local-staging/staging ~/linux-riscv64-local-staging/staging ~/linux-x86_64-java11-local-staging/staging
-
       - uses: s4u/maven-settings-action@v3.0.0
         with:
           servers: |
@@ -246,6 +391,79 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-deploy-staged-release-
             ${{ runner.os }}-maven-
+
+      # Hardcode the staging artifacts that need to be downloaded.
+      # These must match the matrix setups. There is currently no way to pull this out of the config.
+      - name: Download windows_x86_64 staging directory
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-x86_64-local-staging
+          path: ~/windows-x86_64-local-staging
+
+      - name: Download macos-aarch64-java11 staging directory
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-aarch64-java11-local-staging
+          path: ~/macos-aarch64-java11-local-staging
+
+      - name: Download macos-x86_64-java11 staging directory
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-x86_64-java11-local-staging
+          path: ~/macos-x86_64-java11-local-staging
+
+      - name: Download linux-aarch64 staging directory
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-aarch64-local-staging
+          path: ~/linux-aarch64-local-staging
+
+      - name: Download linux-riscv64 staging directory
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-riscv64-local-staging
+          path: ~/linux-riscv64-local-staging
+
+      - name: Download linux-x86_64-java11 staging directory
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-x86_64-java11-local-staging
+          path: ~/linux-x86_64-java11-local-staging
+
+      - name: Copy previous build artifacts to local maven repository
+        run: |
+          cp -r ~/windows-x86_64-local-staging/deferred/* ~/.m2/repository/
+          cp -r ~/macos-aarch64-java11-local-staging/deferred/* ~/.m2/repository/
+          cp -r ~/macos-x86_64-java11-local-staging/deferred/* ~/.m2/repository/
+          cp -r ~/linux-aarch64-local-staging/deferred/* ~/.m2/repository/
+          cp -r ~/linux-riscv64-local-staging/deferred/* ~/.m2/repository/
+          cp -r ~/linux-x86_64-java11-local-staging/deferred/* ~/.m2/repository/
+
+      - name: Generate netty-all and deploy to local staging.
+        run: |
+          mkdir -p ~/all-local-staging
+          ./mvnw -B --file pom.xml -Psonatype-oss-release,native-dependencies -am -pl all clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=$HOME/all-local-staging -DskipRemoteStaging=true -DskipTests=true
+
+      # This step takes care of merging all the previous staged repositories in a way that will allow us to deploy
+      # all together with one maven command.
+      - name: Merge staging repositories
+        working-directory: ./prepare-release-workspace/
+        run: |
+          mkdir -p ~/local-staging/deferred
+          cat ~/windows-x86_64-local-staging/deferred/.index >>  ~/local-staging/deferred/.index
+          cp -r ~/windows-x86_64-local-staging/deferred/* ~/local-staging/deferred/
+          cat ~/macos-aarch64-java11-local-staging/deferred/.index >>  ~/local-staging/deferred/.index
+          cp -r ~/macos-aarch64-java11-local-staging/deferred/* ~/local-staging/deferred/
+          cat ~/macos-x86_64-java11-local-staging/deferred/.index >>  ~/local-staging/deferred/.index
+          cp -r ~/macos-x86_64-java11-local-staging/deferred/* ~/local-staging/deferred/
+          cat ~/linux-aarch64-local-staging/deferred/.index >>  ~/local-staging/deferred/.index
+          cp -r ~/linux-aarch64-local-staging/deferred/* ~/local-staging/deferred/
+          cat ~/linux-riscv64-local-staging/deferred/.index >>  ~/local-staging/deferred/.index
+          cp -r ~/linux-riscv64-local-staging/deferred/* ~/local-staging/deferred/
+          cat ~/linux-x86_64-java11-local-staging/deferred/.index >>  ~/local-staging/deferred/.index
+          cp -r ~/linux-x86_64-java11-local-staging/deferred/* ~/local-staging/deferred/
+          cat ~/all-local-staging/deferred/.index >>  ~/local-staging/deferred/.index
+          cp -r ~/all-local-staging/deferred/io/netty/netty-all/* ~/local-staging/deferred/io/netty/netty-all/
 
       - name: Deploy local staged artifacts
         working-directory: ./prepare-release-workspace/


### PR DESCRIPTION
Motivation:

We need to adjust the release workflow for 4.2 (we already did 4.1) so it also build and include artifacts for macos and windows. This allows a fully automated release process.

Modifications:

- Add steps to include macos and windows artifacts
- Fix deploy workflow to include the correct netty-all for snapshots

Result:

Be able to release fully automated 4.2