### PR TITLE
Optimize ByteBuf.setCharSequence for adaptive allocator (#15165)

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -41,6 +41,7 @@ import java.nio.channels.ClosedChannelException;
 import java.nio.channels.FileChannel;
 import java.nio.channels.GatheringByteChannel;
 import java.nio.channels.ScatteringByteChannel;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Queue;
 import java.util.Set;
@@ -1320,6 +1321,12 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
             } catch (ClosedChannelException ignored) {
                 return -1;
             }
+        }
+
+        @Override
+        public int setCharSequence(int index, CharSequence sequence, Charset charset) {
+            checkIndex(index, sequence.length());
+            return rootParent().setCharSequence(idx(index), sequence, charset);
         }
 
         @Override


### PR DESCRIPTION
Motivation:
The `setCharSequence` method is used a fair bit when encoding HTTP headers. I noticed the AdaptiveByteBuf was sending the call down a path with a more indirections than strictly necessary.

Modification:
Implement `setCharSequence` in the `AdaptiveByteBuf` so we skip a level of indirections. This is especially profitable for direct/off-heap buffers, where we see up to a 50% performance improvement in the benchmark. The benefit is greater the longer the string is.

Interestingly, the benchmark also show that it isn't profitable to do this for the `getCharSequence` sibling method.

Result:
Direct buffers from the adaptive allocator now have much faster `setCharSequence`, which will help with HTTP header encoding.
