### PR TITLE
WebSocket08FrameEncoder improvements

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameEncoder.java
@@ -143,7 +143,7 @@ public class WebSocket08FrameEncoder extends MessageToMessageEncoder<WebSocketFr
                 int size = 2 + maskLength + length;
                 buf = ctx.alloc().buffer(size);
                 buf.writeByte(b0);
-                byte b = (byte) (maskGenerator != null ? 0x80 | (byte) length : (byte) length);
+                byte b = (byte) (maskGenerator != null ? 0x80 | length : length);
                 buf.writeByte(b);
             } else if (length <= 0xFFFF) {
                 int size = 4 + maskLength;


### PR DESCRIPTION
While checking https://github.com/netty/netty/issues/15157, I found a few small improvements that could be done for `WebSocket08FrameEncoder`:

- `opcode` resolving moved to its own method to make the code more readable
- removed unnecessary `isReadable()` call and replaced it with `length > 0` check
- replaced modulo operations with bit operations which are cheaper