### PR TITLE
[refactor] decrease scope if few loggers

### DIFF
--- a/common/src/main/java/io/netty/util/internal/logging/JdkLogger.java
+++ b/common/src/main/java/io/netty/util/internal/logging/JdkLogger.java
@@ -51,7 +51,7 @@ class JdkLogger extends AbstractInternalLogger {
 
     private static final long serialVersionUID = -1767272577989225979L;
 
-    final transient Logger logger;
+    private final transient Logger logger;
 
     JdkLogger(Logger logger) {
         super(logger.getName());

--- a/common/src/main/java/io/netty/util/internal/logging/Log4JLogger.java
+++ b/common/src/main/java/io/netty/util/internal/logging/Log4JLogger.java
@@ -50,7 +50,7 @@ class Log4JLogger extends AbstractInternalLogger {
 
     private static final long serialVersionUID = 2851357342488183058L;
 
-    final transient Logger logger;
+    private final transient Logger logger;
 
     /**
      * Following the pattern discussed in pages 162 through 168 of "The complete

--- a/microbench/src/main/java/io/netty/microbench/util/AbstractSharedExecutorMicrobenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/util/AbstractSharedExecutorMicrobenchmark.java
@@ -64,7 +64,7 @@ public class AbstractSharedExecutorMicrobenchmark extends AbstractMicrobenchmark
      */
     public static final class DelegateHarnessExecutor extends AbstractEventExecutor {
         private static EventLoop executor;
-        private final InternalLogger logger = InternalLoggerFactory.getInstance(DelegateHarnessExecutor.class);
+        private static final InternalLogger logger = InternalLoggerFactory.getInstance(DelegateHarnessExecutor.class);
 
         public DelegateHarnessExecutor(int maxThreads, String prefix) {
             logger.debug("Using DelegateHarnessExecutor executor {}", this);


### PR DESCRIPTION
Motivation:

Try to fix few minor IDEA warnings in Netty codebase.

Modification:

Made few `logger` fields private.
Made one `logger` field static final.

Result:

Fixes a warning in IDEA code inspections.
