### PR TITLE
Make JdkZlibEncoder accept Deflater.DEFAULT_COMPRESSION as level (#15…

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibEncoder.java
@@ -76,7 +76,7 @@ public class JdkZlibEncoder extends ZlibEncoder {
     }
 
     /**
-     * Creates a new zlib encoder with the default compression level ({@code 6})
+     * Creates a new zlib encoder with a compression level of ({@code 6})
      * and the default wrapper ({@link ZlibWrapper#ZLIB}).
      *
      * @throws CompressionException if failed to initialize zlib
@@ -101,7 +101,7 @@ public class JdkZlibEncoder extends ZlibEncoder {
     }
 
     /**
-     * Creates a new zlib encoder with the default compression level ({@code 6})
+     * Creates a new zlib encoder with a compression level of ({@code 6})
      * and the specified wrapper.
      *
      * @throws CompressionException if failed to initialize zlib
@@ -117,12 +117,14 @@ public class JdkZlibEncoder extends ZlibEncoder {
      * @param compressionLevel
      *        {@code 1} yields the fastest compression and {@code 9} yields the
      *        best compression.  {@code 0} means no compression.  The default
-     *        compression level is {@code 6}.
+     *        compression level can be set as {@code -1} which correlates to the underlying
+     *        {@link Deflater#DEFAULT_COMPRESSION} level.
      *
      * @throws CompressionException if failed to initialize zlib
      */
     public JdkZlibEncoder(ZlibWrapper wrapper, int compressionLevel) {
-        ObjectUtil.checkInRange(compressionLevel, 0, 9, "compressionLevel");
+        ObjectUtil.checkInRange(compressionLevel, Deflater.DEFAULT_COMPRESSION, Deflater.BEST_COMPRESSION,
+                "compressionLevel");
         ObjectUtil.checkNotNull(wrapper, "wrapper");
 
         if (wrapper == ZlibWrapper.ZLIB_OR_NONE) {
@@ -136,7 +138,7 @@ public class JdkZlibEncoder extends ZlibEncoder {
     }
 
     /**
-     * Creates a new zlib encoder with the default compression level ({@code 6})
+     * Creates a new zlib encoder with a compression level of ({@code 6})
      * and the specified preset dictionary.  The wrapper is always
      * {@link ZlibWrapper#ZLIB} because it is the only format that supports
      * the preset dictionary.
@@ -158,13 +160,15 @@ public class JdkZlibEncoder extends ZlibEncoder {
      * @param compressionLevel
      *        {@code 1} yields the fastest compression and {@code 9} yields the
      *        best compression.  {@code 0} means no compression.  The default
-     *        compression level is {@code 6}.
+     *        compression level can be set as {@code -1} which correlates to the underlying
+     *        {@link Deflater#DEFAULT_COMPRESSION} level.
      * @param dictionary  the preset dictionary
      *
      * @throws CompressionException if failed to initialize zlib
      */
     public JdkZlibEncoder(int compressionLevel, byte[] dictionary) {
-        ObjectUtil.checkInRange(compressionLevel, 0, 9, "compressionLevel");
+        ObjectUtil.checkInRange(compressionLevel, Deflater.DEFAULT_COMPRESSION, Deflater.BEST_COMPRESSION,
+                "compressionLevel");
         ObjectUtil.checkNotNull(dictionary, "dictionary");
 
         wrapper = ZlibWrapper.ZLIB;

--- a/codec/src/test/java/io/netty/handler/codec/compression/JdkZlibTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/JdkZlibTest.java
@@ -31,8 +31,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Queue;
+import java.util.zip.Deflater;
 import java.util.zip.GZIPOutputStream;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -181,6 +183,16 @@ public class JdkZlibTest extends ZlibTest {
         assertTrue(channel.finish());
         channel.checkException();
         assertTrue(channel.releaseOutbound());
+    }
+
+    @Test
+    void testAllowDefaultCompression() {
+        assertDoesNotThrow(new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                new JdkZlibEncoder(Deflater.DEFAULT_COMPRESSION);
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
…217)

Motivation:
Right now the default compression level inside the used Deflater is defined as "-1", which according to zlib manual also defaults to "6" which is used inside netty as the default. That said, we should also allow to provide Deflater.DEFAULT_COMPRESSION (-1) as an argument.

Modifications:
The range check has been modified to allow for -1 and it now uses the constants instead of magic numbers. Small regression test added which just makes sure that no exception is thrown when provided.

Result:
Fixes #15212
