### PR TITLE
fix buffer leak in TcpDnsQueryDecoder

### DIFF
--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/TcpDnsQueryDecoder.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/TcpDnsQueryDecoder.java
@@ -48,7 +48,9 @@ public final class TcpDnsQueryDecoder extends LengthFieldBasedFrameDecoder {
             if (frame == null) {
                 return null;
             }
-            return DnsMessageUtil.decodeDnsQuery(decoder, ctx.bufferAllocator(), frame.split(), DefaultDnsQuery::new);
+            try (Buffer buffer = frame.split()) {
+                return DnsMessageUtil.decodeDnsQuery(decoder, ctx.bufferAllocator(), buffer, DefaultDnsQuery::new);
+            }
         }
     }
 }


### PR DESCRIPTION
Motivation:
There is a buffer leak in TcpDnsQueryDecoder:
```
2025-05-14T09:35:38.5221055Z 09:35:38.495 [Cleaner-0] ERROR i.netty5.buffer.LoggingLeakCallback - LEAK: Object "buffer (1024 bytes)" was not property closed before it was garbage collected. A life-cycle back-trace (if any) is attached as suppressed exceptions. See https://netty.io/wiki/reference-counted-objects.html for more information.
2025-05-14T09:35:38.5224476Z io.netty5.buffer.LoggingLeakCallback$LeakReport: Object life-cycle trace:
2025-05-14T09:35:38.5225541Z 	Suppressed: io.netty5.buffer.internal.LifecycleTracer$Traceback: ALLOCATE (current acquires = 0) T-205310us.
2025-05-14T09:35:38.5226635Z 		at io.netty5.buffer.internal.ResourceSupport.<init>(ResourceSupport.java:42)
2025-05-14T09:35:38.5227538Z 		at io.netty5.buffer.internal.AdaptableBuffer.<init>(AdaptableBuffer.java:28)
2025-05-14T09:35:38.5228352Z 		at io.netty5.buffer.bytebuffer.NioBuffer.<init>(NioBuffer.java:65)
2025-05-14T09:35:38.5229109Z 		at io.netty5.buffer.bytebuffer.NioBuffer.split(NioBuffer.java:548)
2025-05-14T09:35:38.5229797Z 		at io.netty5.buffer.Buffer.split(Buffer.java:990)
2025-05-14T09:35:38.5230601Z 		at io.netty5.handler.codec.dns.TcpDnsQueryDecoder.decode0(TcpDnsQueryDecoder.java:51)
2025-05-14T09:35:38.5232348Z 		at io.netty5.handler.codec.LengthFieldBasedFrameDecoder.decode(LengthFieldBasedFrameDecoder.java:305)
2025-05-14T09:35:38.5234311Z 		at io.netty5.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:391)
2025-05-14T09:35:38.5235744Z 		at io.netty5.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:334)
```

Modification:
Close split buffer passed to `DnsMessageUtil.decodeDnsQuery`.

Result:
No more buffer leak in TcpDnsQueryDecoder.
