### PR TITLE
Rename native lib so incubator version and new version can co-exists

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/Quiche.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/Quiche.java
@@ -67,7 +67,8 @@ final class Quiche {
 
     private static void loadNativeLibrary() {
         // This needs to be kept in sync with what is defined in netty_quic_quiche.c
-        String libName = "netty_quiche";
+        // and pom.xml as jniLibPrefix.
+        String libName = "netty_quiche42";
         ClassLoader cl = PlatformDependent.getClassLoader(Quiche.class);
 
         if (!PlatformDependent.isAndroid()) {

--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -38,7 +38,8 @@
     <skipTests>false</skipTests>
     <packaging.type>jar</packaging.type>
     <jni.classifier>${os.detected.name}-${os.detected.arch}</jni.classifier>
-    <jniLibName>netty_quiche_${os.detected.name}_${os.detected.arch}</jniLibName>
+    <jniLibPrefix>netty_quiche42</jniLibPrefix>
+    <jniLibName>${jniLibPrefix}_${os.detected.name}_${os.detected.arch}</jniLibName>
     <jniUtilIncludeDir>${project.build.directory}/netty-jni-util/</jniUtilIncludeDir>
     <boringsslSourceDir>${project.build.directory}/boringssl-source</boringsslSourceDir>
     <boringsslBuildDir>${boringsslSourceDir}/build-target</boringsslBuildDir>
@@ -137,7 +138,7 @@
     <profile>
       <id>mac-m1-cross-compile</id>
       <properties>
-        <jniLibName>netty_quiche_osx_aarch_64</jniLibName>
+        <jniLibName>${jniLibPrefix}_osx_aarch_64</jniLibName>
         <jni.classifier>osx-aarch_64</jni.classifier>
         <javaModuleNameClassifier>osx.aarch_64</javaModuleNameClassifier>
         <macosxDeploymentTarget>11.0</macosxDeploymentTarget>
@@ -167,7 +168,7 @@
     <profile>
       <id>mac-intel-cross-compile</id>
       <properties>
-        <jniLibName>netty_quiche_osx_x86_64</jniLibName>
+        <jniLibName>${jniLibPrefix}_osx_x86_64</jniLibName>
         <jni.classifier>osx-x86_64</jni.classifier>
         <javaModuleNameClassifier>osx.x86_64</javaModuleNameClassifier>
         <macosxDeploymentTarget>10.12</macosxDeploymentTarget>
@@ -486,7 +487,7 @@
         <libquiche>libquiche.a</libquiche>
         <extraLdflags>-static-libstdc++ -l:libstdc++.a -Wl,--strip-debug -Wl,--exclude-libs,ALL</extraLdflags>
         <bundleNativeCode>META-INF/native/lib${jniLibName}.so;osname=linux;processor=aarch64</bundleNativeCode>
-        <jniLibName>netty_quiche_linux_aarch_64</jniLibName>
+        <jniLibName>${jniLibPrefix}_linux_aarch_64</jniLibName>
         <jni.classifier>linux-aarch_64</jni.classifier>
         <javaModuleNameClassifier>linux.aarch_64</javaModuleNameClassifier>
         <extraConfigureArg>--host=aarch64-linux-gnu</extraConfigureArg>

--- a/codec-native-quic/src/main/c/netty_quic_quiche.c
+++ b/codec-native-quic/src/main/c/netty_quic_quiche.c
@@ -45,7 +45,10 @@
 
 #define STATICALLY_CLASSNAME "io/netty/handler/codec/quic/QuicheNativeStaticallyReferencedJniMethods"
 #define QUICHE_CLASSNAME "io/netty/handler/codec/quic/Quiche"
-#define LIBRARYNAME "netty_quiche"
+
+// This needs to be kept in sync with what is defined in Quiche.java
+// and pom.xml as jniLibPrefix.
+#define LIBRARYNAME "netty_quiche42"
 
 static jweak    quiche_logger_class_weak = NULL;
 static jmethodID quiche_logger_class_log = NULL;

--- a/codec-native-quic/src/main/resources/META-INF/native-image/io.netty/netty-codec-native-quic/resource-config.json
+++ b/codec-native-quic/src/main/resources/META-INF/native-image/io.netty/netty-codec-native-quic/resource-config.json
@@ -3,23 +3,23 @@
   "includes":[
     {
       "condition":{"typeReachable":"io.netty.handler.codec.quic.Quiche"},
-      "pattern":"\\QMETA-INF/native/libnetty_quiche_osx_x86_64.jnilib\\E"
+      "pattern":"\\QMETA-INF/native/libnetty_quiche42_osx_x86_64.jnilib\\E"
     },
     {
       "condition":{"typeReachable":"io.netty.handler.codec.quic.Quiche"},
-      "pattern":"\\QMETA-INF/native/libnetty_quiche_osx_aarch_64.jnilib\\E"
+      "pattern":"\\QMETA-INF/native/libnetty_quiche42_osx_aarch_64.jnilib\\E"
     },
     {
       "condition":{"typeReachable":"io.netty.handler.codec.quic.Quiche"},
-      "pattern":"\\QMETA-INF/native/libnetty_quiche_linux_x86_64.so\\E"
+      "pattern":"\\QMETA-INF/native/libnetty_quiche42_linux_x86_64.so\\E"
     },
     {
       "condition":{"typeReachable":"io.netty.handler.codec.quic.Quiche"},
-      "pattern":"\\QMETA-INF/native/libnetty_quiche_linux_aarch_64.so\\E"
+      "pattern":"\\QMETA-INF/native/libnetty_quiche42_linux_aarch_64.so\\E"
     },
     {
       "condition":{"typeReachable":"io.netty.handler.codec.quic.Quiche"},
-      "pattern":"\\QMETA-INF/native/netty_quiche_windows_x86_64.dll\\E"
+      "pattern":"\\QMETA-INF/native/netty_quiche42_windows_x86_64.dll\\E"
     }
   ]},
   "bundles":[]


### PR DESCRIPTION
Motivation:

We should ensure the incubator version of quic and the included version of quic can co-exists for now as people might have both on the class-path for some period of time

Modifications:

Rename native lib so it does not clash with the incubator version

Result:

Be able to have the incubator version of quic on the classpath