### PR TITLE
Small adaptive allocator optimization (#15062)

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
@@ -28,6 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class AdaptiveByteBufAllocatorTest extends AbstractByteBufAllocatorTest<AdaptiveByteBufAllocator> {
     @Override

--- a/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
@@ -150,6 +150,9 @@ public class AdaptiveByteBufAllocatorTest extends AbstractByteBufAllocatorTest<A
             }).start();
         }
         countDownLatch.await();
-        assertNull(throwableAtomicReference.get());
+        Throwable throwable = throwableAtomicReference.get();
+        if (throwable != null) {
+            fail("Expected no exception, but got", throwable);
+        }
     }
 }

--- a/microbench/src/main/java/io/netty/microbench/buffer/ByteBufAllocatorBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/ByteBufAllocatorBenchmark.java
@@ -38,7 +38,7 @@ public class ByteBufAllocatorBenchmark extends AbstractMicrobenchmark {
 
     private static final ByteBufAllocator unpooledAllocator = new UnpooledByteBufAllocator(true);
     private static final ByteBufAllocator pooledAllocator =
-            new PooledByteBufAllocator(true, 4, 4, 8192, 11, 0, 0, 0, true, 0); // Disable thread-local cache
+            new PooledByteBufAllocator(true, 4, 4, 8192, 11, 0, 0, 0, true, 0);
     private static final ByteBufAllocator adaptiveAllocator = new AdaptiveByteBufAllocator();
 
     private static final int MAX_LIVE_BUFFERS = 8192;


### PR DESCRIPTION
Motivation:

The ByteBuffer.slice() operation is fairly costly, and not always necessary.
We can instead create it upon first use.

Modification:

Create the tmp nio buffer on demand in the AdaptiveByteBuf instead of in the buffer initialization.
Also clean up some nits I noticed.

Result:

The `ByteBufAllocatorConcurrentBenchmark` goes from this:

```
Benchmark                                                    (size)   Mode  Cnt          Score          Error  Units
ByteBufAllocatorConcurrentBenchmark.allocateReleaseAdaptive   00256  thrpt   20   90016002.762 ± 16401133.377  ops/s
ByteBufAllocatorConcurrentBenchmark.allocateReleasePooled     00256  thrpt   20  133278469.959 ± 23482602.497  ops/s
```

To this:

```
Benchmark                                                    (size)   Mode  Cnt          Score         Error  Units
ByteBufAllocatorConcurrentBenchmark.allocateReleaseAdaptive   00256  thrpt   20  246909449.159 ± 1472871.187  ops/s
ByteBufAllocatorConcurrentBenchmark.allocateReleasePooled     00256  thrpt   20  159183952.551 ±  177573.851  ops/s
```

Although there is still quite a lot of run-to-run variability, e.g. the "pooled" numbers are supposed to be unchanged between the two runs, but clearly aren't. Adaptive suffers similar, or perhaps worse variability.