### PR TITLE
PlatformDependent cleanup: remove unnecessary static field ALLOWED_LI…

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -108,8 +108,6 @@ public final class PlatformDependent {
     private static final String NORMALIZED_ARCH = normalizeArch(SystemPropertyUtil.get("os.arch", ""));
     private static final String NORMALIZED_OS = normalizeOs(SystemPropertyUtil.get("os.name", ""));
 
-    // keep in sync with maven's pom.xml via os.detection.classifierWithLikes!
-    private static final String[] ALLOWED_LINUX_OS_CLASSIFIERS = {"fedora", "suse", "arch"};
     private static final Set<String> LINUX_OS_CLASSIFIERS;
 
     private static final boolean IS_WINDOWS = isWindows0();
@@ -198,18 +196,15 @@ public final class PlatformDependent {
                     "instability.");
         }
 
-        final Set<String> allowedClassifiers = Collections.unmodifiableSet(
-                new HashSet<String>(Arrays.asList(ALLOWED_LINUX_OS_CLASSIFIERS)));
-        final Set<String> availableClassifiers = new LinkedHashSet<String>();
+        final Set<String> availableClassifiers = new LinkedHashSet<>();
 
-        if (!addPropertyOsClassifiers(allowedClassifiers, availableClassifiers)) {
-            addFilesystemOsClassifiers(allowedClassifiers, availableClassifiers);
+        if (!addPropertyOsClassifiers(availableClassifiers)) {
+            addFilesystemOsClassifiers(availableClassifiers);
         }
         LINUX_OS_CLASSIFIERS = Collections.unmodifiableSet(availableClassifiers);
     }
 
