### PR TITLE
update maven-surefire-plugin to v3.5.3

### DIFF
--- a/buffer-memory-segment/pom.xml
+++ b/buffer-memory-segment/pom.xml
@@ -36,7 +36,6 @@
     <java.compatibility>22</java.compatibility>
     <!-- Java version actually used to perform the build; compiling and testing. -->
     <java.version>22</java.version>
-    <surefire.version>3.0.0-M5</surefire.version>
     <jmh.version>1.33</jmh.version>
   </properties>
 
@@ -65,7 +64,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire.version}</version>
       </plugin>
     </plugins>
   </build>

--- a/codec/src/test/resources/io/netty/handler/codec/xml/sample-04.xml
+++ b/codec/src/test/resources/io/netty/handler/codec/xml/sample-04.xml
@@ -593,12 +593,12 @@
         <!-- keep surefire and failsafe in sync -->
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.19.1</version>
+          <version>3.5.3</version>
         </plugin>
         <!-- keep surefire and failsafe in sync -->
         <plugin>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>2.19.1</version>
+          <version>3.5.3</version>
         </plugin>
         <plugin>
           <artifactId>maven-clean-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1306,12 +1306,12 @@
         <!-- keep surefire and failsafe in sync -->
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.22.2</version>
+          <version>3.5.3</version>
         </plugin>
         <!-- keep surefire and failsafe in sync -->
         <plugin>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>2.22.2</version>
+          <version>3.5.3</version>
         </plugin>
         <plugin>
           <artifactId>maven-clean-plugin</artifactId>


### PR DESCRIPTION
Motivation:
The maven surefire plugin was outdated which caused an issue with test discovering, leading to no tests being executed.
```
2025-05-03T12:13:05.4442449Z May 03, 2025 12:13:05 PM org.junit.platform.launcher.core.DefaultLauncher handleThrowable
2025-05-03T12:13:05.4443907Z WARNING: TestEngine with ID 'junit-jupiter' failed to discover tests
2025-05-03T12:13:05.4446481Z org.junit.platform.commons.JUnitException: OutputDirectoryProvider not available; probably due to unaligned versions of the junit-platform-engine and junit-platform-launcher jars on the classpath/module path.
2025-05-03T12:13:05.4449542Z 	at org.junit.platform.engine.EngineDiscoveryRequest.getOutputDirectoryProvider(EngineDiscoveryRequest.java:94)
2025-05-03T12:13:05.4451240Z 	at org.junit.jupiter.engine.JupiterTestEngine.discover(JupiterTestEngine.java:67)
2025-05-03T12:13:05.4452701Z 	at org.junit.platform.launcher.core.DefaultLauncher.discoverEngineRoot(DefaultLauncher.java:168)
2025-05-03T12:13:05.4454213Z 	at org.junit.platform.launcher.core.DefaultLauncher.discoverRoot(DefaultLauncher.java:155)
2025-05-03T12:13:05.4456076Z 	at org.junit.platform.launcher.core.DefaultLauncher.discover(DefaultLauncher.java:120)
2025-05-03T12:13:05.4459583Z 	at org.apache.maven.surefire.junitplatform.TestPlanScannerFilter.accept(TestPlanScannerFilter.java:56)
2025-05-03T12:13:05.4460942Z 	at org.apache.maven.surefire.util.DefaultScanResult.applyFilter(DefaultScanResult.java:102)
2025-05-03T12:13:05.4462342Z 	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.scanClasspath(JUnitPlatformProvider.java:143)
2025-05-03T12:13:05.4463834Z 	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:124)
2025-05-03T12:13:05.4465253Z 	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:384)
2025-05-03T12:13:05.4466617Z 	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:345)
2025-05-03T12:13:05.4476233Z 	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:126)
2025-05-03T12:13:05.4477271Z 	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:418)
```

Modification:
Update maven-surefire-plugin to the latest version.

Result:
Tests are discovered and executed correctly again.

Note:
Starting to run the tests again uncovered two test failures which were resolved in #15172 and #15171
