### PR TITLE
Kqueue: Fix registration failure when fd is reused

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketConnectionAttemptTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketConnectionAttemptTest.java
@@ -39,6 +39,7 @@ import java.util.concurrent.TimeUnit;
 
 import static io.netty.testsuite.transport.socket.SocketTestPermutation.BAD_HOST;
 import static io.netty.testsuite.transport.socket.SocketTestPermutation.BAD_PORT;
+import static io.netty.testsuite.transport.socket.SocketTestPermutation.UNASSIGNED_PORT;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -46,9 +47,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class SocketConnectionAttemptTest extends AbstractClientSocketTest {
-
-    // See /etc/services
-    private static final int UNASSIGNED_PORT = 4;
 
     @Test
     @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketTestPermutation.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketTestPermutation.java
@@ -47,6 +47,9 @@ public class SocketTestPermutation {
     static final String BAD_HOST = SystemPropertyUtil.get("io.netty.testsuite.badHost", "198.51.100.254");
     static final int BAD_PORT = SystemPropertyUtil.getInt("io.netty.testsuite.badPort", 65535);
 
+    // See /etc/services
+    public static final int UNASSIGNED_PORT = 4;
+
     static {
         InternalLogger logger = InternalLoggerFactory.getInstance(SocketConnectionAttemptTest.class);
         logger.debug("-Dio.netty.testsuite.badHost: {}", BAD_HOST);

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
@@ -68,6 +68,7 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
     final BsdSocket socket;
     private boolean readFilterEnabled;
     private boolean writeFilterEnabled;
+    long registerId;
     boolean readReadyRunnablePending;
     boolean inputClosedSeenErrorOnRead;
     protected volatile boolean active;
@@ -194,7 +195,7 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
         // new EventLoop.
         readReadyRunnablePending = false;
 
-        ((KQueueEventLoop) eventLoop()).add(this);
+        registerId = ((KQueueEventLoop) eventLoop()).add(this);
 
         // Add the write event first so we get notified of connection refused on the client side!
         if (writeFilterEnabled) {
@@ -364,7 +365,7 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
     private void evSet0(short filter, short flags, int fflags) {
         // Only try to add to changeList if the FD is still open, if not we already closed it in the meantime.
         if (isOpen()) {
-            ((KQueueEventLoop) eventLoop()).evSet(this, filter, flags, fflags);
+            ((KQueueEventLoop) eventLoop()).evSet(this, filter, flags, fflags, 0, registerId);
         }
     }
 

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/Native.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/Native.java
@@ -142,6 +142,7 @@ final class Native {
     static native int offsetofKEventFFlags();
     static native int offsetofKEventFilter();
     static native int offsetofKeventData();
+    static native int offsetofKeventUdata();
 
     private static void loadNativeLibrary() {
         String name = PlatformDependent.normalizedOs();

--- a/transport-native-kqueue/src/main/c/netty_kqueue_eventarray.c
+++ b/transport-native-kqueue/src/main/c/netty_kqueue_eventarray.c
@@ -26,13 +26,13 @@
 
 #define EVENT_ARRAY_CLASSNAME "io/netty/channel/kqueue/KQueueEventArray"
 
-static void netty_kqueue_eventarray_evSet(JNIEnv* env, jclass clzz, jlong keventAddress, jint ident, jshort filter, jshort flags, jint fflags) {
-    EV_SET((struct kevent*) keventAddress, ident, filter, flags, fflags, 0, NULL);
+static void netty_kqueue_eventarray_evSet(JNIEnv* env, jclass clzz, jlong keventAddress, jint ident, jshort filter, jshort flags, jint fflags, jlong data, jlong udata) {
+    EV_SET((struct kevent*) keventAddress, ident, filter, flags, fflags, data, (void *) udata);
 }
 
 // JNI Method Registration Table Begin
 static const JNINativeMethod fixed_method_table[] = {
-  { "evSet", "(JISSI)V", (void *) netty_kqueue_eventarray_evSet }
+  { "evSet", "(JISSIJJ)V", (void *) netty_kqueue_eventarray_evSet }
 };
 static const jint fixed_method_table_size = sizeof(fixed_method_table) / sizeof(fixed_method_table[0]);
 

--- a/transport-native-kqueue/src/main/c/netty_kqueue_native.c
+++ b/transport-native-kqueue/src/main/c/netty_kqueue_native.c
@@ -204,6 +204,10 @@ static jint netty_kqueue_native_offsetofKeventData(JNIEnv* env, jclass clazz) {
     return offsetof(struct kevent, data);
 }
 
+static jint netty_kqueue_native_offsetofKeventUdata(JNIEnv* env, jclass clazz) {
+    return offsetof(struct kevent, udata);
+}
+
 static jshort netty_kqueue_native_evfiltRead(JNIEnv* env, jclass clazz) {
     return EVFILT_READ;
 }
@@ -357,6 +361,7 @@ static const JNINativeMethod fixed_method_table[] = {
   { "offsetofKEventFFlags", "()I", (void *) netty_kqueue_native_offsetofKEventFFlags },
   { "offsetofKEventFilter", "()I", (void *) netty_kqueue_native_offsetofKEventFilter },
   { "offsetofKeventData", "()I", (void *) netty_kqueue_native_offsetofKeventData },
+  { "offsetofKeventUdata", "()I", (void *) netty_kqueue_native_offsetofKeventUdata },
   { "registerUnix", "()I", (void *) netty_kqueue_native_registerUnix }
 };
 static const jint fixed_method_table_size = sizeof(fixed_method_table) / sizeof(fixed_method_table[0]);

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KqueueRegistrationTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KqueueRegistrationTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.kqueue;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.EventLoopGroup;
+import io.netty.handler.logging.LoggingHandler;
+import io.netty.testsuite.transport.socket.SocketTestPermutation;
+import io.netty.util.NetUtil;
+import io.netty.util.concurrent.ImmediateEventExecutor;
+import io.netty.util.concurrent.Promise;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.ConnectException;
+import java.net.InetSocketAddress;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class KqueueRegistrationTest {
+
+    @BeforeEach
+    public void setUp() {
+        KQueue.ensureAvailability();
+    }
+
+    @Test
+    void testFdReuse() throws Exception {
+        final Bootstrap bootstrap = new Bootstrap();
+        EventLoopGroup group = new KQueueEventLoopGroup(1);
+        final Promise<Throwable> promise = ImmediateEventExecutor.INSTANCE.newPromise();
+        try {
+            bootstrap.group(group)
+                    .channel(KQueueSocketChannel.class)
+                    //.channel(NioSocketChannel.class)
+                    .handler(new LoggingHandler());
+            bootstrap.connect(new InetSocketAddress(NetUtil.LOCALHOST, SocketTestPermutation.UNASSIGNED_PORT))
+                    .addListener(new ChannelFutureListener() {
+                        @Override
+                        public void operationComplete(ChannelFuture f1) {
+                            if (f1.cause() instanceof ConnectException) {
+                                f1.channel().close();
+                                bootstrap.connect(new InetSocketAddress(NetUtil.LOCALHOST,
+                                                SocketTestPermutation.UNASSIGNED_PORT))
+                                        .addListener(new ChannelFutureListener() {
+                                            @Override
+                                            public void operationComplete(ChannelFuture f2) {
+                                                f2.channel().close();
+                                                promise.setSuccess(f2.cause());
+                                            }
+                                        });
+                            } else {
+                                promise.setFailure(new IllegalStateException());
+                            }
+                        }
+                    });
+            Throwable cause = promise.sync().getNow();
+            assertThat(cause, is(instanceOf(ConnectException.class)));
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+}

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KqueueRegistrationTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KqueueRegistrationTest.java
@@ -30,9 +30,7 @@ import org.junit.jupiter.api.Test;
 import java.net.ConnectException;
 import java.net.InetSocketAddress;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 public class KqueueRegistrationTest {
 
@@ -49,7 +47,6 @@ public class KqueueRegistrationTest {
         try {
             bootstrap.group(group)
                     .channel(KQueueSocketChannel.class)
-                    //.channel(NioSocketChannel.class)
                     .handler(new LoggingHandler());
             bootstrap.connect(new InetSocketAddress(NetUtil.LOCALHOST, SocketTestPermutation.UNASSIGNED_PORT))
                     .addListener(new ChannelFutureListener() {
@@ -72,7 +69,7 @@ public class KqueueRegistrationTest {
                         }
                     });
             Throwable cause = promise.sync().getNow();
-            assertThat(cause, is(instanceOf(ConnectException.class)));
+            assertInstanceOf(ConnectException.class, cause);
         } finally {
             group.shutdownGracefully();
         }


### PR DESCRIPTION
Motivation:

We need to ensure the id we use is unique so we don't end up with problems when the FD is reused.

Modifications:

Generate a unqiue id during registration
Store the id as udata and use it to lookup the handle Result:

Fixes #15041
