### PR TITLE
fix docker related build failures

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -144,14 +144,19 @@ jobs:
           # Install dependencies
           install: |
             apt-get update -q -y
-            apt-get install -q -y openjdk-22-jdk autoconf automake libtool make tar maven git
+            apt-get install -q -y autoconf automake libtool make tar maven git gnupg ca-certificates curl
+
+            curl -s https://repos.azul.com/azul-repo.key | sudo gpg --dearmor -o /usr/share/keyrings/azul.gpg
+            echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" | sudo tee /etc/apt/sources.list.d/zulu.list
+            apt-get update -q -y
+            apt-get install -q -y zulu22-jdk
 
           # Compile native code and the modules it depend on and run NativeLoadingTest. This is enough to ensure
           # we can load the native module on aarch64
           #
           # Use tcnative.classifier that is empty as we don't support using the shared lib version on ubuntu.
           run: |
-            JAVA_HOME=/usr/lib/jvm/java-22-openjdk-arm64 ./mvnw -B -ntp -pl testsuite-native -am clean package -Pboringssl -DskipTests=true -Dcheckstyle.skip=true -DskipNativeTestsuite=false -Dtcnative.classifier=
+            JAVA_HOME=/usr/lib/jvm/zulu22 ./mvnw -B -ntp -pl testsuite-native -am clean package -Pboringssl -DskipTests=true -Dcheckstyle.skip=true -DskipNativeTestsuite=false -Dtcnative.classifier=
 
   build-pr:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -146,8 +146,8 @@ jobs:
             apt-get update -q -y
             apt-get install -q -y autoconf automake libtool make tar maven git gnupg ca-certificates curl
 
-            curl -s https://repos.azul.com/azul-repo.key | sudo gpg --dearmor -o /usr/share/keyrings/azul.gpg
-            echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" | sudo tee /etc/apt/sources.list.d/zulu.list
+            curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg
+            echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" | tee /etc/apt/sources.list.d/zulu.list
             apt-get update -q -y
             apt-get install -q -y zulu22-jdk
 

--- a/docker/docker-compose.ubi9.yaml
+++ b/docker/docker-compose.ubi9.yaml
@@ -6,7 +6,7 @@ services:
     image: netty:ubi9
     build:
       args:
-        java_version : "22.0.2-zulu"
+        java_version: "22.0.2-zulu"
       context: .
       dockerfile: Dockerfile.ubi9
 
@@ -16,13 +16,22 @@ services:
   build-leak:
     image: netty:ubi9
 
-  build-boringssl-snapshot:
+  deploy:
+    image: netty:ubi9
+
+  stage-snapshot:
+    image: netty:ubi9
+
+  stage-release:
     image: netty:ubi9
 
   build-unsafe-buffer:
     image: netty:ubi9
 
   build-leak-adaptive:
+    image: netty:ubi9
+
+  build-boringssl-snapshot:
     image: netty:ubi9
 
   shell:


### PR DESCRIPTION
Motivation:
I noticed two issues with docker related ci failures and tried to fix them:
1. The snapshot deploy action on main isn't working, as the command `stage-snapshot` tries to use the docker image `netty:default` which doesn't exist in the context.
2. The `Build PR / linux-aarch64-verify-native` steps fails due to ubuntu_rolling removing the `openjdk22-jdk` package.

Modification:
1. Add correct overrides to `docker/docker-compose.ubi9.yaml`, so that all commands use the previously build `netty:ubi9` docker image, rather than the `netty:default` image inherited from `docker/docker-compose.yaml`. However, I wasn't able to verify if the simple fix is enough to fix snapshot/release deploys.
2. Install java 22 from Azul APT repository rather than depending on the current openjdk image in ubuntu repos. Not sure if this is the best solution tho.

Result:
Snapshot deploys should be working again and [PR verification is working again](https://github.com/derklaro/netty/actions/runs/14692253056)
