### PR TITLE
fix checkstyle violation

### DIFF
--- a/microbench/src/main/java/io/netty5/microbench/util/AbstractSharedExecutorMicrobenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/util/AbstractSharedExecutorMicrobenchmark.java
@@ -65,7 +65,6 @@ public class AbstractSharedExecutorMicrobenchmark extends AbstractMicrobenchmark
         private static EventLoop executor;
         private static final Logger logger = LoggerFactory.getLogger(DelegateHarnessExecutor.class);
 
-
         public DelegateHarnessExecutor(int maxThreads, String prefix) {
             logger.debug("Using DelegateHarnessExecutor executor {}", this);
         }


### PR DESCRIPTION
Motivation:
A checkstyle violation was introduced in commit 53817804f32cd5305e185d5d9ca484bf8bb1963b

Modification:
Remove duplicate newline that causes the checkstyle violation.

Result:
No more build failures due to checkstyle violations.
