### PR TITLE
Add missing dependencies on Ubuntu Devcontainer

### DIFF
--- a/.devcontainer/ubuntu/Dockerfile
+++ b/.devcontainer/ubuntu/Dockerfile
@@ -1,5 +1,30 @@
 FROM mcr.microsoft.com/devcontainers/base:ubuntu
 RUN apt-get update && apt-get install -y \
-    autotools-dev autoconf automake libtool make tar libaio-dev libssl-dev libapr1-dev lksctp-tools gcc \
-    htop strace  openjdk-8-jdk-headless openjdk-8-source openjdk-11-jdk-headless openjdk-11-source \
-    openjdk-17-jdk-headless openjdk-17-source openjdk-21-jdk-headless openjdk-21-source
+    autotools-dev \
+    autoconf \
+    automake \
+    libtool \
+    make \
+    tar \
+    libaio-dev \
+    libssl-dev \
+    libapr1-dev \
+    lksctp-tools \
+    gcc \
+    htop \
+    strace \
+    openjdk-8-jdk-headless \
+    openjdk-8-source \
+    openjdk-11-jdk-headless \
+    openjdk-11-source \
+    openjdk-17-jdk-headless \
+    openjdk-17-source \
+    openjdk-21-jdk-headless \
+    openjdk-21-source \
+    cmake \
+    ninja-build \
+    perl \
+    golang
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+RUN . "$HOME/.cargo/env"


### PR DESCRIPTION
Motivation:
Now that we've added QUIC, with new native dependencies such as Rust, we also need to update our devcontainer.

Modification:
- Add cmake, ninja-build, and golang to the Ubuntu devcontainer so it can build BoringSSL.
- Add Rust and Cargo via rustup so we can build Quiche.

Note, Ubuntu has 'cargo' and 'rustc' packages, but they are version 1.75 as if this writing, and Quiche needs Rust 1.81.

Result:
The build once again works from within the Ubuntu devcontainer.

