### PR TITLE
removed deprecated and unused fields counterHashCode and random from …

### DIFF
--- a/common/src/main/java/io/netty/util/internal/InternalThreadLocalMap.java
+++ b/common/src/main/java/io/netty/util/internal/InternalThreadLocalMap.java
@@ -67,8 +67,6 @@ public final class InternalThreadLocalMap extends UnpaddedInternalThreadLocalMap
     private int futureListenerStackDepth;
     private int localChannelReaderStackDepth;
     private Map<Class<?>, Boolean> handlerSharableCache;
-    private IntegerHolder counterHashCode;
-    private ThreadLocalRandom random;
     private Map<Class<?>, TypeParameterMatcher> typeParameterMatcherGetCache;
     private Map<Class<?>, Map<String, TypeParameterMatcher>> typeParameterMatcherFindCache;
 
@@ -183,12 +181,6 @@ public final class InternalThreadLocalMap extends UnpaddedInternalThreadLocalMap
         if (handlerSharableCache != null) {
             count ++;
         }
-        if (counterHashCode != null) {
-            count ++;
-        }
-        if (random != null) {
-            count ++;
-        }
         if (typeParameterMatcherGetCache != null) {
             count ++;
         }
@@ -234,7 +226,7 @@ public final class InternalThreadLocalMap extends UnpaddedInternalThreadLocalMap
     public Map<Charset, CharsetEncoder> charsetEncoderCache() {
         Map<Charset, CharsetEncoder> cache = charsetEncoderCache;
         if (cache == null) {
-            charsetEncoderCache = cache = new IdentityHashMap<Charset, CharsetEncoder>();
+            charsetEncoderCache = cache = new IdentityHashMap<>();
         }
         return cache;
     }
@@ -242,7 +234,7 @@ public final class InternalThreadLocalMap extends UnpaddedInternalThreadLocalMap
     public Map<Charset, CharsetDecoder> charsetDecoderCache() {
         Map<Charset, CharsetDecoder> cache = charsetDecoderCache;
         if (cache == null) {
-            charsetDecoderCache = cache = new IdentityHashMap<Charset, CharsetDecoder>();
+            charsetDecoderCache = cache = new IdentityHashMap<>();
         }
         return cache;
     }
@@ -255,7 +247,7 @@ public final class InternalThreadLocalMap extends UnpaddedInternalThreadLocalMap
     public <E> ArrayList<E> arrayList(int minCapacity) {
         ArrayList<E> list = (ArrayList<E>) arrayList;
         if (list == null) {
-            arrayList = new ArrayList<Object>(minCapacity);
+            arrayList = new ArrayList<>(minCapacity);
             return (ArrayList<E>) arrayList;
         }
         list.clear();
@@ -271,18 +263,18 @@ public final class InternalThreadLocalMap extends UnpaddedInternalThreadLocalMap
         this.futureListenerStackDepth = futureListenerStackDepth;
     }
 
+    /**
+     * @deprecated Use {@link java.util.concurrent.ThreadLocalRandom#current()} instead.
+     */
+    @Deprecated
     public ThreadLocalRandom random() {
-        ThreadLocalRandom r = random;
-        if (r == null) {
-            random = r = new ThreadLocalRandom();
-        }
-        return r;
+        return new ThreadLocalRandom();
     }
 
     public Map<Class<?>, TypeParameterMatcher> typeParameterMatcherGetCache() {
         Map<Class<?>, TypeParameterMatcher> cache = typeParameterMatcherGetCache;
         if (cache == null) {
-            typeParameterMatcherGetCache = cache = new IdentityHashMap<Class<?>, TypeParameterMatcher>();
+            typeParameterMatcherGetCache = cache = new IdentityHashMap<>();
         }
         return cache;
     }
@@ -290,26 +282,26 @@ public final class InternalThreadLocalMap extends UnpaddedInternalThreadLocalMap
     public Map<Class<?>, Map<String, TypeParameterMatcher>> typeParameterMatcherFindCache() {
         Map<Class<?>, Map<String, TypeParameterMatcher>> cache = typeParameterMatcherFindCache;
         if (cache == null) {
-            typeParameterMatcherFindCache = cache = new IdentityHashMap<Class<?>, Map<String, TypeParameterMatcher>>();
+            typeParameterMatcherFindCache = cache = new IdentityHashMap<>();
         }
         return cache;
     }
 
     @Deprecated
     public IntegerHolder counterHashCode() {
-        return counterHashCode;
+        return new IntegerHolder();
     }
 
     @Deprecated
     public void setCounterHashCode(IntegerHolder counterHashCode) {
-        this.counterHashCode = counterHashCode;
+        // No-op.
     }
 
     public Map<Class<?>, Boolean> handlerSharableCache() {
         Map<Class<?>, Boolean> cache = handlerSharableCache;
         if (cache == null) {
             // Start with small capacity to keep memory overhead as low as possible.
-            handlerSharableCache = cache = new WeakHashMap<Class<?>, Boolean>(HANDLER_SHARABLE_CACHE_INITIAL_CAPACITY);
+            handlerSharableCache = cache = new WeakHashMap<>(HANDLER_SHARABLE_CACHE_INITIAL_CAPACITY);
         }
         return cache;
     }
@@ -386,10 +378,12 @@ public final class InternalThreadLocalMap extends UnpaddedInternalThreadLocalMap
         return index < lookup.length && lookup[index] != UNSET;
     }
 
+    @Deprecated
     public boolean isCleanerFlagSet(int index) {
         return cleanerFlags != null && cleanerFlags.get(index);
     }
 
+    @Deprecated
     public void setCleanerFlag(int index) {
         if (cleanerFlags == null) {
             cleanerFlags = new BitSet();


### PR DESCRIPTION
…InternalThreadLocalMap

This fields were deprecated ~5 years ago and not used for a long time.
Also, deprecated `isCleanerFlagSet` and `setCleanerFlag` that are not used in netty codebase.