### PR TITLE
Try to give our docker images more disk storage

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -22,6 +22,8 @@ services:
       - ~/.m2:/root/.m2
       - ..:/code
     working_dir: /code
+    storage_opt:
+      size: '6g'
     security_opt:
       - seccomp:unconfined
 


### PR DESCRIPTION
Motivation:
We currently have builds that fail from running out of disk storage. Running a build locally, it appears to use a bit over 2 GiB of storage.

Modification:
Add a storage option to the docker compose common service definition to give all builds 6 GiB of storage.

Result:
Hopefully the builds work now.
