### PR TITLE
Fix possible file leaks

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/BoringSSLKeylessManagerFactory.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/BoringSSLKeylessManagerFactory.java
@@ -71,7 +71,9 @@ public final class BoringSSLKeylessManagerFactory extends KeyManagerFactory {
     public static BoringSSLKeylessManagerFactory newKeyless(BoringSSLAsyncPrivateKeyMethod privateKeyMethod, File chain)
             throws CertificateException, IOException,
             KeyStoreException, NoSuchAlgorithmException, UnrecoverableKeyException {
-        return newKeyless(privateKeyMethod, Files.newInputStream(chain.toPath()));
+        try (InputStream chainInputStream = Files.newInputStream(chain.toPath())) {
+            return newKeyless(privateKeyMethod, chainInputStream);
+        }
     }
 
     /**

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/JdkZlibTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/JdkZlibTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.function.Executable;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Queue;
 import java.util.concurrent.ThreadLocalRandom;
@@ -68,8 +69,8 @@ public class JdkZlibTest extends ZlibTest {
     public void testConcatenatedStreamsReadFirstOnly() throws IOException {
         EmbeddedChannel chDecoderGZip = new EmbeddedChannel(createDecoder(ZlibWrapper.GZIP));
 
-        try {
-            byte[] bytes = IOUtils.toByteArray(getClass().getResourceAsStream("/multiple.gz"));
+        try (InputStream resourceAsStream = getClass().getResourceAsStream("/multiple.gz")) {
+            byte[] bytes = IOUtils.toByteArray(resourceAsStream);
 
             assertTrue(chDecoderGZip.writeInbound(Unpooled.copiedBuffer(bytes)));
             Queue<Object> messages = chDecoderGZip.inboundMessages();
@@ -88,8 +89,8 @@ public class JdkZlibTest extends ZlibTest {
     public void testConcatenatedStreamsReadFully() throws IOException {
         EmbeddedChannel chDecoderGZip = new EmbeddedChannel(new JdkZlibDecoder(true, 0));
 
-        try {
-            byte[] bytes = IOUtils.toByteArray(getClass().getResourceAsStream("/multiple.gz"));
+        try (InputStream resourceAsStream = getClass().getResourceAsStream("/multiple.gz")) {
+            byte[] bytes = IOUtils.toByteArray(resourceAsStream);
 
             assertTrue(chDecoderGZip.writeInbound(Unpooled.copiedBuffer(bytes)));
             Queue<Object> messages = chDecoderGZip.inboundMessages();
@@ -110,8 +111,8 @@ public class JdkZlibTest extends ZlibTest {
     public void testConcatenatedStreamsReadFullyWhenFragmented() throws IOException {
         EmbeddedChannel chDecoderGZip = new EmbeddedChannel(new JdkZlibDecoder(true, 0));
 
-        try {
-            byte[] bytes = IOUtils.toByteArray(getClass().getResourceAsStream("/multiple.gz"));
+        try (InputStream resourceAsStream = getClass().getResourceAsStream("/multiple.gz")) {
+            byte[] bytes = IOUtils.toByteArray(resourceAsStream);
 
             // Let's feed the input byte by byte to simulate fragmentation.
             ByteBuf buf = Unpooled.copiedBuffer(bytes);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackTest.java
@@ -53,9 +53,10 @@ public class HpackTest {
     @ParameterizedTest(name = "file = {0}")
     @MethodSource("files")
     public void test(File file) throws Exception {
-        InputStream is = HpackTest.class.getResourceAsStream(TEST_DIR + file.getName());
-        HpackTestCase hpackTestCase = HpackTestCase.load(is);
-        hpackTestCase.testCompress();
-        hpackTestCase.testDecompress();
+        try (InputStream is = HpackTest.class.getResourceAsStream(TEST_DIR + file.getName())) {
+            HpackTestCase hpackTestCase = HpackTestCase.load(is);
+            hpackTestCase.testCompress();
+            hpackTestCase.testDecompress();
+        }
     }
 }

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -218,11 +218,8 @@ public final class PlatformDependent {
                     Pattern lineSplitPattern = Pattern.compile("[ ]+");
                     try {
                         if (Files.exists(file)) {
-                            BufferedReader reader = null;
-                            try {
-                                reader = new BufferedReader(new InputStreamReader(
-                                        new BoundedInputStream(Files.newInputStream(file)), StandardCharsets.UTF_8));
-
+                            try (BufferedReader reader = new BufferedReader(new InputStreamReader(
+                                    new BoundedInputStream(Files.newInputStream(file)), StandardCharsets.UTF_8))) {
                                 String line;
                                 while ((line = reader.readLine()) != null) {
                                     if (line.startsWith(LINUX_ID_PREFIX)) {

--- a/example/src/main/java/io/netty/example/http2/tiles/ImageCache.java
+++ b/example/src/main/java/io/netty/example/http2/tiles/ImageCache.java
@@ -21,6 +21,7 @@ import static io.netty.example.http2.Http2ExampleUtil.toByteBuf;
 import io.netty.buffer.ByteBuf;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -48,10 +49,9 @@ public final class ImageCache {
     private void init() {
         for (int y = 0; y < 10; y++) {
             for (int x = 0; x < 20; x++) {
-                try {
-                    String name = name(x, y);
-                    ByteBuf fileBytes = unreleasableBuffer(toByteBuf(getClass()
-                            .getResourceAsStream(name)).asReadOnly());
+                String name = name(x, y);
+                try (InputStream resourceAsStream = getClass().getResourceAsStream(name)) {
+                    ByteBuf fileBytes = unreleasableBuffer(toByteBuf(resourceAsStream).asReadOnly());
                     imageBank.put(name, fileBytes);
                 } catch (IOException e) {
                     e.printStackTrace();

--- a/example/src/main/java/io/netty/example/ocsp/OcspServerExample.java
+++ b/example/src/main/java/io/netty/example/ocsp/OcspServerExample.java
@@ -165,20 +165,13 @@ public class OcspServerExample {
     }
 
     private static X509Certificate[] parseCertificates(Class<?> clazz, String name) throws Exception {
-        InputStream in = clazz.getResourceAsStream(name);
-        if (in == null) {
-            throw new FileNotFoundException("clazz=" + clazz + ", name=" + name);
-        }
-
-        try {
-            BufferedReader reader = new BufferedReader(new InputStreamReader(in, CharsetUtil.US_ASCII));
-            try {
-                return parseCertificates(reader);
-            } finally {
-                reader.close();
+        try (InputStream in = clazz.getResourceAsStream(name)) {
+            if (in == null) {
+                throw new FileNotFoundException("clazz=" + clazz + ", name=" + name);
             }
-        } finally {
-            in.close();
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(in, CharsetUtil.US_ASCII))) {
+                return parseCertificates(reader);
+            }
         }
     }
 

--- a/handler/src/test/java/io/netty/handler/ssl/Java8SslTestUtils.java
+++ b/handler/src/test/java/io/netty/handler/ssl/Java8SslTestUtils.java
@@ -67,16 +67,10 @@ public final class Java8SslTestUtils {
         X509Certificate[] certCollection = new X509Certificate[resourceNames.length];
         for (int i = 0; i < resourceNames.length; i++) {
             String resourceName = resourceNames[i];
-            InputStream is = null;
-            try {
-                is = SslContextTest.class.getResourceAsStream(resourceName);
+            try (InputStream is = SslContextTest.class.getResourceAsStream(resourceName)) {
                 assertNotNull(is, "Cannot find " + resourceName);
                 certCollection[i] = (X509Certificate) certFactory
                         .generateCertificate(is);
-            } finally {
-                if (is != null) {
-                    is.close();
-                }
             }
         }
         return certCollection;

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslX509KeyManagerFactoryProviderTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslX509KeyManagerFactoryProviderTest.java
@@ -16,6 +16,7 @@
 package io.netty.handler.ssl;
 
 import javax.net.ssl.KeyManagerFactory;
+import java.io.InputStream;
 import java.security.KeyStore;
 
 public class OpenSslX509KeyManagerFactoryProviderTest extends OpenSslCachingKeyMaterialProviderTest {
@@ -24,11 +25,13 @@ public class OpenSslX509KeyManagerFactoryProviderTest extends OpenSslCachingKeyM
     protected KeyManagerFactory newKeyManagerFactory() throws Exception {
         char[] password = PASSWORD.toCharArray();
         final KeyStore keystore = KeyStore.getInstance("PKCS12");
-        keystore.load(getClass().getResourceAsStream("mutual_auth_server.p12"), password);
+        try (InputStream resourceAsStream = getClass().getResourceAsStream("mutual_auth_server.p12")) {
+            keystore.load(resourceAsStream, password);
 
-        OpenSslX509KeyManagerFactory kmf = new OpenSslX509KeyManagerFactory();
-        kmf.init(keystore, password);
-        return kmf;
+            OpenSslX509KeyManagerFactory kmf = new OpenSslX509KeyManagerFactory();
+            kmf.init(keystore, password);
+            return kmf;
+        }
     }
 
     @Override

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -746,9 +746,13 @@ public abstract class SSLEngineTest {
     private void testMutualAuthInvalidClientCertSucceed(SSLEngineTestParam param, ClientAuth auth) throws Exception {
         char[] password = "example".toCharArray();
         final KeyStore serverKeyStore = KeyStore.getInstance("PKCS12");
-        serverKeyStore.load(getClass().getResourceAsStream("mutual_auth_server.p12"), password);
+        try (InputStream resourceAsStream = getClass().getResourceAsStream("mutual_auth_server.p12")) {
+            serverKeyStore.load(resourceAsStream, password);
+        }
         final KeyStore clientKeyStore = KeyStore.getInstance("PKCS12");
-        clientKeyStore.load(getClass().getResourceAsStream("mutual_auth_invalid_client.p12"), password);
+        try (InputStream resourceAsStream = getClass().getResourceAsStream("mutual_auth_invalid_client.p12")) {
+            clientKeyStore.load(resourceAsStream, password);
+        }
         final KeyManagerFactory serverKeyManagerFactory =
                 KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
         serverKeyManagerFactory.init(serverKeyStore, password);
@@ -774,9 +778,13 @@ public abstract class SSLEngineTest {
             throws Exception {
         char[] password = "example".toCharArray();
         final KeyStore serverKeyStore = KeyStore.getInstance("PKCS12");
-        serverKeyStore.load(getClass().getResourceAsStream("mutual_auth_server.p12"), password);
+        try (InputStream resourceAsStream = getClass().getResourceAsStream("mutual_auth_server.p12")) {
+            serverKeyStore.load(resourceAsStream, password);
+        }
         final KeyStore clientKeyStore = KeyStore.getInstance("PKCS12");
-        clientKeyStore.load(getClass().getResourceAsStream(clientCert), password);
+        try (InputStream resourceAsStream = getClass().getResourceAsStream(clientCert)) {
+            clientKeyStore.load(resourceAsStream, password);
+        }
         final KeyManagerFactory serverKeyManagerFactory =
                 KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
         serverKeyManagerFactory.init(serverKeyStore, password);
@@ -4725,10 +4733,14 @@ public abstract class SSLEngineTest {
         char[] password = "password".toCharArray();
 
         final KeyStore serverKeyStore = KeyStore.getInstance("PKCS12");
-        serverKeyStore.load(getClass().getResourceAsStream("rsaValidations-server-keystore.p12"), password);
+        try (InputStream resourceAsStream = getClass().getResourceAsStream("rsaValidations-server-keystore.p12")) {
+            serverKeyStore.load(resourceAsStream, password);
+        }
 
         final KeyStore clientKeyStore = KeyStore.getInstance("PKCS12");
-        clientKeyStore.load(getClass().getResourceAsStream("rsaValidation-user-certs.p12"), password);
+        try (InputStream resourceAsStream = getClass().getResourceAsStream("rsaValidation-user-certs.p12")) {
+            clientKeyStore.load(resourceAsStream, password);
+        }
 
         final KeyManagerFactory serverKeyManagerFactory =
                 KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());

--- a/microbench/src/main/java/io/netty/microbench/buffer/Utf8EncodingBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/Utf8EncodingBenchmark.java
@@ -90,18 +90,15 @@ public class Utf8EncodingBenchmark extends AbstractMicrobenchmark {
     @Setup
     public void init() {
         System.setProperty("io.netty.noUnsafe", Boolean.valueOf(noUnsafe).toString());
-        InputStream testTextStream = null;
-        InputStreamReader inStreamReader = null;
-        BufferedReader buffReader = null;
         int maxExpectedSize = 0;
         List<String> strings = new ArrayList<String>();
         List<StringBuilder> stringBuilders = new ArrayList<StringBuilder>();
         List<AnotherCharSequence> anotherCharSequenceList = new ArrayList<AnotherCharSequence>();
         List<AsciiString> asciiStrings = new ArrayList<AsciiString>();
-        try {
-            testTextStream = getClass().getResourceAsStream("/Utf8Samples.txt");
-            inStreamReader = new InputStreamReader(testTextStream, "UTF-8");
-            buffReader = new BufferedReader(inStreamReader);
+        try (InputStream testTextStream = getClass().getResourceAsStream("/Utf8Samples.txt");
+             InputStreamReader inStreamReader = new InputStreamReader(testTextStream, "UTF-8");
+             BufferedReader buffReader = new BufferedReader(inStreamReader);) {
+
             String line;
             while ((line = buffReader.readLine()) != null) {
                 strings.add(line);
@@ -112,10 +109,6 @@ public class Utf8EncodingBenchmark extends AbstractMicrobenchmark {
             }
         } catch (Exception e) {
             throw new RuntimeException(e);
-        } finally {
-            closeStream(testTextStream);
-            closeReader(inStreamReader);
-            closeReader(buffReader);
         }
         buffer = direct? Unpooled.directBuffer(maxExpectedSize, maxExpectedSize) :
                 Unpooled.buffer(maxExpectedSize, maxExpectedSize);


### PR DESCRIPTION
Motivation:

`PlatformDependent.addFilesystemOsClassifiers` and `BoringSSLKeylessManagerFactory.newKeyless(BoringSSLAsyncPrivateKeyMethod privateKeyMethod, File chain)` don't close the opened files.

Modification:

Wrap in try/catch so we 100% sure the file is closed.
Also, wrapped all `getClass().getResourceAsStream` in tests

Result:

No more file leaks.