### PR TITLE
Kqueue: Fix registration failure when fd is reused

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketConnectionAttemptTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketConnectionAttemptTest.java
@@ -39,6 +39,7 @@ import java.util.concurrent.TimeUnit;
 
 import static io.netty.testsuite.transport.socket.SocketTestPermutation.BAD_HOST;
 import static io.netty.testsuite.transport.socket.SocketTestPermutation.BAD_PORT;
+import static io.netty.testsuite.transport.socket.SocketTestPermutation.UNASSIGNED_PORT;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -46,9 +47,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class SocketConnectionAttemptTest extends AbstractClientSocketTest {
-
-    // See /etc/services
-    private static final int UNASSIGNED_PORT = 4;
 
     @Test
     @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketTestPermutation.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketTestPermutation.java
@@ -48,6 +48,9 @@ public class SocketTestPermutation {
     static final String BAD_HOST = SystemPropertyUtil.get("io.netty.testsuite.badHost", "198.51.100.254");
     static final int BAD_PORT = SystemPropertyUtil.getInt("io.netty.testsuite.badPort", 65535);
 
+    // See /etc/services
+    public static final int UNASSIGNED_PORT = 4;
+
     static {
         InternalLogger logger = InternalLoggerFactory.getInstance(SocketConnectionAttemptTest.class);
         logger.debug("-Dio.netty.testsuite.badHost: {}", BAD_HOST);

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventArray.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventArray.java
@@ -23,6 +23,7 @@ import java.nio.ByteBuffer;
 /**
  * Represents an array of kevent structures, backed by offheap memory.
  *
+ * <pre>
  * struct kevent {
  *  uintptr_t ident;
  *  short     keventFilter;
@@ -31,6 +32,7 @@ import java.nio.ByteBuffer;
  *  intptr_t  data;
  *  void      *udata;
  * };
+ * </pre>
  */
 final class KQueueEventArray {
     private static final int KQUEUE_EVENT_SIZE = Native.sizeofKEvent();
@@ -39,6 +41,7 @@ final class KQueueEventArray {
     private static final int KQUEUE_FFLAGS_OFFSET = Native.offsetofKEventFFlags();
     private static final int KQUEUE_FLAGS_OFFSET = Native.offsetofKEventFlags();
     private static final int KQUEUE_DATA_OFFSET = Native.offsetofKeventData();
+    private static final int KQUEUE_UDATA_OFFSET = Native.offsetofKeventUdata();
 
     private ByteBuffer memory;
     private long memoryAddress;
@@ -77,9 +80,9 @@ final class KQueueEventArray {
         size = 0;
     }
 
-    void evSet(int ident, short filter, short flags, int fflags) {
+    void evSet(int ident, short filter, short flags, int fflags, long data, long udata) {
         reallocIfNeeded();
-        evSet(getKEventOffset(size++) + memoryAddress, ident, filter, flags, fflags);
+        evSet(getKEventOffset(size++) + memoryAddress, ident, filter, flags, fflags, data, udata);
     }
 
     private void reallocIfNeeded() {
@@ -159,15 +162,24 @@ final class KQueueEventArray {
     }
 
     long data(int index) {
+        return getLong(index, KQUEUE_DATA_OFFSET);
+    }
+
+    long udata(int index) {
+        return getLong(index, KQUEUE_UDATA_OFFSET);
+    }
+
+    private long getLong(int index, int offset) {
         if (PlatformDependent.hasUnsafe()) {
-            return PlatformDependent.getLong(getKEventOffsetAddress(index) + KQUEUE_DATA_OFFSET);
+            return PlatformDependent.getLong(getKEventOffsetAddress(index) + offset);
         }
-        return memory.getLong(getKEventOffset(index) + KQUEUE_DATA_OFFSET);
+        return memory.getLong(getKEventOffset(index) + offset);
     }
 
     private static int calculateBufferCapacity(int capacity) {
         return capacity * KQUEUE_EVENT_SIZE;
     }
 
-    private static native void evSet(long keventAddress, int ident, short filter, short flags, int fflags);
+    private static native void evSet(
+            long keventAddress, int ident, short filter, short flags, int fflags, long data, long udata);
 }

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoEvent.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoEvent.java
@@ -26,6 +26,7 @@ public final class KQueueIoEvent implements IoEvent {
     private short flags;
     private int fflags;
     private long data;
+    private long udata;
 
     /**
      * Creates a new {@link KQueueIoEvent}.
@@ -35,30 +36,49 @@ public final class KQueueIoEvent implements IoEvent {
      * @param flags     the general flags.
      * @param fflags    filter-specific flags.
      * @return          {@link KQueueIoEvent}.
+     * @deprecated use {@link #newEvent(int, short, short, int, long, long)}
      */
+    @Deprecated
     public static KQueueIoEvent newEvent(int ident, short filter, short flags, int fflags) {
-        return new KQueueIoEvent(ident, filter, flags, fflags, 0);
+        return new KQueueIoEvent(ident, filter, flags, fflags, 0, 0);
     }
 
-    private KQueueIoEvent(int ident, short filter, short flags, int fflags, long data) {
+    /**
+     * Creates a new {@link KQueueIoEvent}.
+     *
+     * @param ident     the identifier for this event.
+     * @param filter    the filter for this event.
+     * @param flags     the general flags.
+     * @param fflags    filter-specific flags.
+     * @param data      the data
+     * @param udata     the user defined data that is passed through.
+     * @return          {@link KQueueIoEvent}.
+     */
+    public static KQueueIoEvent newEvent(int ident, short filter, short flags, int fflags, long data, long udata) {
+        return new KQueueIoEvent(ident, filter, flags, fflags, data, udata);
+    }
+
+    private KQueueIoEvent(int ident, short filter, short flags, int fflags, long data, long udata) {
         this.ident = ident;
         this.filter = filter;
         this.flags = flags;
         this.fflags = fflags;
         this.data = data;
+        this.udata = udata;
     }
 
     KQueueIoEvent() {
-        this(0, (short) 0, (short) 0, 0, 0);
+        this(0, (short) 0, (short) 0, 0, 0, 0);
     }
 
     // Only used internally for re-use.
-    void update(int ident, short filter, short flags, int fflags, long data) {
+    void update(int ident, short filter, short flags, int fflags, long data, long udata) {
         this.ident = ident;
         this.filter = filter;
         this.flags = flags;
         this.fflags = fflags;
         this.data = data;
+        this.udata = udata;
     }
 
     /**
@@ -106,6 +126,15 @@ public final class KQueueIoEvent implements IoEvent {
         return data;
     }
 
+    /**
+     * Returns user specified data.
+     *
+     * @return udata.
+     */
+    public long udata() {
+        return udata;
+    }
+
     @Override
     public String toString() {
         return "KQueueIoEvent{" +
@@ -114,6 +143,7 @@ public final class KQueueIoEvent implements IoEvent {
                 ", flags=" + flags +
                 ", fflags=" + fflags +
                 ", data=" + data +
+                ", udata=" + udata +
                 '}';
     }
 }

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoHandler.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoHandler.java
@@ -27,8 +27,8 @@ import io.netty.channel.SelectStrategy;
 import io.netty.channel.SelectStrategyFactory;
 import io.netty.channel.unix.FileDescriptor;
 import io.netty.util.IntSupplier;
-import io.netty.util.collection.IntObjectHashMap;
-import io.netty.util.collection.IntObjectMap;
+import io.netty.util.collection.LongObjectHashMap;
+import io.netty.util.collection.LongObjectMap;
 import io.netty.util.concurrent.ThreadAwareExecutor;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
@@ -76,10 +76,30 @@ public final class KQueueIoHandler implements IoHandler {
         }
     };
     private final ThreadAwareExecutor executor;
-    private final IntObjectMap<DefaultKqueueIoRegistration> registrations = new IntObjectHashMap<>(4096);
+    private final LongObjectMap<DefaultKqueueIoRegistration> registrations = new LongObjectHashMap<>(4096);
     private int numChannels;
+    private long nextId;
 
     private volatile int wakenUp;
+
+    private long generateNextId() {
+        boolean reset = false;
+        for (;;) {
+            if (nextId == Long.MAX_VALUE) {
+                if (reset) {
+                    throw new IllegalStateException("All possible ids in use");
+                }
+                reset = true;
+            }
+            nextId++;
+            if (nextId == KQUEUE_WAKE_UP_IDENT) {
+                continue;
+            }
+            if (!registrations.containsKey(nextId)) {
+                return nextId;
+            }
+        }
+    }
 
     /**
      * Returns a new {@link IoHandlerFactory} that creates {@link KQueueIoHandler} instances.
@@ -170,15 +190,16 @@ public final class KQueueIoHandler implements IoHandler {
                 continue;
             }
 
-            DefaultKqueueIoRegistration registration = registrations.get(ident);
+            long id = eventList.udata(i);
+            DefaultKqueueIoRegistration registration = registrations.get(id);
             if (registration == null) {
                 // This may happen if the channel has already been closed, and it will be removed from kqueue anyways.
                 // We also handle EV_ERROR above to skip this even early if it is a result of a referencing a closed and
                 // thus removed from kqueue FD.
-                logger.warn("events[{}]=[{}, {}] had no registration!", i, ident, filter);
+                logger.warn("events[{}]=[{}, {}, {}] had no registration!", i, ident, id, filter);
                 continue;
             }
-            registration.handle(ident, filter, flags, eventList.fflags(i), eventList.data(i));
+            registration.handle(ident, filter, flags, eventList.fflags(i), eventList.data(i), id);
         }
     }
 
@@ -254,7 +275,7 @@ public final class KQueueIoHandler implements IoHandler {
     }
 
     List<Channel> registeredChannelsList() {
-        IntObjectMap<DefaultKqueueIoRegistration> ch = registrations;
+        LongObjectMap<DefaultKqueueIoRegistration> ch = registrations;
         if (ch.isEmpty()) {
             return Collections.emptyList();
         }
@@ -323,11 +344,11 @@ public final class KQueueIoHandler implements IoHandler {
 
         DefaultKqueueIoRegistration registration = new DefaultKqueueIoRegistration(
                 executor, kqueueHandle);
-        DefaultKqueueIoRegistration old = registrations.put(kqueueHandle.ident(), registration);
+        DefaultKqueueIoRegistration old = registrations.put(registration.id, registration);
         if (old != null) {
-            // restore old mapping and throw exception
-            registrations.put(kqueueHandle.ident(), old);
-            throw new IllegalStateException("registration for the KQueueIoHandle.ident() already exists");
+            // This should never happen but just in case.
+            registrations.put(old.id, old);
+            throw new IllegalStateException();
         }
 
         if (kqueueHandle instanceof AbstractKQueueChannel.AbstractKQueueUnsafe) {
@@ -360,12 +381,13 @@ public final class KQueueIoHandler implements IoHandler {
         private final KQueueIoEvent event = new KQueueIoEvent();
 
         final KQueueIoHandle handle;
-
+        final long id;
         private final ThreadAwareExecutor executor;
 
         DefaultKqueueIoRegistration(ThreadAwareExecutor executor, KQueueIoHandle handle) {
             this.executor = executor;
             this.handle = handle;
+            id = generateNextId();
         }
 
         @SuppressWarnings("unchecked")
@@ -391,13 +413,13 @@ public final class KQueueIoHandler implements IoHandler {
             return 0;
         }
 
-        void handle(int ident, short filter, short flags, int fflags, long data) {
-            event.update(ident, filter, flags, fflags, data);
+        void handle(int ident, short filter, short flags, int fflags, long data, long udata) {
+            event.update(ident, filter, flags, fflags, data, udata);
             handle.handle(this, event);
         }
 
         private void evSet(short filter, short flags, int fflags) {
-            changeList.evSet(handle.ident(), filter, flags, fflags);
+            changeList.evSet(handle.ident(), filter, flags, fflags, 0, id);
         }
 
         @Override
@@ -419,12 +441,11 @@ public final class KQueueIoHandler implements IoHandler {
         }
 
         private void cancel0() {
-            int ident = handle.ident();
-            DefaultKqueueIoRegistration old = registrations.remove(ident);
+            DefaultKqueueIoRegistration old = registrations.remove(id);
             if (old != null) {
                 if (old != this) {
                     // The Channel mapping was already replaced due FD reuse, put back the stored Channel.
-                    registrations.put(ident, old);
+                    registrations.put(id, old);
                 } else if (old.handle instanceof AbstractKQueueChannel.AbstractKQueueUnsafe) {
                     numChannels--;
                 }

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/Native.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/Native.java
@@ -142,6 +142,7 @@ final class Native {
     static native int offsetofKEventFFlags();
     static native int offsetofKEventFilter();
     static native int offsetofKeventData();
+    static native int offsetofKeventUdata();
 
     private static void loadNativeLibrary() {
         String name = PlatformDependent.normalizedOs();

--- a/transport-native-kqueue/src/main/c/netty_kqueue_eventarray.c
+++ b/transport-native-kqueue/src/main/c/netty_kqueue_eventarray.c
@@ -26,13 +26,13 @@
 
 #define EVENT_ARRAY_CLASSNAME "io/netty/channel/kqueue/KQueueEventArray"
 
-static void netty_kqueue_eventarray_evSet(JNIEnv* env, jclass clzz, jlong keventAddress, jint ident, jshort filter, jshort flags, jint fflags) {
-    EV_SET((struct kevent*) keventAddress, ident, filter, flags, fflags, 0, NULL);
+static void netty_kqueue_eventarray_evSet(JNIEnv* env, jclass clzz, jlong keventAddress, jint ident, jshort filter, jshort flags, jint fflags, jlong data, jlong udata) {
+    EV_SET((struct kevent*) keventAddress, ident, filter, flags, fflags, data, (void *) udata);
 }
 
 // JNI Method Registration Table Begin
 static const JNINativeMethod fixed_method_table[] = {
-  { "evSet", "(JISSI)V", (void *) netty_kqueue_eventarray_evSet }
+  { "evSet", "(JISSIJJ)V", (void *) netty_kqueue_eventarray_evSet }
 };
 static const jint fixed_method_table_size = sizeof(fixed_method_table) / sizeof(fixed_method_table[0]);
 

--- a/transport-native-kqueue/src/main/c/netty_kqueue_native.c
+++ b/transport-native-kqueue/src/main/c/netty_kqueue_native.c
@@ -204,6 +204,10 @@ static jint netty_kqueue_native_offsetofKeventData(JNIEnv* env, jclass clazz) {
     return offsetof(struct kevent, data);
 }
 
+static jint netty_kqueue_native_offsetofKeventUdata(JNIEnv* env, jclass clazz) {
+    return offsetof(struct kevent, udata);
+}
+
 static jshort netty_kqueue_native_evfiltRead(JNIEnv* env, jclass clazz) {
     return EVFILT_READ;
 }
@@ -357,6 +361,7 @@ static const JNINativeMethod fixed_method_table[] = {
   { "offsetofKEventFFlags", "()I", (void *) netty_kqueue_native_offsetofKEventFFlags },
   { "offsetofKEventFilter", "()I", (void *) netty_kqueue_native_offsetofKEventFilter },
   { "offsetofKeventData", "()I", (void *) netty_kqueue_native_offsetofKeventData },
+  { "offsetofKeventUdata", "()I", (void *) netty_kqueue_native_offsetofKeventUdata },
   { "registerUnix", "()I", (void *) netty_kqueue_native_registerUnix }
 };
 static const jint fixed_method_table_size = sizeof(fixed_method_table) / sizeof(fixed_method_table[0]);

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KqueueRegistrationTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KqueueRegistrationTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.kqueue;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.handler.logging.LoggingHandler;
+import io.netty.testsuite.transport.socket.SocketTestPermutation;
+import io.netty.util.NetUtil;
+import io.netty.util.concurrent.ImmediateEventExecutor;
+import io.netty.util.concurrent.Promise;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.ConnectException;
+import java.net.InetSocketAddress;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class KqueueRegistrationTest {
+
+    @BeforeEach
+    public void setUp() {
+        KQueue.ensureAvailability();
+    }
+
+    @Test
+    void testFdReuse() throws Exception {
+        Bootstrap bootstrap = new Bootstrap();
+        EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, KQueueIoHandler.newFactory());
+        Promise<Throwable> promise = ImmediateEventExecutor.INSTANCE.newPromise();
+        try {
+            bootstrap.group(group)
+                    .channel(KQueueSocketChannel.class)
+                    //.channel(NioSocketChannel.class)
+                    .handler(new LoggingHandler());
+            bootstrap.connect(new InetSocketAddress(NetUtil.LOCALHOST, SocketTestPermutation.UNASSIGNED_PORT))
+                    .addListener((ChannelFutureListener) f1 -> {
+                        if (f1.cause() instanceof ConnectException) {
+                            f1.channel().close();
+                            bootstrap.connect(new InetSocketAddress(NetUtil.LOCALHOST,
+                                            SocketTestPermutation.UNASSIGNED_PORT))
+                                    .addListener((ChannelFutureListener) f2 -> {
+                                        f2.channel().close();
+                                        promise.setSuccess(f2.cause());
+                                    });
+                        } else {
+                            promise.setFailure(new IllegalStateException());
+                        }
+                    });
+            Throwable cause = promise.sync().getNow();
+            assertThat(cause, is(instanceOf(ConnectException.class)));
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+}

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KqueueRegistrationTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KqueueRegistrationTest.java
@@ -30,9 +30,7 @@ import org.junit.jupiter.api.Test;
 import java.net.ConnectException;
 import java.net.InetSocketAddress;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 public class KqueueRegistrationTest {
 
@@ -49,7 +47,6 @@ public class KqueueRegistrationTest {
         try {
             bootstrap.group(group)
                     .channel(KQueueSocketChannel.class)
-                    //.channel(NioSocketChannel.class)
                     .handler(new LoggingHandler());
             bootstrap.connect(new InetSocketAddress(NetUtil.LOCALHOST, SocketTestPermutation.UNASSIGNED_PORT))
                     .addListener((ChannelFutureListener) f1 -> {
@@ -66,7 +63,7 @@ public class KqueueRegistrationTest {
                         }
                     });
             Throwable cause = promise.sync().getNow();
-            assertThat(cause, is(instanceOf(ConnectException.class)));
+            assertInstanceOf(ConnectException.class, cause);
         } finally {
             group.shutdownGracefully();
         }


### PR DESCRIPTION
Motivation:

We need to ensure the id we use is unique so we don't end up with problems when the FD is reused.

Modifications:

- Generate a unqiue id during registration
- Store the id as udata and use it to lookup the handle
    
Result:
    
Fixes https://github.com/netty/netty/issues/15041
