### PR TITLE
Upgrade lz4 dependencies as the old version did not correctly handle …

### DIFF
--- a/codec/pom.xml
+++ b/codec/pom.xml
@@ -74,8 +74,8 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>net.jpountz.lz4</groupId>
-      <artifactId>lz4</artifactId>
+      <groupId>org.lz4</groupId>
+      <artifactId>lz4-java</artifactId>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -968,9 +968,9 @@
         <version>1.0.3</version>
       </dependency>
       <dependency>
-        <groupId>net.jpountz.lz4</groupId>
-        <artifactId>lz4</artifactId>
-        <version>1.3.0</version>
+        <groupId>org.lz4</groupId>
+        <artifactId>lz4-java</artifactId>
+        <version>1.8.0</version>
       </dependency>
       <dependency>
         <groupId>com.github.jponge</groupId>


### PR DESCRIPTION
…… (#15146)

…ByteBuffer that have an arrayOffset > 0

Motivation:

The lz4 dependency we used does have a bug that lead to corruption when a ByteBuffer is used that has an arrayOffset > 0. This did lead to test-failures in the case of using heap buffers backed by a buffer pool sometimes

Modifications:

Update dependency

Result:

No more test-failures when heap buffers are used in general