### PR TITLE
Add "unpadded" support to Base64 encoder/decoder

### DIFF
--- a/codec/src/main/java/io/netty5/handler/codec/base64/Base64.java
+++ b/codec/src/main/java/io/netty5/handler/codec/base64/Base64.java
@@ -74,14 +74,30 @@ public final class Base64 {
         return encode(src, breakLines(dialect), dialect);
     }
 
+    public static Buffer encode(Buffer src, Base64Dialect dialect, boolean addPadding) {
+        return encode(src, breakLines(dialect), dialect, addPadding);
+    }
+
     public static Buffer encode(Buffer src, boolean breakLines) {
         return encode(src, breakLines, Base64Dialect.STANDARD);
+    }
+
+    public static Buffer encode(Buffer src, boolean breakLines, boolean addPadding) {
+        return encode(src, breakLines, Base64Dialect.STANDARD, addPadding);
     }
 
     public static Buffer encode(Buffer src, boolean breakLines, Base64Dialect dialect) {
         requireNonNull(src, "src");
 
         Buffer dest = encode(src, src.readerOffset(), src.readableBytes(), breakLines, dialect);
+        src.readerOffset(src.writerOffset());
+        return dest;
+    }
+
+    public static Buffer encode(Buffer src, boolean breakLines, Base64Dialect dialect, boolean addPadding) {
+        requireNonNull(src, "src");
+
+        Buffer dest = encode(src, src.readerOffset(), src.readableBytes(), breakLines, dialect, addPadding);
         src.readerOffset(src.writerOffset());
         return dest;
     }
@@ -94,19 +110,40 @@ public final class Base64 {
         return encode(src, off, len, breakLines(dialect), dialect);
     }
 
