### PR TITLE
Revert "Try to give our docker images more disk storage (#15071)"

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -22,8 +22,6 @@ services:
       - ~/.m2:/root/.m2
       - ..:/code
     working_dir: /code
-    storage_opt:
-      size: '6g'
     security_opt:
       - seccomp:unconfined
 


### PR DESCRIPTION
Motivation:

The added option is not supported by the fs that is used by GH actions and so the job is not even run via docker.

```
Error response from daemon: --storage-opt is supported only for overlay over xfs with 'pquota' mount option
```

Modifications:

This reverts commit 56bed2d220271e9af32ee32826a271c961e8e42e.

Result:

Build is not skipped anymore