### PR TITLE
codec-http needs codec-compression as non-optional dependency for backwards compatibility

### DIFF
--- a/codec-http/pom.xml
+++ b/codec-http/pom.xml
@@ -57,7 +57,6 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-codec-compression</artifactId>
       <version>${project.version}</version>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
Motivation:
PR #15060 Introduces backwards incompatible change as codec-http is made to depend optionally on codec-compression

Modifications:
- codec-compression is no more optional dependency

Result:
Backwards compatibility and easier migration from 4.1 to 4.2
