### PR TITLE
Fix signing keys with ML-DSA in CertificateBuilder

### DIFF
--- a/pkitesting/src/main/java/io/netty/pkitesting/CertificateBuilder.java
+++ b/pkitesting/src/main/java/io/netty/pkitesting/CertificateBuilder.java
@@ -763,7 +763,7 @@ public final class CertificateBuilder {
         }
         if ("ML-DSA".equals(keyAlgorithm)) {
             try {
-                Method getParams = key.getClass().getMethod("getParams");
+                Method getParams = Class.forName("java.security.AsymmetricKey").getMethod("getParams");
                 Object params = getParams.invoke(key);
                 Method getName = params.getClass().getMethod("getName");
                 return (String) getName.invoke(params);

--- a/pkitesting/src/test/java/io/netty/pkitesting/CertificateBuilderTest.java
+++ b/pkitesting/src/test/java/io/netty/pkitesting/CertificateBuilderTest.java
@@ -99,7 +99,6 @@ class CertificateBuilderTest {
         assertNotNull(keyPair.getPublic());
     }
 
-    @Disabled
     @EnabledForJreRange(
             min = JRE.JAVA_24,
             disabledReason = "ML-KEM is only supported in Java 24 onwards")


### PR DESCRIPTION
Motivation:
Because in Java 8 we can't talk about the `AssymetricKey` class, or otherwise get the parameters of keys, we relied on reflection to obtain the `getParams` method. However, we did so using the concrete key type class, which may be an implementation specific class that is not visible to us. This caused illegal access problems.

Modification:
Instead explicitly obtain the `getParams` method from the `AssymetricKey` interface, which is the public API that defines it. This is safe because the `PublicKey` interface, in the relevant Java versions, extend the `AssymetricKey` interface.

Result:
We can now sign keys and certificates using ML-DSA keys, and the CertificateBuilderTest passes.