### PR TITLE
IoUring: Disable support for RECVSEND_BUNDLE for now

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUring.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUring.java
@@ -95,6 +95,12 @@ public final class IoUring {
                         recvsendBundleSupported = (ringBuffer.features() & Native.IORING_FEAT_RECVSEND_BUNDLE) != 0;
                         // IORING_FEAT_RECVSEND_BUNDLE was added in the same release.
                         acceptSupportNoWait = recvsendBundleSupported;
+                        // Explicit disable recvsend bundles as there seems to be a bug which cause
+                        // and AssertionError which leads to the CI running out of memory.
+                        // We will enable this again once we found the bug and fixed it.
+                        //
+                        // TODO: Remove once fixed.
+                        recvsendBundleSupported = false;
                         acceptMultishotSupported = Native.isAcceptMultishotSupported(ringBuffer.fd());
                         recvMultishotSupported = Native.isRecvMultishotSupported();
                         pollAddMultishotSupported = Native.isPollAddMultiShotSupported(ringBuffer.fd());

--- a/transport-native-io_uring/pom.xml
+++ b/transport-native-io_uring/pom.xml
@@ -59,8 +59,8 @@
         </os>
       </activation>
       <properties>
-        <!-- Skip tests until we figured out why this kills the GHA runner -->
-        <skipTests>true</skipTests>
+        <!-- Enable testsuite -->
+        <skipTests>false</skipTests>
       </properties>
 
       <build>


### PR DESCRIPTION
Motivation:

We did disable the testsuite for io_uring in the past as it did cause the GH runner to die. After debugging more it seems to be caused by a bug in our RECVSEND_BUNDLE support. Because of this we should just disable the support for now (until we figured out what is the problem) and enable the testsuite again.

Modifications:

- Disable RECVSEND_BUNDLE support
- Enable testsuite for io_uring again

Result:

Testsuite for io_uring is used again and support for RECVSEND_BUNDLE is temporary disabled
