### PR TITLE
Don't try to download test results for macos builds

### DIFF
--- a/.github/workflows/ci-pr-reports.yml
+++ b/.github/workflows/ci-pr-reports.yml
@@ -43,8 +43,6 @@ jobs:
           - setup: linux-x86_64-java21
           - setup: linux-x86_64-java22
           - setup: windows-x86_64-java11-boringssl
-          - setup: macos-x86_64-java11-boringssl
-          - setup: macos-aarch64-java11-boringssl
     continue-on-error: ${{ matrix.ignore-if-missing }}
     steps:
       - name: Download Artifacts


### PR DESCRIPTION
Motivation:

We currently don't run the full testsuite on macos so we will also not upload any test reports.

Modifications:

Remove macos builds frm pr-reports workflow

Result:

Workflow does pass