### PR TITLE
Deprecate and replace custom MathUtil.compare with jdk alternatives

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/WeightedFairQueueByteDistributor.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/WeightedFairQueueByteDistributor.java
@@ -19,7 +19,6 @@ import io.netty.util.collection.IntObjectHashMap;
 import io.netty.util.collection.IntObjectMap;
 import io.netty.util.internal.DefaultPriorityQueue;
 import io.netty.util.internal.EmptyPriorityQueue;
-import io.netty.util.internal.MathUtil;
 import io.netty.util.internal.PriorityQueue;
 import io.netty.util.internal.PriorityQueueNode;
 import io.netty.util.internal.SystemPropertyUtil;
@@ -423,7 +422,7 @@ public final class WeightedFairQueueByteDistributor implements StreamByteDistrib
 
         @Override
         public int compare(State o1, State o2) {
-            return MathUtil.compare(o1.pseudoTimeToWrite, o2.pseudoTimeToWrite);
+            return Long.compare(o1.pseudoTimeToWrite, o2.pseudoTimeToWrite);
         }
     }
 

--- a/common/src/main/java/io/netty/util/internal/MathUtil.java
+++ b/common/src/main/java/io/netty/util/internal/MathUtil.java
@@ -65,6 +65,7 @@ public final class MathUtil {
     }
 
     /**
+     * @deprecated not used anymore. User Integer.compare() instead. For removal.
      * Compares two {@code int} values.
      *
      * @param  x the first {@code int} to compare
@@ -73,12 +74,14 @@ public final class MathUtil {
      *         {@code -1} if {@code x < y}; and
      *         {@code 1} if {@code x > y}
      */
+    @Deprecated
     public static int compare(final int x, final int y) {
         // do not subtract for comparison, it could overflow
-        return x < y ? -1 : (x > y ? 1 : 0);
+        return Integer.compare(x, y);
     }
 
     /**
+     * @deprecated not used anymore. User Long.compare() instead. For removal.
      * Compare two {@code long} values.
      * @param x the first {@code long} to compare.
      * @param y the second {@code long} to compare.
@@ -89,7 +92,9 @@ public final class MathUtil {
      * <li>{@code < 0} if {@code x < y}</li>
      * </ul>
      */
+    @Deprecated
     public static int compare(long x, long y) {
-        return (x < y) ? -1 : (x > y) ? 1 : 0;
+        return Long.compare(x, y);
     }
+
 }

