### PR TITLE
implement readable/writeable array accessors on MemSegBuffer

### DIFF
--- a/buffer-memory-segment/src/main/java/io/netty5/buffer/memseg/MemSegBuffer.java
+++ b/buffer-memory-segment/src/main/java/io/netty5/buffer/memseg/MemSegBuffer.java
@@ -233,6 +233,7 @@ class MemSegBuffer extends AdaptableBuffer<MemSegBuffer>
 
     @Override
     public int writableArrayOffset() {
+        assertHasArray(wseg);
         return Math.toIntExact(wseg.address()) + woff;
     }
 

--- a/buffer-memory-segment/src/main/java/io/netty5/buffer/memseg/MemSegBuffer.java
+++ b/buffer-memory-segment/src/main/java/io/netty5/buffer/memseg/MemSegBuffer.java
@@ -185,19 +185,20 @@ class MemSegBuffer extends AdaptableBuffer<MemSegBuffer>
 
     @Override
     public boolean hasReadableArray() {
-        return this.seg.heapBase().isPresent();
+        return seg.heapBase().isPresent();
     }
 
     @Override
     public byte[] readableArray() {
-        Object heapBase = this.seg.heapBase()
-            .orElseThrow(() -> new UnsupportedOperationException("This component has no backing array."));
+        Object heapBase = seg.heapBase().orElseThrow(MemSegBuffer::createNoBackingArrayException);
         return (byte[]) heapBase;
     }
 
     @Override
     public int readableArrayOffset() {
-        assertHasArray(seg);
+        if (!hasReadableArray()) {
+            throw createNoBackingArrayException();
+        }
         return Math.toIntExact(seg.address()) + roff;
     }
 
@@ -221,19 +222,20 @@ class MemSegBuffer extends AdaptableBuffer<MemSegBuffer>
 
     @Override
     public boolean hasWritableArray() {
-        return this.wseg.heapBase().isPresent();
+        return wseg.heapBase().isPresent();
     }
 
     @Override
     public byte[] writableArray() {
-        Object heapBase = this.wseg.heapBase()
-            .orElseThrow(() -> new UnsupportedOperationException("This component has no backing array."));
+        Object heapBase = wseg.heapBase().orElseThrow(MemSegBuffer::createNoBackingArrayException);
         return (byte[]) heapBase;
     }
 
     @Override
     public int writableArrayOffset() {
-        assertHasArray(wseg);
+        if (!hasWritableArray()) {
+            throw createNoBackingArrayException();
+        }
         return Math.toIntExact(wseg.address()) + woff;
     }
 
@@ -242,10 +244,8 @@ class MemSegBuffer extends AdaptableBuffer<MemSegBuffer>
         return writableBytes();
     }
 
-    private static void assertHasArray(MemorySegment seg) {
-        if (seg.heapBase().isEmpty()) {
-            throw new UnsupportedOperationException("This component has no backing array.");
-        }
+    private static UnsupportedOperationException createNoBackingArrayException() {
+        return new UnsupportedOperationException("This component has no backing array.");
     }
 
     @Override

--- a/buffer-memory-segment/src/main/java/io/netty5/buffer/memseg/MemSegBuffer.java
+++ b/buffer-memory-segment/src/main/java/io/netty5/buffer/memseg/MemSegBuffer.java
@@ -185,22 +185,25 @@ class MemSegBuffer extends AdaptableBuffer<MemSegBuffer>
 
     @Override
     public boolean hasReadableArray() {
-        return false;
+        return this.seg.heapBase().isPresent();
     }
 
     @Override
     public byte[] readableArray() {
-        throw new UnsupportedOperationException("This component has no backing array.");
+        Object heapBase = this.seg.heapBase()
+            .orElseThrow(() -> new UnsupportedOperationException("This component has no backing array."));
+        return (byte[]) heapBase;
     }
 
     @Override
     public int readableArrayOffset() {
-        throw new UnsupportedOperationException("This component has no backing array.");
+        assertHasArray(seg);
+        return Math.toIntExact(seg.address()) + roff;
     }
 
     @Override
     public int readableArrayLength() {
-        throw new UnsupportedOperationException("This component has no backing array.");
+        return woff - roff;
     }
 
     @Override
@@ -218,22 +221,30 @@ class MemSegBuffer extends AdaptableBuffer<MemSegBuffer>
 
     @Override
     public boolean hasWritableArray() {
-        return false;
+        return this.wseg.heapBase().isPresent();
     }
 
     @Override
     public byte[] writableArray() {
-        throw new UnsupportedOperationException("This component has no backing array.");
+        Object heapBase = this.wseg.heapBase()
+            .orElseThrow(() -> new UnsupportedOperationException("This component has no backing array."));
+        return (byte[]) heapBase;
     }
 
     @Override
     public int writableArrayOffset() {
-        throw new UnsupportedOperationException("This component has no backing array.");
+        return Math.toIntExact(wseg.address()) + woff;
     }
 
     @Override
     public int writableArrayLength() {
-        throw new UnsupportedOperationException("This component has no backing array.");
+        return writableBytes();
+    }
+
+    private static void assertHasArray(MemorySegment seg) {
+        if (seg.heapBase().isEmpty()) {
+            throw new UnsupportedOperationException("This component has no backing array.");
+        }
     }
 
     @Override


### PR DESCRIPTION
Motivation:
The `readableArray` and `writableArray` methods (and related) are currently not implemented for MemorySegment backed buffers, even if the MemorySegmentt is backed by a byte array.

Modification:
Implement the methods.

Result:
The `readableArray` and `writableArray` methods (and related) are useable with MemorySegment based buffers like they are with all other buffer types.

Fixes #15164
