### PR TITLE
Fix graal build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -695,6 +695,7 @@
     <brotli4j.version>1.16.0</brotli4j.version>
     <!-- By default skip native testsuite as it requires a custom environment with graalvm installed -->
     <skipNativeImageTestsuite>true</skipNativeImageTestsuite>
+    <native.maven.plugin.version>0.10.6</native.maven.plugin.version>
     <skipShadingTestsuite>false</skipShadingTestsuite>
     <skipDeploy>false</skipDeploy>
     <multiReleaseJar>true</multiReleaseJar>

--- a/testsuite-native-image/pom.xml
+++ b/testsuite-native-image/pom.xml
@@ -61,6 +61,16 @@
       <artifactId>netty-codec-http</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-codec-classes-quic</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-transport-classes-epoll</artifactId>
+      <version>${project.version}</version>
+    </dependency>
 
   </dependencies>
 

--- a/testsuite-native-image/pom.xml
+++ b/testsuite-native-image/pom.xml
@@ -97,14 +97,7 @@
           <groupId>io.netty</groupId>
           <artifactId>netty-transport-native-epoll</artifactId>
           <version>${project.version}</version>
-          <classifier>linux-x86_64</classifier>
-          <scope>runtime</scope>
-        </dependency>
-        <dependency>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-transport-native-epoll</artifactId>
-          <version>${project.version}</version>
-          <classifier>linux-aarch_64</classifier>
+          <classifier>${os.detected.classifier}</classifier>
           <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/testsuite-native-image/pom.xml
+++ b/testsuite-native-image/pom.xml
@@ -96,14 +96,14 @@
         <dependency>
           <groupId>io.netty</groupId>
           <artifactId>netty-transport-native-epoll</artifactId>
-          <version>${netty.version}</version>
+          <version>${project.version}</version>
           <classifier>linux-x86_64</classifier>
           <scope>runtime</scope>
         </dependency>
         <dependency>
           <groupId>io.netty</groupId>
           <artifactId>netty-transport-native-epoll</artifactId>
-          <version>${netty.version}</version>
+          <version>${project.version}</version>
           <classifier>linux-aarch_64</classifier>
           <scope>runtime</scope>
         </dependency>


### PR DESCRIPTION
Motivation:
Our build was missing the plugin version for 'org.graalvm.buildtools:native-maven-plugin'. This failed the build at maven pom parse time, which to our scripts looked like a successful build, exception one that only took a minute.

Modification:
Define the missing property to the latest version of the 'native-maven-plugin'.

Result:
The graal builds and the native test suites should now actually run.
