### PR TITLE
IoUring: Don't depend on the fact that ByteBuf.memoryAddress() works

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/MsgHdrMemory.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/MsgHdrMemory.java
@@ -86,7 +86,8 @@ final class MsgHdrMemory {
         int bufferLength = Iov.getBufferLength(iovMemory);
         // reconstruct the reader index based on the memoryAddress of the buffer and the bufferAddress that was used
         // in the iovec.
-        int readerIndex = (int) (bufferAddress - buffer.memoryAddress());
+        long memoryAddress = IoUring.memoryAddress(buffer);
+        int readerIndex = (int) (bufferAddress - memoryAddress);
 
         ByteBuf slice = buffer.slice(readerIndex, bufferLength)
                 .writerIndex(bytesRead);


### PR DESCRIPTION
Motivation:

ByteBuf.memoryAddress() might not be supported so use our helper to obtain it that can also handle the case when this is not supported.

Modifications:

Use IoUring.memoryAddress(...) helper

Result:

IoUring also works when the ByteBuf does not support directly obtaining the memory address