-    static void addFilesystemOsClassifiers(final Set<String> allowedClassifiers,
-                                           final Set<String> availableClassifiers) {
+    static void addFilesystemOsClassifiers(final Set<String> availableClassifiers) {
         for (final String osReleaseFileName : OS_RELEASE_FILES) {
             final Path file = Paths.get(osReleaseFileName);
             boolean found = AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
@@ -218,7 +213,7 @@ public final class PlatformDependent {
                     Pattern lineSplitPattern = Pattern.compile("[ ]+");
                     try {
                         if (Files.exists(file)) {
-                            BufferedReader reader = null;
+                            BufferedReader reader;
                             try {
                                 reader = new BufferedReader(new InputStreamReader(
                                         new BoundedInputStream(Files.newInputStream(file)), StandardCharsets.UTF_8));
@@ -228,12 +223,11 @@ public final class PlatformDependent {
                                     if (line.startsWith(LINUX_ID_PREFIX)) {
                                         String id = normalizeOsReleaseVariableValue(
                                                 line.substring(LINUX_ID_PREFIX.length()));
-                                        addClassifier(allowedClassifiers, availableClassifiers, id);
+                                        addClassifier(availableClassifiers, id);
                                     } else if (line.startsWith(LINUX_ID_LIKE_PREFIX)) {
                                         line = normalizeOsReleaseVariableValue(
                                                 line.substring(LINUX_ID_LIKE_PREFIX.length()));
-                                        addClassifier(allowedClassifiers, availableClassifiers,
-                                                lineSplitPattern.split(line));
+                                        addClassifier(availableClassifiers, lineSplitPattern.split(line));
                                     }
                                 }
                             } catch (SecurityException e) {
@@ -257,7 +251,7 @@ public final class PlatformDependent {
         }
     }
 
-    static boolean addPropertyOsClassifiers(Set<String> allowedClassifiers, Set<String> availableClassifiers) {
+    static boolean addPropertyOsClassifiers(Set<String> availableClassifiers) {
         // empty: -Dio.netty.osClassifiers (no distro specific classifiers for native libs)
         // single ID: -Dio.netty.osClassifiers=ubuntu
         // pair ID, ID_LIKE: -Dio.netty.osClassifiers=ubuntu,debian
@@ -283,7 +277,7 @@ public final class PlatformDependent {
                     osClassifiersPropertyName + " property contains more than 2 classifiers: " + osClassifiers);
         }
         for (String classifier : classifiers) {
-            addClassifier(allowedClassifiers, availableClassifiers, classifier);
+            addClassifier(availableClassifiers, classifier);
         }
         return true;
     }
@@ -1486,15 +1480,25 @@ public final class PlatformDependent {
     /**
      * Adds only those classifier strings to <tt>dest</tt> which are present in <tt>allowed</tt>.
      *
-     * @param allowed          allowed classifiers
      * @param dest             destination set
      * @param maybeClassifiers potential classifiers to add
      */
-    private static void addClassifier(Set<String> allowed, Set<String> dest, String... maybeClassifiers) {
+    private static void addClassifier(Set<String> dest, String... maybeClassifiers) {
         for (String id : maybeClassifiers) {
-            if (allowed.contains(id)) {
+            if (isAllowedClassifier(id)) {
                 dest.add(id);
             }
+        }
+    }
+    // keep in sync with maven's pom.xml via os.detection.classifierWithLikes!
+    private static boolean isAllowedClassifier(String classifier) {
+        switch (classifier) {
+            case "fedora":
+            case "suse":
+            case "arch":
+                return true;
+            default:
+                return false;
         }
     }
 

--- a/common/src/test/java/io/netty/util/internal/OsClassifiersTest.java
+++ b/common/src/test/java/io/netty/util/internal/OsClassifiersTest.java
@@ -19,11 +19,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Properties;
 import java.util.Set;
@@ -49,9 +45,8 @@ public class OsClassifiersTest {
 
     @Test
     void testOsClassifiersPropertyAbsent() {
-        Set<String> allowed = new HashSet<String>(Arrays.asList("fedora", "suse", "arch"));
-        Set<String> available = new LinkedHashSet<String>(2);
-        boolean added = PlatformDependent.addPropertyOsClassifiers(allowed, available);
+        Set<String> available = new LinkedHashSet<>(2);
+        boolean added = PlatformDependent.addPropertyOsClassifiers(available);
         assertFalse(added);
         assertTrue(available.isEmpty());
     }
@@ -60,9 +55,8 @@ public class OsClassifiersTest {
     void testOsClassifiersPropertyEmpty() {
         // empty property -Dio.netty.osClassifiers
         systemProperties.setProperty(OS_CLASSIFIERS_PROPERTY, "");
-        Set<String> allowed = Collections.singleton("fedora");
-        Set<String> available = new LinkedHashSet<String>(2);
-        boolean added = PlatformDependent.addPropertyOsClassifiers(allowed, available);
+        Set<String> available = new LinkedHashSet<>(2);
+        boolean added = PlatformDependent.addPropertyOsClassifiers(available);
         assertTrue(added);
         assertTrue(available.isEmpty());
     }
@@ -71,23 +65,16 @@ public class OsClassifiersTest {
     void testOsClassifiersPropertyNotEmptyNoClassifiers() {
         // ID
         systemProperties.setProperty(OS_CLASSIFIERS_PROPERTY, ",");
-        final Set<String> allowed = new HashSet<String>(Arrays.asList("fedora", "suse", "arch"));
-        final Set<String> available = new LinkedHashSet<String>(2);
-        Assertions.assertThrows(IllegalArgumentException.class, new Executable() {
-            @Override
-            public void execute() throws Throwable {
-                PlatformDependent.addPropertyOsClassifiers(allowed, available);
-            }
-        });
+        final Set<String> available = new LinkedHashSet<>(2);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> PlatformDependent.addPropertyOsClassifiers(available));
     }
 
     @Test
     void testOsClassifiersPropertySingle() {
         // ID
         systemProperties.setProperty(OS_CLASSIFIERS_PROPERTY, "fedora");
-        Set<String> allowed = Collections.singleton("fedora");
-        Set<String> available = new LinkedHashSet<String>(2);
-        boolean added = PlatformDependent.addPropertyOsClassifiers(allowed, available);
+        Set<String> available = new LinkedHashSet<>(2);
+        boolean added = PlatformDependent.addPropertyOsClassifiers(available);
         assertTrue(added);
         assertEquals(1, available.size());
         assertEquals("fedora", available.iterator().next());
@@ -97,9 +84,8 @@ public class OsClassifiersTest {
     void testOsClassifiersPropertyPair() {
         // ID, ID_LIKE
         systemProperties.setProperty(OS_CLASSIFIERS_PROPERTY, "manjaro,arch");
-        Set<String> allowed = new HashSet<String>(Arrays.asList("fedora", "suse", "arch"));
-        Set<String> available = new LinkedHashSet<String>(2);
-        boolean added = PlatformDependent.addPropertyOsClassifiers(allowed, available);
+        Set<String> available = new LinkedHashSet<>(2);
+        boolean added = PlatformDependent.addPropertyOsClassifiers(available);
         assertTrue(added);
         assertEquals(1, available.size());
         assertEquals("arch", available.iterator().next());
@@ -109,13 +95,7 @@ public class OsClassifiersTest {
     void testOsClassifiersPropertyExcessive() {
         // ID, ID_LIKE, excessive
         systemProperties.setProperty(OS_CLASSIFIERS_PROPERTY, "manjaro,arch,slackware");
-        final Set<String> allowed = new HashSet<String>(Arrays.asList("fedora", "suse", "arch"));
-        final Set<String> available = new LinkedHashSet<String>(2);
-        Assertions.assertThrows(IllegalArgumentException.class, new Executable() {
-            @Override
-            public void execute() throws Throwable {
-                PlatformDependent.addPropertyOsClassifiers(allowed, available);
-            }
-        });
+        final Set<String> available = new LinkedHashSet<>(2);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> PlatformDependent.addPropertyOsClassifiers(available));
     }
 }

--- a/common/src/test/java/io/netty/util/internal/OsClassifiersTest.java
+++ b/common/src/test/java/io/netty/util/internal/OsClassifiersTest.java
@@ -66,7 +66,8 @@ public class OsClassifiersTest {
         // ID
         systemProperties.setProperty(OS_CLASSIFIERS_PROPERTY, ",");
         final Set<String> available = new LinkedHashSet<>(2);
-        Assertions.assertThrows(IllegalArgumentException.class, () -> PlatformDependent.addPropertyOsClassifiers(available));
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> PlatformDependent.addPropertyOsClassifiers(available));
     }
 
     @Test
@@ -96,6 +97,7 @@ public class OsClassifiersTest {
         // ID, ID_LIKE, excessive
         systemProperties.setProperty(OS_CLASSIFIERS_PROPERTY, "manjaro,arch,slackware");
         final Set<String> available = new LinkedHashSet<>(2);
-        Assertions.assertThrows(IllegalArgumentException.class, () -> PlatformDependent.addPropertyOsClassifiers(available));
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> PlatformDependent.addPropertyOsClassifiers(available));
     }
 }


### PR DESCRIPTION
…NUX_OS_CLASSIFIERS

Removes unnecessary allocations, removes unnecessary static variable and replaces it with static switch method.

The only downside - some changed methods are package-private. If you think it's a high risk of changing the signature of those methods, I can return a variable, and will ignore it.