### PR TITLE
Fix javadocs / xref generation for 4.2.x

### DIFF
--- a/codec/pom.xml
+++ b/codec/pom.xml
@@ -30,6 +30,7 @@
 
   <properties>
     <javaModuleName>io.netty.codec.unused</javaModuleName>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
 
   <dependencies>

--- a/dev-tools/pom.xml
+++ b/dev-tools/pom.xml
@@ -29,6 +29,9 @@
 
   <name>Netty/Dev-Tools</name>
 
+  <properties>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
+  </properties>
   <build>
     <plugins>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.2.0</version>
+            <version>3.11.2</version>
             <executions>
               <execution>
                 <id>aggregate</id>
@@ -88,6 +88,7 @@
               </execution>
             </executions>
             <configuration>
+              <legacyMode>true</legacyMode>
               <skippedModules>
                 netty-all,netty-bom,netty-testsuite,netty-testsuite-autobahn,netty-testsuite-http2,
                 netty-testsuite-native,netty-testsuite-native-image,netty-testsuite-native-image-client,
@@ -112,6 +113,8 @@
               <doctitle>Netty API Reference (${project.version})</doctitle>
               <windowtitle>Netty API Reference (${project.version})</windowtitle>
               <detectJavaApiLink>false</detectJavaApiLink>
+              <release>${javadoc.release}</release>
+              <source>${javadoc.source}</source>
               <links>
                 <link>https://docs.oracle.com/javase/8/docs/api/</link>
                 <link>https://developers.google.com/protocol-buffers/docs/reference/java/</link>
@@ -640,6 +643,8 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.release />
+    <javadoc.release>9</javadoc.release>
+    <javadoc.source>9</javadoc.source>
     <netty.dev.tools.directory>${project.build.directory}/dev-tools</netty.dev.tools.directory>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -1605,13 +1610,17 @@
       </plugin>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.10.4</version>
+        <version>3.11.2</version>
         <configuration>
           <detectOfflineLinks>false</detectOfflineLinks>
           <breakiterator>true</breakiterator>
           <version>false</version>
           <author>false</author>
           <keywords>true</keywords>
+          <release>${javadoc.release}</release>
+          <source>${javadoc.source}</source>
+          <failOnError>false</failOnError>
+          <failOnWarnings>false</failOnWarnings>
         </configuration>
       </plugin>
       <plugin>
@@ -1850,7 +1859,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-jxr-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.6.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-antrun-plugin</artifactId>

--- a/scripts/generate_docs.sh
+++ b/scripts/generate_docs.sh
@@ -33,11 +33,11 @@ BRANCH=$(git branch --show-current)
 TAG="$2"
 WEBSITE_API_DIR="$1"/"$VERSION"/api/
 WEBSITE_XREF_DIR="$1"/"$VERSION"/xref/
-API_DIR=target/site/apidocs/
-XREF_DIR=target/site/xref/
+API_DIR=target/api/apidocs/
+XREF_DIR=target/reports/xref/
 
 git checkout "$TAG"
-JAVA_HOME=$JAVA8_HOME ./mvnw -Paggregate clean package javadoc:aggregate jxr:aggregate -DskipTests=true
+JAVA_HOME=$JAVA_HOME ./mvnw -Paggregate clean package javadoc:aggregate jxr:aggregate -DskipTests=true
 
 echo "Delete old javadocs and xref files"
 rm -rf "$WEBSITE_API_DIR"/*

--- a/testsuite-autobahn/pom.xml
+++ b/testsuite-autobahn/pom.xml
@@ -32,6 +32,7 @@
     <revapi.skip>true</revapi.skip>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
 
   <dependencies>

--- a/testsuite-http2/pom.xml
+++ b/testsuite-http2/pom.xml
@@ -32,6 +32,7 @@
     <revapi.skip>true</revapi.skip>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
 
   <dependencies>

--- a/testsuite-jpms/pom.xml
+++ b/testsuite-jpms/pom.xml
@@ -32,6 +32,7 @@
     <revapi.skip>true</revapi.skip>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
     <javaModuleName>io.netty.testsuite_jpms</javaModuleName>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>

--- a/testsuite-native-image-client-runtime-init/pom.xml
+++ b/testsuite-native-image-client-runtime-init/pom.xml
@@ -32,6 +32,7 @@
     <revapi.skip>true</revapi.skip>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
 
   <dependencies>

--- a/testsuite-native-image-client/pom.xml
+++ b/testsuite-native-image-client/pom.xml
@@ -32,6 +32,7 @@
     <revapi.skip>true</revapi.skip>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
 
   <dependencies>

--- a/testsuite-native-image/pom.xml
+++ b/testsuite-native-image/pom.xml
@@ -32,6 +32,7 @@
     <revapi.skip>true</revapi.skip>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
     <packaging.type>jar</packaging.type>
   </properties>
 

--- a/testsuite-native/pom.xml
+++ b/testsuite-native/pom.xml
@@ -33,6 +33,7 @@
     <skipNativeTestsuite>false</skipNativeTestsuite>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
     <jni.classifier.linux/>
     <jni.classifier.macos/>
   </properties>

--- a/testsuite-osgi/pom.xml
+++ b/testsuite-osgi/pom.xml
@@ -33,6 +33,7 @@
     <argLine.java9.extras>--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/jdk.internal.loader=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.security=ALL-UNNAMED</argLine.java9.extras>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
 
   <profiles>

--- a/testsuite-shading/pom.xml
+++ b/testsuite-shading/pom.xml
@@ -42,6 +42,7 @@
     <revapi.skip>true</revapi.skip>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
 
   <build>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -132,6 +132,7 @@
     <!-- Needed for SSL tests as these use the SelfSignedCertificate --> 
     <argLine.java9.extras>--add-exports java.base/sun.security.x509=ALL-UNNAMED</argLine.java9.extras>
     <revapi.skip>true</revapi.skip>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
 
   <build>

--- a/transport-blockhound-tests/pom.xml
+++ b/transport-blockhound-tests/pom.xml
@@ -141,6 +141,7 @@
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
     <javaModuleName>io.netty.transport_blockhound_tests</javaModuleName>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
 
   <dependencies>

--- a/transport-native-io_uring/pom.xml
+++ b/transport-native-io_uring/pom.xml
@@ -48,6 +48,8 @@
     <!-- Always check JNI during test run so we catch bugs that could cause crashes -->
     <argLine.jni>-Xcheck:jni</argLine.jni>
     <test.argLine>-D_</test.argLine>
+    <javadoc.release>9</javadoc.release>
+    <javadoc.source>9</javadoc.source>
   </properties>
 
   <profiles>

--- a/transport-native-io_uring/pom.xml
+++ b/transport-native-io_uring/pom.xml
@@ -48,8 +48,6 @@
     <!-- Always check JNI during test run so we catch bugs that could cause crashes -->
     <argLine.jni>-Xcheck:jni</argLine.jni>
     <test.argLine>-D_</test.argLine>
-    <javadoc.release>9</javadoc.release>
-    <javadoc.source>9</javadoc.source>
   </properties>
 
   <profiles>


### PR DESCRIPTION
Motivation:

Due our change of using java11 to compile 4.2.x we also need to adjust the javadoc configuration as otherwise it will fail

Modifications:

- Update javadoc plugin version
- Adjust configuration to work with our setup
- Adjust jxr plugin version
- Update script for the new path

Result:

javadoc / jxr generation works again
