### PR TITLE
IoUring: Allow users to explicit enable RECVSEND_BUNDLE support

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -448,43 +448,35 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
                     allocHandle.lastBytesRead(ioResult("io_uring read", res));
                 } else if (res > 0) {
                     if (useBufferRing) {
-
-                        if (IoUring.isRecvsendBundleEnabled()) {
-                            // If RECVSEND_BUNDLE is supported we need to do a bit more work here.
-                            // In this case we might need to obtain multiple buffers out of the buffer ring as
-                            // multiple of them might have been filled for one recv operation.
-                            // See https://github.com/axboe/liburing/wiki/
-                            // What's-new-with-io_uring-in-6.10#add-support-for-sendrecv-bundles
-                            int read = res;
-                            for (;;) {
-                                int attemptedBytesRead = bufferRing.attemptedBytesRead(bid);
-                                byteBuf = bufferRing.useBuffer(bid, read, more);
-                                read -= byteBuf.readableBytes();
-                                allocHandle.attemptedBytesRead(attemptedBytesRead);
-                                allocHandle.lastBytesRead(byteBuf.readableBytes());
-
-                                assert read >= 0;
-                                if (read == 0) {
-                                    // Just break here, we will handle the byteBuf below and also fill the bufferRing
-                                    // if needed later.
-                                    break;
-                                }
-                                allocHandle.incMessagesRead(1);
-                                pipeline.fireChannelRead(byteBuf);
-                                byteBuf = null;
-                                bid = bufferRing.nextBid(bid);
-                                if (!allocHandle.continueReading()) {
-                                    // We should call fireChannelReadComplete() to mimic a normal read loop.
-                                    allocHandle.readComplete();
-                                    pipeline.fireChannelReadComplete();
-                                    allocHandle.reset(config());
-                                }
-                            }
-                        } else {
+                        // If RECVSEND_BUNDLE is used we need to do a bit more work here.
+                        // In this case we might need to obtain multiple buffers out of the buffer ring as
+                        // multiple of them might have been filled for one recv operation.
+                        // See https://github.com/axboe/liburing/wiki/
+                        // What's-new-with-io_uring-in-6.10#add-support-for-sendrecv-bundles
+                        int read = res;
+                        for (;;) {
                             int attemptedBytesRead = bufferRing.attemptedBytesRead(bid);
-                            byteBuf = bufferRing.useBuffer(bid, res, more);
+                            byteBuf = bufferRing.useBuffer(bid, read, more);
+                            read -= byteBuf.readableBytes();
                             allocHandle.attemptedBytesRead(attemptedBytesRead);
-                            allocHandle.lastBytesRead(res);
+                            allocHandle.lastBytesRead(byteBuf.readableBytes());
+
+                            assert read >= 0;
+                            if (read == 0) {
+                                // Just break here, we will handle the byteBuf below and also fill the bufferRing
+                                // if needed later.
+                                break;
+                            }
+                            allocHandle.incMessagesRead(1);
+                            pipeline.fireChannelRead(byteBuf);
+                            byteBuf = null;
+                            bid = bufferRing.nextBid(bid);
+                            if (!allocHandle.continueReading()) {
+                                // We should call fireChannelReadComplete() to mimic a normal read loop.
+                                allocHandle.readComplete();
+                                pipeline.fireChannelReadComplete();
+                                allocHandle.reset(config());
+                            }
                         }
                     } else {
                         int attemptedBytesRead = byteBuf.writableBytes();

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUring.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUring.java
@@ -45,7 +45,6 @@ public final class IoUring {
     private static final boolean IORING_RECV_MULTISHOT_ENABLED;
     private static final boolean IORING_RECVSEND_BUNDLE_ENABLED;
     private static final boolean IORING_POLL_ADD_MULTISHOT_ENABLED;
-
     static final int NUM_ELEMENTS_IOVEC;
 
     private static final InternalLogger logger;
@@ -95,12 +94,7 @@ public final class IoUring {
                         recvsendBundleSupported = (ringBuffer.features() & Native.IORING_FEAT_RECVSEND_BUNDLE) != 0;
                         // IORING_FEAT_RECVSEND_BUNDLE was added in the same release.
                         acceptSupportNoWait = recvsendBundleSupported;
-                        // Explicit disable recvsend bundles as there seems to be a bug which cause
-                        // and AssertionError which leads to the CI running out of memory.
-                        // We will enable this again once we found the bug and fixed it.
-                        //
-                        // TODO: Remove once fixed.
-                        recvsendBundleSupported = false;
+
                         acceptMultishotSupported = Native.isAcceptMultishotSupported(ringBuffer.fd());
                         recvMultishotSupported = Native.isRecvMultishotSupported();
                         pollAddMultishotSupported = Native.isPollAddMultiShotSupported(ringBuffer.fd());
@@ -180,8 +174,11 @@ public final class IoUring {
                 "io.netty.iouring.acceptMultiShotEnabled", true);
         IORING_RECV_MULTISHOT_ENABLED = IORING_RECV_MULTISHOT_SUPPORTED && SystemPropertyUtil.getBoolean(
                 "io.netty.iouring.recvMultiShotEnabled", true);
+        // Explicit disable RECVSEND_BUNDLE as there is a know kernel bug that will be fixed in the future:
+        // See https://lore.kernel.org/io-uring/364679fa-8fc3-4bcb-8296-0877f39d6f2c@gmail.com/
+        //      T/#ma949ad361d376247a16db73e741cb1043e56e6a4
         IORING_RECVSEND_BUNDLE_ENABLED = IORING_RECVSEND_BUNDLE_SUPPORTED && SystemPropertyUtil.getBoolean(
-                "io.netty.iouring.recvsendBundleEnabled", true);
+                "io.netty.iouring.recvsendBundleEnabled", false);
         IORING_POLL_ADD_MULTISHOT_ENABLED = IORING_POLL_ADD_MULTISHOT_SUPPORTED && SystemPropertyUtil.getBoolean(
                "io.netty.iouring.pollAddMultishotEnabled", true);
         NUM_ELEMENTS_IOVEC = numElementsIoVec;


### PR DESCRIPTION
Motivation:

In the past we did disable support for RECVSEND_BUNDLE completely as we did see issues on our CI. After more debugging we were able to report the issue to the io_uring kernel maintainers as it turned out to be a kernel bug:

https://lore.kernel.org/io-uring/364679fa-8fc3-4bcb-8296-0877f39d6f2c@gmail.com/T/#ma949ad361d376247a16db73e741cb1043e56e6a4

Once there is a kernel which has this bug-fix it is save to use RECVSEND_BUNDLE again and so make use of the extra performance. Because of this we should enable support but disable the feature explicit if not told otherwise. This will allow the end-user to explicit enable it if it is know that there current kernel is not affected anymore.

Modifications:

- Reenable support for RECVSEND_BUNDLE
- Disable usage of RECVSEND_BUNDLE by default but let users explicit enable it again via -Dio.netty.iouring.recvsendBundleEnabled=true
- Simplify code to use the same code path for RECVSEND_BUNDLE usage and non-usage

Result:

Allow users to explicit opt in for RECVSEND_BUNDLE