### PR TITLE
Port over fix for crash in QUIC codec

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicConnection.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicConnection.java
@@ -60,6 +60,7 @@ final class QuicheQuicConnection {
     private long connection;
 
     QuicheQuicConnection(long connection, long ssl, QuicheQuicSslEngine engine, ReferenceCounted refCnt) {
+        assert connection != -1;
         this.connection = connection;
         this.ssl = ssl;
         this.engine = engine;
@@ -216,8 +217,7 @@ final class QuicheQuicConnection {
     }
 
     boolean isClosed() {
-        assert connection != -1;
-        return Quiche.quiche_conn_is_closed(connection);
+        return isFreed() || Quiche.quiche_conn_is_closed(connection);
     }
 
     // Let's override finalize() as we want to ensure we never leak memory even if the user will miss to close


### PR DESCRIPTION
Motivation:
When QuicheQuicConnection is freed, it sets the connection reference to
-1. Unfortunately, it's possible to then inspect the native closed state
of this connection, which will crash in Quiche.

Modification:
Change the `assert connection != -1` to a real conditional in
`isClosed`, to avoid calling into Quiche on freed connections.

Result:
This fixes a JVM crash bug with our QUIC codec.