### PR TITLE
Remove ConcurrentSet usage and replace Collections.newSetFromMap

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/DeleteFileOnExitHook.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/DeleteFileOnExitHook.java
@@ -16,7 +16,6 @@
 package io.netty.handler.codec.http.multipart;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -24,7 +23,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * DeleteFileOnExitHook.
  */
 final class DeleteFileOnExitHook {
-    private static final Set<String> FILES = Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>());
+    private static final Set<String> FILES = ConcurrentHashMap.newKeySet();
 
     private DeleteFileOnExitHook() {
     }

--- a/common/src/main/java/io/netty/util/ResourceLeakDetector.java
+++ b/common/src/main/java/io/netty/util/ResourceLeakDetector.java
@@ -161,12 +161,10 @@ public class ResourceLeakDetector<T> {
     }
 
     /** the collection of active resources */
-    private final Set<DefaultResourceLeak<?>> allLeaks =
-            Collections.newSetFromMap(new ConcurrentHashMap<DefaultResourceLeak<?>, Boolean>());
+    private final Set<DefaultResourceLeak<?>> allLeaks = ConcurrentHashMap.newKeySet();
 
-    private final ReferenceQueue<Object> refQueue = new ReferenceQueue<Object>();
-    private final Set<String> reportedLeaks =
-            Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>());
+    private final ReferenceQueue<Object> refQueue = new ReferenceQueue<>();
+    private final Set<String> reportedLeaks = ConcurrentHashMap.newKeySet();
 
     private final String resourceType;
     private final int samplingInterval;

--- a/common/src/main/java/io/netty/util/internal/ConcurrentSet.java
+++ b/common/src/main/java/io/netty/util/internal/ConcurrentSet.java
@@ -17,6 +17,7 @@ package io.netty.util.internal;
 
 import java.io.Serializable;
 import java.util.AbstractSet;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;

--- a/common/src/main/java/io/netty/util/internal/ObjectCleaner.java
+++ b/common/src/main/java/io/netty/util/internal/ObjectCleaner.java
@@ -22,6 +22,7 @@ import java.lang.ref.WeakReference;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.netty.util.internal.SystemPropertyUtil.getInt;
@@ -38,8 +39,8 @@ public final class ObjectCleaner {
     // Package-private for testing
     static final String CLEANER_THREAD_NAME = ObjectCleaner.class.getSimpleName() + "Thread";
     // This will hold a reference to the AutomaticCleanerReference which will be removed once we called cleanup()
-    private static final Set<AutomaticCleanerReference> LIVE_SET = new ConcurrentSet<AutomaticCleanerReference>();
-    private static final ReferenceQueue<Object> REFERENCE_QUEUE = new ReferenceQueue<Object>();
+    private static final Set<AutomaticCleanerReference> LIVE_SET = ConcurrentHashMap.newKeySet();
+    private static final ReferenceQueue<Object> REFERENCE_QUEUE = new ReferenceQueue<>();
     private static final AtomicBoolean CLEANER_RUNNING = new AtomicBoolean(false);
     private static final Runnable CLEANER_TASK = new Runnable() {
         @Override

--- a/handler/src/main/java/io/netty/handler/ipfilter/UniqueIpFilter.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/UniqueIpFilter.java
@@ -20,11 +20,11 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.util.internal.ConcurrentSet;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * This class allows one to ensure that at all times for every IP address there is at most one
@@ -33,7 +33,7 @@ import java.util.Set;
 @ChannelHandler.Sharable
 public class UniqueIpFilter extends AbstractRemoteAddressFilter<InetSocketAddress> {
 
-    private final Set<InetAddress> connected = new ConcurrentSet<InetAddress>();
+    private final Set<InetAddress> connected = ConcurrentHashMap.newKeySet();
 
     @Override
     protected boolean accept(ChannelHandlerContext ctx, InetSocketAddress remoteAddress) throws Exception {

--- a/transport/src/main/java/io/netty/channel/ChannelInitializer.java
+++ b/transport/src/main/java/io/netty/channel/ChannelInitializer.java
@@ -56,8 +56,7 @@ public abstract class ChannelInitializer<C extends Channel> extends ChannelInbou
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(ChannelInitializer.class);
     // We use a Set as a ChannelInitializer is usually shared between all Channels in a Bootstrap /
     // ServerBootstrap. This way we can reduce the memory usage compared to use Attributes.
-    private final Set<ChannelHandlerContext> initMap = Collections.newSetFromMap(
-            new ConcurrentHashMap<ChannelHandlerContext, Boolean>());
+    private final Set<ChannelHandlerContext> initMap = ConcurrentHashMap.newKeySet();
 
     /**
      * This method will be called once the {@link Channel} was registered. After the method returns this instance

--- a/transport/src/main/java/io/netty/channel/ThreadPerChannelEventLoopGroup.java
+++ b/transport/src/main/java/io/netty/channel/ThreadPerChannelEventLoopGroup.java
@@ -51,9 +51,8 @@ public class ThreadPerChannelEventLoopGroup extends AbstractEventExecutorGroup i
     private final Object[] childArgs;
     private final int maxChannels;
     final Executor executor;
-    final Set<EventLoop> activeChildren
-            = Collections.newSetFromMap(new ConcurrentHashMap<>());
-    final Queue<EventLoop> idleChildren = new ConcurrentLinkedQueue<EventLoop>();
+    final Set<EventLoop> activeChildren = ConcurrentHashMap.newKeySet();
+    final Queue<EventLoop> idleChildren = new ConcurrentLinkedQueue<>();
     private final ChannelException tooManyChannels;
 
     private volatile boolean shuttingDown;


### PR DESCRIPTION
 with ConcurrentHashMap.newKeySet().

`ConcurrentHashMap.newKeySet()` creates a more specialized version of `Map` than `Collections.newSetFromMap`, so it should be a bit more effective.