### PR TITLE
Fix concurrent ByteBuf write access bug in adaptive allocator

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -1090,7 +1090,7 @@ final class AdaptivePoolingAllocator {
 
         private ByteBuffer internalNioBuffer() {
             if (tmpNioBuf == null) {
-                tmpNioBuf = rootParent().internalNioBuffer(adjustment, length).slice();
+                tmpNioBuf = rootParent().nioBuffer(adjustment, length);
             }
             return (ByteBuffer) tmpNioBuf.clear();
         }
@@ -1237,21 +1237,24 @@ final class AdaptivePoolingAllocator {
         @Override
         public ByteBuf setBytes(int index, byte[] src, int srcIndex, int length) {
             checkIndex(index, length);
-            rootParent().setBytes(idx(index), src, srcIndex, length);
+            ByteBuffer tmp = (ByteBuffer) internalNioBuffer().clear().position(index);
+            tmp.put(src, srcIndex, length);
             return this;
         }
 
         @Override
         public ByteBuf setBytes(int index, ByteBuf src, int srcIndex, int length) {
             checkIndex(index, length);
-            rootParent().setBytes(idx(index), src, srcIndex, length);
+            ByteBuffer tmp = (ByteBuffer) internalNioBuffer().clear().position(index);
+            tmp.put(src.nioBuffer(srcIndex, length));
             return this;
         }
 
         @Override
         public ByteBuf setBytes(int index, ByteBuffer src) {
             checkIndex(index, src.remaining());
-            rootParent().setBytes(idx(index), src);
+            ByteBuffer tmp = (ByteBuffer) internalNioBuffer().clear().position(index);
+            tmp.put(src);
             return this;
         }
 


### PR DESCRIPTION
Motivation:
The bulk-write methods ByteBuf.copy and setBytes on buffers from the adaptive allocator were delegating to their root parents, which is effectively a shared ByteBuf for the chunk. This can cause concurrent write access to the chunk buffer, which is unsafe.

Modification:
Change the method implementations in AdaptiveByteBuf to no longer delegate to the root parent implementation, but instead obtain the underlying NIO ByteBuffer slices and operate on those in a way that avoids concurrent manipulation of the position and limits of the root parent underlying buffer.

Result:
No more data-races in the bulk-write setBytes and copy methods for AdaptiveByteBuf.