### PR TITLE
Ensure OpenSsl.availableJavaCipherSuites does not contain null value …

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/CipherSuiteConverter.java
+++ b/handler/src/main/java/io/netty/handler/ssl/CipherSuiteConverter.java
@@ -298,7 +298,7 @@ public final class CipherSuiteConverter {
      * Convert from OpenSSL cipher suite name convention to java cipher suite name convention.
      * @param openSslCipherSuite An OpenSSL cipher suite name.
      * @param protocol The cryptographic protocol (i.e. SSL, TLS, ...).
-     * @return The translated cipher suite name according to java conventions. This will not be {@code null}.
+     * @return The translated cipher suite name according to java conventions (or null if translation was not possible).
      */
     public static String toJava(String openSslCipherSuite, String protocol) {
         Map<String, String> p2j = o2j.get(openSslCipherSuite);

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
@@ -363,8 +363,14 @@ public final class OpenSsl {
             for (String cipher: AVAILABLE_OPENSSL_CIPHER_SUITES) {
                 // Included converted but also openssl cipher name
                 if (!isTLSv13Cipher(cipher)) {
-                    availableJavaCipherSuites.add(CipherSuiteConverter.toJava(cipher, "TLS"));
-                    availableJavaCipherSuites.add(CipherSuiteConverter.toJava(cipher, "SSL"));
+                    final String tlsConversion = CipherSuiteConverter.toJava(cipher, "TLS");
+                    if (tlsConversion != null) {
+                        availableJavaCipherSuites.add(tlsConversion);
+                    }
+                    final String sslConversion = CipherSuiteConverter.toJava(cipher, "SSL");
+                    if (sslConversion != null) {
+                        availableJavaCipherSuites.add(sslConversion);
+                    }
                 } else {
                     // TLSv1.3 ciphers have the correct format.
                     availableJavaCipherSuites.add(cipher);

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslTest.java
@@ -17,15 +17,33 @@ package io.netty.handler.ssl;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class OpenSslTest {
+final class OpenSslTest {
 
     @Test
-    public void testDefaultCiphers() {
+    void testDefaultCiphers() {
         if (!OpenSsl.isTlsv13Supported()) {
             assertTrue(
                     OpenSsl.DEFAULT_CIPHERS.size() <= SslUtils.DEFAULT_CIPHER_SUITES.length);
+        }
+    }
+
+    @Test
+    void availableJavaCipherSuitesMustNotContainNullOrEmptyElement() {
+        for (String suite :OpenSsl.availableJavaCipherSuites()) {
+            assertNotNull(suite);
+            assertFalse(suite.isEmpty());
+        }
+    }
+
+    @Test
+    void availableOpenSslCipherSuitesMustNotContainNullOrEmptyElement() {
+        for (String suite :OpenSsl.availableOpenSslCipherSuites()) {
+            assertNotNull(suite);
+            assertFalse(suite.isEmpty());
         }
     }
 }


### PR DESCRIPTION
…(#15215)

Motivation:
The way BoringSSL-related TLS 1.3 certificates are regisgtered and then converted to their java equivalent name, will cause a null value to be added to the set of OpenSsl.availableJavaCipherSuites.

Modifications:
While the underlying root cause (the differently named ciphers) is not resolved with this changeset, the code now makes sure that if a conversion has not been successful (and returning null as a result), it is not added to the list of available cipher suites and therefore acts as a safeguard to the caller.

A related, outdated javadoc has been fixed as well and regression tests added.

Fixes #15214