### PR TITLE
forward-port #15156 to main

### DIFF
--- a/pkitesting/src/main/java/io/netty5/pkitesting/CertificateBuilder.java
+++ b/pkitesting/src/main/java/io/netty5/pkitesting/CertificateBuilder.java
@@ -763,8 +763,7 @@ public final class CertificateBuilder {
         }
         if ("ML-DSA".equals(keyAlgorithm)) {
             try {
-                Method getParams = key.getClass().getMethod("getParams");
-                Object params = getParams.invoke(key);
+                AlgorithmParameterSpec params = key.getParams();
                 Method getName = params.getClass().getMethod("getName");
                 return (String) getName.invoke(params);
             } catch (Exception e) {


### PR DESCRIPTION
Motivation:
Ports the fix for ML-DSA keys on java 24 to main.

Modification:
Modified the original fix to directly use `AssymetricKey#getParams` as main uses java 22 and doesn't need to rely on reflection.

Result:
ML-DSA key generation on java 24 works in main as well.
