### PR TITLE
[refactor] simplify expressions

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/DefaultByteBufHolderTest.java
+++ b/buffer/src/test/java/io/netty/buffer/DefaultByteBufHolderTest.java
@@ -17,8 +17,7 @@ package io.netty.buffer;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.Objects;
-
+import static io.netty.util.internal.ObjectUtil.hashSum;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -102,7 +101,7 @@ public class DefaultByteBufHolderTest {
 
         @Override
         public int hashCode() {
-            return Objects.hash(super.hashCode(), extraField);
+            return hashSum(super.hashCode(), extraField);
         }
     }
 }

--- a/buffer/src/test/java/io/netty/buffer/DefaultByteBufHolderTest.java
+++ b/buffer/src/test/java/io/netty/buffer/DefaultByteBufHolderTest.java
@@ -17,6 +17,8 @@ package io.netty.buffer;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Objects;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -100,9 +102,7 @@ public class DefaultByteBufHolderTest {
 
         @Override
         public int hashCode() {
-            int result = super.hashCode();
-            result = 31 * result + extraField;
-            return result;
+            return Objects.hash(super.hashCode(), extraField);
         }
     }
 }

--- a/codec-base/src/main/java/io/netty/handler/codec/DefaultHeaders.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/DefaultHeaders.java
@@ -988,8 +988,8 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
         for (K name : names()) {
             result = 31 * result + hashingStrategy.hashCode(name);
             List<V> values = getAll(name);
-            for (int i = 0; i < values.size(); ++i) {
-                result = 31 * result + valueHashingStrategy.hashCode(values.get(i));
+            for (V value : values) {
+                result = 31 * result + valueHashingStrategy.hashCode(value);
             }
         }
         return result;
@@ -1021,7 +1021,7 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
     }
 
     protected HeaderEntry<K, V> newHeaderEntry(int h, K name, V value, HeaderEntry<K, V> next) {
-        return new HeaderEntry<K, V>(h, name, value, next, head);
+        return new HeaderEntry<>(h, name, value, next, head);
     }
 
     protected ValueConverter<V> valueConverter() {

--- a/codec-base/src/main/java/io/netty/handler/codec/DefaultHeaders.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/DefaultHeaders.java
@@ -988,8 +988,8 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
         for (K name : names()) {
             result = 31 * result + hashingStrategy.hashCode(name);
             List<V> values = getAll(name);
-            for (V value : values) {
-                result = 31 * result + valueHashingStrategy.hashCode(value);
+            for (int i = 0; i < values.size(); ++i) {
+                result = 31 * result + valueHashingStrategy.hashCode(values.get(i));
             }
         }
         return result;

--- a/codec-base/src/test/java/io/netty/handler/codec/serialization/CompatibleObjectEncoderTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/serialization/CompatibleObjectEncoderTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
+import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -42,6 +43,7 @@ public class CompatibleObjectEncoderTest {
         channel.writeOutbound(original);
         Object o = channel.readOutbound();
         ByteBuf buf = (ByteBuf) o;
+
         try (ObjectInputStream ois = new ObjectInputStream(new ByteBufInputStream(buf))) {
             assertEquals(original, ois.readObject());
         } finally {
@@ -71,7 +73,7 @@ public class CompatibleObjectEncoderTest {
 
         @Override
         public int hashCode() {
-            return 31 * (31 + x) + y;
+            return Objects.hash(x, y);
         }
     }
 }

--- a/codec-base/src/test/java/io/netty/handler/codec/serialization/CompatibleObjectEncoderTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/serialization/CompatibleObjectEncoderTest.java
@@ -23,8 +23,8 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
-import java.util.Objects;
 
+import static io.netty.util.internal.ObjectUtil.hashSum;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
@@ -73,7 +73,7 @@ public class CompatibleObjectEncoderTest {
 
         @Override
         public int hashCode() {
-            return Objects.hash(x, y);
+            return hashSum(x, y);
         }
     }
 }

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/DefaultQuicStreamFrame.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/DefaultQuicStreamFrame.java
@@ -18,6 +18,8 @@ package io.netty.handler.codec.quic;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.DefaultByteBufHolder;
 
+import java.util.Objects;
+
 public final class DefaultQuicStreamFrame extends DefaultByteBufHolder implements QuicStreamFrame {
 
     private final boolean fin;
@@ -103,8 +105,6 @@ public final class DefaultQuicStreamFrame extends DefaultByteBufHolder implement
 
     @Override
     public int hashCode() {
-        int result = super.hashCode();
-        result = 31 * result + (fin ? 1 : 0);
-        return result;
+        return Objects.hash(super.hashCode(), fin);
     }
 }

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/DefaultQuicStreamFrame.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/DefaultQuicStreamFrame.java
@@ -18,8 +18,6 @@ package io.netty.handler.codec.quic;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.DefaultByteBufHolder;
 
-import java.util.Objects;
-
 public final class DefaultQuicStreamFrame extends DefaultByteBufHolder implements QuicStreamFrame {
 
     private final boolean fin;
@@ -105,6 +103,6 @@ public final class DefaultQuicStreamFrame extends DefaultByteBufHolder implement
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), fin);
+        return 31 * super.hashCode() + (fin ? 1 : 0);
     }
 }

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicConnectionAddress.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicConnectionAddress.java
@@ -22,7 +22,8 @@ import io.netty.util.internal.EmptyArrays;
 
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
-import java.util.Objects;
+
+import static io.netty.util.internal.ObjectUtil.hash;
 
 /**
  * A {@link QuicConnectionAddress} that can be used to connect too.
@@ -90,7 +91,7 @@ public final class QuicConnectionAddress extends SocketAddress {
         if (this == EPHEMERAL) {
             return System.identityHashCode(EPHEMERAL);
         }
-        return Objects.hash(connId);
+        return hash(connId);
     }
 
     @Override

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicPathEvent.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicPathEvent.java
@@ -77,9 +77,7 @@ public abstract class QuicPathEvent implements QuicEvent {
 
     @Override
     public int hashCode() {
-        int result = local != null ? local.hashCode() : 0;
-        result = 31 * result + (remote != null ? remote.hashCode() : 0);
-        return result;
+        return Objects.hash(local, remote);
     }
 
     public static final class New extends QuicPathEvent {
@@ -258,11 +256,7 @@ public abstract class QuicPathEvent implements QuicEvent {
 
         @Override
         public int hashCode() {
-            int result = super.hashCode();
-            result = 31 * result + (int) (seq ^ (seq >>> 32));
-            result = 31 * result + (oldLocal != null ? oldLocal.hashCode() : 0);
-            result = 31 * result + (oldRemote != null ? oldRemote.hashCode() : 0);
-            return result;
+            return Objects.hash(super.hashCode(), seq, oldLocal, oldRemote);
         }
 
         @Override

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicPathEvent.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicPathEvent.java
@@ -18,6 +18,8 @@ package io.netty.handler.codec.quic;
 import java.net.InetSocketAddress;
 import java.util.Objects;
 
+import static io.netty.util.internal.ObjectUtil.hash;
+import static io.netty.util.internal.ObjectUtil.hashSum;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -77,7 +79,7 @@ public abstract class QuicPathEvent implements QuicEvent {
 
     @Override
     public int hashCode() {
-        return Objects.hash(local, remote);
+        return hash(local, remote);
     }
 
     public static final class New extends QuicPathEvent {
@@ -256,7 +258,7 @@ public abstract class QuicPathEvent implements QuicEvent {
 
         @Override
         public int hashCode() {
-            return Objects.hash(super.hashCode(), seq, oldLocal, oldRemote);
+            return hashSum(super.hashCode(), Long.hashCode(seq), hash(oldLocal), hash(oldRemote));
         }
 
         @Override

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicStreamAddress.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicStreamAddress.java
@@ -16,7 +16,6 @@
 package io.netty.handler.codec.quic;
 
 import java.net.SocketAddress;
-import java.util.Objects;
 
 /**
  * A {@link SocketAddress} for QUIC stream.
@@ -49,7 +48,7 @@ public final class QuicStreamAddress extends SocketAddress {
 
     @Override
     public int hashCode() {
-        return Objects.hash(streamId);
+        return Long.hashCode(streamId);
     }
 
     @Override

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicStreamPriority.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicStreamPriority.java
@@ -17,7 +17,7 @@ package io.netty.handler.codec.quic;
 
 import io.netty.util.internal.ObjectUtil;
 
-import java.util.Objects;
+import static io.netty.util.internal.ObjectUtil.hash;
 
 /**
  * The priority of a {@link QuicStreamChannel}.
@@ -70,7 +70,7 @@ public final class QuicStreamPriority {
 
     @Override
     public int hashCode() {
-        return Objects.hash(urgency, incremental);
+        return ObjectUtil.hashSum(urgency, hash(incremental));
     }
 
     @Override

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicTransportError.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicTransportError.java
@@ -17,7 +17,6 @@ package io.netty.handler.codec.quic;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * <a href="https://www.rfc-editor.org/rfc/rfc9000.html#name-transport-error-codes">
@@ -224,7 +223,7 @@ public final class QuicTransportError {
 
     @Override
     public int hashCode() {
-        return Objects.hash(code);
+        return Long.hashCode(code);
     }
 
     @Override

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/SslSessionTicketKey.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/SslSessionTicketKey.java
@@ -17,6 +17,7 @@
 package io.netty.handler.codec.quic;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 /**
  * Session Ticket Key
@@ -112,10 +113,7 @@ public final class SslSessionTicketKey {
 
     @Override
     public int hashCode() {
-        int result = Arrays.hashCode(name);
-        result = 31 * result + Arrays.hashCode(hmacKey);
-        result = 31 * result + Arrays.hashCode(aesKey);
-        return result;
+        return Objects.hash(Arrays.hashCode(name), Arrays.hashCode(hmacKey), Arrays.hashCode(aesKey));
     }
 
     @Override

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/SslSessionTicketKey.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/SslSessionTicketKey.java
@@ -17,7 +17,8 @@
 package io.netty.handler.codec.quic;
 
 import java.util.Arrays;
-import java.util.Objects;
+
+import static io.netty.util.internal.ObjectUtil.hashSum;
 
 /**
  * Session Ticket Key
@@ -113,7 +114,7 @@ public final class SslSessionTicketKey {
 
     @Override
     public int hashCode() {
-        return Objects.hash(Arrays.hashCode(name), Arrays.hashCode(hmacKey), Arrays.hashCode(aesKey));
+        return hashSum(Arrays.hashCode(name), Arrays.hashCode(hmacKey), Arrays.hashCode(aesKey));
     }
 
     @Override

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/AbstractDnsMessage.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/AbstractDnsMessage.java
@@ -25,6 +25,7 @@ import io.netty.util.internal.StringUtil;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
@@ -399,20 +400,12 @@ public abstract class AbstractDnsMessage extends AbstractReferenceCounted implem
             return false;
         }
 
-        if (this instanceof DnsQuery) {
-            if (!(that instanceof DnsQuery)) {
-                return false;
-            }
-        } else if (that instanceof DnsQuery) {
-            return false;
-        }
-
-        return true;
+      return (this instanceof DnsQuery) == (that instanceof DnsQuery);
     }
 
     @Override
     public int hashCode() {
-        return id() * 31 + (this instanceof DnsQuery? 0 : 1);
+        return Objects.hash(id(), this instanceof DnsQuery);
     }
 
     private Object sectionAt(int section) {
@@ -467,6 +460,6 @@ public abstract class AbstractDnsMessage extends AbstractReferenceCounted implem
     }
 
     private static ArrayList<DnsRecord> newRecordList() {
-        return new ArrayList<DnsRecord>(2);
+        return new ArrayList<>(2);
     }
 }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/AbstractDnsMessage.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/AbstractDnsMessage.java
@@ -25,9 +25,9 @@ import io.netty.util.internal.StringUtil;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import static io.netty.util.internal.ObjectUtil.hashSum;
 
 /**
  * A skeletal implementation of {@link DnsMessage}.
@@ -405,7 +405,7 @@ public abstract class AbstractDnsMessage extends AbstractReferenceCounted implem
 
     @Override
     public int hashCode() {
-        return Objects.hash(id(), this instanceof DnsQuery);
+        return hashSum(id(), this instanceof DnsQuery? 0 : 1);
     }
 
     private Object sectionAt(int section) {

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsQuery.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsQuery.java
@@ -19,6 +19,7 @@ import io.netty.channel.AddressedEnvelope;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.Objects;
 
 /**
  * A {@link DnsQuery} implementation for UDP/IP.
@@ -156,35 +157,13 @@ public class DatagramDnsQuery extends DefaultDnsQuery
         }
 
         @SuppressWarnings("unchecked")
-        final AddressedEnvelope<?, SocketAddress> that = (AddressedEnvelope<?, SocketAddress>) obj;
-        if (sender() == null) {
-            if (that.sender() != null) {
-                return false;
-            }
-        } else if (!sender().equals(that.sender())) {
-            return false;
-        }
-
-        if (recipient() == null) {
-            if (that.recipient() != null) {
-                return false;
-            }
-        } else if (!recipient().equals(that.recipient())) {
-            return false;
-        }
-
-        return true;
+        AddressedEnvelope<?, SocketAddress> that = (AddressedEnvelope<?, SocketAddress>) obj;
+        return Objects.equals(sender(), that.sender()) &&
+          Objects.equals(recipient(), that.recipient());
     }
 
     @Override
     public int hashCode() {
-        int hashCode = super.hashCode();
-        if (sender() != null) {
-            hashCode = hashCode * 31 + sender().hashCode();
-        }
-        if (recipient() != null) {
-            hashCode = hashCode * 31 + recipient().hashCode();
-        }
-        return hashCode;
+        return Objects.hash(super.hashCode(), sender(), recipient());
     }
 }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsQuery.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsQuery.java
@@ -21,6 +21,9 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Objects;
 
+import static io.netty.util.internal.ObjectUtil.hash;
+import static io.netty.util.internal.ObjectUtil.hashSum;
+
 /**
  * A {@link DnsQuery} implementation for UDP/IP.
  */