+    public static Buffer encode(Buffer src, int off, int len, Base64Dialect dialect, boolean addPadding) {
+        return encode(src, off, len, breakLines(dialect), dialect, true);
+    }
+
     public static Buffer encode(
             Buffer src, int off, int len, boolean breakLines) {
         return encode(src, off, len, breakLines, Base64Dialect.STANDARD);
     }
 
     public static Buffer encode(
+            Buffer src, int off, int len, boolean breakLines, boolean addPadding) {
+        return encode(src, off, len, breakLines, Base64Dialect.STANDARD, addPadding);
+    }
+
+    public static Buffer encode(
             Buffer src, int off, int len, boolean breakLines, Base64Dialect dialect) {
         return encode(src, off, len, breakLines, dialect,
-                      src.isDirect() ? offHeapAllocator() : onHeapAllocator());
+                      src.isDirect() ? offHeapAllocator() : onHeapAllocator(), true);
+    }
+
+    public static Buffer encode(
+            Buffer src, int off, int len, boolean breakLines, Base64Dialect dialect, boolean addPadding) {
+        return encode(src, off, len, breakLines, dialect,
+                src.isDirect() ? offHeapAllocator() : onHeapAllocator(), addPadding);
     }
 
     public static Buffer encode(
             Buffer src, int off, int len, boolean breakLines, Base64Dialect dialect, BufferAllocator allocator) {
+        return encode(src, off, len, breakLines, dialect, allocator, true);
+    }
+
+    public static Buffer encode(
+            Buffer src, int off, int len, boolean breakLines, Base64Dialect dialect, BufferAllocator allocator,
+            boolean addPadding) {
         requireNonNull(src, "src");
         requireNonNull(dialect, "dialect");
 
@@ -117,7 +154,7 @@ public final class Base64 {
         int len2 = len - 2;
         int lineLength = 0;
         for (; d < len2; d += 3, e += 4) {
-            encode3to4(src, d + off, 3, dest, e, alphabet);
+            encode3to4(src, d + off, 3, dest, e, alphabet, addPadding);
 
             lineLength += 4;
 
@@ -129,8 +166,7 @@ public final class Base64 {
         } // end for: each piece of array
 
         if (d < len) {
-            encode3to4(src, d + off, len - d, dest, e, alphabet);
-            e += 4;
+            e += encode3to4(src, d + off, len - d, dest, e, alphabet, addPadding);
         } // end if: some padding needed
 
         // Remove last byte if it's a newline
@@ -141,8 +177,9 @@ public final class Base64 {
         return dest.writerOffset(e);
     }
 
-    private static void encode3to4(
-            Buffer src, int srcOffset, int numSigBytes, Buffer dest, int destOffset, byte[] alphabet) {
+    private static int encode3to4(
+            Buffer src, int srcOffset, int numSigBytes, Buffer dest, int destOffset, byte[] alphabet,
+            boolean addPadding) {
         //           1         2         3
         // 01234567890123456789012345678901 Bit position
         // --------000000001111111122222222 Array position from threeBytes
@@ -166,7 +203,7 @@ public final class Base64 {
             inBuff = numSigBytes <= 0 ? 0 : toIntBE(src.getMedium(srcOffset));
             break;
         }
-        encode3to4BigEndian(inBuff, numSigBytes, dest, destOffset, alphabet);
+        return encode3to4BigEndian(inBuff, numSigBytes, dest, destOffset, alphabet, addPadding);
     }
 
     // package-private for testing
@@ -197,8 +234,8 @@ public final class Base64 {
         return (mediumValue & 0xff0000) | (mediumValue & 0xff00) | (mediumValue & 0xff);
     }
 
-    private static void encode3to4BigEndian(
-            int inBuff, int numSigBytes, Buffer dest, int destOffset, byte[] alphabet) {
+    private static int encode3to4BigEndian(
+            int inBuff, int numSigBytes, Buffer dest, int destOffset, byte[] alphabet, boolean addPadding) {
         // Packing bytes into an int to reduce bound and reference count checking.
         switch (numSigBytes) {
             case 3:
@@ -206,22 +243,35 @@ public final class Base64 {
                                         alphabet[inBuff >>> 12 & 0x3f] << 16 |
                                         alphabet[inBuff >>>  6 & 0x3f] << 8  |
                                         alphabet[inBuff        & 0x3f]);
-                break;
+                return 4;
             case 2:
-                dest.setInt(destOffset, alphabet[inBuff >>> 18       ] << 24 |
-                                        alphabet[inBuff >>> 12 & 0x3f] << 16 |
-                                        alphabet[inBuff >>> 6  & 0x3f] << 8  |
-                                        EQUALS_SIGN);
-                break;
+                if (addPadding) {
+                    dest.setInt(destOffset, alphabet[inBuff >>> 18       ] << 24 |
+                                            alphabet[inBuff >>> 12 & 0x3f] << 16 |
+                                            alphabet[inBuff >>> 6  & 0x3f] << 8  |
+                                            EQUALS_SIGN);
+                    return 4;
+                } else {
+                    dest.setMedium(destOffset, alphabet[inBuff >>> 18       ] << 16 |
+                                               alphabet[inBuff >>> 12 & 0x3f] << 8  |
+                                               alphabet[inBuff >>> 6 & 0x3f ]);
+                    return 3;
+                }
             case 1:
-                dest.setInt(destOffset, alphabet[inBuff >>> 18       ] << 24 |
-                                        alphabet[inBuff >>> 12 & 0x3f] << 16 |
-                                        EQUALS_SIGN << 8                     |
-                                        EQUALS_SIGN);
-                break;
+                if (addPadding) {
+                    dest.setInt(destOffset, alphabet[inBuff >>> 18       ] << 24 |
+                                            alphabet[inBuff >>> 12 & 0x3f] << 16 |
+                                            EQUALS_SIGN                    << 8  |
+                                            EQUALS_SIGN);
+                    return 4;
+                } else {
+                    dest.setShort(destOffset, (short) (alphabet[inBuff >>> 18       ] << 8 |
+                                                       alphabet[inBuff >>> 12 & 0x3f]));
+                    return 2;
+                }
             default:
                 // NOOP
-                break;
+                return 0;
         }
     }
 
@@ -275,6 +325,20 @@ public final class Base64 {
             try {
                 decodabet = decodabet(dialect);
                 src.openCursor(off, len).process(this);
+
+                // Padding missing, process additional bytes
+                if (b4Posn == 1) {
+                    throw new IllegalArgumentException(
+                            "Invalid Base64 input, single remaining character implies incorrect length or padding");
+                } else if (b4Posn == 2) {
+                    b4[2] = EQUALS_SIGN;
+                    b4[3] = EQUALS_SIGN;
+                    outBuffPosn += decode4to3(b4, dest, outBuffPosn, decodabet);
+                } else if (b4Posn == 3) {
+                    b4[3] = EQUALS_SIGN;
+                    outBuffPosn += decode4to3(b4, dest, outBuffPosn, decodabet);
+                }
+
                 return dest.writerOffset(outBuffPosn);
             } catch (Throwable cause) {
                 dest.close();


### PR DESCRIPTION
Add "unpadded" support to Base64 encoder/decoder

Motivation:

This patch aims to improve the flexibility of the base64 encoder to allow it to be used more broadly as a general purpose base64 encoder by supporting output with no padding. While RFC 4648 suggests that base64 is always padded, Base64 URL does not require padding in all circumstances, especially when length is known ahead of time. The implementation in Netty assumes the length is always the size of the buffer. In this case the decoder can produce correct output regardless of whether padding is added for either Base64 or Base64 URL encoding.

When the encoder receives an unpadded Base64 URL string today it is possible that one or two bytes are omitted from the resulting buffer. By detecting if these bytes were not processed we can infer the necessary padding and produce the full length decoded source text. Similarly on the encoding side we can omit the padding if the user elects to do so.

Modifications:

Decode:
The `ByteProcessor` on the decode loop processes 4 bytes at a time, calling `decode4to3` using a byte[] buffer of size 4. When the `ByteProcessor` completes and there is no padding, the final call to `decode4to3` will not have been made. We can infer based on the index into the 4 byte buffer how much padding is necessary and we can make the final call to `decode4to3` with appropriate padding added.

Encode:
If no padding is necessary, we can simply omit the padding bytes at the end of our processing rounds instead of appending them.

Result:

The base64 encoder will support encoding and decoding Base64 without padding. The decoder will handle both modes gracefully, and the encoder will by default add padding, as is suggested by the RFC, but will allow the user to elect not to in the event they want padding omitted.

Motivation:

Explain here the context, and why you're making that change.
What is the problem you're trying to solve.

Modification:

Describe the modifications you've done.

Result:

Fixes #<GitHub issue number>. 

If there is no issue then describe the changes introduced by this PR.
