### PR TITLE
fix build

### DIFF
--- a/microbench/src/main/java/io/netty/buffer/ByteBufZeroingBenchmark.java
+++ b/microbench/src/main/java/io/netty/buffer/ByteBufZeroingBenchmark.java
@@ -49,7 +49,7 @@ public class ByteBufZeroingBenchmark extends AbstractMicrobenchmark {
             "65",
             "1024",
     })
-    private final int bytes = 1024;
+    private int bytes = 1024;
     @Param({
             "true",
             "false",


### PR DESCRIPTION
Command "./mvnw verify" fails with the following error:

```
Error:  /home/runner/work/netty/netty/microbench/src/main/java/io/netty/buffer/ByteBufZeroingBenchmark.java:[52,22] 
error: @Param annotation is not acceptable on final fields.
```

Motivation:

Fix failing build in branch `4.2`

Modification:

Made field non-final (in other words, partially reverted PR https://github.com/netty/netty/pull/15114)

Result:

The build should get green on GitHub Acitons.