### PR TITLE
Disable OIO tests by default

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -200,7 +200,7 @@ jobs:
             docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-7.117.yaml run build"
           - setup: linux-x86_64-java21
             docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-7.21.yaml build"
-            docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-7.21.yaml run build"
+            docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-7.21.yaml run build-with-oio-testsuite"
           - setup: linux-x86_64-java24
             docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-7.24.yaml build"
             docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-7.24.yaml run build"

--- a/docker/docker-compose.centos-6.18.yaml
+++ b/docker/docker-compose.centos-6.18.yaml
@@ -16,6 +16,9 @@ services:
   build-leak:
     image: netty:centos-6-1.8
 
+  build-with-oio-testsuite:
+    image: netty:centos-6-1.8
+
   build-boringssl-static:
     image: netty:centos-6-1.8
 

--- a/docker/docker-compose.centos-7.111.yaml
+++ b/docker/docker-compose.centos-7.111.yaml
@@ -14,6 +14,9 @@ services:
   build-leak:
     image: netty:centos-7-1.11
 
+  build-with-oio-testsuite:
+    image: netty:centos-7-1.11
+
   build-boringssl-static:
     image: netty:centos-7-1.11
 

--- a/docker/docker-compose.centos-7.117.yaml
+++ b/docker/docker-compose.centos-7.117.yaml
@@ -14,6 +14,9 @@ services:
   build-leak:
     image: netty:centos-7-1.17
 
+  build-with-oio-testsuite:
+    image: netty:centos-7-1.17
+
   build-boringssl-static:
     image: netty:centos-7-1.17
 

--- a/docker/docker-compose.centos-7.18.yaml
+++ b/docker/docker-compose.centos-7.18.yaml
@@ -14,6 +14,9 @@ services:
   build-leak:
     image: netty:centos-7-1.8
 
+  build-with-oio-testsuite:
+    image: netty:centos-7-1.8
+
   build-boringssl-static:
     image: netty:centos-7-1.8
 

--- a/docker/docker-compose.centos-7.21.yaml
+++ b/docker/docker-compose.centos-7.21.yaml
@@ -14,6 +14,9 @@ services:
   build-leak:
     image: netty:centos-7-21
 
+  build-with-oio-testsuite:
+    image: netty:centos-7-21
+
   build-boringssl-static:
     image: netty:centos-7-21
 

--- a/docker/docker-compose.centos-7.24.yaml
+++ b/docker/docker-compose.centos-7.24.yaml
@@ -14,6 +14,9 @@ services:
   build-leak:
     image: netty:centos-7-24
 
+  build-with-oio-testsuite:
+    image: netty:centos-7-24
+
   build-boringssl-static:
     image: netty:centos-7-24
 

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -60,6 +60,10 @@ services:
       - ..:/code
     command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && ./mvnw -B -ntp clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME} -Dtcnative.classifier=linux-x86_64-fedora -Drevapi.skip=true -Dcheckstyle.skip=true -Dforbiddenapis.skip=true"
 
