### PR TITLE
Always correctly calculate the memory address of the ByteBuf even if …

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
@@ -35,6 +35,7 @@ import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.io.ByteArrayInputStream;
+import java.nio.ByteBuffer;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
@@ -667,9 +668,14 @@ public final class OpenSsl {
 
     static long memoryAddress(ByteBuf buf) {
         assert buf.isDirect();
-        return buf.hasMemoryAddress() ? buf.memoryAddress() :
-                // Use internalNioBuffer to reduce object creation.
-                Buffer.address(buf.internalNioBuffer(0, buf.readableBytes()));
+        if (buf.hasMemoryAddress()) {
+            return buf.memoryAddress();
+        }
+        // Use internalNioBuffer to reduce object creation.
+        // It is important to add the position as the returned ByteBuffer might be shared by multiple ByteBuf
+        // instances and so has an address that starts before the start of the ByteBuf itself.
+        ByteBuffer byteBuffer = buf.internalNioBuffer(0, buf.readableBytes());
+        return Buffer.address(byteBuffer) + byteBuffer.position();
     }
 
     private OpenSsl() { }

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/IovArray.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/IovArray.java
@@ -82,7 +82,12 @@ public final class IovArray implements MessageProcessor {
             memoryAddress = memory.memoryAddress();
         } else {
             // Fallback to using JNI as we were not be able to access the address otherwise.
-            memoryAddress = Buffer.memoryAddress(memory.internalNioBuffer(0, memory.capacity()));
+
+            // Use internalNioBuffer to reduce object creation.
+            // It is important to add the position as the returned ByteBuffer might be shared by multiple ByteBuf
+            // instances and so has an address that starts before the start of the ByteBuf itself.
+            ByteBuffer byteBuffer = memory.internalNioBuffer(0, memory.capacity());
+            memoryAddress = Buffer.memoryAddress(byteBuffer) + byteBuffer.position();
         }
     }
 


### PR DESCRIPTION
…… (#15143)

…sun.misc.Unsafe is not usable

Motivation:

We might not be able to use sun.misc.Unsafe and so might need to use JNI to obtain the memory address of the ByteBuf by using the internal ByteBuffer. When doing so we need to take special care when the ByteBuffer was obtained via internalNioBuffer(...) as this method might return a ByteBuffer that is shared across different ByteBuf instances. Because of this we need to also take the position of the returned ByteBuffer and add it to the memory address that is returned via JNI. Failing to do so might result in data-corruption.

Modifications:

Correct calculate the memory address of the ByteBuf even if sun.misc.Unsafe is not usable.

Result:

Not more data-corruptions when sun.misc.Unsafe is not usable and our native SSL implementation is used or io_uring is used. Also fixes https://github.com/netty/netty/issues/15037