### PR TITLE
fix some issues with memory-segment based buffer implementation

### DIFF
--- a/buffer-memory-segment/pom.xml
+++ b/buffer-memory-segment/pom.xml
@@ -64,6 +64,14 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>-Dio.netty5.buffer.MemoryManager=MemorySegment</argLine>
+          <dependenciesToScan>
+            <dependency>io.netty:netty5-buffer</dependency>
+            <dependency>io.netty:netty5-handler</dependency>
+            <dependency>io.netty:netty5-codec-http</dependency>
+          </dependenciesToScan>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/buffer-memory-segment/pom.xml
+++ b/buffer-memory-segment/pom.xml
@@ -68,8 +68,6 @@
           <argLine>-Dio.netty5.buffer.MemoryManager=MemorySegment</argLine>
           <dependenciesToScan>
             <dependency>io.netty:netty5-buffer</dependency>
-            <dependency>io.netty:netty5-handler</dependency>
-            <dependency>io.netty:netty5-codec-http</dependency>
           </dependenciesToScan>
         </configuration>
       </plugin>
@@ -109,12 +107,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty5-handler</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty5-codec-http</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>

--- a/buffer-memory-segment/src/main/java/io/netty5/buffer/memseg/MemSegBuffer.java
+++ b/buffer-memory-segment/src/main/java/io/netty5/buffer/memseg/MemSegBuffer.java
@@ -125,8 +125,7 @@ class MemSegBuffer extends AdaptableBuffer<MemSegBuffer>
 
     @Override
     public MemSegBuffer skipReadableBytes(int delta) {
-        readerOffset(readerOffset() + delta);
-        return this;
+        return (MemSegBuffer) super.skipReadableBytes(delta);
     }
 
     @Override
@@ -143,8 +142,7 @@ class MemSegBuffer extends AdaptableBuffer<MemSegBuffer>
 
     @Override
     public MemSegBuffer skipWritableBytes(int delta) {
-        writerOffset(writerOffset() + delta);
-        return this;
+        return (MemSegBuffer) super.skipWritableBytes(delta);
     }
 
     @Override
@@ -159,12 +157,12 @@ class MemSegBuffer extends AdaptableBuffer<MemSegBuffer>
 
     @Override
     public int readableBytes() {
-        return writerOffset() - readerOffset();
+        return super.readableBytes();
     }
 
     @Override
     public int writableBytes() {
-        return capacity() - writerOffset();
+        return super.writableBytes();
     }
 
     @Override
@@ -354,14 +352,19 @@ class MemSegBuffer extends AdaptableBuffer<MemSegBuffer>
             throw bufferIsClosed(this);
         }
         if (srcPos < 0) {
-            throw new IllegalArgumentException("The srcPos cannot be negative: " + srcPos + '.');
+            throw new IndexOutOfBoundsException("The srcPos cannot be negative: " + srcPos + '.');
         }
-        if (length < 0) {
-            throw new IllegalArgumentException("The length cannot be negative: " + length + '.');
+        if (destPos < 0) {
+            throw new IndexOutOfBoundsException("The destination position cannot be negative: " + destPos);
         }
-        if (seg.byteSize() < srcPos + length) {
-            throw new IllegalArgumentException("The srcPos + length is beyond the end of the buffer: " +
-                                               "srcPos = " + srcPos + ", length = " + length + '.');
+        checkLength(length);
+        if (capacity() < srcPos + length) {
+            throw new IndexOutOfBoundsException("The srcPos + length is beyond the end of the buffer: " +
+                "srcPos = " + srcPos + ", length = " + length + '.');
+        }
+        if (dest.byteSize() < destPos + length) {
+            throw new IndexOutOfBoundsException("The destPos + length is beyond the end of the buffer: " +
+                "destPos = " + destPos + ", length = " + length + '.');
         }
         dest.asSlice(destPos, length).copyFrom(seg.asSlice(srcPos, length));
     }
@@ -392,8 +395,9 @@ class MemSegBuffer extends AdaptableBuffer<MemSegBuffer>
         if (length == 0) {
             return 0;
         }
-        checkGet(readerOffset(), length);
-        int bytesWritten = channel.write(readableBuffer().limit(length));
+        final int roff = readerOffset();
+        checkGet(roff, length);
+        int bytesWritten = channel.write(readableBuffer().limit(roff + length));
         skipReadableBytes(bytesWritten);
         return bytesWritten;
     }
@@ -407,8 +411,9 @@ class MemSegBuffer extends AdaptableBuffer<MemSegBuffer>
         if (length == 0) {
             return 0;
         }
-        checkGet(readerOffset(), length);
-        int bytesWritten = channel.write(readableBuffer().limit(length), position);
+        final int roff = readerOffset();
+        checkGet(roff, length);
+        int bytesWritten = channel.write(readableBuffer().limit(roff + length), position);
         skipReadableBytes(bytesWritten);
         return bytesWritten;
     }
@@ -427,8 +432,9 @@ class MemSegBuffer extends AdaptableBuffer<MemSegBuffer>
         if (length == 0) {
             return 0;
         }
