### PR TITLE
Add BlockHound exception for EmbeddedEventLoop$FreezableTicker

### DIFF
--- a/common/src/main/java/io/netty/util/internal/Hidden.java
+++ b/common/src/main/java/io/netty/util/internal/Hidden.java
@@ -174,6 +174,22 @@ class Hidden {
             builder.allowBlockingCallsInside("io.netty.util.internal.ReferenceCountUpdater",
                     "retryRelease0");
 
+            builder.allowBlockingCallsInside(
+                    "io.netty.channel.embedded.EmbeddedEventLoop$FreezableTicker",
+                    "advance");
+
+            builder.allowBlockingCallsInside(
+                    "io.netty.channel.embedded.EmbeddedEventLoop$FreezableTicker",
+                    "freezeTime");
+
+            builder.allowBlockingCallsInside(
+                    "io.netty.channel.embedded.EmbeddedEventLoop$FreezableTicker",
+                    "nanoTime");
+
+            builder.allowBlockingCallsInside(
+                    "io.netty.channel.embedded.EmbeddedEventLoop$FreezableTicker",
+                    "unfreezeTime");
+
             builder.allowBlockingCallsInside("io.netty.util.internal.PlatformDependent", "createTempFile");
             builder.nonBlockingThreadPredicate(new Function<Predicate<Thread>, Predicate<Thread>>() {
                 @Override


### PR DESCRIPTION
Motivation:
`EmbeddedEventLoop$FreezableTicker` uses internally `ReentrantLock.lock`. This will cause the error below when `BlockHound` is enabled.

```
reactor.blockhound.BlockingOperationError: Blocking call! sun.misc.Unsafe#park
    at sun.misc.Unsafe.park(Unsafe.java)
    at java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)
    at java.util.concurrent.locks.AbstractQueuedSynchronizer.parkAndCheckInterrupt(AbstractQueuedSynchronizer.java:836)
    at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireQueued(AbstractQueuedSynchronizer.java:870)
    at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(AbstractQueuedSynchronizer.java:1199)
    at java.util.concurrent.locks.ReentrantLock$NonfairSync.lock(ReentrantLock.java:209)
    at java.util.concurrent.locks.ReentrantLock.lock(ReentrantLock.java:285)
    at io.netty.channel.embedded.EmbeddedEventLoop$FreezableTicker.nanoTime(EmbeddedEventLoop.java:221)
    at io.netty.channel.embedded.EmbeddedEventLoop.getCurrentTimeNanos(EmbeddedEventLoop.java:95)
    at io.netty.channel.embedded.EmbeddedEventLoop.runScheduledTasks(EmbeddedEventLoop.java:73)
    at io.netty.channel.embedded.EmbeddedChannel.runPendingTasks(EmbeddedChannel.java:820)
```

Modification:
Allow blocking calls in `EmbeddedEventLoop$FreezableTicker`

Result:
No `BlockHound` exceptions
