### PR TITLE
Update the 4.2 version of QUIC

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicSslContext.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicSslContext.java
@@ -101,11 +101,12 @@ final class QuicheQuicSslContext extends QuicSslContext {
                     Set<String> unsupportedNamedGroups = new LinkedHashSet<>();
                     for (String namedGroup : nGroups) {
                         String converted = GroupsConverter.toBoringSSL(namedGroup);
+                        // Will return 0 on failure.
                         if (BoringSSL.SSLContext_set1_groups_list(sslCtx, converted) == 0) {
+                            unsupportedNamedGroups.add(namedGroup);
+                        } else {
                             supportedConvertedNamedGroups.add(converted);
                             supportedNamedGroups.add(namedGroup);
-                        } else {
-                            unsupportedNamedGroups.add(namedGroup);
                         }
                     }
 

--- a/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicStreamShutdownTest.java
+++ b/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicStreamShutdownTest.java
@@ -23,13 +23,18 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.socket.ChannelOutputShutdownException;
+import io.netty.handler.codec.ByteToMessageDecoder;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class QuicStreamShutdownTest extends AbstractQuicTest {
 
@@ -73,6 +78,85 @@ public class QuicStreamShutdownTest extends AbstractQuicTest {
             streamChannel.writeAndFlush(Unpooled.buffer().writeLong(8)).sync();
 
             latch.await();
+        } finally {
+            QuicTestUtils.closeIfNotNull(channel);
+            QuicTestUtils.closeIfNotNull(server);
+
+            shutdown(executor);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("newSslTaskExecutors")
+    public void testShutdownInputClosureByServerCausesStreamStopped(Executor executor) throws Throwable {
+        Channel server = null;
+        Channel channel = null;
+        CountDownLatch latch = new CountDownLatch(2);
+        AtomicReference<Throwable> errorRef = new AtomicReference<>();
+        try {
+            server = QuicTestUtils.newServer(executor, new ChannelInboundHandlerAdapter(),
+                    new ChannelInboundHandlerAdapter() {
+                        @Override
+                        public void channelRegistered(ChannelHandlerContext ctx) {
+                            ctx.fireChannelRegistered();
+                        }
+
+                        @Override
+                        public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+                            QuicStreamChannel streamChannel = (QuicStreamChannel) ctx.channel();
+                            streamChannel.shutdownInput().addListener(new ChannelFutureListener() {
+                                @Override
+                                public void operationComplete(ChannelFuture f) throws Exception {
+                                    ByteBuf buffer = (ByteBuf) msg;
+                                    if (!f.isSuccess()) {
+                                        errorRef.compareAndSet(null, f.cause());
+                                        latch.countDown();
+                                        buffer.release();
+                                    } else {
+                                        ctx.writeAndFlush(buffer).addListener(new ChannelFutureListener() {
+                                            @Override
+                                            public void operationComplete(ChannelFuture channelFuture) {
+                                                if (!channelFuture.isSuccess()) {
+                                                    errorRef.compareAndSet(null, channelFuture.cause());
+                                                }
+                                                latch.countDown();
+                                            }
+                                        });
+                                    }
+
+                                }
+                            });
+                        }
+                    });
+
+            channel = QuicTestUtils.newClient(executor);
+            QuicChannel quicChannel = QuicTestUtils.newQuicChannelBootstrap(channel)
+                    .handler(new ChannelInboundHandlerAdapter())
+                    .streamHandler(new ChannelInboundHandlerAdapter())
+                    .remoteAddress(server.localAddress())
+                    .connect()
+                    .get();
+
+            QuicStreamChannel streamChannel = quicChannel.createStream(QuicStreamType.BIDIRECTIONAL,
+                    new ByteToMessageDecoder() {
+                        @Override
+                        protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> list) {
+                            if (in.readableBytes() == 4) {
+                                latch.countDown();
+                                ctx.close();
+                            }
+                        }
+                    }).sync().getNow();
+
+            streamChannel.writeAndFlush(Unpooled.buffer().writeInt(4)).sync();
+
+            if (!latch.await(5, TimeUnit.SECONDS)) {
+                fail("Timeout while waiting for completion", errorRef.get());
+            }
+            Throwable error = errorRef.get();
+            if (error != null) {
+                fail("Failure during execution", error);
+            }
         } finally {
             QuicTestUtils.closeIfNotNull(channel);
             QuicTestUtils.closeIfNotNull(server);


### PR DESCRIPTION
Motivation:

This brings over the latest changes merged into the incubator QUIC codec.

Modification:

- Merge https://github.com/netty/netty/pull/790 into 4.2
- Merge https://github.com/netty/netty/pull/791 into 4.2

Other changes in the incubator QUIC codec are build related, and are ignored but considered merged.

Result:

Keeping the 4.2 QUIC codec up to date.