@@ -164,6 +167,6 @@ public class DatagramDnsQuery extends DefaultDnsQuery
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), sender(), recipient());
+        return hashSum(super.hashCode(), hash(sender()), hash(recipient()));
     }
 }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsResponse.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsResponse.java
@@ -19,7 +19,9 @@ import io.netty.channel.AddressedEnvelope;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
-import java.util.Objects;
+
+import static io.netty.util.internal.ObjectUtil.hash;
+import static io.netty.util.internal.ObjectUtil.hashSum;
 
 /**
  * A {@link DnsResponse} implementation for UDP/IP.
@@ -209,6 +211,6 @@ public class DatagramDnsResponse extends DefaultDnsResponse
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), sender(), recipient());
+        return hashSum(super.hashCode(), hash(sender()), hash(recipient()));
     }
 }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsResponse.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsResponse.java
@@ -19,6 +19,7 @@ import io.netty.channel.AddressedEnvelope;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.Objects;
 
 /**
  * A {@link DnsResponse} implementation for UDP/IP.
@@ -208,13 +209,6 @@ public class DatagramDnsResponse extends DefaultDnsResponse
 
     @Override
     public int hashCode() {
-        int hashCode = super.hashCode();
-        if (sender() != null) {
-            hashCode = hashCode * 31 + sender().hashCode();
-        }
-        if (recipient() != null) {
-            hashCode = hashCode * 31 + recipient().hashCode();
-        }
-        return hashCode;
+        return Objects.hash(super.hashCode(), sender(), recipient());
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpMessage.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpMessage.java
@@ -15,13 +15,14 @@
  */
 package io.netty.handler.codec.http;
 
