### PR TITLE
Make public API specify explicit maxAllocation to prevent OOM (#15005)

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/DeflateDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/DeflateDecoder.java
@@ -50,6 +50,7 @@ abstract class DeflateDecoder extends WebSocketExtensionDecoder {
 
     private final boolean noContext;
     private final WebSocketExtensionFilter extensionDecoderFilter;
+    private final int maxAllocation;
 
     private EmbeddedChannel decoder;
 
@@ -59,9 +60,10 @@ abstract class DeflateDecoder extends WebSocketExtensionDecoder {
      * @param noContext true to disable context takeover.
      * @param extensionDecoderFilter extension decoder filter.
      */
-    DeflateDecoder(boolean noContext, WebSocketExtensionFilter extensionDecoderFilter) {
+    DeflateDecoder(boolean noContext, WebSocketExtensionFilter extensionDecoderFilter, int maxAllocation) {
         this.noContext = noContext;
         this.extensionDecoderFilter = checkNotNull(extensionDecoderFilter, "extensionDecoderFilter");
+        this.maxAllocation = maxAllocation;
     }
 
     /**
@@ -110,7 +112,7 @@ abstract class DeflateDecoder extends WebSocketExtensionDecoder {
             if (!(msg instanceof TextWebSocketFrame) && !(msg instanceof BinaryWebSocketFrame)) {
                 throw new CodecException("unexpected initial frame type: " + msg.getClass().getName());
             }
-            decoder = new EmbeddedChannel(ZlibCodecFactory.newZlibDecoder(ZlibWrapper.NONE));
+            decoder = new EmbeddedChannel(ZlibCodecFactory.newZlibDecoder(ZlibWrapper.NONE, maxAllocation));
         }
 
         boolean readable = msg.content().isReadable();

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/DeflateFrameClientExtensionHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/DeflateFrameClientExtensionHandshaker.java
@@ -36,12 +36,27 @@ public final class DeflateFrameClientExtensionHandshaker implements WebSocketCli
     private final int compressionLevel;
     private final boolean useWebkitExtensionName;
     private final WebSocketExtensionFilterProvider extensionFilterProvider;
+    private final int maxAllocation;
 
     /**
      * Constructor with default configuration.
+     *
+     * @deprecated
+     *            Use {@link DeflateFrameClientExtensionHandshaker#DeflateFrameClientExtensionHandshaker(boolean, int)}.
      */
+    @Deprecated
     public DeflateFrameClientExtensionHandshaker(boolean useWebkitExtensionName) {
-        this(6, useWebkitExtensionName);
+        this(6, useWebkitExtensionName, 0);
+    }
+
+    /**
+     * Constructor with default configuration.
+     *
+     * @param maxAllocation
+     *            Maximum size of the decompression buffer. Must be &gt;= 0. If zero, maximum size is not limited.
+     */
+    public DeflateFrameClientExtensionHandshaker(boolean useWebkitExtensionName, int maxAllocation) {
+        this(6, useWebkitExtensionName, maxAllocation);
     }
 
     /**
@@ -49,9 +64,26 @@ public final class DeflateFrameClientExtensionHandshaker implements WebSocketCli
      *
      * @param compressionLevel
      *            Compression level between 0 and 9 (default is 6).
+     * @deprecated
+     *            Use {@link
+     *            DeflateFrameClientExtensionHandshaker#DeflateFrameClientExtensionHandshaker(int, boolean, int)}.
      */
+    @Deprecated
     public DeflateFrameClientExtensionHandshaker(int compressionLevel, boolean useWebkitExtensionName) {
-        this(compressionLevel, useWebkitExtensionName, WebSocketExtensionFilterProvider.DEFAULT);
+        this(compressionLevel, useWebkitExtensionName, 0);
+    }
+
+    /**
+     * Constructor with custom configuration.
+     *
+     * @param compressionLevel
+     *            Compression level between 0 and 9 (default is 6).
+     * @param maxAllocation
+     *            Maximum size of the decompression buffer. Must be &gt;= 0. If zero, maximum size is not limited.
+     */
+    public DeflateFrameClientExtensionHandshaker(int compressionLevel, boolean useWebkitExtensionName,
+                                                 int maxAllocation) {
+        this(compressionLevel, useWebkitExtensionName, WebSocketExtensionFilterProvider.DEFAULT, maxAllocation);
     }
 
     /**
@@ -61,9 +93,28 @@ public final class DeflateFrameClientExtensionHandshaker implements WebSocketCli
      *            Compression level between 0 and 9 (default is 6).
      * @param extensionFilterProvider
      *            provides client extension filters for per frame deflate encoder and decoder.
+     * @deprecated
+     *            Use {@link DeflateFrameClientExtensionHandshaker#DeflateFrameClientExtensionHandshaker(int, boolean,
+     *            WebSocketExtensionFilterProvider, int)}.
+     */
+    @Deprecated
+    public DeflateFrameClientExtensionHandshaker(int compressionLevel, boolean useWebkitExtensionName,
+                                                 WebSocketExtensionFilterProvider extensionFilterProvider) {
+        this(compressionLevel, useWebkitExtensionName, extensionFilterProvider, 0);
+    }
+
+    /**
+     * Constructor with custom configuration.
+     *
+     * @param compressionLevel
+     *            Compression level between 0 and 9 (default is 6).
+     * @param extensionFilterProvider
+     *            provides client extension filters for per frame deflate encoder and decoder.
+     * @param maxAllocation
+     *            Maximum size of the decompression buffer. Must be &gt;= 0. If zero, maximum size is not limited.
      */
     public DeflateFrameClientExtensionHandshaker(int compressionLevel, boolean useWebkitExtensionName,
-            WebSocketExtensionFilterProvider extensionFilterProvider) {
+            WebSocketExtensionFilterProvider extensionFilterProvider, int maxAllocation) {
         if (compressionLevel < 0 || compressionLevel > 9) {
             throw new IllegalArgumentException(
                     "compressionLevel: " + compressionLevel + " (expected: 0-9)");
@@ -71,6 +122,7 @@ public final class DeflateFrameClientExtensionHandshaker implements WebSocketCli
         this.compressionLevel = compressionLevel;
         this.useWebkitExtensionName = useWebkitExtensionName;
         this.extensionFilterProvider = checkNotNull(extensionFilterProvider, "extensionFilterProvider");
+        this.maxAllocation = checkPositiveOrZero(maxAllocation, "maxAllocation");
     }
 
     @Override
@@ -88,7 +140,7 @@ public final class DeflateFrameClientExtensionHandshaker implements WebSocketCli
         }
 
         if (extensionData.parameters().isEmpty()) {
-            return new DeflateFrameClientExtension(compressionLevel, extensionFilterProvider);
+            return new DeflateFrameClientExtension(compressionLevel, extensionFilterProvider, maxAllocation);
         } else {
             return null;
         }
@@ -98,10 +150,13 @@ public final class DeflateFrameClientExtensionHandshaker implements WebSocketCli
 
         private final int compressionLevel;
         private final WebSocketExtensionFilterProvider extensionFilterProvider;
+        private final int maxAllocation;
 
-        DeflateFrameClientExtension(int compressionLevel, WebSocketExtensionFilterProvider extensionFilterProvider) {
+        DeflateFrameClientExtension(int compressionLevel, WebSocketExtensionFilterProvider extensionFilterProvider,
+                                    int maxAllocation) {
             this.compressionLevel = compressionLevel;
             this.extensionFilterProvider = extensionFilterProvider;
+            this.maxAllocation = maxAllocation;
         }
 
         @Override
@@ -117,7 +172,7 @@ public final class DeflateFrameClientExtensionHandshaker implements WebSocketCli
 
         @Override
         public WebSocketExtensionDecoder newExtensionDecoder() {
-            return new PerFrameDeflateDecoder(false, extensionFilterProvider.decoderFilter());
+            return new PerFrameDeflateDecoder(false, extensionFilterProvider.decoderFilter(), maxAllocation);
         }
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerFrameDeflateDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerFrameDeflateDecoder.java
@@ -31,9 +31,11 @@ class PerFrameDeflateDecoder extends DeflateDecoder {
      * Constructor
      *
      * @param noContext true to disable context takeover.
+     * @param maxAllocation
+     *          maximum size of the decompression buffer. Must be &gt;= 0. If zero, maximum size is not limited.
      */
-    PerFrameDeflateDecoder(boolean noContext) {
-        super(noContext, WebSocketExtensionFilter.NEVER_SKIP);
+    PerFrameDeflateDecoder(boolean noContext, int maxAllocation) {
+        super(noContext, WebSocketExtensionFilter.NEVER_SKIP, maxAllocation);
     }
 
     /**
@@ -41,9 +43,11 @@ class PerFrameDeflateDecoder extends DeflateDecoder {
      *
      * @param noContext true to disable context takeover.
      * @param extensionDecoderFilter extension decoder filter for per frame deflate decoder.
+     * @param maxAllocation
+     *            maximum size of the decompression buffer. Must be &gt;= 0. If zero, maximum size is not limited.
      */
-    PerFrameDeflateDecoder(boolean noContext, WebSocketExtensionFilter extensionDecoderFilter) {
-        super(noContext, extensionDecoderFilter);
+    PerFrameDeflateDecoder(boolean noContext, WebSocketExtensionFilter extensionDecoderFilter, int maxAllocation) {
+        super(noContext, extensionDecoderFilter, maxAllocation);
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateDecoder.java
@@ -36,9 +36,11 @@ class PerMessageDeflateDecoder extends DeflateDecoder {
      * Constructor
      *
      * @param noContext true to disable context takeover.
+     * @param maxAllocation
+     *             maximum size of the decompression buffer. Must be &gt;= 0. If zero, maximum size is not limited.
      */
-    PerMessageDeflateDecoder(boolean noContext) {
-        super(noContext, WebSocketExtensionFilter.NEVER_SKIP);
+    PerMessageDeflateDecoder(boolean noContext, int maxAllocation) {
+        super(noContext, WebSocketExtensionFilter.NEVER_SKIP, maxAllocation);
     }
 
     /**
@@ -46,9 +48,11 @@ class PerMessageDeflateDecoder extends DeflateDecoder {
      *
      * @param noContext true to disable context takeover.
      * @param extensionDecoderFilter extension decoder for per message deflate decoder.
+     * @param maxAllocation
+     *            maximum size of the decompression buffer. Must be &gt;= 0. If zero, maximum size is not limited.
      */
-    PerMessageDeflateDecoder(boolean noContext, WebSocketExtensionFilter extensionDecoderFilter) {
-        super(noContext, extensionDecoderFilter);
+    PerMessageDeflateDecoder(boolean noContext, WebSocketExtensionFilter extensionDecoderFilter, int maxAllocation) {
+        super(noContext, extensionDecoderFilter, maxAllocation);
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/WebSocketClientCompressionHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/WebSocketClientCompressionHandler.java
@@ -27,12 +27,25 @@ import io.netty.handler.codec.http.websocketx.extensions.WebSocketClientExtensio
 @ChannelHandler.Sharable
 public final class WebSocketClientCompressionHandler extends WebSocketClientExtensionHandler {
 
+    /**
+     * @deprecated Use {@link WebSocketClientCompressionHandler#WebSocketClientCompressionHandler(int)}
+     */
+    @Deprecated
     public static final WebSocketClientCompressionHandler INSTANCE = new WebSocketClientCompressionHandler();
 
     private WebSocketClientCompressionHandler() {
-        super(new PerMessageDeflateClientExtensionHandshaker(),
-                new DeflateFrameClientExtensionHandshaker(false),
-                new DeflateFrameClientExtensionHandshaker(true));
+        this(0);
+    }
+
+    /**
+     * Constructor with default configuration.
+     * @param maxAllocation
+     *            Maximum size of the decompression buffer. Must be &gt;= 0. If zero, maximum size is not limited.
+     */
+    public WebSocketClientCompressionHandler(int maxAllocation) {
+        super(new PerMessageDeflateClientExtensionHandshaker(maxAllocation),
+                new DeflateFrameClientExtensionHandshaker(false, maxAllocation),
+                new DeflateFrameClientExtensionHandshaker(true, maxAllocation));
     }
 
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/WebSocketServerCompressionHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/WebSocketServerCompressionHandler.java
@@ -27,10 +27,25 @@ public class WebSocketServerCompressionHandler extends WebSocketServerExtensionH
 
     /**
      * Constructor with default configuration.
+     *
+     * @deprecated
+     *            Use {@link WebSocketServerCompressionHandler#WebSocketServerCompressionHandler(int)}.
      */
+    @Deprecated
     public WebSocketServerCompressionHandler() {
-        super(new PerMessageDeflateServerExtensionHandshaker(),
-                new DeflateFrameServerExtensionHandshaker());
+        this(0);
+    }
+
+    /**
+     * Constructor with default configuration.
+     *
+     * @param maxAllocation
+     *            Maximum size of the decompression buffer. Must be &gt;= 0. If zero, maximum size is not limited.
+     */
+    public WebSocketServerCompressionHandler(int maxAllocation) {
+        super(new PerMessageDeflateServerExtensionHandshaker(maxAllocation),
+                new DeflateFrameServerExtensionHandshaker(
+                        DeflateFrameServerExtensionHandshaker.DEFAULT_COMPRESSION_LEVEL, maxAllocation));
     }
 
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentDecoderTest.java
@@ -90,7 +90,7 @@ public class HttpContentDecoderTest {
     public void testRequestDecompression() {
         // baseline test: request decoder, content decompressor && request aggregator work as expected
         HttpRequestDecoder decoder = new HttpRequestDecoder();
-        HttpContentDecoder decompressor = new HttpContentDecompressor();
+        HttpContentDecoder decompressor = new HttpContentDecompressor(0);
         HttpObjectAggregator aggregator = new HttpObjectAggregator(1024);
         EmbeddedChannel channel = new EmbeddedChannel(decoder, decompressor, aggregator);
 
@@ -116,7 +116,7 @@ public class HttpContentDecoderTest {
     @Test
     public void testChunkedRequestDecompression() {
         HttpResponseDecoder decoder = new HttpResponseDecoder();
-        HttpContentDecoder decompressor = new HttpContentDecompressor();
+        HttpContentDecoder decompressor = new HttpContentDecompressor(0);
 
         EmbeddedChannel channel = new EmbeddedChannel(decoder, decompressor, null);
 
@@ -159,7 +159,7 @@ public class HttpContentDecoderTest {
     public void testSnappyResponseDecompression() {
         // baseline test: response decoder, content decompressor && request aggregator work as expected
         HttpResponseDecoder decoder = new HttpResponseDecoder();
-        HttpContentDecoder decompressor = new HttpContentDecompressor();
+        HttpContentDecoder decompressor = new HttpContentDecompressor(0);
         HttpObjectAggregator aggregator = new HttpObjectAggregator(1024);
         EmbeddedChannel channel = new EmbeddedChannel(decoder, decompressor, aggregator);
 
@@ -186,7 +186,7 @@ public class HttpContentDecoderTest {
     public void testResponseDecompression() {
         // baseline test: response decoder, content decompressor && request aggregator work as expected
         HttpResponseDecoder decoder = new HttpResponseDecoder();
-        HttpContentDecoder decompressor = new HttpContentDecompressor();
+        HttpContentDecoder decompressor = new HttpContentDecompressor(0);
         HttpObjectAggregator aggregator = new HttpObjectAggregator(1024);
 
         EmbeddedChannel channel = new EmbeddedChannel(decoder, decompressor, aggregator);
@@ -216,7 +216,7 @@ public class HttpContentDecoderTest {
         Brotli.ensureAvailability();
 
         HttpResponseDecoder decoder = new HttpResponseDecoder();
-        HttpContentDecoder decompressor = new HttpContentDecompressor();
+        HttpContentDecoder decompressor = new HttpContentDecompressor(0);
         HttpObjectAggregator aggregator = new HttpObjectAggregator(Integer.MAX_VALUE);
         EmbeddedChannel channel = new EmbeddedChannel(decoder, decompressor, aggregator);
 
@@ -246,7 +246,7 @@ public class HttpContentDecoderTest {
         Brotli.ensureAvailability();
 
         HttpResponseDecoder decoder = new HttpResponseDecoder();
-        HttpContentDecoder decompressor = new HttpContentDecompressor();
+        HttpContentDecoder decompressor = new HttpContentDecompressor(0);
         HttpObjectAggregator aggregator = new HttpObjectAggregator(Integer.MAX_VALUE);
         EmbeddedChannel channel = new EmbeddedChannel(decoder, decompressor, aggregator);
 
@@ -284,7 +284,7 @@ public class HttpContentDecoderTest {
     @Test
     public void testResponseZstdDecompression() throws Throwable {
         HttpResponseDecoder decoder = new HttpResponseDecoder();
-        HttpContentDecoder decompressor = new HttpContentDecompressor();
+        HttpContentDecoder decompressor = new HttpContentDecompressor(0);
         HttpObjectAggregator aggregator = new HttpObjectAggregator(Integer.MAX_VALUE);
         EmbeddedChannel channel = new EmbeddedChannel(decoder, decompressor, aggregator);
 
@@ -311,7 +311,7 @@ public class HttpContentDecoderTest {
     @Test
     public void testResponseChunksZstdDecompression() throws Throwable {
         HttpResponseDecoder decoder = new HttpResponseDecoder();
-        HttpContentDecoder decompressor = new HttpContentDecompressor();
+        HttpContentDecoder decompressor = new HttpContentDecompressor(0);
         HttpObjectAggregator aggregator = new HttpObjectAggregator(Integer.MAX_VALUE);
         EmbeddedChannel channel = new EmbeddedChannel(decoder, decompressor, aggregator);
 
@@ -379,7 +379,7 @@ public class HttpContentDecoderTest {
         // request with header "Expect: 100-continue" must be replied with one "100 Continue" response
         // case 2: contentDecoder is in chain, but the content is not encoded, should be no-op
         HttpRequestDecoder decoder = new HttpRequestDecoder();
-        HttpContentDecoder decompressor = new HttpContentDecompressor();
+        HttpContentDecoder decompressor = new HttpContentDecompressor(0);
         HttpObjectAggregator aggregator = new HttpObjectAggregator(1024);
         EmbeddedChannel channel = new EmbeddedChannel(decoder, decompressor, aggregator);
         String req = "POST / HTTP/1.1\r\n" +
@@ -405,7 +405,7 @@ public class HttpContentDecoderTest {
         // request with header "Expect: 100-continue" must be replied with one "100 Continue" response
         // case 3: ContentDecoder is in chain and content is encoded
         HttpRequestDecoder decoder = new HttpRequestDecoder();
-        HttpContentDecoder decompressor = new HttpContentDecompressor();
+        HttpContentDecoder decompressor = new HttpContentDecompressor(0);
         HttpObjectAggregator aggregator = new HttpObjectAggregator(1024);
         EmbeddedChannel channel = new EmbeddedChannel(decoder, decompressor, aggregator);
         String req = "POST / HTTP/1.1\r\n" +
@@ -433,7 +433,7 @@ public class HttpContentDecoderTest {
         // case 4: ObjectAggregator is up in chain
         HttpRequestDecoder decoder = new HttpRequestDecoder();
         HttpObjectAggregator aggregator = new HttpObjectAggregator(1024);
-        HttpContentDecoder decompressor = new HttpContentDecompressor();
+        HttpContentDecoder decompressor = new HttpContentDecompressor(0);
         EmbeddedChannel channel = new EmbeddedChannel(decoder, aggregator, decompressor);
         String req = "POST / HTTP/1.1\r\n" +
                      "Content-Length: " + GZ_HELLO_WORLD.length + "\r\n" +
@@ -515,7 +515,7 @@ public class HttpContentDecoderTest {
 
         // force content to be in more than one chunk (5 bytes/chunk)
         HttpRequestDecoder decoder = new HttpRequestDecoder(4096, 4096, 5);
-        HttpContentDecoder decompressor = new HttpContentDecompressor();
+        HttpContentDecoder decompressor = new HttpContentDecompressor(0);
         EmbeddedChannel channel = new EmbeddedChannel(decoder, decompressor);
         String headers = "POST / HTTP/1.1\r\n" +
                          "Content-Length: " + GZ_HELLO_WORLD.length + "\r\n" +
@@ -544,7 +544,7 @@ public class HttpContentDecoderTest {
 
         // force content to be in more than one chunk (5 bytes/chunk)
         HttpRequestDecoder decoder = new HttpRequestDecoder(4096, 4096, 5);
-        HttpContentDecoder decompressor = new HttpContentDecompressor();
+        HttpContentDecoder decompressor = new HttpContentDecompressor(0);
         HttpObjectAggregator aggregator = new HttpObjectAggregator(1024);
         EmbeddedChannel channel = new EmbeddedChannel(decoder, decompressor, aggregator);
         String headers = "POST / HTTP/1.1\r\n" +
@@ -576,7 +576,7 @@ public class HttpContentDecoderTest {
 
         // force content to be in more than one chunk (5 bytes/chunk)
         HttpResponseDecoder decoder = new HttpResponseDecoder(4096, 4096, 5);
-        HttpContentDecoder decompressor = new HttpContentDecompressor();
+        HttpContentDecoder decompressor = new HttpContentDecompressor(0);
         EmbeddedChannel channel = new EmbeddedChannel(decoder, decompressor);
         String headers = "HTTP/1.1 200 OK\r\n" +
                          "Content-Length: " + GZ_HELLO_WORLD.length + "\r\n" +
@@ -608,7 +608,7 @@ public class HttpContentDecoderTest {
 
         // force content to be in more than one chunk (5 bytes/chunk)
         HttpResponseDecoder decoder = new HttpResponseDecoder(4096, 4096, 5);
-        HttpContentDecoder decompressor = new HttpContentDecompressor();
+        HttpContentDecoder decompressor = new HttpContentDecompressor(0);
         HttpObjectAggregator aggregator = new HttpObjectAggregator(1024);
         EmbeddedChannel channel = new EmbeddedChannel(decoder, decompressor, aggregator);
         String headers = "HTTP/1.1 200 OK\r\n" +
@@ -637,7 +637,7 @@ public class HttpContentDecoderTest {
         // test that ContentDecoder can be used after the ObjectAggregator
         HttpRequestDecoder decoder = new HttpRequestDecoder(4096, 4096, 5);
         HttpObjectAggregator aggregator = new HttpObjectAggregator(1024);
-        HttpContentDecoder decompressor = new HttpContentDecompressor();
+        HttpContentDecoder decompressor = new HttpContentDecompressor(0);
         EmbeddedChannel channel = new EmbeddedChannel(decoder, aggregator, decompressor);
         String headers = "POST / HTTP/1.1\r\n" +
                          "Content-Length: " + GZ_HELLO_WORLD.length + "\r\n" +
@@ -664,7 +664,7 @@ public class HttpContentDecoderTest {
         // test that ContentDecoder can be used after the ObjectAggregator
         HttpResponseDecoder decoder = new HttpResponseDecoder(4096, 4096, 5);
         HttpObjectAggregator aggregator = new HttpObjectAggregator(1024);
-        HttpContentDecoder decompressor = new HttpContentDecompressor();
+        HttpContentDecoder decompressor = new HttpContentDecompressor(0);
         EmbeddedChannel channel = new EmbeddedChannel(decoder, aggregator, decompressor);
         String headers = "HTTP/1.1 200 OK\r\n" +
                          "Content-Length: " + GZ_HELLO_WORLD.length + "\r\n" +
@@ -691,7 +691,7 @@ public class HttpContentDecoderTest {
     public void testFullHttpResponseEOF() {
         // test that ContentDecoder can be used after the ObjectAggregator
         HttpResponseDecoder decoder = new HttpResponseDecoder(4096, 4096, 5);
-        HttpContentDecoder decompressor = new HttpContentDecompressor();
+        HttpContentDecoder decompressor = new HttpContentDecompressor(0);
         EmbeddedChannel channel = new EmbeddedChannel(decoder, decompressor);
         String headers = "HTTP/1.1 200 OK\r\n" +
                 "Content-Encoding: gzip\r\n" +
@@ -758,7 +758,7 @@ public class HttpContentDecoderTest {
                 "Transfer-Encoding: gzip\r\n" +
                 "\r\n";
         HttpRequestDecoder decoder = new HttpRequestDecoder();
-        HttpContentDecoder decompressor = new HttpContentDecompressor();
+        HttpContentDecoder decompressor = new HttpContentDecompressor(0);
         EmbeddedChannel channel = new EmbeddedChannel(decoder, decompressor);
 
         channel.writeInbound(Unpooled.copiedBuffer(requestStr.getBytes()));
@@ -792,7 +792,7 @@ public class HttpContentDecoderTest {
                 "Transfer-Encoding: gzip, chunked\r\n" +
                 "\r\n";
         HttpRequestDecoder decoder = new HttpRequestDecoder();
-        HttpContentDecoder decompressor = new HttpContentDecompressor();
+        HttpContentDecoder decompressor = new HttpContentDecompressor(0);
         EmbeddedChannel channel = new EmbeddedChannel(decoder, decompressor);
 
         assertTrue(channel.writeInbound(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)));
@@ -824,7 +824,7 @@ public class HttpContentDecoderTest {
     }
 
     private static byte[] gzDecompress(byte[] input) {
-        ZlibDecoder decoder = ZlibCodecFactory.newZlibDecoder(ZlibWrapper.GZIP);
+        ZlibDecoder decoder = ZlibCodecFactory.newZlibDecoder(ZlibWrapper.GZIP, 0);
         EmbeddedChannel channel = new EmbeddedChannel(decoder);
         assertTrue(channel.writeInbound(Unpooled.copiedBuffer(input)));
         assertTrue(channel.finish()); // close the channel to indicate end-of-data

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentDecompressorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentDecompressorTest.java
@@ -40,7 +40,7 @@ public class HttpContentDecompressorTest {
                 readCalled.incrementAndGet();
                 ctx.read();
             }
-        }, new HttpContentDecompressor(), new ChannelInboundHandlerAdapter() {
+        }, new HttpContentDecompressor(0), new ChannelInboundHandlerAdapter() {
             @Override
             public void channelRead(ChannelHandlerContext ctx, Object msg) {
                 ctx.fireChannelRead(msg);

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/DeflateFrameClientExtensionHandshakerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/DeflateFrameClientExtensionHandshakerTest.java
@@ -36,7 +36,7 @@ public class DeflateFrameClientExtensionHandshakerTest {
     @Test
     public void testWebkitDeflateFrameData() {
         DeflateFrameClientExtensionHandshaker handshaker =
-                new DeflateFrameClientExtensionHandshaker(true);
+                new DeflateFrameClientExtensionHandshaker(true, 0);
 
         WebSocketExtensionData data = handshaker.newRequestData();
 
@@ -47,7 +47,7 @@ public class DeflateFrameClientExtensionHandshakerTest {
     @Test
     public void testDeflateFrameData() {
         DeflateFrameClientExtensionHandshaker handshaker =
-                new DeflateFrameClientExtensionHandshaker(false);
+                new DeflateFrameClientExtensionHandshaker(false, 0);
 
         WebSocketExtensionData data = handshaker.newRequestData();
 
@@ -58,7 +58,7 @@ public class DeflateFrameClientExtensionHandshakerTest {
     @Test
     public void testNormalHandshake() {
         DeflateFrameClientExtensionHandshaker handshaker =
-                new DeflateFrameClientExtensionHandshaker(false);
+                new DeflateFrameClientExtensionHandshaker(false, 0);
 
         WebSocketClientExtension extension = handshaker.handshakeExtension(
                 new WebSocketExtensionData(DEFLATE_FRAME_EXTENSION, Collections.<String, String>emptyMap()));
@@ -73,7 +73,7 @@ public class DeflateFrameClientExtensionHandshakerTest {
     public void testFailedHandshake() {
         // initialize
         DeflateFrameClientExtensionHandshaker handshaker =
-                new DeflateFrameClientExtensionHandshaker(false);
+                new DeflateFrameClientExtensionHandshaker(false, 0);
 
         Map<String, String> parameters = new HashMap<String, String>();
         parameters.put("invalid", "12");

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/DeflateFrameServerExtensionHandshakerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/DeflateFrameServerExtensionHandshakerTest.java
@@ -37,7 +37,8 @@ public class DeflateFrameServerExtensionHandshakerTest {
     public void testNormalHandshake() {
         // initialize
         DeflateFrameServerExtensionHandshaker handshaker =
-                new DeflateFrameServerExtensionHandshaker();
+                new DeflateFrameServerExtensionHandshaker(
+                        DeflateFrameServerExtensionHandshaker.DEFAULT_COMPRESSION_LEVEL, 0);
 
         // execute
         WebSocketServerExtension extension = handshaker.handshakeExtension(
@@ -54,7 +55,8 @@ public class DeflateFrameServerExtensionHandshakerTest {
     public void testWebkitHandshake() {
         // initialize
         DeflateFrameServerExtensionHandshaker handshaker =
-                new DeflateFrameServerExtensionHandshaker();
+                new DeflateFrameServerExtensionHandshaker(
+                        DeflateFrameServerExtensionHandshaker.DEFAULT_COMPRESSION_LEVEL, 0);
 
         // execute
         WebSocketServerExtension extension = handshaker.handshakeExtension(
@@ -71,7 +73,8 @@ public class DeflateFrameServerExtensionHandshakerTest {
     public void testFailedHandshake() {
         // initialize
         DeflateFrameServerExtensionHandshaker handshaker =
-                new DeflateFrameServerExtensionHandshaker();
+                new DeflateFrameServerExtensionHandshaker(
+                        DeflateFrameServerExtensionHandshaker.DEFAULT_COMPRESSION_LEVEL, 0);
 
         Map<String, String> parameters;
         parameters = new HashMap<String, String>();

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerFrameDeflateDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerFrameDeflateDecoderTest.java
@@ -42,7 +42,7 @@ public class PerFrameDeflateDecoderTest {
     public void testCompressedFrame() {
         EmbeddedChannel encoderChannel = new EmbeddedChannel(
                 ZlibCodecFactory.newZlibEncoder(ZlibWrapper.NONE, 9, 15, 8));
-        EmbeddedChannel decoderChannel = new EmbeddedChannel(new PerFrameDeflateDecoder(false));
+        EmbeddedChannel decoderChannel = new EmbeddedChannel(new PerFrameDeflateDecoder(false, 0));
 
         // initialize
         byte[] payload = new byte[300];
@@ -73,7 +73,7 @@ public class PerFrameDeflateDecoderTest {
 
     @Test
     public void testNormalFrame() {
-        EmbeddedChannel decoderChannel = new EmbeddedChannel(new PerFrameDeflateDecoder(false));
+        EmbeddedChannel decoderChannel = new EmbeddedChannel(new PerFrameDeflateDecoder(false, 0));
 
         // initialize
         byte[] payload = new byte[300];
@@ -103,7 +103,7 @@ public class PerFrameDeflateDecoderTest {
     public void testCompressedEmptyFrame() {
         EmbeddedChannel encoderChannel = new EmbeddedChannel(
                 ZlibCodecFactory.newZlibEncoder(ZlibWrapper.NONE, 9, 15, 8));
-        EmbeddedChannel decoderChannel = new EmbeddedChannel(new PerFrameDeflateDecoder(false));
+        EmbeddedChannel decoderChannel = new EmbeddedChannel(new PerFrameDeflateDecoder(false, 0));
 
         assertTrue(encoderChannel.writeOutbound(Unpooled.EMPTY_BUFFER));
         ByteBuf compressedPayload = encoderChannel.readOutbound();
@@ -126,7 +126,7 @@ public class PerFrameDeflateDecoderTest {
     public void testDecompressionSkip() {
         EmbeddedChannel encoderChannel = new EmbeddedChannel(
                 ZlibCodecFactory.newZlibEncoder(ZlibWrapper.NONE, 9, 15, 8));
-        EmbeddedChannel decoderChannel = new EmbeddedChannel(new PerFrameDeflateDecoder(false, ALWAYS_SKIP));
+        EmbeddedChannel decoderChannel = new EmbeddedChannel(new PerFrameDeflateDecoder(false, ALWAYS_SKIP, 0));
 
         byte[] payload = new byte[300];
         random.nextBytes(payload);

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerFrameDeflateEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerFrameDeflateEncoderTest.java
@@ -43,7 +43,7 @@ public class PerFrameDeflateEncoderTest {
     public void testCompressedFrame() {
         EmbeddedChannel encoderChannel = new EmbeddedChannel(new PerFrameDeflateEncoder(9, 15, false));
         EmbeddedChannel decoderChannel = new EmbeddedChannel(
-                ZlibCodecFactory.newZlibDecoder(ZlibWrapper.NONE));
+                ZlibCodecFactory.newZlibDecoder(ZlibWrapper.NONE, 0));
 
         // initialize
         byte[] payload = new byte[300];
@@ -102,7 +102,7 @@ public class PerFrameDeflateEncoderTest {
     public void testFramementedFrame() {
         EmbeddedChannel encoderChannel = new EmbeddedChannel(new PerFrameDeflateEncoder(9, 15, false));
         EmbeddedChannel decoderChannel = new EmbeddedChannel(
-                ZlibCodecFactory.newZlibDecoder(ZlibWrapper.NONE));
+                ZlibCodecFactory.newZlibDecoder(ZlibWrapper.NONE, 0));
 
         // initialize
         byte[] payload1 = new byte[100];

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateClientExtensionHandshakerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateClientExtensionHandshakerTest.java
@@ -42,7 +42,7 @@ public class PerMessageDeflateClientExtensionHandshakerTest {
     @Test
     public void testNormalData() {
         PerMessageDeflateClientExtensionHandshaker handshaker =
-                new PerMessageDeflateClientExtensionHandshaker();
+                new PerMessageDeflateClientExtensionHandshaker(0);
 
         WebSocketExtensionData data = handshaker.newRequestData();
 
@@ -53,7 +53,7 @@ public class PerMessageDeflateClientExtensionHandshakerTest {
     @Test
     public void testCustomData() {
         PerMessageDeflateClientExtensionHandshaker handshaker =
-                new PerMessageDeflateClientExtensionHandshaker(6, true, 10, true, true);
+                new PerMessageDeflateClientExtensionHandshaker(6, true, 10, true, true, 0);
 
         WebSocketExtensionData data = handshaker.newRequestData();
 
@@ -68,7 +68,7 @@ public class PerMessageDeflateClientExtensionHandshakerTest {
     @Test
     public void testNormalHandshake() {
         PerMessageDeflateClientExtensionHandshaker handshaker =
-                new PerMessageDeflateClientExtensionHandshaker();
+                new PerMessageDeflateClientExtensionHandshaker(0);
 
         WebSocketClientExtension extension = handshaker.handshakeExtension(
                 new WebSocketExtensionData(PERMESSAGE_DEFLATE_EXTENSION, Collections.<String, String>emptyMap()));
@@ -86,7 +86,7 @@ public class PerMessageDeflateClientExtensionHandshakerTest {
 
         // initialize
         PerMessageDeflateClientExtensionHandshaker handshaker =
-                new PerMessageDeflateClientExtensionHandshaker(6, true, 10, true, true);
+                new PerMessageDeflateClientExtensionHandshaker(6, true, 10, true, true, 0);
 
         parameters = new HashMap<String, String>();
         parameters.put(CLIENT_MAX_WINDOW, "12");
@@ -136,7 +136,7 @@ public class PerMessageDeflateClientExtensionHandshakerTest {
         Map<String, String> parameters;
 
         PerMessageDeflateClientExtensionHandshaker handshaker =
-                new PerMessageDeflateClientExtensionHandshaker(6, true, 15, true, false);
+                new PerMessageDeflateClientExtensionHandshaker(6, true, 15, true, false, 0);
 
         parameters = new HashMap<String, String>();
         parameters.put(CLIENT_MAX_WINDOW, "15");
@@ -165,7 +165,7 @@ public class PerMessageDeflateClientExtensionHandshakerTest {
         Map<String, String> parameters;
 
         PerMessageDeflateClientExtensionHandshaker handshaker =
-                new PerMessageDeflateClientExtensionHandshaker(6, true, 15, true, false);
+                new PerMessageDeflateClientExtensionHandshaker(6, true, 15, true, false, 0);
 
         parameters = new HashMap<String, String>();
         parameters.put(SERVER_NO_CONTEXT, null);
@@ -178,7 +178,7 @@ public class PerMessageDeflateClientExtensionHandshakerTest {
         assertTrue(extension.newExtensionEncoder() instanceof PerMessageDeflateEncoder);
 
         // initialize
-        handshaker = new PerMessageDeflateClientExtensionHandshaker(6, true, 15, true, true);
+        handshaker = new PerMessageDeflateClientExtensionHandshaker(6, true, 15, true, true, 0);
 
         parameters = new HashMap<String, String>();
         extension = handshaker.handshakeExtension(new WebSocketExtensionData(PERMESSAGE_DEFLATE_EXTENSION, parameters));
@@ -190,7 +190,7 @@ public class PerMessageDeflateClientExtensionHandshakerTest {
     @Test
     public void testDecoderNoClientContext() {
         PerMessageDeflateClientExtensionHandshaker handshaker =
-                new PerMessageDeflateClientExtensionHandshaker(6, true, MAX_WINDOW_SIZE, true, false);
+                new PerMessageDeflateClientExtensionHandshaker(6, true, MAX_WINDOW_SIZE, true, false, 0);
 
         byte[] firstPayload = new byte[] {
                 76, -50, -53, 10, -62, 48, 20, 4, -48, 95, 41, 89, -37, 36, 77, 90, 31, -39, 41, -72, 112, 33, -120, 20,

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateDecoderTest.java
@@ -51,7 +51,7 @@ public class PerMessageDeflateDecoderTest {
     public void testCompressedFrame() {
         EmbeddedChannel encoderChannel = new EmbeddedChannel(
                 ZlibCodecFactory.newZlibEncoder(ZlibWrapper.NONE, 9, 15, 8));
-        EmbeddedChannel decoderChannel = new EmbeddedChannel(new PerMessageDeflateDecoder(false));
+        EmbeddedChannel decoderChannel = new EmbeddedChannel(new PerMessageDeflateDecoder(false, 0));
 
         // initialize
         byte[] payload = new byte[300];
@@ -82,7 +82,7 @@ public class PerMessageDeflateDecoderTest {
 
     @Test
     public void testNormalFrame() {
-        EmbeddedChannel decoderChannel = new EmbeddedChannel(new PerMessageDeflateDecoder(false));
+        EmbeddedChannel decoderChannel = new EmbeddedChannel(new PerMessageDeflateDecoder(false, 0));
 
         // initialize
         byte[] payload = new byte[300];
@@ -111,7 +111,7 @@ public class PerMessageDeflateDecoderTest {
     public void testFragmentedFrame() {
         EmbeddedChannel encoderChannel = new EmbeddedChannel(
                 ZlibCodecFactory.newZlibEncoder(ZlibWrapper.NONE, 9, 15, 8));
-        EmbeddedChannel decoderChannel = new EmbeddedChannel(new PerMessageDeflateDecoder(false));
+        EmbeddedChannel decoderChannel = new EmbeddedChannel(new PerMessageDeflateDecoder(false, 0));
 
         // initialize
         byte[] payload = new byte[300];
@@ -161,7 +161,7 @@ public class PerMessageDeflateDecoderTest {
     public void testMultiCompressedPayloadWithinFrame() {
         EmbeddedChannel encoderChannel = new EmbeddedChannel(
                 ZlibCodecFactory.newZlibEncoder(ZlibWrapper.NONE, 9, 15, 8));
-        EmbeddedChannel decoderChannel = new EmbeddedChannel(new PerMessageDeflateDecoder(false));
+        EmbeddedChannel decoderChannel = new EmbeddedChannel(new PerMessageDeflateDecoder(false, 0));
 
         // initialize
         byte[] payload1 = new byte[100];
@@ -203,7 +203,7 @@ public class PerMessageDeflateDecoderTest {
     public void testDecompressionSkipForBinaryFrame() {
         EmbeddedChannel encoderChannel = new EmbeddedChannel(
                 ZlibCodecFactory.newZlibEncoder(ZlibWrapper.NONE, 9, 15, 8));
-        EmbeddedChannel decoderChannel = new EmbeddedChannel(new PerMessageDeflateDecoder(false, ALWAYS_SKIP));
+        EmbeddedChannel decoderChannel = new EmbeddedChannel(new PerMessageDeflateDecoder(false, ALWAYS_SKIP, 0));
 
         byte[] payload = new byte[300];
         random.nextBytes(payload);
@@ -236,7 +236,7 @@ public class PerMessageDeflateDecoderTest {
         EmbeddedChannel encoderChannel = new EmbeddedChannel(
                 ZlibCodecFactory.newZlibEncoder(ZlibWrapper.NONE, 9, 15, 8));
         EmbeddedChannel decoderChannel = new EmbeddedChannel(
-                new PerMessageDeflateDecoder(false, selectivityDecompressionFilter));
+                new PerMessageDeflateDecoder(false, selectivityDecompressionFilter, 0));
 
         String textPayload = "compressed payload";
         byte[] binaryPayload = new byte[300];
@@ -282,7 +282,7 @@ public class PerMessageDeflateDecoderTest {
         EmbeddedChannel encoderChannel = new EmbeddedChannel(
                 ZlibCodecFactory.newZlibEncoder(ZlibWrapper.NONE, 9, 15, 8));
         final EmbeddedChannel decoderChannel = new EmbeddedChannel(
-                new PerMessageDeflateDecoder(false, selectivityDecompressionFilter));
+                new PerMessageDeflateDecoder(false, selectivityDecompressionFilter, 0));
 
         byte[] firstPayload = new byte[200];
         random.nextBytes(firstPayload);
@@ -324,7 +324,7 @@ public class PerMessageDeflateDecoderTest {
 
     @Test
     public void testEmptyFrameDecompression() {
-        EmbeddedChannel decoderChannel = new EmbeddedChannel(new PerMessageDeflateDecoder(false));
+        EmbeddedChannel decoderChannel = new EmbeddedChannel(new PerMessageDeflateDecoder(false, 0));
 
         TextWebSocketFrame emptyDeflateBlockFrame = new TextWebSocketFrame(true, WebSocketExtension.RSV1,
                                                                            EMPTY_DEFLATE_BLOCK);
@@ -349,7 +349,7 @@ public class PerMessageDeflateDecoderTest {
                          "977616f79736475676f76736f7178746a7a7479626c64636b6b6778637768746c62";
         EmbeddedChannel encoderChannel = new EmbeddedChannel(
                 ZlibCodecFactory.newZlibEncoder(ZlibWrapper.NONE, 9, 15, 8));
-        EmbeddedChannel decoderChannel = new EmbeddedChannel(new PerMessageDeflateDecoder(false));
+        EmbeddedChannel decoderChannel = new EmbeddedChannel(new PerMessageDeflateDecoder(false, 0));
 
         ByteBuf originPayload = Unpooled.wrappedBuffer(ByteBufUtil.decodeHexDump(hexDump));
         assertTrue(encoderChannel.writeOutbound(originPayload.duplicate().retain()));

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateEncoderTest.java
@@ -52,7 +52,7 @@ public class PerMessageDeflateEncoderTest {
     public void testCompressedFrame() {
         EmbeddedChannel encoderChannel = new EmbeddedChannel(new PerMessageDeflateEncoder(9, 15, false));
         EmbeddedChannel decoderChannel = new EmbeddedChannel(
-                ZlibCodecFactory.newZlibDecoder(ZlibWrapper.NONE));
+                ZlibCodecFactory.newZlibDecoder(ZlibWrapper.NONE, 0));
 
         // initialize
         byte[] payload = new byte[300];
@@ -113,7 +113,7 @@ public class PerMessageDeflateEncoderTest {
         EmbeddedChannel encoderChannel = new EmbeddedChannel(new PerMessageDeflateEncoder(9, 15, false,
                                                                                           NEVER_SKIP));
         EmbeddedChannel decoderChannel = new EmbeddedChannel(
-                ZlibCodecFactory.newZlibDecoder(ZlibWrapper.NONE));
+                ZlibCodecFactory.newZlibDecoder(ZlibWrapper.NONE, 0));
 
         // initialize
         byte[] payload1 = new byte[100];
@@ -206,7 +206,7 @@ public class PerMessageDeflateEncoderTest {
         EmbeddedChannel encoderChannel = new EmbeddedChannel(
                 new PerMessageDeflateEncoder(9, 15, false, selectivityCompressionFilter));
         EmbeddedChannel decoderChannel = new EmbeddedChannel(
-                ZlibCodecFactory.newZlibDecoder(ZlibWrapper.NONE));
+                ZlibCodecFactory.newZlibDecoder(ZlibWrapper.NONE, 0));
 
         String textPayload = "not compressed payload";
         byte[] binaryPayload = new byte[101];

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateServerExtensionHandshakerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateServerExtensionHandshakerTest.java
@@ -41,7 +41,7 @@ public class PerMessageDeflateServerExtensionHandshakerTest {
 
         // initialize
         PerMessageDeflateServerExtensionHandshaker handshaker =
-                new PerMessageDeflateServerExtensionHandshaker();
+                new PerMessageDeflateServerExtensionHandshaker(0);
 
         // execute
         extension = handshaker.handshakeExtension(
@@ -102,7 +102,7 @@ public class PerMessageDeflateServerExtensionHandshakerTest {
 
         // initialize
         PerMessageDeflateServerExtensionHandshaker handshaker =
-                new PerMessageDeflateServerExtensionHandshaker(6, true, 10, true, true);
+                new PerMessageDeflateServerExtensionHandshaker(6, true, 10, true, true, 0);
 
         parameters = new HashMap<String, String>();
         parameters.put(CLIENT_MAX_WINDOW, null);

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/WebSocketServerCompressionHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/WebSocketServerCompressionHandlerTest.java
@@ -40,7 +40,7 @@ public class WebSocketServerCompressionHandlerTest {
 
     @Test
     public void testNormalSuccess() {
-        EmbeddedChannel ch = new EmbeddedChannel(new WebSocketServerCompressionHandler());
+        EmbeddedChannel ch = new EmbeddedChannel(new WebSocketServerCompressionHandler(0));
 
         HttpRequest req = newUpgradeRequest(PERMESSAGE_DEFLATE_EXTENSION);
         ch.writeInbound(req);
@@ -61,7 +61,7 @@ public class WebSocketServerCompressionHandlerTest {
     @Test
     public void testClientWindowSizeSuccess() {
         EmbeddedChannel ch = new EmbeddedChannel(new WebSocketServerExtensionHandler(
-                new PerMessageDeflateServerExtensionHandshaker(6, false, 10, false, false)));
+                new PerMessageDeflateServerExtensionHandshaker(6, false, 10, false, false, 0)));
 
         HttpRequest req = newUpgradeRequest(PERMESSAGE_DEFLATE_EXTENSION + "; " + CLIENT_MAX_WINDOW);
         ch.writeInbound(req);
@@ -82,7 +82,7 @@ public class WebSocketServerCompressionHandlerTest {
     @Test
     public void testClientWindowSizeUnavailable() {
         EmbeddedChannel ch = new EmbeddedChannel(new WebSocketServerExtensionHandler(
-                new PerMessageDeflateServerExtensionHandshaker(6, false, 10, false, false)));
+                new PerMessageDeflateServerExtensionHandshaker(6, false, 10, false, false, 0)));
 
         HttpRequest req = newUpgradeRequest(PERMESSAGE_DEFLATE_EXTENSION);
         ch.writeInbound(req);
@@ -103,7 +103,7 @@ public class WebSocketServerCompressionHandlerTest {
     @Test
     public void testServerWindowSizeSuccess() {
         EmbeddedChannel ch = new EmbeddedChannel(new WebSocketServerExtensionHandler(
-                new PerMessageDeflateServerExtensionHandshaker(6, true, 15, false, false)));
+                new PerMessageDeflateServerExtensionHandshaker(6, true, 15, false, false, 0)));
 
         HttpRequest req = newUpgradeRequest(PERMESSAGE_DEFLATE_EXTENSION + "; " + SERVER_MAX_WINDOW + "=10");
         ch.writeInbound(req);
@@ -124,7 +124,7 @@ public class WebSocketServerCompressionHandlerTest {
     @Test
     public void testServerWindowSizeDisable() {
         EmbeddedChannel ch = new EmbeddedChannel(new WebSocketServerExtensionHandler(
-                new PerMessageDeflateServerExtensionHandshaker(6, false, 15, false, false)));
+                new PerMessageDeflateServerExtensionHandshaker(6, false, 15, false, false, 0)));
 
         HttpRequest req = newUpgradeRequest(PERMESSAGE_DEFLATE_EXTENSION + "; " + SERVER_MAX_WINDOW + "=10");
         ch.writeInbound(req);
@@ -141,7 +141,7 @@ public class WebSocketServerCompressionHandlerTest {
 
     @Test
     public void testServerNoContext() {
-        EmbeddedChannel ch = new EmbeddedChannel(new WebSocketServerCompressionHandler());
+        EmbeddedChannel ch = new EmbeddedChannel(new WebSocketServerCompressionHandler(0));
 
         HttpRequest req = newUpgradeRequest(PERMESSAGE_DEFLATE_EXTENSION + "; " + SERVER_NO_CONTEXT);
         ch.writeInbound(req);
@@ -158,7 +158,7 @@ public class WebSocketServerCompressionHandlerTest {
 
     @Test
     public void testClientNoContext() {
-        EmbeddedChannel ch = new EmbeddedChannel(new WebSocketServerCompressionHandler());
+        EmbeddedChannel ch = new EmbeddedChannel(new WebSocketServerCompressionHandler(0));
 
         HttpRequest req = newUpgradeRequest(PERMESSAGE_DEFLATE_EXTENSION + "; " + CLIENT_NO_CONTEXT);
         ch.writeInbound(req);
@@ -179,7 +179,7 @@ public class WebSocketServerCompressionHandlerTest {
     @Test
     public void testServerWindowSizeDisableThenFallback() {
         EmbeddedChannel ch = new EmbeddedChannel(new WebSocketServerExtensionHandler(
-                new PerMessageDeflateServerExtensionHandshaker(6, false, 15, false, false)));
+                new PerMessageDeflateServerExtensionHandshaker(6, false, 15, false, false, 0)));
 
         HttpRequest req = newUpgradeRequest(PERMESSAGE_DEFLATE_EXTENSION + "; " + SERVER_MAX_WINDOW + "=10, " +
                 PERMESSAGE_DEFLATE_EXTENSION);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
@@ -466,7 +466,7 @@ public class DataCompressionHttp2Test {
                 Http2ConnectionDecoder decoder =
                         new DefaultHttp2ConnectionDecoder(serverConnection, encoder, new DefaultHttp2FrameReader());
                 Http2ConnectionHandler connectionHandler = new Http2ConnectionHandlerBuilder()
-                        .frameListener(new DelegatingDecompressorFrameListener(serverConnection, serverListener))
+                        .frameListener(new DelegatingDecompressorFrameListener(serverConnection, serverListener, 0))
                         .codec(decoder, encoder).build();
                 p.addLast(connectionHandler);
                 serverChannelLatch.countDown();
@@ -491,7 +491,7 @@ public class DataCompressionHttp2Test {
                         new DefaultHttp2ConnectionDecoder(clientConnection, clientEncoder,
                                 new DefaultHttp2FrameReader());
                 clientHandler = new Http2ConnectionHandlerBuilder()
-                        .frameListener(new DelegatingDecompressorFrameListener(clientConnection, clientListener))
+                        .frameListener(new DelegatingDecompressorFrameListener(clientConnection, clientListener, 0))
                         // By default tests don't wait for server to gracefully shutdown streams
                         .gracefulShutdownTimeoutMillis(0)
                         .codec(decoder, clientEncoder).build();

--- a/codec/src/main/java/io/netty/handler/codec/compression/JZlibDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JZlibDecoder.java
@@ -34,7 +34,9 @@ public class JZlibDecoder extends ZlibDecoder {
      * Creates a new instance with the default wrapper ({@link ZlibWrapper#ZLIB}).
      *
      * @throws DecompressionException if failed to initialize zlib
+     * @deprecated Use {@link JZlibDecoder#JZlibDecoder(int)}.
      */
+    @Deprecated
     public JZlibDecoder() {
         this(ZlibWrapper.ZLIB, 0);
     }
@@ -57,7 +59,9 @@ public class JZlibDecoder extends ZlibDecoder {
      * Creates a new instance with the specified wrapper.
      *
      * @throws DecompressionException if failed to initialize zlib
+     * @deprecated Use {@link JZlibDecoder#JZlibDecoder(ZlibWrapper, int)}.
      */
+    @Deprecated
     public JZlibDecoder(ZlibWrapper wrapper) {
         this(wrapper, 0);
     }
@@ -88,7 +92,9 @@ public class JZlibDecoder extends ZlibDecoder {
      * supports the preset dictionary.
      *
      * @throws DecompressionException if failed to initialize zlib
+     * @deprecated Use {@link JZlibDecoder#JZlibDecoder(byte[], int)}.
      */
+    @Deprecated
     public JZlibDecoder(byte[] dictionary) {
         this(dictionary, 0);
     }

--- a/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibDecoder.java
@@ -64,7 +64,10 @@ public class JdkZlibDecoder extends ZlibDecoder {
 
     /**
      * Creates a new instance with the default wrapper ({@link ZlibWrapper#ZLIB}).
+     *
+     * @deprecated Use {@link JdkZlibDecoder#JdkZlibDecoder(int)}.
      */
+    @Deprecated
     public JdkZlibDecoder() {
         this(ZlibWrapper.ZLIB, null, false, 0);
     }
@@ -85,7 +88,10 @@ public class JdkZlibDecoder extends ZlibDecoder {
      * Creates a new instance with the specified preset dictionary. The wrapper
      * is always {@link ZlibWrapper#ZLIB} because it is the only format that
      * supports the preset dictionary.
+     *
+     * @deprecated Use {@link JdkZlibDecoder#JdkZlibDecoder(byte[], int)}.
      */
+    @Deprecated
     public JdkZlibDecoder(byte[] dictionary) {
         this(ZlibWrapper.ZLIB, dictionary, false, 0);
     }
@@ -107,7 +113,10 @@ public class JdkZlibDecoder extends ZlibDecoder {
      * Creates a new instance with the specified wrapper.
      * Be aware that only {@link ZlibWrapper#GZIP}, {@link ZlibWrapper#ZLIB} and {@link ZlibWrapper#NONE} are
      * supported atm.
+     *
+     * @deprecated Use {@link JdkZlibDecoder#JdkZlibDecoder(ZlibWrapper, int)}.
      */
+    @Deprecated
     public JdkZlibDecoder(ZlibWrapper wrapper) {
         this(wrapper, null, false, 0);
     }
@@ -125,6 +134,10 @@ public class JdkZlibDecoder extends ZlibDecoder {
         this(wrapper, null, false, maxAllocation);
     }
 
+    /**
+     * @deprecated Use {@link JdkZlibDecoder#JdkZlibDecoder(ZlibWrapper, boolean, int)}.
+     */
+    @Deprecated
     public JdkZlibDecoder(ZlibWrapper wrapper, boolean decompressConcatenated) {
         this(wrapper, null, decompressConcatenated, 0);
     }
@@ -133,6 +146,10 @@ public class JdkZlibDecoder extends ZlibDecoder {
         this(wrapper, null, decompressConcatenated, maxAllocation);
     }
 
+    /**
+     * @deprecated Use {@link JdkZlibDecoder#JdkZlibDecoder(boolean, int)}.
+     */
+    @Deprecated
     public JdkZlibDecoder(boolean decompressConcatenated) {
         this(ZlibWrapper.GZIP, null, decompressConcatenated, 0);
     }

--- a/codec/src/main/java/io/netty/handler/codec/compression/ZlibCodecFactory.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/ZlibCodecFactory.java
@@ -120,27 +120,82 @@ public final class ZlibCodecFactory {
         }
     }
 
+    /**
+     * Create a new decoder instance.
+     *
+     * @deprecated Use {@link ZlibCodecFactory#newZlibDecoder(int)}.
+     */
+    @Deprecated
     public static ZlibDecoder newZlibDecoder() {
+        return newZlibDecoder(0);
+    }
+
+    /**
+     * Create a new decoder instance with specified maximum buffer allocation.
+     *
+     * @param maxAllocation
+     *           Maximum size of the decompression buffer. Must be &gt;= 0.
+     *           If zero, maximum size is not limited by decoder.
+     */
+    public static ZlibDecoder newZlibDecoder(int maxAllocation) {
         if (PlatformDependent.javaVersion() < 7 || noJdkZlibDecoder) {
-            return new JZlibDecoder();
+            return new JZlibDecoder(maxAllocation);
         } else {
-            return new JdkZlibDecoder(true);
+            return new JdkZlibDecoder(true, maxAllocation);
         }
     }
 
+    /**
+     * Create a new decoder instance with the specified wrapper.
+     *
+     * @deprecated Use {@link ZlibCodecFactory#newZlibDecoder(ZlibWrapper, int)}.
+     */
+    @Deprecated
     public static ZlibDecoder newZlibDecoder(ZlibWrapper wrapper) {
+        return newZlibDecoder(wrapper, 0);
+    }
+
+    /**
+     * Create a new decoder instance with the specified wrapper and maximum buffer allocation.
+     *
+     * @param maxAllocation
+     *          Maximum size of the decompression buffer. Must be &gt;= 0.
+     *          If zero, maximum size is not limited by decoder.
+     */
+    public static ZlibDecoder newZlibDecoder(ZlibWrapper wrapper, int maxAllocation) {
         if (PlatformDependent.javaVersion() < 7 || noJdkZlibDecoder) {
-            return new JZlibDecoder(wrapper);
+            return new JZlibDecoder(wrapper, maxAllocation);
         } else {
-            return new JdkZlibDecoder(wrapper, true);
+            return new JdkZlibDecoder(wrapper, true, maxAllocation);
         }
     }
 
+    /**
+     * Create a new decoder instance with the specified preset dictionary. The wrapper
+     * is always {@link ZlibWrapper#ZLIB} because it is the only format that
+     * supports the preset dictionary.
+     *
+     * @deprecated Use {@link ZlibCodecFactory#newZlibDecoder(byte[], int)}.
+     */
+    @Deprecated
     public static ZlibDecoder newZlibDecoder(byte[] dictionary) {
+        return newZlibDecoder(dictionary, 0);
+    }
+
+    /**
+     * Create a new decoder instance with the specified preset dictionary and maximum buffer allocation.
+     * The wrapper is always {@link ZlibWrapper#ZLIB} because it is the only format that
+     * supports the preset dictionary.
+     *
+     * @param maxAllocation
+     *          Maximum size of the decompression buffer. Must be &gt;= 0.
+     *          If zero, maximum size is not limited by decoder.
+     */
+    public static ZlibDecoder newZlibDecoder(byte[] dictionary, int maxAllocation) {
         if (PlatformDependent.javaVersion() < 7 || noJdkZlibDecoder) {
-            return new JZlibDecoder(dictionary);
+            return new JZlibDecoder(dictionary, maxAllocation);
         } else {
-            return new JdkZlibDecoder(dictionary);
+            return new JdkZlibDecoder(dictionary, maxAllocation);
         }
     }
 

--- a/codec/src/test/java/io/netty/handler/codec/compression/JdkZlibTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/JdkZlibTest.java
@@ -86,7 +86,7 @@ public class JdkZlibTest extends ZlibTest {
 
     @Test
     public void testConcatenatedStreamsReadFully() throws IOException {
-        EmbeddedChannel chDecoderGZip = new EmbeddedChannel(new JdkZlibDecoder(true));
+        EmbeddedChannel chDecoderGZip = new EmbeddedChannel(new JdkZlibDecoder(true, 0));
 
         try {
             byte[] bytes = IOUtils.toByteArray(getClass().getResourceAsStream("/multiple.gz"));
@@ -108,7 +108,7 @@ public class JdkZlibTest extends ZlibTest {
 
     @Test
     public void testConcatenatedStreamsReadFullyWhenFragmented() throws IOException {
-        EmbeddedChannel chDecoderGZip = new EmbeddedChannel(new JdkZlibDecoder(true));
+        EmbeddedChannel chDecoderGZip = new EmbeddedChannel(new JdkZlibDecoder(true, 0));
 
         try {
             byte[] bytes = IOUtils.toByteArray(getClass().getResourceAsStream("/multiple.gz"));
@@ -147,7 +147,7 @@ public class JdkZlibTest extends ZlibTest {
 
         byte[] compressed = bytesOut.toByteArray();
         ByteBuf buffer = Unpooled.buffer().writeBytes(compressed).writeBytes(compressed);
-        EmbeddedChannel channel = new EmbeddedChannel(new JdkZlibDecoder(ZlibWrapper.GZIP, true));
+        EmbeddedChannel channel = new EmbeddedChannel(new JdkZlibDecoder(ZlibWrapper.GZIP, true, 0));
         // Write it into the Channel in a way that we were able to decompress the first data completely but not the
         // whole footer.
         assertTrue(channel.writeInbound(buffer.readRetainedSlice(compressed.length - 1)));

--- a/example/src/main/java/io/netty/example/factorial/FactorialClientInitializer.java
+++ b/example/src/main/java/io/netty/example/factorial/FactorialClientInitializer.java
@@ -27,6 +27,8 @@ import io.netty.handler.ssl.SslContext;
  */
 public class FactorialClientInitializer extends ChannelInitializer<SocketChannel> {
 
+    private static final int MAX_CONTENT_LENGTH = 65536;
+
     private final SslContext sslCtx;
 
     public FactorialClientInitializer(SslContext sslCtx) {
@@ -43,7 +45,7 @@ public class FactorialClientInitializer extends ChannelInitializer<SocketChannel
 
         // Enable stream compression (you can remove these two if unnecessary)
         pipeline.addLast(ZlibCodecFactory.newZlibEncoder(ZlibWrapper.GZIP));
-        pipeline.addLast(ZlibCodecFactory.newZlibDecoder(ZlibWrapper.GZIP));
+        pipeline.addLast(ZlibCodecFactory.newZlibDecoder(ZlibWrapper.GZIP, MAX_CONTENT_LENGTH));
 
         // Add the number codec first,
         pipeline.addLast(new BigIntegerDecoder());

--- a/example/src/main/java/io/netty/example/factorial/FactorialServerInitializer.java
+++ b/example/src/main/java/io/netty/example/factorial/FactorialServerInitializer.java
@@ -27,6 +27,8 @@ import io.netty.handler.ssl.SslContext;
  */
 public class FactorialServerInitializer extends ChannelInitializer<SocketChannel> {
 
+    private static final int MAX_CONTENT_LENGTH = 65536;
+
     private final SslContext sslCtx;
 
     public FactorialServerInitializer(SslContext sslCtx) {
@@ -43,7 +45,7 @@ public class FactorialServerInitializer extends ChannelInitializer<SocketChannel
 
         // Enable stream compression (you can remove these two if unnecessary)
         pipeline.addLast(ZlibCodecFactory.newZlibEncoder(ZlibWrapper.GZIP));
-        pipeline.addLast(ZlibCodecFactory.newZlibDecoder(ZlibWrapper.GZIP));
+        pipeline.addLast(ZlibCodecFactory.newZlibDecoder(ZlibWrapper.GZIP, MAX_CONTENT_LENGTH));
 
         // Add the number codec first,
         pipeline.addLast(new BigIntegerDecoder());

--- a/example/src/main/java/io/netty/example/http/snoop/HttpSnoopClientInitializer.java
+++ b/example/src/main/java/io/netty/example/http/snoop/HttpSnoopClientInitializer.java
@@ -24,6 +24,8 @@ import io.netty.handler.ssl.SslContext;
 
 public class HttpSnoopClientInitializer extends ChannelInitializer<SocketChannel> {
 
+    private static final int MAX_CONTENT_LENGTH = 65536;
+
     private final SslContext sslCtx;
 
     public HttpSnoopClientInitializer(SslContext sslCtx) {
@@ -42,7 +44,7 @@ public class HttpSnoopClientInitializer extends ChannelInitializer<SocketChannel
         p.addLast(new HttpClientCodec());
 
         // Remove the following line if you don't want automatic content decompression.
-        p.addLast(new HttpContentDecompressor());
+        p.addLast(new HttpContentDecompressor(MAX_CONTENT_LENGTH));
 
         // Uncomment the following line if you don't want to handle HttpContents.
         //p.addLast(new HttpObjectAggregator(1048576));

--- a/example/src/main/java/io/netty/example/http/upload/HttpUploadClientInitializer.java
+++ b/example/src/main/java/io/netty/example/http/upload/HttpUploadClientInitializer.java
@@ -25,6 +25,8 @@ import io.netty.handler.stream.ChunkedWriteHandler;
 
 public class HttpUploadClientInitializer extends ChannelInitializer<SocketChannel> {
 
+    private static final int MAX_CONTENT_LENGTH = 65536;
+
     private final SslContext sslCtx;
 
     public HttpUploadClientInitializer(SslContext sslCtx) {
@@ -42,7 +44,7 @@ public class HttpUploadClientInitializer extends ChannelInitializer<SocketChanne
         pipeline.addLast("codec", new HttpClientCodec());
 
         // Remove the following line if you don't want automatic content decompression.
-        pipeline.addLast("inflater", new HttpContentDecompressor());
+        pipeline.addLast("inflater", new HttpContentDecompressor(MAX_CONTENT_LENGTH));
 
         // to be used since huge file transfer
         pipeline.addLast("chunkedWriter", new ChunkedWriteHandler());

--- a/example/src/main/java/io/netty/example/http/websocketx/benchmarkserver/WebSocketServerInitializer.java
+++ b/example/src/main/java/io/netty/example/http/websocketx/benchmarkserver/WebSocketServerInitializer.java
@@ -26,6 +26,8 @@ import io.netty.handler.ssl.SslContext;
  */
 public class WebSocketServerInitializer extends ChannelInitializer<SocketChannel> {
 
+    private static final int MAX_CONTENT_LENGTH = 65536;
+
     private final SslContext sslCtx;
 
     public WebSocketServerInitializer(SslContext sslCtx) {
@@ -39,7 +41,7 @@ public class WebSocketServerInitializer extends ChannelInitializer<SocketChannel
             pipeline.addLast(sslCtx.newHandler(ch.alloc()));
         }
         pipeline.addLast(new HttpServerCodec());
-        pipeline.addLast(new HttpObjectAggregator(65536));
+        pipeline.addLast(new HttpObjectAggregator(MAX_CONTENT_LENGTH));
         pipeline.addLast(new WebSocketServerHandler());
     }
 }

--- a/example/src/main/java/io/netty/example/http/websocketx/client/WebSocketClient.java
+++ b/example/src/main/java/io/netty/example/http/websocketx/client/WebSocketClient.java
@@ -58,6 +58,7 @@ import java.net.URI;
 public final class WebSocketClient {
 
     static final String URL = System.getProperty("url", "ws://127.0.0.1:8080/websocket");
+    static final int MAX_CONTENT_LENGTH = 8192;
 
     public static void main(String[] args) throws Exception {
         URI uri = new URI(URL);
@@ -112,8 +113,8 @@ public final class WebSocketClient {
                      }
                      p.addLast(
                              new HttpClientCodec(),
-                             new HttpObjectAggregator(8192),
-                             WebSocketClientCompressionHandler.INSTANCE,
+                             new HttpObjectAggregator(MAX_CONTENT_LENGTH),
+                             new WebSocketClientCompressionHandler(MAX_CONTENT_LENGTH),
                              handler);
                  }
              });

--- a/example/src/main/java/io/netty/example/http/websocketx/server/WebSocketServerInitializer.java
+++ b/example/src/main/java/io/netty/example/http/websocketx/server/WebSocketServerInitializer.java
@@ -30,6 +30,8 @@ public class WebSocketServerInitializer extends ChannelInitializer<SocketChannel
 
     private static final String WEBSOCKET_PATH = "/websocket";
 
+    private static final int MAX_CONTENT_LENGTH = 65536;
+
     private final SslContext sslCtx;
 
     public WebSocketServerInitializer(SslContext sslCtx) {
@@ -43,9 +45,9 @@ public class WebSocketServerInitializer extends ChannelInitializer<SocketChannel
             pipeline.addLast(sslCtx.newHandler(ch.alloc()));
         }
         pipeline.addLast(new HttpServerCodec());
-        pipeline.addLast(new HttpObjectAggregator(65536));
+        pipeline.addLast(new HttpObjectAggregator(MAX_CONTENT_LENGTH));
         pipeline.addLast(new WebSocketIndexPageHandler(WEBSOCKET_PATH));
-        pipeline.addLast(new WebSocketServerCompressionHandler());
+        pipeline.addLast(new WebSocketServerCompressionHandler(MAX_CONTENT_LENGTH));
         pipeline.addLast(new WebSocketServerProtocolHandler(WEBSOCKET_PATH, null, true));
         pipeline.addLast(new WebSocketFrameHandler());
     }

--- a/example/src/main/java/io/netty/example/http2/helloworld/client/Http2ClientInitializer.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/client/Http2ClientInitializer.java
@@ -68,7 +68,8 @@ public class Http2ClientInitializer extends ChannelInitializer<SocketChannel> {
                         new InboundHttp2ToHttpAdapterBuilder(connection)
                                 .maxContentLength(maxContentLength)
                                 .propagateSettings(true)
-                                .build()))
+                                .build(),
+                        maxContentLength))
                 .frameLogger(logger)
                 .connection(connection)
                 .build();
@@ -123,7 +124,8 @@ public class Http2ClientInitializer extends ChannelInitializer<SocketChannel> {
     private void configureClearText(SocketChannel ch) {
         HttpClientCodec sourceCodec = new HttpClientCodec();
         Http2ClientUpgradeCodec upgradeCodec = new Http2ClientUpgradeCodec(connectionHandler);
-        HttpClientUpgradeHandler upgradeHandler = new HttpClientUpgradeHandler(sourceCodec, upgradeCodec, 65536);
+        HttpClientUpgradeHandler upgradeHandler = new HttpClientUpgradeHandler(sourceCodec, upgradeCodec,
+                maxContentLength);
 
         ch.pipeline().addLast(sourceCodec,
                               upgradeHandler,

--- a/example/src/main/java/io/netty/example/portunification/PortUnificationServerHandler.java
+++ b/example/src/main/java/io/netty/example/portunification/PortUnificationServerHandler.java
@@ -40,6 +40,8 @@ import java.util.List;
  */
 public class PortUnificationServerHandler extends ByteToMessageDecoder {
 
+    private static final int MAX_CONTENT_LENGTH = 65536;
+
     private final SslContext sslCtx;
     private final boolean detectSsl;
     private final boolean detectGzip;
@@ -121,7 +123,7 @@ public class PortUnificationServerHandler extends ByteToMessageDecoder {
     private void enableGzip(ChannelHandlerContext ctx) {
         ChannelPipeline p = ctx.pipeline();
         p.addLast("gzipdeflater", ZlibCodecFactory.newZlibEncoder(ZlibWrapper.GZIP));
-        p.addLast("gzipinflater", ZlibCodecFactory.newZlibDecoder(ZlibWrapper.GZIP));
+        p.addLast("gzipinflater", ZlibCodecFactory.newZlibDecoder(ZlibWrapper.GZIP, MAX_CONTENT_LENGTH));
         p.addLast("unificationB", new PortUnificationServerHandler(sslCtx, detectSsl, false));
         p.remove(this);
     }


### PR DESCRIPTION
Motivation:

The current `ZLibCodecFactory` provides `newZlibDecoder` methods without an option to specify a maximum memory limit for decompression. These methods are utilized in various parts of the project, such as the per-message WebSocket extension. As a result, a client could send a small, maliciously crafted compressed message that, upon decompression, would consume all available memory. This can lead to an `OutOfMemoryError` scenario, which can easily be reproduced as follows:

```
Exception in thread "io-compute-15" java.lang.OutOfMemoryError: Java heap space
	at io.netty.util.internal.PlatformDependent.allocateUninitializedArray(PlatformDependent.java:326)
	at io.netty.buffer.PoolArena$HeapArena.newByteArray(PoolArena.java:628)
	at io.netty.buffer.PoolArena$HeapArena.newUnpooledChunk(PoolArena.java:652)
	at io.netty.buffer.PoolArena.allocateHuge(PoolArena.java:224)
	at io.netty.buffer.PoolArena.allocate(PoolArena.java:142)
	at io.netty.buffer.PoolArena.reallocate(PoolArena.java:317)
	at io.netty.buffer.PooledByteBuf.capacity(PooledByteBuf.java:123)
	at io.netty.buffer.AbstractByteBuf.ensureWritable(AbstractByteBuf.java:333)
	at io.netty.handler.codec.compression.ZlibDecoder.prepareDecompressBuffer(ZlibDecoder.java:74)
	at io.netty.handler.codec.compression.JdkZlibDecoder.decode(JdkZlibDecoder.java:265)
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:530)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:469)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:290)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1357)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:868)
	at io.netty.channel.embedded.EmbeddedChannel.writeInbound(EmbeddedChannel.java:348)
	at io.netty.handler.codec.http.websocketx.extensions.compression.DeflateDecoder.decompressContent(DeflateDecoder.java:119)
	at io.netty.handler.codec.http.websocketx.extensions.compression.DeflateDecoder.decode(DeflateDecoder.java:80)
	at io.netty.handler.codec.http.websocketx.extensions.compression.PerMessageDeflateDecoder.decode(PerMessageDeflateDecoder.java:87)
	at io.netty.handler.codec.http.websocketx.extensions.compression.PerMessageDeflateDecoder.decode(PerMessageDeflateDecoder.java:31)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:91)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:289)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
java.lang.OutOfMemoryError: Java heap space
	at io.netty.util.internal.PlatformDependent.allocateUninitializedArray(PlatformDependent.java:326)
	at io.netty.buffer.PoolArena$HeapArena.newByteArray(PoolArena.java:628)
	at io.netty.buffer.PoolArena$HeapArena.newUnpooledChunk(PoolArena.java:652)
```

Modification:

- Introduced new `newZlibDecoder` methods within `ZlibCodecFactory` that include an explicit `maxAllocation` parameter to specify the maximum allowed memory during decompression.
- The older methods have been deprecated in favor of the new ones.
- Public APIs that invoke `newZlibDecoder` now require the `maxAllocation` parameter as well.

Result:

This change does not modify the public API behavior, but it encourages users to adopt the updated methods, which include the explicit `maxAllocation` argument, providing more control over memory usage during decompression.

Fixes #6663.