### PR TITLE
Remove references to sun.* classes to be able to compile with JDK24

### DIFF
--- a/common/src/main/java/io/netty/util/internal/JavaVersion.java
+++ b/common/src/main/java/io/netty/util/internal/JavaVersion.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.internal;
+
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+final class JavaVersion {
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(JavaVersion.class);
+
+    private static final boolean IS_ANDROID = isAndroid0();
+    private static final int JAVA_VERSION = javaVersion0();
+
+    static boolean isAndroid() {
+        return IS_ANDROID;
+    }
+
+    private static boolean isAndroid0() {
+        // Idea: Sometimes java binaries include Android classes on the classpath, even if it isn't actually Android.
+        // Rather than check if certain classes are present, just check the VM, which is tied to the JDK.
+
+        // Optional improvement: check if `android.os.Build.VERSION` is >= 24. On later versions of Android, the
+        // OpenJDK is used, which means `Unsafe` will actually work as expected.
+
+        // Android sets this property to Dalvik, regardless of whether it actually is.
+        String vmName = SystemPropertyUtil.get("java.vm.name");
+        boolean isAndroid = "Dalvik".equals(vmName);
+        if (isAndroid) {
+            logger.debug("Platform: Android");
+        }
+        return isAndroid;
+    }
+
+    static int javaVersion() {
+        return JAVA_VERSION;
+    }
+
+    private static int javaVersion0() {
+        final int majorVersion;
+
+        if (isAndroid()) {
+            majorVersion = 6;
+        } else {
+            majorVersion = majorVersionFromJavaSpecificationVersion();
+        }
+
+        logger.debug("Java version: {}", majorVersion);
+
+        return majorVersion;
+    }
+
+    // Package-private for testing only
+    static int majorVersionFromJavaSpecificationVersion() {
+        return majorVersion(SystemPropertyUtil.get("java.specification.version", "1.6"));
+    }
+
+    // Package-private for testing only
+    static int majorVersion(final String javaSpecVersion) {
+        final String[] components = javaSpecVersion.split("\\.");
+        final int[] version = new int[components.length];
+        for (int i = 0; i < components.length; i++) {
+            version[i] = Integer.parseInt(components[i]);
+        }
+
+        if (version[0] == 1) {
+            assert version[1] >= 6;
+            return version[1];
+        } else {
+            return version[0];
+        }
+    }
+
+
+    private JavaVersion() { }
+}

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -17,7 +17,6 @@ package io.netty.util.internal;
 
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
-import sun.misc.Unsafe;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -39,18 +38,23 @@ import static java.lang.invoke.MethodType.methodType;
 final class PlatformDependent0 {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(PlatformDependent0.class);
+
+    /**
+     * Limits the number of bytes to copy per {@link sun.misc.Unsafe#copyMemory(long, long, long)} to allow
+     * safepoint polling during a large copy.
+     */
+    private static final long UNSAFE_COPY_THRESHOLD = 1024L * 1024L;
+
     private static final long ADDRESS_FIELD_OFFSET;
     private static final long BYTE_ARRAY_BASE_OFFSET;
     private static final long INT_ARRAY_BASE_OFFSET;
     private static final long INT_ARRAY_INDEX_SCALE;
     private static final long LONG_ARRAY_BASE_OFFSET;
     private static final long LONG_ARRAY_INDEX_SCALE;
+
     private static final MethodHandle DIRECT_BUFFER_CONSTRUCTOR;
     private static final MethodHandle ALLOCATE_ARRAY_METHOD;
     private static final MethodHandle ALIGN_SLICE;
-    private static final boolean IS_ANDROID = isAndroid0();
-    private static final int JAVA_VERSION = javaVersion0();
-    private static final Throwable EXPLICIT_NO_UNSAFE_CAUSE = explicitNoUnsafeCause0();
 
     private static final Throwable UNSAFE_UNAVAILABILITY_CAUSE;
 
@@ -64,21 +68,12 @@ final class PlatformDependent0 {
     // Package-private for testing.
     static final MethodHandle IS_VIRTUAL_THREAD_METHOD_HANDLE = getIsVirtualThreadMethodHandle();
 
-    static final Unsafe UNSAFE;
-
     // constants borrowed from murmur3
     static final int HASH_CODE_ASCII_SEED = 0xc2b2ae35;
     static final int HASH_CODE_C1 = 0xcc9e2d51;
     static final int HASH_CODE_C2 = 0x1b873593;
 
-    /**
-     * Limits the number of bytes to copy per {@link Unsafe#copyMemory(long, long, long)} to allow safepoint polling
-     * during a large copy.
-     */
-    private static final long UNSAFE_COPY_THRESHOLD = 1024L * 1024L;
-
     private static final boolean UNALIGNED;
-
     private static final long BITS_MAX_DIRECT_MEMORY;
 
     static {
@@ -86,200 +81,91 @@ final class PlatformDependent0 {
         final ByteBuffer direct;
         Field addressField = null;
         MethodHandle allocateArrayMethod = null;
-        Throwable unsafeUnavailabilityCause;
-        Unsafe unsafe;
-        if ((unsafeUnavailabilityCause = EXPLICIT_NO_UNSAFE_CAUSE) != null) {
+        Throwable unsafeUnavailabilityCause = null;
+        long byteArrayBaseOffset = -1;
+        long intArrayBaseOffset = -1;
+        long longArrayBaseOffset = -1;
+        long intArrayIndexScale = -1;
+        long longArrayIndexScale = -1;
+
+        if (!SunMiscUnsafeAccess.isAvailabile()) {
             direct = null;
-            addressField = null;
-            unsafe = null;
+            unsafeUnavailabilityCause = SunMiscUnsafeAccess.unavailabilityCause();
+            assert unsafeUnavailabilityCause != null;
         } else {
             direct = ByteBuffer.allocateDirect(1);
-
-            // attempt to access field Unsafe#theUnsafe
-            final Object maybeUnsafe = AccessController.doPrivileged(new PrivilegedAction<Object>() {
+            // attempt to access field Buffer#address
+            final Object maybeAddressField = AccessController.doPrivileged(new PrivilegedAction<Object>() {
                 @Override
                 public Object run() {
                     try {
-                        final Field unsafeField = Unsafe.class.getDeclaredField("theUnsafe");
-                        // We always want to try using Unsafe as the access still works on java9 as well and
-                        // we need it for out native-transports and many optimizations.
-                        Throwable cause = ReflectionUtil.trySetAccessible(unsafeField, false);
-                        if (cause != null) {
-                            return cause;
+                        final Field field = Buffer.class.getDeclaredField("address");
+                        // Use Unsafe to read value of the address field. This way it will not fail on JDK9+ which
+                        // will forbid changing the access level via reflection.
+                        final long offset = SunMiscUnsafeAccess.objectFieldOffset(field);
+                        final long address = SunMiscUnsafeAccess.getLong(direct, offset);
+
+                        // if direct really is a direct buffer, address will be non-zero
+                        if (address == 0) {
+                            return null;
                         }
-                        // the unsafe instance
-                        return unsafeField.get(null);
-                    } catch (NoSuchFieldException e) {
-                        return e;
-                    } catch (SecurityException e) {
-                        return e;
-                    } catch (IllegalAccessException e) {
-                        return e;
-                    } catch (NoClassDefFoundError e) {
-                        // Also catch NoClassDefFoundError in case someone uses for example OSGI and it made
-                        // Unsafe unloadable.
+                        return field;
+                    } catch (Throwable e) {
                         return e;
                     }
                 }
             });
 
-            // the conditional check here can not be replaced with checking that maybeUnsafe
-            // is an instanceof Unsafe and reversing the if and else blocks; this is because an
-            // instanceof check against Unsafe will trigger a class load and we might not have
-            // the runtime permission accessClassInPackage.sun.misc
-            if (maybeUnsafe instanceof Throwable) {
-                unsafe = null;
-                unsafeUnavailabilityCause = (Throwable) maybeUnsafe;
-                if (logger.isTraceEnabled()) {
-                    logger.debug("sun.misc.Unsafe.theUnsafe: unavailable", (Throwable) maybeUnsafe);
-                } else {
-                    logger.debug("sun.misc.Unsafe.theUnsafe: unavailable: {}", unsafeUnavailabilityCause.getMessage());
-                }
+            if (maybeAddressField instanceof Field) {
+                addressField = (Field) maybeAddressField;
+                logger.debug("java.nio.Buffer.address: available");
             } else {
-                unsafe = (Unsafe) maybeUnsafe;
-                logger.debug("sun.misc.Unsafe.theUnsafe: available");
-            }
-
-            // ensure the unsafe supports all necessary methods to work around the mistake in the latest OpenJDK,
-            // or that they haven't been removed by JEP 471.
-            // https://github.com/netty/netty/issues/1061
-            // https://www.mail-archive.com/jdk6-dev@openjdk.java.net/msg00698.html
-            // https://openjdk.org/jeps/471
-            if (unsafe != null) {
-                final Unsafe finalUnsafe = unsafe;
-                final Object maybeException = AccessController.doPrivileged(new PrivilegedAction<Object>() {
-                    @Override
-                    public Object run() {
-                        try {
-                            // Other methods like storeFence() and invokeCleaner() are tested for elsewhere.
-                            Class<? extends Unsafe> cls = finalUnsafe.getClass();
-                            cls.getDeclaredMethod(
-                                    "copyMemory", Object.class, long.class, Object.class, long.class, long.class);
-                            if (javaVersion() > 23) {
-                                cls.getDeclaredMethod("objectFieldOffset", Field.class);
-                                cls.getDeclaredMethod("staticFieldOffset", Field.class);
-                                cls.getDeclaredMethod("staticFieldBase", Field.class);
-                                cls.getDeclaredMethod("arrayBaseOffset", Class.class);
-                                cls.getDeclaredMethod("arrayIndexScale", Class.class);
-                                cls.getDeclaredMethod("allocateMemory", long.class);
-                                cls.getDeclaredMethod("reallocateMemory", long.class, long.class);
-                                cls.getDeclaredMethod("freeMemory", long.class);
-                                cls.getDeclaredMethod("setMemory", long.class, long.class, byte.class);
-                                cls.getDeclaredMethod("setMemory", Object.class, long.class, long.class, byte.class);
-                                cls.getDeclaredMethod("getBoolean", Object.class, long.class);
-                                cls.getDeclaredMethod("getByte", long.class);
-                                cls.getDeclaredMethod("getByte", Object.class, long.class);
-                                cls.getDeclaredMethod("getInt", long.class);
-                                cls.getDeclaredMethod("getInt", Object.class, long.class);
-                                cls.getDeclaredMethod("getLong", long.class);
-                                cls.getDeclaredMethod("getLong", Object.class, long.class);
-                                cls.getDeclaredMethod("putByte", long.class, byte.class);
-                                cls.getDeclaredMethod("putByte", Object.class, long.class, byte.class);
-                                cls.getDeclaredMethod("putInt", long.class, int.class);
-                                cls.getDeclaredMethod("putInt", Object.class, long.class, int.class);
-                                cls.getDeclaredMethod("putLong", long.class, long.class);
-                                cls.getDeclaredMethod("putLong", Object.class, long.class, long.class);
-                                cls.getDeclaredMethod("addressSize");
-                            }
-                            if (javaVersion() >= 23) {
-                                // The following tests the methods are usable.
-                                // Will throw UnsupportedOperationException if unsafe memory access is denied:
-                                long address = finalUnsafe.allocateMemory(8);
-                                finalUnsafe.putLong(address, 42);
-                                finalUnsafe.freeMemory(address);
-                            }
-                            return null;
-                        } catch (UnsupportedOperationException e) {
-                            return e;
-                        } catch (NoSuchMethodException e) {
-                            return e;
-                        } catch (SecurityException e) {
-                            return e;
-                        }
-                    }
-                });
-
-                if (maybeException == null) {
-                    logger.debug("sun.misc.Unsafe base methods: all available");
+                unsafeUnavailabilityCause = (Throwable) maybeAddressField;
+                if (logger.isTraceEnabled()) {
+                    logger.debug("java.nio.Buffer.address: unavailable", (Throwable) maybeAddressField);
                 } else {
-                    // Unsafe.copyMemory(Object, long, Object, long, long) unavailable.
-                    unsafe = null;
-                    unsafeUnavailabilityCause = (Throwable) maybeException;
-                    if (logger.isTraceEnabled()) {
-                        logger.debug("sun.misc.Unsafe method unavailable:", unsafeUnavailabilityCause);
-                    } else {
-                        logger.debug("sun.misc.Unsafe method unavailable: {}",
-                                ((Throwable) maybeException).getMessage());
-                    }
+                    logger.debug("java.nio.Buffer.address: unavailable: {}",
+                            ((Throwable) maybeAddressField).getMessage());
                 }
             }
 
-            if (unsafe != null) {
-                final Unsafe finalUnsafe = unsafe;
-
-                // attempt to access field Buffer#address
-                final Object maybeAddressField = AccessController.doPrivileged(new PrivilegedAction<Object>() {
-                    @Override
-                    public Object run() {
-                        try {
-                            final Field field = Buffer.class.getDeclaredField("address");
-                            // Use Unsafe to read value of the address field. This way it will not fail on JDK9+ which
-                            // will forbid changing the access level via reflection.
-                            final long offset = finalUnsafe.objectFieldOffset(field);
-                            final long address = finalUnsafe.getLong(direct, offset);
-
-                            // if direct really is a direct buffer, address will be non-zero
-                            if (address == 0) {
-                                return null;
-                            }
-                            return field;
-                        } catch (NoSuchFieldException e) {
-                            return e;
-                        } catch (SecurityException e) {
-                            return e;
-                        }
+            if (unsafeUnavailabilityCause == null) {
+                try {
+                    long byteArrayIndexScale = SunMiscUnsafeAccess.arrayIndexScale(byte[].class);
+                    if (byteArrayIndexScale != 1) {
+                        logger.debug(
+                                "unsafe.arrayIndexScale is {} (expected: 1). Not using unsafe.", byteArrayIndexScale);
+                        unsafeUnavailabilityCause = new UnsupportedOperationException(
+                                "Unexpected unsafe.arrayIndexScale");
                     }
-                });
-
-                if (maybeAddressField instanceof Field) {
-                    addressField = (Field) maybeAddressField;
-                    logger.debug("java.nio.Buffer.address: available");
-                } else {
-                    unsafeUnavailabilityCause = (Throwable) maybeAddressField;
-                    if (logger.isTraceEnabled()) {
-                        logger.debug("java.nio.Buffer.address: unavailable", (Throwable) maybeAddressField);
-                    } else {
-                        logger.debug("java.nio.Buffer.address: unavailable: {}",
-                                ((Throwable) maybeAddressField).getMessage());
-                    }
-
-                    // If we cannot access the address of a direct buffer, there's no point of using unsafe.
-                    // Let's just pretend unsafe is unavailable for overall simplicity.
-                    unsafe = null;
+                } catch (Throwable cause) {
+                    logger.debug("unsafe.arrayIndexScale did throw", cause);
+                    unsafeUnavailabilityCause = new UnsupportedOperationException(
+                            "Unexpected unsafe.arrayIndexScale", cause);
                 }
             }
 
-            if (unsafe != null) {
-                // There are assumptions made where ever BYTE_ARRAY_BASE_OFFSET is used (equals, hashCodeAscii, and
-                // primitive accessors) that arrayIndexScale == 1, and results are undefined if this is not the case.
-                long byteArrayIndexScale = unsafe.arrayIndexScale(byte[].class);
-                if (byteArrayIndexScale != 1) {
-                    logger.debug("unsafe.arrayIndexScale is {} (expected: 1). Not using unsafe.", byteArrayIndexScale);
-                    unsafeUnavailabilityCause = new UnsupportedOperationException("Unexpected unsafe.arrayIndexScale");
-                    unsafe = null;
+            if (unsafeUnavailabilityCause == null) {
+                try {
+                    byteArrayBaseOffset = SunMiscUnsafeAccess.arrayBaseOffset(byte[].class);
+                    intArrayBaseOffset = SunMiscUnsafeAccess.arrayBaseOffset(int[].class);
+                    longArrayBaseOffset = SunMiscUnsafeAccess.arrayBaseOffset(long[].class);
+                    intArrayIndexScale = SunMiscUnsafeAccess.arrayIndexScale(int[].class);
+                    longArrayIndexScale = SunMiscUnsafeAccess.arrayIndexScale(long[].class);
+                } catch (Throwable cause) {
+                    byteArrayBaseOffset = 1;
+                    intArrayBaseOffset = -1;
+                    intArrayIndexScale = -1;
+                    longArrayBaseOffset = -1;
+                    longArrayIndexScale = -1;
+                    unsafeUnavailabilityCause = cause;
                 }
             }
         }
         UNSAFE_UNAVAILABILITY_CAUSE = unsafeUnavailabilityCause;
-        UNSAFE = unsafe;
 
-        if (unsafe == null) {
+        if (unsafeUnavailabilityCause != null) {
             ADDRESS_FIELD_OFFSET = -1;
-            BYTE_ARRAY_BASE_OFFSET = -1;
-            LONG_ARRAY_BASE_OFFSET = -1;
-            LONG_ARRAY_INDEX_SCALE = -1;
-            INT_ARRAY_BASE_OFFSET = -1;
-            INT_ARRAY_INDEX_SCALE = -1;
             UNALIGNED = false;
             BITS_MAX_DIRECT_MEMORY = -1;
             DIRECT_BUFFER_CONSTRUCTOR = null;
@@ -294,7 +180,7 @@ final class PlatformDependent0 {
                             public Object run() {
                                 try {
                                     Class<? extends ByteBuffer> directClass = direct.getClass();
-                                    final Constructor<?> constructor = javaVersion() >= 21 ?
+                                    final Constructor<?> constructor = JavaVersion.javaVersion() >= 21 ?
                                             directClass.getDeclaredConstructor(long.class, long.class) :
                                             directClass.getDeclaredConstructor(long.class, int.class);
                                     Throwable cause = ReflectionUtil.trySetAccessible(constructor, true);
@@ -310,9 +196,9 @@ final class PlatformDependent0 {
                         });
 
                 if (maybeDirectBufferConstructor instanceof MethodHandle) {
-                    address = UNSAFE.allocateMemory(1);
                     // try to use the constructor now
                     try {
+                        address = SunMiscUnsafeAccess.allocateMemory(1);
                         MethodHandle constructor = (MethodHandle) maybeDirectBufferConstructor;
                         ByteBuffer ignore = (ByteBuffer) constructor.invokeExact(address, 1);
                         directBufferConstructor = constructor;
@@ -332,17 +218,18 @@ final class PlatformDependent0 {
                 }
             } finally {
                 if (address != -1) {
-                    UNSAFE.freeMemory(address);
+                    try {
+                        SunMiscUnsafeAccess.freeMemory(address);
+                    } catch (Throwable ignore) {
+                        // ignore
+                    }
                 }
             }
             DIRECT_BUFFER_CONSTRUCTOR = directBufferConstructor;
-            ADDRESS_FIELD_OFFSET = objectFieldOffset(addressField);
-            BYTE_ARRAY_BASE_OFFSET = UNSAFE.arrayBaseOffset(byte[].class);
-            INT_ARRAY_BASE_OFFSET = UNSAFE.arrayBaseOffset(int[].class);
-            INT_ARRAY_INDEX_SCALE = UNSAFE.arrayIndexScale(int[].class);
-            LONG_ARRAY_BASE_OFFSET = UNSAFE.arrayBaseOffset(long[].class);
-            LONG_ARRAY_INDEX_SCALE = UNSAFE.arrayIndexScale(long[].class);
+            ADDRESS_FIELD_OFFSET = SunMiscUnsafeAccess.objectFieldOffset(addressField);
+
             final boolean unaligned;
+
             // using a known type to avoid loading new classes
             final AtomicLong maybeMaxMemory = new AtomicLong(-1);
             Object maybeUnaligned = AccessController.doPrivileged(new PrivilegedAction<Object>() {
@@ -351,7 +238,7 @@ final class PlatformDependent0 {
                     try {
                         Class<?> bitsClass =
                                 Class.forName("java.nio.Bits", false, getSystemClassLoader());
-                        int version = javaVersion();
+                        int version = JavaVersion.javaVersion();
                         if (unsafeStaticFieldOffsetSupported() && version >= 9) {
                             // Java9/10 use all lowercase and later versions all uppercase.
                             String fieldName = version >= 11? "MAX_MEMORY" : "maxMemory";
@@ -360,9 +247,10 @@ final class PlatformDependent0 {
                             try {
                                 Field maxMemoryField = bitsClass.getDeclaredField(fieldName);
                                 if (maxMemoryField.getType() == long.class) {
-                                    long offset = UNSAFE.staticFieldOffset(maxMemoryField);
-                                    Object object = UNSAFE.staticFieldBase(maxMemoryField);
-                                    maybeMaxMemory.lazySet(UNSAFE.getLong(object, offset));
+
+                                    long offset = SunMiscUnsafeAccess.staticFieldOffset(maxMemoryField);
+                                    Object object = SunMiscUnsafeAccess.staticFieldBase(maxMemoryField);
+                                    maybeMaxMemory.lazySet(SunMiscUnsafeAccess.getLong(object, offset));
                                 }
                             } catch (Throwable ignore) {
                                 // ignore if can't access
@@ -371,13 +259,13 @@ final class PlatformDependent0 {
                             try {
                                 Field unalignedField = bitsClass.getDeclaredField(fieldName);
                                 if (unalignedField.getType() == boolean.class) {
-                                    long offset = UNSAFE.staticFieldOffset(unalignedField);
-                                    Object object = UNSAFE.staticFieldBase(unalignedField);
-                                    return UNSAFE.getBoolean(object, offset);
+                                    long offset = SunMiscUnsafeAccess.staticFieldOffset(unalignedField);
+                                    Object object = SunMiscUnsafeAccess.staticFieldBase(unalignedField);
+                                    return SunMiscUnsafeAccess.getBoolean(object, offset);
                                 }
                                 // There is something unexpected stored in the field,
                                 // let us fall-back and try to use a reflective method call as last resort.
-                            } catch (NoSuchFieldException ignore) {
+                            } catch (Throwable ignore) {
                                 // We did not find the field we expected, move on.
                             }
                         }
@@ -387,15 +275,8 @@ final class PlatformDependent0 {
                             return cause;
                         }
                         return unalignedMethod.invoke(null);
-                    } catch (NoSuchMethodException e) {
-                        return e;
-                    } catch (SecurityException e) {
-                        return e;
-                    } catch (IllegalAccessException e) {
-                        return e;
-                    } catch (ClassNotFoundException e) {
-                        return e;
-                    } catch (InvocationTargetException e) {
+                    } catch (NoSuchMethodException | SecurityException | IllegalAccessException |
+                             ClassNotFoundException | InvocationTargetException e) {
                         return e;
                     }
                 }
@@ -419,7 +300,7 @@ final class PlatformDependent0 {
             UNALIGNED = unaligned;
             BITS_MAX_DIRECT_MEMORY = maybeMaxMemory.get() >= 0? maybeMaxMemory.get() : -1;
 
-            if (javaVersion() >= 9) {
+            if (JavaVersion.javaVersion() >= 9) {
                 Object maybeException = AccessController.doPrivileged(new PrivilegedAction<Object>() {
                     @Override
                     public Object run() {
@@ -481,7 +362,7 @@ final class PlatformDependent0 {
             ALLOCATE_ARRAY_METHOD = allocateArrayMethod;
         }
 
-        if (javaVersion() > 9) {
+        if (JavaVersion.javaVersion() > 9) {
             ALIGN_SLICE = (MethodHandle) AccessController.doPrivileged(new PrivilegedAction<Object>() {
                 @Override
                 public Object run() {
@@ -496,6 +377,11 @@ final class PlatformDependent0 {
         } else {
             ALIGN_SLICE = null;
         }
+        BYTE_ARRAY_BASE_OFFSET = byteArrayBaseOffset;
+        INT_ARRAY_BASE_OFFSET = intArrayBaseOffset;
+        INT_ARRAY_INDEX_SCALE = intArrayIndexScale;
+        LONG_ARRAY_BASE_OFFSET = longArrayBaseOffset;
+        LONG_ARRAY_INDEX_SCALE = longArrayIndexScale;
 
         logger.debug("java.nio.DirectByteBuffer.<init>(long, {int,long}): {}",
                 DIRECT_BUFFER_CONSTRUCTOR != null ? "available" : "unavailable");
@@ -542,48 +428,7 @@ final class PlatformDependent0 {
     }
 
     static boolean isExplicitNoUnsafe() {
-        return EXPLICIT_NO_UNSAFE_CAUSE != null;
-    }
-
-    private static Throwable explicitNoUnsafeCause0() {
-        boolean explicitProperty = SystemPropertyUtil.contains("io.netty.noUnsafe");
-        boolean noUnsafe = SystemPropertyUtil.getBoolean("io.netty.noUnsafe", false);
-        logger.debug("-Dio.netty.noUnsafe: {}", noUnsafe);
-
-        // See JDK 23 JEP 471 https://openjdk.org/jeps/471 and sun.misc.Unsafe.beforeMemoryAccess() on JDK 23+.
-        // And JDK 24 JEP 498 https://openjdk.org/jeps/498, that enable warnings by default.
-        String reason = "io.netty.noUnsafe";
-        String unspecified = "<unspecified>";
-        String unsafeMemoryAccess = SystemPropertyUtil.get("sun.misc.unsafe.memory.access", unspecified);
-        if (!explicitProperty && unspecified.equals(unsafeMemoryAccess) && javaVersion() >= 24) {
-            reason = "io.netty.noUnsafe=true by default on Java 24+";
-            noUnsafe = true;
-        } else if (!("allow".equals(unsafeMemoryAccess) || unspecified.equals(unsafeMemoryAccess))) {
-            reason = "--sun-misc-unsafe-memory-access=" + unsafeMemoryAccess;
-            noUnsafe = true;
-        }
-
-        if (noUnsafe) {
-            String msg = "sun.misc.Unsafe: unavailable (" + reason + ')';
-            logger.debug(msg);
-            return new UnsupportedOperationException(msg);
-        }
-
-        // Legacy properties
-        String unsafePropName;
-        if (SystemPropertyUtil.contains("io.netty.tryUnsafe")) {
-            unsafePropName = "io.netty.tryUnsafe";
-        } else {
-            unsafePropName = "org.jboss.netty.tryUnsafe";
-        }
-
-        if (!SystemPropertyUtil.getBoolean(unsafePropName, true)) {
-            String msg = "sun.misc.Unsafe: unavailable (" + unsafePropName + ')';
-            logger.debug(msg);
-            return new UnsupportedOperationException(msg);
-        }
-
-        return null;
+        return SunMiscUnsafeAccess.isExplicitNoUnsafe();
     }
 
     static boolean isUnaligned() {
@@ -598,7 +443,7 @@ final class PlatformDependent0 {
     }
 
     static boolean hasUnsafe() {
-        return UNSAFE != null;
+        return SunMiscUnsafeAccess.isAvailabile() && UNSAFE_UNAVAILABILITY_CAUSE == null;
     }
 
     static Throwable getUnsafeUnavailabilityCause() {
@@ -609,12 +454,9 @@ final class PlatformDependent0 {
         return UNALIGNED;
     }
 
-    static void throwException(Throwable cause) {
-        throwException0(cause);
-    }
-
     @SuppressWarnings("unchecked")
-    private static <E extends Throwable> void throwException0(Throwable t) throws E {
+    static <E extends Throwable> void throwException(Throwable t) throws E {
+        ObjectUtil.checkNotNull(t, "t");
         throw (E) t;
     }
 
@@ -623,14 +465,19 @@ final class PlatformDependent0 {
     }
 
     static ByteBuffer reallocateDirectNoCleaner(ByteBuffer buffer, int capacity) {
-        return newDirectBuffer(UNSAFE.reallocateMemory(directBufferAddress(buffer), capacity), capacity);
+        try {
+            return newDirectBuffer(reallocateMemory(directBufferAddress(buffer), capacity), capacity);
+        } catch (Throwable e) {
+            rethrowIfPossible(e);
+            throw new LinkageError("Unsafe.allocateUninitializedArray not available", e);
+        }
     }
 
     static ByteBuffer allocateDirectNoCleaner(int capacity) {
         // Calling malloc with capacity of 0 may return a null ptr or a memory address that can be used.
         // Just use 1 to make it safe to use in all cases:
         // See: https://pubs.opengroup.org/onlinepubs/009695399/functions/malloc.html
-        return newDirectBuffer(UNSAFE.allocateMemory(Math.max(1, capacity)), capacity);
+        return newDirectBuffer(allocateMemory(Math.max(1, capacity)), capacity);
     }
 
     static boolean hasAlignSliceMethod() {
@@ -688,137 +535,141 @@ final class PlatformDependent0 {
     }
 
     static Object getObject(Object object, long fieldOffset) {
-        return UNSAFE.getObject(object, fieldOffset);
+        return SunMiscUnsafeAccess.getObject(object, fieldOffset);
     }
 
     static int getInt(Object object, long fieldOffset) {
-        return UNSAFE.getInt(object, fieldOffset);
+        return SunMiscUnsafeAccess.getInt(object, fieldOffset);
+    }
+
+    static short getShort(Object object, long fieldOffset) {
+        return SunMiscUnsafeAccess.getShort(object, fieldOffset);
     }
 
     static void safeConstructPutInt(Object object, long fieldOffset, int value) {
-        UNSAFE.putInt(object, fieldOffset, value);
-        UNSAFE.storeFence();
+        SunMiscUnsafeAccess.putInt(object, fieldOffset, value);
+        SunMiscUnsafeAccess.storeFence();
     }
 
     private static long getLong(Object object, long fieldOffset) {
-        return UNSAFE.getLong(object, fieldOffset);
+        return SunMiscUnsafeAccess.getLong(object, fieldOffset);
     }
 
     static long objectFieldOffset(Field field) {
-        return UNSAFE.objectFieldOffset(field);
+        return SunMiscUnsafeAccess.objectFieldOffset(field);
     }
 
     static byte getByte(long address) {
-        return UNSAFE.getByte(address);
+        return SunMiscUnsafeAccess.getByte(address);
     }
 
     static short getShort(long address) {
-        return UNSAFE.getShort(address);
+        return SunMiscUnsafeAccess.getShort(address);
     }
 
     static int getInt(long address) {
-        return UNSAFE.getInt(address);
+        return SunMiscUnsafeAccess.getInt(address);
     }
 
     static long getLong(long address) {
-        return UNSAFE.getLong(address);
+        return SunMiscUnsafeAccess.getLong(address);
     }
 
     static byte getByte(byte[] data, int index) {
-        return UNSAFE.getByte(data, BYTE_ARRAY_BASE_OFFSET + index);
+        return SunMiscUnsafeAccess.getByte(data, BYTE_ARRAY_BASE_OFFSET + index);
     }
 
     static byte getByte(byte[] data, long index) {
-        return UNSAFE.getByte(data, BYTE_ARRAY_BASE_OFFSET + index);
+        return SunMiscUnsafeAccess.getByte(data, BYTE_ARRAY_BASE_OFFSET + index);
     }
 
     static short getShort(byte[] data, int index) {
-        return UNSAFE.getShort(data, BYTE_ARRAY_BASE_OFFSET + index);
+        return SunMiscUnsafeAccess.getShort(data, BYTE_ARRAY_BASE_OFFSET + index);
     }
 
     static int getInt(byte[] data, int index) {
-        return UNSAFE.getInt(data, BYTE_ARRAY_BASE_OFFSET + index);
+        return SunMiscUnsafeAccess.getInt(data, BYTE_ARRAY_BASE_OFFSET + index);
     }
 
     static int getInt(int[] data, long index) {
-        return UNSAFE.getInt(data, INT_ARRAY_BASE_OFFSET + INT_ARRAY_INDEX_SCALE * index);
+        return SunMiscUnsafeAccess.getInt(data, INT_ARRAY_BASE_OFFSET + INT_ARRAY_INDEX_SCALE * index);
     }
 
     static int getIntVolatile(long address) {
-        return UNSAFE.getIntVolatile(null, address);
+        return SunMiscUnsafeAccess.getIntVolatile(null, address);
     }
 
-    static void putIntOrdered(long adddress, int newValue) {
-        UNSAFE.putOrderedInt(null, adddress, newValue);
+    static void putIntOrdered(long address, int newValue) {
+        SunMiscUnsafeAccess.putIntOrdered(null, address, newValue);
     }
 
     static long getLong(byte[] data, int index) {
-        return UNSAFE.getLong(data, BYTE_ARRAY_BASE_OFFSET + index);
+        return SunMiscUnsafeAccess.getLong(data, BYTE_ARRAY_BASE_OFFSET + index);
     }
 
     static long getLong(long[] data, long index) {
-        return UNSAFE.getLong(data, LONG_ARRAY_BASE_OFFSET + LONG_ARRAY_INDEX_SCALE * index);
+       return SunMiscUnsafeAccess.getLong(data, LONG_ARRAY_BASE_OFFSET + LONG_ARRAY_INDEX_SCALE * index);
     }
 
     static void putByte(long address, byte value) {
-        UNSAFE.putByte(address, value);
+        SunMiscUnsafeAccess.putByte(address, value);
     }
 
     static void putShort(long address, short value) {
-        UNSAFE.putShort(address, value);
+        SunMiscUnsafeAccess.putShort(address, value);
     }
 
     static void putShortOrdered(long adddress, short newValue) {
-        UNSAFE.storeFence();
-        UNSAFE.putShort(null, adddress, newValue);
+        SunMiscUnsafeAccess.storeFence();
+        SunMiscUnsafeAccess.putShort(null, adddress, newValue);
     }
 
     static void putInt(long address, int value) {
-        UNSAFE.putInt(address, value);
+        SunMiscUnsafeAccess.putInt(address, value);
     }
 
     static void putLong(long address, long value) {
-        UNSAFE.putLong(address, value);
+        SunMiscUnsafeAccess.putLong(address, value);
     }
 
     static void putByte(byte[] data, int index, byte value) {
-        UNSAFE.putByte(data, BYTE_ARRAY_BASE_OFFSET + index, value);
+        SunMiscUnsafeAccess.putByte(data, BYTE_ARRAY_BASE_OFFSET + index, value);
     }
 
     static void putByte(Object data, long offset, byte value) {
-        UNSAFE.putByte(data, offset, value);
+        SunMiscUnsafeAccess.putByte(data, offset, value);
     }
 
     static void putShort(byte[] data, int index, short value) {
-        UNSAFE.putShort(data, BYTE_ARRAY_BASE_OFFSET + index, value);
+        SunMiscUnsafeAccess.putShort(data, BYTE_ARRAY_BASE_OFFSET + index, value);
     }
 
     static void putInt(byte[] data, int index, int value) {
-        UNSAFE.putInt(data, BYTE_ARRAY_BASE_OFFSET + index, value);
+        SunMiscUnsafeAccess.putInt(data, BYTE_ARRAY_BASE_OFFSET + index, value);
     }
 
     static void putLong(byte[] data, int index, long value) {
-        UNSAFE.putLong(data, BYTE_ARRAY_BASE_OFFSET + index, value);
+        SunMiscUnsafeAccess.putLong(data, BYTE_ARRAY_BASE_OFFSET + index, value);
     }
 
     static void putObject(Object o, long offset, Object x) {
-        UNSAFE.putObject(o, offset, x);
+        SunMiscUnsafeAccess.putObject(o, offset, x);
     }
 
     static void copyMemory(long srcAddr, long dstAddr, long length) {
         // Manual safe-point polling is only needed prior Java9:
         // See https://bugs.openjdk.java.net/browse/JDK-8149596
-        if (javaVersion() <= 8) {
+        if (JavaVersion.javaVersion() <= 8) {
             copyMemoryWithSafePointPolling(srcAddr, dstAddr, length);
         } else {
-            UNSAFE.copyMemory(srcAddr, dstAddr, length);
+            SunMiscUnsafeAccess.copyMemory(srcAddr, dstAddr, length);
         }
     }
 
     private static void copyMemoryWithSafePointPolling(long srcAddr, long dstAddr, long length) {
         while (length > 0) {
             long size = Math.min(length, UNSAFE_COPY_THRESHOLD);
-            UNSAFE.copyMemory(srcAddr, dstAddr, size);
+            SunMiscUnsafeAccess.copyMemory(srcAddr, dstAddr, size);
             length -= size;
             srcAddr += size;
             dstAddr += size;
@@ -828,10 +679,10 @@ final class PlatformDependent0 {
     static void copyMemory(Object src, long srcOffset, Object dst, long dstOffset, long length) {
         // Manual safe-point polling is only needed prior Java9:
         // See https://bugs.openjdk.java.net/browse/JDK-8149596
-        if (javaVersion() <= 8) {
+        if (JavaVersion.javaVersion() <= 8) {
             copyMemoryWithSafePointPolling(src, srcOffset, dst, dstOffset, length);
         } else {
-            UNSAFE.copyMemory(src, srcOffset, dst, dstOffset, length);
+            SunMiscUnsafeAccess.copyMemory(src, srcOffset, dst, dstOffset, length);
         }
     }
 
@@ -839,7 +690,7 @@ final class PlatformDependent0 {
             Object src, long srcOffset, Object dst, long dstOffset, long length) {
         while (length > 0) {
             long size = Math.min(length, UNSAFE_COPY_THRESHOLD);
-            UNSAFE.copyMemory(src, srcOffset, dst, dstOffset, size);
+            SunMiscUnsafeAccess.copyMemory(src, srcOffset, dst, dstOffset, size);
             length -= size;
             srcOffset += size;
             dstOffset += size;
@@ -847,11 +698,11 @@ final class PlatformDependent0 {
     }
 
     static void setMemory(long address, long bytes, byte value) {
-        UNSAFE.setMemory(address, bytes, value);
+        SunMiscUnsafeAccess.setMemory(address, bytes, value);
     }
 
     static void setMemory(Object o, long offset, long bytes, byte value) {
-        UNSAFE.setMemory(o, offset, bytes, value);
+        SunMiscUnsafeAccess.setMemory(o, offset, bytes, value);
     }
 
     static boolean equals(byte[] bytes1, int startPos1, byte[] bytes2, int startPos2, int length) {
@@ -861,7 +712,7 @@ final class PlatformDependent0 {
         if (length >= 8) {
             final long end = baseOffset1 + remainingBytes;
             for (long i = baseOffset1 - 8 + length; i >= end; i -= 8) {
-                if (UNSAFE.getLong(bytes1, i) != UNSAFE.getLong(bytes2, i + diff)) {
+                if (SunMiscUnsafeAccess.getLong(bytes1, i) != SunMiscUnsafeAccess.getLong(bytes2, i + diff)) {
                     return false;
                 }
             }
@@ -869,18 +720,19 @@ final class PlatformDependent0 {
         if (remainingBytes >= 4) {
             remainingBytes -= 4;
             long pos = baseOffset1 + remainingBytes;
-            if (UNSAFE.getInt(bytes1, pos) != UNSAFE.getInt(bytes2, pos + diff)) {
+            if (SunMiscUnsafeAccess.getInt(bytes1, pos) != SunMiscUnsafeAccess.getInt(bytes2, pos + diff)) {
                 return false;
             }
         }
         final long baseOffset2 = baseOffset1 + diff;
         if (remainingBytes >= 2) {
-            return UNSAFE.getChar(bytes1, baseOffset1) == UNSAFE.getChar(bytes2, baseOffset2) &&
-                    (remainingBytes == 2 ||
-                    UNSAFE.getByte(bytes1, baseOffset1 + 2) == UNSAFE.getByte(bytes2, baseOffset2 + 2));
+            return SunMiscUnsafeAccess.getChar(bytes1, baseOffset1) ==
+                    SunMiscUnsafeAccess.getChar(bytes2, baseOffset2) &&
+                    (remainingBytes == 2 || SunMiscUnsafeAccess.getByte(bytes1, baseOffset1 + 2) ==
+                            SunMiscUnsafeAccess.getByte(bytes2, baseOffset2 + 2));
         }
         return remainingBytes == 0 ||
-                UNSAFE.getByte(bytes1, baseOffset1) == UNSAFE.getByte(bytes2, baseOffset2);
+                SunMiscUnsafeAccess.getByte(bytes1, baseOffset1) == SunMiscUnsafeAccess.getByte(bytes2, baseOffset2);
     }
 
     static int equalsConstantTime(byte[] bytes1, int startPos1, byte[] bytes2, int startPos2, int length) {
@@ -890,20 +742,21 @@ final class PlatformDependent0 {
         final long end = baseOffset1 + remainingBytes;
         final long diff = startPos2 - startPos1;
         for (long i = baseOffset1 - 8 + length; i >= end; i -= 8) {
-            result |= UNSAFE.getLong(bytes1, i) ^ UNSAFE.getLong(bytes2, i + diff);
+            result |= SunMiscUnsafeAccess.getLong(bytes1, i) ^ SunMiscUnsafeAccess.getLong(bytes2, i + diff);
         }
         if (remainingBytes >= 4) {
-            result |= UNSAFE.getInt(bytes1, baseOffset1) ^ UNSAFE.getInt(bytes2, baseOffset1 + diff);
+            result |= SunMiscUnsafeAccess.getInt(bytes1, baseOffset1) ^
+                    SunMiscUnsafeAccess.getInt(bytes2, baseOffset1 + diff);
             remainingBytes -= 4;
         }
         if (remainingBytes >= 2) {
             long pos = end - remainingBytes;
-            result |= UNSAFE.getChar(bytes1, pos) ^ UNSAFE.getChar(bytes2, pos + diff);
+            result |= SunMiscUnsafeAccess.getChar(bytes1, pos) ^ SunMiscUnsafeAccess.getChar(bytes2, pos + diff);
             remainingBytes -= 2;
         }
         if (remainingBytes == 1) {
             long pos = end - 1;
-            result |= UNSAFE.getByte(bytes1, pos) ^ UNSAFE.getByte(bytes2, pos + diff);
+            result |= SunMiscUnsafeAccess.getByte(bytes1, pos) ^ SunMiscUnsafeAccess.getByte(bytes2, pos + diff);
         }
         return ConstantTimeUtils.equalsConstantTime(result, 0);
     }
@@ -916,19 +769,20 @@ final class PlatformDependent0 {
         int remainingBytes = length & 7;
         final long end = baseOffset + remainingBytes;
         for (long i = baseOffset - 8 + length; i >= end; i -= 8) {
-            if (UNSAFE.getLong(bytes, i) != 0) {
+            if (SunMiscUnsafeAccess.getLong(bytes, i) != 0) {
                 return false;
             }
         }
 
         if (remainingBytes >= 4) {
             remainingBytes -= 4;
-            if (UNSAFE.getInt(bytes, baseOffset + remainingBytes) != 0) {
+
+            if (SunMiscUnsafeAccess.getInt(bytes, baseOffset + remainingBytes) != 0) {
                 return false;
             }
         }
         if (remainingBytes >= 2) {
-            return UNSAFE.getChar(bytes, baseOffset) == 0 &&
+            return SunMiscUnsafeAccess.getChar(bytes, baseOffset) == 0 &&
                     (remainingBytes == 2 || bytes[startPos + 2] == 0);
         }
         return bytes[startPos] == 0;
@@ -940,24 +794,24 @@ final class PlatformDependent0 {
         final int remainingBytes = length & 7;
         final long end = baseOffset + remainingBytes;
         for (long i = baseOffset - 8 + length; i >= end; i -= 8) {
-            hash = hashCodeAsciiCompute(UNSAFE.getLong(bytes, i), hash);
+            hash = hashCodeAsciiCompute(SunMiscUnsafeAccess.getLong(bytes, i), hash);
         }
         if (remainingBytes == 0) {
             return hash;
         }
         int hcConst = HASH_CODE_C1;
         if (remainingBytes != 2 & remainingBytes != 4 & remainingBytes != 6) { // 1, 3, 5, 7
-            hash = hash * HASH_CODE_C1 + hashCodeAsciiSanitize(UNSAFE.getByte(bytes, baseOffset));
+            hash = hash * HASH_CODE_C1 + hashCodeAsciiSanitize(SunMiscUnsafeAccess.getByte(bytes, baseOffset));
             hcConst = HASH_CODE_C2;
             baseOffset++;
         }
         if (remainingBytes != 1 & remainingBytes != 4 & remainingBytes != 5) { // 2, 3, 6, 7
-            hash = hash * hcConst + hashCodeAsciiSanitize(UNSAFE.getShort(bytes, baseOffset));
+            hash = hash * hcConst + hashCodeAsciiSanitize(SunMiscUnsafeAccess.getShort(bytes, baseOffset));
             hcConst = hcConst == HASH_CODE_C1 ? HASH_CODE_C2 : HASH_CODE_C1;
             baseOffset += 2;
         }
         if (remainingBytes >= 4) { // 4, 5, 6, 7
-            return hash * hcConst + hashCodeAsciiSanitize(UNSAFE.getInt(bytes, baseOffset));
+            return hash * hcConst + hashCodeAsciiSanitize(SunMiscUnsafeAccess.getInt(bytes, baseOffset));
         }
         return hash;
     }
@@ -1024,88 +878,29 @@ final class PlatformDependent0 {
     }
 
     static int addressSize() {
-        return UNSAFE.addressSize();
+        return SunMiscUnsafeAccess.addressSize();
     }
 
     static long allocateMemory(long size) {
-        return UNSAFE.allocateMemory(size);
+        return SunMiscUnsafeAccess.allocateMemory(size);
     }
 
     static void freeMemory(long address) {
-        UNSAFE.freeMemory(address);
+        SunMiscUnsafeAccess.freeMemory(address);
     }
 
     static long reallocateMemory(long address, long newSize) {
-        return UNSAFE.reallocateMemory(address, newSize);
-    }
-
-    static boolean isAndroid() {
-        return IS_ANDROID;
-    }
-
-    private static boolean isAndroid0() {
-        // Idea: Sometimes java binaries include Android classes on the classpath, even if it isn't actually Android.
-        // Rather than check if certain classes are present, just check the VM, which is tied to the JDK.
-
-        // Optional improvement: check if `android.os.Build.VERSION` is >= 24. On later versions of Android, the
-        // OpenJDK is used, which means `Unsafe` will actually work as expected.
-
-        // Android sets this property to Dalvik, regardless of whether it actually is.
-        String vmName = SystemPropertyUtil.get("java.vm.name");
-        boolean isAndroid = "Dalvik".equals(vmName);
-        if (isAndroid) {
-            logger.debug("Platform: Android");
-        }
-        return isAndroid;
+        return SunMiscUnsafeAccess.reallocateMemory(address, newSize);
     }
 
     private static boolean explicitTryReflectionSetAccessible0() {
         // we disable reflective access
         return SystemPropertyUtil.getBoolean("io.netty.tryReflectionSetAccessible",
-                javaVersion() < 9 || RUNNING_IN_NATIVE_IMAGE);
+                JavaVersion.javaVersion() < 9 || RUNNING_IN_NATIVE_IMAGE);
     }
 
     static boolean isExplicitTryReflectionSetAccessible() {
         return IS_EXPLICIT_TRY_REFLECTION_SET_ACCESSIBLE;
-    }
-
-    static int javaVersion() {
-        return JAVA_VERSION;
-    }
-
-    private static int javaVersion0() {
-        final int majorVersion;
-
-        if (isAndroid()) {
-            majorVersion = 6;
-        } else {
-            majorVersion = majorVersionFromJavaSpecificationVersion();
-        }
-
-        logger.debug("Java version: {}", majorVersion);
-
-        return majorVersion;
-    }
-
-    // Package-private for testing only
-    static int majorVersionFromJavaSpecificationVersion() {
-        return majorVersion(SystemPropertyUtil.get("java.specification.version", "1.6"));
-    }
-
-    // Package-private for testing only
-    static int majorVersion(final String javaSpecVersion) {
-        final String[] components = javaSpecVersion.split("\\.");
-        final int[] version = new int[components.length];
-        for (int i = 0; i < components.length; i++) {
-            version[i] = Integer.parseInt(components[i]);
-        }
-
-        if (version[0] == 1) {
-            assert version[1] >= 6;
-            return version[1];
-        } else {
-            return version[0];
-        }
     }
 
     private PlatformDependent0() {

--- a/common/src/main/java/io/netty/util/internal/SunMiscUnsafeAccess.java
+++ b/common/src/main/java/io/netty/util/internal/SunMiscUnsafeAccess.java
@@ -1,0 +1,855 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.internal;
+
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Field;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.lang.invoke.MethodType.methodType;
+
+/**
+ * Helper class which delegates to {@link sun.misc.Unsafe} via {@link MethodHandle}s.
+ */
+final class SunMiscUnsafeAccess {
+
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(SunMiscUnsafeAccess.class);
+    private static final String SUN_MISC_UNSAFE_CLASS_NAME = "sun.misc.Unsafe";
+    private static final Throwable EXPLICIT_NO_UNSAFE_CAUSE = explicitNoUnsafeCause0();
+    private static final Throwable UNSAFE_UNAVAILABILITY_CAUSE;
+    private static final MethodHandle UNSAFE_ALLOCATE_MEMORY_HANDLE;
+    private static final MethodHandle UNSAFE_COPY_MEMORY_WITH_OBJECT_HANDLE;
+    private static final MethodHandle UNSAFE_COPY_MEMORY_WITH_LONG_HANDLE;
+    private static final MethodHandle UNSAFE_OBJECT_FIELD_OFFSET_HANDLE;
+    private static final MethodHandle UNSAFE_REALLOCATE_MEMORY_HANDLE;
+    private static final MethodHandle UNSAFE_FREE_MEMORY_HANDLE;
+    private static final MethodHandle UNSAFE_SET_MEMORY_WITH_LONG_HANDLE;
+    private static final MethodHandle UNSAFE_SET_MEMORY_WITH_OBJECT_HANDLE;
+    private static final MethodHandle UNSAFE_GET_BYTE_WITH_LONG_HANDLE;
+    private static final MethodHandle UNSAFE_GET_BYTE_WITH_OBJECT_HANDLE;
+    private static final MethodHandle UNSAFE_GET_CHAR_WITH_OBJECT_HANDLE;
+    private static final MethodHandle UNSAFE_GET_SHORT_WITH_LONG_HANDLE;
+    private static final MethodHandle UNSAFE_GET_SHORT_WITH_OBJECT_HANDLE;
+    private static final MethodHandle UNSAFE_GET_INT_WITH_LONG_HANDLE;
+    private static final MethodHandle UNSAFE_GET_INT_WITH_OBJECT_HANDLE;
+    private static final MethodHandle UNSAFE_GET_INT_VOLATILE_WITH_OBJECT_HANDLE;
+    private static final MethodHandle UNSAFE_GET_LONG_WITH_LONG_HANDLE;
+    private static final MethodHandle UNSAFE_GET_LONG_WITH_OBJECT_HANDLE;
+    private static final MethodHandle UNSAFE_GET_OBJECT_WITH_OBJECT_HANDLE;
+    private static final MethodHandle UNSAFE_PUT_BYTE_WITH_LONG_HANDLE;
+    private static final MethodHandle UNSAFE_PUT_BYTE_WITH_OBJECT_HANDLE;
+    private static final MethodHandle UNSAFE_PUT_SHORT_WITH_LONG_HANDLE;
+    private static final MethodHandle UNSAFE_PUT_SHORT_WITH_OBJECT_HANDLE;
+    private static final MethodHandle UNSAFE_PUT_INT_WITH_LONG_HANDLE;
+    private static final MethodHandle UNSAFE_PUT_INT_WITH_OBJECT_HANDLE;
+    private static final MethodHandle UNSAFE_PUT_ORDERED_INT_WITH_OBJECT_HANDLE;
+    private static final MethodHandle UNSAFE_PUT_LONG_WITH_LONG_HANDLE;
+    private static final MethodHandle UNSAFE_PUT_LONG_WITH_OBJECT_HANDLE;
+    private static final MethodHandle UNSAFE_PUT_OBJECT_WITH_OBJECT_HANDLE;
+    private static final MethodHandle UNSAFE_ADDRESS_SIZE_HANDLE;
+    private static final MethodHandle UNSAFE_STORE_FENCE_HANDLE;
+    private static final MethodHandle UNSAFE_ARRAY_BASE_OFFSET_HANDLE;
+    private static final MethodHandle UNSAFE_ARRAY_INDEX_SCALE_HANDLE;
+    private static final MethodHandle UNSAFE_STATIC_FIELD_OFFSET_HANDLE;
+    private static final MethodHandle UNSAFE_STATIC_FIELD_BASE_HANDLE;
+    private static final MethodHandle UNSAFE_GET_BOOLEAN_WITH_OBJECT_HANDLE;
+
+    // Store as Object so we can compile with --release
+    static final Object UNSAFE;
+
+    static {
+        MethodHandles.Lookup lookup = MethodHandles.lookup();
+        Throwable unsafeUnavailabilityCause = null;
+        Object unsafe;
+        MethodHandle allocateMemoryHandle = null;
+        MethodHandle copyMemoryWithLongHandle = null;
+        MethodHandle copyMemoryWithObjectHandle = null;
+        MethodHandle objectFieldOffsetHandle = null;
+        MethodHandle staticFieldOffsetHandle = null;
+        MethodHandle staticFieldBaseHandle = null;
+        MethodHandle arrayBaseOffsetHandle = null;
+        MethodHandle arrayIndexScaleHandle = null;
+        MethodHandle reallocateMemoryHandle = null;
+        MethodHandle freeMemoryHandle = null;
+        MethodHandle setMemoryWithLongHandle = null;
+        MethodHandle setMemoryWithObjectHandle = null;
+        MethodHandle getBooleanWithObjectHandle = null;
+        MethodHandle getByteWithLongHandle = null;
+        MethodHandle getByteWithObjectHandle = null;
+        MethodHandle getCharWithObjectHandle = null;
+        MethodHandle getShortWithLongHandle = null;
+        MethodHandle getShortWithObjectHandle = null;
+        MethodHandle getIntWithLongHandle = null;
+        MethodHandle getIntWithObjectHandle = null;
+        MethodHandle getIntVolatileWithObjectHandle = null;
+        MethodHandle getLongWithLongHandle = null;
+        MethodHandle getLongWithObjectHandle = null;
+        MethodHandle getObjectWithObjectHandle = null;
+        MethodHandle putByteWithLongHandle = null;
+        MethodHandle putByteWithObjectHandle = null;
+        MethodHandle putShortWithLongHandle = null;
+        MethodHandle putShortWithObjectHandle = null;
+        MethodHandle putIntWithLongHandle = null;
+        MethodHandle putIntWithObjectHandle = null;
+        MethodHandle putOrderedIntWithObjectHandle = null;
+        MethodHandle putLongWithLongHandle = null;
+        MethodHandle putLongWithObjectHandle = null;
+        MethodHandle putObjectWithObjectHandle = null;
+        MethodHandle addressSizeHandle = null;
+        MethodHandle storeFenceHandle = null;
+
+        if ((unsafeUnavailabilityCause = EXPLICIT_NO_UNSAFE_CAUSE) != null) {
+            unsafe = null;
+        } else {
+            // attempt to access field Unsafe#theUnsafe
+            final Object maybeUnsafe = AccessController.doPrivileged(new PrivilegedAction<Object>() {
+                @Override
+                public Object run() {
+                    try {
+                        Class<?> unsafeClass = Class.forName(SUN_MISC_UNSAFE_CLASS_NAME);
+                        final Field unsafeField = unsafeClass.getDeclaredField("theUnsafe");
+                        // We always want to try using Unsafe as the access still works on java9 as well and
+                        // we need it for out native-transports and many optimizations.
+                        Throwable cause = ReflectionUtil.trySetAccessible(unsafeField, false);
+                        if (cause != null) {
+                            return cause;
+                        }
+                        // the unsafe instance
+                        return unsafeField.get(null);
+                    } catch (NoSuchFieldException | SecurityException |
+                             IllegalAccessException | ClassNotFoundException e) {
+                        return e;
+                    } catch (NoClassDefFoundError e) {
+                        // Also catch NoClassDefFoundError in case someone uses for example OSGI and it made
+                        // Unsafe unloadable.
+                        return e;
+                    }
+                }
+            });
+
+            // the conditional check here can not be replaced with checking that maybeUnsafe
+            // is an instanceof Unsafe and reversing the if and else blocks; this is because an
+            // instanceof check against Unsafe will trigger a class load and we might not have
+            // the runtime permission accessClassInPackage.sun.misc
+            if (maybeUnsafe instanceof Throwable) {
+                unsafe = null;
+                unsafeUnavailabilityCause = (Throwable) maybeUnsafe;
+                if (logger.isTraceEnabled()) {
+                    logger.debug("{}: unavailable", SUN_MISC_UNSAFE_CLASS_NAME, maybeUnsafe);
+                } else {
+                    logger.debug("{}.theUnsafe: unavailable: {}", SUN_MISC_UNSAFE_CLASS_NAME,
+                            unsafeUnavailabilityCause.getMessage());
+                }
+            } else {
+                unsafe = maybeUnsafe;
+                logger.debug("sun.misc.Unsafe.theUnsafe: available");
+            }
+
+            // ensure the unsafe supports all necessary methods to work around the mistake in the latest OpenJDK,
+            // or that they haven't been removed by JEP 471.
+            // https://github.com/netty/netty/issues/1061
+            // https://www.mail-archive.com/jdk6-dev@openjdk.java.net/msg00698.html
+            // https://openjdk.org/jeps/471
+            if (unsafe != null) {
+                final Object finalUnsafe = unsafe;
+                final Object maybeException = AccessController.doPrivileged(new PrivilegedAction<Object>() {
+                    @Override
+                    public Object run() {
+                        try {
+                            // Other methods like invokeCleaner() are tested for elsewhere.
+                            Class<?> cls = finalUnsafe.getClass();
+                            List<MethodHandle> methodHandles = new ArrayList<>();
+                            MethodHandle allocateMemoryHandle = lookup.findVirtual(cls, "allocateMemory",
+                                    methodType(long.class, long.class)).bindTo(finalUnsafe);
+                            methodHandles.add(allocateMemoryHandle);
+                            methodHandles.add(
+                                    lookup.findVirtual(cls, "copyMemory",
+                                                    methodType(void.class, long.class, long.class, long.class))
+                                            .bindTo(finalUnsafe)
+                            );
+                            methodHandles.add(
+                                    lookup.findVirtual(cls, "copyMemory",
+                                                    methodType(void.class, Object.class, long.class, Object.class,
+                                                            long.class, long.class))
+                                            .bindTo(finalUnsafe)
+                                    );
+                            methodHandles.add(
+                                    lookup.findVirtual(cls, "objectFieldOffset",
+                                                    methodType(long.class, Field.class))
+                                            .bindTo(finalUnsafe)
+                            );
+                            methodHandles.add(
+                                    lookup.findVirtual(cls, "staticFieldOffset",
+                                                    methodType(long.class, Field.class))
+                                            .bindTo(finalUnsafe)
+                            );
+                            methodHandles.add(
+                                    lookup.findVirtual(cls, "staticFieldBase",
+                                                    methodType(Object.class, Field.class))
+                                            .bindTo(finalUnsafe)
+                            );
+                            methodHandles.add(
+                                    lookup.findVirtual(cls, "arrayBaseOffset",
+                                                    methodType(int.class, Class.class))
+                                            .bindTo(finalUnsafe)
+                            );
+                            methodHandles.add(
+                                    lookup.findVirtual(cls, "arrayIndexScale",
+                                                    methodType(int.class, Class.class))
+                                            .bindTo(finalUnsafe)
+                            );
+                            methodHandles.add(
+                                    lookup.findVirtual(cls, "reallocateMemory",
+                                                    methodType(long.class, long.class, long.class))
+                                            .bindTo(finalUnsafe)
+                            );
+                            MethodHandle freeMemoryHandle = lookup.findVirtual(cls, "freeMemory",
+                                    methodType(void.class, long.class)).bindTo(finalUnsafe);
+                            methodHandles.add(freeMemoryHandle);
+                            methodHandles.add(
+                                    lookup.findVirtual(cls, "setMemory",
+                                                    methodType(void.class, long.class, long.class, byte.class))
+                                            .bindTo(finalUnsafe)
+                            );
+                            methodHandles.add(
+                                    lookup.findVirtual(cls, "setMemory",
+                                                    methodType(void.class, Object.class, long.class,
+                                                            long.class, byte.class))
+                                            .bindTo(finalUnsafe)
+                            );
+                            methodHandles.add(
+                                    lookup.findVirtual(cls, "getBoolean",
+                                                    methodType(boolean.class, Object.class, long.class))
+                                            .bindTo(finalUnsafe)
+                            );
+                            methodHandles.add(
+                                    lookup.findVirtual(cls, "getByte",
+                                                    methodType(byte.class, long.class))
+                                            .bindTo(finalUnsafe)
+                            );
+                            methodHandles.add(
+                                    lookup.findVirtual(cls, "getByte",
+                                                    methodType(byte.class, Object.class, long.class))
+                                            .bindTo(finalUnsafe)
+                            );
+                            methodHandles.add(
+                                    lookup.findVirtual(cls, "getChar",
+                                                    methodType(char.class, Object.class, long.class))
+                                            .bindTo(finalUnsafe)
+                            );
+                            methodHandles.add(
+                                    lookup.findVirtual(cls, "getShort",
+                                                    methodType(short.class, long.class))
+                                            .bindTo(finalUnsafe)
+                            );
+                            methodHandles.add(
+                                    lookup.findVirtual(cls, "getShort",
+                                                    methodType(short.class, Object.class, long.class))
+                                            .bindTo(finalUnsafe)
+                            );
+                            methodHandles.add(
+                                    lookup.findVirtual(cls, "getInt",
+                                                    methodType(int.class, long.class))
+                                            .bindTo(finalUnsafe)
+                            );
+                            methodHandles.add(
+                                    lookup.findVirtual(cls, "getInt",
+                                                    methodType(int.class, Object.class, long.class))
+                                            .bindTo(finalUnsafe)
+                            );
+                            methodHandles.add(
+                                    lookup.findVirtual(cls, "getIntVolatile",
+                                                    methodType(int.class, Object.class, long.class))
+                                            .bindTo(finalUnsafe)
+                            );
+                            methodHandles.add(
+                                    lookup.findVirtual(cls, "getLong",
+                                                    methodType(long.class, long.class))
+                                            .bindTo(finalUnsafe)
+                            );
+                            methodHandles.add(
+                                    lookup.findVirtual(cls, "getLong",
+                                                    methodType(long.class, Object.class, long.class))
+                                            .bindTo(finalUnsafe)
+                            );
+                            methodHandles.add(
+                                    lookup.findVirtual(cls, "getObject",
+                                                    methodType(Object.class, Object.class, long.class))
+                                            .bindTo(finalUnsafe)
+                            );
+                            methodHandles.add(
+                                    lookup.findVirtual(cls, "putByte",
+                                                    methodType(void.class, long.class, byte.class))
+                                            .bindTo(finalUnsafe)
+                            );
+                            methodHandles.add(
+                                    lookup.findVirtual(cls, "putByte",
+                                                    methodType(void.class, Object.class, long.class, byte.class))
+                                            .bindTo(finalUnsafe)
+                            );
+                            methodHandles.add(
+                                    lookup.findVirtual(cls, "putShort",
+                                                    methodType(void.class, long.class, short.class))
+                                            .bindTo(finalUnsafe)
+                            );
+                            methodHandles.add(
+                                    lookup.findVirtual(cls, "putShort",
+                                                    methodType(void.class, Object.class, long.class, short.class))
+                                            .bindTo(finalUnsafe)
+                            );
+                            methodHandles.add(
+                                    lookup.findVirtual(cls, "putInt",
+                                            methodType(void.class, long.class, int.class))
+                                            .bindTo(finalUnsafe)
+                            );
+                            methodHandles.add(
+                                    lookup.findVirtual(cls, "putInt",
+                                                    methodType(void.class, Object.class, long.class, int.class))
+                                            .bindTo(finalUnsafe)
+                            );
+                            methodHandles.add(
+                                    lookup.findVirtual(cls, "putOrderedInt",
+                                                    methodType(void.class, Object.class, long.class, int.class))
+                                            .bindTo(finalUnsafe)
+                            );
+                            MethodHandle putLongHandle = lookup.findVirtual(cls, "putLong",
+                                    methodType(void.class, long.class, long.class)).bindTo(finalUnsafe);
+                            methodHandles.add(putLongHandle);
+                            methodHandles.add(
+                                    lookup.findVirtual(cls, "putLong",
+                                                    methodType(void.class, Object.class, long.class, long.class))
+                                            .bindTo(finalUnsafe)
+                            );
+                            methodHandles.add(
+                                    lookup.findVirtual(cls, "putObject",
+                                                    methodType(void.class, Object.class, long.class, Object.class))
+                                            .bindTo(finalUnsafe)
+                            );
+                            methodHandles.add(
+                                    lookup.findVirtual(cls, "addressSize",
+                                                    methodType(int.class))
+                                            .bindTo(finalUnsafe)
+                            );
+                            methodHandles.add(
+                                    lookup.findVirtual(cls, "storeFence",
+                                                    methodType(void.class))
+                                            .bindTo(finalUnsafe)
+                            );
+
+                            // The following tests the methods are usable.
+                            // Will throw UnsupportedOperationException if unsafe memory access is denied:
+                            long address = (long) allocateMemoryHandle.invokeExact((long) 8);
+                            putLongHandle.invokeExact(address, (long) 42);
+                            freeMemoryHandle.invokeExact(address);
+                            return methodHandles;
+                        } catch (Throwable cause) {
+                            return cause;
+                        }
+                    }
+                });
+
+                if (maybeException instanceof Throwable) {
+                    // Unsafe.copyMemory(Object, long, Object, long, long) unavailable.
+                    unsafe = null;
+                    unsafeUnavailabilityCause = (Throwable) maybeException;
+                    if (logger.isTraceEnabled()) {
+                        logger.debug("{} method unavailable:", SUN_MISC_UNSAFE_CLASS_NAME, unsafeUnavailabilityCause);
+                    } else {
+                        logger.debug("{} method unavailable: {}", SUN_MISC_UNSAFE_CLASS_NAME,
+                                ((Throwable) maybeException).getMessage());
+                    }
+                } else {
+                    logger.debug("{} base methods: all available", SUN_MISC_UNSAFE_CLASS_NAME);
+                    @SuppressWarnings("unchecked") List<MethodHandle> handles = (List<MethodHandle>) maybeException;
+
+                    int idx = 0;
+                    allocateMemoryHandle = handles.get(idx++);
+                    copyMemoryWithLongHandle = handles.get(idx++);
+                    copyMemoryWithObjectHandle = handles.get(idx++);
+                    objectFieldOffsetHandle = handles.get(idx++);
+                    staticFieldOffsetHandle = handles.get(idx++);
+                    staticFieldBaseHandle = handles.get(idx++);
+                    arrayBaseOffsetHandle = handles.get(idx++);
+                    arrayIndexScaleHandle = handles.get(idx++);
+                    reallocateMemoryHandle = handles.get(idx++);
+                    freeMemoryHandle = handles.get(idx++);
+                    setMemoryWithLongHandle = handles.get(idx++);
+                    setMemoryWithObjectHandle = handles.get(idx++);
+                    getBooleanWithObjectHandle = handles.get(idx++);
+                    getByteWithLongHandle = handles.get(idx++);
+                    getByteWithObjectHandle = handles.get(idx++);
+                    getCharWithObjectHandle = handles.get(idx++);
+                    getShortWithLongHandle = handles.get(idx++);
+                    getShortWithObjectHandle = handles.get(idx++);
+                    getIntWithLongHandle = handles.get(idx++);
+                    getIntWithObjectHandle = handles.get(idx++);
+                    getIntVolatileWithObjectHandle = handles.get(idx++);
+                    getLongWithLongHandle = handles.get(idx++);
+                    getLongWithObjectHandle = handles.get(idx++);
+                    getObjectWithObjectHandle = handles.get(idx++);
+                    putByteWithLongHandle = handles.get(idx++);
+                    putByteWithObjectHandle = handles.get(idx++);
+                    putShortWithLongHandle = handles.get(idx++);
+                    putShortWithObjectHandle = handles.get(idx++);
+                    putIntWithLongHandle = handles.get(idx++);
+                    putIntWithObjectHandle = handles.get(idx++);
+                    putOrderedIntWithObjectHandle = handles.get(idx++);
+                    putLongWithLongHandle = handles.get(idx++);
+                    putLongWithObjectHandle = handles.get(idx++);
+                    putObjectWithObjectHandle = handles.get(idx++);
+                    addressSizeHandle = handles.get(idx++);
+                    storeFenceHandle = handles.get(idx);
+                }
+            }
+        }
+
+        UNSAFE_ALLOCATE_MEMORY_HANDLE = allocateMemoryHandle;
+        UNSAFE_COPY_MEMORY_WITH_LONG_HANDLE = copyMemoryWithLongHandle;
+        UNSAFE_COPY_MEMORY_WITH_OBJECT_HANDLE = copyMemoryWithObjectHandle;
+        UNSAFE_OBJECT_FIELD_OFFSET_HANDLE = objectFieldOffsetHandle;
+        UNSAFE_REALLOCATE_MEMORY_HANDLE = reallocateMemoryHandle;
+        UNSAFE_FREE_MEMORY_HANDLE = freeMemoryHandle;
+        UNSAFE_SET_MEMORY_WITH_LONG_HANDLE = setMemoryWithLongHandle;
+        UNSAFE_SET_MEMORY_WITH_OBJECT_HANDLE = setMemoryWithObjectHandle;
+        UNSAFE_GET_BYTE_WITH_LONG_HANDLE = getByteWithLongHandle;
+        UNSAFE_GET_BYTE_WITH_OBJECT_HANDLE = getByteWithObjectHandle;
+        UNSAFE_GET_CHAR_WITH_OBJECT_HANDLE = getCharWithObjectHandle;
+        UNSAFE_GET_SHORT_WITH_LONG_HANDLE = getShortWithLongHandle;
+        UNSAFE_GET_SHORT_WITH_OBJECT_HANDLE = getShortWithObjectHandle;
+        UNSAFE_GET_INT_WITH_LONG_HANDLE = getIntWithLongHandle;
+        UNSAFE_GET_INT_WITH_OBJECT_HANDLE = getIntWithObjectHandle;
+        UNSAFE_GET_INT_VOLATILE_WITH_OBJECT_HANDLE = getIntVolatileWithObjectHandle;
+        UNSAFE_GET_LONG_WITH_LONG_HANDLE = getLongWithLongHandle;
+        UNSAFE_GET_LONG_WITH_OBJECT_HANDLE = getLongWithObjectHandle;
+        UNSAFE_GET_OBJECT_WITH_OBJECT_HANDLE = getObjectWithObjectHandle;
+        UNSAFE_PUT_BYTE_WITH_LONG_HANDLE = putByteWithLongHandle;
+        UNSAFE_PUT_BYTE_WITH_OBJECT_HANDLE = putByteWithObjectHandle;
+        UNSAFE_PUT_SHORT_WITH_LONG_HANDLE = putShortWithLongHandle;
+        UNSAFE_PUT_SHORT_WITH_OBJECT_HANDLE = putShortWithObjectHandle;
+        UNSAFE_PUT_INT_WITH_LONG_HANDLE = putIntWithLongHandle;
+        UNSAFE_PUT_INT_WITH_OBJECT_HANDLE = putIntWithObjectHandle;
+        UNSAFE_PUT_ORDERED_INT_WITH_OBJECT_HANDLE = putOrderedIntWithObjectHandle;
+        UNSAFE_PUT_LONG_WITH_LONG_HANDLE = putLongWithLongHandle;
+        UNSAFE_PUT_LONG_WITH_OBJECT_HANDLE = putLongWithObjectHandle;
+        UNSAFE_PUT_OBJECT_WITH_OBJECT_HANDLE = putObjectWithObjectHandle;
+        UNSAFE_ADDRESS_SIZE_HANDLE = addressSizeHandle;
+        UNSAFE_STORE_FENCE_HANDLE = storeFenceHandle;
+        UNSAFE_ARRAY_BASE_OFFSET_HANDLE = arrayBaseOffsetHandle;
+        UNSAFE_ARRAY_INDEX_SCALE_HANDLE = arrayIndexScaleHandle;
+        UNSAFE_STATIC_FIELD_OFFSET_HANDLE = staticFieldOffsetHandle;
+        UNSAFE_STATIC_FIELD_BASE_HANDLE = staticFieldBaseHandle;
+        UNSAFE_GET_BOOLEAN_WITH_OBJECT_HANDLE = getBooleanWithObjectHandle;
+        UNSAFE_UNAVAILABILITY_CAUSE = unsafeUnavailabilityCause;
+        UNSAFE = unsafe;
+    }
+
+    static boolean isExplicitNoUnsafe() {
+        return EXPLICIT_NO_UNSAFE_CAUSE != null;
+    }
+
+    private static Throwable explicitNoUnsafeCause0() {
+        boolean explicitProperty = SystemPropertyUtil.contains("io.netty.noUnsafe");
+        boolean noUnsafe = SystemPropertyUtil.getBoolean("io.netty.noUnsafe", false);
+        logger.debug("-Dio.netty.noUnsafe: {}", noUnsafe);
+
+        // See JDK 23 JEP 471 https://openjdk.org/jeps/471 and sun.misc.Unsafe.beforeMemoryAccess() on JDK 23+.
+        // And JDK 24 JEP 498 https://openjdk.org/jeps/498, that enable warnings by default.
+        String reason = "io.netty.noUnsafe";
+        String unspecified = "<unspecified>";
+        String unsafeMemoryAccess = SystemPropertyUtil.get("sun.misc.unsafe.memory.access", unspecified);
+        if (!explicitProperty && unspecified.equals(unsafeMemoryAccess) && JavaVersion.javaVersion() >= 24) {
+            reason = "io.netty.noUnsafe=true by default on Java 24+";
+            noUnsafe = true;
+        } else if (!("allow".equals(unsafeMemoryAccess) || unspecified.equals(unsafeMemoryAccess))) {
+            reason = "--sun-misc-unsafe-memory-access=" + unsafeMemoryAccess;
+            noUnsafe = true;
+        }
+
+        if (noUnsafe) {
+            String msg = "sun.misc.Unsafe: unavailable (" + reason + ')';
+            logger.debug(msg);
+            return new UnsupportedOperationException(msg);
+        }
+
+        // Legacy properties
+        String unsafePropName;
+        if (SystemPropertyUtil.contains("io.netty.tryUnsafe")) {
+            unsafePropName = "io.netty.tryUnsafe";
+        } else {
+            unsafePropName = "org.jboss.netty.tryUnsafe";
+        }
+
+        if (!SystemPropertyUtil.getBoolean(unsafePropName, true)) {
+            String msg = "sun.misc.Unsafe: unavailable (" + unsafePropName + ')';
+            logger.debug(msg);
+            return new UnsupportedOperationException(msg);
+        }
+
+        return null;
+    }
+
+    static int arrayIndexScale(Class<?> arrayClass) {
+        try {
+            return (int) UNSAFE_ARRAY_INDEX_SCALE_HANDLE.invokeExact(arrayClass);
+        } catch (Throwable cause) {
+            rethrowIfPossible(cause);
+            throw new IllegalStateException(cause);
+        }
+    }
+
+    static int arrayBaseOffset(Class<?> arrayClass) {
+        try {
+            return (int) UNSAFE_ARRAY_BASE_OFFSET_HANDLE.invokeExact(arrayClass);
+        } catch (Throwable cause) {
+            rethrowIfPossible(cause);
+            throw new IllegalStateException(cause);
+        }
+    }
+
+    static void storeFence() {
+        try {
+            UNSAFE_STORE_FENCE_HANDLE.invokeExact();
+        } catch (Throwable cause) {
+            rethrowIfPossible(cause);
+            throw new IllegalStateException(cause);
+        }
+    }
+
+    static long objectFieldOffset(Field field) {
+        try {
+            return (long) UNSAFE_OBJECT_FIELD_OFFSET_HANDLE.invokeExact(field);
+        } catch (Throwable cause) {
+            rethrowIfPossible(cause);
+            throw new IllegalStateException(cause);
+        }
+    }
+
+    static long staticFieldOffset(Field f) {
+        try {
+            return (long) UNSAFE_STATIC_FIELD_OFFSET_HANDLE.invokeExact(f);
+        } catch (Throwable cause) {
+            rethrowIfPossible(cause);
+            throw new IllegalStateException(cause);
+        }
+    }
+
+    static Object staticFieldBase(Field f) {
+        try {
+            return UNSAFE_STATIC_FIELD_BASE_HANDLE.invokeExact(f);
+        } catch (Throwable cause) {
+            rethrowIfPossible(cause);
+            throw new IllegalStateException(cause);
+        }
+    }
+
+    static boolean getBoolean(Object o, long offset) {
+        try {
+            return (boolean) UNSAFE_GET_BOOLEAN_WITH_OBJECT_HANDLE.invokeExact(o, offset);
+        } catch (Throwable cause) {
+            rethrowIfPossible(cause);
+            throw new IllegalStateException(cause);
+        }
+    }
+
+    static Object getObject(Object object, long fieldOffset) {
+        try {
+            return (Object) UNSAFE_GET_OBJECT_WITH_OBJECT_HANDLE.invokeExact(object, fieldOffset);
+        } catch (Throwable cause) {
+            rethrowIfPossible(cause);
+            throw new IllegalStateException(cause);
+        }
+    }
+
+    static long getLong(Object object, long fieldOffset) {
+        try {
+            return (long) UNSAFE_GET_LONG_WITH_OBJECT_HANDLE.invokeExact(object, fieldOffset);
+        } catch (Throwable cause) {
+            rethrowIfPossible(cause);
+            throw new IllegalStateException(cause);
+        }
+    }
+
+    static byte getByte(long address) {
+        try {
+            return (byte) UNSAFE_GET_BYTE_WITH_LONG_HANDLE.invokeExact(address);
+        } catch (Throwable cause) {
+            rethrowIfPossible(cause);
+            throw new IllegalStateException(cause);
+        }
+    }
+
+    static short getShort(long address) {
+        try {
+            return (short) UNSAFE_GET_SHORT_WITH_LONG_HANDLE.invokeExact(address);
+        } catch (Throwable cause) {
+            rethrowIfPossible(cause);
+            throw new IllegalStateException(cause);
+        }
+    }
+
+    static int getInt(long address) {
+        try {
+            return (int) UNSAFE_GET_INT_WITH_LONG_HANDLE.invokeExact(address);
+        } catch (Throwable cause) {
+            rethrowIfPossible(cause);
+            throw new IllegalStateException(cause);
+        }
+    }
+
+    static long getLong(long address) {
+        try {
+            return (long) UNSAFE_GET_LONG_WITH_LONG_HANDLE.invokeExact(address);
+        } catch (Throwable cause) {
+            rethrowIfPossible(cause);
+            throw new IllegalStateException(cause);
+        }
+    }
+
+    static byte getByte(Object o, long offset) {
+        try {
+            return (byte) UNSAFE_GET_BYTE_WITH_OBJECT_HANDLE.invokeExact(o, offset);
+        } catch (Throwable cause) {
+            rethrowIfPossible(cause);
+            throw new IllegalStateException(cause);
+        }
+    }
+
+    static short getShort(Object o, long offset) {
+        try {
+            return (short) UNSAFE_GET_SHORT_WITH_OBJECT_HANDLE.invokeExact(o, offset);
+        } catch (Throwable cause) {
+            rethrowIfPossible(cause);
+            throw new IllegalStateException(cause);
+        }
+    }
+
+    static char getChar(Object o, long offset) {
+        try {
+            return (char) UNSAFE_GET_CHAR_WITH_OBJECT_HANDLE.invokeExact(o, offset);
+        } catch (Throwable cause) {
+            rethrowIfPossible(cause);
+            throw new IllegalStateException(cause);
+        }
+    }
+
+    static int getInt(Object o, long offset) {
+        try {
+            return (int) UNSAFE_GET_INT_WITH_OBJECT_HANDLE.invokeExact(o, offset);
+        } catch (Throwable cause) {
+            rethrowIfPossible(cause);
+            throw new IllegalStateException(cause);
+        }
+    }
+
+    static int getIntVolatile(Object o, long address) {
+        try {
+            return (int) UNSAFE_GET_INT_VOLATILE_WITH_OBJECT_HANDLE.invokeExact(o, address);
+        } catch (Throwable cause) {
+            rethrowIfPossible(cause);
+            throw new IllegalStateException(cause);
+        }
+    }
+
+    static void putIntOrdered(Object o, long address, int newValue) {
+        try {
+            UNSAFE_PUT_ORDERED_INT_WITH_OBJECT_HANDLE.invokeExact(o, address, newValue);
+        } catch (Throwable cause) {
+            rethrowIfPossible(cause);
+            throw new IllegalStateException(cause);
+        }
+    }
+
+    static void putByte(long address, byte value) {
+        try {
+            UNSAFE_PUT_BYTE_WITH_LONG_HANDLE.invokeExact(address, value);
+        } catch (Throwable cause) {
+            rethrowIfPossible(cause);
+            throw new IllegalStateException(cause);
+        }
+    }
+
+    static void putShort(long address, short value) {
+        try {
+            UNSAFE_PUT_SHORT_WITH_LONG_HANDLE.invokeExact(address, value);
+        } catch (Throwable cause) {
+            rethrowIfPossible(cause);
+            throw new IllegalStateException(cause);
+        }
+    }
+
+    static void putInt(long address, int value) {
+        try {
+            UNSAFE_PUT_INT_WITH_LONG_HANDLE.invokeExact(address, value);
+        } catch (Throwable cause) {
+            rethrowIfPossible(cause);
+            throw new IllegalStateException(cause);
+        }
+    }
+
+    static void putLong(long address, long value) {
+        try {
+            UNSAFE_PUT_LONG_WITH_LONG_HANDLE.invokeExact(address, value);
+        } catch (Throwable cause) {
+            rethrowIfPossible(cause);
+            throw new IllegalStateException(cause);
+        }
+    }
+
+    static void putByte(Object o, long offset, byte value) {
+        try {
+            UNSAFE_PUT_BYTE_WITH_OBJECT_HANDLE.invokeExact(o, offset, value);
+        } catch (Throwable cause) {
+            rethrowIfPossible(cause);
+            throw new IllegalStateException(cause);
+        }
+    }
+
+    static void putShort(Object o, long offset, short value) {
+        try {
+            UNSAFE_PUT_SHORT_WITH_OBJECT_HANDLE.invokeExact(o, offset, value);
+        } catch (Throwable cause) {
+            rethrowIfPossible(cause);
+            throw new IllegalStateException(cause);
+        }
+    }
+
+    static void putInt(Object o, long offset, int value) {
+        try {
+            UNSAFE_PUT_INT_WITH_OBJECT_HANDLE.invokeExact(o, offset, value);
+        } catch (Throwable cause) {
+            rethrowIfPossible(cause);
+            throw new IllegalStateException(cause);
+        }
+    }
+
+    static void putLong(Object o, long offset, long value) {
+        try {
+            UNSAFE_PUT_LONG_WITH_OBJECT_HANDLE.invokeExact(o, offset, value);
+        } catch (Throwable cause) {
+            rethrowIfPossible(cause);
+            throw new IllegalStateException(cause);
+        }
+    }
+
+    static void putObject(Object o, long offset, Object value) {
+        try {
+            UNSAFE_PUT_OBJECT_WITH_OBJECT_HANDLE.invokeExact(o, offset, value);
+        } catch (Throwable cause) {
+            rethrowIfPossible(cause);
+            throw new IllegalStateException(cause);
+        }
+    }
+
+    static void copyMemory(Object srcBase, long srcOffset,
+                           Object destBase, long destOffset,
+                           long bytes) {
+        try {
+            UNSAFE_COPY_MEMORY_WITH_OBJECT_HANDLE.invokeExact(srcBase, srcOffset, destBase, destOffset, bytes);
+        } catch (Throwable cause) {
+            rethrowIfPossible(cause);
+            throw new IllegalStateException(cause);
+        }
+    }
+
+    static void copyMemory(long srcAddress, long destAddress, long bytes) {
+        try {
+            UNSAFE_COPY_MEMORY_WITH_LONG_HANDLE.invokeExact(srcAddress, destAddress, bytes);
+        } catch (Throwable cause) {
+            rethrowIfPossible(cause);
+            throw new IllegalStateException(cause);
+        }
+    }
+
+    static void setMemory(long address, long bytes, byte value) {
+        try {
+            UNSAFE_SET_MEMORY_WITH_LONG_HANDLE.invokeExact(address, bytes, value);
+        } catch (Throwable cause) {
+            rethrowIfPossible(cause);
+            throw new IllegalStateException(cause);
+        }
+    }
+
+    static void setMemory(Object o, long offset, long bytes, byte value) {
+        try {
+            UNSAFE_SET_MEMORY_WITH_OBJECT_HANDLE.invokeExact(o, offset, bytes, value);
+        } catch (Throwable cause) {
+            rethrowIfPossible(cause);
+            throw new IllegalStateException(cause);
+        }
+    }
+
+    static int addressSize() {
+        try {
+            return (int) UNSAFE_ADDRESS_SIZE_HANDLE.invokeExact();
+        } catch (Throwable cause) {
+            rethrowIfPossible(cause);
+            throw new IllegalStateException(cause);
+        }
+    }
+
+    static long allocateMemory(long size) {
+        try {
+            return (long) UNSAFE_ALLOCATE_MEMORY_HANDLE.invokeExact(size);
+        } catch (Throwable cause) {
+            rethrowIfPossible(cause);
+            throw new IllegalStateException(cause);
+        }
+    }
+
+    static void freeMemory(long address) {
+        try {
+            UNSAFE_FREE_MEMORY_HANDLE.invokeExact(address);
+        } catch (Throwable cause) {
+            rethrowIfPossible(cause);
+            throw new IllegalStateException(cause);
+        }
+    }
+
+    static long reallocateMemory(long address, long newSize) {
+        try {
+            return (long) UNSAFE_REALLOCATE_MEMORY_HANDLE.invokeExact(address, newSize);
+        } catch (Throwable cause) {
+            rethrowIfPossible(cause);
+            throw new IllegalStateException(cause);
+        }
+    }
+
+    private static void rethrowIfPossible(Throwable cause) {
+        if (cause instanceof Error) {
+            throw (Error) cause;
+        }
+        if (cause instanceof RuntimeException) {
+            throw (RuntimeException) cause;
+        }
+    }
+
+    static boolean isAvailabile() {
+        return UNSAFE_UNAVAILABILITY_CAUSE == null && UNSAFE != null;
+    }
+
+    static Throwable unavailabilityCause() {
+        return UNSAFE_UNAVAILABILITY_CAUSE;
+    }
+
+    private SunMiscUnsafeAccess() { }
+}

--- a/common/src/test/java/io/netty/util/internal/JavaVersionTest.java
+++ b/common/src/test/java/io/netty/util/internal/JavaVersionTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.internal;
+
+import org.junit.jupiter.api.Test;
+
+import java.security.Permission;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class JavaVersionTest {
+
+    @Test
+    public void testMajorVersionFromJavaSpecificationVersion() {
+        final SecurityManager current = System.getSecurityManager();
+
+        try {
+            System.setSecurityManager(new SecurityManager() {
+                @Override
+                public void checkPropertyAccess(String key) {
+                    if (key.equals("java.specification.version")) {
+                        // deny
+                        throw new SecurityException(key);
+                    }
+                }
+
+                // so we can restore the security manager
+                @Override
+                public void checkPermission(Permission perm) {
+                }
+            });
+
+            assertEquals(6, JavaVersion.majorVersionFromJavaSpecificationVersion());
+        } finally {
+            System.setSecurityManager(current);
+        }
+    }
+
+    @Test
+    public void testMajorVersion() {
+        assertEquals(6, JavaVersion.majorVersion("1.6"));
+        assertEquals(7, JavaVersion.majorVersion("1.7"));
+        assertEquals(8, JavaVersion.majorVersion("1.8"));
+        assertEquals(8, JavaVersion.majorVersion("8"));
+        assertEquals(9, JavaVersion.majorVersion("1.9")); // early version of JDK 9 before Project Verona
+        assertEquals(9, JavaVersion.majorVersion("9"));
+    }
+}

--- a/common/src/test/java/io/netty/util/internal/PlatformDependent0Test.java
+++ b/common/src/test/java/io/netty/util/internal/PlatformDependent0Test.java
@@ -55,40 +55,4 @@ public class PlatformDependent0Test {
         assertEquals(address, PlatformDependent0.directBufferAddress(buffer));
         assertEquals(capacity, buffer.capacity());
     }
-
-    @Test
-    public void testMajorVersionFromJavaSpecificationVersion() {
-        final SecurityManager current = System.getSecurityManager();
-
-        try {
-            System.setSecurityManager(new SecurityManager() {
-                @Override
-                public void checkPropertyAccess(String key) {
-                    if (key.equals("java.specification.version")) {
-                        // deny
-                        throw new SecurityException(key);
-                    }
-                }
-
-                // so we can restore the security manager
-                @Override
-                public void checkPermission(Permission perm) {
-                }
-            });
-
-            assertEquals(6, PlatformDependent0.majorVersionFromJavaSpecificationVersion());
-        } finally {
-            System.setSecurityManager(current);
-        }
-    }
-
-    @Test
-    public void testMajorVersion() {
-        assertEquals(6, PlatformDependent0.majorVersion("1.6"));
-        assertEquals(7, PlatformDependent0.majorVersion("1.7"));
-        assertEquals(8, PlatformDependent0.majorVersion("1.8"));
-        assertEquals(8, PlatformDependent0.majorVersion("8"));
-        assertEquals(9, PlatformDependent0.majorVersion("1.9")); // early version of JDK 9 before Project Verona
-        assertEquals(9, PlatformDependent0.majorVersion("9"));
-    }
 }


### PR DESCRIPTION
Motivation:

Compilation with JDK24 might fail when sun.misc.Unsafe is directly referenced in the source code. We can remove the direct reference of it by using MethodHandles.

Modifications:

- Move sun.misc.Unsafe access to new class SunMiscUnsafeAccess and use MethodHandles to call it

Result:

Be able to compile on JDK24+