+import java.util.Objects;
+
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
  * The default {@link HttpMessage} implementation.
  */
 public abstract class DefaultHttpMessage extends DefaultHttpObject implements HttpMessage {
-    private static final int HASH_CODE_PRIME = 31;
     private HttpVersion version;
     private final HttpHeaders headers;
 
@@ -79,11 +80,7 @@ public abstract class DefaultHttpMessage extends DefaultHttpObject implements Ht
 
     @Override
     public int hashCode() {
-        int result = 1;
-        result = HASH_CODE_PRIME * result + headers.hashCode();
-        result = HASH_CODE_PRIME * result + version.hashCode();
-        result = HASH_CODE_PRIME * result + super.hashCode();
-        return result;
+        return Objects.hash(headers, version, super.hashCode());
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpMessage.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpMessage.java
@@ -15,9 +15,9 @@
  */
 package io.netty.handler.codec.http;
 
-import java.util.Objects;
-
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import static io.netty.util.internal.ObjectUtil.hash;
+import static io.netty.util.internal.ObjectUtil.hashSum;
 
 /**
  * The default {@link HttpMessage} implementation.
@@ -80,7 +80,7 @@ public abstract class DefaultHttpMessage extends DefaultHttpObject implements Ht
 
     @Override
     public int hashCode() {
-        return Objects.hash(headers, version, super.hashCode());
+        return hashSum(hash(headers), hash(version), super.hashCode());
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpObject.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpObject.java
@@ -18,9 +18,10 @@ package io.netty.handler.codec.http;
 import io.netty.handler.codec.DecoderResult;
 import io.netty.util.internal.ObjectUtil;
 
+import java.util.Objects;
+
 public class DefaultHttpObject implements HttpObject {
 
-    private static final int HASH_CODE_PRIME = 31;
     private DecoderResult decoderResult = DecoderResult.SUCCESS;
 
     protected DefaultHttpObject() {
@@ -45,9 +46,7 @@ public class DefaultHttpObject implements HttpObject {
 
     @Override
     public int hashCode() {
-        int result = 1;
-        result = HASH_CODE_PRIME * result + decoderResult.hashCode();
-        return result;
+        return Objects.hash(decoderResult);
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpObject.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpObject.java
@@ -18,7 +18,7 @@ package io.netty.handler.codec.http;
 import io.netty.handler.codec.DecoderResult;
 import io.netty.util.internal.ObjectUtil;
 
-import java.util.Objects;
+import static io.netty.util.internal.ObjectUtil.hash;
 
 public class DefaultHttpObject implements HttpObject {
 
@@ -46,7 +46,7 @@ public class DefaultHttpObject implements HttpObject {
 
     @Override
     public int hashCode() {
-        return Objects.hash(decoderResult);
+        return hash(decoderResult);
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpRequest.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpRequest.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.http;
 
+import java.util.Objects;
+
 import static io.netty.handler.codec.http.DefaultHttpHeadersFactory.headersFactory;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
@@ -22,7 +24,6 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
  * The default {@link HttpRequest} implementation.
  */
 public class DefaultHttpRequest extends DefaultHttpMessage implements HttpRequest {
-    private static final int HASH_CODE_PRIME = 31;
     private HttpMethod method;
     private String uri;
 
@@ -122,11 +123,7 @@ public class DefaultHttpRequest extends DefaultHttpMessage implements HttpReques
 
     @Override
     public int hashCode() {
-        int result = 1;
-        result = HASH_CODE_PRIME * result + method.hashCode();
-        result = HASH_CODE_PRIME * result + uri.hashCode();
-        result = HASH_CODE_PRIME * result + super.hashCode();
-        return result;
+        return Objects.hash(method, uri, super.hashCode());
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpRequest.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpRequest.java
@@ -15,10 +15,10 @@
  */
 package io.netty.handler.codec.http;
 
-import java.util.Objects;
-
 import static io.netty.handler.codec.http.DefaultHttpHeadersFactory.headersFactory;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import static io.netty.util.internal.ObjectUtil.hash;
+import static io.netty.util.internal.ObjectUtil.hashSum;
 
 /**
  * The default {@link HttpRequest} implementation.
@@ -123,7 +123,7 @@ public class DefaultHttpRequest extends DefaultHttpMessage implements HttpReques
 
     @Override
     public int hashCode() {
-        return Objects.hash(method, uri, super.hashCode());
+        return hashSum(hash(method), hash(uri), super.hashCode());
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpResponse.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpResponse.java
@@ -17,6 +17,8 @@ package io.netty.handler.codec.http;
 
 import io.netty.util.internal.ObjectUtil;
 
+import java.util.Objects;
+
 import static io.netty.handler.codec.http.DefaultHttpHeadersFactory.headersFactory;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
@@ -126,10 +128,7 @@ public class DefaultHttpResponse extends DefaultHttpMessage implements HttpRespo
 
     @Override
     public int hashCode() {
-        int result = 1;
-        result = 31 * result + status.hashCode();
-        result = 31 * result + super.hashCode();
-        return result;
+        return Objects.hash(status, super.hashCode());
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpResponse.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpResponse.java
@@ -17,10 +17,10 @@ package io.netty.handler.codec.http;
 
 import io.netty.util.internal.ObjectUtil;
 
-import java.util.Objects;
-
 import static io.netty.handler.codec.http.DefaultHttpHeadersFactory.headersFactory;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import static io.netty.util.internal.ObjectUtil.hash;
+import static io.netty.util.internal.ObjectUtil.hashSum;
 
 /**
  * The default {@link HttpResponse} implementation.
@@ -128,7 +128,7 @@ public class DefaultHttpResponse extends DefaultHttpMessage implements HttpRespo
 
     @Override
     public int hashCode() {
-        return Objects.hash(status, super.hashCode());
+        return hashSum(hash(status), super.hashCode());
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaders.java
@@ -1613,9 +1613,7 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
         int end;
         if (ignoreCase) {
             if ((end = AsciiString.indexOf(rawNext, ',', begin)) == -1) {
-                if (contentEqualsIgnoreCase(trim(rawNext), expected)) {
-                    return true;
-                }
+              return contentEqualsIgnoreCase(trim(rawNext), expected);
             } else {
                 do {
                     if (contentEqualsIgnoreCase(trim(rawNext.subSequence(begin, end)), expected)) {
@@ -1625,16 +1623,12 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
                 } while ((end = AsciiString.indexOf(rawNext, ',', begin)) != -1);
 
                 if (begin < rawNext.length()) {
-                    if (contentEqualsIgnoreCase(trim(rawNext.subSequence(begin, rawNext.length())), expected)) {
-                        return true;
-                    }
+                  return contentEqualsIgnoreCase(trim(rawNext.subSequence(begin, rawNext.length())), expected);
                 }
             }
         } else {
             if ((end = AsciiString.indexOf(rawNext, ',', begin)) == -1) {
-                if (contentEquals(trim(rawNext), expected)) {
-                    return true;
-                }
+              return contentEquals(trim(rawNext), expected);
             } else {
                 do {
                     if (contentEquals(trim(rawNext.subSequence(begin, end)), expected)) {
@@ -1644,9 +1638,7 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
                 } while ((end = AsciiString.indexOf(rawNext, ',', begin)) != -1);
 
                 if (begin < rawNext.length()) {
-                    if (contentEquals(trim(rawNext.subSequence(begin, rawNext.length())), expected)) {
-                        return true;
-                    }
+                  return contentEquals(trim(rawNext.subSequence(begin, rawNext.length())), expected);
                 }
             }
         }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpScheme.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpScheme.java
@@ -17,6 +17,8 @@ package io.netty.handler.codec.http;
 
 import io.netty.util.AsciiString;
 
+import java.util.Objects;
+
 /**
  * Defines the common schemes used for the HTTP protocol as defined by
  * <a href="https://tools.ietf.org/html/rfc7230">rfc7230</a>.
@@ -60,7 +62,7 @@ public final class HttpScheme {
 
     @Override
     public int hashCode() {
-        return port * 31 + name.hashCode();
+        return Objects.hash(port, name);
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpScheme.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpScheme.java
@@ -17,7 +17,8 @@ package io.netty.handler.codec.http;
 
 import io.netty.util.AsciiString;
 
-import java.util.Objects;
+import static io.netty.util.internal.ObjectUtil.hash;
+import static io.netty.util.internal.ObjectUtil.hashSum;
 
 /**
  * Defines the common schemes used for the HTTP protocol as defined by
@@ -62,7 +63,7 @@ public final class HttpScheme {
 
     @Override
     public int hashCode() {
-        return Objects.hash(port, name);
+        return hashSum(port, hash(name));
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpVersion.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpVersion.java
@@ -19,9 +19,13 @@ import io.netty.buffer.ByteBuf;
 import io.netty.util.CharsetUtil;
 import io.netty.util.internal.ObjectUtil;
 
-import java.util.Objects;
 import static io.netty.util.internal.ObjectUtil.checkNonEmptyAfterTrim;
 import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
+
+import static io.netty.util.internal.ObjectUtil.checkNonEmptyAfterTrim;
+import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
+import static io.netty.util.internal.ObjectUtil.hash;
+import static io.netty.util.internal.ObjectUtil.hashSum;
 
 /**
  * The version of HTTP or its derived protocols, such as
@@ -269,7 +273,7 @@ public class HttpVersion implements Comparable<HttpVersion> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(protocolName(), majorVersion(), minorVersion());
+        return hashSum(hash(protocolName()), majorVersion(), minorVersion());
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpVersion.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpVersion.java
@@ -19,6 +19,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.util.CharsetUtil;
 import io.netty.util.internal.ObjectUtil;
 
+import java.util.Objects;
 import static io.netty.util.internal.ObjectUtil.checkNonEmptyAfterTrim;
 import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 
@@ -268,8 +269,7 @@ public class HttpVersion implements Comparable<HttpVersion> {
 
     @Override
     public int hashCode() {
-        return (protocolName().hashCode() * 31 + majorVersion()) * 31 +
-               minorVersion();
+        return Objects.hash(protocolName(), majorVersion(), minorVersion());
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/DefaultCookie.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/DefaultCookie.java
@@ -22,6 +22,8 @@ import static io.netty.handler.codec.http.cookie.CookieUtil.validateAttributeVal
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import static io.netty.util.internal.ObjectUtil.checkNonEmptyAfterTrim;
 
+import java.util.Objects;
+
 /**
  * The default {@link Cookie} implementation.
  */
@@ -179,25 +181,11 @@ public class DefaultCookie implements Cookie {
             return false;
         }
 
-        if (path() == null) {
-            if (that.path() != null) {
-                return false;
-            }
-        } else if (that.path() == null) {
-            return false;
-        } else if (!path().equals(that.path())) {
+        if (!Objects.equals(path(), that.path())) {
             return false;
         }
 
-        if (domain() == null) {
-            if (that.domain() != null) {
-                return false;
-            }
-        } else {
-            return domain().equalsIgnoreCase(that.domain());
-        }
-
-        return true;
+        return domain() == null ? that.domain() == null : domain().equalsIgnoreCase(that.domain());
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketScheme.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketScheme.java
@@ -17,6 +17,8 @@ package io.netty.handler.codec.http.websocketx;
 
 import io.netty.util.AsciiString;
 
+import java.util.Objects;
+
 /**
  * Defines the common schemes used for the WebSocket protocol as defined by
  * <a href="https://tools.ietf.org/html/rfc6455">rfc6455</a>.
@@ -59,7 +61,7 @@ public final class WebSocketScheme {
 
     @Override
     public int hashCode() {
-        return port * 31 + name.hashCode();
+        return Objects.hash(port, name);
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketScheme.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketScheme.java
@@ -16,8 +16,10 @@
 package io.netty.handler.codec.http.websocketx;
 
 import io.netty.util.AsciiString;
+import io.netty.util.internal.ObjectUtil;
 
-import java.util.Objects;
+import static io.netty.util.internal.ObjectUtil.hash;
+import static io.netty.util.internal.ObjectUtil.hashSum;
 
 /**
  * Defines the common schemes used for the WebSocket protocol as defined by
@@ -61,7 +63,7 @@ public final class WebSocketScheme {
 
     @Override
     public int hashCode() {
-        return Objects.hash(port, name);
+        return hashSum(port, hash(name));
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdyUnknownFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdyUnknownFrame.java
@@ -19,7 +19,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.DefaultByteBufHolder;
 import io.netty.util.internal.StringUtil;
 
-import java.util.Objects;
+import static io.netty.util.internal.ObjectUtil.hashSum;
 
 public final class DefaultSpdyUnknownFrame extends DefaultByteBufHolder implements SpdyUnknownFrame {
     private final int frameType;
@@ -98,7 +98,7 @@ public final class DefaultSpdyUnknownFrame extends DefaultByteBufHolder implemen
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), frameType, flags);
+        return hashSum(super.hashCode(), frameType, Byte.hashCode(flags));
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdyUnknownFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdyUnknownFrame.java
@@ -19,6 +19,8 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.DefaultByteBufHolder;
 import io.netty.util.internal.StringUtil;
 
+import java.util.Objects;
+
 public final class DefaultSpdyUnknownFrame extends DefaultByteBufHolder implements SpdyUnknownFrame {
     private final int frameType;
     private final byte flags;
@@ -96,10 +98,7 @@ public final class DefaultSpdyUnknownFrame extends DefaultByteBufHolder implemen
 
     @Override
     public int hashCode() {
-        int result = super.hashCode();
-        result = 31 * result + frameType;
-        result = 31 * result + flags;
-        return result;
+        return Objects.hash(super.hashCode(), frameType, flags);
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpEncoder.java
@@ -215,8 +215,7 @@ public class SpdyHttpEncoder extends MessageToMessageEncoder<HttpObject> {
         }
     }
 
-    @SuppressWarnings("deprecation")
-    private SpdySynStreamFrame createSynStreamFrame(HttpRequest httpRequest) throws Exception {
+    private SpdySynStreamFrame createSynStreamFrame(HttpRequest httpRequest) {
         // Get the Stream-ID, Associated-To-Stream-ID, Priority, and scheme from the headers
         final HttpHeaders httpHeaders = httpRequest.headers();
         int streamId = httpHeaders.getInt(SpdyHttpHeaders.Names.STREAM_ID);
@@ -273,8 +272,7 @@ public class SpdyHttpEncoder extends MessageToMessageEncoder<HttpObject> {
         return spdySynStreamFrame;
     }
 
-    @SuppressWarnings("deprecation")
-    private SpdyHeadersFrame createHeadersFrame(HttpResponse httpResponse) throws Exception {
+    private SpdyHeadersFrame createHeadersFrame(HttpResponse httpResponse) {
         // Get the Stream-ID from the headers
         final HttpHeaders httpHeaders = httpResponse.headers();
         int streamId = httpHeaders.getInt(SpdyHttpHeaders.Names.STREAM_ID);
@@ -322,9 +320,7 @@ public class SpdyHttpEncoder extends MessageToMessageEncoder<HttpObject> {
     private static boolean isLast(HttpMessage httpMessage) {
         if (httpMessage instanceof FullHttpMessage) {
             FullHttpMessage fullMessage = (FullHttpMessage) httpMessage;
-            if (fullMessage.trailingHeaders().isEmpty() && !fullMessage.content().isReadable()) {
-                return true;
-            }
+            return fullMessage.trailingHeaders().isEmpty() && !fullMessage.content().isReadable();
         }
 
         return false;

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpObjectAggregatorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpObjectAggregatorTest.java
@@ -269,13 +269,7 @@ public class HttpObjectAggregatorTest {
         }
         // The connection should only be kept open if Expect: 100-continue is set,
         // or if keep-alive is on.
-        if (HttpUtil.is100ContinueExpected(message)) {
-            return false;
-        }
-        if (HttpUtil.isKeepAlive(message)) {
-            return false;
-        }
-        return true;
+        return !HttpUtil.is100ContinueExpected(message) && !HttpUtil.isKeepAlive(message);
     }
 
     @Test
@@ -634,9 +628,7 @@ public class HttpObjectAggregatorTest {
                     HttpRequest request = (HttpRequest) msg;
                     HttpMethod method = request.method();
 
-                    if (method.equals(HttpMethod.POST)) {
-                        return true;
-                    }
+                    return method.equals(HttpMethod.POST);
                 }
 
                 return false;
@@ -694,9 +686,7 @@ public class HttpObjectAggregatorTest {
                     HttpHeaders headers = response.headers();
 
                     String contentType = headers.get(HttpHeaderNames.CONTENT_TYPE);
-                    if (AsciiString.contentEqualsIgnoreCase(contentType, HttpHeaderValues.TEXT_PLAIN)) {
-                        return true;
-                    }
+                    return AsciiString.contentEqualsIgnoreCase(contentType, HttpHeaderValues.TEXT_PLAIN);
                 }
 
                 return false;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
@@ -63,7 +63,7 @@ import static java.lang.Integer.MAX_VALUE;
 public class DefaultHttp2Connection implements Http2Connection {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(DefaultHttp2Connection.class);
     // Fields accessed by inner classes
-    final IntObjectMap<Http2Stream> streamMap = new IntObjectHashMap<Http2Stream>();
+    final IntObjectMap<Http2Stream> streamMap = new IntObjectHashMap<>();
     final PropertyKeyRegistry propertyKeyRegistry = new PropertyKeyRegistry();
     final ConnectionStream connectionStream = new ConnectionStream();
     final DefaultEndpoint<Http2LocalFlowController> localEndpoint;
@@ -77,13 +77,13 @@ public class DefaultHttp2Connection implements Http2Connection {
      * (local/remote flow controller and {@link StreamByteDistributor}) and we leave room for 1 extra.
      * We could be more aggressive but the ArrayList resize will double the size if we are too small.
      */
-    final List<Listener> listeners = new ArrayList<Listener>(4);
+    final List<Listener> listeners = new ArrayList<>(4);
     final ActiveStreams activeStreams;
     Promise<Void> closePromise;
 
     /**
      * Creates a new connection with the given settings.
-     * @param server whether or not this end-point is the server-side of the HTTP/2 connection.
+     * @param server whether this end-point is the server-side of the HTTP/2 connection.
      */
     public DefaultHttp2Connection(boolean server) {
         this(server, DEFAULT_MAX_RESERVED_STREAMS);
@@ -91,7 +91,7 @@ public class DefaultHttp2Connection implements Http2Connection {
 
     /**
      * Creates a new connection with the given settings.
-     * @param server whether or not this end-point is the server-side of the HTTP/2 connection.
+     * @param server whether this end-point is the server-side of the HTTP/2 connection.
      * @param maxReservedStreams The maximum amount of streams which can exist in the reserved state for each endpoint.
      */
     public DefaultHttp2Connection(boolean server, int maxReservedStreams) {
@@ -101,8 +101,8 @@ public class DefaultHttp2Connection implements Http2Connection {
         // in response to any locally enforced limits being exceeded [2].
         // [1] https://tools.ietf.org/html/rfc7540#section-5.1.2
         // [2] https://tools.ietf.org/html/rfc7540#section-8.2.2
-        localEndpoint = new DefaultEndpoint<Http2LocalFlowController>(server, server ? MAX_VALUE : maxReservedStreams);
-        remoteEndpoint = new DefaultEndpoint<Http2RemoteFlowController>(!server, maxReservedStreams);
+        localEndpoint = new DefaultEndpoint<>(server, server ? MAX_VALUE : maxReservedStreams);
+        remoteEndpoint = new DefaultEndpoint<>(!server, maxReservedStreams);
 
         // Add the connection stream to the map.
         streamMap.put(connectionStream.id(), connectionStream);
@@ -230,9 +230,9 @@ public class DefaultHttp2Connection implements Http2Connection {
         }
 
         localEndpoint.lastStreamKnownByPeer(lastKnownStream);
-        for (int i = 0; i < listeners.size(); ++i) {
+        for (Listener listener : listeners) {
             try {
-                listeners.get(i).onGoAwayReceived(lastKnownStream, errorCode, debugData);
+                listener.onGoAwayReceived(lastKnownStream, errorCode, debugData);
             } catch (Throwable cause) {
                 logger.error("Caught Throwable from listener onGoAwayReceived.", cause);
             }
@@ -262,9 +262,9 @@ public class DefaultHttp2Connection implements Http2Connection {
         }
 
         remoteEndpoint.lastStreamKnownByPeer(lastKnownStream);
-        for (int i = 0; i < listeners.size(); ++i) {
+        for (Listener listener : listeners) {
             try {
-                listeners.get(i).onGoAwaySent(lastKnownStream, errorCode, debugData);
+                listener.onGoAwaySent(lastKnownStream, errorCode, debugData);
             } catch (Throwable cause) {
                 logger.error("Caught Throwable from listener onGoAwaySent.", cause);
             }
@@ -276,14 +276,11 @@ public class DefaultHttp2Connection implements Http2Connection {
 
     private void closeStreamsGreaterThanLastKnownStreamId(final int lastKnownStream,
                                                           final DefaultEndpoint<?> endpoint) throws Http2Exception {
-        forEachActiveStream(new Http2StreamVisitor() {
-            @Override
-            public boolean visit(Http2Stream stream) {
-                if (stream.id() > lastKnownStream && endpoint.isValidStreamId(stream.id())) {
-                    stream.close();
-                }
-                return true;
+        forEachActiveStream(stream -> {
+            if (stream.id() > lastKnownStream && endpoint.isValidStreamId(stream.id())) {
+                stream.close();
             }
+            return true;
         });
     }
 
@@ -310,9 +307,9 @@ public class DefaultHttp2Connection implements Http2Connection {
         }
 
         if (removed) {
-            for (int i = 0; i < listeners.size(); i++) {
+            for (Listener listener : listeners) {
                 try {
-                    listeners.get(i).onStreamRemoved(stream);
+                    listener.onStreamRemoved(stream);
                 } catch (Throwable cause) {
                     logger.error("Caught Throwable from listener onStreamRemoved.", cause);
                 }
@@ -340,9 +337,9 @@ public class DefaultHttp2Connection implements Http2Connection {
     }
 
     void notifyHalfClosed(Http2Stream stream) {
-        for (int i = 0; i < listeners.size(); i++) {
+        for (Listener listener : listeners) {
             try {
-                listeners.get(i).onStreamHalfClosed(stream);
+                listener.onStreamHalfClosed(stream);
             } catch (Throwable cause) {
                 logger.error("Caught Throwable from listener onStreamHalfClosed.", cause);
             }
@@ -350,9 +347,9 @@ public class DefaultHttp2Connection implements Http2Connection {
     }
 
     void notifyClosed(Http2Stream stream) {
-        for (int i = 0; i < listeners.size(); i++) {
+        for (Listener listener : listeners) {
             try {
-                listeners.get(i).onStreamClosed(stream);
+                listener.onStreamClosed(stream);
             } catch (Throwable cause) {
                 logger.error("Caught Throwable from listener onStreamClosed.", cause);
             }
@@ -608,10 +605,7 @@ public class DefaultHttp2Connection implements Http2Connection {
         @Override
         public int hashCode() {
             long value = identity;
-            if (value == 0) {
-                return System.identityHashCode(this);
-            }
-            return (int) (value ^ (value >>> 32));
+            return value == 0 ? System.identityHashCode(this) : Long.hashCode(value);
         }
 
         @Override
@@ -832,9 +826,9 @@ public class DefaultHttp2Connection implements Http2Connection {
             streamMap.put(stream.id(), stream);
 
             // Notify the listeners of the event.
-            for (int i = 0; i < listeners.size(); i++) {
+            for (Listener listener : listeners) {
                 try {
-                    listeners.get(i).onStreamAdded(stream);
+                    listener.onStreamAdded(stream);
                 } catch (Throwable cause) {
                     logger.error("Caught Throwable from listener onStreamAdded.", cause);
                 }
@@ -969,8 +963,8 @@ public class DefaultHttp2Connection implements Http2Connection {
      */
     private final class ActiveStreams {
         private final List<Listener> listeners;
-        private final Queue<Event> pendingEvents = new ArrayDeque<Event>(4);
-        private final Set<Http2Stream> streams = new LinkedHashSet<Http2Stream>();
+        private final Queue<Event> pendingEvents = new ArrayDeque<>(4);
+        private final Set<Http2Stream> streams = new LinkedHashSet<>();
         private int pendingIterations;
 
         ActiveStreams(List<Listener> listeners) {
@@ -985,12 +979,7 @@ public class DefaultHttp2Connection implements Http2Connection {
             if (allowModifications()) {
                 addToActiveStreams(stream);
             } else {
-                pendingEvents.add(new Event() {
-                    @Override
-                    public void process() {
-                        addToActiveStreams(stream);
-                    }
-                });
+                pendingEvents.add(() -> addToActiveStreams(stream));
             }
         }
 
@@ -998,12 +987,7 @@ public class DefaultHttp2Connection implements Http2Connection {
             if (allowModifications() || itr != null) {
                 removeFromActiveStreams(stream, itr);
             } else {
-                pendingEvents.add(new Event() {
-                    @Override
-                    public void process() {
-                        removeFromActiveStreams(stream, itr);
-                    }
-                });
+                pendingEvents.add(() -> removeFromActiveStreams(stream, itr));
             }
         }
 
@@ -1026,9 +1010,9 @@ public class DefaultHttp2Connection implements Http2Connection {
                 // Update the number of active streams initiated by the endpoint.
                 stream.createdBy().numActiveStreams++;
 
-                for (int i = 0; i < listeners.size(); i++) {
+                for (Listener listener : listeners) {
                     try {
-                        listeners.get(i).onStreamActive(stream);
+                        listener.onStreamActive(stream);
                     } catch (Throwable cause) {
                         logger.error("Caught Throwable from listener onStreamActive.", cause);
                     }
@@ -1098,7 +1082,7 @@ public class DefaultHttp2Connection implements Http2Connection {
          * (local/remote flow controller and {@link StreamByteDistributor}) and we leave room for 1 extra.
          * We could be more aggressive but the ArrayList resize will double the size if we are too small.
          */
-        final List<DefaultPropertyKey> keys = new ArrayList<DefaultPropertyKey>(4);
+        final List<DefaultPropertyKey> keys = new ArrayList<>(4);
 
         /**
          * Registers a new property key.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
@@ -230,9 +230,9 @@ public class DefaultHttp2Connection implements Http2Connection {
         }
 
         localEndpoint.lastStreamKnownByPeer(lastKnownStream);
-        for (Listener listener : listeners) {
+        for (int i = 0; i < listeners.size(); ++i) {
             try {
-                listener.onGoAwayReceived(lastKnownStream, errorCode, debugData);
+                listeners.get(i).onGoAwayReceived(lastKnownStream, errorCode, debugData);
             } catch (Throwable cause) {
                 logger.error("Caught Throwable from listener onGoAwayReceived.", cause);
             }
@@ -262,9 +262,9 @@ public class DefaultHttp2Connection implements Http2Connection {
         }
 
         remoteEndpoint.lastStreamKnownByPeer(lastKnownStream);
-        for (Listener listener : listeners) {
+        for (int i = 0; i < listeners.size(); ++i) {
             try {
-                listener.onGoAwaySent(lastKnownStream, errorCode, debugData);
+                listeners.get(i).onGoAwaySent(lastKnownStream, errorCode, debugData);
             } catch (Throwable cause) {
                 logger.error("Caught Throwable from listener onGoAwaySent.", cause);
             }
@@ -307,9 +307,9 @@ public class DefaultHttp2Connection implements Http2Connection {
         }
 
         if (removed) {
-            for (Listener listener : listeners) {
+            for (int i = 0; i < listeners.size(); i++) {
                 try {
-                    listener.onStreamRemoved(stream);
+                    listeners.get(i).onStreamRemoved(stream);
                 } catch (Throwable cause) {
                     logger.error("Caught Throwable from listener onStreamRemoved.", cause);
                 }
@@ -337,9 +337,9 @@ public class DefaultHttp2Connection implements Http2Connection {
     }
 
     void notifyHalfClosed(Http2Stream stream) {
-        for (Listener listener : listeners) {
+        for (int i = 0; i < listeners.size(); i++) {
             try {
-                listener.onStreamHalfClosed(stream);
+                listeners.get(i).onStreamHalfClosed(stream);
             } catch (Throwable cause) {
                 logger.error("Caught Throwable from listener onStreamHalfClosed.", cause);
             }
@@ -347,9 +347,9 @@ public class DefaultHttp2Connection implements Http2Connection {
     }
 
     void notifyClosed(Http2Stream stream) {
-        for (Listener listener : listeners) {
+        for (int i = 0; i < listeners.size(); i++) {
             try {
-                listener.onStreamClosed(stream);
+                listeners.get(i).onStreamClosed(stream);
             } catch (Throwable cause) {
                 logger.error("Caught Throwable from listener onStreamClosed.", cause);
             }
@@ -826,9 +826,9 @@ public class DefaultHttp2Connection implements Http2Connection {
             streamMap.put(stream.id(), stream);
 
             // Notify the listeners of the event.
-            for (Listener listener : listeners) {
+            for (int i = 0; i < listeners.size(); i++) {
                 try {
-                    listener.onStreamAdded(stream);
+                    listeners.get(i).onStreamAdded(stream);
                 } catch (Throwable cause) {
                     logger.error("Caught Throwable from listener onStreamAdded.", cause);
                 }
@@ -1010,9 +1010,9 @@ public class DefaultHttp2Connection implements Http2Connection {
                 // Update the number of active streams initiated by the endpoint.
                 stream.createdBy().numActiveStreams++;
 
-                for (Listener listener : listeners) {
+                for (int i = 0; i < listeners.size(); i++) {
                     try {
-                        listener.onStreamActive(stream);
+                        listeners.get(i).onStreamActive(stream);
                     } catch (Throwable cause) {
                         logger.error("Caught Throwable from listener onStreamActive.", cause);
                     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2DataFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2DataFrame.java
@@ -20,6 +20,8 @@ import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.util.internal.StringUtil;
 
+import java.util.Objects;
+
 import static io.netty.handler.codec.http2.Http2CodecUtil.verifyPadding;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
@@ -187,10 +189,6 @@ public final class DefaultHttp2DataFrame extends AbstractHttp2StreamFrame implem
 
     @Override
     public int hashCode() {
-        int hash = super.hashCode();
-        hash = hash * 31 + content.hashCode();
-        hash = hash * 31 + (endStream ? 0 : 1);
-        hash = hash * 31 + padding;
-        return hash;
+        return Objects.hash(super.hashCode(), content, endStream, padding);
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2DataFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2DataFrame.java
@@ -20,10 +20,10 @@ import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.util.internal.StringUtil;
 
-import java.util.Objects;
-
 import static io.netty.handler.codec.http2.Http2CodecUtil.verifyPadding;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import static io.netty.util.internal.ObjectUtil.hash;
+import static io.netty.util.internal.ObjectUtil.hashSum;
 
 /**
  * The default {@link Http2DataFrame} implementation.
@@ -189,6 +189,6 @@ public final class DefaultHttp2DataFrame extends AbstractHttp2StreamFrame implem
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), content, endStream, padding);
+        return hashSum(super.hashCode(), hash(content), Boolean.hashCode(endStream), padding);
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2GoAwayFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2GoAwayFrame.java
@@ -15,14 +15,13 @@
  */
 package io.netty.handler.codec.http2;
 
-import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.DefaultByteBufHolder;
 import io.netty.buffer.Unpooled;
 import io.netty.util.internal.StringUtil;
 
-import java.util.Objects;
+import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
+import static io.netty.util.internal.ObjectUtil.hashSum;
 
 /**
  * The default {@link Http2GoAwayFrame} implementation.
@@ -165,7 +164,7 @@ public final class DefaultHttp2GoAwayFrame extends DefaultByteBufHolder implemen
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), errorCode, extraStreamIds);
+        return hashSum(super.hashCode(), Long.hashCode(errorCode), extraStreamIds);
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2GoAwayFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2GoAwayFrame.java
@@ -22,6 +22,8 @@ import io.netty.buffer.DefaultByteBufHolder;
 import io.netty.buffer.Unpooled;
 import io.netty.util.internal.StringUtil;
 
+import java.util.Objects;
+
 /**
  * The default {@link Http2GoAwayFrame} implementation.
  */
@@ -163,10 +165,7 @@ public final class DefaultHttp2GoAwayFrame extends DefaultByteBufHolder implemen
 
     @Override
     public int hashCode() {
-        int hash = super.hashCode();
-        hash = hash * 31 + (int) (errorCode ^ errorCode >>> 32);
-        hash = hash * 31 + extraStreamIds;
-        return hash;
+        return Objects.hash(super.hashCode(), errorCode, extraStreamIds);
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersFrame.java
@@ -17,10 +17,10 @@ package io.netty.handler.codec.http2;
 
 import io.netty.util.internal.StringUtil;
 
-import java.util.Objects;
-
 import static io.netty.handler.codec.http2.Http2CodecUtil.verifyPadding;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import static io.netty.util.internal.ObjectUtil.hash;
+import static io.netty.util.internal.ObjectUtil.hashSum;
 
 /**
  * The default {@link Http2HeadersFrame} implementation.
@@ -107,6 +107,6 @@ public final class DefaultHttp2HeadersFrame extends AbstractHttp2StreamFrame imp
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), headers, endStream, padding);
+        return hashSum(super.hashCode(), hash(headers), Boolean.hashCode(endStream), padding);
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersFrame.java
@@ -17,6 +17,8 @@ package io.netty.handler.codec.http2;
 
 import io.netty.util.internal.StringUtil;
 
+import java.util.Objects;
+
 import static io.netty.handler.codec.http2.Http2CodecUtil.verifyPadding;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
@@ -105,10 +107,6 @@ public final class DefaultHttp2HeadersFrame extends AbstractHttp2StreamFrame imp
 
     @Override
     public int hashCode() {
-        int hash = super.hashCode();
-        hash = hash * 31 + headers.hashCode();
-        hash = hash * 31 + (endStream ? 0 : 1);
-        hash = hash * 31 + padding;
-        return hash;
+        return Objects.hash(super.hashCode(), headers, endStream, padding);
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2PingFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2PingFrame.java
@@ -18,6 +18,8 @@ package io.netty.handler.codec.http2;
 
 import io.netty.util.internal.StringUtil;
 
+import java.util.Objects;
+
 /**
  * The default {@link Http2PingFrame} implementation.
  */
@@ -61,9 +63,7 @@ public class DefaultHttp2PingFrame implements Http2PingFrame {
 
     @Override
     public int hashCode() {
-        int hash = super.hashCode();
-        hash = hash * 31 + (ack ? 1 : 0);
-        return hash;
+        return Objects.hash(super.hashCode(), ack);
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2PingFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2PingFrame.java
@@ -18,7 +18,7 @@ package io.netty.handler.codec.http2;
 
 import io.netty.util.internal.StringUtil;
 
-import java.util.Objects;
+import static io.netty.util.internal.ObjectUtil.hashSum;
 
 /**
  * The default {@link Http2PingFrame} implementation.
@@ -63,7 +63,7 @@ public class DefaultHttp2PingFrame implements Http2PingFrame {
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), ack);
+        return hashSum(super.hashCode(), Boolean.hashCode(ack));
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2PriorityFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2PriorityFrame.java
@@ -15,7 +15,7 @@
  */
 package io.netty.handler.codec.http2;
 
-import java.util.Objects;
+import static io.netty.util.internal.ObjectUtil.hashSum;
 
 /**
  * Default implementation of {@linkplain Http2PriorityFrame}
@@ -71,7 +71,7 @@ public final class DefaultHttp2PriorityFrame extends AbstractHttp2StreamFrame im
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), streamDependency, weight, exclusive);
+        return hashSum(super.hashCode(), streamDependency, Short.hashCode(weight), Boolean.hashCode(exclusive));
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2PriorityFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2PriorityFrame.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.http2;
 
+import java.util.Objects;
+
 /**
  * Default implementation of {@linkplain Http2PriorityFrame}
  */
@@ -69,11 +71,7 @@ public final class DefaultHttp2PriorityFrame extends AbstractHttp2StreamFrame im
 
     @Override
     public int hashCode() {
-        int hash = super.hashCode();
-        hash = hash * 31 + streamDependency;
-        hash = hash * 31 + weight;
-        hash = hash * 31 + (exclusive ? 1 : 0);
-        return hash;
+        return Objects.hash(super.hashCode(), streamDependency, weight, exclusive);
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ResetFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ResetFrame.java
@@ -17,9 +17,8 @@ package io.netty.handler.codec.http2;
 
 import io.netty.util.internal.StringUtil;
 
-import java.util.Objects;
-
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import static io.netty.util.internal.ObjectUtil.hashSum;
 
 /**
  * The default {@link Http2ResetFrame} implementation.
@@ -78,6 +77,6 @@ public final class DefaultHttp2ResetFrame extends AbstractHttp2StreamFrame imple
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), errorCode);
+        return hashSum(super.hashCode(), Long.hashCode(errorCode));
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ResetFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ResetFrame.java
@@ -17,6 +17,8 @@ package io.netty.handler.codec.http2;
 
 import io.netty.util.internal.StringUtil;
 
+import java.util.Objects;
+
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
@@ -76,8 +78,6 @@ public final class DefaultHttp2ResetFrame extends AbstractHttp2StreamFrame imple
 
     @Override
     public int hashCode() {
-        int hash = super.hashCode();
-        hash = hash * 31 + (int) (errorCode ^ errorCode >>> 32);
-        return hash;
+        return Objects.hash(super.hashCode(), errorCode);
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2UnknownFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2UnknownFrame.java
@@ -20,6 +20,8 @@ import io.netty.buffer.DefaultByteBufHolder;
 import io.netty.buffer.Unpooled;
 import io.netty.util.internal.StringUtil;
 
+import java.util.Objects;
+
 public final class DefaultHttp2UnknownFrame extends DefaultByteBufHolder implements Http2UnknownFrame {
     private final byte frameType;
     private final Http2Flags flags;
@@ -118,7 +120,7 @@ public final class DefaultHttp2UnknownFrame extends DefaultByteBufHolder impleme
         }
         DefaultHttp2UnknownFrame other = (DefaultHttp2UnknownFrame) o;
         Http2FrameStream otherStream = other.stream();
-        return (stream == otherStream || otherStream != null && otherStream.equals(stream))
+        return Objects.equals(otherStream, stream)
                && flags.equals(other.flags())
                && frameType == other.frameType()
                && super.equals(other);
@@ -126,13 +128,6 @@ public final class DefaultHttp2UnknownFrame extends DefaultByteBufHolder impleme
 
     @Override
     public int hashCode() {
-        int hash = super.hashCode();
-        hash = hash * 31 + frameType;
-        hash = hash * 31 + flags.hashCode();
-        if (stream != null) {
-            hash = hash * 31 + stream.hashCode();
-        }
-
-        return hash;
+        return Objects.hash(super.hashCode(), frameType, flags, stream);
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2UnknownFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2UnknownFrame.java
@@ -22,6 +22,9 @@ import io.netty.util.internal.StringUtil;
 
 import java.util.Objects;
 
+import static io.netty.util.internal.ObjectUtil.hash;
+import static io.netty.util.internal.ObjectUtil.hashSum;
+
 public final class DefaultHttp2UnknownFrame extends DefaultByteBufHolder implements Http2UnknownFrame {
     private final byte frameType;
     private final Http2Flags flags;
@@ -128,6 +131,6 @@ public final class DefaultHttp2UnknownFrame extends DefaultByteBufHolder impleme
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), frameType, flags, stream);
+        return hashSum(super.hashCode(), Byte.hashCode(frameType), hash(flags), hash(stream));
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Flags.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Flags.java
@@ -148,7 +148,7 @@ public final class Http2Flags {
     }
 
     /**
-     * Indicates whether or not a particular flag is set.
+     * Indicates whether a particular flag is set.
      * @param mask the mask identifying the bit for the particular flag being tested
      * @return {@code true} if the flag is set
      */
@@ -158,10 +158,7 @@ public final class Http2Flags {
 
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + value;
-        return result;
+        return value;
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamChannelId.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamChannelId.java
@@ -17,6 +17,8 @@ package io.netty.handler.codec.http2;
 
 import io.netty.channel.ChannelId;
 
+import java.util.Objects;
+
 /**
  * ChannelId implementation which is used by our {@link Http2StreamChannel} implementation.
  */
@@ -57,7 +59,7 @@ final class Http2StreamChannelId implements ChannelId {
 
     @Override
     public int hashCode() {
-        return id * 31 + parentId.hashCode();
+        return Objects.hash(id, parentId);
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamChannelId.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamChannelId.java
@@ -17,7 +17,8 @@ package io.netty.handler.codec.http2;
 
 import io.netty.channel.ChannelId;
 
-import java.util.Objects;
+import static io.netty.util.internal.ObjectUtil.hash;
+import static io.netty.util.internal.ObjectUtil.hashSum;
 
 /**
  * ChannelId implementation which is used by our {@link Http2StreamChannel} implementation.
@@ -59,7 +60,7 @@ final class Http2StreamChannelId implements ChannelId {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, parentId);
+        return hashSum(id, hash(parentId));
     }
 
     @Override

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttProperties.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttProperties.java
@@ -16,12 +16,16 @@
 package io.netty.handler.codec.mqtt;
 
 import io.netty.util.collection.IntObjectHashMap;
+import io.netty.util.internal.ObjectUtil;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+
+import static io.netty.util.internal.ObjectUtil.hash;
+import static io.netty.util.internal.ObjectUtil.hashSum;
 
 /**
  * MQTT Properties container
@@ -183,7 +187,7 @@ public final class MqttProperties {
 
         @Override
         public int hashCode() {
-            return Objects.hash(propertyId, value);
+            return hashSum(propertyId, hash(value));
         }
 
         @Override
@@ -234,7 +238,7 @@ public final class MqttProperties {
 
         @Override
         public int hashCode() {
-            return Objects.hash(key, value);
+            return hash(key, value);
         }
 
         @Override

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttProperties.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttProperties.java
@@ -17,10 +17,11 @@ package io.netty.handler.codec.mqtt;
 
 import io.netty.util.collection.IntObjectHashMap;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.ArrayList;
+import java.util.Objects;
 
 /**
  * MQTT Properties container
@@ -182,7 +183,7 @@ public final class MqttProperties {
 
         @Override
         public int hashCode() {
-            return propertyId + 31 * value.hashCode();
+            return Objects.hash(propertyId, value);
         }
 
         @Override
@@ -233,7 +234,7 @@ public final class MqttProperties {
 
         @Override
         public int hashCode() {
-            return key.hashCode() + 31 * value.hashCode();
+            return Objects.hash(key, value);
         }
 
         @Override

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttSubscriptionOption.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttSubscriptionOption.java
@@ -15,7 +15,8 @@
  */
 package io.netty.handler.codec.mqtt;
 
-import java.util.Objects;
+import static io.netty.util.internal.ObjectUtil.hash;
+import static io.netty.util.internal.ObjectUtil.hashSum;
 
 /**
  * Model the SubscriptionOption used in Subscribe MQTT v5 packet
@@ -104,7 +105,7 @@ public final class MqttSubscriptionOption {
 
     @Override
     public int hashCode() {
-        return Objects.hash(qos, noLocal, retainAsPublished, retainHandling);
+        return hashSum(hash(qos), Boolean.hashCode(noLocal), Boolean.hashCode(retainAsPublished), hash(retainHandling));
     }
 
     @Override

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttSubscriptionOption.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttSubscriptionOption.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.mqtt;
 
+import java.util.Objects;
+
 /**
  * Model the SubscriptionOption used in Subscribe MQTT v5 packet
  */
@@ -94,26 +96,15 @@ public final class MqttSubscriptionOption {
         }
 
         MqttSubscriptionOption that = (MqttSubscriptionOption) o;
-
-        if (noLocal != that.noLocal) {
-            return false;
-        }
-        if (retainAsPublished != that.retainAsPublished) {
-            return false;
-        }
-        if (qos != that.qos) {
-            return false;
-        }
-        return retainHandling == that.retainHandling;
+        return noLocal == that.noLocal &&
+                retainAsPublished == that.retainAsPublished &&
+                qos == that.qos &&
+                retainHandling == that.retainHandling;
     }
 
     @Override
     public int hashCode() {
-        int result = qos.hashCode();
-        result = 31 * result + (noLocal ? 1 : 0);
-        result = 31 * result + (retainAsPublished ? 1 : 0);
-        result = 31 * result + retainHandling.hashCode();
-        return result;
+        return Objects.hash(qos, noLocal, retainAsPublished, retainHandling);
     }
 
     @Override

--- a/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicheQuicCodecTest.java
+++ b/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicheQuicCodecTest.java
@@ -60,13 +60,7 @@ public abstract class QuicheQuicCodecTest<B extends QuicCodecBuilder<B>> extends
         builder.flushStrategy((numPackets, numBytes) -> {
             numPacketsTracker.set(numPackets);
             numBytesTracker.set(numBytes);
-            if (useBytes) {
-                return numBytes > 8;
-            }
-            if (numPackets == 2) {
-                return true;
-            }
-            return false;
+            return useBytes ? numBytes > 8 : numPackets == 2;
         });
 
         EmbeddedChannel channel = new EmbeddedChannel(new ChannelOutboundHandlerAdapter() {

--- a/codec-smtp/src/main/java/io/netty/handler/codec/smtp/DefaultSmtpRequest.java
+++ b/codec-smtp/src/main/java/io/netty/handler/codec/smtp/DefaultSmtpRequest.java
@@ -20,7 +20,8 @@ import io.netty.util.internal.UnstableApi;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
+
+import static io.netty.util.internal.ObjectUtil.hash;
 
 /**
  * Default {@link SmtpRequest} implementation.
@@ -72,7 +73,7 @@ public final class DefaultSmtpRequest implements SmtpRequest {
 
     @Override
     public int hashCode() {
-        return Objects.hash(command, parameters);
+        return hash(command, parameters);
     }
 
     @Override

--- a/codec-smtp/src/main/java/io/netty/handler/codec/smtp/DefaultSmtpRequest.java
+++ b/codec-smtp/src/main/java/io/netty/handler/codec/smtp/DefaultSmtpRequest.java
@@ -20,6 +20,7 @@ import io.netty.util.internal.UnstableApi;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Default {@link SmtpRequest} implementation.
@@ -71,7 +72,7 @@ public final class DefaultSmtpRequest implements SmtpRequest {
 
     @Override
     public int hashCode() {
-        return command.hashCode() * 31 + parameters.hashCode();
+        return Objects.hash(command, parameters);
     }
 
     @Override

--- a/codec-smtp/src/main/java/io/netty/handler/codec/smtp/DefaultSmtpResponse.java
+++ b/codec-smtp/src/main/java/io/netty/handler/codec/smtp/DefaultSmtpResponse.java
@@ -19,7 +19,9 @@ import io.netty.util.internal.UnstableApi;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
+
+import static io.netty.util.internal.ObjectUtil.hash;
+import static io.netty.util.internal.ObjectUtil.hashSum;
 
 /**
  * Default {@link SmtpResponse} implementation.
@@ -68,7 +70,7 @@ public final class DefaultSmtpResponse implements SmtpResponse {
 
     @Override
     public int hashCode() {
-        return Objects.hash(code, details);
+        return hashSum(code, hash(details));
     }
 
     @Override

--- a/codec-smtp/src/main/java/io/netty/handler/codec/smtp/DefaultSmtpResponse.java
+++ b/codec-smtp/src/main/java/io/netty/handler/codec/smtp/DefaultSmtpResponse.java
@@ -19,6 +19,7 @@ import io.netty.util.internal.UnstableApi;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Default {@link SmtpResponse} implementation.
@@ -67,7 +68,7 @@ public final class DefaultSmtpResponse implements SmtpResponse {
 
     @Override
     public int hashCode() {
-        return code * 31 + details.hashCode();
+        return Objects.hash(code, details);
     }
 
     @Override

--- a/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlAttribute.java
+++ b/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlAttribute.java
@@ -16,6 +16,8 @@
 package io.netty.handler.codec.xml;
 
 
+import java.util.Objects;
+
 /**
  * XML attributes, it is part of {@link XmlElement}
  */
@@ -65,34 +67,16 @@ public class XmlAttribute {
         }
 
         XmlAttribute that = (XmlAttribute) o;
-
-        if (!name.equals(that.name)) {
-            return false;
-        }
-        if (namespace != null ? !namespace.equals(that.namespace) : that.namespace != null) {
-            return false;
-        }
-        if (prefix != null ? !prefix.equals(that.prefix) : that.prefix != null) {
-            return false;
-        }
-        if (type != null ? !type.equals(that.type) : that.type != null) {
-            return false;
-        }
-        if (value != null ? !value.equals(that.value) : that.value != null) {
-            return false;
-        }
-
-        return true;
+        return name.equals(that.name) &&
+                Objects.equals(namespace, that.namespace) &&
+                Objects.equals(prefix, that.prefix) &&
+                Objects.equals(type, that.type) &&
+                Objects.equals(value, that.value);
     }
 
     @Override
     public int hashCode() {
-        int result = type != null ? type.hashCode() : 0;
-        result = 31 * result + name.hashCode();
-        result = 31 * result + (prefix != null ? prefix.hashCode() : 0);
-        result = 31 * result + (namespace != null ? namespace.hashCode() : 0);
-        result = 31 * result + (value != null ? value.hashCode() : 0);
-        return result;
+        return Objects.hash(type, name, prefix, namespace, value);
     }
 
     @Override

--- a/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlAttribute.java
+++ b/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlAttribute.java
@@ -18,6 +18,8 @@ package io.netty.handler.codec.xml;
 
 import java.util.Objects;
 
+import static io.netty.util.internal.ObjectUtil.hash;
+
 /**
  * XML attributes, it is part of {@link XmlElement}
  */
@@ -76,7 +78,7 @@ public class XmlAttribute {
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, name, prefix, namespace, value);
+        return hash(type, name, prefix, namespace, value);
     }
 
     @Override

--- a/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlContent.java
+++ b/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlContent.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.xml;
 
+import java.util.Objects;
+
 /**
  * XML Content is base class for XML CDATA, Comments, Characters and Space
  */
@@ -40,17 +42,12 @@ public abstract class XmlContent {
         }
 
         XmlContent that = (XmlContent) o;
-
-        if (data != null ? !data.equals(that.data) : that.data != null) {
-            return false;
-        }
-
-        return true;
+        return Objects.equals(data, that.data);
     }
 
     @Override
     public int hashCode() {
-        return data != null ? data.hashCode() : 0;
+        return Objects.hash(data);
     }
 
     @Override

--- a/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlContent.java
+++ b/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlContent.java
@@ -17,6 +17,8 @@ package io.netty.handler.codec.xml;
 
 import java.util.Objects;
 
+import static io.netty.util.internal.ObjectUtil.hash;
+
 /**
  * XML Content is base class for XML CDATA, Comments, Characters and Space
  */
@@ -47,7 +49,7 @@ public abstract class XmlContent {
 
     @Override
     public int hashCode() {
-        return Objects.hash(data);
+        return hash(data);
     }
 
     @Override

--- a/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlDTD.java
+++ b/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlDTD.java
@@ -17,6 +17,8 @@ package io.netty.handler.codec.xml;
 
 import java.util.Objects;
 
+import static io.netty.util.internal.ObjectUtil.hash;
+
 /**
  * DTD (Document Type Definition)
  */
@@ -47,7 +49,7 @@ public class XmlDTD {
 
     @Override
     public int hashCode() {
-        return Objects.hash(text);
+        return hash(text);
     }
 
     @Override

--- a/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlDTD.java
+++ b/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlDTD.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.xml;
 
+import java.util.Objects;
+
 /**
  * DTD (Document Type Definition)
  */
@@ -40,17 +42,12 @@ public class XmlDTD {
         }
 
         XmlDTD xmlDTD = (XmlDTD) o;
-
-        if (text != null ? !text.equals(xmlDTD.text) : xmlDTD.text != null) {
-            return false;
-        }
-
-        return true;
+        return Objects.equals(text, xmlDTD.text);
     }
 
     @Override
     public int hashCode() {
-        return text != null ? text.hashCode() : 0;
+        return Objects.hash(text);
     }
 
     @Override

--- a/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlDocumentStart.java
+++ b/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlDocumentStart.java
@@ -17,6 +17,9 @@ package io.netty.handler.codec.xml;
 
 import java.util.Objects;
 
+import static io.netty.util.internal.ObjectUtil.hash;
+import static io.netty.util.internal.ObjectUtil.hashSum;
+
 /**
  * Beginning of the XML document ... i.e. XML header
  */
@@ -72,7 +75,7 @@ public class XmlDocumentStart {
 
     @Override
     public int hashCode() {
-        return Objects.hash(encoding, version, standalone, encodingScheme);
+        return hashSum(hash(encoding), hash(version), Boolean.hashCode(standalone), hash(encodingScheme));
     }
 
     @Override

--- a/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlDocumentStart.java
+++ b/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlDocumentStart.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.xml;
 
+import java.util.Objects;
+
 /**
  * Beginning of the XML document ... i.e. XML header
  */
@@ -62,30 +64,15 @@ public class XmlDocumentStart {
         }
 
         XmlDocumentStart that = (XmlDocumentStart) o;
-
-        if (standalone != that.standalone) {
-            return false;
-        }
-        if (encoding != null ? !encoding.equals(that.encoding) : that.encoding != null) {
-            return false;
-        }
-        if (encodingScheme != null ? !encodingScheme.equals(that.encodingScheme) : that.encodingScheme != null) {
-            return false;
-        }
-        if (version != null ? !version.equals(that.version) : that.version != null) {
-            return false;
-        }
-
-        return true;
+        return standalone == that.standalone &&
+                Objects.equals(encoding, that.encoding) &&
+                Objects.equals(encodingScheme, that.encodingScheme) &&
+                Objects.equals(version, that.version);
     }
 
     @Override
     public int hashCode() {
-        int result = encoding != null ? encoding.hashCode() : 0;
-        result = 31 * result + (version != null ? version.hashCode() : 0);
-        result = 31 * result + (standalone ? 1 : 0);
-        result = 31 * result + (encodingScheme != null ? encodingScheme.hashCode() : 0);
-        return result;
+        return Objects.hash(encoding, version, standalone, encodingScheme);
     }
 
     @Override

--- a/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlElement.java
+++ b/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlElement.java
@@ -19,6 +19,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import static io.netty.util.internal.ObjectUtil.hash;
+
 /**
  * Generic XML element in document, {@link XmlElementStart} represents open element and provides access to attributes,
  * {@link XmlElementEnd} represents closing element.
@@ -72,7 +74,7 @@ public abstract class XmlElement {
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, namespace, prefix, namespaces);
+        return hash(name, namespace, prefix, namespaces);
     }
 
     @Override

--- a/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlElement.java
+++ b/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlElement.java
@@ -17,6 +17,7 @@ package io.netty.handler.codec.xml;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Generic XML element in document, {@link XmlElementStart} represents open element and provides access to attributes,
@@ -28,7 +29,7 @@ public abstract class XmlElement {
     private final String namespace;
     private final String prefix;
 
-    private final List<XmlNamespace> namespaces = new ArrayList<XmlNamespace>();
+    private final List<XmlNamespace> namespaces = new ArrayList<>();
 
     protected XmlElement(String name, String namespace, String prefix) {
         this.name = name;
@@ -63,29 +64,15 @@ public abstract class XmlElement {
 
         XmlElement that = (XmlElement) o;
 
-        if (!name.equals(that.name)) {
-            return false;
-        }
-        if (namespace != null ? !namespace.equals(that.namespace) : that.namespace != null) {
-            return false;
-        }
-        if (!namespaces.equals(that.namespaces)) {
-            return false;
-        }
-        if (prefix != null ? !prefix.equals(that.prefix) : that.prefix != null) {
-            return false;
-        }
-
-        return true;
+        return Objects.equals(name, that.name) &&
+                Objects.equals(namespace, that.namespace) &&
+                Objects.equals(namespaces, that.namespaces) &&
+                Objects.equals(prefix, that.prefix);
     }
 
     @Override
     public int hashCode() {
-        int result = name.hashCode();
-        result = 31 * result + (namespace != null ? namespace.hashCode() : 0);
-        result = 31 * result + (prefix != null ? prefix.hashCode() : 0);
-        result = 31 * result + namespaces.hashCode();
-        return result;
+        return Objects.hash(name, namespace, prefix, namespaces);
     }
 
     @Override

--- a/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlElementStart.java
+++ b/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlElementStart.java
@@ -17,7 +17,9 @@ package io.netty.handler.codec.xml;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
+
+import static io.netty.util.internal.ObjectUtil.hash;
+import static io.netty.util.internal.ObjectUtil.hashSum;
 
 /**
  * Specific {@link XmlElement} representing beginning  of element.
@@ -53,7 +55,7 @@ public class XmlElementStart extends XmlElement {
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), attributes);
+        return hashSum(super.hashCode(), hash(attributes));
     }
 
     @Override

--- a/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlElementStart.java
+++ b/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlElementStart.java
@@ -17,13 +17,14 @@ package io.netty.handler.codec.xml;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Specific {@link XmlElement} representing beginning  of element.
  */
 public class XmlElementStart extends XmlElement {
 
-    private final List<XmlAttribute> attributes = new ArrayList<XmlAttribute>();
+    private final List<XmlAttribute> attributes = new ArrayList<>();
 
     public XmlElementStart(String name, String namespace, String prefix) {
         super(name, namespace, prefix);
@@ -52,9 +53,7 @@ public class XmlElementStart extends XmlElement {
 
     @Override
     public int hashCode() {
-        int result = super.hashCode();
-        result = 31 * result + attributes.hashCode();
-        return result;
+        return Objects.hash(super.hashCode(), attributes);
     }
 
     @Override

--- a/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlEntityReference.java
+++ b/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlEntityReference.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.xml;
 
+import java.util.Objects;
+
 /**
  * XML entity reference ... {@code &#nnnn;}
  */
@@ -46,18 +48,13 @@ public class XmlEntityReference {
         }
 
         XmlEntityReference that = (XmlEntityReference) o;
-
-        if (name != null ? !name.equals(that.name) : that.name != null) {
-            return false;
-        }
-        return text != null ? text.equals(that.text) : that.text == null;
+        return Objects.equals(name, that.name) &&
+                Objects.equals(text, that.text);
     }
 
     @Override
     public int hashCode() {
-        int result = name != null ? name.hashCode() : 0;
-        result = 31 * result + (text != null ? text.hashCode() : 0);
-        return result;
+        return Objects.hash(name, text);
     }
 
     @Override

--- a/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlEntityReference.java
+++ b/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlEntityReference.java
@@ -17,6 +17,8 @@ package io.netty.handler.codec.xml;
 
 import java.util.Objects;
 
+import static io.netty.util.internal.ObjectUtil.hash;
+
 /**
  * XML entity reference ... {@code &#nnnn;}
  */
@@ -54,7 +56,7 @@ public class XmlEntityReference {
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, text);
+        return hash(name, text);
     }
 
     @Override

--- a/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlNamespace.java
+++ b/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlNamespace.java
@@ -17,6 +17,8 @@ package io.netty.handler.codec.xml;
 
 import java.util.Objects;
 
+import static io.netty.util.internal.ObjectUtil.hash;
+
 /**
  * XML namespace is part of XML element.
  */
@@ -54,7 +56,7 @@ public class XmlNamespace {
 
     @Override
     public int hashCode() {
-        return Objects.hash(prefix, uri);
+        return hash(prefix, uri);
     }
 
     @Override

--- a/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlNamespace.java
+++ b/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlNamespace.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.xml;
 
+import java.util.Objects;
+
 /**
  * XML namespace is part of XML element.
  */
@@ -46,22 +48,13 @@ public class XmlNamespace {
         }
 
         XmlNamespace that = (XmlNamespace) o;
-
-        if (prefix != null ? !prefix.equals(that.prefix) : that.prefix != null) {
-            return false;
-        }
-        if (uri != null ? !uri.equals(that.uri) : that.uri != null) {
-            return false;
-        }
-
-        return true;
+        return Objects.equals(prefix, that.prefix) &&
+                Objects.equals(uri, that.uri);
     }
 
     @Override
     public int hashCode() {
-        int result = prefix != null ? prefix.hashCode() : 0;
-        result = 31 * result + (uri != null ? uri.hashCode() : 0);
-        return result;
+        return Objects.hash(prefix, uri);
     }
 
     @Override

--- a/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlProcessingInstruction.java
+++ b/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlProcessingInstruction.java
@@ -17,6 +17,8 @@ package io.netty.handler.codec.xml;
 
 import java.util.Objects;
 
+import static io.netty.util.internal.ObjectUtil.hash;
+
 /**
  * XML processing instruction
  */
@@ -54,7 +56,7 @@ public class XmlProcessingInstruction {
 
     @Override
     public int hashCode() {
-        return Objects.hash(data, target);
+        return hash(data, target);
     }
 
     @Override

--- a/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlProcessingInstruction.java
+++ b/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlProcessingInstruction.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.xml;
 
+import java.util.Objects;
+
 /**
  * XML processing instruction
  */
@@ -46,22 +48,13 @@ public class XmlProcessingInstruction {
         }
 
         XmlProcessingInstruction that = (XmlProcessingInstruction) o;
-
-        if (data != null ? !data.equals(that.data) : that.data != null) {
-            return false;
-        }
-        if (target != null ? !target.equals(that.target) : that.target != null) {
-            return false;
-        }
-
-        return true;
+        return Objects.equals(data, that.data) &&
+                Objects.equals(target, that.target);
     }
 
     @Override
     public int hashCode() {
-        int result = data != null ? data.hashCode() : 0;
-        result = 31 * result + (target != null ? target.hashCode() : 0);
-        return result;
+        return Objects.hash(data, target);
     }
 
     @Override

--- a/common/src/main/java/io/netty/util/internal/ObjectUtil.java
+++ b/common/src/main/java/io/netty/util/internal/ObjectUtil.java
@@ -14,8 +14,11 @@
  */
 package io.netty.util.internal;
 
+import org.jetbrains.annotations.Nullable;
+
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * A grab-bag of useful utility methods.
@@ -346,5 +349,47 @@ public final class ObjectUtil {
      */
     public static long longValue(Long wrapper, long defaultValue) {
         return wrapper != null ? wrapper : defaultValue;
+    }
+
+    public static int hash(@Nullable Object object) {
+        return Objects.hashCode(object);
+    }
+
+    public static int hash(boolean value) {
+        return Boolean.hashCode(value);
+    }
+
+    public static int hash(@Nullable Object first, @Nullable Object second) {
+        return hashSum(hash(first), hash(second));
+    }
+
+    public static int hash(@Nullable Object first, @Nullable Object second, @Nullable Object third) {
+        return hashSum(hash(first), hash(second), hash(third));
+    }
+
+    public static int hash(@Nullable Object first, @Nullable Object second, @Nullable Object third,
+                           @Nullable Object fourth) {
+        return hashSum(hash(first), hash(second), hash(third), hash(fourth));
+    }
+
+    public static int hash(@Nullable Object first, @Nullable Object second, @Nullable Object third,
+                           @Nullable Object fourth, @Nullable Object fifth) {
+        return hashSum(hash(first), hash(second), hash(third), hash(fourth), hash(fifth));
+    }
+
+    public static int hashSum(int firstHash, int secondHash) {
+        return 31 * firstHash + secondHash;
+    }
+
+    public static int hashSum(int firstHash, int secondHash, int thirdHash) {
+        return 31 * (31 * firstHash + secondHash) + thirdHash;
+    }
+
+    public static int hashSum(int firstHash, int secondHash, int thirdHash, int fourthHash) {
+        return 31 * (31 * (31 * firstHash + secondHash) + thirdHash) + fourthHash;
+    }
+
+    public static int hashSum(int firstHash, int secondHash, int thirdHash, int fourthHash, int fifthHash) {
+        return 31 * (31 * (31 * (31 * firstHash + secondHash) + thirdHash) + fourthHash) + fifthHash;
     }
 }

--- a/common/src/test/java/io/netty/util/internal/DefaultPriorityQueueTest.java
+++ b/common/src/test/java/io/netty/util/internal/DefaultPriorityQueueTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class DefaultPriorityQueueTest {
     @Test
     public void testPoll() {
-        PriorityQueue<TestElement> queue = new DefaultPriorityQueue<TestElement>(TestElementComparator.INSTANCE, 0);
+        PriorityQueue<TestElement> queue = new DefaultPriorityQueue<>(TestElementComparator.INSTANCE, 0);
         assertEmptyQueue(queue);
 
         TestElement a = new TestElement(5);
@@ -77,7 +77,7 @@ public class DefaultPriorityQueueTest {
 
     @Test
     public void testClear() {
-        PriorityQueue<TestElement> queue = new DefaultPriorityQueue<TestElement>(TestElementComparator.INSTANCE, 0);
+        PriorityQueue<TestElement> queue = new DefaultPriorityQueue<>(TestElementComparator.INSTANCE, 0);
         assertEmptyQueue(queue);
 
         TestElement a = new TestElement(5);
@@ -109,7 +109,7 @@ public class DefaultPriorityQueueTest {
 
     @Test
     public void testClearIgnoringIndexes() {
-        PriorityQueue<TestElement> queue = new DefaultPriorityQueue<TestElement>(TestElementComparator.INSTANCE, 0);
+        PriorityQueue<TestElement> queue = new DefaultPriorityQueue<>(TestElementComparator.INSTANCE, 0);
         assertEmptyQueue(queue);
 
         TestElement a = new TestElement(5);

--- a/common/src/test/java/io/netty/util/internal/ObjectUtilTest.java
+++ b/common/src/test/java/io/netty/util/internal/ObjectUtilTest.java
@@ -17,6 +17,7 @@ package io.netty.util.internal;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -72,6 +73,10 @@ public class ObjectUtilTest {
     private static final String NUM_POS_NAME = "NUMBER_POSITIVE";
     private static final String NUM_ZERO_NAME = "NUMBER_ZERO";
     private static final String NUM_NEG_NAME = "NUMBER_NEGATIVE";
+    private static final int p1 = 31;
+    private static final int p2 = p1 * p1;
+    private static final int p3 = p1 * p1 * p1;
+    private static final int p4 = p1 * p1 * p1 * p1;
 
     @Test
     public void testCheckNotNull() {
@@ -610,5 +615,47 @@ public class ObjectUtilTest {
         assertThrows(IllegalArgumentException.class, () -> {
             ObjectUtil.checkInRange(1.1, 0.0, 1.0, "above range");
         });
+    }
+
+    @Test
+    void hash_forSingleObject() {
+        assertEquals(5, ObjectUtil.hash(5));
+        assertEquals(0, ObjectUtil.hash(null));
+    }
+
+    @Test
+    void hash_forBoolean() {
+        assertEquals(1231, ObjectUtil.hash(true));
+        assertEquals(1237, ObjectUtil.hash(false));
+    }
+
+    @Test
+    void hash_forTwoObjects() {
+        assertEquals(p1 * 100 + 200, ObjectUtil.hash(100, 200));
+        assertEquals(p1 * 100, ObjectUtil.hash(100, null));
+        assertEquals(200, ObjectUtil.hash(null, 200));
+        assertEquals(0, ObjectUtil.hash(null, null));
+    }
+
+    @Test
+    void hash_forThreeObjects() {
+        assertEquals(p2 * 100 + p1 * 200 + 300, ObjectUtil.hash(100, 200, 300));
+        assertEquals(p2 * 100 + p1 * 200, ObjectUtil.hash(100, 200, null));
+        assertEquals(p2 * 100 + 300, ObjectUtil.hash(100, null, 300));
+        assertEquals(p1 * 200 + 300, ObjectUtil.hash(null, 200, 300));
+        assertEquals(p2 * 100, ObjectUtil.hash(100, null, null));
+        assertEquals(0, ObjectUtil.hash(null, null, null));
+    }
+
+    @Test
+    void hash_forFourObjects() {
+        assertEquals(p3 * 100 + p2 * 200 + p1 * 300 + 400, ObjectUtil.hash(100, 200, 300, 400));
+        assertEquals(0, ObjectUtil.hash(null, null, null, null));
+    }
+
+    @Test
+    void hash_forFiveObjects() {
+        assertEquals(p4 * 100 + p3 * 200 + p2 * 300 + p1 * 400 + 500, ObjectUtil.hash(100, 200, 300, 400, 500));
+        assertEquals(0, ObjectUtil.hash(null, null, null, null, null));
     }
 }

--- a/example/src/main/java/io/netty/example/stomp/websocket/StompSubscription.java
+++ b/example/src/main/java/io/netty/example/stomp/websocket/StompSubscription.java
@@ -18,6 +18,8 @@ package io.netty.example.stomp.websocket;
 import io.netty.channel.Channel;
 import io.netty.util.internal.ObjectUtil;
 
+import java.util.Objects;
+
 public final class StompSubscription {
 
     private final String id;
@@ -53,23 +55,13 @@ public final class StompSubscription {
         }
 
         StompSubscription that = (StompSubscription) obj;
-
-        if (!id.equals(that.id)) {
-            return false;
-        }
-
-        if (!destination.equals(that.destination)) {
-            return false;
-        }
-
-        return channel.equals(that.channel);
+        return id.equals(that.id) &&
+                destination.equals(that.destination) &&
+                channel.equals(that.channel);
     }
 
     @Override
     public int hashCode() {
-        int result = id.hashCode();
-        result = 31 * result + destination.hashCode();
-        result = 31 * result + channel.hashCode();
-        return result;
+        return Objects.hash(id, destination, channel);
     }
 }

--- a/example/src/main/java/io/netty/example/stomp/websocket/StompSubscription.java
+++ b/example/src/main/java/io/netty/example/stomp/websocket/StompSubscription.java
@@ -18,7 +18,7 @@ package io.netty.example.stomp.websocket;
 import io.netty.channel.Channel;
 import io.netty.util.internal.ObjectUtil;
 
-import java.util.Objects;
+import static io.netty.util.internal.ObjectUtil.hash;
 
 public final class StompSubscription {
 
@@ -62,6 +62,6 @@ public final class StompSubscription {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, destination, channel);
+        return hash(id, destination, channel);
     }
 }

--- a/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRule.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRule.java
@@ -125,8 +125,10 @@ public final class IpSubnetFilterRule implements IpFilterRule, Comparable<IpSubn
     @Override
     public int compareTo(IpSubnetFilterRule ipSubnetFilterRule) {
         if (filterRule instanceof Ip4SubnetFilterRule) {
-            return compareInt(((Ip4SubnetFilterRule) filterRule).networkAddress,
-                    ((Ip4SubnetFilterRule) ipSubnetFilterRule.filterRule).networkAddress);
+            return Integer.compare(
+                    ((Ip4SubnetFilterRule) filterRule).networkAddress,
+                    ((Ip4SubnetFilterRule) ipSubnetFilterRule.filterRule).networkAddress
+            );
         } else {
             return ((Ip6SubnetFilterRule) filterRule).networkAddress
                     .compareTo(((Ip6SubnetFilterRule) ipSubnetFilterRule.filterRule).networkAddress);
@@ -143,21 +145,15 @@ public final class IpSubnetFilterRule implements IpFilterRule, Comparable<IpSubn
     int compareTo(InetSocketAddress inetSocketAddress) {
         if (filterRule instanceof Ip4SubnetFilterRule) {
             Ip4SubnetFilterRule ip4SubnetFilterRule = (Ip4SubnetFilterRule) filterRule;
-            return compareInt(ip4SubnetFilterRule.networkAddress, NetUtil.ipv4AddressToInt((Inet4Address)
-                    inetSocketAddress.getAddress()) & ip4SubnetFilterRule.subnetMask);
+            Inet4Address address = (Inet4Address) inetSocketAddress.getAddress();
+            int networkAddress = NetUtil.ipv4AddressToInt(address) & ip4SubnetFilterRule.subnetMask;
+            return Integer.compare(ip4SubnetFilterRule.networkAddress, networkAddress);
         } else {
             Ip6SubnetFilterRule ip6SubnetFilterRule = (Ip6SubnetFilterRule) filterRule;
-            return ip6SubnetFilterRule.networkAddress
-                    .compareTo(Ip6SubnetFilterRule.ipToInt((Inet6Address) inetSocketAddress.getAddress())
-                            .and(ip6SubnetFilterRule.networkAddress));
+            Inet6Address address = (Inet6Address) inetSocketAddress.getAddress();
+            BigInteger networkAddress = Ip6SubnetFilterRule.ipToInt(address).and(ip6SubnetFilterRule.networkAddress);
+            return ip6SubnetFilterRule.networkAddress.compareTo(networkAddress);
         }
-    }
-
-    /**
-     * Equivalent to {@link Integer#compare(int, int)}
-     */
-    private static int compareInt(int x, int y) {
-        return (x < y) ? -1 : ((x == y) ? 0 : 1);
     }
 
     static final class Ip4SubnetFilterRule implements IpFilterRule {

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
@@ -71,6 +71,7 @@ import static io.netty.handler.ssl.SslProvider.isOptionSupported;
 import static io.netty.internal.tcnative.SSL.SSL_CVERIFY_IGNORED;
 import static java.lang.Integer.MAX_VALUE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static java.lang.Integer.parseInt;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -183,24 +184,22 @@ public class OpenSslEngineTest extends SSLEngineTest {
         if (versionStringParts.length == 2 && "LibreSSL".equals(versionStringParts[0])) {
             String[] versionParts = versionStringParts[1].split("\\.", -1);
             if (versionParts.length == 3) {
-                int major = Integer.parseInt(versionParts[0]);
+                int major = parseInt(versionParts[0]);
                 if (major < 2) {
                     return true;
                 }
                 if (major > 2) {
                     return false;
                 }
-                int minor = Integer.parseInt(versionParts[1]);
+                int minor = parseInt(versionParts[1]);
                 if (minor < 6) {
                     return true;
                 }
                 if (minor > 6) {
                     return false;
                 }
-                int bugfix = Integer.parseInt(versionParts[2]);
-                if (bugfix > 0) {
-                    return false;
-                }
+                int bugfix = parseInt(versionParts[2]);
+                return bugfix <= 0;
             }
         }
         return true;

--- a/microbench/src/main/java/io/netty/handler/codec/http2/HpackBenchmarkUtil.java
+++ b/microbench/src/main/java/io/netty/handler/codec/http2/HpackBenchmarkUtil.java
@@ -108,7 +108,8 @@ public final class HpackBenchmarkUtil {
     static Http2Headers http2Headers(HpackHeadersSize size, boolean limitToAscii) {
         List<HpackHeader> hpackHeaders = headersMap.get(new HeadersKey(size, limitToAscii));
         Http2Headers http2Headers = new DefaultHttp2Headers(false);
-        for (HpackHeader hpackHeader : hpackHeaders) {
+        for (int i = 0; i < hpackHeaders.size(); ++i) {
+            HpackHeader hpackHeader = hpackHeaders.get(i);
             http2Headers.add(hpackHeader.name, hpackHeader.value);
         }
         return http2Headers;

--- a/microbench/src/main/java/io/netty/handler/codec/http2/HpackBenchmarkUtil.java
+++ b/microbench/src/main/java/io/netty/handler/codec/http2/HpackBenchmarkUtil.java
@@ -34,7 +34,9 @@ package io.netty.handler.codec.http2;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
+
+import static io.netty.util.internal.ObjectUtil.hash;
+import static io.netty.util.internal.ObjectUtil.hashSum;
 
 /**
  * Utility methods for hpack tests.
@@ -78,7 +80,7 @@ public final class HpackBenchmarkUtil {
 
         @Override
         public int hashCode() {
-            return Objects.hash(size, limitToAscii);
+            return hashSum(hash(size), hash(limitToAscii));
         }
     }
 

--- a/microbench/src/main/java/io/netty/handler/codec/http2/HpackBenchmarkUtil.java
+++ b/microbench/src/main/java/io/netty/handler/codec/http2/HpackBenchmarkUtil.java
@@ -34,6 +34,7 @@ package io.netty.handler.codec.http2;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Utility methods for hpack tests.
@@ -77,9 +78,7 @@ public final class HpackBenchmarkUtil {
 
         @Override
         public int hashCode() {
-            int result = size.hashCode();
-            result = 31 * result + (limitToAscii ? 1 : 0);
-            return result;
+            return Objects.hash(size, limitToAscii);
         }
     }
 
@@ -87,7 +86,7 @@ public final class HpackBenchmarkUtil {
 
     static {
         HpackHeadersSize[] sizes = HpackHeadersSize.values();
-        headersMap = new HashMap<HeadersKey, List<HpackHeader>>(sizes.length * 2);
+        headersMap = new HashMap<>(sizes.length * 2);
         for (HpackHeadersSize size : sizes) {
             HeadersKey key = new HeadersKey(size, true);
             headersMap.put(key, key.newHeaders());
@@ -107,8 +106,7 @@ public final class HpackBenchmarkUtil {
     static Http2Headers http2Headers(HpackHeadersSize size, boolean limitToAscii) {
         List<HpackHeader> hpackHeaders = headersMap.get(new HeadersKey(size, limitToAscii));
         Http2Headers http2Headers = new DefaultHttp2Headers(false);
-        for (int i = 0; i < hpackHeaders.size(); ++i) {
-            HpackHeader hpackHeader = hpackHeaders.get(i);
+        for (HpackHeader hpackHeader : hpackHeaders) {
             http2Headers.add(hpackHeader.name, hpackHeader.value);
         }
         return http2Headers;

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContext.java
@@ -43,11 +43,11 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
-import java.util.Objects;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.TimeUnit;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import static io.netty.util.internal.ObjectUtil.hash;
 
 abstract class DnsQueryContext {
 
@@ -549,7 +549,7 @@ abstract class DnsQueryContext {
 
         @Override
         public int hashCode() {
-            return Objects.hash(response, sender(), recipient());
+            return hash(response, sender(), recipient());
         }
     }
 }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContext.java
@@ -43,6 +43,7 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.Objects;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.TimeUnit;
 
@@ -548,14 +549,7 @@ abstract class DnsQueryContext {
 
         @Override
         public int hashCode() {
-            int hashCode = response.hashCode();
-            if (sender() != null) {
-                hashCode = hashCode * 31 + sender().hashCode();
-            }
-            if (recipient() != null) {
-                hashCode = hashCode * 31 + recipient().hashCode();
-            }
-            return hashCode;
+            return Objects.hash(response, sender(), recipient());
         }
     }
 }

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/VSockAddress.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/VSockAddress.java
@@ -17,7 +17,8 @@
 package io.netty.channel.epoll;
 
 import java.net.SocketAddress;
-import java.util.Objects;
+
+import static io.netty.util.internal.ObjectUtil.hashSum;
 
 /**
  * A address for a
@@ -74,6 +75,6 @@ public final class VSockAddress extends SocketAddress {
 
     @Override
     public int hashCode() {
-        return Objects.hash(cid, port);
+        return hashSum(cid, port);
     }
 }

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/VSockAddress.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/VSockAddress.java
@@ -17,6 +17,7 @@
 package io.netty.channel.epoll;
 
 import java.net.SocketAddress;
+import java.util.Objects;
 
 /**
  * A address for a
@@ -73,8 +74,6 @@ public final class VSockAddress extends SocketAddress {
 
     @Override
     public int hashCode() {
-        int result = cid;
-        result = 31 * result + port;
-        return result;
+        return Objects.hash(cid, port);
     }
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRingConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRingConfig.java
@@ -19,8 +19,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.util.internal.MathUtil;
 import io.netty.util.internal.ObjectUtil;
 
-import java.util.Objects;
-
 /**
  * Configuration class for an {@link IoUringBufferRing}.
  * It will configure the buffer ring size, buffer group id and the chunk size.
@@ -177,7 +175,7 @@ public final class IoUringBufferRingConfig {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(bgId);
+        return Short.hashCode(bgId);
     }
 
     public static Builder builder() {

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AcceptFilter.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AcceptFilter.java
@@ -18,6 +18,8 @@ package io.netty.channel.kqueue;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.UnstableApi;
 
+import java.util.Objects;
+
 @UnstableApi
 public final class AcceptFilter {
     static final AcceptFilter PLATFORM_UNSUPPORTED = new AcceptFilter("", "");
@@ -51,7 +53,7 @@ public final class AcceptFilter {
 
     @Override
     public int hashCode() {
-        return 31 * (31 + filterName.hashCode()) + filterArgs.hashCode();
+        return Objects.hash(filterName, filterArgs);
     }
 
     @Override

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AcceptFilter.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AcceptFilter.java
@@ -18,7 +18,7 @@ package io.netty.channel.kqueue;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.UnstableApi;
 
-import java.util.Objects;
+import static io.netty.util.internal.ObjectUtil.hash;
 
 @UnstableApi
 public final class AcceptFilter {
@@ -53,7 +53,7 @@ public final class AcceptFilter {
 
     @Override
     public int hashCode() {
-        return Objects.hash(filterName, filterArgs);
+        return hash(filterName, filterArgs);
     }
 
     @Override

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollReuseAddrTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollReuseAddrTest.java
@@ -220,9 +220,7 @@ public class EpollReuseAddrTest {
             if (MINOR > minor) {
                 return true;
             } else if (MINOR == minor) {
-                if (BUGFIX >= bugfix) {
-                    return true;
-                }
+                return BUGFIX >= bugfix;
             }
         }
         return false;

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/SctpMessage.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/SctpMessage.java
@@ -20,7 +20,8 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.DefaultByteBufHolder;
 import io.netty.util.internal.ObjectUtil;
 
-import java.util.Objects;
+import static io.netty.util.internal.ObjectUtil.hash;
+import static io.netty.util.internal.ObjectUtil.hashSum;
 
 /**
  * Representation of SCTP Data Chunk
@@ -140,7 +141,7 @@ public final class SctpMessage extends DefaultByteBufHolder {
 
     @Override
     public int hashCode() {
-        return Objects.hash(streamIdentifier, protocolIdentifier, unordered, content());
+        return hashSum(streamIdentifier, protocolIdentifier, hash(unordered), hash(content()));
     }
 
     @Override

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/SctpMessage.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/SctpMessage.java
@@ -20,6 +20,8 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.DefaultByteBufHolder;
 import io.netty.util.internal.ObjectUtil;
 
+import java.util.Objects;
+
 /**
  * Representation of SCTP Data Chunk
  */
@@ -138,12 +140,7 @@ public final class SctpMessage extends DefaultByteBufHolder {
 
     @Override
     public int hashCode() {
-        int result = streamIdentifier;
-        result = 31 * result + protocolIdentifier;
-        // values 1231 and 1237 are referenced in the javadocs of Boolean#hashCode()
-        result = 31 * result + (unordered ? 1231 : 1237);
-        result = 31 * result + content().hashCode();
-        return result;
+        return Objects.hash(streamIdentifier, protocolIdentifier, unordered, content());
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/ManualIoEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/ManualIoEventLoop.java
@@ -567,10 +567,7 @@ public final class ManualIoEventLoop extends AbstractScheduledEventExecutor impl
             // There were tasks in the queue. Wait a little bit more until no tasks are queued for the quiet period or
             // terminate if the quiet period is 0.
             // See https://github.com/netty/netty/issues/4241
-            if (gracefulShutdownQuietPeriod == 0) {
-                return true;
-            }
-            return false;
+            return gracefulShutdownQuietPeriod == 0;
         }
 
         final long nanoTime = ticker.nanoTime();

--- a/transport/src/test/java/io/netty/nativeimage/ChannelHandlerMetadataUtil.java
+++ b/transport/src/test/java/io/netty/nativeimage/ChannelHandlerMetadataUtil.java
@@ -32,10 +32,9 @@ import java.net.URL;
 import java.text.Collator;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -66,7 +65,7 @@ public final class ChannelHandlerMetadataUtil {
             subtypes.add(ChannelHandler.class);
         }
 
-        Set<HandlerMetadata> handlerMetadata = new HashSet<HandlerMetadata>();
+        Set<HandlerMetadata> handlerMetadata = new HashSet<>();
         for (Class<?> subtype : subtypes) {
             handlerMetadata.add(new HandlerMetadata(subtype.getName(), new Condition(subtype.getName()), true));
         }
@@ -76,7 +75,7 @@ public final class ChannelHandlerMetadataUtil {
         File existingMetadataFile = new File(projectRelativeResourcePath);
         String existingMetadataPath = existingMetadataFile.getAbsolutePath();
         if (!existingMetadataFile.exists()) {
-            if (handlerMetadata.size() == 0) {
+            if (handlerMetadata.isEmpty()) {
                 return;
             }
 
@@ -97,10 +96,10 @@ public final class ChannelHandlerMetadataUtil {
             Assertions.fail("Failed to open the native-image metadata file at: " + existingMetadataPath, e);
         }
 
-        Set<HandlerMetadata> newMetadata = new HashSet<HandlerMetadata>(handlerMetadata);
-        newMetadata.removeAll(existingMetadata);
+        Set<HandlerMetadata> newMetadata = new HashSet<>(handlerMetadata);
+        existingMetadata.forEach(newMetadata::remove);
 
-        Set<HandlerMetadata> removedMetadata = new HashSet<HandlerMetadata>(existingMetadata);
+        Set<HandlerMetadata> removedMetadata = new HashSet<>(existingMetadata);
         removedMetadata.removeAll(handlerMetadata);
 
         if (!newMetadata.isEmpty() || !removedMetadata.isEmpty()) {
@@ -133,7 +132,7 @@ public final class ChannelHandlerMetadataUtil {
                         .forPackages(packageNames));
 
         Set<Class<? extends ChannelHandler>> allSubtypes = reflections.getSubTypesOf(ChannelHandler.class);
-        Set<Class<? extends ChannelHandler>> targetSubtypes = new HashSet<Class<? extends ChannelHandler>>();
+        Set<Class<? extends ChannelHandler>> targetSubtypes = new HashSet<>();
 
         for (Class<? extends ChannelHandler> subtype : allSubtypes) {
             if (isTestClass(subtype)) {
@@ -168,13 +167,8 @@ public final class ChannelHandlerMetadataUtil {
     }
 
     private static String getMetadataJsonString(Set<HandlerMetadata> metadata) {
-        List<HandlerMetadata> metadataList = new ArrayList<HandlerMetadata>(metadata);
-        Collections.sort(metadataList, new Comparator<HandlerMetadata>() {
-            @Override
-            public int compare(HandlerMetadata h1, HandlerMetadata h2) {
-                return Collator.getInstance().compare(h1.name, h2.name);
-            }
-        });
+        List<HandlerMetadata> metadataList = new ArrayList<>(metadata);
+        metadataList.sort((h1, h2) -> Collator.getInstance().compare(h1.name, h2.name));
         return gson.toJson(metadataList, HANDLER_METADATA_LIST_TYPE);
     }
 
@@ -233,8 +227,8 @@ public final class ChannelHandlerMetadataUtil {
 
             HandlerMetadata that = (HandlerMetadata) o;
             return queryAllPublicMethods == that.queryAllPublicMethods
-                    && (name != null && name.equals(that.name))
-                    && (condition != null && condition.equals(that.condition));
+                    && Objects.equals(name, that.name)
+                    && Objects.equals(condition, that.condition);
         }
 
         @Override


### PR DESCRIPTION
this commit mostly simplifies "equals" and "hashCode" implementations by using Java built-in methods `Objects.equals` and `Objects.hash`.

Motivation:

Improve Netty codebase.

Modification:

Small refactorings that simplify code and don't affect functionality.

Result:

Slightly improved code: simplified IFs, shortened methods.
