### PR TITLE
Revert "Try to give our docker images more disk storage (#15071)"

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -22,8 +22,6 @@ services:
       - ~/.m2:/root/.m2
       - ..:/code
     working_dir: /code
-    storage_opt:
-      size: '6g'
     security_opt:
       - seccomp:unconfined
 


### PR DESCRIPTION
Motivation:

The added storage option is not supported on the fs used by gh actions, causing an error to be printed and the job aborts: https://github.com/netty/netty/actions/runs/14710201216/job/41280392533

```
Error response from daemon: --storage-opt is supported only for overlay over xfs with 'pquota' mount option
```

Modifications:

Revert commit 592e05bc746959f0af98c2ecdb142119c257fb8b which added the option that is causing the failure. Same was done for 4.2 in #15074.

Result:

Action should not fail anymore due to the unsupported option.