### PR TITLE
Allows manually running tasks with timeout (in ns)

### DIFF
--- a/transport/src/main/java/io/netty/channel/ManualIoEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/ManualIoEventLoop.java
@@ -48,6 +48,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * {@link #waitAndRun()}} methods are called in a timely fashion.
  */
 public final class ManualIoEventLoop extends AbstractScheduledEventExecutor implements IoEventLoop {
+
     private static final int ST_STARTED = 0;
     private static final int ST_SHUTTING_DOWN = 1;
     private static final int ST_SHUTDOWN = 2;
@@ -148,28 +149,71 @@ public final class ManualIoEventLoop extends AbstractScheduledEventExecutor impl
         return ticker;
     }
 
-    private int runAllTasks() {
-        assert inEventLoop();
-        int numRun = 0;
-        boolean fetchedAll;
-        do {
-            fetchedAll = fetchFromScheduledTaskQueue(taskQueue);
-            for (;;) {
-                Runnable task = taskQueue.poll();
-                if (task == null) {
-                    break;
-                }
-                safeExecute(task);
-                numRun++;
-            }
-        } while (!fetchedAll); // keep on processing until we fetched all scheduled tasks.
-        if (numRun > 0) {
-            lastExecutionTime = ticker.nanoTime();
-        }
-        return numRun;
+    /**
+     * Poll all tasks from the task queue and run them via {@link Runnable#run()} method.
+     * <br>
+     * The behaviour of this method is the same as {@link #runNonIoTasks(long)}
+     * with {@code timeoutNanos} set {@code <= 0}.
+     */
+    public int runNonIoTasks() {
+        return runAllTasks(-1, true);
     }
 
-    private int run(IoHandlerContext context) {
+    /**
+     * Poll all tasks from the task queue and run them via {@link Runnable#run()} method.  This method stops running
+     * the tasks in the task queue and returns if it ran longer than {@code timeoutNanos}.<br>
+     *
+     * @param timeoutNanos the maximum time in nanoseconds to run tasks. If {@code <= 0}, no timeout is applied.
+     */
+    public int runNonIoTasks(long timeoutNanos) {
+        return runAllTasks(timeoutNanos, true);
+    }
+
+    private int runAllTasks(long timeoutNanos, boolean setCurrentExecutor) {
+        assert inEventLoop();
+        final Queue<Runnable> taskQueue = this.taskQueue;
+        // since the taskQueue is unbounded we don't need to keep on calling this while draining it.
+        boolean alwaysTrue = fetchFromScheduledTaskQueue(taskQueue);
+        assert alwaysTrue;
+        Runnable task = taskQueue.poll();
+        if (task == null) {
+            return 0;
+        }
+        EventExecutor old = setCurrentExecutor? ThreadExecutorMap.setCurrentExecutor(this) : null;
+        try {
+            final long deadline = timeoutNanos > 0 ? getCurrentTimeNanos() + timeoutNanos : 0;
+            int runTasks = 0;
+            long lastExecutionTime;
+            final Ticker ticker = this.ticker;
+            for (;;) {
+                safeExecute(task);
+
+                runTasks++;
+
+                // Check timeout every each TICKER_FREQUENCY tasks because nanoTime() is relatively expensive.
+                if (timeoutNanos > 0) {
+                    lastExecutionTime = ticker.nanoTime();
+                    if ((lastExecutionTime - deadline) >= 0) {
+                        break;
+                    }
+                }
+
+                task = taskQueue.poll();
+                if (task == null) {
+                    lastExecutionTime = ticker.nanoTime();
+                    break;
+                }
+            }
+            this.lastExecutionTime = lastExecutionTime;
+            return runTasks;
+        } finally {
+            if (setCurrentExecutor) {
+                ThreadExecutorMap.setCurrentExecutor(old);
+            }
+        }
+    }
+
+    private int run(IoHandlerContext context, long runAllTasksTimeoutNanos) {
         if (!initialized) {
             if (owningThread.get() == null) {
                 throw new IllegalStateException("Owning thread not set");
@@ -184,33 +228,55 @@ public final class ManualIoEventLoop extends AbstractScheduledEventExecutor impl
                     // Already completely terminated
                     return 0;
                 }
-                // Run all tasks before prepare to destroy.
-                int run = runAllTasks();
-                handler.prepareToDestroy();
-                if (confirmShutdown()) {
-                    // Destroy the handler now and run all remaining tasks.
-                    try {
-                        handler.destroy();
-                        for (;;) {
-                            int r = runAllTasks();
-                            run += r;
-                            if (r == 0) {
-                                break;
-                            }
-                        }
-                    } finally {
-                        state.set(ST_TERMINATED);
-                        terminationFuture.setSuccess(null);
-                    }
-                }
-                return run;
+                return runAllTasksBeforeDestroy();
             }
             int run = handler.run(context);
             // Now run all tasks.
-            return run + runAllTasks();
+            return run + runAllTasks(runAllTasksTimeoutNanos, false);
         } finally {
             ThreadExecutorMap.setCurrentExecutor(old);
         }
+    }
+
+    private int runAllTasksBeforeDestroy() {
+        // Run all tasks before prepare to destroy.
+        int run = runAllTasks(-1, false);
+        handler.prepareToDestroy();
+        if (confirmShutdown()) {
+            // Destroy the handler now and run all remaining tasks.
+            try {
+                handler.destroy();
+                for (;;) {
+                    int r = runAllTasks(-1, false);
+                    run += r;
+                    if (r == 0) {
+                        break;
+                    }
+                }
+            } finally {
+                state.set(ST_TERMINATED);
+                terminationFuture.setSuccess(null);
+            }
+        }
+        return run;
+    }
+
+    /**
+     * Executes all ready IO and tasks for this {@link IoEventLoop}.
+     * This methods will <strong>NOT</strong> block and wait for IO / tasks to be ready, it will just
+     * return directly if there is nothing to do.
+     * <p>
+     * <strong>Must be called from the owning {@link Thread} that was passed as a parameter on construction.</strong>
+     * <p>
+     *
+     * @param runAllTasksTimeoutNanos the maximum time in nanoseconds to run tasks. If {@code <= 0},
+     *                                no timeout is applied.
+     * @return the number of IO and tasks executed.
+     * @throws IllegalStateException if the method is not called from the owning {@link Thread}.
+     */
+    public int runNow(long runAllTasksTimeoutNanos) {
+        checkCurrentThread();
+        return run(nonBlockingContext, runAllTasksTimeoutNanos);
     }
 
     /**
@@ -218,13 +284,40 @@ public final class ManualIoEventLoop extends AbstractScheduledEventExecutor impl
      * This methods will <strong>NOT</strong> block and wait for IO / tasks to be ready, it will just
      * return directly if there is nothing to do.
      * <p>
-     * <strong>Must be called from the owning {@link Thread} that was passed as an parameter on construction.</strong>
+     * <strong>Must be called from the owning {@link Thread} that was passed as a parameter on construction.</strong>
      *
      * @return the number of IO and tasks executed.
      */
     public int runNow() {
         checkCurrentThread();
-        return run(nonBlockingContext);
+        return run(nonBlockingContext, -1);
+    }
+
+    /**
+     * Run all ready IO and tasks for this {@link IoEventLoop}.
+     * This methods will block and wait for IO / tasks to be ready if there is nothing to process atm for the given
+     * {@code waitNanos}.
+     * <p>
+     * <strong>Must be called from the owning {@link Thread} that was passed as an parameter on construction.</strong>
+     *
+     * @param runAllTasksTimeoutNanos the maximum time in nanoseconds to run tasks. If {@code <= 0},
+     *                                no timeout is applied.
+     * @param waitNanos the maximum amount of nanoseconds to wait before returning. IF {@code 0} it will block until
+     *                  there is some IO / tasks ready, if {@code -1} will not block at all and just return directly
+     *                  if there is nothing to run (like {@link #runNow()}).
+     * @return          the number of IO and tasks executed.
+     */
+    public int run(long waitNanos, long runAllTasksTimeoutNanos) {
+        checkCurrentThread();
+
+        final IoHandlerContext context;
+        if (waitNanos < 0) {
+            context = nonBlockingContext;
+        } else {
+            context = blockingContext;
+            blockingContext.maxBlockingNanos = waitNanos == 0 ? Long.MAX_VALUE : waitNanos;
+        }
+        return run(context, runAllTasksTimeoutNanos);
     }
 
     /**
@@ -240,16 +333,7 @@ public final class ManualIoEventLoop extends AbstractScheduledEventExecutor impl
      * @return          the number of IO and tasks executed.
      */
     public int run(long waitNanos) {
-        checkCurrentThread();
-
-        final IoHandlerContext context;
-        if (waitNanos < 0) {
-            context = nonBlockingContext;
-        } else {
-            context = blockingContext;
-            blockingContext.maxBlockingNanos = waitNanos == 0 ? Long.MAX_VALUE : waitNanos;
-        }
-        return run(context);
+        return run(waitNanos, -1);
     }
 
     private void checkCurrentThread() {
@@ -482,7 +566,7 @@ public final class ManualIoEventLoop extends AbstractScheduledEventExecutor impl
             gracefulShutdownStartTime = ticker.nanoTime();
         }
 
-        if (runAllTasks() > 0) {
+        if (runAllTasks(-1, false) > 0) {
             if (isShutdown()) {
                 // Executor shut down - no new tasks anymore.
                 return true;

--- a/transport/src/test/java/io/netty/channel/ManualIoEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/ManualIoEventLoopTest.java
@@ -15,6 +15,7 @@
  */
 package io.netty.channel;
 
+import io.netty.channel.local.LocalIoHandler;
 import io.netty.channel.nio.NioIoHandler;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.MockTicker;
@@ -39,12 +40,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ManualIoEventLoopTest {
 
@@ -262,6 +258,49 @@ public class ManualIoEventLoopTest {
 
         eventLoop.runNow(); // runs fine
 
+        eventLoop.shutdownGracefully();
+    }
+
+    @Test
+    public void testRunNonIoTasksSetupEventExecutor() {
+        MockTicker ticker = Ticker.newMockTicker();
+        ManualIoEventLoop eventLoop = new ManualIoEventLoop(
+                null, Thread.currentThread(), LocalIoHandler.newFactory(), ticker);
+        assertNull(ThreadExecutorMap.currentExecutor());
+        AtomicBoolean executed = new AtomicBoolean(false);
+        eventLoop.execute(() -> {
+            assertTrue(executed.compareAndSet(false, true));
+            assertSame(eventLoop, ThreadExecutorMap.currentExecutor());
+        });
+        assertEquals(1, eventLoop.runNonIoTasks());
+        assertTrue(executed.get());
+        eventLoop.shutdownGracefully();
+    }
+
+    @Test
+    public void testRunNonIoTasksWhileExpiringTimeout() {
+        MockTicker ticker = Ticker.newMockTicker();
+        ManualIoEventLoop eventLoop = new ManualIoEventLoop(
+                null, Thread.currentThread(), LocalIoHandler.newFactory(), ticker);
+        AtomicBoolean executedFirst = new AtomicBoolean(false);
+        eventLoop.execute(() -> {
+            assertTrue(executedFirst.compareAndSet(false, true));
+            ticker.advance(1, TimeUnit.NANOSECONDS);
+        });
+        AtomicBoolean canExecute = new AtomicBoolean(false);
+        AtomicBoolean executedSecond = new AtomicBoolean(false);
+        eventLoop.execute(() -> {
+            if (!canExecute.get()) {
+                fail("Should not be executed");
+            } else {
+                assertTrue(executedSecond.compareAndSet(false, true));
+            }
+        });
+        assertEquals(1, eventLoop.runNonIoTasks(1));
+        assertTrue(executedFirst.get());
+        assertFalse(executedSecond.get());
+        canExecute.set(true);
+        assertEquals(1, eventLoop.runNonIoTasks(1));
         eventLoop.shutdownGracefully();
     }
 

--- a/transport/src/test/java/io/netty/channel/ManualIoEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/ManualIoEventLoopTest.java
@@ -274,7 +274,7 @@ public class ManualIoEventLoopTest {
             assertTrue(executed.compareAndSet(false, true));
             assertSame(eventLoop, ThreadExecutorMap.currentExecutor());
         });
-        assertEquals(1, eventLoop.runNonIoTasks());
+        assertEquals(1, eventLoop.runNonBlockingTasks(0));
         assertTrue(executed.get());
         eventLoop.shutdownGracefully();
     }
@@ -291,7 +291,7 @@ public class ManualIoEventLoopTest {
                 case Wait:
                     return el.run(TimeUnit.HOURS.toNanos(1), timeoutNs);
                 case NonIoNow:
-                    return el.runNonIoTasks(timeoutNs);
+                    return el.runNonBlockingTasks(timeoutNs);
                 default:
                     throw new IllegalStateException("Unknown run mode: " + this);
             }


### PR DESCRIPTION
Motivation:

ManualIoEventLoop allow users to customize the different handling of I/O tasks - and how they interleave/get drained: currently there's no API to run just tasks till a perceived deadline

Modifications:

Implements #14556 for ManualIoEventLoop

Result:

More customizable event loop