### PR TITLE
Fix cross-compilation to also include codec-native-quic

### DIFF
--- a/docker/docker-compose.centos-7.cross.yaml
+++ b/docker/docker-compose.centos-7.cross.yaml
@@ -28,7 +28,7 @@ services:
 
   cross-compile-aarch64-deploy:
     <<: *cross-compile-aarch64-common
-    command: /bin/bash -cl "./mvnw -B -ntp -Plinux-aarch64 -pl transport-native-unix-common,transport-native-epoll,transport-native-io_uring -am clean deploy -DskipTests=true"
+    command: /bin/bash -cl "./mvnw -B -ntp -Plinux-aarch64 -pl transport-native-unix-common,transport-native-epoll,transport-native-io_uring,codec-native-quic -am clean deploy -DskipTests=true"
 
   cross-compile-aarch64-stage-snapshot:
     <<: *cross-compile-aarch64-common
@@ -38,7 +38,7 @@ services:
       - ~/.m2:/root/.m2
       - ~/local-staging:/root/local-staging
       - ..:/code
-    command: /bin/bash -cl "./mvnw -B -ntp -Plinux-aarch64 -pl transport-native-unix-common,transport-native-epoll,transport-native-io_uring -am clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"
+    command: /bin/bash -cl "./mvnw -B -ntp -Plinux-aarch64 -pl transport-native-unix-common,transport-native-epoll,transport-native-io_uring,codec-native-quic -am clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"
 
   cross-compile-aarch64-stage-release:
     <<: *cross-compile-aarch64-common
@@ -47,7 +47,7 @@ services:
       - ~/.m2:/root/.m2
       - ~/local-staging:/root/local-staging
       - ..:/code
-    command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && ./mvnw -B -ntp -Plinux-aarch64 -pl transport-native-unix-common,transport-native-epoll,transport-native-io_uring -am clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME}"
+    command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && ./mvnw -B -ntp -Plinux-aarch64 -pl transport-native-unix-common,transport-native-epoll,transport-native-io_uring,codec-native-quic -am clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME}"
 
   cross-compile-aarch64-shell:
     <<: *cross-compile-aarch64-common
@@ -55,4 +55,4 @@ services:
 
   cross-compile-aarch64-build:
     <<: *cross-compile-aarch64-common
-    command: /bin/bash -cl "./mvnw -B -ntp -Plinux-aarch64 -pl transport-native-unix-common,transport-native-epoll,transport-native-io_uring -am clean package -DskipTests=true"
+    command: /bin/bash -cl "./mvnw -B -ntp -Plinux-aarch64 -pl transport-native-unix-common,transport-native-epoll,transport-native-io_uring,codec-native-quic -am clean package -DskipTests=true"

--- a/docker/docker-compose.ubuntu-20.04.cross.yaml
+++ b/docker/docker-compose.ubuntu-20.04.cross.yaml
@@ -25,7 +25,7 @@ services:
 
   cross-compile-riscv64-deploy:
     <<: *cross-compile-riscv64-common
-    command: /bin/bash -cl "./mvnw -B -ntp -Plinux-riscv64 -pl transport-native-unix-common,transport-native-epoll,transport-native-io_uring -am clean deploy -DskipTests=true"
+    command: /bin/bash -cl "./mvnw -B -ntp -Plinux-riscv64 -pl transport-native-unix-common,transport-native-epoll,transport-native-io_uring,codec-native-quic -am clean deploy -DskipTests=true"
 
   cross-compile-riscv64-stage-snapshot:
     <<: *cross-compile-riscv64-common
@@ -35,7 +35,7 @@ services:
       - ~/.m2:/root/.m2
       - ~/local-staging:/root/local-staging
       - ..:/code
-    command: /bin/bash -cl "./mvnw -B -ntp -Plinux-riscv64 -pl transport-native-unix-common,transport-native-epoll,transport-native-io_uring -am clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"
+    command: /bin/bash -cl "./mvnw -B -ntp -Plinux-riscv64 -pl transport-native-unix-common,transport-native-epoll,transport-native-io_uring,codec-native-quic -am clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"
 
   cross-compile-riscv64-stage-release:
     <<: *cross-compile-riscv64-common
@@ -44,7 +44,7 @@ services:
       - ~/.m2:/root/.m2
       - ~/local-staging:/root/local-staging
       - ..:/code
-    command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && ./mvnw -B -ntp -Plinux-riscv64 -pl transport-native-unix-common,transport-native-epoll,transport-native-io_uring -am clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME}"
+    command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && ./mvnw -B -ntp -Plinux-riscv64 -pl transport-native-unix-common,transport-native-epoll,transport-native-io_uring,codec-native-quic -am clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME}"
 
   cross-compile-riscv64-shell:
     <<: *cross-compile-riscv64-common
@@ -52,4 +52,4 @@ services:
 
   cross-compile-riscv64-build:
     <<: *cross-compile-riscv64-common
-    command: /bin/bash -cl "./mvnw -B -ntp -Plinux-riscv64 -pl transport-native-unix-common,transport-native-epoll,transport-native-io_uring -am clean package -DskipTests=true"
+    command: /bin/bash -cl "./mvnw -B -ntp -Plinux-riscv64 -pl transport-native-unix-common,transport-native-epoll,transport-native-io_uring,codec-native-quic -am clean package -DskipTests=true"


### PR DESCRIPTION
Motivation:

We need to ensure we also build the codec-native-quic artifact when cross-compiling

Modifications:

Add codec-native-quic to the command line when cross-compile

Result:

Also produce codec-native-quic artifacts when cross compile