### PR TITLE
Inline PlatformDependent.threadLocalRandom() method, with java 8+ it …

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
@@ -48,6 +48,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -2690,7 +2691,7 @@ public abstract class AbstractByteBufTest {
         assertEquals(1, buf.remaining());
 
         byte[] data = new byte[a];
-        PlatformDependent.threadLocalRandom().nextBytes(data);
+        ThreadLocalRandom.current().nextBytes(data);
         buffer.writeBytes(data);
 
         buf = buffer.internalNioBuffer(buffer.readerIndex(), a);

--- a/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
@@ -18,7 +18,6 @@ package io.netty.buffer;
 import io.netty.util.ByteProcessor;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.ObjectUtil;
-import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
@@ -31,6 +30,7 @@ import java.util.ConcurrentModificationException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static io.netty.buffer.Unpooled.EMPTY_BUFFER;
 import static io.netty.buffer.Unpooled.buffer;
@@ -1456,7 +1456,7 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
 
     private void testDecompose(int offset, int length, int expectedListSize) {
         byte[] bytes = new byte[1024];
-        PlatformDependent.threadLocalRandom().nextBytes(bytes);
+        ThreadLocalRandom.current().nextBytes(bytes);
         ByteBuf buf = wrappedBuffer(bytes);
 
         CompositeByteBuf composite = newCompositeBuffer();

--- a/buffer/src/test/java/io/netty/buffer/ReadOnlyByteBufferBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ReadOnlyByteBufferBufTest.java
@@ -15,10 +15,10 @@
  */
 package io.netty.buffer;
 
-import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -40,7 +40,7 @@ public class ReadOnlyByteBufferBufTest extends ReadOnlyDirectByteBufferBufTest {
 
     private static void testCopy(boolean direct) {
         byte[] bytes = new byte[1024];
-        PlatformDependent.threadLocalRandom().nextBytes(bytes);
+        ThreadLocalRandom.current().nextBytes(bytes);
 
         ByteBuffer nioBuffer = direct ? ByteBuffer.allocateDirect(bytes.length) : ByteBuffer.allocate(bytes.length);
         nioBuffer.put(bytes).flip();

--- a/buffer/src/test/java/io/netty/buffer/ReadOnlyDirectByteBufferBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ReadOnlyDirectByteBufferBufTest.java
@@ -30,6 +30,7 @@ import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.ReadOnlyBufferException;
 import java.nio.channels.FileChannel;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
 import static io.netty.buffer.AbstractByteBufTest.assertReadyOnlyNioBuffer;
@@ -390,7 +391,7 @@ public class ReadOnlyDirectByteBufferBufTest {
         try {
             output = new RandomAccessFile(file, "rw").getChannel();
             byte[] bytes = new byte[1024];
-            PlatformDependent.threadLocalRandom().nextBytes(bytes);
+            ThreadLocalRandom.current().nextBytes(bytes);
             output.write(ByteBuffer.wrap(bytes));
 
             input = new RandomAccessFile(file, "r").getChannel();
@@ -492,7 +493,7 @@ public class ReadOnlyDirectByteBufferBufTest {
     @Test
     public void testDuplicateReadGatheringByteChannelMultipleThreads() throws Exception {
         final byte[] bytes = new byte[8];
-        PlatformDependent.threadLocalRandom().nextBytes(bytes);
+        ThreadLocalRandom.current().nextBytes(bytes);
         ByteBuffer nioBuffer = allocate(bytes.length);
         nioBuffer.put(bytes);
         nioBuffer.flip();
@@ -507,7 +508,7 @@ public class ReadOnlyDirectByteBufferBufTest {
     @Test
     public void testSliceReadGatheringByteChannelMultipleThreads() throws Exception {
         final byte[] bytes = new byte[8];
-        PlatformDependent.threadLocalRandom().nextBytes(bytes);
+        ThreadLocalRandom.current().nextBytes(bytes);
         ByteBuffer nioBuffer = allocate(bytes.length);
         nioBuffer.put(bytes);
         nioBuffer.flip();
@@ -522,7 +523,7 @@ public class ReadOnlyDirectByteBufferBufTest {
     @Test
     public void testDuplicateReadOutputStreamMultipleThreads() throws Exception {
         final byte[] bytes = new byte[8];
-        PlatformDependent.threadLocalRandom().nextBytes(bytes);
+        ThreadLocalRandom.current().nextBytes(bytes);
         ByteBuffer nioBuffer = allocate(bytes.length);
         nioBuffer.put(bytes);
         nioBuffer.flip();
@@ -537,7 +538,7 @@ public class ReadOnlyDirectByteBufferBufTest {
     @Test
     public void testSliceReadOutputStreamMultipleThreads() throws Exception {
         final byte[] bytes = new byte[8];
-        PlatformDependent.threadLocalRandom().nextBytes(bytes);
+        ThreadLocalRandom.current().nextBytes(bytes);
         ByteBuffer nioBuffer = allocate(bytes.length);
         nioBuffer.put(bytes);
         nioBuffer.flip();
@@ -552,7 +553,7 @@ public class ReadOnlyDirectByteBufferBufTest {
     @Test
     public void testDuplicateBytesInArrayMultipleThreads() throws Exception {
         final byte[] bytes = new byte[8];
-        PlatformDependent.threadLocalRandom().nextBytes(bytes);
+        ThreadLocalRandom.current().nextBytes(bytes);
         ByteBuffer nioBuffer = allocate(bytes.length);
         nioBuffer.put(bytes);
         nioBuffer.flip();
@@ -567,7 +568,7 @@ public class ReadOnlyDirectByteBufferBufTest {
     @Test
     public void testSliceBytesInArrayMultipleThreads() throws Exception {
         final byte[] bytes = new byte[8];
-        PlatformDependent.threadLocalRandom().nextBytes(bytes);
+        ThreadLocalRandom.current().nextBytes(bytes);
         ByteBuffer nioBuffer = allocate(bytes.length);
         nioBuffer.put(bytes);
         nioBuffer.flip();
@@ -798,7 +799,7 @@ public class ReadOnlyDirectByteBufferBufTest {
 
     private ByteBuf newRandomReadOnlyBuffer() {
         final byte[] bytes = new byte[8];
-        PlatformDependent.threadLocalRandom().nextBytes(bytes);
+        ThreadLocalRandom.current().nextBytes(bytes);
         ByteBuffer nioBuffer = allocate(bytes.length);
         nioBuffer.put(bytes);
         nioBuffer.flip();

--- a/buffer/src/test/java/io/netty/buffer/SlicedByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/SlicedByteBufTest.java
@@ -15,14 +15,13 @@
  */
 package io.netty.buffer;
 
-import io.netty.util.internal.PlatformDependent;
-
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
 import java.nio.ByteBuffer;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -37,7 +36,8 @@ public class SlicedByteBufTest extends AbstractByteBufTest {
     @Override
     protected final ByteBuf newBuffer(int length, int maxCapacity) {
         Assumptions.assumeTrue(maxCapacity == Integer.MAX_VALUE);
-        int offset = length == 0 ? 0 : PlatformDependent.threadLocalRandom().nextInt(length);
+        int offset;
+        offset = length == 0 ? 0 : ThreadLocalRandom.current().nextInt(length);
         ByteBuf buffer = Unpooled.buffer(length * 2);
         ByteBuf slice = newSlice(buffer, offset, length);
         assertEquals(0, slice.readerIndex());

--- a/codec-base/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
@@ -29,12 +29,12 @@ import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.socket.ChannelInputShutdownEvent;
 import io.netty.util.CharsetUtil;
-import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.netty.buffer.Unpooled.wrappedBuffer;
@@ -160,7 +160,7 @@ public class ByteToMessageDecoderTest {
             }
         });
         byte[] bytes = new byte[1024];
-        PlatformDependent.threadLocalRandom().nextBytes(bytes);
+        ThreadLocalRandom.current().nextBytes(bytes);
 
         assertTrue(channel.writeInbound(Unpooled.wrappedBuffer(bytes)));
         assertTrue(channel.finishAndReleaseAll());
@@ -257,7 +257,7 @@ public class ByteToMessageDecoderTest {
             }
         });
         byte[] bytes = new byte[1024];
-        PlatformDependent.threadLocalRandom().nextBytes(bytes);
+        ThreadLocalRandom.current().nextBytes(bytes);
 
         assertTrue(channel.writeInbound(Unpooled.copiedBuffer(bytes)));
         assertBuffer(Unpooled.wrappedBuffer(bytes), (ByteBuf) channel.readInbound());
@@ -289,7 +289,7 @@ public class ByteToMessageDecoderTest {
             }
         });
         byte[] bytes = new byte[1024];
-        PlatformDependent.threadLocalRandom().nextBytes(bytes);
+        ThreadLocalRandom.current().nextBytes(bytes);
 
         assertTrue(channel.writeInbound(Unpooled.copiedBuffer(bytes)));
         assertBuffer(Unpooled.wrappedBuffer(bytes, 0, bytes.length - 1), (ByteBuf) channel.readInbound());
@@ -561,7 +561,7 @@ public class ByteToMessageDecoderTest {
             }
         });
         byte[] bytes = new byte[1024];
-        PlatformDependent.threadLocalRandom().nextBytes(bytes);
+        ThreadLocalRandom.current().nextBytes(bytes);
 
         assertFalse(channel.writeInbound(Unpooled.copiedBuffer(bytes)));
         assertNull(channel.readInbound());

--- a/codec-base/src/test/java/io/netty/handler/codec/ReplayingDecoderTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/ReplayingDecoderTest.java
@@ -21,12 +21,12 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.socket.ChannelInputShutdownEvent;
-import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -306,7 +306,7 @@ public class ReplayingDecoderTest {
             }
         });
         byte[] bytes = new byte[1024];
-        PlatformDependent.threadLocalRandom().nextBytes(bytes);
+        ThreadLocalRandom.current().nextBytes(bytes);
 
         assertTrue(channel.writeInbound(Unpooled.wrappedBuffer(bytes)));
         assertTrue(channel.finishAndReleaseAll());

--- a/codec-base/src/test/java/io/netty/handler/codec/base64/Base64Test.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/base64/Base64Test.java
@@ -20,7 +20,6 @@ import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
-import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
 import org.junit.jupiter.api.Test;
 
@@ -30,6 +29,7 @@ import java.io.IOException;
 import java.nio.ByteOrder;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static io.netty.buffer.Unpooled.copiedBuffer;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -161,7 +161,7 @@ public class Base64Test {
     private static void testEncodeDecode(
             int size, ByteOrder order, Base64Dialect dialect, boolean breakLines, boolean padded) throws IOException {
         byte[] bytes = new byte[size];
-        PlatformDependent.threadLocalRandom().nextBytes(bytes);
+        ThreadLocalRandom.current().nextBytes(bytes);
 
         // JDK encoder / decoder
         java.util.Base64.Encoder jdkEncoder =

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/JdkZlibTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/JdkZlibTest.java
@@ -22,7 +22,6 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
-import io.netty.util.internal.PlatformDependent;
 import org.apache.commons.compress.utils.IOUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
@@ -31,6 +30,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Queue;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.zip.GZIPOutputStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -139,7 +139,7 @@ public class JdkZlibTest extends ZlibTest {
     @Test
     public void testDecodeWithHeaderFollowingFooter() throws Exception {
         byte[] bytes = new byte[1024];
-        PlatformDependent.threadLocalRandom().nextBytes(bytes);
+        ThreadLocalRandom.current().nextBytes(bytes);
         ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
         GZIPOutputStream out = new GZIPOutputStream(bytesOut);
         out.write(bytes);

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/ZlibTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/ZlibTest.java
@@ -24,7 +24,6 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.EmptyArrays;
-import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
@@ -32,6 +31,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
@@ -90,7 +90,7 @@ public abstract class ZlibTest {
             "</body></html>").getBytes(CharsetUtil.UTF_8);
 
     static {
-        Random rand = PlatformDependent.threadLocalRandom();
+        Random rand = ThreadLocalRandom.current();
         rand.nextBytes(BYTES_SMALL);
         rand.nextBytes(BYTES_LARGE);
     }

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/DefaultDnsRecordEncoderTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/DefaultDnsRecordEncoderTest.java
@@ -17,13 +17,13 @@ package io.netty.handler.codec.dns;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SocketUtils;
 import io.netty.util.internal.StringUtil;
 import org.junit.jupiter.api.Test;
 
 import java.net.Inet4Address;
 import java.net.InetAddress;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -182,6 +182,6 @@ public class DefaultDnsRecordEncoderTest {
     }
 
     private static int nextInt(int max) {
-        return PlatformDependent.threadLocalRandom().nextInt(max);
+        return ThreadLocalRandom.current().nextInt(max);
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostRequestEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostRequestEncoder.java
@@ -35,7 +35,6 @@ import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.stream.ChunkedInput;
 import io.netty.util.internal.ObjectUtil;
-import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
 
 import java.io.File;
@@ -47,6 +46,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.regex.Pattern;
 
 import static io.netty.buffer.Unpooled.wrappedBuffer;
@@ -290,7 +290,7 @@ public class HttpPostRequestEncoder implements ChunkedInput<HttpContent> {
      */
     private static String getNewMultipartDelimiter() {
         // construct a generated delimiter
-        return Long.toHexString(PlatformDependent.threadLocalRandom().nextLong());
+        return Long.toHexString(ThreadLocalRandom.current().nextLong());
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameEncoder.java
@@ -57,12 +57,12 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToMessageEncoder;
 import io.netty.handler.codec.TooLongFrameException;
-import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.nio.ByteOrder;
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * <p>
@@ -173,7 +173,7 @@ public class WebSocket08FrameEncoder extends MessageToMessageEncoder<WebSocketFr
 
             // Write payload
             if (maskPayload) {
-                int mask = PlatformDependent.threadLocalRandom().nextInt(Integer.MAX_VALUE);
+                int mask = ThreadLocalRandom.current().nextInt(Integer.MAX_VALUE);
                 buf.writeInt(mask);
 
                 if (data.isReadable()) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker00.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker00.java
@@ -26,10 +26,10 @@ import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
-import io.netty.util.internal.PlatformDependent;
 
 import java.net.URI;
 import java.nio.ByteBuffer;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * <p>
@@ -293,7 +293,7 @@ public class WebSocketClientHandshaker00 extends WebSocketClientHandshaker {
         char[] randomChars = new char[count];
         int randCount = 0;
         while (randCount < count) {
-            int rand = PlatformDependent.threadLocalRandom().nextInt(0x7e) + 0x21;
+            int rand = ThreadLocalRandom.current().nextInt(0x7e) + 0x21;
             if (0x21 < rand && rand < 0x2f || 0x3a < rand && rand < 0x7e) {
                 randomChars[randCount] = (char) rand;
                 randCount += 1;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketUtil.java
@@ -16,11 +16,11 @@
 package io.netty.handler.codec.http.websocketx;
 
 import io.netty.util.concurrent.FastThreadLocal;
-import io.netty.util.internal.PlatformDependent;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * A utility class mainly for use by web sockets
@@ -103,7 +103,7 @@ final class WebSocketUtil {
      */
     static byte[] randomBytes(int size) {
         byte[] bytes = new byte[size];
-        PlatformDependent.threadLocalRandom().nextBytes(bytes);
+        ThreadLocalRandom.current().nextBytes(bytes);
         return bytes;
     }
 
@@ -116,7 +116,7 @@ final class WebSocketUtil {
      */
     static int randomNumber(int minimum, int maximum) {
         assert minimum < maximum;
-        double fraction = PlatformDependent.threadLocalRandom().nextDouble();
+        double fraction = ThreadLocalRandom.current().nextDouble();
 
         // the idea here is that nextDouble gives us a random value
         //

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpDataTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpDataTest.java
@@ -25,6 +25,7 @@ import java.io.FileOutputStream;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static io.netty.util.CharsetUtil.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -43,7 +44,7 @@ public class AbstractDiskHttpDataTest {
             tmpFile.deleteOnExit();
             FileOutputStream fos = new FileOutputStream(tmpFile);
             byte[] bytes = new byte[4096];
-            PlatformDependent.threadLocalRandom().nextBytes(bytes);
+            ThreadLocalRandom.current().nextBytes(bytes);
             try {
                 fos.write(bytes);
                 fos.flush();

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/AbstractMemoryHttpDataTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/AbstractMemoryHttpDataTest.java
@@ -32,6 +32,7 @@ import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Random;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static io.netty.util.CharsetUtil.*;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -50,7 +51,7 @@ public class AbstractMemoryHttpDataTest {
             tmpFile.deleteOnExit();
             FileOutputStream fos = new FileOutputStream(tmpFile);
             byte[] bytes = new byte[4096];
-            PlatformDependent.threadLocalRandom().nextBytes(bytes);
+            ThreadLocalRandom.current().nextBytes(bytes);
             try {
                 fos.write(bytes);
                 fos.flush();
@@ -77,7 +78,7 @@ public class AbstractMemoryHttpDataTest {
             tmpFile.deleteOnExit();
             final int totalByteCount = 4096;
             byte[] bytes = new byte[totalByteCount];
-            PlatformDependent.threadLocalRandom().nextBytes(bytes);
+            ThreadLocalRandom.current().nextBytes(bytes);
             ByteBuf content = Unpooled.wrappedBuffer(bytes);
             test.setContent(content);
             boolean succ = test.renameTo(tmpFile);

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/DiskFileUploadTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/DiskFileUploadTest.java
@@ -30,6 +30,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -114,7 +115,7 @@ public class DiskFileUploadTest {
         DiskFileUpload f1 = new DiskFileUpload("file1", "file1", "application/json", null, null, 0);
         try {
             byte[] jsonBytes = new byte[4096];
-            PlatformDependent.threadLocalRandom().nextBytes(jsonBytes);
+            ThreadLocalRandom.current().nextBytes(jsonBytes);
 
             f1.addContent(Unpooled.wrappedBuffer(jsonBytes, 0, 1024), false);
             f1.addContent(Unpooled.wrappedBuffer(jsonBytes, 1024, jsonBytes.length - 1024), true);
@@ -200,7 +201,7 @@ public class DiskFileUploadTest {
         DiskFileUpload f1 = new DiskFileUpload("file3", "file3", "application/json", null, null, 0);
         try {
             byte[] bytes = new byte[4096];
-            PlatformDependent.threadLocalRandom().nextBytes(bytes);
+            ThreadLocalRandom.current().nextBytes(bytes);
 
             final ByteBuf buffer;
 
@@ -272,7 +273,7 @@ public class DiskFileUploadTest {
             assertEquals(maxSize, originalFile.length());
             assertEquals(maxSize, f1.length());
             byte[] bytes = new byte[8];
-            PlatformDependent.threadLocalRandom().nextBytes(bytes);
+            ThreadLocalRandom.current().nextBytes(bytes);
             File tmpFile = PlatformDependent.createTempFile(UUID.randomUUID().toString(), ".tmp", null);
             tmpFile.deleteOnExit();
             FileOutputStream fos = new FileOutputStream(tmpFile);

--- a/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicCodecDispatcherTest.java
+++ b/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicCodecDispatcherTest.java
@@ -21,10 +21,10 @@ import io.netty.channel.Channel;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.util.NetUtil;
-import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -90,16 +90,16 @@ public class QuicCodecDispatcherTest {
 
     private static void writePacket(EmbeddedChannel[] channels, boolean shortHeader, short localConnectionIdLength) {
         DatagramPacket packet = createQuicPacket(
-                PlatformDependent.threadLocalRandom().nextInt(channels.length),
+                ThreadLocalRandom.current().nextInt(channels.length),
                 shortHeader, localConnectionIdLength);
-        channels[PlatformDependent.threadLocalRandom().nextInt(channels.length)].writeInbound(packet);
+        channels[ThreadLocalRandom.current().nextInt(channels.length)].writeInbound(packet);
     }
 
     // See https://www.rfc-editor.org/rfc/rfc9000.html#section-17
     private static DatagramPacket createQuicPacket(int idx, boolean shortHeader, short localConnectionIdLength) {
         ByteBuf content = Unpooled.buffer();
         byte[] random = new byte[localConnectionIdLength];
-        PlatformDependent.threadLocalRandom().nextBytes(random);
+        ThreadLocalRandom.current().nextBytes(random);
 
         if (shortHeader) {
             content.writeByte(0);
@@ -115,7 +115,7 @@ public class QuicCodecDispatcherTest {
             content.setShort(writerIndex, (short) idx);
         }
         // Add some more data.
-        content.writeZero(PlatformDependent.threadLocalRandom().nextInt(32));
+        content.writeZero(ThreadLocalRandom.current().nextInt(32));
         return new DatagramPacket(content, new InetSocketAddress(NetUtil.LOCALHOST, 0));
     }
 }

--- a/common/src/main/java/io/netty/util/ResourceLeakDetector.java
+++ b/common/src/main/java/io/netty/util/ResourceLeakDetector.java
@@ -18,7 +18,6 @@ package io.netty.util;
 
 import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.ObjectUtil;
-import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -31,6 +30,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
@@ -269,7 +269,7 @@ public class ResourceLeakDetector<T> {
         Level level = ResourceLeakDetector.level;
         if (force ||
                 level == Level.PARANOID ||
-                (level != Level.DISABLED && PlatformDependent.threadLocalRandom().nextInt(samplingInterval) == 0)) {
+                (level != Level.DISABLED && ThreadLocalRandom.current().nextInt(samplingInterval) == 0)) {
             reportLeak();
             return new DefaultResourceLeak(obj, refQueue, allLeaks, getInitialHint(resourceType));
         }
@@ -478,7 +478,7 @@ public class ResourceLeakDetector<T> {
                     final int numElements = oldHead.pos + 1;
                     if (numElements >= TARGET_RECORDS) {
                         final int backOffFactor = Math.min(numElements - TARGET_RECORDS, 30);
-                        dropped = PlatformDependent.threadLocalRandom().nextInt(1 << backOffFactor) != 0;
+                        dropped = ThreadLocalRandom.current().nextInt(1 << backOffFactor) != 0;
                         if (dropped) {
                             prevHead = oldHead.next;
                         }

--- a/common/src/main/java/io/netty/util/internal/MacAddressUtil.java
+++ b/common/src/main/java/io/netty/util/internal/MacAddressUtil.java
@@ -28,6 +28,7 @@ import java.util.Enumeration;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static io.netty.util.internal.EmptyArrays.EMPTY_BYTES;
 
@@ -129,7 +130,7 @@ public final class MacAddressUtil {
         byte[] bestMacAddr = bestAvailableMac();
         if (bestMacAddr == null) {
             bestMacAddr = new byte[EUI64_MAC_ADDRESS_LENGTH];
-            PlatformDependent.threadLocalRandom().nextBytes(bestMacAddr);
+            ThreadLocalRandom.current().nextBytes(bestMacAddr);
             logger.warn(
                     "Failed to find a usable hardware address from the network interfaces; using random bytes: {}",
                     formatAddress(bestMacAddr));

--- a/common/src/main/java/io/netty/util/internal/NativeLibraryLoader.java
+++ b/common/src/main/java/io/netty/util/internal/NativeLibraryLoader.java
@@ -42,6 +42,7 @@ import java.util.EnumSet;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * Helper class to load JNI resources.
@@ -372,7 +373,7 @@ public final class NativeLibraryLoader {
         byte[] idBytes = new byte[length];
         for (int i = 0; i < idBytes.length; i++) {
             // We should only use bytes as replacement that are in our UNIQUE_ID_BYTES array.
-            idBytes[i] = UNIQUE_ID_BYTES[PlatformDependent.threadLocalRandom()
+            idBytes[i] = UNIQUE_ID_BYTES[ThreadLocalRandom.current()
                     .nextInt(UNIQUE_ID_BYTES.length)];
         }
         return idBytes;

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -1097,7 +1097,9 @@ public final class PlatformDependent {
 
     /**
      * Return a {@link Random} which is not-threadsafe and so can only be used from the same thread.
+     * @deprecated Use ThreadLocalRandom.current() instead.
      */
+    @Deprecated
     public static Random threadLocalRandom() {
         return ThreadLocalRandom.current();
     }

--- a/common/src/test/java/io/netty/util/internal/BoundedInputStreamTest.java
+++ b/common/src/test/java/io/netty/util/internal/BoundedInputStreamTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.function.Executable;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -33,7 +34,7 @@ public class BoundedInputStreamTest {
     @RepeatedTest(50)
     void testBoundEnforced() throws IOException {
         final byte[] bytes = new byte[64];
-        PlatformDependent.threadLocalRandom().nextBytes(bytes);
+        ThreadLocalRandom.current().nextBytes(bytes);
         final BoundedInputStream reader = new BoundedInputStream(new ByteArrayInputStream(bytes), bytes.length - 1);
         assertEquals(bytes[0], (byte) reader.read());
 
@@ -80,7 +81,7 @@ public class BoundedInputStreamTest {
     @RepeatedTest(50)
     void testBigReadsPermittedIfUnderlyingStreamIsSmall() throws IOException {
         final byte[] bytes = new byte[64];
-        PlatformDependent.threadLocalRandom().nextBytes(bytes);
+        ThreadLocalRandom.current().nextBytes(bytes);
         final BoundedInputStream reader = new BoundedInputStream(new ByteArrayInputStream(bytes), 8192);
         final byte[] buffer = new byte[10000];
         assertThat(reader.read(buffer, 0, 10000)).isEqualTo(64);

--- a/handler/src/main/java/io/netty/handler/ssl/util/ThreadLocalInsecureRandom.java
+++ b/handler/src/main/java/io/netty/handler/ssl/util/ThreadLocalInsecureRandom.java
@@ -20,6 +20,7 @@ import io.netty.util.internal.PlatformDependent;
 
 import java.security.SecureRandom;
 import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * Insecure {@link SecureRandom} which relies on {@link PlatformDependent#threadLocalRandom()} for random number
@@ -96,6 +97,6 @@ final class ThreadLocalInsecureRandom extends SecureRandom {
     }
 
     private static Random random() {
-        return PlatformDependent.threadLocalRandom();
+        return ThreadLocalRandom.current();
     }
 }

--- a/handler/src/test/java/io/netty/handler/ssl/DelayingExecutor.java
+++ b/handler/src/test/java/io/netty/handler/ssl/DelayingExecutor.java
@@ -15,12 +15,11 @@
  */
 package io.netty.handler.ssl;
 
-import io.netty.util.internal.PlatformDependent;
-
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
 final class DelayingExecutor implements Executor {
@@ -39,7 +38,7 @@ final class DelayingExecutor implements Executor {
     public void execute(Runnable command) {
         // Let's add some jitter in terms of when the task is actual run
         service.schedule(command,
-                PlatformDependent.threadLocalRandom().nextInt(100), TimeUnit.MILLISECONDS);
+                ThreadLocalRandom.current().nextInt(100), TimeUnit.MILLISECONDS);
     }
 
     void shutdown() {

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
@@ -25,12 +25,9 @@ import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.internal.tcnative.SSL;
 import io.netty.util.CharsetUtil;
 import io.netty.util.internal.EmptyArrays;
-import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -50,6 +47,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
 import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
@@ -269,7 +267,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
 
             ByteBuffer src = allocateBuffer(param.type(), 1024 * 10);
             byte[] data = new byte[src.capacity()];
-            PlatformDependent.threadLocalRandom().nextBytes(data);
+            ThreadLocalRandom.current().nextBytes(data);
             src.put(data).flip();
             ByteBuffer dst = allocateBuffer(param.type(), 1);
             // Try to wrap multiple times so we are more likely to hit the issue.

--- a/handler/src/test/java/io/netty/handler/ssl/ParameterizedSslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ParameterizedSslHandlerTest.java
@@ -48,7 +48,6 @@ import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.concurrent.PromiseNotifier;
 import io.netty.util.internal.EmptyArrays;
-import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.ResourcesUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -74,6 +73,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -553,7 +553,7 @@ public class ParameterizedSslHandlerTest {
             Class<? extends ServerChannel> serverClass = LocalServerChannel.class;
             Class<? extends Channel> clientClass = LocalChannel.class;
             SocketAddress bindAddress = new LocalAddress(String.valueOf(
-                    PlatformDependent.threadLocalRandom().nextLong()));
+                    ThreadLocalRandom.current().nextLong()));
             reentryOnHandshakeComplete(clientProvider, serverProvider, group, bindAddress,
                     serverClass, clientClass, false, false);
             reentryOnHandshakeComplete(clientProvider, serverProvider, group, bindAddress,

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -100,6 +100,7 @@ import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -110,7 +111,6 @@ import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.KeyManagerFactorySpi;
 import javax.net.ssl.ManagerFactoryParameters;
 import javax.net.ssl.SNIHostName;
-import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLEngineResult;
@@ -318,7 +318,7 @@ public abstract class SSLEngineTest {
             case Heap:
                 return ByteBuffer.allocate(len);
             case Mixed:
-                return PlatformDependent.threadLocalRandom().nextBoolean() ?
+                return ThreadLocalRandom.current().nextBoolean() ?
                         ByteBuffer.allocateDirect(len) : ByteBuffer.allocate(len);
             default:
                 throw new Error();
@@ -343,7 +343,7 @@ public abstract class SSLEngineTest {
                 case Heap:
                     return allocator.heapBuffer();
                 case Mixed:
-                    return PlatformDependent.threadLocalRandom().nextBoolean() ?
+                    return ThreadLocalRandom.current().nextBoolean() ?
                             allocator.directBuffer() : allocator.heapBuffer();
                 default:
                     throw new Error();
@@ -358,7 +358,7 @@ public abstract class SSLEngineTest {
                 case Heap:
                     return allocator.heapBuffer(initialCapacity);
                 case Mixed:
-                    return PlatformDependent.threadLocalRandom().nextBoolean() ?
+                    return ThreadLocalRandom.current().nextBoolean() ?
                             allocator.directBuffer(initialCapacity) : allocator.heapBuffer(initialCapacity);
                 default:
                     throw new Error();
@@ -373,7 +373,7 @@ public abstract class SSLEngineTest {
                 case Heap:
                     return allocator.heapBuffer(initialCapacity, maxCapacity);
                 case Mixed:
-                    return PlatformDependent.threadLocalRandom().nextBoolean() ?
+                    return ThreadLocalRandom.current().nextBoolean() ?
                             allocator.directBuffer(initialCapacity, maxCapacity) :
                             allocator.heapBuffer(initialCapacity, maxCapacity);
                 default:
@@ -434,7 +434,7 @@ public abstract class SSLEngineTest {
                 case Heap:
                     return allocator.compositeHeapBuffer();
                 case Mixed:
-                    return PlatformDependent.threadLocalRandom().nextBoolean() ?
+                    return ThreadLocalRandom.current().nextBoolean() ?
                             allocator.compositeDirectBuffer() :
                             allocator.compositeHeapBuffer();
                 default:
@@ -450,7 +450,7 @@ public abstract class SSLEngineTest {
                 case Heap:
                     return allocator.compositeHeapBuffer(maxNumComponents);
                 case Mixed:
-                    return PlatformDependent.threadLocalRandom().nextBoolean() ?
+                    return ThreadLocalRandom.current().nextBoolean() ?
                             allocator.compositeDirectBuffer(maxNumComponents) :
                             allocator.compositeHeapBuffer(maxNumComponents);
                 default:

--- a/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
@@ -64,7 +64,6 @@ import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.ImmediateExecutor;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.EmptyArrays;
-import io.netty.util.internal.PlatformDependent;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -91,6 +90,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -1326,7 +1326,7 @@ public class SslHandlerTest {
         EventLoopGroup group = new MultiThreadIoEventLoopGroup(NioIoHandler.newFactory());
         Channel sc = null;
         final byte[] bytes = new byte[96];
-        PlatformDependent.threadLocalRandom().nextBytes(bytes);
+        ThreadLocalRandom.current().nextBytes(bytes);
         try {
             final AtomicReference<AssertionError> assertErrorRef = new AtomicReference<AssertionError>();
             sc = new ServerBootstrap()

--- a/microbench/src/main/java/io/netty/handler/codec/http/HttpPostDecoderBenchmark.java
+++ b/microbench/src/main/java/io/netty/handler/codec/http/HttpPostDecoderBenchmark.java
@@ -21,7 +21,6 @@ import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.multipart.HttpPostRequestDecoder;
 import io.netty.handler.codec.http.multipart.InterfaceHttpData;
 import io.netty.microbench.util.AbstractMicrobenchmark;
-import io.netty.util.internal.PlatformDependent;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
@@ -34,6 +33,7 @@ import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
 @Threads(1)
@@ -65,7 +65,7 @@ public class HttpPostDecoderBenchmark extends AbstractMicrobenchmark {
     }
 
     private static CharSequence randomString() {
-        Random rng = PlatformDependent.threadLocalRandom();
+        Random rng = ThreadLocalRandom.current();
         int len = 4 + rng.nextInt(110);
         StringBuilder sb = new StringBuilder(len);
         for (int i = 0; i < len; i++) {

--- a/microbench/src/main/java/io/netty/microbench/handler/ssl/AbstractSslEngineThroughputBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/handler/ssl/AbstractSslEngineThroughputBenchmark.java
@@ -17,13 +17,13 @@ package io.netty.microbench.handler.ssl;
 
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.PooledByteBufAllocator;
-import io.netty.util.internal.PlatformDependent;
 import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.TearDown;
 
 import java.nio.ByteBuffer;
+import java.util.concurrent.ThreadLocalRandom;
 import javax.net.ssl.SSLEngineResult;
 import javax.net.ssl.SSLException;
 
@@ -45,7 +45,7 @@ public abstract class AbstractSslEngineThroughputBenchmark extends AbstractSslEn
         wrapSrcBuffer = allocateBuffer(messageSize);
 
         byte[] bytes = new byte[messageSize];
-        PlatformDependent.threadLocalRandom().nextBytes(bytes);
+        ThreadLocalRandom.current().nextBytes(bytes);
         wrapSrcBuffer.put(bytes);
         wrapSrcBuffer.flip();
 

--- a/microbench/src/main/java/io/netty/microbench/handler/ssl/AbstractSslHandlerThroughputBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/handler/ssl/AbstractSslHandlerThroughputBenchmark.java
@@ -18,11 +18,12 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.util.internal.PlatformDependent;
 import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.TearDown;
+
+import java.util.concurrent.ThreadLocalRandom;
 
 public abstract class AbstractSslHandlerThroughputBenchmark extends AbstractSslHandlerBenchmark {
     @Param({ "64", "128", "512", "1024", "4096" })
@@ -61,7 +62,7 @@ public abstract class AbstractSslHandlerThroughputBenchmark extends AbstractSslH
         wrapSrcBuffer = allocateBuffer(messageSize);
 
         byte[] bytes = new byte[messageSize];
-        PlatformDependent.threadLocalRandom().nextBytes(bytes);
+        ThreadLocalRandom.current().nextBytes(bytes);
         wrapSrcBuffer.writeBytes(bytes);
 
         // Complete the initial TLS handshake.

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryIdSpace.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryIdSpace.java
@@ -16,9 +16,9 @@
 package io.netty.resolver.dns;
 
 import io.netty.util.internal.MathUtil;
-import io.netty.util.internal.PlatformDependent;
 
 import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * Special data-structure that will allow to retrieve the next query id to use, while still guarantee some sort
@@ -61,7 +61,7 @@ final class DnsQueryIdSpace {
                 }
             } else if (freeIdx == -1 ||
                     // Let's make it somehow random which free slot is used.
-                    PlatformDependent.threadLocalRandom().nextBoolean()) {
+                    ThreadLocalRandom.current().nextBoolean()) {
                 // We have a slot that we can use to create a new bucket if we need to.
                 freeIdx = bucketIdx;
             }
@@ -178,7 +178,7 @@ final class DnsQueryIdSpace {
             }
             assert id <= startId + ids.length && id >= startId;
             // pick a slot for our index, and whatever was in that slot before will get moved to the tail.
-            Random random = PlatformDependent.threadLocalRandom();
+            Random random = ThreadLocalRandom.current();
             int insertionPosition = random.nextInt(count + 1);
             short moveId = ids[insertionPosition];
             short insertId = (short) id;

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/ShuffledDnsServerAddressStream.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/ShuffledDnsServerAddressStream.java
@@ -16,11 +16,10 @@
 
 package io.netty.resolver.dns;
 
-import io.netty.util.internal.PlatformDependent;
-
 import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 
 final class ShuffledDnsServerAddressStream implements DnsServerAddressStream {
 
@@ -44,7 +43,7 @@ final class ShuffledDnsServerAddressStream implements DnsServerAddressStream {
     }
 
     private void shuffle() {
-        Collections.shuffle(addresses, PlatformDependent.threadLocalRandom());
+        Collections.shuffle(addresses, ThreadLocalRandom.current());
     }
 
     @Override

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -499,7 +499,7 @@ public class DnsNameResolverTest {
                 if (EXCLUSIONS_RESOLVE_A.contains(name)) {
                     continue;
                 }
-                if (PlatformDependent.threadLocalRandom().nextBoolean()) {
+                if (java.util.concurrent.ThreadLocalRandom.current().nextBoolean()) {
                     overriddenHostnames.add(name);
                 }
             }

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/TestDnsServer.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/TestDnsServer.java
@@ -16,7 +16,6 @@
 package io.netty.resolver.dns;
 
 import io.netty.util.NetUtil;
-import io.netty.util.internal.PlatformDependent;
 import org.apache.directory.server.dns.DnsServer;
 import org.apache.directory.server.dns.io.decoder.DnsMessageDecoder;
 import org.apache.directory.server.dns.io.encoder.DnsMessageEncoder;
@@ -55,6 +54,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
 
 class TestDnsServer extends DnsServer {
     private static final Map<String, byte[]> BYTES = new HashMap<String, byte[]>();
@@ -294,7 +294,7 @@ class TestDnsServer extends DnsServer {
         }
 
         private static int index(int arrayLength) {
-            return Math.abs(PlatformDependent.threadLocalRandom().nextInt()) % arrayLength;
+            return Math.abs(ThreadLocalRandom.current().nextInt()) % arrayLength;
         }
 
         private static String nextDomain() {
@@ -328,19 +328,19 @@ class TestDnsServer extends DnsServer {
                     case A:
                         do {
                             attr.put(DnsAttribute.IP_ADDRESS.toLowerCase(Locale.US), nextIp());
-                        } while (PlatformDependent.threadLocalRandom().nextBoolean());
+                        } while (ThreadLocalRandom.current().nextBoolean());
                         break;
                     case AAAA:
                         do {
                             attr.put(DnsAttribute.IP_ADDRESS.toLowerCase(Locale.US), nextIp6());
-                        } while (PlatformDependent.threadLocalRandom().nextBoolean());
+                        } while (ThreadLocalRandom.current().nextBoolean());
                         break;
                     case MX:
                         int priority = 0;
                         do {
                             attr.put(DnsAttribute.DOMAIN_NAME.toLowerCase(Locale.US), nextDomain());
                             attr.put(DnsAttribute.MX_PREFERENCE.toLowerCase(Locale.US), String.valueOf(++priority));
-                        } while (PlatformDependent.threadLocalRandom().nextBoolean());
+                        } while (ThreadLocalRandom.current().nextBoolean());
                         break;
                     default:
                         return null;

--- a/resolver/src/main/java/io/netty/resolver/RoundRobinInetAddressResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/RoundRobinInetAddressResolver.java
@@ -19,7 +19,6 @@ import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.Promise;
-import io.netty.util.internal.PlatformDependent;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -27,6 +26,7 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * A {@link NameResolver} that resolves {@link InetAddress} and force Round Robin by choosing a single address
@@ -96,7 +96,7 @@ public class RoundRobinInetAddressResolver extends InetNameResolver {
     }
 
     private static int randomIndex(int numAddresses) {
-        return numAddresses == 1 ? 0 : PlatformDependent.threadLocalRandom().nextInt(numAddresses);
+        return numAddresses == 1 ? 0 : ThreadLocalRandom.current().nextInt(numAddresses);
     }
 
     @Override

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFileRegionTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFileRegionTest.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.channels.WritableByteChannel;
 import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -51,7 +52,7 @@ public class SocketFileRegionTest extends AbstractSocketTest {
     static final byte[] data = new byte[1048576 * 10];
 
     static {
-        PlatformDependent.threadLocalRandom().nextBytes(data);
+        ThreadLocalRandom.current().nextBytes(data);
     }
 
     @Test
@@ -178,7 +179,7 @@ public class SocketFileRegionTest extends AbstractSocketTest {
         file.deleteOnExit();
 
         final FileOutputStream out = new FileOutputStream(file);
-        final Random random = PlatformDependent.threadLocalRandom();
+        final Random random = ThreadLocalRandom.current();
 
         // Prepend random data which will not be transferred, so that we can test non-zero start offset
         final int startOffset = random.nextInt(8192);

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramScatteringReadTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramScatteringReadTest.java
@@ -25,7 +25,6 @@ import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.AbstractDatagramTest;
-import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -35,6 +34,7 @@ import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -255,7 +255,7 @@ public class EpollDatagramScatteringReadTest extends AbstractDatagramTest  {
 
             final AtomicReference<Throwable> errorRef = new AtomicReference<Throwable>();
             final byte[] bytes = new byte[packetSize];
-            PlatformDependent.threadLocalRandom().nextBytes(bytes);
+            ThreadLocalRandom.current().nextBytes(bytes);
 
             final CountDownLatch latch = new CountDownLatch(1);
             sb.handler(new SimpleChannelInboundHandler<DatagramPacket>() {

--- a/transport-udt/src/test/java/io/netty/test/udt/util/UnitHelp.java
+++ b/transport-udt/src/test/java/io/netty/test/udt/util/UnitHelp.java
@@ -18,7 +18,6 @@ package io.netty.test.udt.util;
 
 import com.barchart.udt.SocketUDT;
 import com.barchart.udt.StatusUDT;
-import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SocketUtils;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -33,6 +32,7 @@ import java.util.Locale;
 import java.util.Random;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.regex.Pattern;
 
 /**
@@ -223,7 +223,7 @@ public final class UnitHelp {
 
     public static int[] randomIntArray(final int length, final int range) {
         final int[] array = new int[length];
-        final Random generator = PlatformDependent.threadLocalRandom();
+        final Random generator = ThreadLocalRandom.current();
         for (int i = 0; i < array.length; i++) {
             array[i] = generator.nextInt(range);
         }

--- a/transport/src/main/java/io/netty/channel/DefaultChannelId.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelId.java
@@ -26,6 +26,7 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static io.netty.util.internal.MacAddressUtil.defaultMachineId;
@@ -57,7 +58,7 @@ public final class DefaultChannelId implements ChannelId {
                                     PROCESS_ID,
                                     nextSequence.getAndIncrement(),
                                     Long.reverse(System.nanoTime()) ^ System.currentTimeMillis(),
-                                    PlatformDependent.threadLocalRandom().nextInt());
+                                    ThreadLocalRandom.current().nextInt());
     }
 
     static {
@@ -171,7 +172,7 @@ public final class DefaultChannelId implements ChannelId {
         }
 
         if (pid < 0) {
-            pid = PlatformDependent.threadLocalRandom().nextInt();
+            pid = ThreadLocalRandom.current().nextInt();
             logger.warn("Failed to find the current process ID from '{}'; using a random value: {}",  value, pid);
         }
 

--- a/transport/src/test/java/io/netty/channel/DefaultFileRegionTest.java
+++ b/transport/src/test/java/io/netty/channel/DefaultFileRegionTest.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -35,7 +36,7 @@ public class DefaultFileRegionTest {
     private static final byte[] data = new byte[1048576 * 10];
 
     static {
-        PlatformDependent.threadLocalRandom().nextBytes(data);
+        ThreadLocalRandom.current().nextBytes(data);
     }
 
     private static File newFile() throws IOException {

--- a/transport/src/test/java/io/netty/channel/socket/nio/NioSocketChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/socket/nio/NioSocketChannelTest.java
@@ -35,7 +35,6 @@ import io.netty.channel.nio.NioIoHandler;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.util.CharsetUtil;
 import io.netty.util.NetUtil;
-import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -54,6 +53,7 @@ import java.nio.channels.NetworkChannel;
 import java.util.Queue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.*;
@@ -182,7 +182,7 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
 
         // Just some random bytes
         byte[] bytes = new byte[1024];
-        PlatformDependent.threadLocalRandom().nextBytes(bytes);
+        ThreadLocalRandom.current().nextBytes(bytes);
 
         Channel sc = null;
         Channel cc = null;


### PR DESCRIPTION
…no longer needed

4.2 netty version now have java 8 as min requirement, so we no longer need `PlatformDependent.threadLocalRandom()`. `ThreadLocalRandom.current()` could be used directly.

`PlatformDependent.threadLocalRandom()` is deprecated.