### PR TITLE
Fix buffer leak in TcpDnsTest (#15115)

### DIFF
--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/TcpDnsTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/TcpDnsTest.java
@@ -61,6 +61,9 @@ public class TcpDnsTest {
         assertTrue(decoder.writeInbound(encoded));
         final DnsQuery decoded = decoder.readInbound();
         assertThat(decoded, is(query));
+
+        ReferenceCountUtil.release(decoded);
+
         // Make sure the ByteBuf is released by TcpDnsQueryDecoder
         assertTrue(encoded.refCnt() == 0);
 


### PR DESCRIPTION
Motivation:

TcpDnsTest.testDecoderLeak() did not correct release a msg and so produced a leak.

Modifications:

Leak decoded message

Result:

No more leaks in test