-        checkSet(writerOffset(), length);
-        int bytesRead = channel.read(writableBuffer().limit(length), position);
+        final int woff = writerOffset();
+        checkSet(woff, length);
+        int bytesRead = channel.read(writableBuffer().limit(woff + length), position);
         if (bytesRead > 0) { // Don't skipWritable if bytesRead is 0 or -1
             skipWritableBytes(bytesRead);
         }
@@ -447,8 +453,9 @@ class MemSegBuffer extends AdaptableBuffer<MemSegBuffer>
         if (length == 0) {
             return 0;
         }
-        checkSet(writerOffset(), length);
-        int bytesRead = channel.read(writableBuffer().limit(length));
+        final int woff = writerOffset();
+        checkSet(woff, length);
+        int bytesRead = channel.read(writableBuffer().limit(woff + length));
         if (bytesRead != -1) {
             skipWritableBytes(bytesRead);
         }
@@ -512,14 +519,12 @@ class MemSegBuffer extends AdaptableBuffer<MemSegBuffer>
             throw bufferIsClosed(this);
         }
         if (fromOffset < 0) {
-            throw new IllegalArgumentException("The fromOffset cannot be negative: " + fromOffset + '.');
+            throw new IndexOutOfBoundsException("The fromOffset cannot be negative: " + fromOffset + '.');
         }
-        if (length < 0) {
-            throw new IllegalArgumentException("The length cannot be negative: " + length + '.');
-        }
-        if (seg.byteSize() < fromOffset + length) {
-            throw new IllegalArgumentException("The fromOffset + length is beyond the end of the buffer: " +
-                                               "fromOffset = " + fromOffset + ", length = " + length + '.');
+        checkLength(length);
+        if (capacity() < fromOffset + length) {
+            throw new IndexOutOfBoundsException("The fromOffset + length is beyond the end of the buffer: " +
+                "fromOffset = " + fromOffset + ", length = " + length + '.');
         }
         return new ByteCursor() {
             final MemorySegment segment = seg;
@@ -566,17 +571,15 @@ class MemSegBuffer extends AdaptableBuffer<MemSegBuffer>
             throw bufferIsClosed(this);
         }
         if (fromOffset < 0) {
-            throw new IllegalArgumentException("The fromOffset cannot be negative: " + fromOffset + '.');
+            throw new IndexOutOfBoundsException("The fromOffset cannot be negative: " + fromOffset + '.');
         }
-        if (length < 0) {
-            throw new IllegalArgumentException("The length cannot be negative: " + length + '.');
-        }
-        if (seg.byteSize() <= fromOffset) {
-            throw new IllegalArgumentException("The fromOffset is beyond the end of the buffer: " + fromOffset + '.');
+        checkLength(length);
+        if (capacity() <= fromOffset) {
+            throw new IndexOutOfBoundsException("The fromOffset is beyond the end of the buffer: " + fromOffset + '.');
         }
         if (fromOffset - length < -1) {
-            throw new IllegalArgumentException("The fromOffset - length would underflow the buffer: " +
-                                               "fromOffset = " + fromOffset + ", length = " + length + '.');
+            throw new IndexOutOfBoundsException("The fromOffset - length would underflow the buffer: " +
+                "fromOffset = " + fromOffset + ", length = " + length + '.');
         }
         return new ByteCursor() {
             final MemorySegment segment = seg;
@@ -1183,7 +1186,7 @@ class MemSegBuffer extends AdaptableBuffer<MemSegBuffer>
 
     @Override
     public Buffer writeDouble(double value) {
-        checkWrite(woff, Byte.BYTES, true);
+        checkWrite(woff, Double.BYTES, true);
         setDoubleAtOffset(wseg, woff, value);
         woff += Double.BYTES;
         return this;

--- a/buffer/src/main/java/io/netty5/buffer/Buffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/Buffer.java
@@ -668,7 +668,7 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
      *                  The first byte read from the iterator will be the byte at this offset.
      * @param length The number of bytes to iterate.
      * @return A {@link ByteCursor} for the given stretch of bytes of this buffer.
-     * @throws IllegalArgumentException if the length is negative, or if the region given by the {@code fromOffset} and
+     * @throws IndexOutOfBoundsException if the length is negative, or if the region given by the {@code fromOffset} and
      * the {@code length} reaches outside the bounds of this buffer.
      */
     ByteCursor openReverseCursor(int fromOffset, int length);


### PR DESCRIPTION
Motivation:
Enabling tests for the memory segment buffer module revealed some test failures which are addressed in this PR.

Modification:
1. Fix `MemSegBuffer#writeDouble` as it checked if enough space was available to write a byte, not a double.
2. Fix `MemSegBuffer#transferFrom/transferTo` methods, as they were limiting the length of the src/dest ByteBuffer incorrectly
3. Align exceptions thrown by methods with other buffer implementations. Tests were failing as IllegalArgumentExceptions were thrown in places where IndexOutOfBoundsExceptions should've been used instead. Some methods didn't throw an exception on invalid input at all.

Result:
MemSegBuffer aligns with other buffer implementation, the `transferFrom` and `transferTo` methods are now correctly implemented and tests are being executed.

Note:
Some discussion about this can be found in #15164, tests are still failing as the `readableArray/writeableArray` (and related methods) are still not implemented (original reason for the issue). I will implement them in a subsequent PR.
