### PR TITLE
Fix init order of PlatformDependent0 fields

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -46,11 +46,11 @@ final class PlatformDependent0 {
     private static final long LONG_ARRAY_BASE_OFFSET;
     private static final long LONG_ARRAY_INDEX_SCALE;
     private static final MethodHandle DIRECT_BUFFER_CONSTRUCTOR;
-    private static final Throwable EXPLICIT_NO_UNSAFE_CAUSE = explicitNoUnsafeCause0();
     private static final MethodHandle ALLOCATE_ARRAY_METHOD;
     private static final MethodHandle ALIGN_SLICE;
-    private static final int JAVA_VERSION = javaVersion0();
     private static final boolean IS_ANDROID = isAndroid0();
+    private static final int JAVA_VERSION = javaVersion0();
+    private static final Throwable EXPLICIT_NO_UNSAFE_CAUSE = explicitNoUnsafeCause0();
 
     private static final Throwable UNSAFE_UNAVAILABILITY_CAUSE;
 
@@ -1076,7 +1076,7 @@ final class PlatformDependent0 {
     private static int javaVersion0() {
         final int majorVersion;
 
-        if (isAndroid0()) {
+        if (isAndroid()) {
             majorVersion = 6;
         } else {
             majorVersion = majorVersionFromJavaSpecificationVersion();


### PR DESCRIPTION
Motivation:

After #14975, `EXPLICIT_NO_UNSAFE_CAUSE` has a dependency to `JAVA_VERSION`, which is initialized after it. When `explicitNoUnsafeCause0()` tries to set `io.netty.noUnsafe` to true by default on Java 24, it fails, because `javaVersion()` always returns 0 at that point.

Also, `isAndroid0()` is called twice, once in `javaVersion0()` and once to initialize `IS_ANDROID`. This is not a bug or a performance issue, but it does have a visible side-effect when debug logging is enabled.

Modification:

The declaration of `EXPLICIT_NO_UNSAFE_CAUSE` is moved after `JAVA_VERSION`, ensuring `javaVersion()` returns the correct version when `explicitNoUnsafeCause0()` calls it.

`IS_ANDROID` is also moved before `JAVA_VERSION`, such that the `isAndroid0()` method is called only once.

Result:

Fixes #14942 correctly
