### PR TITLE
WebSockets: Allow to adjust mask generation for payload masking

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/RandomWebSocketFrameMaskGenerator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/RandomWebSocketFrameMaskGenerator.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http.websocketx;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * {@link WebSocketFrameMaskGenerator} implementation which returns a random int for masking.
+ */
+public final class RandomWebSocketFrameMaskGenerator implements WebSocketFrameMaskGenerator {
+    public static final RandomWebSocketFrameMaskGenerator INSTANCE = new RandomWebSocketFrameMaskGenerator();
+
+    private RandomWebSocketFrameMaskGenerator() {
+    }
+
+    @Override
+    public int nextMask() {
+        return ThreadLocalRandom.current().nextInt();
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket07FrameEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket07FrameEncoder.java
@@ -70,4 +70,15 @@ public class WebSocket07FrameEncoder extends WebSocket08FrameEncoder {
     public WebSocket07FrameEncoder(boolean maskPayload) {
         super(maskPayload);
     }
+
+    /**
+     * Constructor
+     *
+     * @param maskGenerator
+     *            Web socket clients must set this to {@code non null} to mask payload.
+     *            Server implementations must set this to {@code null}.
+     */
+    public WebSocket07FrameEncoder(WebSocketFrameMaskGenerator maskGenerator) {
+        super(maskGenerator);
+    }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameDecoder.java
@@ -396,6 +396,10 @@ public class WebSocket08FrameDecoder extends ByteToMessageDecoder
         ByteOrder order = frame.order();
 
         int intMask = mask;
+        if (intMask == 0) {
+            // If the mask is 0 we can just return directly as the XOR operations will just produce the same value.
+            return;
+        }
         // Avoid sign extension on widening primitive conversion
         long longMask = intMask & 0xFFFFFFFFL;
         longMask |= longMask << 32;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameEncoder.java
@@ -184,7 +184,7 @@ public class WebSocket08FrameEncoder extends MessageToMessageEncoder<WebSocketFr
 
             // Write payload
             if (maskGenerator != null) {
-                int mask = ThreadLocalRandom.current().nextInt(Integer.MAX_VALUE);
+                int mask = maskGenerator.nextMask();
                 buf.writeInt(mask);
 
                 // If the mask is 0 we can skip all the XOR operations.

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameEncoder.java
@@ -89,7 +89,7 @@ public class WebSocket08FrameEncoder extends MessageToMessageEncoder<WebSocketFr
      */
     private static final int GATHERING_WRITE_THRESHOLD = 1024;
 
-    private final boolean maskPayload;
+    private final WebSocketFrameMaskGenerator maskGenerator;
 
     /**
      * Constructor
@@ -99,7 +99,18 @@ public class WebSocket08FrameEncoder extends MessageToMessageEncoder<WebSocketFr
      *            false.
      */
     public WebSocket08FrameEncoder(boolean maskPayload) {
-        this.maskPayload = maskPayload;
+        this(maskPayload ? RandomWebSocketFrameMaskGenerator.INSTANCE : null);
+    }
+
+    /**
+     * Constructor
+     *
+     * @param maskGenerator
+     *            Web socket clients must set this to {@code non null} to mask payload.
+     *            Server implementations must set this to {@code null}.
+     */
+    public WebSocket08FrameEncoder(WebSocketFrameMaskGenerator maskGenerator) {
+        this.maskGenerator = maskGenerator;
     }
 
     @Override
@@ -143,89 +154,99 @@ public class WebSocket08FrameEncoder extends MessageToMessageEncoder<WebSocketFr
         boolean release = true;
         ByteBuf buf = null;
         try {
-            int maskLength = maskPayload ? 4 : 0;
+            int maskLength = maskGenerator != null ? 4 : 0;
             if (length <= 125) {
                 int size = 2 + maskLength + length;
                 buf = ctx.alloc().buffer(size);
                 buf.writeByte(b0);
-                byte b = (byte) (maskPayload ? 0x80 | (byte) length : (byte) length);
+                byte b = (byte) (maskGenerator != null ? 0x80 | (byte) length : (byte) length);
                 buf.writeByte(b);
             } else if (length <= 0xFFFF) {
                 int size = 4 + maskLength;
-                if (maskPayload || length <= GATHERING_WRITE_THRESHOLD) {
+                if (maskGenerator != null || length <= GATHERING_WRITE_THRESHOLD) {
                     size += length;
                 }
                 buf = ctx.alloc().buffer(size);
                 buf.writeByte(b0);
-                buf.writeByte(maskPayload ? 0xFE : 126);
+                buf.writeByte(maskGenerator != null ? 0xFE : 126);
                 buf.writeByte(length >>> 8 & 0xFF);
                 buf.writeByte(length & 0xFF);
             } else {
                 int size = 10 + maskLength;
-                if (maskPayload) {
+                if (maskGenerator != null) {
                     size += length;
                 }
                 buf = ctx.alloc().buffer(size);
                 buf.writeByte(b0);
-                buf.writeByte(maskPayload ? 0xFF : 127);
+                buf.writeByte(maskGenerator != null ? 0xFF : 127);
                 buf.writeLong(length);
             }
 
             // Write payload
-            if (maskPayload) {
+            if (maskGenerator != null) {
                 int mask = ThreadLocalRandom.current().nextInt(Integer.MAX_VALUE);
                 buf.writeInt(mask);
 
-                if (data.isReadable()) {
+                // If the mask is 0 we can skip all the XOR operations.
+                if (mask != 0) {
+                    if (data.isReadable()) {
+                        ByteOrder srcOrder = data.order();
+                        ByteOrder dstOrder = buf.order();
 
-                    ByteOrder srcOrder = data.order();
-                    ByteOrder dstOrder = buf.order();
+                        int i = data.readerIndex();
+                        int end = data.writerIndex();
 
-                    int i = data.readerIndex();
-                    int end = data.writerIndex();
+                        if (srcOrder == dstOrder) {
+                            // Use the optimized path only when byte orders match.
+                            // Avoid sign extension on widening primitive conversion
+                            long longMask = mask & 0xFFFFFFFFL;
+                            longMask |= longMask << 32;
 
-                    if (srcOrder == dstOrder) {
-                        // Use the optimized path only when byte orders match.
-                        // Avoid sign extension on widening primitive conversion
-                        long longMask = mask & 0xFFFFFFFFL;
-                        longMask |= longMask << 32;
+                            // If the byte order of our buffers it little endian we have to bring our mask
+                            // into the same format, because getInt() and writeInt() will use a reversed byte order
+                            if (srcOrder == ByteOrder.LITTLE_ENDIAN) {
+                                longMask = Long.reverseBytes(longMask);
+                            }
 
-                        // If the byte order of our buffers it little endian we have to bring our mask
-                        // into the same format, because getInt() and writeInt() will use a reversed byte order
-                        if (srcOrder == ByteOrder.LITTLE_ENDIAN) {
-                            longMask = Long.reverseBytes(longMask);
+                            for (int lim = end - 7; i < lim; i += 8) {
+                                buf.writeLong(data.getLong(i) ^ longMask);
+                            }
+
+                            if (i < end - 3) {
+                                buf.writeInt(data.getInt(i) ^ (int) longMask);
+                                i += 4;
+                            }
                         }
-
-                        for (int lim = end - 7; i < lim; i += 8) {
-                            buf.writeLong(data.getLong(i) ^ longMask);
-                        }
-
-                        if (i < end - 3) {
-                            buf.writeInt(data.getInt(i) ^ (int) longMask);
-                            i += 4;
+                        int maskOffset = 0;
+                        for (; i < end; i++) {
+                            byte byteData = data.getByte(i);
+                            buf.writeByte(byteData ^ WebSocketUtil.byteAtIndex(mask, maskOffset++ & 3));
                         }
                     }
-                    int maskOffset = 0;
-                    for (; i < end; i++) {
-                        byte byteData = data.getByte(i);
-                        buf.writeByte(byteData ^ WebSocketUtil.byteAtIndex(mask, maskOffset++ & 3));
-                    }
-                }
-                out.add(buf);
-            } else {
-                if (buf.writableBytes() >= data.readableBytes()) {
-                    // merge buffers as this is cheaper then a gathering write if the payload is small enough
-                    buf.writeBytes(data);
                     out.add(buf);
                 } else {
-                    out.add(buf);
-                    out.add(data.retain());
+                    addBuffers(buf, data, out);
                 }
+            } else {
+                addBuffers(buf, data, out);
             }
             release = false;
         } finally {
             if (release && buf != null) {
                 buf.release();
+            }
+        }
+    }
+
+    private static void addBuffers(ByteBuf buf, ByteBuf data, List<Object> out) {
+        if (buf.writableBytes() >= data.readableBytes()) {
+            // merge buffers as this is cheaper then a gathering write if the payload is small enough
+            buf.writeBytes(data);
+            out.add(buf);
+        } else {
+            out.add(buf);
+            if (data.isReadable()) {
+                out.add(data.retain());
             }
         }
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket13FrameEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket13FrameEncoder.java
@@ -70,4 +70,15 @@ public class WebSocket13FrameEncoder extends WebSocket08FrameEncoder {
     public WebSocket13FrameEncoder(boolean maskPayload) {
         super(maskPayload);
     }
+
+    /**
+     * Constructor
+     *
+     * @param maskGenerator
+     *            Web socket clients must set this to {@code non null} to mask payload.
+     *            Server implementations must set this to {@code null}.
+     */
+    public WebSocket13FrameEncoder(WebSocketFrameMaskGenerator maskGenerator) {
+        super(maskGenerator);
+    }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketFrameMaskGenerator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketFrameMaskGenerator.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http.websocketx;
+
+/**
+ * Allows to customize how the mask is generated that is used to mask the {@link WebSocketFrame}. Masking
+ * is only be done on the client-side.
+ */
+public interface WebSocketFrameMaskGenerator {
+
+    /**
+     * Return the next mask that is used to mask the payload of the {@link WebSocketFrame}.
+     *
+     * @return  mask.
+     */
+    int nextMask();
+}


### PR DESCRIPTION
Motivation:

Sometimes a user might want to provide a custom mask generation to reduce overhead.

Modifications:

- Add new WebSocketFrameMaskGenerator interface that can be implemented to customize mask generation
- Allow to inject generator via constructor
- optimize mask operations if mask is 0

Result:

More flexible usage possible