### PR TITLE
Improve `isValidPublishTopicName` method performance

### DIFF
--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttCodecUtil.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttCodecUtil.java
@@ -25,8 +25,6 @@ import static io.netty.handler.codec.mqtt.MqttConstant.MIN_CLIENT_ID_LENGTH;
 
 final class MqttCodecUtil {
 
-    private static final char[] TOPIC_WILDCARDS = {'#', '+'};
-
     static final AttributeKey<MqttVersion> MQTT_VERSION_KEY = AttributeKey.valueOf("NETTY_CODEC_MQTT_VERSION");
 
     static MqttVersion getMqttVersion(ChannelHandlerContext ctx) {
@@ -45,8 +43,9 @@ final class MqttCodecUtil {
 
     static boolean isValidPublishTopicName(String topicName) {
         // publish topic name must not contain any wildcard
-        for (char c : TOPIC_WILDCARDS) {
-            if (topicName.indexOf(c) >= 0) {
+        for (int i = 0; i < topicName.length(); i++) {
+            char c = topicName.charAt(i);
+            if (c == '#' || c == '+') {
                 return false;
             }
         }


### PR DESCRIPTION
Refactored `MqttCodecUtil.isValidPublishTopicName()` method to boost the performance. According to my benchmarks, it is boosted almost twice:
```
Benchmark                           Mode  Cnt   Score   Error  Units
TwoIndexOfVSLoopImprove.charAt      avgt    3  13.973 ± 0.137  ns/op
TwoIndexOfVSLoopImprove.twoIndexOf  avgt    3  24.519 ± 7.310  ns/op
```

```java
import org.junit.Test;
import org.openjdk.jmh.annotations.Benchmark;
import org.openjdk.jmh.annotations.BenchmarkMode;
import org.openjdk.jmh.annotations.Fork;
import org.openjdk.jmh.annotations.Measurement;
import org.openjdk.jmh.annotations.Mode;
import org.openjdk.jmh.annotations.OutputTimeUnit;
import org.openjdk.jmh.annotations.Scope;
import org.openjdk.jmh.annotations.State;
import org.openjdk.jmh.annotations.Warmup;
import org.openjdk.jmh.runner.Runner;
import org.openjdk.jmh.runner.RunnerException;
import org.openjdk.jmh.runner.options.Options;
import org.openjdk.jmh.runner.options.OptionsBuilder;

import java.util.concurrent.TimeUnit;

@Fork(value = 1)
@BenchmarkMode(Mode.AverageTime)
@State(Scope.Benchmark)
@Warmup(iterations = 3)
@Measurement(iterations = 3)
@OutputTimeUnit(TimeUnit.NANOSECONDS)
public class TwoIndexOfVSLoopImprove {
    private static String[] s = {
            "abcde",
            "abcd#e",
            "abc+de"
    };

    @Test
    public void bench() throws RunnerException {
        Options options = new OptionsBuilder()
                .include(TwoIndexOfVSLoopImprove.class.getSimpleName())
                .build();
        new Runner(options).run();
    }

    @Benchmark
    public int twoIndexOf() {
        int count = 0;
        for (String string : s) {
            if (hasWildcardIndexOf(string)) {
                ++count;
            }
        }
        return count;
    }

    private static final char[] TOPIC_WILDCARDS = {'#', '+'};
    private static boolean hasWildcardIndexOf(String string) {
        for (char c : TOPIC_WILDCARDS) {
            if (string.indexOf(c) >= 0) {
                return false;
            }
        }
        return true;
    }

    @Benchmark
    public int charAt() {
        int count = 0;
        for (String string : s) {
            if (hasWhildcardCharAt(string)) {
                ++count;
            }
        }
        return count;
    }

    private static boolean hasWhildcardCharAt(String string) {
        for (int i = 0; i < string.length(); i++) {
            char c = string.charAt(i);
            if (c == '+' || c == '#') {
                return true;
            }
        }
        return false;
    }
}
```