### PR TITLE
Delete cloned projects once these are not needed anymore to free up d…

### DIFF
--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -684,6 +684,7 @@
                           <arg value="clone" />
                           <arg value="--branch" />
                           <arg value="${boringsslBranch}" />
+                          <arg value="--single-branch"/>
                           <arg value="${boringsslRepository}" />
                           <arg value="${boringsslSourceDir}" />
                         </exec>
@@ -756,6 +757,9 @@
                     <copy todir="${boringsslHomeIncludeDir}" verbose="true">
                       <fileset dir="${boringsslSourceDir}/include" />
                     </copy>
+
+                    <!-- Delete boringssl source directory after build to free up space -->
+                    <delete dir="${boringsslSourceDir}"/>
                   </else>
                 </if>
               </target>
@@ -790,9 +794,9 @@
 
                         <exec executable="git" failonerror="true" dir="${project.build.directory}" resolveexecutable="true">
                           <arg value="clone" />
-                          <arg value="--recursive" />
                           <arg value="--branch" />
                           <arg value="${quicheBranch}" />
+                          <arg value="--single-branch"/>
                           <arg value="${quicheRepository}" />
                           <arg value="${quicheSourceDir}" />
                         </exec>
@@ -876,6 +880,9 @@
                     <copy todir="${quicheHomeIncludeDir}">
                       <fileset dir="${quicheSourceDir}/quiche/include" />
                     </copy>
+
+                    <!-- Delete quiche source directory after build to free up space -->
+                    <delete dir="${quicheSourceDir}"/>
                   </else>
                 </if>
               </target>


### PR DESCRIPTION
…iskspace

Motivation:

We started to see build failures as we ran out of diskspace when using docker.

Modifications:

- Delete cloned projects after we are done with compilation
- Don't recursive checkout quiche
- Clone single branch only

Result:

Builds need less disk-space