--- a/common/src/test/java/io/netty/util/internal/MathUtilTest.java
+++ b/common/src/test/java/io/netty/util/internal/MathUtilTest.java
@@ -75,21 +75,15 @@ public class MathUtilTest {
 
     @Test
     public void testCompare() {
-        // do not subtract for comparison, it could overflow
         assertEquals(-1, Integer.compare(0, 1));
         assertEquals(-1, Long.compare(0L, 1L));
-        // do not subtract for comparison, it could overflow
         assertEquals(-1, Integer.compare(0, Integer.MAX_VALUE));
         assertEquals(-1, Long.compare(0L, Long.MAX_VALUE));
-        // do not subtract for comparison, it could overflow
         assertEquals(0, Integer.compare(0, 0));
         assertEquals(0, Long.compare(0L, 0L));
-        // do not subtract for comparison, it could overflow
         assertEquals(0, Integer.compare(Integer.MIN_VALUE, Integer.MIN_VALUE));
         assertEquals(0, Long.compare(Long.MIN_VALUE, Long.MIN_VALUE));
-        // do not subtract for comparison, it could overflow
         assertEquals(1, Integer.compare(Integer.MAX_VALUE, 0));
-        // do not subtract for comparison, it could overflow
         assertEquals(1, Integer.compare(Integer.MAX_VALUE, Integer.MAX_VALUE - 1));
         assertEquals(1, Long.compare(Long.MAX_VALUE, 0L));
         assertEquals(1, Long.compare(Long.MAX_VALUE, Long.MAX_VALUE - 1));

--- a/common/src/test/java/io/netty/util/internal/MathUtilTest.java
+++ b/common/src/test/java/io/netty/util/internal/MathUtilTest.java
@@ -73,19 +73,4 @@ public class MathUtilTest {
         assertTrue(isOutOfBounds(0, Integer.MAX_VALUE, 0));
     }
 
-    @Test
-    public void testCompare() {
-        assertEquals(-1, Integer.compare(0, 1));
-        assertEquals(-1, Long.compare(0L, 1L));
-        assertEquals(-1, Integer.compare(0, Integer.MAX_VALUE));
-        assertEquals(-1, Long.compare(0L, Long.MAX_VALUE));
-        assertEquals(0, Integer.compare(0, 0));
-        assertEquals(0, Long.compare(0L, 0L));
-        assertEquals(0, Integer.compare(Integer.MIN_VALUE, Integer.MIN_VALUE));
-        assertEquals(0, Long.compare(Long.MIN_VALUE, Long.MIN_VALUE));
-        assertEquals(1, Integer.compare(Integer.MAX_VALUE, 0));
-        assertEquals(1, Integer.compare(Integer.MAX_VALUE, Integer.MAX_VALUE - 1));
-        assertEquals(1, Long.compare(Long.MAX_VALUE, 0L));
-        assertEquals(1, Long.compare(Long.MAX_VALUE, Long.MAX_VALUE - 1));
-    }
 }

--- a/common/src/test/java/io/netty/util/internal/MathUtilTest.java
+++ b/common/src/test/java/io/netty/util/internal/MathUtilTest.java
@@ -75,17 +75,23 @@ public class MathUtilTest {
 
     @Test
     public void testCompare() {
-        assertEquals(-1, compare(0, 1));
-        assertEquals(-1, compare(0L, 1L));
-        assertEquals(-1, compare(0, Integer.MAX_VALUE));
-        assertEquals(-1, compare(0L, Long.MAX_VALUE));
-        assertEquals(0, compare(0, 0));
-        assertEquals(0, compare(0L, 0L));
-        assertEquals(0, compare(Integer.MIN_VALUE, Integer.MIN_VALUE));
-        assertEquals(0, compare(Long.MIN_VALUE, Long.MIN_VALUE));
-        assertEquals(1, compare(Integer.MAX_VALUE, 0));
-        assertEquals(1, compare(Integer.MAX_VALUE, Integer.MAX_VALUE - 1));
-        assertEquals(1, compare(Long.MAX_VALUE, 0L));
-        assertEquals(1, compare(Long.MAX_VALUE, Long.MAX_VALUE - 1));
+        // do not subtract for comparison, it could overflow
+        assertEquals(-1, Integer.compare(0, 1));
+        assertEquals(-1, Long.compare(0L, 1L));
+        // do not subtract for comparison, it could overflow
+        assertEquals(-1, Integer.compare(0, Integer.MAX_VALUE));
+        assertEquals(-1, Long.compare(0L, Long.MAX_VALUE));
+        // do not subtract for comparison, it could overflow
+        assertEquals(0, Integer.compare(0, 0));
+        assertEquals(0, Long.compare(0L, 0L));
+        // do not subtract for comparison, it could overflow
+        assertEquals(0, Integer.compare(Integer.MIN_VALUE, Integer.MIN_VALUE));
+        assertEquals(0, Long.compare(Long.MIN_VALUE, Long.MIN_VALUE));
+        // do not subtract for comparison, it could overflow
+        assertEquals(1, Integer.compare(Integer.MAX_VALUE, 0));
+        // do not subtract for comparison, it could overflow
+        assertEquals(1, Integer.compare(Integer.MAX_VALUE, Integer.MAX_VALUE - 1));
+        assertEquals(1, Long.compare(Long.MAX_VALUE, 0L));
+        assertEquals(1, Long.compare(Long.MAX_VALUE, Long.MAX_VALUE - 1));
     }
 }

--- a/transport/src/test/java/io/netty/channel/embedded/CustomChannelId.java
+++ b/transport/src/test/java/io/netty/channel/embedded/CustomChannelId.java
@@ -30,7 +30,6 @@ public class CustomChannelId implements ChannelId {
     @Override
     public int compareTo(final ChannelId o) {
         if (o instanceof CustomChannelId) {
-            // do not subtract for comparison, it could overflow
             return Integer.compare(id, ((CustomChannelId) o).id);
         }
 

--- a/transport/src/test/java/io/netty/channel/embedded/CustomChannelId.java
+++ b/transport/src/test/java/io/netty/channel/embedded/CustomChannelId.java
@@ -16,7 +16,6 @@
 package io.netty.channel.embedded;
 
 import io.netty.channel.ChannelId;
-import io.netty.util.internal.MathUtil;
 
 public class CustomChannelId implements ChannelId {
 
@@ -31,7 +30,8 @@ public class CustomChannelId implements ChannelId {
     @Override
     public int compareTo(final ChannelId o) {
         if (o instanceof CustomChannelId) {
-            return MathUtil.compare(id, ((CustomChannelId) o).id);
+            // do not subtract for comparison, it could overflow
+            return Integer.compare(id, ((CustomChannelId) o).id);
         }
 
         return asLongText().compareTo(o.asLongText());


### PR DESCRIPTION
Custom netty `MathUtil.compare` replaced with JDK `Integer.compare` methods