### PR TITLE
Use LongAdder directly without wrapping into LongAdderCounter

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.ReentrantLock;
 
 import static io.netty.buffer.PoolChunk.isSubpage;
@@ -55,9 +56,9 @@ abstract class PoolArena<T> implements PoolArenaMetric {
     // Metrics for allocations and deallocations
     private long allocationsNormal;
     // We need to use the LongCounter here as this is not guarded via synchronized block.
-    private final LongCounter allocationsSmall = PlatformDependent.newLongCounter();
-    private final LongCounter allocationsHuge = PlatformDependent.newLongCounter();
-    private final LongCounter activeBytesHuge = PlatformDependent.newLongCounter();
+    private final LongAdder allocationsSmall = new LongAdder();
+    private final LongAdder allocationsHuge = new LongAdder();
+    private final LongAdder activeBytesHuge = new LongAdder();
 
     private long deallocationsSmall;
     private long deallocationsNormal;
@@ -66,7 +67,7 @@ abstract class PoolArena<T> implements PoolArenaMetric {
     private long pooledChunkDeallocations;
 
     // We need to use the LongCounter here as this is not guarded via synchronized block.
-    private final LongCounter deallocationsHuge = PlatformDependent.newLongCounter();
+    private final LongAdder deallocationsHuge = new LongAdder();
 
     // Number of thread caches backed by this arena.
     final AtomicInteger numThreadCaches = new AtomicInteger();
@@ -397,7 +398,7 @@ abstract class PoolArena<T> implements PoolArenaMetric {
         } finally {
             unlock();
         }
-        return allocationsSmall.value() + allocsNormal + allocationsHuge.value();
+        return allocationsSmall.longValue() + allocsNormal + allocationsHuge.longValue();
     }
 
     @Override
@@ -407,7 +408,7 @@ abstract class PoolArena<T> implements PoolArenaMetric {
 
     @Override
     public long numSmallAllocations() {
-        return allocationsSmall.value();
+        return allocationsSmall.longValue();
     }
 
     @Override
@@ -439,7 +440,7 @@ abstract class PoolArena<T> implements PoolArenaMetric {
         } finally {
             unlock();
         }
-        return deallocs + deallocationsHuge.value();
+        return deallocs + deallocationsHuge.longValue();
     }
 
     @Override
@@ -479,18 +480,18 @@ abstract class PoolArena<T> implements PoolArenaMetric {
 
     @Override
     public long numHugeAllocations() {
-        return allocationsHuge.value();
+        return allocationsHuge.longValue();
     }
 
     @Override
     public long numHugeDeallocations() {
-        return deallocationsHuge.value();
+        return deallocationsHuge.longValue();
     }
 
     @Override
     public  long numActiveAllocations() {
-        long val = allocationsSmall.value() + allocationsHuge.value()
-                - deallocationsHuge.value();
+        long val = allocationsSmall.longValue() + allocationsHuge.longValue()
+                - deallocationsHuge.longValue();
         lock();
         try {
             val += allocationsNormal - (deallocationsSmall + deallocationsNormal);
@@ -541,7 +542,7 @@ abstract class PoolArena<T> implements PoolArenaMetric {
 
     @Override
     public long numActiveBytes() {
-        long val = activeBytesHuge.value();
+        long val = activeBytesHuge.longValue();
         lock();
         try {
             for (int i = 0; i < chunkListMetrics.size(); i++) {
@@ -560,7 +561,7 @@ abstract class PoolArena<T> implements PoolArenaMetric {
      * pinned memory is not accessible for use by any other allocation, until the buffers using have all been released.
      */
     public long numPinnedBytes() {
-        long val = activeBytesHuge.value(); // Huge chunks are exact-sized for the buffers they were allocated to.
+        long val = activeBytesHuge.longValue(); // Huge chunks are exact-sized for the buffers they were allocated to.
         for (int i = 0; i < chunkListMetrics.size(); i++) {
             for (PoolChunkMetric m: chunkListMetrics.get(i)) {
                 val += ((PoolChunk<?>) m).pinnedBytes();

--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -398,7 +398,7 @@ abstract class PoolArena<T> implements PoolArenaMetric {
         } finally {
             unlock();
         }
-        return allocationsSmall.longValue() + allocsNormal + allocationsHuge.longValue();
+        return allocationsSmall.sum() + allocsNormal + allocationsHuge.sum();
     }
 
     @Override
@@ -408,7 +408,7 @@ abstract class PoolArena<T> implements PoolArenaMetric {
 
     @Override
     public long numSmallAllocations() {
-        return allocationsSmall.longValue();
+        return allocationsSmall.sum();
     }
 
     @Override
@@ -440,7 +440,7 @@ abstract class PoolArena<T> implements PoolArenaMetric {
         } finally {
             unlock();
         }
-        return deallocs + deallocationsHuge.longValue();
+        return deallocs + deallocationsHuge.sum();
     }
 
     @Override
@@ -480,18 +480,18 @@ abstract class PoolArena<T> implements PoolArenaMetric {
 
     @Override
     public long numHugeAllocations() {
-        return allocationsHuge.longValue();
+        return allocationsHuge.sum();
     }
 
     @Override
     public long numHugeDeallocations() {
-        return deallocationsHuge.longValue();
+        return deallocationsHuge.sum();
     }
 
     @Override
     public  long numActiveAllocations() {
-        long val = allocationsSmall.longValue() + allocationsHuge.longValue()
-                - deallocationsHuge.longValue();
+        long val = allocationsSmall.sum() + allocationsHuge.sum()
+                - deallocationsHuge.sum();
         lock();
         try {
             val += allocationsNormal - (deallocationsSmall + deallocationsNormal);
@@ -542,7 +542,7 @@ abstract class PoolArena<T> implements PoolArenaMetric {
 
     @Override
     public long numActiveBytes() {
-        long val = activeBytesHuge.longValue();
+        long val = activeBytesHuge.sum();
         lock();
         try {
             for (int i = 0; i < chunkListMetrics.size(); i++) {
@@ -561,7 +561,7 @@ abstract class PoolArena<T> implements PoolArenaMetric {
      * pinned memory is not accessible for use by any other allocation, until the buffers using have all been released.
      */
     public long numPinnedBytes() {
-        long val = activeBytesHuge.longValue(); // Huge chunks are exact-sized for the buffers they were allocated to.
+        long val = activeBytesHuge.sum(); // Huge chunks are exact-sized for the buffers they were allocated to.
         for (int i = 0; i < chunkListMetrics.size(); i++) {
             for (PoolChunkMetric m: chunkListMetrics.get(i)) {
                 val += ((PoolChunk<?>) m).pinnedBytes();

--- a/buffer/src/main/java/io/netty/buffer/PoolChunk.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunk.java
@@ -649,7 +649,7 @@ final class PoolChunk<T> implements PoolChunkMetric {
     }
 
     public int pinnedBytes() {
-        return (int) pinnedBytes.longValue();
+        return (int) pinnedBytes.sum();
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/PoolChunk.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunk.java
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.PriorityQueue;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
@@ -169,7 +170,7 @@ final class PoolChunk<T> implements PoolChunkMetric {
     /**
      * Accounting of pinned memory – memory that is currently in use by ByteBuf instances.
      */
-    private final LongCounter pinnedBytes = PlatformDependent.newLongCounter();
+    private final LongAdder pinnedBytes = new LongAdder();
 
     final int pageSize;
     final int pageShifts;
@@ -648,7 +649,7 @@ final class PoolChunk<T> implements PoolChunkMetric {
     }
 
     public int pinnedBytes() {
-        return (int) pinnedBytes.value();
+        return (int) pinnedBytes.longValue();
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/UnpooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledByteBufAllocator.java
@@ -15,11 +15,11 @@
  */
 package io.netty.buffer;
 
-import io.netty.util.internal.LongCounter;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
 
 import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.LongAdder;
 
 /**
  * Simplistic {@link ByteBufAllocator} implementation that does not pool anything.
@@ -247,17 +247,17 @@ public final class UnpooledByteBufAllocator extends AbstractByteBufAllocator imp
     }
 
     private static final class UnpooledByteBufAllocatorMetric implements ByteBufAllocatorMetric {
-        final LongCounter directCounter = PlatformDependent.newLongCounter();
-        final LongCounter heapCounter = PlatformDependent.newLongCounter();
+        final LongAdder directCounter = new LongAdder();
+        final LongAdder heapCounter = new LongAdder();
 
         @Override
         public long usedHeapMemory() {
-            return heapCounter.value();
+            return heapCounter.longValue();
         }
 
         @Override
         public long usedDirectMemory() {
-            return directCounter.value();
+            return directCounter.longValue();
         }
 
         @Override

--- a/buffer/src/main/java/io/netty/buffer/UnpooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledByteBufAllocator.java
@@ -252,12 +252,12 @@ public final class UnpooledByteBufAllocator extends AbstractByteBufAllocator imp
 
         @Override
         public long usedHeapMemory() {
-            return heapCounter.longValue();
+            return heapCounter.sum();
         }
 
         @Override
         public long usedDirectMemory() {
-            return directCounter.longValue();
+            return directCounter.sum();
         }
 
         @Override

--- a/common/src/main/java/io/netty/util/internal/LongAdderCounter.java
+++ b/common/src/main/java/io/netty/util/internal/LongAdderCounter.java
@@ -17,6 +17,10 @@ package io.netty.util.internal;
 
 import java.util.concurrent.atomic.LongAdder;
 
+/**
+ * @deprecated please use {@link LongAdder} instead.
+ */
+@Deprecated
 final class LongAdderCounter extends LongAdder implements LongCounter {
 
     @Override

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -450,7 +450,9 @@ public final class PlatformDependent {
 
     /**
      * Creates a new fastest {@link LongCounter} implementation for the current platform.
+     * @deprecated please use {@link java.util.concurrent.atomic.LongAdder} instead.
      */
+    @Deprecated
     public static LongCounter newLongCounter() {
         return new LongAdderCounter();
     }


### PR DESCRIPTION
With Java 8+ `LongAdderCounter` is no longer needed and is now deprecated, let's use `LongAdder` directly instead.