+  build-with-oio-testsuite:
+    <<: *common
+    command: /bin/bash -cl "./mvnw -B -ntp -Pboringssl clean install -Dio.netty.testsuite.includeOio=true -Dio.netty.testsuite.badHost=netty.io -Dxml.skip=true -Drevapi.skip=true -Dcheckstyle.skip=true -Dforbiddenapis.skip=true"
+
   build-boringssl-static:
     <<: *common
     command: /bin/bash -cl "./mvnw -B -ntp -Pboringssl clean install -Dio.netty.testsuite.badHost=netty.io -Dxml.skip=true -Drevapi.skip=true -Dcheckstyle.skip=true -Dforbiddenapis.skip=true"

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketTestPermutation.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketTestPermutation.java
@@ -40,7 +40,6 @@ import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 public class SocketTestPermutation {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketTestPermutation.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketTestPermutation.java
@@ -47,6 +47,7 @@ public class SocketTestPermutation {
 
     static final String BAD_HOST = SystemPropertyUtil.get("io.netty.testsuite.badHost", "198.51.100.254");
     static final int BAD_PORT = SystemPropertyUtil.getInt("io.netty.testsuite.badPort", 65535);
+    static final boolean INCLUDE_OIO = SystemPropertyUtil.getBoolean("io.netty.testsuite.includeOio", false);
 
     // See /etc/services
     public static final int UNASSIGNED_PORT = 4;
@@ -111,8 +112,10 @@ public class SocketTestPermutation {
         // Populate the combinations
         List<BootstrapComboFactory<ServerBootstrap, Bootstrap>> list = combo(sbfs, cbfs);
 
-        // Remove the OIO-OIO case which often leads to a dead lock by its nature.
-        list.remove(list.size() - 1);
+        if (INCLUDE_OIO) {
+            // Remove the OIO-OIO case which often leads to a dead lock by its nature.
+            list.remove(list.size() - 1);
+        }
 
         return list;
     }
@@ -127,80 +130,89 @@ public class SocketTestPermutation {
         // Populate the combinations
         List<BootstrapComboFactory<ServerBootstrap, Bootstrap>> list = combo(sbfs, cbfs);
 
-        // Remove the OIO-OIO case which often leads to a dead lock by its nature.
-        list.remove(list.size() - 1);
+        if (INCLUDE_OIO) {
+            // Remove the OIO-OIO case which often leads to a dead lock by its nature.
+            list.remove(list.size() - 1);
+        }
 
         return list;
     }
 
     public List<BootstrapComboFactory<Bootstrap, Bootstrap>> datagram(final SocketProtocolFamily family) {
         // Make the list of Bootstrap factories.
-        List<BootstrapFactory<Bootstrap>> bfs = Arrays.asList(
-                new BootstrapFactory<Bootstrap>() {
-                    @Override
-                    public Bootstrap newInstance() {
-                        return new Bootstrap().group(nioWorkerGroup).channelFactory(new ChannelFactory<Channel>() {
-                            @Override
-                            public Channel newChannel() {
-                                return new NioDatagramChannel(family);
-                            }
+        List<BootstrapFactory<Bootstrap>> bfs = new ArrayList<>();
 
-                            @Override
-                            public String toString() {
-                                return NioDatagramChannel.class.getSimpleName() + ".class";
-                            }
-                        });
-                    }
-                },
-                new BootstrapFactory<Bootstrap>() {
+        bfs.add(new BootstrapFactory<Bootstrap>() {
+            @Override
+            public Bootstrap newInstance() {
+                return new Bootstrap().group(nioWorkerGroup).channelFactory(new ChannelFactory<Channel>() {
                     @Override
-                    public Bootstrap newInstance() {
-                        return new Bootstrap().group(oioWorkerGroup).channel(OioDatagramChannel.class)
-                                .option(ChannelOption.SO_TIMEOUT, OIO_SO_TIMEOUT);
+                    public Channel newChannel() {
+                        return new NioDatagramChannel(family);
                     }
+
+                    @Override
+                    public String toString() {
+                        return NioDatagramChannel.class.getSimpleName() + ".class";
+                    }
+                });
+            }
+        });
+        if (INCLUDE_OIO) {
+            bfs.add(new BootstrapFactory<Bootstrap>() {
+                @Override
+                public Bootstrap newInstance() {
+                    return new Bootstrap().group(oioWorkerGroup).channel(OioDatagramChannel.class)
+                            .option(ChannelOption.SO_TIMEOUT, OIO_SO_TIMEOUT);
                 }
-        );
+            });
+        }
 
         // Populare the combinations.
         return combo(bfs, bfs);
     }
 
     public List<BootstrapFactory<ServerBootstrap>> serverSocket() {
-        return Arrays.asList(
-                new BootstrapFactory<ServerBootstrap>() {
-                    @Override
-                    public ServerBootstrap newInstance() {
-                        return new ServerBootstrap().group(nioBossGroup, nioWorkerGroup)
-                                .channel(NioServerSocketChannel.class);
-                    }
-                },
-                new BootstrapFactory<ServerBootstrap>() {
-                    @Override
-                    public ServerBootstrap newInstance() {
-                        return new ServerBootstrap().group(oioBossGroup, oioWorkerGroup)
-                                .channel(OioServerSocketChannel.class)
-                                .option(ChannelOption.SO_TIMEOUT, OIO_SO_TIMEOUT);
-                    }
+        List<BootstrapFactory<ServerBootstrap>> factories = new ArrayList<>();
+        factories.add(new BootstrapFactory<ServerBootstrap>() {
+            @Override
+            public ServerBootstrap newInstance() {
+                return new ServerBootstrap().group(nioBossGroup, nioWorkerGroup)
+                        .channel(NioServerSocketChannel.class);
+            }
+        });
+        if (INCLUDE_OIO) {
+            factories.add(new BootstrapFactory<ServerBootstrap>() {
+                @Override
+                public ServerBootstrap newInstance() {
+                    return new ServerBootstrap().group(oioBossGroup, oioWorkerGroup)
+                            .channel(OioServerSocketChannel.class)
+                            .option(ChannelOption.SO_TIMEOUT, OIO_SO_TIMEOUT);
                 }
-        );
+            });
+        }
+
+        return factories;
     }
 
     public List<BootstrapFactory<Bootstrap>> clientSocket() {
-        return Arrays.asList(
-                new BootstrapFactory<Bootstrap>() {
-                    @Override
-                    public Bootstrap newInstance() {
-                        return new Bootstrap().group(nioWorkerGroup).channel(NioSocketChannel.class);
-                    }
-                },
-                new BootstrapFactory<Bootstrap>() {
-                    @Override
-                    public Bootstrap newInstance() {
-                        return new Bootstrap().group(oioWorkerGroup).channel(OioSocketChannel.class)
-                                .option(ChannelOption.SO_TIMEOUT, OIO_SO_TIMEOUT);
-                    }
+        List<BootstrapFactory<Bootstrap>> factories = new ArrayList<>();
+        factories.add(new BootstrapFactory<Bootstrap>() {
+            @Override
+            public Bootstrap newInstance() {
+                return new Bootstrap().group(nioWorkerGroup).channel(NioSocketChannel.class);
+            }
+        });
+        if (INCLUDE_OIO) {
+            factories.add(new BootstrapFactory<Bootstrap>() {
+                @Override
+                public Bootstrap newInstance() {
+                    return new Bootstrap().group(oioWorkerGroup).channel(OioSocketChannel.class)
+                            .option(ChannelOption.SO_TIMEOUT, OIO_SO_TIMEOUT);
                 }
-        );
+            });
+        }
+        return factories;
     }
 
     public List<BootstrapFactory<Bootstrap>> clientSocketWithFastOpen() {
@@ -208,20 +220,22 @@ public class SocketTestPermutation {
     }
 
     public List<BootstrapFactory<Bootstrap>> datagramSocket() {
-        return Arrays.asList(
-                new BootstrapFactory<Bootstrap>() {
-                    @Override
-                    public Bootstrap newInstance() {
-                        return new Bootstrap().group(nioWorkerGroup).channel(NioDatagramChannel.class);
-                    }
-                },
-                new BootstrapFactory<Bootstrap>() {
-                    @Override
-                    public Bootstrap newInstance() {
-                        return new Bootstrap().group(oioWorkerGroup).channel(OioDatagramChannel.class)
-                                .option(ChannelOption.SO_TIMEOUT, OIO_SO_TIMEOUT);
-                    }
+        List<BootstrapFactory<Bootstrap>> factories = new ArrayList<>();
+        factories.add(new BootstrapFactory<Bootstrap>() {
+            @Override
+            public Bootstrap newInstance() {
+                return new Bootstrap().group(nioWorkerGroup).channel(NioDatagramChannel.class);
+            }
+        });
+        if (INCLUDE_OIO) {
+            factories.add(new BootstrapFactory<Bootstrap>() {
+                @Override
+                public Bootstrap newInstance() {
+                    return new Bootstrap().group(oioWorkerGroup).channel(OioDatagramChannel.class)
+                            .option(ChannelOption.SO_TIMEOUT, OIO_SO_TIMEOUT);
                 }
-        );
+            });
+        }
+         return factories;
     }
 }


### PR DESCRIPTION
Motivation:

The OIO transport implementation slows down the testsuite a lot.a Let's just not include it by default.

Modifications:

Add property that can control if we include the OIO transport in the testsuite run and set it to false by default

Result:

Speed up the testsuite run