### PR TITLE
Use keytool from java.home

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/util/KeytoolSelfSignedCertGenerator.java
+++ b/handler/src/main/java/io/netty/handler/ssl/util/KeytoolSelfSignedCertGenerator.java
@@ -80,7 +80,7 @@ final class KeytoolSelfSignedCertGenerator {
         try {
             Process process = new ProcessBuilder()
                     .command(
-                            "keytool",
+                            KEYTOOL.toAbsolutePath().toString(),
                             "-genkeypair",
                             "-keyalg", builder.algorithm,
                             "-keysize", String.valueOf(builder.bits),


### PR DESCRIPTION
Motivation:

We used java.home for keytool discovery, but the normal PATH for actually running the keytool. The PATH keytool might not match the one we discovered, or it might even be missing entirely.

Modification:

Use the keytool from java.home.

Result:

No discrepancy depending on PATH.