### PR TITLE
Make EmbeddedChannel ticker configurable

### DIFF
--- a/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
@@ -32,7 +32,9 @@ import io.netty.channel.ChannelPromise;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
+import io.netty.util.concurrent.MockTicker;
 import io.netty.util.concurrent.ScheduledFuture;
+import io.netty.util.concurrent.Ticker;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -626,7 +628,7 @@ public class EmbeddedChannelTest {
             }
         });
 
-        final EmbeddedEventLoop embeddedEventLoop = new EmbeddedEventLoop();
+        final EmbeddedEventLoop embeddedEventLoop = new EmbeddedEventLoop(new EmbeddedEventLoop.FreezableTicker());
         channel.deregister().addListener(new ChannelFutureListener() {
             @Override
             public void operationComplete(ChannelFuture future) {
@@ -730,6 +732,42 @@ public class EmbeddedChannelTest {
         assertFalse(future20.isDone());
 
         channel.unfreezeTime();
+        channel.runPendingTasks();
+        assertTrue(future101.isDone());
+        assertFalse(future20.isDone());
+    }
+
+    @Test
+    @Timeout(30) // generous timeout, just make sure we don't actually wait for the full 10 mins...
+    void testCustomTicker() {
+        MockTicker ticker = Ticker.newMockTicker();
+        EmbeddedChannel channel = EmbeddedChannel.builder().ticker(ticker).build();
+        Runnable runnable = new Runnable() {
+            @Override
+            public void run() {
+            }
+        };
+
+        // this future will complete after 10min
+        ScheduledFuture<?> future10 = channel.eventLoop().schedule(runnable, 10, TimeUnit.MINUTES);
+        // this future will complete after 10min + 1ns
+        ScheduledFuture<?> future101 = channel.eventLoop().schedule(runnable,
+                TimeUnit.MINUTES.toNanos(10) + 1, TimeUnit.NANOSECONDS);
+        // this future will complete after 20min
+        ScheduledFuture<?> future20 = channel.eventLoop().schedule(runnable, 20, TimeUnit.MINUTES);
+
+        channel.runPendingTasks();
+        assertFalse(future10.isDone());
+        assertFalse(future101.isDone());
+        assertFalse(future20.isDone());
+
+        ticker.advance(10, TimeUnit.MINUTES);
+        channel.runPendingTasks();
+        assertTrue(future10.isDone());
+        assertFalse(future101.isDone());
+        assertFalse(future20.isDone());
+
+        ticker.advance(1, TimeUnit.NANOSECONDS);
         channel.runPendingTasks();
         assertTrue(future101.isDone());
         assertFalse(future20.isDone());


### PR DESCRIPTION
Motivation:

EmbeddedChannel still has an old time manipulation API that does not match Ticker and MockTicker perfectly. Implementing Ticker.sleep required a lock, which is worse than the 4.1 implementation.

Modification:

- Move EmbeddedChannel to a builder pattern
- Allow configuring a custom ticker for the EmbeddedEventLoop
- Remove locks from default EmbeddedEventLoop ticker implementation, and make sleep() throw an exception
- Add checks to EmbeddedChannel time manipulation methods to make them only work with the default ticker

Result:

- Default ticker for EmbeddedEventLoop remains lock-free, same as 4.1, and does not support sleep() anymore
- If a user requires sleep(), they can configure a custom ticker, in particular MockTicker

Fixes #15140