### PR TITLE
Skip io_uring tests for now to stabilize builds

### DIFF
--- a/transport-native-io_uring/pom.xml
+++ b/transport-native-io_uring/pom.xml
@@ -59,7 +59,8 @@
         </os>
       </activation>
       <properties>
-        <skipTests>false</skipTests>
+        <!-- Skip tests until we figured out why this kills the GHA runner -->
+        <skipTests>true</skipTests>
       </properties>
 
       <build>


### PR DESCRIPTION
Motivation:

The GHA runners started to get killed during the io_uring testsuite. Let's disable it for now until we figured out whats wrong.

Modifications:

Temporary skip io_uring testsuite

Result:

Stable build