### PR TITLE
Fix incorrect assignment of SingleThreadIoEventLoop constructor

### DIFF
--- a/transport/src/main/java/io/netty/channel/SingleThreadIoEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/SingleThreadIoEventLoop.java
@@ -115,7 +115,8 @@ public class SingleThreadIoEventLoop extends SingleThreadEventLoop implements Io
         super(parent, threadFactory, false, true, maxPendingTasks, rejectedExecutionHandler);
         this.maxTaskProcessingQuantumNs =
                 ObjectUtil.checkPositiveOrZero(maxTaskProcessingQuantumMs, "maxTaskProcessingQuantumMs") == 0 ?
-                        DEFAULT_MAX_TASK_PROCESSING_QUANTUM_NS : maxTaskProcessingQuantumMs;
+                        DEFAULT_MAX_TASK_PROCESSING_QUANTUM_NS :
+                        TimeUnit.MILLISECONDS.toNanos(maxTaskProcessingQuantumMs);
         this.ioHandler = ObjectUtil.checkNotNull(ioHandlerFactory, "ioHandlerFactory").newHandler(this);
     }
 
@@ -141,7 +142,8 @@ public class SingleThreadIoEventLoop extends SingleThreadEventLoop implements Io
         super(parent, executor, false, true, maxPendingTasks, rejectedExecutionHandler);
         this.maxTaskProcessingQuantumNs =
                 ObjectUtil.checkPositiveOrZero(maxTaskProcessingQuantumMs, "maxTaskProcessingQuantumMs") == 0 ?
-                        DEFAULT_MAX_TASK_PROCESSING_QUANTUM_NS : maxTaskProcessingQuantumMs;
+                        DEFAULT_MAX_TASK_PROCESSING_QUANTUM_NS :
+                        TimeUnit.MILLISECONDS.toNanos(maxTaskProcessingQuantumMs);
         this.ioHandler = ObjectUtil.checkNotNull(ioHandlerFactory, "ioHandlerFactory").newHandler(this);
     }
 


### PR DESCRIPTION
Motivation:

The constructor of SingleThreadIoEventLoop incorrectly assigns maxTaskProcessingQuantumMs to maxTaskProcessingQuantumNs.

Modification:

Convert maxTaskProcessingQuantumMs to nanoseconds and assign the value to maxTaskProcessingQuantumNs.

Result:

Fixes #15154
