### PR TITLE
IoUring: Don't depend on the fact that the ringIndex == bid.

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -472,11 +472,6 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
                                 allocHandle.incMessagesRead(1);
                                 pipeline.fireChannelRead(byteBuf);
                                 byteBuf = null;
-
-                                // Fill a new buffer for the bid after we fired the buffer through the pipeline.
-                                // We do it only after we called fireChannelRead(...) as there is a good chance
-                                // that the user will have released the buffer. In this case we reduce memory usage.
-                                bufferRing.fillBuffer();
                                 bid = bufferRing.nextBid(bid);
                                 if (!allocHandle.continueReading()) {
                                     // We should call fireChannelReadComplete() to mimic a normal read loop.
@@ -521,12 +516,6 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
                 allocHandle.incMessagesRead(1);
                 pipeline.fireChannelRead(byteBuf);
                 byteBuf = null;
-                if (useBufferRing && !more) {
-                    // Fill a new buffer for the bid after we fired the buffer through the pipeline.
-                    // We do it only after we called fireChannelRead(...) as there is a good chance
-                    // that the user will have released the buffer. In this case we reduce memory usage.
-                    bufferRing.fillBuffer();
-                }
                 scheduleNextRead(pipeline, allocHandle, rearm, empty);
             } catch (Throwable t) {
                 handleReadException(pipeline, byteBuf, t, allDataRead, allocHandle);

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRingConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRingConfig.java
@@ -15,6 +15,7 @@
  */
 package io.netty.channel.uring;
 
+import io.netty.util.internal.MathUtil;
 import io.netty.util.internal.ObjectUtil;
 
 import java.util.Objects;
@@ -66,7 +67,8 @@ public final class IoUringBufferRingConfig {
                                    boolean incremental, IoUringBufferRingAllocator allocator) {
         this.bgId = (short) ObjectUtil.checkPositiveOrZero(bgId, "bgId");
         this.bufferRingSize = checkBufferRingSize(bufferRingSize);
-        this.batchSize = ObjectUtil.checkInRange(batchSize, 1, bufferRingSize, "batchSize");
+        this.batchSize = MathUtil.findNextPositivePowerOfTwo(
+                ObjectUtil.checkInRange(batchSize, 1, bufferRingSize, "batchSize"));
         this.maxUnreleasedBuffers = ObjectUtil.checkInRange(
                 maxUnreleasedBuffers, bufferRingSize, Integer.MAX_VALUE, "maxUnreleasedBuffers");
         if (incremental && !IoUring.isRegisterBufferRingIncSupported()) {


### PR DESCRIPTION
Motivation:

We should better not depend on the fact that the ringIndex is the same as the bid we generated. Also we need to be careful that when we expand the buffer ring we also keep the sequential order of bids as we depend on it for RECVSEND bundles.

Motifications:

- Decouble bid and ringIndex
- Only expand the ring if we can garantee that the sequential ordering of bids can be preserved, if not we will lazy expand it later.

Result:

More robust and correct handling of the buffer ring