### PR TITLE
Fix installation of rust during docker creation

### DIFF
--- a/.devcontainer/ubuntu/Dockerfile
+++ b/.devcontainer/ubuntu/Dockerfile
@@ -26,5 +26,5 @@ RUN apt-get update && apt-get install -y \
     perl \
     golang
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 RUN . "$HOME/.cargo/env"


### PR DESCRIPTION
Motivation:

We need to supply -y while installing rust as otherwise it will fail

Modifications:

Use sh -s -- -y

Result:

Fix docker file