### PR TITLE
Rename native lib so incubator version and new version can co-exists

### DIFF
--- a/transport-classes-io_uring/src/main/resources/META-INF/native-image/io.netty/netty-transport-classess-io_uring/resource-config.json
+++ b/transport-classes-io_uring/src/main/resources/META-INF/native-image/io.netty/netty-transport-classess-io_uring/resource-config.json
@@ -5,7 +5,7 @@
         "condition": {
           "typeReachable": "io.netty.channel.uring.Native"
         },
-        "pattern":".*libnetty_transport_native_io_uring_.*\\.so"
+        "pattern":".*libnetty_transport_native_io_uring42_.*\\.so"
       }
     ]},
   "bundles":[]

--- a/transport-native-io_uring/pom.xml
+++ b/transport-native-io_uring/pom.xml
@@ -41,7 +41,7 @@
     <skipTests>true</skipTests>
     <jniArch>${os.detected.arch}</jniArch>
     <jni.classifier>${os.detected.name}-${jniArch}</jni.classifier>
-    <jniLibName>netty_transport_native_io_uring_${jniArch}</jniLibName>
+    <jniLibName>netty_transport_native_io_uring42_${jniArch}</jniLibName>
     <nativeLibOnlyDir>${project.build.directory}/native-lib-only</nativeLibOnlyDir>
     <extraConfigureArg />
     <extraConfigureArg2 />
@@ -149,7 +149,7 @@
                 </goals>
                 <configuration>
                   <instructions>
-                    <Bundle-NativeCode>META-INF/native/libnetty_transport_native_io_uring_${os.detected.arch}.so; osname=Linux; processor=${os.detected.arch},*</Bundle-NativeCode>
+                    <Bundle-NativeCode>META-INF/native/libnetty_transport_native_io_uring42_${os.detected.arch}.so; osname=Linux; processor=${os.detected.arch},*</Bundle-NativeCode>
                     <Bundle-SymbolicName>${maven-symbolicname}.${jni.classifier}</Bundle-SymbolicName>
                     <Fragment-Host>io.netty.transport-classes-io_uring</Fragment-Host>
                   </instructions>

--- a/transport-native-io_uring/src/main/c/netty_io_uring_native.c
+++ b/transport-native-io_uring/src/main/c/netty_io_uring_native.c
@@ -64,7 +64,7 @@
 
 #define NATIVE_CLASSNAME "io/netty/channel/uring/Native"
 #define STATICALLY_CLASSNAME "io/netty/channel/uring/NativeStaticallyReferencedJniMethods"
-#define LIBRARYNAME "netty_transport_native_io_uring"
+#define LIBRARYNAME "netty_transport_native_io_uring42"
 
 static jclass longArrayClass = NULL;
 static char* staticPackagePrefix = NULL;


### PR DESCRIPTION
Motivation:

We should ensure the incubator version of iouring and the included version of iouring can co-exists for now as people might have both on the class-path for some period of time

Modifications:

Rename native lib so it does not clash with the incubator version

Result:

Be able to have the incubator version of iouring on the classpath