### PR TITLE
WebSocket08FrameEncoder improvements

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameEncoder.java
@@ -133,7 +133,7 @@ public class WebSocket08FrameEncoder extends MessageToMessageEncoder<WebSocketFr
                 int size = 2 + maskLength + length;
                 buf = ctx.alloc().buffer(size);
                 buf.writeByte(b0);
-                byte b = (byte) (maskPayload ? 0x80 | (byte) length : (byte) length);
+                byte b = (byte) (length | (maskPayload ? 0x80 : 0));
                 buf.writeByte(b);
             } else if (length <= 0xFFFF) {
                 int size = 4 + maskLength;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameEncoder.java
@@ -219,6 +219,9 @@ public class WebSocket08FrameEncoder extends MessageToMessageEncoder<WebSocketFr
         if (msg instanceof TextWebSocketFrame) {
             return OPCODE_TEXT;
         }
+        if (msg instanceof BinaryWebSocketFrame) {
+            return OPCODE_BINARY;
+        }
         if (msg instanceof PingWebSocketFrame) {
             return OPCODE_PING;
         }
@@ -227,9 +230,6 @@ public class WebSocket08FrameEncoder extends MessageToMessageEncoder<WebSocketFr
         }
         if (msg instanceof CloseWebSocketFrame) {
             return OPCODE_CLOSE;
-        }
-        if (msg instanceof BinaryWebSocketFrame) {
-            return OPCODE_BINARY;
         }
         if (msg instanceof ContinuationWebSocketFrame) {
             return OPCODE_CONT;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameEncoder.java
@@ -158,7 +158,7 @@ public class WebSocket08FrameEncoder extends MessageToMessageEncoder<WebSocketFr
 
             // Write payload
             if (maskPayload) {
-                int mask = PlatformDependent.threadLocalRandom().nextInt(Integer.MAX_VALUE);
+                int mask = PlatformDependent.threadLocalRandom().nextInt();
                 buf.writeInt(mask);
 
                 if (length > 0) {


### PR DESCRIPTION
While checking https://github.com/netty/netty/issues/15157, I found a few small improvements that could be done for `WebSocket08FrameEncoder`:

- `opcode` resolving moved to its own method to make the code more readable
- removed unnecessary `isReadable()` call and replaced it with `length > 0` check
- replaced unncessary second call to `readableBytes()` with `length` variable
- removed argument from `nextInt` method call as it's not necessary, and the websocket specification expects any random 32 bits
- simplifies binary operations in one place