### PR TITLE
Provide a protected constructor for UnpooledUnsafeDirectByteBuf with slice flag

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeDirectByteBuf.java
@@ -59,6 +59,17 @@ public class UnpooledUnsafeDirectByteBuf extends UnpooledDirectByteBuf {
         super(alloc, initialBuffer, maxCapacity, /* doFree = */ false, /* slice = */ true);
     }
 
+    /**
+     * Creates a new direct ByteBuf by wrapping the specified initial buffer.
+     * Allows subclasses to control if initialBuffer.slice() should be invoked.
+     *
+     * @param maxCapacity the maximum capacity of the underlying direct buffer
+     */
+    protected UnpooledUnsafeDirectByteBuf(ByteBufAllocator alloc, boolean slice,
+                                          ByteBuffer initialBuffer, int maxCapacity) {
+        super(alloc, initialBuffer, maxCapacity, false, slice);
+    }
+
     UnpooledUnsafeDirectByteBuf(ByteBufAllocator alloc, ByteBuffer initialBuffer, int maxCapacity, boolean doFree) {
         super(alloc, initialBuffer, maxCapacity, doFree, false);
     }


### PR DESCRIPTION
Motivation:
Reduce memory allocation by avoiding slicing of a direct byte buffer if it is not needed. Particularly, Cassandra server has its own pooling mechanism to manage direct buffers and to control the lifecycle of such buffers when they are sent to network layer Cassandra inherits a wrapper class from UnpooledUnsafeDirectByteBuf (org.apache.cassandra.net.BufferPoolAllocator.Wrapped). Currently, such wrapping cannot be done without an extra slicing of a direct byte buffer for every request. The existing slice option could help to eliminate the overhead, but it is provided only in a package private constructor, so it cannot be used by subclasses.

Modifications:
Add a new protected constructor for UnpooledUnsafeDirectByteBuf with slice flag, flag is added not as the last parameter because a constructor with another boolean flag at the end already exists.

An example of a memory allocation path for the slicing captured using JFR:
<img width="871" alt="image" src="https://github.com/user-attachments/assets/c68d2a7c-c569-43d9-b9e6-498c0f22a08d" />

